### PR TITLE
fix: startup state healing — atomic settings, orphan cleanup, tmp pruning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ tests/conftest.py                    # Mock decky module for test isolation
 
 ## Current State
 
-**Latest release**: v0.6.0 on main
+**Latest release**: v0.7.0 on main
 
 Working:
 - Full sync engine (fetch ROMs, create shortcuts, apply cover art)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ Arrow direction: depends-on (A → B means A calls methods from B).
 ```python
 Provides: settings, _state, _metadata_cache,
           _load_settings(), _save_settings_to_disk(), _log_debug(),
-          _load_state(), _save_state(), _prune_stale_state(),
+          _load_state(), _save_state(), _prune_stale_installed_roms(),
           _load_metadata_cache(), _save_metadata_cache()
 ```
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,13 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
         self._load_metadata_cache()
         self._init_save_sync_state()
         self._load_save_sync_state()
-        self._prune_stale_state()
+        # ── Startup state healing ──
+        self._prune_stale_installed_roms()      # lib/state.py
+        self._prune_stale_registry()             # lib/state.py
+        self._prune_orphaned_save_sync_state()   # lib/save_sync.py
+        self._prune_orphaned_artwork_cache()     # lib/sgdb.py
+        self._prune_orphaned_staging_artwork()   # lib/sync.py
+        self._cleanup_leftover_tmp_files()       # lib/downloads.py
         self.loop.create_task(self._poll_download_requests())
         decky.logger.info("RomM Sync plugin loaded")
 


### PR DESCRIPTION
## Summary

- **Atomic `settings.json` writes** — `.tmp` + `os.replace()` prevents corruption on crash mid-write
- **Shortcut registry validation** — prune entries with missing/invalid `app_id` on startup
- **Orphaned save sync state cleanup** — remove `saves`/`playtime`/`pending_conflicts` entries for rom_ids no longer in registry
- **Orphaned SGDB artwork cache cleanup** — delete cached images and leftover `.tmp` files for removed ROMs
- **Orphaned staging artwork cleanup** — remove `romm_*_cover.png` files left by interrupted syncs
- **Leftover `.tmp` file cleanup** — remove `.tmp`/`.zip.tmp` from ROM and BIOS directories on startup
- **Save sync state cleanup on ROM removal** — `remove_rom()` and `uninstall_all_roms()` now clean save sync state
- **PLAN.md updated** — Phase 5/5.6 moved to completed, Bug 3 moved to Future Improvements, BIOS badge testing item added

All 6 cleanup methods run during startup after state is loaded, before the download poller starts. Each method only saves state if changes were actually made.

Verified on device — startup log shows `Pruned 3 orphaned SGDB artwork cache file(s)`.

35 new tests (469 total), all passing.

## Test plan
- [x] `python -m pytest tests/ -q` — 469 passed
- [x] Plugin loads and logs pruning activity on Steam Deck
- [x] Verify startup after simulated crash (kill plugin mid-download, restart)
- [x] Verify `remove_rom()` cleans save sync state