### PR TITLE
feat: pre-launch save sync with conflict resolution

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -45,7 +45,7 @@ export const saveShortcutIcon = callable<[number, string], { success: boolean }>
 // Save sync callables
 export const ensureDeviceRegistered = callable<[], { success: boolean; device_id: string; device_name: string }>("ensure_device_registered");
 export const getSaveStatus = callable<[number], SaveStatus>("get_save_status");
-export const preLaunchSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[] }>("pre_launch_sync");
+export const preLaunchSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: PendingConflict[] }>("pre_launch_sync");
 export const postExitSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[] }>("post_exit_sync");
 export const syncRomSaves = callable<[number], { success: boolean; message: string; synced: number; errors?: string[] }>("sync_rom_saves");
 export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>("sync_all_saves");

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -4,7 +4,7 @@ import { showModal } from "@decky/ui";
 import { resolveConflict } from "../api/backend";
 import type { PendingConflict } from "../types";
 
-export type ConflictResolution = "use_local" | "use_server" | "skip" | "launch_anyway" | "cancel";
+export type ConflictResolution = "use_local" | "use_server" | "launch_anyway" | "cancel";
 
 interface ConflictModalProps {
   conflicts: PendingConflict[];
@@ -65,7 +65,7 @@ const ConflictModalContent: FC<ConflictModalProps> = ({ conflicts, closeModal, o
         console.error("[RomM] Failed to resolve conflict (download):", e);
       }
     }
-    // "skip" and "launch_anyway" leave the conflict unresolved
+    // "launch_anyway" leaves the conflict unresolved
     closeModal?.();
     onDone(resolution);
   };
@@ -145,12 +145,6 @@ const ConflictModalContent: FC<ConflictModalProps> = ({ conflicts, closeModal, o
             Keep Both
           </DialogButton>
           */}
-          <DialogButton
-            onClick={() => handleChoice("skip")}
-            style={{ opacity: 0.7 }}
-          >
-            Skip
-          </DialogButton>
           <DialogButton
             onClick={() => handleChoice("launch_anyway")}
             style={{ opacity: 0.7 }}

--- a/src/components/SaveSyncSettings.tsx
+++ b/src/components/SaveSyncSettings.tsx
@@ -26,10 +26,10 @@ interface SaveSyncSettingsProps {
 }
 
 const conflictModeOptions = [
-  { data: "newest_wins" as ConflictMode, label: "Newest Wins (Default)" },
+  { data: "ask_me" as ConflictMode, label: "Ask Me (Default)" },
+  { data: "newest_wins" as ConflictMode, label: "Newest Wins" },
   { data: "always_upload" as ConflictMode, label: "Always Upload" },
   { data: "always_download" as ConflictMode, label: "Always Download" },
-  { data: "ask_me" as ConflictMode, label: "Ask Me" },
 ];
 
 export const SaveSyncSettings: FC<SaveSyncSettingsProps> = ({ onBack }) => {
@@ -152,12 +152,19 @@ export const SaveSyncSettings: FC<SaveSyncSettingsProps> = ({ onBack }) => {
 
   const handleToggleEnable = (value: boolean) => {
     if (value) {
-      // Two-step confirmation before enabling
       showModal(
         <ConfirmModal
           strTitle="Enable Save Sync?"
-          strDescription="This will sync RetroArch save files between this device and your RomM server. Make sure you are NOT using a shared RomM account (e.g. admin, romm, guest) — save sync is per-user."
-          strOKButtonText="Enable"
+          strDescription={
+            "This will sync RetroArch save files (.srm) between this device and your RomM server.\n\n" +
+            "Before enabling, please back up your local save files. " +
+            "They are stored in your RetroArch/RetroDECK saves directory.\n\n" +
+            "Also make sure you are not using this on a shared RomM account " +
+            "(e.g. admin, romm, guest) - unless you know what you are doing. " +
+            "Save sync is intended for single user accounts.\n\n" +
+            "Are you sure you want to proceed?"
+          }
+          strOKButtonText="I am sure"
           strCancelButtonText="Cancel"
           onOK={() => handleSettingChange({ save_sync_enabled: true })}
         />,

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -8,7 +8,6 @@
 
 import { toaster } from "@decky/api";
 import {
-  preLaunchSync,
   postExitSync,
   recordSessionStart,
   recordSessionEnd,
@@ -17,7 +16,6 @@ import {
   getPendingConflicts,
 } from "../api/backend";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
-import { showConflictResolutionModal } from "../components/ConflictModal";
 
 declare var Router: {
   MainRunningApp: { appid: number; display_name: string } | null;
@@ -74,42 +72,7 @@ async function handleGameStart(appId: number): Promise<void> {
   } catch (e) {
     console.error("[RomM] Failed to record session start:", e);
   }
-
-  // Pre-launch save sync (if enabled)
-  try {
-    const settings = await getSaveSyncSettings();
-    if (settings.save_sync_enabled && settings.sync_before_launch) {
-      const result = await preLaunchSync(romId);
-      if (result.success) {
-        if (result.synced && result.synced > 0) {
-          toaster.toast({ title: "RomM Save Sync", body: "Saves downloaded from RomM" });
-        }
-      } else {
-        console.warn("[RomM] Pre-launch sync issue:", result.message);
-        toaster.toast({ title: "RomM Save Sync", body: "Failed to sync saves \u2014 playing with local saves" });
-      }
-
-      // Check for pending conflicts (ask_me mode shows modal, others just toast)
-      try {
-        const conflictsResult = await getPendingConflicts();
-        if (conflictsResult.conflicts && conflictsResult.conflicts.length > 0) {
-          if (settings.conflict_mode === "ask_me") {
-            await showConflictResolutionModal(conflictsResult.conflicts);
-          } else {
-            toaster.toast({
-              title: "RomM Save Sync",
-              body: "Save conflict detected \u2014 resolve in Save Sync settings",
-            });
-          }
-        }
-      } catch {
-        // non-critical
-      }
-    }
-  } catch (e) {
-    console.error("[RomM] Pre-launch sync failed:", e);
-    toaster.toast({ title: "RomM Save Sync", body: "Failed to sync saves \u2014 playing with local saves" });
-  }
+  // Pre-launch sync moved to CustomPlayButton.handlePlay
 }
 
 async function handleGameStop(): Promise<void> {


### PR DESCRIPTION
## Summary

- **Pre-launch save sync**: `handlePlay` calls `preLaunchSync` before launching — detects conflicts, shows resolution modal, blocks launch until resolved
- **Backend returns conflicts directly**: `pre_launch_sync` returns `conflicts` in response, removing fragile multi-call frontend orchestration
- **Consistent conflict display**: All three game detail components (play button, status bar, detail panel) use `get_save_status` (real-time `_detect_conflict`) instead of stale `pending_conflicts`
- **Resolve Conflict button**: Orange button reopens conflict modal (resolve-only, no launch), transitions back to green Play on resolution
- **Default conflict mode changed to `ask_me`**: Always prompts user when both sides differ
- **Bug fix**: `resolve_conflict` no longer removes conflict from queue before the upload/download succeeds
- **Enable dialog**: Warns about backups and shared accounts before enabling save sync
- **Debug logging**: `_detect_conflict` now logs hash comparisons and decisions for diagnosability

## Test plan

- [x] 224 backend tests pass
- [x] Open game detail page with existing conflict → orange Resolve Conflict button + orange Save Sync status + Conflict label in detail panel (all aligned)
- [x] Click Play on game with differing saves → conflict modal appears before launch
- [x] Resolve conflict (Keep Local / Keep Server) → all status indicators update to green
- [x] Cancel conflict modal → orange Resolve Conflict button, game does not launch
- [x] Click Resolve Conflict → modal reopens, resolve → button turns green Play
- [x] Launch Anyway → game launches with conflict unresolved
- [x] Server unreachable → "Launch with local saves?" confirmation dialog
- [x] Enable save sync toggle → backup warning dialog with "I am sure" / "Cancel"
- [x] Offline play → game launches, saves queued for upload on next connect