### PR TITLE
fix: resolve defaults/ file paths after lib move to py_modules/

### DIFF
--- a/py_modules/lib/es_de_config.py
+++ b/py_modules/lib/es_de_config.py
@@ -157,7 +157,11 @@ def _load_core_defaults():
     if _core_defaults_cache is not None:
         return _core_defaults_cache
 
-    defaults_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "defaults", "core_defaults.json")
+    # Check plugin root first (Decky CLI moves defaults/ contents to root),
+    # then defaults/ subdirectory (dev deploys via mise run deploy)
+    root_path = os.path.join(decky.DECKY_PLUGIN_DIR, "core_defaults.json")
+    dev_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "core_defaults.json")
+    defaults_path = root_path if os.path.exists(root_path) else dev_path
     try:
         with open(defaults_path, "r") as f:
             data = json.load(f)

--- a/py_modules/lib/firmware.py
+++ b/py_modules/lib/firmware.py
@@ -26,10 +26,11 @@ class FirmwareMixin:
     def _load_bios_registry(self):
         self._bios_registry = {}
         self._bios_files_index = {}
-        registry_path = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)),
-            "defaults", "bios_registry.json",
-        )
+        # Check plugin root first (Decky CLI moves defaults/ contents to root),
+        # then defaults/ subdirectory (dev deploys via mise run deploy)
+        root_path = os.path.join(decky.DECKY_PLUGIN_DIR, "bios_registry.json")
+        defaults_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "bios_registry.json")
+        registry_path = root_path if os.path.exists(root_path) else defaults_path
         try:
             with open(registry_path, "r") as f:
                 self._bios_registry = json.load(f)

--- a/py_modules/lib/romm_client.py
+++ b/py_modules/lib/romm_client.py
@@ -28,7 +28,11 @@ if TYPE_CHECKING:
 
 class RommClientMixin:
     def _load_platform_map(self):
-        config_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "config.json")
+        # Check plugin root first (Decky CLI moves defaults/ contents to root),
+        # then defaults/ subdirectory (dev deploys via mise run deploy)
+        root_path = os.path.join(decky.DECKY_PLUGIN_DIR, "config.json")
+        dev_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "config.json")
+        config_path = root_path if os.path.exists(root_path) else dev_path
         with open(config_path, "r") as f:
             config = json.load(f)
         return config.get("platform_map", {})

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -364,11 +364,11 @@ class TestBiosRegistry:
         registry_file = defaults_dir / "bios_registry.json"
         registry_file.write_text(json.dumps(registry_data))
 
-        from unittest.mock import patch
-        # _load_bios_registry uses __file__ to locate bios_registry.json relative to lib/
-        # We patch os.path.dirname to redirect to our tmp_path
-        fake_lib_dir = str(tmp_path / "lib")
-        with patch("lib.firmware.os.path.dirname", side_effect=[fake_lib_dir, str(tmp_path)]):
+        from unittest.mock import patch, MagicMock
+        # _load_bios_registry uses decky.DECKY_PLUGIN_DIR to locate bios_registry.json
+        mock_decky = MagicMock()
+        mock_decky.DECKY_PLUGIN_DIR = str(tmp_path)
+        with patch("lib.firmware.decky", mock_decky):
             plugin._load_bios_registry()
 
         assert "_meta" in plugin._bios_registry
@@ -386,9 +386,11 @@ class TestBiosRegistry:
 
     def test_load_bios_registry_missing_file(self, plugin):
         """When registry file doesn't exist, returns empty dict."""
-        from unittest.mock import patch
+        from unittest.mock import patch, MagicMock
 
-        with patch("lib.firmware.os.path.dirname", side_effect=["/nonexistent/lib", "/nonexistent"]):
+        mock_decky = MagicMock()
+        mock_decky.DECKY_PLUGIN_DIR = "/nonexistent"
+        with patch("lib.firmware.decky", mock_decky):
             plugin._load_bios_registry()
 
         assert plugin._bios_registry == {}


### PR DESCRIPTION
## Problem

PR #65 moved `lib/` into `py_modules/lib/`, but three modules used `dirname(dirname(__file__))` or `DECKY_PLUGIN_DIR/defaults/` to locate config files. After the move:

- `dirname(dirname(__file__))` resolves to `py_modules/` instead of the plugin root (firmware.py, es_de_config.py)
- `DECKY_PLUGIN_DIR/defaults/config.json` doesn't exist in Decky CLI installs — Decky moves defaults/ contents to the plugin root (romm_client.py)

This caused `bios_registry.json not found`, missing platform config, and missing core defaults — breaking BIOS detection, platform mapping, and core switching.

## Fix

All three modules now use `decky.DECKY_PLUGIN_DIR` and check both locations:
1. Plugin root (Decky CLI release installs)
2. `defaults/` subdirectory (dev deploys via `mise run deploy`)

## Files changed

- `py_modules/lib/firmware.py` — bios_registry.json path
- `py_modules/lib/es_de_config.py` — core_defaults.json path
- `py_modules/lib/romm_client.py` — config.json path
- `tests/test_firmware.py` — updated mocks for new path resolution

## Test plan

- [x] 586 tests pass
- [x] Decky CLI release install: BIOS detection works, platform config loads, core switching works