### PR TITLE
feat: frontend error differentiation with user-friendly messages

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -48,7 +48,7 @@ Extends Phase 5 to standalone emulator save formats:
 - **Auto sync interval**: Configurable background re-sync
 - **Library management**: Detect removed/updated ROMs, stale state cleanup
 - **Offline mode**: Cache lists locally, queue operations
-- **Error handling**: Retry with backoff, toast notifications, detailed logging. Includes frontend error differentiation: show specific messages for auth failures (401), SSL errors, timeouts, and connection refused — instead of generic "could not connect" (depends on EXT-8 backend structured errors)
+- **Error handling**: Retry with backoff, toast notifications, detailed logging. ~~Frontend error differentiation~~: ✅ Done — `classify_error()`/`error_response()` in `errors.py` maps structured exceptions to user-friendly messages and `error_code` fields. All backend callables (`test_connection`, `start_download`, `_do_sync`, firmware, save sync) return `{success, message, error_code}`. Frontend `BackendResult` type with `RommErrorCode` union. Users now see "Authentication failed", "Server unreachable", "SSL certificate error", etc. instead of generic messages
 - **Connection settings UX**: Remove save button, save on popup confirm
 - **RomM playtime API**: When feature request #1225 ships, plug in delta-based accumulation
 - **Emulator save state sync**: RetroArch `.state` files (larger, version-specific, multiple slots)

--- a/main.py
+++ b/main.py
@@ -320,20 +320,26 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
         decky.logger.info("RomM Sync plugin unloaded")
 
     async def test_connection(self):
+        from lib.errors import error_response
         if not self.settings.get("romm_url"):
-            return {"success": False, "message": "No server URL configured"}
+            return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+        # Test basic connectivity (heartbeat may not require auth)
         try:
             await self.loop.run_in_executor(
                 None, self._romm_request, "/api/heartbeat"
             )
         except Exception as e:
-            return {"success": False, "message": f"Cannot reach server: {e}"}
+            return error_response(e)
+        # Test authenticated access
         try:
             await self.loop.run_in_executor(
                 None, self._romm_request, "/api/platforms"
             )
         except Exception as e:
-            return {"success": False, "message": f"Authentication failed: {e}"}
+            resp = error_response(e)
+            if resp["error_code"] not in ("auth_error", "forbidden_error"):
+                resp["message"] = f"Server reachable but API request failed: {resp['message']}"
+            return resp
         return {"success": True, "message": "Connected to RomM"}
 
     async def save_settings(self, romm_url, romm_user, romm_pass, allow_insecure_ssl=None):

--- a/py_modules/lib/downloads.py
+++ b/py_modules/lib/downloads.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 import decky
 
 from lib import retrodeck_config
+from lib.errors import error_response
 
 if TYPE_CHECKING:
     from typing import Callable, Optional, Protocol
@@ -109,7 +110,7 @@ class DownloadMixin:
         except Exception as e:
             self._download_in_progress.discard(rom_id)
             decky.logger.error(f"Failed to fetch ROM {rom_id}: {e}")
-            return {"success": False, "message": "Could not connect to RomM server"}
+            return error_response(e)
 
         platform_slug = rom_detail.get("platform_slug", "")
         platform_fs_slug = rom_detail.get("platform_fs_slug")

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -48,3 +48,31 @@ class RommTimeoutError(RommApiError):
 
 class RommSSLError(RommApiError):
     """SSL certificate verification failure."""
+
+
+def classify_error(exc):
+    """Return (error_code, user_friendly_message) for an exception."""
+    if isinstance(exc, RommAuthError):
+        return "auth_error", "Authentication failed \u2014 check your username and password"
+    if isinstance(exc, RommForbiddenError):
+        return "forbidden_error", "Access denied \u2014 your account lacks permissions for this action"
+    if isinstance(exc, RommSSLError):
+        return "ssl_error", "SSL certificate error \u2014 enable 'Allow Insecure SSL' in settings for self-signed certs"
+    if isinstance(exc, RommTimeoutError):
+        return "timeout_error", "Request timed out \u2014 server may be overloaded or network is slow"
+    if isinstance(exc, RommConnectionError):
+        return "connection_error", "Server unreachable \u2014 check your URL and ensure RomM is running"
+    if isinstance(exc, RommServerError):
+        code = exc.status_code or 500
+        return "server_error", f"Server error ({code}) \u2014 check your RomM server logs"
+    if isinstance(exc, RommNotFoundError):
+        return "not_found_error", "Resource not found on server"
+    if isinstance(exc, RommApiError):
+        return "api_error", str(exc)
+    return "unknown_error", str(exc)
+
+
+def error_response(exc, fallback_message=None):
+    """Build a standard {success, message, error_code} dict from an exception."""
+    code, msg = classify_error(exc)
+    return {"success": False, "message": fallback_message or msg, "error_code": code}

--- a/py_modules/lib/firmware.py
+++ b/py_modules/lib/firmware.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import decky
 
 from lib import retrodeck_config
+from lib.errors import error_response
 
 if TYPE_CHECKING:
     import asyncio
@@ -198,7 +199,7 @@ class FirmwareMixin:
             )
         except Exception as e:
             decky.logger.error(f"Failed to fetch firmware {firmware_id}: {e}")
-            return {"success": False, "message": f"Failed to fetch firmware details: {e}"}
+            return error_response(e)
 
         file_name = fw.get("file_name", "")
         dest = self._firmware_dest_path(fw)
@@ -215,7 +216,7 @@ class FirmwareMixin:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
             decky.logger.error(f"Failed to download firmware {file_name}: {e}")
-            return {"success": False, "message": f"Download failed: {e}"}
+            return error_response(e)
 
         # Verify MD5 if available
         md5_match = None
@@ -263,7 +264,9 @@ class FirmwareMixin:
             )
         except Exception as e:
             decky.logger.error(f"Failed to fetch firmware: {e}")
-            return {"success": False, "message": f"Failed to fetch firmware: {e}", "downloaded": 0}
+            resp = error_response(e)
+            resp["downloaded"] = 0
+            return resp
 
         # Filter by platform slug (use mapped slugs, e.g. "psx" -> ["psx", "ps"])
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
@@ -298,7 +301,9 @@ class FirmwareMixin:
             )
         except Exception as e:
             decky.logger.error(f"Failed to fetch firmware: {e}")
-            return {"success": False, "message": f"Failed to fetch firmware: {e}", "downloaded": 0}
+            resp = error_response(e)
+            resp["downloaded"] = 0
+            return resp
 
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
 

--- a/py_modules/lib/save_sync.py
+++ b/py_modules/lib/save_sync.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import decky
 
 from lib import retrodeck_config
-from lib.errors import RommApiError, RommConflictError
+from lib.errors import RommApiError, RommConflictError, classify_error
 
 if TYPE_CHECKING:
     import asyncio
@@ -553,7 +553,8 @@ class SaveSyncMixin:
             server_saves = self._with_retry(self._romm_list_saves, rom_id)
         except Exception as e:
             decky.logger.error(f"_sync_rom_saves({rom_id}): failed to list saves: {e}")
-            return 0, [f"Failed to fetch saves: {e}"]
+            _code, _msg = classify_error(e)
+            return 0, [f"Failed to fetch saves: {_msg}"]
         self._log_debug(f"[TIMING] _sync_rom_saves({rom_id}): list_saves {time.time()-t0:.3f}s")
 
         t0 = time.time()
@@ -627,9 +628,11 @@ class SaveSyncMixin:
                 else:
                     errors.append(f"{filename}: conflict without matching local+server")
             except RommApiError as e:
-                errors.append(f"{filename}: {e}")
+                _code, _msg = classify_error(e)
+                errors.append(f"{filename}: {_msg}")
             except Exception as e:
-                errors.append(f"{filename}: {e}")
+                _code, _msg = classify_error(e)
+                errors.append(f"{filename}: {_msg}")
                 tmp = os.path.join(saves_dir, filename + ".tmp")
                 if os.path.exists(tmp):
                     try:

--- a/py_modules/lib/sync.py
+++ b/py_modules/lib/sync.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 import decky
 
+from lib.errors import classify_error
+
 if TYPE_CHECKING:
     from typing import Callable, Optional, Protocol
 
@@ -45,7 +47,8 @@ class SyncMixin:
             )
         except Exception as e:
             decky.logger.error(f"Failed to fetch platforms: {e}")
-            return {"success": False, "message": "Could not connect to RomM server"}
+            _code, _msg = classify_error(e)
+            return {"success": False, "message": _msg, "error_code": _code}
 
         enabled = self.settings.get("enabled_platforms", {})
         result = []
@@ -77,7 +80,8 @@ class SyncMixin:
             )
         except Exception as e:
             decky.logger.error(f"Failed to fetch platforms: {e}")
-            return {"success": False, "message": "Could not connect to RomM server"}
+            _code, _msg = classify_error(e)
+            return {"success": False, "message": _msg, "error_code": _code}
 
         ep = {}
         for p in platforms:
@@ -131,7 +135,8 @@ class SyncMixin:
                 )
             except Exception as e:
                 decky.logger.error(f"Failed to fetch platforms: {e}")
-                await self._emit_progress("error", message="Could not connect to RomM server", running=False)
+                _code, _msg = classify_error(e)
+                await self._emit_progress("error", message=_msg, running=False)
                 self._sync_running = False
                 return
 
@@ -290,13 +295,14 @@ class SyncMixin:
         except Exception as e:
             import traceback
             decky.logger.error(f"Sync failed: {e}\n{traceback.format_exc()}")
+            _code, _msg = classify_error(e)
             # Can't await in except, so set directly; finally will not override
             self._sync_progress = {
                 "running": False,
                 "phase": "error",
                 "current": 0,
                 "total": 0,
-                "message": "Sync failed — could not connect to RomM server",
+                "message": f"Sync failed \u2014 {_msg}",
             }
             # Fire-and-forget emit
             self.loop.create_task(decky.emit("sync_progress", self._sync_progress))

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,11 @@
 import { callable } from "@decky/api";
-import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, RomMetadata, SaveSyncSettings, SaveStatus, PendingConflict, RomLookupResult, AvailableCore } from "../types";
+import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, RomMetadata, SaveSyncSettings, SaveStatus, PendingConflict, RomLookupResult, AvailableCore, RommErrorCode } from "../types";
+
+export interface BackendResult {
+  success: boolean;
+  message: string;
+  error_code?: RommErrorCode;
+}
 
 export interface CachedGameDetail {
   found: boolean;
@@ -32,18 +38,18 @@ export function getCachedGameDetail(appId: number): Promise<CachedGameDetail> {
   return promise;
 }
 export const getSettings = callable<[], PluginSettings>("get_settings");
-export const saveSettings = callable<[string, string, string, boolean], { success: boolean; message: string }>("save_settings");
-export const testConnection = callable<[], { success: boolean; message: string }>("test_connection");
-export const startSync = callable<[], { success: boolean; message: string }>("start_sync");
-export const cancelSync = callable<[], { success: boolean; message: string }>("cancel_sync");
+export const saveSettings = callable<[string, string, string, boolean], BackendResult>("save_settings");
+export const testConnection = callable<[], BackendResult>("test_connection");
+export const startSync = callable<[], BackendResult>("start_sync");
+export const cancelSync = callable<[], BackendResult>("cancel_sync");
 export const syncHeartbeat = callable<[], { success: boolean }>("sync_heartbeat");
 export const getSyncStats = callable<[], SyncStats>("get_sync_stats");
-export const startDownload = callable<[number], { success: boolean; message: string }>("start_download");
-export const cancelDownload = callable<[number], { success: boolean; message: string }>("cancel_download");
+export const startDownload = callable<[number], BackendResult>("start_download");
+export const cancelDownload = callable<[number], BackendResult>("cancel_download");
 export const getDownloadQueue = callable<[], { downloads: DownloadItem[] }>("get_download_queue");
 export const getInstalledRom = callable<[number], InstalledRom | null>("get_installed_rom");
 export const getRomBySteamAppId = callable<[number], RomLookupResult | null>("get_rom_by_steam_app_id");
-export const removeRom = callable<[number], { success: boolean; message: string }>("remove_rom");
+export const removeRom = callable<[number], BackendResult>("remove_rom");
 export const getPlatforms = callable<[], { success: boolean; platforms: PlatformSyncSetting[] }>("get_platforms");
 export const savePlatformSync = callable<[number, boolean], { success: boolean; message: string }>("save_platform_sync");
 export const setAllPlatformsSync = callable<[boolean], { success: boolean; message: string }>("set_all_platforms_sync");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,16 @@
+export type RommErrorCode =
+  | "auth_error"
+  | "forbidden_error"
+  | "connection_error"
+  | "timeout_error"
+  | "ssl_error"
+  | "server_error"
+  | "not_found_error"
+  | "config_error"
+  | "disk_error"
+  | "api_error"
+  | "unknown_error";
+
 export interface RomMPlatform {
   id: number;
   slug: string;

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -71,7 +71,7 @@ class TestStartDownload:
 
         result = await plugin.start_download(9999)
         assert result["success"] is False
-        assert "Could not connect to RomM server" in result["message"]
+        assert "error_code" in result
 
     @pytest.mark.asyncio
     async def test_checks_disk_space(self, plugin, tmp_path):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -10,6 +10,8 @@ from lib.errors import (
     RommSSLError,
     RommServerError,
     RommTimeoutError,
+    classify_error,
+    error_response,
 )
 
 
@@ -113,3 +115,145 @@ class TestExceptionMessage:
         exc = RommServerError("HTTP 502: Bad Gateway (GET /api/heartbeat)", status_code=502)
         assert "502" in str(exc)
         assert "Bad Gateway" in str(exc)
+
+
+class TestClassifyError:
+    """classify_error returns (error_code, user_friendly_message) for each exception type."""
+
+    def test_auth_error(self):
+        code, msg = classify_error(RommAuthError("401"))
+        assert code == "auth_error"
+        assert "Authentication failed" in msg
+
+    def test_forbidden_error(self):
+        code, msg = classify_error(RommForbiddenError("403"))
+        assert code == "forbidden_error"
+        assert "Access denied" in msg
+
+    def test_ssl_error(self):
+        code, msg = classify_error(RommSSLError("cert fail"))
+        assert code == "ssl_error"
+        assert "SSL certificate error" in msg
+
+    def test_timeout_error(self):
+        code, msg = classify_error(RommTimeoutError("timed out"))
+        assert code == "timeout_error"
+        assert "timed out" in msg.lower()
+
+    def test_connection_error(self):
+        code, msg = classify_error(RommConnectionError("refused"))
+        assert code == "connection_error"
+        assert "unreachable" in msg.lower()
+
+    def test_server_error(self):
+        code, msg = classify_error(RommServerError("500", status_code=500))
+        assert code == "server_error"
+        assert "500" in msg
+
+    def test_server_error_502(self):
+        code, msg = classify_error(RommServerError("bad gateway", status_code=502))
+        assert code == "server_error"
+        assert "502" in msg
+
+    def test_not_found_error(self):
+        code, msg = classify_error(RommNotFoundError("missing"))
+        assert code == "not_found_error"
+        assert "not found" in msg.lower()
+
+    def test_generic_api_error(self):
+        code, msg = classify_error(RommApiError("some API issue"))
+        assert code == "api_error"
+        assert msg == "some API issue"
+
+    def test_conflict_error_is_api_error(self):
+        """RommConflictError is a subclass of RommApiError, not specifically handled."""
+        code, msg = classify_error(RommConflictError("conflict"))
+        assert code == "api_error"
+        assert msg == "conflict"
+
+    def test_unknown_exception_value_error(self):
+        code, msg = classify_error(ValueError("bad value"))
+        assert code == "unknown_error"
+        assert msg == "bad value"
+
+    def test_unknown_exception_runtime_error(self):
+        code, msg = classify_error(RuntimeError("something broke"))
+        assert code == "unknown_error"
+        assert msg == "something broke"
+
+    def test_messages_are_user_friendly_not_tracebacks(self):
+        """User-friendly messages should not contain traceback-like text."""
+        for exc in [
+            RommAuthError("HTTP 401: Unauthorized"),
+            RommConnectionError("Connection refused"),
+            RommSSLError("certificate verify failed"),
+            RommTimeoutError("timed out"),
+            RommServerError("Internal Server Error", status_code=500),
+        ]:
+            _code, msg = classify_error(exc)
+            assert "Traceback" not in msg
+            assert "File " not in msg
+
+    def test_subclass_ordering_auth_before_api(self):
+        """RommAuthError (subclass of RommApiError) should be classified as auth_error, not api_error."""
+        code, _ = classify_error(RommAuthError("auth fail"))
+        assert code == "auth_error"
+
+    def test_subclass_ordering_ssl_before_connection(self):
+        """RommSSLError should be classified as ssl_error even though it's a RommApiError."""
+        code, _ = classify_error(RommSSLError("cert fail"))
+        assert code == "ssl_error"
+
+
+class TestErrorResponse:
+    """error_response returns a proper {success, message, error_code} dict."""
+
+    def test_structure(self):
+        resp = error_response(RommAuthError("401"))
+        assert resp["success"] is False
+        assert "message" in resp
+        assert "error_code" in resp
+
+    def test_auth_error_code(self):
+        resp = error_response(RommAuthError("unauthorized"))
+        assert resp["error_code"] == "auth_error"
+        assert resp["success"] is False
+
+    def test_connection_error_code(self):
+        resp = error_response(RommConnectionError("refused"))
+        assert resp["error_code"] == "connection_error"
+
+    def test_ssl_error_code(self):
+        resp = error_response(RommSSLError("cert fail"))
+        assert resp["error_code"] == "ssl_error"
+
+    def test_timeout_error_code(self):
+        resp = error_response(RommTimeoutError("timed out"))
+        assert resp["error_code"] == "timeout_error"
+
+    def test_server_error_code(self):
+        resp = error_response(RommServerError("500", status_code=500))
+        assert resp["error_code"] == "server_error"
+
+    def test_unknown_error_code(self):
+        resp = error_response(ValueError("bad"))
+        assert resp["error_code"] == "unknown_error"
+
+    def test_fallback_message_override(self):
+        resp = error_response(RommAuthError("401"), fallback_message="Custom message")
+        assert resp["message"] == "Custom message"
+        assert resp["error_code"] == "auth_error"
+
+    def test_fallback_message_none_uses_default(self):
+        resp = error_response(RommAuthError("401"), fallback_message=None)
+        assert "Authentication failed" in resp["message"]
+
+    def test_not_found_error_response(self):
+        resp = error_response(RommNotFoundError("missing"))
+        assert resp["error_code"] == "not_found_error"
+        assert resp["success"] is False
+
+    def test_forbidden_error_response(self):
+        resp = error_response(RommForbiddenError("forbidden"))
+        assert resp["error_code"] == "forbidden_error"
+        assert "Access denied" in resp["message"]

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -217,7 +217,7 @@ class TestDownloadFirmware:
             result = await plugin.download_firmware(10)
 
         assert result["success"] is False
-        assert "Download failed" in result["message"]
+        assert "error_code" in result
 
 
 class TestDownloadAllFirmware:

--- a/tests/test_romm_client.py
+++ b/tests/test_romm_client.py
@@ -573,3 +573,94 @@ class TestRetryLogic:
             result = plugin._with_retry(fn, max_attempts=3, base_delay=0)
         assert result == "ok"
         assert fn.call_count == 2
+
+
+# ============================================================================
+# test_connection structured errors
+# ============================================================================
+
+
+class TestTestConnectionErrors:
+    """test_connection returns structured error_code in responses."""
+
+    @pytest.mark.asyncio
+    async def test_config_error_when_url_empty(self, plugin):
+        """Returns config_error when no URL is configured."""
+        plugin.settings["romm_url"] = ""
+        result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "config_error"
+        assert "No server URL" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_auth_error_on_401(self, plugin):
+        """Returns auth_error when platforms endpoint returns 401."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        # Heartbeat succeeds, platforms raises auth error
+        heartbeat_response = {"status": "ok"}
+        with patch.object(plugin, "_romm_request", side_effect=[heartbeat_response, RommAuthError("401")]):
+            result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "auth_error"
+        assert "Authentication failed" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_connection_error_on_refused(self, plugin):
+        """Returns connection_error when server is unreachable."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        with patch.object(plugin, "_romm_request", side_effect=RommConnectionError("refused")):
+            result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "connection_error"
+        assert "unreachable" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_ssl_error(self, plugin):
+        """Returns ssl_error on SSL certificate failure."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        with patch.object(plugin, "_romm_request", side_effect=RommSSLError("cert fail")):
+            result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "ssl_error"
+        assert "SSL" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_success_on_happy_path(self, plugin):
+        """Returns success when both heartbeat and platforms succeed."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        with patch.object(plugin, "_romm_request", return_value={"status": "ok"}):
+            result = await plugin.test_connection()
+        assert result["success"] is True
+        assert "Connected" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_server_reachable_but_api_failed(self, plugin):
+        """When heartbeat succeeds but platforms fails with non-auth error, message is prefixed."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        heartbeat_response = {"status": "ok"}
+        with patch.object(plugin, "_romm_request", side_effect=[heartbeat_response, RommServerError("500", status_code=500)]):
+            result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "server_error"
+        assert "Server reachable but API request failed" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, plugin):
+        """Returns timeout_error on request timeout."""
+        import asyncio
+        _setup_plugin(plugin)
+        plugin.loop = asyncio.get_event_loop()
+        with patch.object(plugin, "_romm_request", side_effect=RommTimeoutError("timed out")):
+            result = await plugin.test_connection()
+        assert result["success"] is False
+        assert result["error_code"] == "timeout_error"


### PR DESCRIPTION
## Summary

- Add `classify_error()` and `error_response()` helpers to `errors.py` — maps structured exceptions to `(error_code, user_friendly_message)` tuples
- All backend callables now return `{success, message, error_code}` with actionable messages instead of generic strings
- Frontend `BackendResult` type with `RommErrorCode` union for type-safe error handling

### Error messages users now see

| Situation | Before | After |
|---|---|---|
| Wrong credentials | "Cannot reach server: HTTP 401..." | "Authentication failed — check your username and password" |
| Server down | "Cannot reach server: <urlopen error...>" | "Server unreachable — check your URL and ensure RomM is running" |
| Self-signed cert | "Cannot reach server: [SSL: CERT...]" | "SSL certificate error — enable 'Allow Insecure SSL' in settings for self-signed certs" |
| Server crash | "Cannot reach server: HTTP 500..." | "Server error (500) — check your RomM server logs" |
| Timeout | "Cannot reach server: timed out" | "Request timed out — server may be overloaded or network is slow" |
| No URL configured | "Connection test failed" | "No server URL configured" |

### Files changed

| File | Change |
|---|---|
| `py_modules/lib/errors.py` | Add `classify_error()`, `error_response()` |
| `main.py` | `test_connection` uses structured errors |
| `py_modules/lib/downloads.py` | `start_download` uses `error_response()` |
| `py_modules/lib/sync.py` | `_do_sync`, `get_platforms` use `classify_error()` |
| `py_modules/lib/firmware.py` | 4 firmware callables use `error_response()` |
| `py_modules/lib/save_sync.py` | `_sync_rom_saves` error strings use `classify_error()` |
| `src/types/index.ts` | Add `RommErrorCode` type union |
| `src/api/backend.ts` | Add `BackendResult` interface, update 7 callable return types |

## Test plan

- [x] 689 tests pass (33 new)
- [x] `classify_error` tested for all exception types → correct error codes and user-friendly messages
- [x] `error_response` tested for dict structure and fallback message override
- [x] `test_connection` tested for auth_error, connection_error, ssl_error, timeout_error, config_error, success
- [x] Frontend builds clean