### PR TITLE
chore: rename to decky-romm-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# romm-library — Decky Loader Plugin
+# decky-romm-sync — Decky Loader Plugin
 
 ## What This Is
 

--- a/bin/romm-launcher
+++ b/bin/romm-launcher
@@ -1,5 +1,5 @@
 #!/bin/bash
-# romm-launcher — Steam shortcut launcher for RomM Library plugin
+# romm-launcher — Steam shortcut launcher for RomM Sync plugin
 # Called by Steam with LaunchOptions as argument: romm:{rom_id}
 
 set -euo pipefail
@@ -22,8 +22,8 @@ ROM_ID="${BASH_REMATCH[1]}"
 PLUGIN_DIR=""
 for candidate in \
     "${DECKY_PLUGIN_RUNTIME_DIR:-}" \
-    "$HOME/.local/share/decky/plugins/romm-library" \
-    "$HOME/homebrew/plugins/romm-library"; do
+    "$HOME/.local/share/decky/plugins/decky-romm-sync" \
+    "$HOME/homebrew/plugins/decky-romm-sync"; do
     if [[ -d "$candidate" ]]; then
         PLUGIN_DIR="$candidate"
         break
@@ -34,8 +34,8 @@ done
 DATA_DIR=""
 for candidate in \
     "${DECKY_PLUGIN_RUNTIME_DIR:-}" \
-    "$HOME/homebrew/data/romm-library" \
-    "$HOME/.local/share/decky/data/romm-library"; do
+    "$HOME/homebrew/data/decky-romm-sync" \
+    "$HOME/.local/share/decky/data/decky-romm-sync"; do
     if [[ -d "$candidate" ]]; then
         DATA_DIR="$candidate"
         break
@@ -43,7 +43,7 @@ for candidate in \
 done
 
 if [[ -z "$DATA_DIR" ]]; then
-    DATA_DIR="$HOME/homebrew/data/romm-library"
+    DATA_DIR="$HOME/homebrew/data/decky-romm-sync"
     mkdir -p "$DATA_DIR"
 fi
 
@@ -98,7 +98,7 @@ with open(path, 'w') as f:
 
 # Try to show a notification
 if command -v notify-send &>/dev/null; then
-    notify-send "RomM Library" "Download queued for ROM #$ROM_ID. Play again when complete."
+    notify-send "RomM Sync" "Download queued for ROM #$ROM_ID. Play again when complete."
 fi
 
 exit 0

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class Plugin:
         self._load_state()
         self._prune_stale_state()
         self.loop.create_task(self._poll_download_requests())
-        decky.logger.info("RomM Library plugin loaded")
+        decky.logger.info("RomM Sync plugin loaded")
 
     async def _unload(self):
         if self._sync_running:
@@ -69,7 +69,7 @@ class Plugin:
         for rom_id, task in list(self._download_tasks.items()):
             task.cancel()
         self._download_tasks.clear()
-        decky.logger.info("RomM Library plugin unloaded")
+        decky.logger.info("RomM Sync plugin unloaded")
 
     def _load_settings(self):
         settings_path = os.path.join(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "romm-library",
+  "name": "decky-romm-sync",
   "version": "0.0.1",
-  "description": "Decky Loader plugin to browse and play your RomM library from Steam Gaming Mode",
+  "description": "Decky Loader plugin to sync your RomM library to Steam as non-steam shortcuts",
   "type": "module",
   "scripts": {
     "build": "rollup -c"

--- a/plugin.json
+++ b/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "RomM Library",
+  "name": "RomM Sync",
   "author": "Daniel",
   "flags": ["_root"],
   "api_version": 1,
   "publish": {
     "tags": ["romm", "rom-manager", "retrodeck", "emulation"],
-    "description": "Browse and play your RomM library directly from Steam Gaming Mode",
+    "description": "Sync your RomM library to Steam as non-steam shortcuts",
     "image": ""
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "node",
   "packages": {
     ".": {
-      "package-name": "romm-library",
+      "package-name": "decky-romm-sync",
       "initial-version": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [

--- a/src/components/GameDetailPanel.tsx
+++ b/src/components/GameDetailPanel.tsx
@@ -264,7 +264,7 @@ export const GameDetailPanel: FC<GameDetailPanelProps> = ({ appId }) => {
   return (
     <Focusable style={styles.container}>
       <div style={styles.header}>
-        <span style={styles.title}>RomM Library</span>
+        <span style={styles.title}>RomM Sync</span>
         <span style={styles.statusBadge(statusColor)}>{statusLabel}</span>
       </div>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,7 @@ export default definePlugin(() => {
   }) => {
     console.log("[RomM] sync_complete received:", data.total_games, "games");
     toaster.toast({
-      title: "RomM Library",
+      title: "RomM Sync",
       body: `Sync complete! ${data.total_games} games added.`,
     });
   };
@@ -97,14 +97,14 @@ export default definePlugin(() => {
         total_bytes: 0,
       });
       toaster.toast({
-        title: "RomM Library",
+        title: "RomM Sync",
         body: `Downloaded ${data.rom_name}`,
       });
     }
   );
 
   return {
-    name: "RomM Library",
+    name: "RomM Sync",
     icon: <FaGamepad />,
     content: <QAMPanel />,
     onDismount() {


### PR DESCRIPTION
## Summary

- Rename project from `romm-library` to `decky-romm-sync`
- Display name in Decky: "RomM Sync"
- Updated: package.json, plugin.json, release-please config, launcher script, frontend, CLAUDE.md