### PR TITLE
fix: download queue pruning and async blocking I/O audit (EXT-3, EXT-5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -70,14 +70,14 @@ Items from a full code review of `main` and `feat/phase-5-save-sync` branches. N
 ### EXT-2: Atomic Writes for Settings ✅
 All state/settings writes use atomic `.tmp` + `os.replace()` pattern.
 
-### EXT-3: Download Queue Memory Growth
-`_download_queue` grows indefinitely. Prune completed/failed entries after N days or max queue size.
+### EXT-3: Download Queue Memory Growth ✅
+`_prune_download_queue()` keeps max 50 terminal items (completed/failed/cancelled), called after each download. `clear_completed_downloads()` callable lets frontend clear on demand.
 
 ### EXT-4: HTTP Client Code Duplication ✅
 Consolidated into `_romm_ssl_context()` + `_romm_auth_header()` helpers in `romm_client.py`. Moved RomM HTTP methods from `save_sync.py` to `romm_client.py`.
 
-### EXT-5: Blocking I/O in Async Callables — PARTIALLY FIXED
-`save_sync.py` wrapped in `run_in_executor` (`_sync_rom_saves`, `_with_retry`, `_sync_playtime_to_romm`, `_resolve_conflict_io`). Same pattern likely exists in other modules — tracked in Future Improvements async/blocking audit.
+### EXT-5: Blocking I/O in Async Callables ✅
+All HIGH/MEDIUM severity blocking I/O wrapped in `run_in_executor`: `save_sync.get_save_status` (conflict detection + hashing), `downloads._do_download` (ZIP extraction, M3U gen, file renames), `downloads._poll_download_requests` (fcntl lock), `downloads.remove_rom`/`uninstall_all_roms`, `sync.report_sync_results`/`report_removal_results` (artwork renames + VDF writes), `sgdb.verify_sgdb_api_key` (resp.read on event loop), `main.migrate_retrodeck_files`/`get_migration_status` (FS traversal), `main.set_system_core`/`set_game_core` (XML I/O), `firmware.download_firmware` (MD5 hash), `firmware.delete_platform_bios`. Remaining LOW items (single small state file writes) are <10ms and deferred.
 
 ### EXT-6: Shell Interpolation in Launcher
 `bin/romm-launcher` interpolates `$ROM_ID` into Python strings. Regex-validated (digits only) so safe, but fragile. Consider environment variables instead.
@@ -113,7 +113,7 @@ Only `save_sync_state.json` has a `"version"` field. `state.json`, `settings.jso
 - **Per-game sync selection**: Select/deselect individual games within a platform
 - **Translations / i18n**: Adapt to user's Steam language (reference: Unifideck `src/i18n/`)
 - **Global launch interceptor**: Safety net via `SteamClient.Apps.RegisterForGameActionStart` for launches from context menus/search/recent games (outside game detail page). Currently save sync and conflict checks only run when launching from the game detail page.
-- **Async/blocking audit**: Systematic review of all `callable()` handlers for blocking I/O that runs directly on the async event loop instead of in `run_in_executor`. Decky's `callable()` dispatches on the main asyncio loop — any synchronous HTTP call, file I/O, or `time.sleep()` blocks all other callables until it returns. `save_sync.py` was partially fixed (wrapped `_sync_rom_saves`, `_with_retry`, `_sync_playtime_to_romm` in `run_in_executor`), but the same pattern likely exists in `romm_client.py`, `downloads.py`, `sync.py`, `firmware.py`, `metadata.py`, and `sgdb.py`. Audit every `async def` callable for blocking calls and wrap them.
+- ~~**Async/blocking audit**~~: ✅ Done (EXT-5). All HIGH/MEDIUM severity items fixed. Remaining: LOW-priority single-file state writes (`_save_state`, `_save_settings_to_disk`, `_save_metadata_cache`) are <10ms each and not worth the churn.
 - **Save sync conflict architecture refactor**: Remove `pending_conflicts` persistence from `save_sync_state.json` in favor of fully live conflict detection. Currently conflicts are detected live (hash + timestamp) but then stored to disk and looked up later during resolution — this creates stale state risks and unnecessary complexity. Proposed changes:
   1. **Drop `pending_conflicts` from state file.** Every entry point (pre-launch, post-exit, manual sync, lightweight check) already does live detection. No need to persist between detections.
   2. **Derive `server_save_id` at resolution time.** Instead of storing it at detection time, `resolve_conflict()` should list saves for the ROM via API and match by filename. Eliminates the main reason for persistence.

--- a/main.py
+++ b/main.py
@@ -180,20 +180,8 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
 
         return items
 
-    async def migrate_retrodeck_files(self, conflict_strategy=None):
-        """Move downloaded ROMs, BIOS, and save files from old RetroDECK path to new.
-
-        Args:
-            conflict_strategy: None to scan and return conflicts, "overwrite" to
-                replace existing destination files, "skip" to keep existing files
-                and just update state paths.
-        """
-        old_home = self._state.get("retrodeck_home_path_previous", "")
-        new_home = self._state.get("retrodeck_home_path", "")
-
-        if not old_home or not new_home or old_home == new_home:
-            return {"success": False, "message": "No path migration needed"}
-
+    def _migrate_retrodeck_files_io(self, old_home, new_home, conflict_strategy):
+        """Sync helper for migrate_retrodeck_files — FS traversal + moves in executor."""
         import shutil
 
         items = self._collect_migration_items(old_home, new_home)
@@ -288,14 +276,26 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
             "errors": errors,
         }
 
-    async def get_migration_status(self):
-        """Return whether a RetroDECK path migration is pending and file counts."""
+    async def migrate_retrodeck_files(self, conflict_strategy=None):
+        """Move downloaded ROMs, BIOS, and save files from old RetroDECK path to new.
+
+        Args:
+            conflict_strategy: None to scan and return conflicts, "overwrite" to
+                replace existing destination files, "skip" to keep existing files
+                and just update state paths.
+        """
         old_home = self._state.get("retrodeck_home_path_previous", "")
         new_home = self._state.get("retrodeck_home_path", "")
 
         if not old_home or not new_home or old_home == new_home:
-            return {"pending": False}
+            return {"success": False, "message": "No path migration needed"}
 
+        return await self.loop.run_in_executor(
+            None, self._migrate_retrodeck_files_io, old_home, new_home, conflict_strategy
+        )
+
+    def _get_migration_status_io(self, old_home, new_home):
+        """Sync helper for get_migration_status — FS traversal in executor."""
         items = self._collect_migration_items(old_home, new_home)
         roms_count = sum(1 for _, _, _, _, kind in items if kind == "rom")
         bios_count = sum(1 for _, _, _, _, kind in items if kind == "bios")
@@ -309,6 +309,18 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
             "bios_count": bios_count,
             "saves_count": saves_count,
         }
+
+    async def get_migration_status(self):
+        """Return whether a RetroDECK path migration is pending and file counts."""
+        old_home = self._state.get("retrodeck_home_path_previous", "")
+        new_home = self._state.get("retrodeck_home_path", "")
+
+        if not old_home or not new_home or old_home == new_home:
+            return {"pending": False}
+
+        return await self.loop.run_in_executor(
+            None, self._get_migration_status_io, old_home, new_home
+        )
 
     async def _unload(self):
         if self._sync_running:
@@ -512,34 +524,49 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
             "active_core_label": active_core_label,
         }
 
+    @staticmethod
+    def _set_system_core_io(retrodeck_home, platform_slug, core_label):
+        """Sync helper for set_system_core — XML read/parse/write in executor."""
+        from lib import es_de_config
+        es_de_config.set_system_override(
+            retrodeck_home, platform_slug, core_label or None
+        )
+        es_de_config._reset_cache()
+
     async def set_system_core(self, platform_slug, core_label):
         """Set system-wide core override. Pass empty string to reset to default."""
-        from lib import es_de_config
         retrodeck_home = retrodeck_config.get_retrodeck_home()
         if not retrodeck_home:
             return {"success": False, "message": "RetroDECK home not found"}
         try:
-            es_de_config.set_system_override(
-                retrodeck_home, platform_slug, core_label or None
+            await self.loop.run_in_executor(
+                None, self._set_system_core_io, retrodeck_home, platform_slug, core_label
             )
-            es_de_config._reset_cache()
             bios = await self.check_platform_bios(platform_slug)
             return {"success": True, "bios_status": bios}
         except Exception as e:
             decky.logger.error(f"Failed to set system core: {e}")
             return {"success": False, "message": str(e)}
 
+    @staticmethod
+    def _set_game_core_io(retrodeck_home, platform_slug, rom_path, core_label):
+        """Sync helper for set_game_core — XML read/parse/write in executor."""
+        from lib import es_de_config
+        es_de_config.set_game_override(
+            retrodeck_home, platform_slug, rom_path, core_label or None
+        )
+        es_de_config._reset_cache()
+
     async def set_game_core(self, platform_slug, rom_path, core_label):
         """Set per-game core override. Pass empty string to reset to platform default."""
-        from lib import es_de_config
         retrodeck_home = retrodeck_config.get_retrodeck_home()
         if not retrodeck_home:
             return {"success": False, "message": "RetroDECK home not found"}
         try:
-            es_de_config.set_game_override(
-                retrodeck_home, platform_slug, rom_path, core_label or None
+            await self.loop.run_in_executor(
+                None, self._set_game_core_io,
+                retrodeck_home, platform_slug, rom_path, core_label
             )
-            es_de_config._reset_cache()
             # Extract rom filename from path for per-game core detection
             rom_filename = rom_path.lstrip("./") if rom_path else None
             bios = await self.check_platform_bios(platform_slug, rom_filename=rom_filename)

--- a/py_modules/lib/downloads.py
+++ b/py_modules/lib/downloads.py
@@ -29,7 +29,39 @@ if TYPE_CHECKING:
         def _save_state(self) -> None: ...
 
 
+_DOWNLOAD_QUEUE_MAX_TERMINAL = 50
+
+
 class DownloadMixin:
+    def _prune_download_queue(self):
+        """Remove oldest completed/failed/cancelled items when over the limit.
+
+        Keeps all active (downloading) items. Retains up to
+        _DOWNLOAD_QUEUE_MAX_TERMINAL terminal items, removing the oldest
+        (by insertion order) when the count exceeds the limit.
+        """
+        terminal_ids = [
+            rid for rid, item in self._download_queue.items()
+            if item.get("status") in ("completed", "failed", "cancelled")
+        ]
+        excess = len(terminal_ids) - _DOWNLOAD_QUEUE_MAX_TERMINAL
+        if excess <= 0:
+            return
+        # Dict preserves insertion order (Python 3.7+), so the first
+        # entries in terminal_ids are the oldest.
+        for rid in terminal_ids[:excess]:
+            del self._download_queue[rid]
+
+    async def clear_completed_downloads(self):
+        """Remove all completed/failed/cancelled items from the download queue."""
+        terminal_ids = [
+            rid for rid, item in self._download_queue.items()
+            if item.get("status") in ("completed", "failed", "cancelled")
+        ]
+        for rid in terminal_ids:
+            del self._download_queue[rid]
+        return {"success": True, "removed": len(terminal_ids)}
+
     def _cleanup_leftover_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM and BIOS directories on startup."""
         cleaned = 0
@@ -66,6 +98,24 @@ class DownloadMixin:
         if cleaned:
             decky.logger.info(f"Cleaned {cleaned} leftover tmp file(s)")
 
+    def _poll_download_requests_io(self, requests_path):
+        """Sync helper for _poll_download_requests — file lock + read + write in executor."""
+        try:
+            with open(requests_path, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    requests = json.load(f)
+                except json.JSONDecodeError:
+                    requests = []
+                if not requests:
+                    return []
+                f.seek(0)
+                f.truncate()
+                json.dump([], f)
+            return requests
+        except FileNotFoundError:
+            return []
+
     async def _poll_download_requests(self):
         """Poll for download requests from the launcher script."""
         requests_path = os.path.join(
@@ -74,19 +124,10 @@ class DownloadMixin:
         while True:
             try:
                 await asyncio.sleep(2)
-                try:
-                    with open(requests_path, "r+") as f:
-                        fcntl.flock(f, fcntl.LOCK_EX)
-                        try:
-                            requests = json.load(f)
-                        except json.JSONDecodeError:
-                            requests = []
-                        if not requests:
-                            continue
-                        f.seek(0)
-                        f.truncate()
-                        json.dump([], f)
-                except FileNotFoundError:
+                requests = await self.loop.run_in_executor(
+                    None, self._poll_download_requests_io, requests_path
+                )
+                if not requests:
                     continue
                 for req in requests:
                     rom_id = req.get("rom_id")
@@ -157,6 +198,77 @@ class DownloadMixin:
         self._download_tasks[rom_id] = task
         return {"success": True, "message": "Download started"}
 
+    def _post_download_multi_io(self, rom_id, rom_detail, target_path, file_name, system):
+        """Sync helper for _do_download multi-file — extraction + renames in executor."""
+        rom_dir_name = os.path.splitext(file_name)[0]
+        extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
+        os.makedirs(extract_dir, exist_ok=True)
+        # Fix 4: Validate extract_dir is within roms_dir
+        roms_base = retrodeck_config.get_roms_path()
+        if not os.path.realpath(extract_dir).startswith(os.path.realpath(roms_base) + os.sep):
+            raise ValueError(f"Extract directory would be outside roms directory: {extract_dir}")
+        tmp_zip = target_path + ".zip.tmp"
+        with zipfile.ZipFile(tmp_zip, "r") as zf:
+            # Fix 3: ZIP slip protection
+            real_extract = os.path.realpath(extract_dir)
+            for member in zf.namelist():
+                member_path = os.path.realpath(os.path.join(extract_dir, member))
+                if not member_path.startswith(real_extract + os.sep) and member_path != real_extract:
+                    raise ValueError(f"ZIP member {member} would extract outside target directory")
+            zf.extractall(extract_dir)
+        os.remove(tmp_zip)
+        # Fix URL-encoded filenames from RomM (e.g. %20 -> space)
+        for root, dirs, files in os.walk(extract_dir, topdown=False):
+            for fname in files:
+                decoded = urllib.parse.unquote(fname)
+                if decoded != fname:
+                    old_path = os.path.join(root, fname)
+                    new_path = os.path.join(root, decoded)
+                    os.replace(old_path, new_path)
+                    decky.logger.info(f"Renamed URL-encoded file: {fname} -> {decoded}")
+            for dname in dirs:
+                decoded = urllib.parse.unquote(dname)
+                if decoded != dname:
+                    old_path = os.path.join(root, dname)
+                    new_path = os.path.join(root, decoded)
+                    os.replace(old_path, new_path)
+                    decky.logger.info(f"Renamed URL-encoded dir: {dname} -> {decoded}")
+        # Auto-generate M3U if missing and multiple disc files exist
+        self._maybe_generate_m3u(extract_dir, rom_detail)
+        # Detect launch file: prefer M3U > CUE > largest file
+        launch_file = self._detect_launch_file(extract_dir)
+
+        # Register as installed
+        installed_entry = {
+            "rom_id": rom_id,
+            "file_name": file_name,
+            "file_path": launch_file,
+            "system": system,
+            "platform_slug": rom_detail.get("platform_slug", ""),
+            "installed_at": datetime.now().isoformat(),
+            "rom_dir": extract_dir,
+        }
+        self._state["installed_roms"][str(rom_id)] = installed_entry
+        self._save_state()
+        return launch_file
+
+    def _post_download_single_io(self, rom_id, rom_detail, target_path, file_name, system):
+        """Sync helper for _do_download single-file — rename + state update in executor."""
+        tmp_path = target_path + ".tmp"
+        os.replace(tmp_path, target_path)
+
+        installed_entry = {
+            "rom_id": rom_id,
+            "file_name": file_name,
+            "file_path": target_path,
+            "system": system,
+            "platform_slug": rom_detail.get("platform_slug", ""),
+            "installed_at": datetime.now().isoformat(),
+        }
+        self._state["installed_roms"][str(rom_id)] = installed_entry
+        self._save_state()
+        return target_path
+
     async def _do_download(self, rom_id, rom_detail, target_path, system):
         file_name = rom_detail.get("fs_name", f"rom_{rom_id}")
         rom_name = rom_detail.get("name", file_name)
@@ -198,65 +310,19 @@ class DownloadMixin:
                 await self.loop.run_in_executor(
                     None, self._romm_download, download_path, tmp_zip, progress_callback
                 )
-                # Extract to a subdirectory named after the ROM
-                rom_dir_name = os.path.splitext(file_name)[0]
-                extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
-                os.makedirs(extract_dir, exist_ok=True)
-                # Fix 4: Validate extract_dir is within roms_dir
-                roms_base = retrodeck_config.get_roms_path()
-                if not os.path.realpath(extract_dir).startswith(os.path.realpath(roms_base) + os.sep):
-                    raise ValueError(f"Extract directory would be outside roms directory: {extract_dir}")
-                with zipfile.ZipFile(tmp_zip, "r") as zf:
-                    # Fix 3: ZIP slip protection
-                    real_extract = os.path.realpath(extract_dir)
-                    for member in zf.namelist():
-                        member_path = os.path.realpath(os.path.join(extract_dir, member))
-                        if not member_path.startswith(real_extract + os.sep) and member_path != real_extract:
-                            raise ValueError(f"ZIP member {member} would extract outside target directory")
-                    zf.extractall(extract_dir)
-                os.remove(tmp_zip)
-                # Fix URL-encoded filenames from RomM (e.g. %20 -> space)
-                for root, dirs, files in os.walk(extract_dir, topdown=False):
-                    for fname in files:
-                        decoded = urllib.parse.unquote(fname)
-                        if decoded != fname:
-                            old_path = os.path.join(root, fname)
-                            new_path = os.path.join(root, decoded)
-                            os.replace(old_path, new_path)
-                            decky.logger.info(f"Renamed URL-encoded file: {fname} -> {decoded}")
-                    for dname in dirs:
-                        decoded = urllib.parse.unquote(dname)
-                        if decoded != dname:
-                            old_path = os.path.join(root, dname)
-                            new_path = os.path.join(root, decoded)
-                            os.replace(old_path, new_path)
-                            decky.logger.info(f"Renamed URL-encoded dir: {dname} -> {decoded}")
-                # Auto-generate M3U if missing and multiple disc files exist
-                self._maybe_generate_m3u(extract_dir, rom_detail)
-                # Detect launch file: prefer M3U > CUE > largest file
-                launch_file = self._detect_launch_file(extract_dir)
-                final_path = launch_file
+                final_path = await self.loop.run_in_executor(
+                    None, self._post_download_multi_io,
+                    rom_id, rom_detail, target_path, file_name, system
+                )
             else:
                 tmp_path = target_path + ".tmp"
                 await self.loop.run_in_executor(
                     None, self._romm_download, download_path, tmp_path, progress_callback
                 )
-                os.replace(tmp_path, target_path)
-                final_path = target_path
-
-            # Register as installed
-            installed_entry = {
-                "rom_id": rom_id,
-                "file_name": file_name,
-                "file_path": final_path,
-                "system": system,
-                "platform_slug": rom_detail.get("platform_slug", ""),
-                "installed_at": datetime.now().isoformat(),
-            }
-            if has_multiple:
-                installed_entry["rom_dir"] = extract_dir
-            self._state["installed_roms"][str(rom_id)] = installed_entry
-            self._save_state()
+                final_path = await self.loop.run_in_executor(
+                    None, self._post_download_single_io,
+                    rom_id, rom_detail, target_path, file_name, system
+                )
 
             self._download_queue[rom_id]["status"] = "completed"
             self._download_queue[rom_id]["progress"] = 1.0
@@ -282,6 +348,7 @@ class DownloadMixin:
         finally:
             self._download_tasks.pop(rom_id, None)
             self._download_in_progress.discard(rom_id)
+            self._prune_download_queue()
 
     def _maybe_generate_m3u(self, extract_dir, rom_detail):
         """Auto-generate an M3U playlist if none exists and multiple disc files are found."""
@@ -399,17 +466,9 @@ class DownloadMixin:
             elif os.path.exists(file_path):
                 os.remove(file_path)
 
-    async def remove_rom(self, rom_id):
-        rom_id_str = str(int(rom_id))
-        installed = self._state["installed_roms"].get(rom_id_str)
-        if not installed:
-            return {"success": False, "message": "ROM not installed"}
-
-        try:
-            self._delete_rom_files(installed)
-        except Exception as e:
-            decky.logger.error(f"Failed to delete ROM files: {e}")
-            return {"success": False, "message": "Failed to delete ROM files"}
+    def _remove_rom_io(self, rom_id_str, installed):
+        """Sync helper for remove_rom — file deletion + state update in executor."""
+        self._delete_rom_files(installed)
 
         del self._state["installed_roms"][rom_id_str]
         # Clean save sync state for removed ROM
@@ -421,11 +480,27 @@ class DownloadMixin:
                 save_changed = True
             if save_changed:
                 self._save_save_sync_state()
-        self._download_queue.pop(int(rom_id), None)
         self._save_state()
+
+    async def remove_rom(self, rom_id):
+        rom_id_str = str(int(rom_id))
+        installed = self._state["installed_roms"].get(rom_id_str)
+        if not installed:
+            return {"success": False, "message": "ROM not installed"}
+
+        try:
+            await self.loop.run_in_executor(
+                None, self._remove_rom_io, rom_id_str, installed
+            )
+        except Exception as e:
+            decky.logger.error(f"Failed to delete ROM files: {e}")
+            return {"success": False, "message": "Failed to delete ROM files"}
+
+        self._download_queue.pop(int(rom_id), None)
         return {"success": True, "message": "ROM removed"}
 
-    async def uninstall_all_roms(self):
+    def _uninstall_all_roms_io(self):
+        """Sync helper for uninstall_all_roms — bulk file deletion + state update in executor."""
         count = 0
         errors = []
         successfully_deleted = []
@@ -450,8 +525,14 @@ class DownloadMixin:
                     save_changed = True
             if save_changed:
                 self._save_save_sync_state()
-        self._download_queue.clear()
         self._save_state()
+        return count, errors
+
+    async def uninstall_all_roms(self):
+        count, errors = await self.loop.run_in_executor(
+            None, self._uninstall_all_roms_io
+        )
+        self._download_queue.clear()
         msg = f"Removed {count} ROMs"
         if errors:
             msg += f" ({len(errors)} errors)"

--- a/py_modules/lib/firmware.py
+++ b/py_modules/lib/firmware.py
@@ -190,33 +190,10 @@ class FirmwareMixin:
         platforms = sorted(platforms_map.values(), key=lambda p: p["platform_slug"])
         return {"success": True, "server_offline": server_offline, "platforms": platforms}
 
-    async def download_firmware(self, firmware_id):
-        """Download a single firmware file from RomM."""
-        firmware_id = int(firmware_id)
-        try:
-            fw = await self.loop.run_in_executor(
-                None, self._romm_request, f"/api/firmware/{firmware_id}"
-            )
-        except Exception as e:
-            decky.logger.error(f"Failed to fetch firmware {firmware_id}: {e}")
-            return error_response(e)
-
+    def _download_firmware_post_io(self, fw, firmware_id, dest, tmp_path):
+        """Sync helper for download_firmware — rename, hash verification, state save in executor."""
         file_name = fw.get("file_name", "")
-        dest = self._firmware_dest_path(fw)
-        tmp_path = dest + ".tmp"
-
-        try:
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            download_path = f"/api/firmware/{firmware_id}/content/{urllib.parse.quote(file_name, safe='')}"
-            await self.loop.run_in_executor(
-                None, self._romm_download, download_path, tmp_path
-            )
-            os.replace(tmp_path, dest)
-        except Exception as e:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            decky.logger.error(f"Failed to download firmware {file_name}: {e}")
-            return error_response(e)
+        os.replace(tmp_path, dest)
 
         # Verify MD5 if available
         md5_match = None
@@ -252,6 +229,39 @@ class FirmwareMixin:
             "downloaded_at": datetime.now(timezone.utc).isoformat(),
         }
         self._save_state()
+
+        return md5_match, registry_hash_valid
+
+    async def download_firmware(self, firmware_id):
+        """Download a single firmware file from RomM."""
+        firmware_id = int(firmware_id)
+        try:
+            fw = await self.loop.run_in_executor(
+                None, self._romm_request, f"/api/firmware/{firmware_id}"
+            )
+        except Exception as e:
+            decky.logger.error(f"Failed to fetch firmware {firmware_id}: {e}")
+            return error_response(e)
+
+        file_name = fw.get("file_name", "")
+        dest = self._firmware_dest_path(fw)
+        tmp_path = dest + ".tmp"
+
+        try:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            download_path = f"/api/firmware/{firmware_id}/content/{urllib.parse.quote(file_name, safe='')}"
+            await self.loop.run_in_executor(
+                None, self._romm_download, download_path, tmp_path
+            )
+        except Exception as e:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            decky.logger.error(f"Failed to download firmware {file_name}: {e}")
+            return error_response(e)
+
+        md5_match, registry_hash_valid = await self.loop.run_in_executor(
+            None, self._download_firmware_post_io, fw, firmware_id, dest, tmp_path
+        )
 
         decky.logger.info(f"Firmware downloaded: {file_name} -> {dest}")
         return {"success": True, "file_path": dest, "md5_match": md5_match, "registry_hash_valid": registry_hash_valid}
@@ -488,15 +498,11 @@ class FirmwareMixin:
             "available_cores": available_cores,
         }
 
-    async def delete_platform_bios(self, platform_slug):
-        """Delete locally downloaded BIOS files for a platform."""
-        bios_status = await self.check_platform_bios(platform_slug)
-        if not bios_status.get("needs_bios") or not bios_status.get("files"):
-            return {"success": True, "deleted_count": 0, "message": "No BIOS files for this platform"}
-
+    def _delete_platform_bios_io(self, files):
+        """Sync helper for delete_platform_bios — file deletions + state save in executor."""
         deleted = 0
         errors = []
-        for f in bios_status["files"]:
+        for f in files:
             if not f.get("downloaded"):
                 continue
             try:
@@ -509,6 +515,18 @@ class FirmwareMixin:
 
         if deleted:
             self._save_state()
+
+        return deleted, errors
+
+    async def delete_platform_bios(self, platform_slug):
+        """Delete locally downloaded BIOS files for a platform."""
+        bios_status = await self.check_platform_bios(platform_slug)
+        if not bios_status.get("needs_bios") or not bios_status.get("files"):
+            return {"success": True, "deleted_count": 0, "message": "No BIOS files for this platform"}
+
+        deleted, errors = await self.loop.run_in_executor(
+            None, self._delete_platform_bios_io, bios_status["files"]
+        )
 
         if errors:
             return {"success": False, "deleted_count": deleted, "message": f"Deleted {deleted} file(s), {len(errors)} error(s)"}

--- a/py_modules/lib/save_sync.py
+++ b/py_modules/lib/save_sync.py
@@ -678,19 +678,13 @@ class SaveSyncMixin:
         decky.logger.info(f"Device ID generated: {device_id} ({hostname})")
         return {"success": True, "device_id": device_id, "device_name": hostname}
 
-    async def get_save_status(self, rom_id):
-        """Get save sync status for a ROM (local files, server saves, conflict state)."""
-        rom_id = int(rom_id)
+    def _get_save_status_io(self, rom_id, server_saves):
+        """Sync helper for get_save_status — runs in executor.
+
+        Performs local file checks, MD5 hashing, and conflict detection.
+        """
         rom_id_str = str(rom_id)
         local_files = self._find_save_files(rom_id)
-
-        server_saves = []
-        try:
-            server_saves = await self.loop.run_in_executor(
-                None, self._with_retry, self._romm_list_saves, rom_id
-            )
-        except Exception as e:
-            self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
 
         server_by_name = {
             ss.get("file_name", ""): ss for ss in server_saves if ss.get("file_name")
@@ -753,6 +747,22 @@ class SaveSyncMixin:
             "device_id": self._save_sync_state.get("device_id", ""),
             "last_sync_check_at": save_entry.get("last_sync_check_at"),
         }
+
+    async def get_save_status(self, rom_id):
+        """Get save sync status for a ROM (local files, server saves, conflict state)."""
+        rom_id = int(rom_id)
+
+        server_saves = []
+        try:
+            server_saves = await self.loop.run_in_executor(
+                None, self._with_retry, self._romm_list_saves, rom_id
+            )
+        except Exception as e:
+            self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
+
+        return await self.loop.run_in_executor(
+            None, self._get_save_status_io, rom_id, server_saves
+        )
 
     async def check_save_status_lightweight(self, rom_id):
         """Lightweight save status: timestamps only, no file hashing or downloads.

--- a/py_modules/lib/sgdb.py
+++ b/py_modules/lib/sgdb.py
@@ -195,6 +195,16 @@ class SgdbMixin:
 
         return {"base64": None, "no_api_key": False}
 
+    def _verify_sgdb_api_key_io(self, api_key):
+        """Sync helper for verify_sgdb_api_key — full HTTP round-trip in executor."""
+        url = "https://www.steamgriddb.com/api/v2/search/autocomplete/test"
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("User-Agent", "decky-romm-sync/0.1")
+        ctx = ssl.create_default_context(cafile=_ca_bundle())
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+
     async def verify_sgdb_api_key(self, api_key=None):
         # Use saved key if no valid key provided (modal pattern doesn't hold the real key)
         if not api_key or api_key == "••••":
@@ -202,15 +212,9 @@ class SgdbMixin:
         if not api_key:
             return {"success": False, "message": "No API key configured"}
         try:
-            url = "https://www.steamgriddb.com/api/v2/search/autocomplete/test"
-            req = urllib.request.Request(url, method="GET")
-            req.add_header("Authorization", f"Bearer {api_key}")
-            req.add_header("User-Agent", "decky-romm-sync/0.1")
-            ctx = ssl.create_default_context(cafile=_ca_bundle())
-            resp = await self.loop.run_in_executor(
-                None, lambda: urllib.request.urlopen(req, context=ctx, timeout=30)
+            data = await self.loop.run_in_executor(
+                None, self._verify_sgdb_api_key_io, api_key
             )
-            data = json.loads(resp.read().decode())
             if data.get("success"):
                 return {"success": True, "message": "API key is valid"}
             return {"success": False, "message": "API key rejected by SteamGridDB"}

--- a/py_modules/lib/sync.py
+++ b/py_modules/lib/sync.py
@@ -348,8 +348,8 @@ class SyncMixin:
         self._sync_running = False
         decky.logger.info(message)
 
-    async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
-        """Called by frontend after applying shortcuts via SteamClient."""
+    def _report_sync_results_io(self, rom_id_to_app_id, removed_rom_ids):
+        """Sync helper for report_sync_results — artwork renames, VDF writes, state save in executor."""
         grid = self._grid_dir()
 
         # Update registry with new mappings from frontend
@@ -408,6 +408,14 @@ class SyncMixin:
         for entry in self._state["shortcut_registry"].values():
             pname = entry.get("platform_name", "Unknown")
             platform_app_ids.setdefault(pname, []).append(entry.get("app_id"))
+
+        return platform_app_ids
+
+    async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
+        """Called by frontend after applying shortcuts via SteamClient."""
+        platform_app_ids = await self.loop.run_in_executor(
+            None, self._report_sync_results_io, rom_id_to_app_id, removed_rom_ids
+        )
 
         total = len(self._state["shortcut_registry"])
         processed = len(rom_id_to_app_id)
@@ -638,8 +646,8 @@ class SyncMixin:
         rom_ids = list(registry.keys())
         return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids}
 
-    async def report_removal_results(self, removed_rom_ids):
-        """Called by frontend after removing shortcuts via SteamClient."""
+    def _report_removal_results_io(self, removed_rom_ids):
+        """Sync helper for report_removal_results — file deletions, VDF writes, state save in executor."""
         # Clean up Steam Input config for removed shortcuts (always reset to default)
         removed_app_ids = []
         for rom_id in removed_rom_ids:
@@ -688,6 +696,12 @@ class SyncMixin:
             "roms": len(registry),
         }
         self._save_state()
+
+    async def report_removal_results(self, removed_rom_ids):
+        """Called by frontend after removing shortcuts via SteamClient."""
+        await self.loop.run_in_executor(
+            None, self._report_removal_results_io, removed_rom_ids
+        )
         return {"success": True, "message": f"Removed {len(removed_rom_ids)} shortcuts"}
 
     async def get_artwork_base64(self, rom_id):

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -24,6 +24,12 @@ def plugin():
     return p
 
 
+@pytest.fixture(autouse=True)
+async def _set_event_loop(plugin):
+    """Ensure plugin.loop matches the running event loop for async tests."""
+    plugin.loop = asyncio.get_event_loop()
+
+
 class TestStartDownload:
     @pytest.mark.asyncio
     async def test_starts_download_task(self, plugin, tmp_path):
@@ -1139,3 +1145,112 @@ class TestRemoveRomCleansSaveSyncState:
         assert plugin._save_sync_state["playtime"] == {}
         # _save_save_sync_state should have been called
         assert len(save_calls) == 1
+
+
+class TestPruneDownloadQueue:
+    def test_keeps_active_downloads(self, plugin):
+        """Active (downloading) items are never pruned."""
+        for i in range(60):
+            plugin._download_queue[i] = {"rom_id": i, "status": "downloading"}
+        plugin._prune_download_queue()
+        assert len(plugin._download_queue) == 60
+
+    def test_removes_oldest_terminal_when_over_limit(self, plugin):
+        """When there are more than 50 terminal items, remove the oldest."""
+        # Insert 60 completed items (rom_id 0..59)
+        for i in range(60):
+            plugin._download_queue[i] = {"rom_id": i, "status": "completed"}
+        plugin._prune_download_queue()
+        # Should keep the 50 most recent (10..59)
+        assert len(plugin._download_queue) == 50
+        for i in range(10):
+            assert i not in plugin._download_queue
+        for i in range(10, 60):
+            assert i in plugin._download_queue
+
+    def test_does_nothing_when_under_limit(self, plugin):
+        """No pruning if terminal count is at or below the limit."""
+        for i in range(30):
+            plugin._download_queue[i] = {"rom_id": i, "status": "completed"}
+        plugin._prune_download_queue()
+        assert len(plugin._download_queue) == 30
+
+    def test_does_nothing_at_exactly_limit(self, plugin):
+        """No pruning when terminal count is exactly 50."""
+        for i in range(50):
+            plugin._download_queue[i] = {"rom_id": i, "status": "failed"}
+        plugin._prune_download_queue()
+        assert len(plugin._download_queue) == 50
+
+    def test_mixed_active_and_terminal(self, plugin):
+        """Active items are kept; only terminal items count toward the limit."""
+        # 5 active + 55 completed = 55 terminal -> prune 5 oldest terminal
+        for i in range(5):
+            plugin._download_queue[1000 + i] = {"rom_id": 1000 + i, "status": "downloading"}
+        for i in range(55):
+            plugin._download_queue[i] = {"rom_id": i, "status": "completed"}
+        plugin._prune_download_queue()
+        # 5 active + 50 terminal = 55 total
+        assert len(plugin._download_queue) == 55
+        # All active still present
+        for i in range(5):
+            assert 1000 + i in plugin._download_queue
+        # Oldest 5 terminal removed (0..4)
+        for i in range(5):
+            assert i not in plugin._download_queue
+        # Remaining terminal still present (5..54)
+        for i in range(5, 55):
+            assert i in plugin._download_queue
+
+    def test_handles_all_terminal_statuses(self, plugin):
+        """Completed, failed, and cancelled items are all treated as terminal."""
+        for i in range(20):
+            plugin._download_queue[i] = {"rom_id": i, "status": "completed"}
+        for i in range(20, 40):
+            plugin._download_queue[i] = {"rom_id": i, "status": "failed"}
+        for i in range(40, 60):
+            plugin._download_queue[i] = {"rom_id": i, "status": "cancelled"}
+        plugin._prune_download_queue()
+        assert len(plugin._download_queue) == 50
+        # Oldest 10 (all completed, 0..9) should be removed
+        for i in range(10):
+            assert i not in plugin._download_queue
+
+
+class TestClearCompletedDownloads:
+    @pytest.mark.asyncio
+    async def test_removes_all_terminal_items(self, plugin):
+        plugin._download_queue[1] = {"rom_id": 1, "status": "completed"}
+        plugin._download_queue[2] = {"rom_id": 2, "status": "failed"}
+        plugin._download_queue[3] = {"rom_id": 3, "status": "cancelled"}
+        result = await plugin.clear_completed_downloads()
+        assert result["success"] is True
+        assert result["removed"] == 3
+        assert len(plugin._download_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_keeps_active_downloads(self, plugin):
+        plugin._download_queue[1] = {"rom_id": 1, "status": "downloading"}
+        plugin._download_queue[2] = {"rom_id": 2, "status": "completed"}
+        plugin._download_queue[3] = {"rom_id": 3, "status": "downloading"}
+        result = await plugin.clear_completed_downloads()
+        assert result["success"] is True
+        assert result["removed"] == 1
+        assert len(plugin._download_queue) == 2
+        assert 1 in plugin._download_queue
+        assert 3 in plugin._download_queue
+
+    @pytest.mark.asyncio
+    async def test_empty_queue(self, plugin):
+        result = await plugin.clear_completed_downloads()
+        assert result["success"] is True
+        assert result["removed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_only_active_items(self, plugin):
+        plugin._download_queue[1] = {"rom_id": 1, "status": "downloading"}
+        plugin._download_queue[2] = {"rom_id": 2, "status": "downloading"}
+        result = await plugin.clear_completed_downloads()
+        assert result["success"] is True
+        assert result["removed"] == 0
+        assert len(plugin._download_queue) == 2

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -24,6 +24,12 @@ def plugin():
     return p
 
 
+@pytest.fixture(autouse=True)
+async def _set_event_loop(plugin):
+    """Ensure plugin.loop matches the running event loop for async tests."""
+    plugin.loop = asyncio.get_event_loop()
+
+
 class TestFirmwareDestPath:
     """Tests for _firmware_dest_path — registry-based BIOS destination mapping."""
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,6 +25,12 @@ def plugin():
     return p
 
 
+@pytest.fixture(autouse=True)
+async def _set_event_loop(plugin):
+    """Ensure plugin.loop matches the running event loop for async tests."""
+    plugin.loop = asyncio.get_event_loop()
+
+
 class TestPathChangeDetection:
     def test_first_run_stores_path(self, plugin, tmp_path):
         """First run (empty stored path) stores current path, no event."""

--- a/tests/test_sgdb.py
+++ b/tests/test_sgdb.py
@@ -21,6 +21,12 @@ def plugin():
     return p
 
 
+@pytest.fixture(autouse=True)
+async def _set_event_loop(plugin):
+    """Ensure plugin.loop matches the running event loop for async tests."""
+    plugin.loop = asyncio.get_event_loop()
+
+
 class TestSgdbSslVerification:
     def test_sgdb_request_verifies_ssl(self, plugin):
         """SGDB requests should always verify SSL certificates."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -23,6 +23,12 @@ def plugin():
     return p
 
 
+@pytest.fixture(autouse=True)
+async def _set_event_loop(plugin):
+    """Ensure plugin.loop matches the running event loop for async tests."""
+    plugin.loop = asyncio.get_event_loop()
+
+
 class TestReportSyncResults:
     @pytest.mark.asyncio
     async def test_updates_registry(self, plugin, tmp_path):


### PR DESCRIPTION
## Summary

- **EXT-3**: `_prune_download_queue()` caps terminal items (completed/failed/cancelled) at 50, called after each download. New `clear_completed_downloads()` callable for frontend on-demand cleanup.
- **EXT-5**: Systematic audit and fix of all HIGH/MEDIUM severity blocking I/O in async callable handlers. All heavy operations now run in `run_in_executor`.

### Blocking I/O fixes

| File | Method | Issue fixed |
|---|---|---|
| `save_sync.py` | `get_save_status` | Conflict detection + MD5 hashing on event loop |
| `downloads.py` | `_do_download` | ZIP extraction, M3U gen, file renames on event loop |
| `downloads.py` | `_poll_download_requests` | `fcntl.flock` blocking lock on event loop |
| `downloads.py` | `remove_rom` / `uninstall_all_roms` | `shutil.rmtree` loops on event loop |
| `sync.py` | `report_sync_results` / `report_removal_results` | Artwork renames + VDF writes on event loop |
| `sgdb.py` | `verify_sgdb_api_key` | `resp.read()` network I/O on event loop |
| `main.py` | `migrate_retrodeck_files` / `get_migration_status` | Heavy FS traversal + moves on event loop |
| `main.py` | `set_system_core` / `set_game_core` | XML read/parse/write on event loop |
| `firmware.py` | `download_firmware` | MD5 hash after download on event loop |
| `firmware.py` | `delete_platform_bios` | File deletions on event loop |

### Pattern used

Extract blocking work into sync helper method (`_foo_io`), call via `await self.loop.run_in_executor(None, self._foo_io, ...)`. No method signatures or return values changed.

## Test plan

- [x] 699 tests pass (10 new for queue pruning)
- [x] Queue pruning: keeps active downloads, prunes oldest terminal items over limit
- [x] `clear_completed_downloads`: removes terminal, keeps active
- [x] All existing tests updated with event loop fixtures where needed
- [x] Frontend builds clean