### PR TITLE
feat: frontend logging overhaul — log level system

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -32,8 +32,12 @@ export const getFirmwareStatus = callable<[], FirmwareStatus>("get_firmware_stat
 export const downloadFirmware = callable<[number], FirmwareDownloadResult>("download_firmware");
 export const downloadAllFirmware = callable<[string], FirmwareDownloadResult>("download_all_firmware");
 export const checkPlatformBios = callable<[string], BiosStatus>("check_platform_bios");
-export const saveDebugLogging = callable<[boolean], { success: boolean }>("save_debug_logging");
+export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
 export const debugLog = callable<[string], void>("debug_log");
+const frontendLog = callable<[string, string], void>("frontend_log");
+export const logInfo = (msg: string) => { frontendLog("info", msg); };
+export const logWarn = (msg: string) => { frontendLog("warn", msg); };
+export const logError = (msg: string) => { frontendLog("error", msg); };
 export const fixRetroarchInputDriver = callable<[], { success: boolean; message: string }>("fix_retroarch_input_driver");
 export const getRomMetadata = callable<[number], RomMetadata>("get_rom_metadata");
 export const getAllMetadataCache = callable<[], Record<string, RomMetadata>>("get_all_metadata_cache");

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { ModalRoot, DialogButton } from "@decky/ui";
 import { showModal } from "@decky/ui";
-import { resolveConflict } from "../api/backend";
+import { resolveConflict, logError } from "../api/backend";
 import type { PendingConflict } from "../types";
 
 export type ConflictResolution = "use_local" | "use_server" | "launch_anyway" | "cancel";
@@ -56,13 +56,13 @@ const ConflictModalContent: FC<ConflictModalProps> = ({ conflicts, closeModal, o
       try {
         await resolveConflict(conflict.rom_id, conflict.filename, "upload");
       } catch (e) {
-        console.error("[RomM] Failed to resolve conflict (upload):", e);
+        logError(`Failed to resolve conflict (upload): ${e}`);
       }
     } else if (resolution === "use_server") {
       try {
         await resolveConflict(conflict.rom_id, conflict.filename, "download");
       } catch (e) {
-        console.error("[RomM] Failed to resolve conflict (download):", e);
+        logError(`Failed to resolve conflict (download): ${e}`);
       }
     }
     // "launch_anyway" leaves the conflict unresolved

--- a/src/components/ConnectionSettings.tsx
+++ b/src/components/ConnectionSettings.tsx
@@ -10,7 +10,7 @@ import {
   ConfirmModal,
   showModal,
 } from "@decky/ui";
-import { getSettings, saveSettings, testConnection, saveSgdbApiKey, verifySgdbApiKey, saveSteamInputSetting, applySteamInputSetting } from "../api/backend";
+import { getSettings, saveSettings, testConnection, saveSgdbApiKey, verifySgdbApiKey, saveSteamInputSetting, applySteamInputSetting, logError } from "../api/backend";
 
 // Module-level state survives component remounts (modal close can remount QAM)
 const pendingEdits: { url?: string; username?: string; password?: string } = {};
@@ -72,7 +72,7 @@ export const ConnectionSettings: FC<ConnectionSettingsProps> = ({ onBack }) => {
       setSgdbApiKey(s.sgdb_api_key_masked);
       setSteamInputMode(s.steam_input_mode || "default");
     }).catch((e) => {
-      console.error("[RomM] Failed to load settings:", e);
+      logError(`Failed to load settings: ${e}`);
       setStatus("Failed to load settings");
     });
   }, []);

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -31,6 +31,7 @@ import {
   debugLog,
   preLaunchSync,
   getSaveStatus,
+  logError,
 } from "../api/backend";
 import { showConflictResolutionModal } from "./ConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent } from "../types";
@@ -57,7 +58,6 @@ function showLaunchConfirmation(title: string, message: string): Promise<boolean
 }
 
 export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
-  debugLog(`CustomPlayButton: mounted appId=${appId}`);
   const [state, setState] = useState<PlayButtonState>("loading");
   const [romId, setRomId] = useState<number | null>(null);
   const [romName, setRomName] = useState<string>("");
@@ -112,7 +112,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           }
         }
       } catch (e) {
-        console.error("[RomM] CustomPlayButton init error:", e);
+        logError(`CustomPlayButton init error: ${e}`);
         if (!cancelled) {
           setState("not_romm");
           toaster.toast({ title: "RomM Sync", body: "Could not connect to RomM server" });

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -16,6 +16,9 @@ import {
   uninstallAllRoms,
   deletePlatformSaves,
   deletePlatformBios,
+  logInfo,
+  logWarn,
+  logError,
 } from "../api/backend";
 import { removeShortcut } from "../utils/steamShortcuts";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
@@ -59,17 +62,17 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
     const apps: { appId: number; name: string }[] = [];
     try {
       if (typeof collectionStore === "undefined") {
-        console.warn("[RomM] collectionStore not available");
+        logWarn("collectionStore not available");
         setNonSteamApps([]);
         return;
       }
       const deckApps = collectionStore.deckDesktopApps?.apps;
       if (!deckApps) {
-        console.warn("[RomM] deckDesktopApps.apps not available");
+        logWarn("deckDesktopApps.apps not available");
         setNonSteamApps([]);
         return;
       }
-      console.log("[RomM] deckDesktopApps.apps size:", deckApps.size);
+      logInfo(`deckDesktopApps.apps size: ${deckApps.size}`);
       let appIds = Array.from(deckApps.keys());
       const autoWhitelist = new Set<number>();
       for (const appId of appIds) {
@@ -94,7 +97,7 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
         });
       }
     } catch (e) {
-      console.error("[RomM] Failed to enumerate non-steam games:", e);
+      logError(`Failed to enumerate non-steam games: ${e}`);
     }
     apps.sort((a, b) => a.name.localeCompare(b.name));
     setNonSteamApps(apps);

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -5,7 +5,7 @@ import {
   ButtonItem,
   Field,
   ProgressBarWithInfo,
-  ToggleField,
+  DropdownItem,
 } from "@decky/ui";
 import {
   testConnection,
@@ -13,7 +13,7 @@ import {
   cancelSync,
   getSyncStats,
   getSettings,
-  saveDebugLogging,
+  saveLogLevel,
   fixRetroarchInputDriver,
 } from "../api/backend";
 import { getSyncProgress } from "../utils/syncProgress";
@@ -32,7 +32,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
   const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(false);
-  const [debugLogging, setDebugLogging] = useState(false);
+  const [logLevel, setLogLevel] = useState("warn");
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
   const [retroarchFixStatus, setRetroarchFixStatus] = useState("");
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -68,7 +68,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     getSyncStats().then(setStats);
     testConnection().then((r) => setConnected(r.success));
     getSettings().then((s) => {
-      setDebugLogging(s.debug_logging ?? false);
+      setLogLevel(s.log_level ?? "warn");
       if (s.retroarch_input_check) {
         setRetroarchWarning(s.retroarch_input_check);
       }
@@ -295,13 +295,19 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
       <PanelSection title="Advanced">
         <PanelSectionRow>
-          <ToggleField
-            label="Debug Logging"
-            description="Log additional details for troubleshooting"
-            checked={debugLogging}
-            onChange={(value) => {
-              setDebugLogging(value);
-              saveDebugLogging(value);
+          <DropdownItem
+            label="Log Level"
+            description="Controls which frontend messages are written to the plugin log file"
+            rgOptions={[
+              { data: "error", label: "Error" },
+              { data: "warn", label: "Warn" },
+              { data: "info", label: "Info" },
+              { data: "debug", label: "Debug" },
+            ]}
+            selectedOption={logLevel}
+            onChange={(option) => {
+              setLogLevel(option.data);
+              saveLogLevel(option.data);
             }}
           />
         </PanelSectionRow>

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -169,6 +169,25 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       const detail = (e as CustomEvent).detail;
       if (!romIdRef.current) return;
 
+      if (detail?.type === "save_sync_settings") {
+        const enabled = detail.save_sync_enabled as boolean;
+        if (enabled) {
+          const [updatedStatus, updatedConflicts] = await Promise.all([
+            getSaveStatus(romIdRef.current).catch((): SaveStatus | null => null),
+            getPendingConflicts().catch((): { conflicts: PendingConflict[] } => ({ conflicts: [] })),
+          ]);
+          setState((prev) => ({
+            ...prev,
+            saveSyncEnabled: true,
+            saveStatus: updatedStatus,
+            conflicts: updatedConflicts.conflicts.filter((c) => c.rom_id === romIdRef.current),
+          }));
+        } else {
+          setState((prev) => ({ ...prev, saveSyncEnabled: false }));
+        }
+        return;
+      }
+
       if (detail?.type === "save_sync" && (!detail.rom_id || detail.rom_id === romIdRef.current)) {
         const [updatedStatus, updatedConflicts] = await Promise.all([
           getSaveStatus(romIdRef.current).catch((): SaveStatus | null => null),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import { updateDownload } from "./utils/downloadStore";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
 import { registerMetadataPatches, unregisterMetadataPatches, applyAllPlaytime } from "./patches/metadataPatches";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
-import { getAllMetadataCache, getAppIdRomIdMap, ensureDeviceRegistered, getSaveSyncSettings, getAllPlaytime } from "./api/backend";
+import { getAllMetadataCache, getAppIdRomIdMap, ensureDeviceRegistered, getSaveSyncSettings, getAllPlaytime, logError, logInfo } from "./api/backend";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent } from "./types";
 
@@ -76,10 +76,10 @@ export default definePlugin(() => {
         const { playtime } = await getAllPlaytime();
         applyAllPlaytime(playtime, appIdMap);
       } catch (e) {
-        console.error("[RomM] Failed to apply playtime:", e);
+        logError(`Failed to apply playtime: ${e}`);
       }
     } catch (e) {
-      console.error("[RomM] Failed to load metadata cache:", e);
+      logError(`Failed to load metadata cache: ${e}`);
     }
   })();
 
@@ -93,7 +93,7 @@ export default definePlugin(() => {
       // Always init session manager — it handles playtime tracking too
       await initSessionManager();
     } catch (e) {
-      console.error("[RomM] Failed to init save sync:", e);
+      logError(`Failed to init save sync: ${e}`);
     }
   })();
 
@@ -101,7 +101,7 @@ export default definePlugin(() => {
     platform_app_ids: Record<string, number[]>;
     total_games: number;
   }) => {
-    console.log("[RomM] sync_complete received:", data.total_games, "games");
+    logInfo(`sync_complete received: ${data.total_games} games`);
     toaster.toast({
       title: "RomM Sync",
       body: `Sync complete! ${data.total_games} games added.`,
@@ -123,7 +123,7 @@ export default definePlugin(() => {
         ]);
         applyAllPlaytime(playtime, appIdMap);
       } catch (e) {
-        console.error("[RomM] Failed to re-apply playtime after sync:", e);
+        logError(`Failed to re-apply playtime after sync: ${e}`);
       }
     })();
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,7 +44,7 @@ export interface PluginSettings {
   has_credentials: boolean;
   steam_input_mode: "default" | "force_on" | "force_off";
   sgdb_api_key_masked: string;
-  debug_logging: boolean;
+  log_level: "debug" | "info" | "warn" | "error";
   retroarch_input_check?: RetroArchInputCheck;
 }
 

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -7,7 +7,7 @@
 
 import { toaster } from "@decky/api";
 import { isRomMAppId } from "../patches/gameDetailPatch";
-import { getInstalledRom, getPendingConflicts, getSaveSyncSettings } from "../api/backend";
+import { getInstalledRom, getPendingConflicts, getSaveSyncSettings, logInfo, logError } from "../api/backend";
 
 let gameActionHook: { unregister: () => void } | null = null;
 
@@ -58,13 +58,13 @@ export function registerLaunchInterceptor(): void {
           // Non-critical — let the game launch if we can't check conflicts
         }
       } catch (e) {
-        console.error("[RomM] Launch interceptor error:", e);
+        logError(`Launch interceptor error: ${e}`);
         // On error, don't block the launch
       }
     },
   );
 
-  console.log("[RomM] Launch interceptor registered");
+  logInfo("Launch interceptor registered");
 }
 
 export function unregisterLaunchInterceptor(): void {
@@ -72,5 +72,5 @@ export function unregisterLaunchInterceptor(): void {
     gameActionHook.unregister();
     gameActionHook = null;
   }
-  console.log("[RomM] Launch interceptor unregistered");
+  logInfo("Launch interceptor unregistered");
 }

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -1,4 +1,5 @@
 import type { SyncAddItem } from "../types";
+import { logError } from "../api/backend";
 
 const ROMM_MARKER = "romm:";
 
@@ -75,7 +76,7 @@ export async function addShortcut(data: SyncAddItem): Promise<number | null> {
 
     return appId;
   } catch (e) {
-    console.error(`[RomM] Failed to add shortcut for ${data.name}:`, e);
+    logError(`Failed to add shortcut for ${data.name}: ${e}`);
     return null;
   }
 }
@@ -87,6 +88,6 @@ export function removeShortcut(appId: number): void {
   try {
     SteamClient.Apps.RemoveShortcut(appId);
   } catch (e) {
-    console.error(`[RomM] Failed to remove shortcut ${appId}:`, e);
+    logError(`Failed to remove shortcut ${appId}: ${e}`);
   }
 }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -116,7 +116,7 @@ class TestGetRomMetadata:
             "player_count": "1",
             "cached_at": time.time(),
         }
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
         result = await plugin.get_rom_metadata(42)
         assert result["summary"] == "Cached summary"
         assert result["genres"] == ["RPG"]
@@ -129,7 +129,7 @@ class TestGetRomMetadata:
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         romm_response = {
             "id": 42,
@@ -170,7 +170,7 @@ class TestGetRomMetadata:
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         # Set cache as 8 days old
         plugin._metadata_cache["42"] = {
@@ -202,7 +202,7 @@ class TestGetRomMetadata:
         from unittest.mock import patch
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         # Stale cache (8 days old)
         plugin._metadata_cache["42"] = {
@@ -228,7 +228,7 @@ class TestGetRomMetadata:
         from unittest.mock import patch
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         with patch.object(plugin, "_romm_request", side_effect=Exception("Connection refused")):
             result = await plugin.get_rom_metadata(42)
@@ -249,7 +249,7 @@ class TestGetRomMetadata:
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         romm_response = {"id": 42, "summary": "Just a summary"}
 
@@ -267,7 +267,7 @@ class TestGetRomMetadata:
         import time
         import decky
 
-        plugin.settings["debug_logging"] = True
+        plugin.settings["log_level"] = "debug"
         plugin._metadata_cache["42"] = {
             "summary": "cached",
             "genres": [],
@@ -292,7 +292,7 @@ class TestGetRomMetadata:
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = True
+        plugin.settings["log_level"] = "debug"
 
         romm_response = {"id": 42, "summary": "test", "metadatum": {}}
 
@@ -483,7 +483,7 @@ class TestGetRomMetadata404:
         import urllib.error
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         http_404 = urllib.error.HTTPError(
             url="http://example.com/api/roms/999",
@@ -509,7 +509,7 @@ class TestGetRomMetadata404:
         import urllib.error
 
         plugin.loop = asyncio.get_event_loop()
-        plugin.settings["debug_logging"] = False
+        plugin.settings["log_level"] = "warn"
 
         plugin._metadata_cache["999"] = {
             "summary": "Old cached data",

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -19,7 +19,7 @@ def plugin(tmp_path):
         "romm_user": "user",
         "romm_pass": "pass",
         "enabled_platforms": {},
-        "debug_logging": False,
+        "log_level": "warn",
     }
     p._sync_running = False
     p._sync_cancel = False


### PR DESCRIPTION
## Summary

- Replace `debug_logging` boolean toggle with a proper **log level dropdown** (`debug` / `info` / `warn` / `error`). Default: `warn`
- Convert all 58 `console.log/warn/error` calls across 12 frontend files to `logInfo/logWarn/logError` — messages now route to Decky log files via a `frontend_log` backend callable with level-based filtering
- Migrate `debug_logging: bool` setting to `log_level: str` with backward-compat migration (old `true` → `"debug"`, old `false` → `"warn"`)
- Also includes: save sync settings reactivity, `computeSaveSyncDisplay` refactor, playtime display retry logic, PLAN.md playtime research notes

## Test plan

- [x] `pnpm build` passes (no TS errors)
- [x] `python -m pytest tests/ -q` — 417 tests pass
- [x] `grep -r "console\." src/` — zero hits
- [x] Deploy, reload plugin — default log level is `warn`
- [x] Trigger a warning/error → appears in log file
- [x] Trigger an info event (sync) → does NOT appear at `warn` level
- [x] Change log level to `debug` → debug messages appear
- [x] Old `debug_logging: true` in settings.json migrates to `log_level: "debug"` on first load