### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the release workflow so builds can be manually triggered from the Actions page
- This push to main will also trigger release-please to create the v0.1.6 release PR, which will be the first release with `requirements.txt` (and therefore working `py_modules/vdf`)