### PR TITLE
fix: don't show migration warning on fresh install

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,20 +79,13 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
         if stored_home == current_home:
             return
 
-        if stored_home:
-            old_home = stored_home
-        else:
-            # First run — check if files exist at the hardcoded fallback path
-            # that differ from the actual RetroDECK config path
-            fallback_home = os.path.join(decky.DECKY_USER_HOME, "retrodeck")
-            if fallback_home != current_home and os.path.isdir(fallback_home):
-                # Files may have been downloaded to fallback before we read config
-                old_home = fallback_home
-            else:
-                # Genuine first run, no migration needed
-                self._state["retrodeck_home_path"] = current_home
-                self._save_state()
-                return
+        if not stored_home:
+            # First run — just store the current path, no migration needed
+            self._state["retrodeck_home_path"] = current_home
+            self._save_state()
+            return
+
+        old_home = stored_home
 
         # Path changed — store both old and new, emit event
         self._state["retrodeck_home_path_previous"] = old_home


### PR DESCRIPTION
## Summary

- Remove fallback path heuristic from `_detect_retrodeck_path_change()` that incorrectly triggered migration warning on fresh installs
- On first run with no stored path, just store the current RetroDECK home path — no migration needed

## Problem

On a clean install (no state files), the plugin detected `~/retrodeck` existing and treated it as "path changed from ~/retrodeck to the configured path", showing a false migration warning.

## Test plan

- [x] All 724 tests pass
- [x] `test_first_run_stores_path` confirms first run stores path without events
- [x] Manual: fresh install on Steam Deck shows no migration warning