### PR TITLE
chore: make workflow_dispatch rebuild and upload to latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
   build-plugin:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +56,17 @@ jobs:
           sudo $(which decky) plugin build -b -o /tmp/output -s directory $GITHUB_WORKSPACE
           sudo chown -R $(whoami) .
 
+      - name: Determine tag name
+        id: tag
+        run: |
+          if [ -n "${{ needs.release-please.outputs.tag_name }}" ]; then
+            echo "tag=${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$(gh release list --limit 1 --json tagName -q '.[0].tagName')" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,6 +76,6 @@ jobs:
           if [ "$BUILT_ZIP" != "$DEST" ]; then
             cp "$BUILT_ZIP" "$DEST"
           fi
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+          gh release upload "${{ steps.tag.outputs.tag }}" \
             "$DEST" \
             --clobber


### PR DESCRIPTION
## Summary

- Makes the `workflow_dispatch` trigger actually useful — when manually triggered, it builds the plugin and uploads to the latest existing release
- On normal release flow (release-please), behavior is unchanged
- This also triggers release-please to create the v0.1.6 PR, which will be the first release that bundles `py_modules/vdf` via `requirements.txt`