### PR TITLE
feat: compact inline status display in QAM

### DIFF
--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -11,6 +11,7 @@ import {
   ConfirmModal,
   showModal,
 } from "@decky/ui";
+import { FaCheckCircle, FaTimesCircle } from "react-icons/fa";
 import {
   testConnection,
   cancelSync,
@@ -256,29 +257,39 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <Field
             label="Connection"
-            description={
-              connected === null
-                ? "Checking..."
-                : connected
-                  ? "Connected"
-                  : "Not connected"
-            }
-          />
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              {connected === null ? (
+                <>
+                  <Spinner width={14} height={14} />
+                  <span style={{ fontSize: "12px", opacity: 0.7 }}>Checking...</span>
+                </>
+              ) : connected ? (
+                <>
+                  <FaCheckCircle style={{ color: "#59bf40", fontSize: "14px" }} />
+                  <span style={{ fontSize: "12px" }}>Connected</span>
+                </>
+              ) : (
+                <>
+                  <FaTimesCircle style={{ color: "#d4343c", fontSize: "14px" }} />
+                  <span style={{ fontSize: "12px" }}>Not connected</span>
+                </>
+              )}
+            </div>
+          </Field>
         </PanelSectionRow>
         {stats && (
           <>
             <PanelSectionRow>
-              <Field
-                label="Last sync"
-                description={formatLastSync(stats.last_sync)}
-              />
+              <Field label="Last sync">
+                <span style={{ fontSize: "12px" }}>{formatLastSync(stats.last_sync)}</span>
+              </Field>
             </PanelSectionRow>
             {stats.roms > 0 && (
               <PanelSectionRow>
-                <Field
-                  label="Library"
-                  description={`${stats.roms} ROMs from ${stats.platforms} platforms`}
-                />
+                <Field label="Library">
+                  <span style={{ fontSize: "12px" }}>{stats.roms} ROMs · {stats.platforms} platforms</span>
+                </Field>
               </PanelSectionRow>
             )}
           </>


### PR DESCRIPTION
## Summary

- Condense status section from two lines per item to one (label left, value right)
- Add connection status icons: green checkmark (connected), red cross (not connected), spinner (checking)
- Use `·` separator for library stats: `66 ROMs · 2 platforms`

## Test plan

- [x] QAM shows inline status fields on one line each
- [x] Connection icon: spinner on load, green check when connected, red cross when disconnected
- [x] Library and last sync values display correctly on the right