### PR TITLE
feat: Phase 7 RetroAchievements (WIP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Working (Phases 1-6 complete):
 - RetroDECK path migration (internal SSD ↔ SD card)
 - Native Steam metadata display (descriptions, genres, release date, controller support)
 
-See PLAN.md for the full roadmap (Phases 1-6 done, 7-8 planned).
+See PLAN.md for the full roadmap (Phases 1-6 done, 7=RetroAchievements+Tabs, 8=Save Sync v2, 9-10 deferred).
 
 ## Development
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,9 +5,166 @@ Reference material (API tables, architecture, environment) lives in CLAUDE.md.
 
 ---
 
+## Phase 7: RetroAchievements + Game Detail Tabs
+
+**Goal**: Display RetroAchievements data from RomM and restructure the game detail page into a tabbed layout matching Steam's native pattern.
+
+### 7A — Backend: RA Data Extraction & Caching
+
+**Extract `ra_id` during sync:**
+- Add `ra_id` to ROM data extraction in `sync.py` (alongside `igdb_id`, `sgdb_id`)
+- Store `ra_id` in shortcut registry per ROM
+- On every sync, re-fetch `ra_id` from RomM — if RA gets configured in RomM between syncs, new IDs appear automatically
+
+**New backend module: `py_modules/lib/achievements.py`:**
+- `get_achievements(rom_id)` callable — fetch `ra_metadata` from RomM ROM detail, return achievement list (title, description, points, badge URLs, type, display_order)
+- `get_user_achievement_progress(rom_id)` callable — fetch user's earned achievements for the game's `ra_id` from RomM. Returns earned/total counts + per-achievement earned status with dates
+- `sync_achievements_after_session(rom_id)` callable — post-session refresh: fetch latest user progress for a single game from RomM (which in turn queries RA API)
+- Cache achievement data in `_metadata_cache` or new `_achievements_cache` with TTL (achievement lists rarely change, user progress refreshed post-session)
+- `get_cached_game_detail()` extended to include `ra_id` and achievement summary (earned/total) for badge rendering without a separate fetch
+
+**RomM API integration:**
+- ROM detail (`GET /api/roms/{id}`) returns `ra_id`, `ra_metadata` (achievement list with badge URLs), `merged_ra_metadata`
+- User progression: research which RomM endpoint exposes per-game user progress (likely via user schema's `ra_progression` field or dedicated endpoint)
+- Badge image URLs from RomM: `https://media.retroachievements.org/Badge/{badge_id}.png` (locked: `{badge_id}_lock.png`)
+
+### 7B — QAM Settings: RA Configuration
+
+**New "RetroAchievements" section in ConnectionSettings:**
+- RA username text field (stored in `settings.json` as `ra_username`)
+- Note/disclaimer: "This only displays achievement progress. To earn achievements during gameplay, configure RetroAchievements in RetroDECK or RetroArch."
+- Similar disclaimer added to SGDB API key section: "Requires IGDB metadata to be configured in RomM for artwork matching."
+- Badge + tab hidden when `ra_username` is empty
+- No API key needed on our side — RomM handles RA API calls with its own key
+
+### 7C — Game Detail Page: Tab Restructure
+
+**Replace flat layout with tabbed layout:**
+
+Current:
+```
+[PlaySection: Play button + info items row]
+[GameInfoPanel: description, genres, developer, release date]
+```
+
+New:
+```
+[PlaySection: Play button + compact info row (last played, playtime, achievements badge)]
+[Tab Bar: GAME INFO | ACHIEVEMENTS | SAVES | BIOS]
+[Tab Content]
+```
+
+**Tab definitions:**
+- **GAME INFO** (default): Current `RomMGameInfoPanel` content — description, genres, developer/publisher, release date, game modes, rating
+- **ACHIEVEMENTS**: Full achievement list with icons (badge images), names, descriptions, points. Earned achievements shown with unlocked badge + earned date. Unearned shown with locked badge (greyed). Progress bar at top. Sorted by `display_order`. Achievement `type` shown as label (progression, win_condition, missable)
+- **SAVES**: Current save sync info item content expanded — save file status, last sync time, sync button, conflict indicator. Moved from PlaySection info row
+- **BIOS**: Current BIOS info item content expanded — per-file status with dot colors, download buttons, core annotations. Moved from PlaySection info row
+
+**Tab visibility rules:**
+- GAME INFO: always shown
+- ACHIEVEMENTS: shown only when `ra_id` exists for the ROM AND `ra_username` is configured in settings
+- SAVES: shown only when save sync is enabled
+- BIOS: shown only when the platform needs BIOS files
+
+**Implementation:**
+- New component: `src/components/GameDetailTabs.tsx` — tab bar + content switching
+- Extract save/BIOS content from `RomMPlaySection` into standalone tab components
+- `RomMPlaySection` keeps: Play button + compact info row (last played, playtime, achievements badge)
+- Tab state persisted per-page-visit (not across navigations)
+
+### 7D — Achievements Badge (PlaySection Info Item)
+
+**Compact badge in info row:**
+- Shows `"3 / 24"` (earned / total) or `"100%"` when mastered
+- Gold sparkle animation: tiny golden dots (CSS particles) appearing and disappearing around the badge
+- Hidden when: no `ra_username` in settings OR no `ra_id` on the ROM
+- Clickable: switches to ACHIEVEMENTS tab when tapped
+- Data source: achievement summary from `get_cached_game_detail()` (no extra fetch needed for badge)
+
+**Post-session refresh:**
+- When game session ends, call `sync_achievements_after_session(rom_id)` alongside save sync and playtime upload
+- Update badge with new earned/total counts
+- If achievements were earned during session, badge updates immediately
+
+### 7E — Achievements Tab (Full View)
+
+**Achievement list layout:**
+- Progress bar at top: `15 / 23 achievements (65%)` with filled bar
+- Hardcore indicator if user has hardcore unlocks
+- List items:
+  - Badge icon (40x40, from `badge_url` or `badge_url_lock`)
+  - Title + description
+  - Points value
+  - Type label (progression / win_condition / missable) as colored chip
+  - Earned date (if earned) or locked state
+- Earned achievements sorted first, then unearned
+- Within each group, sorted by `display_order`
+
+**Caching strategy:**
+- Achievement list (game metadata): cached with 24h TTL (achievement definitions rarely change)
+- User progress: cached with 1h TTL, force-refreshed post-session
+- Badge images: loaded from RA CDN URLs directly (browser/Steam handles caching)
+
+### Implementation Order
+
+1. Backend: `ra_id` extraction during sync + registry storage
+2. Backend: `achievements.py` module with callables
+3. Frontend: `GameDetailTabs.tsx` component + tab bar
+4. Frontend: Move save/BIOS content into tab components
+5. Frontend: Achievements tab component
+6. Frontend: Achievement badge with gold sparkle animation
+7. Frontend: Post-session achievement refresh in `sessionManager.ts`
+8. QAM: RA username settings + disclaimers
+9. Tests: Backend achievement callables + sync integration
+
 ---
 
-## Phase 7: Multi-Emulator Support (Deferred)
+## Phase 8: Save Sync v2 — RomM 4.7.0 Migration
+
+**Goal**: Migrate save sync to RomM 4.7.0's device-based sync architecture. Simplify conflict detection, remove workarounds for 4.6.1 bugs.
+
+### Key RomM 4.7.0 Changes
+
+**Device registration:**
+- `POST /api/devices` — register with hostname/MAC fingerprint, returns `device_id`
+- Pass `device_id` on all save operations for proper sync tracking
+- Replace our hostname-based `register_device()` with RomM's native device API
+
+**Save endpoint improvements:**
+- `GET /api/saves/{id}/content` **now works** — remove `download_path` workaround
+- `content_hash` in SaveSchema — remove download-and-hash workaround
+- `POST /api/saves` returns **409 Conflict** on stale sync — server-side conflict detection
+- `device_syncs[]` array per save — per-device sync status tracking
+- New endpoints: `POST /api/saves/{id}/track`, `POST /api/saves/{id}/untrack`
+- Slot support: `slot` parameter on save endpoints
+- Bulk delete: `POST /api/saves/delete` with ID list
+
+**Backwards compatibility strategy:**
+Not all users upgrade RomM at the same time. Hard-requiring 4.7.0 would break existing users.
+
+- **Version detection**: On connection test / first sync, probe RomM API version (check for 4.7.0 device endpoints — `GET /api/devices` returns 200 vs 404/405). Cache detected version.
+- **Dual-path approach**: Keep existing 4.6.x save sync code as fallback. When RomM ≥ 4.7.0 detected, use new device-based endpoints. When < 4.7.0, use current workarounds.
+- **Graceful degradation**: Features that require 4.7.0 (device registration, server-side conflict detection, `content_hash`) simply don't activate on older servers. Core save sync still works.
+- **Settings indicator**: Show RomM version in connection settings. If < 4.7.0, show info note: "Upgrade RomM to 4.7.0+ for improved save sync."
+- **Migration timeline**: After ~2-3 releases with dual support, consider dropping 4.6.x support with a deprecation notice in release notes.
+
+**Migration plan (4.7.0 path):**
+1. Add RomM version detection to connection test
+2. Register device via `POST /api/devices` (replace custom device registration)
+3. Use `content_hash` from save responses (remove `_get_server_save_hash()` download-and-hash)
+4. Use `GET /api/saves/{id}/content` directly (remove `download_path` URL construction)
+5. Handle 409 responses from `POST /api/saves` as conflict signal (complement client-side detection)
+6. Track device sync status via `device_syncs[]` (know which devices are in sync)
+7. Consider removing `pending_conflicts` persistence (see save sync conflict architecture refactor in Future Improvements)
+
+**Other 4.7.0 features to leverage:**
+- `last_played` auto-updated on save upload — could complement our playtime tracking
+- `RomUserSchema` fields: `backlogged`, `now_playing`, `hidden`, `rating`, `completion`, `status` — future UI features
+- New ROM identifier fields: `moby_id`, `ss_id`, `hltb_id`, `launchbox_id` — future metadata enrichment
+
+---
+
+## Phase 9: Multi-Emulator Support (Deferred)
 
 **Goal**: Support EmuDeck, standalone RetroArch, and manual emulator installs beyond RetroDECK. Extends save sync to standalone emulators.
 
@@ -42,7 +199,7 @@ Extends Phase 5 to standalone emulator save formats:
 
 ---
 
-## Phase 8: Polish & Advanced Features (Deferred)
+## Phase 10: Polish & Advanced Features (Deferred)
 
 - **Multi-version/language ROM selector**: Dropdown when multiple versions exist
 - **Auto sync interval**: Configurable background re-sync
@@ -102,13 +259,13 @@ Only `save_sync_state.json` has a `"version"` field. `state.json`, `settings.jso
 ## Future Improvements (nice-to-have)
 
 - **Concurrent download queue**: Multiple queued downloads
-- **RomM native device sync**: Migrate to RomM v4.7+ server-side conflict detection when available
+- ~~**RomM native device sync**~~: → Promoted to Phase 8
 - **Download queue priority/reordering**
 - **Developer vs Publisher distinction**: RomM's `companies` is flat — research IGDB's `involved_companies` relationship for proper split
-- **RetroAchievements integration**: Show/track via RomM's RA data, direct API, or existing Decky plugin
 - **Sync completion notification accuracy**: Track new vs updated vs unchanged shortcuts, show accurate breakdown (cancel notifications already show correct count)
 - **Library home playtime display**: Non-Steam shortcuts show "Never Played" despite tracked playtime. Steam doesn't persist `minutes_playtime_forever` for shortcuts. No known solution — all similar plugins have same limitation. Our game detail page shows accurate playtime.
 - **Playtime sync between RomM and Steam**: Bidirectional cross-device playtime merging
+- **Boot-time server playtime fetch**: `get_all_playtime()` at plugin load reads local state only. If a second device uploaded playtime since last boot, Steam shows stale local totals until next session end triggers a sync. Fix: fetch server playtime on boot and merge with local before applying to Steam UI.
 - **UI settings page**: Machine-scoped collections toggle, device labels toggle, custom device name
 - **Per-game sync selection**: Select/deselect individual games within a platform
 - **Translations / i18n**: Adapt to user's Steam language (reference: Unifideck `src/i18n/`)

--- a/main.py
+++ b/main.py
@@ -14,13 +14,14 @@ from lib.steam_config import SteamConfigMixin
 from lib.firmware import FirmwareMixin
 from lib.metadata import MetadataMixin
 from lib.sgdb import SgdbMixin
+from lib.achievements import AchievementsMixin
 from lib.downloads import DownloadMixin
 from lib.sync import SyncMixin
 from lib.save_sync import SaveSyncMixin
 from lib import retrodeck_config
 
 
-class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareMixin, MetadataMixin, DownloadMixin, SyncMixin, SaveSyncMixin):
+class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareMixin, MetadataMixin, AchievementsMixin, DownloadMixin, SyncMixin, SaveSyncMixin):
     settings: dict
     loop: asyncio.AbstractEventLoop
 
@@ -51,6 +52,7 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
         self._download_queue = {}   # rom_id -> DownloadItem dict
         self._download_in_progress = set()  # rom_ids currently being processed
         self._metadata_cache = {}
+        self._achievements_cache = {}
         self._load_state()
         self._load_bios_registry()
         self._load_metadata_cache()
@@ -492,6 +494,22 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
             except Exception as e:
                 decky.logger.warning(f"BIOS status check failed for {platform_slug}: {e}")
 
+        # Achievement summary (for badge rendering)
+        ra_id = entry.get("ra_id")
+        achievement_summary = None
+        if ra_id and self._get_ra_username():
+            # Try cache first for quick badge rendering
+            cached_progress = self._get_progress_cache_entry(rom_id_str)
+            if cached_progress:
+                achievement_summary = {
+                    "earned": cached_progress.get("earned", 0),
+                    "total": cached_progress.get("total", 0),
+                    "earned_hardcore": cached_progress.get("earned_hardcore", 0),
+                }
+            else:
+                # Return None — frontend will fetch on demand
+                achievement_summary = None
+
         return {
             "found": True,
             "rom_id": rom_id,
@@ -505,6 +523,8 @@ class Plugin(StateMixin, RommClientMixin, SgdbMixin, SteamConfigMixin, FirmwareM
             "metadata": metadata,
             "bios_status": bios_status,
             "rom_file": rom_file,
+            "ra_id": ra_id,
+            "achievement_summary": achievement_summary,
         }
 
     async def get_available_cores(self, platform_slug):

--- a/py_modules/lib/achievements.py
+++ b/py_modules/lib/achievements.py
@@ -1,0 +1,256 @@
+import time
+from typing import TYPE_CHECKING, Any
+
+import decky
+
+if TYPE_CHECKING:
+    import asyncio
+    from typing import Protocol
+
+    class _AchievementsDeps(Protocol):
+        _state: dict
+        _metadata_cache: dict
+        _achievements_cache: dict
+        loop: asyncio.AbstractEventLoop
+        def _log_debug(self, msg: str) -> None: ...
+        def _romm_request(self, path: str) -> Any: ...
+
+
+class AchievementsMixin:
+    """RetroAchievements data fetching via RomM server."""
+
+    ACHIEVEMENTS_CACHE_TTL = 24 * 3600  # 24h for achievement definitions
+    PROGRESS_CACHE_TTL = 3600           # 1h for user progress
+    RA_USERNAME_CACHE_TTL = 3600        # 1h for RA username detection
+
+    def _get_ra_username(self):
+        """Get RA username from RomM user profile (cached).
+
+        Returns the cached ra_username if fresh, empty string otherwise.
+        The cache is populated by _fetch_ra_username() which calls /api/users/me.
+        """
+        cached = self._achievements_cache.get("_ra_user")
+        if cached:
+            age = time.time() - cached.get("cached_at", 0)
+            if age < self.RA_USERNAME_CACHE_TTL:
+                return cached.get("username", "")
+        return ""
+
+    async def _fetch_ra_username(self):
+        """Fetch RA username from RomM user profile and cache it."""
+        try:
+            user_data = await self.loop.run_in_executor(
+                None, self._romm_request, "/api/users/me"
+            )
+            ra_username = (user_data.get("ra_username") or "").strip()
+            self._achievements_cache["_ra_user"] = {
+                "username": ra_username,
+                "cached_at": time.time(),
+            }
+            return ra_username
+        except Exception as e:
+            decky.logger.warning(f"Failed to fetch RA username from RomM: {e}")
+            # Return stale cache if available
+            cached = self._achievements_cache.get("_ra_user")
+            if cached:
+                return cached.get("username", "")
+            return ""
+
+    def _get_achievements_cache_entry(self, rom_id_str):
+        """Get cached achievement data for a ROM if not expired."""
+        entry = self._achievements_cache.get(rom_id_str)
+        if not entry:
+            return None
+        age = time.time() - entry.get("cached_at", 0)
+        if age > self.ACHIEVEMENTS_CACHE_TTL:
+            return None
+        return entry
+
+    def _get_progress_cache_entry(self, rom_id_str):
+        """Get cached user progress for a ROM if not expired."""
+        entry = self._achievements_cache.get(rom_id_str, {}).get("user_progress")
+        if not entry:
+            return None
+        age = time.time() - entry.get("cached_at", 0)
+        if age > self.PROGRESS_CACHE_TTL:
+            return None
+        return entry
+
+    def _extract_achievements_from_rom(self, rom_data):
+        """Extract achievement list from RomM ROM detail ra_metadata."""
+        ra_metadata = rom_data.get("ra_metadata") or {}
+        # Also check merged_ra_metadata which has resolved badge paths
+        if not ra_metadata:
+            ra_metadata = rom_data.get("merged_ra_metadata") or {}
+        achievements = ra_metadata.get("achievements") or []
+        return [
+            {
+                "ra_id": a.get("ra_id"),
+                "title": a.get("title", ""),
+                "description": a.get("description", ""),
+                "points": a.get("points", 0),
+                "badge_id": a.get("badge_id", ""),
+                "badge_url": a.get("badge_url", ""),
+                "badge_url_lock": a.get("badge_url_lock", ""),
+                "display_order": a.get("display_order", 0),
+                "type": a.get("type", ""),
+                "num_awarded": a.get("num_awarded", 0),
+                "num_awarded_hardcore": a.get("num_awarded_hardcore", 0),
+            }
+            for a in achievements
+        ]
+
+    async def get_achievements(self, rom_id):
+        """Fetch achievement list for a ROM from RomM. Returns cached if fresh."""
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+
+        # Check cache
+        cached = self._get_achievements_cache_entry(rom_id_str)
+        if cached and cached.get("achievements"):
+            self._log_debug(f"Achievements cache hit for rom_id={rom_id}")
+            return {"success": True, "achievements": cached["achievements"], "total": len(cached["achievements"])}
+
+        # Look up ra_id from registry
+        reg = self._state["shortcut_registry"].get(rom_id_str, {})
+        ra_id = reg.get("ra_id")
+        if not ra_id:
+            return {"success": True, "achievements": [], "total": 0, "no_ra_id": True}
+
+        # Fetch ROM detail from RomM (includes ra_metadata)
+        try:
+            rom_data = await self.loop.run_in_executor(
+                None, self._romm_request, f"/api/roms/{rom_id}"
+            )
+            achievements = self._extract_achievements_from_rom(rom_data)
+
+            # Cache it
+            if rom_id_str not in self._achievements_cache:
+                self._achievements_cache[rom_id_str] = {}
+            self._achievements_cache[rom_id_str]["achievements"] = achievements
+            self._achievements_cache[rom_id_str]["cached_at"] = time.time()
+            self._achievements_cache[rom_id_str]["ra_id"] = ra_id
+
+            return {"success": True, "achievements": achievements, "total": len(achievements)}
+        except Exception as e:
+            decky.logger.warning(f"Failed to fetch achievements for rom_id={rom_id}: {e}")
+            # Return stale cache if available
+            stale = self._achievements_cache.get(rom_id_str, {})
+            if stale.get("achievements"):
+                return {"success": True, "achievements": stale["achievements"], "total": len(stale["achievements"]), "stale": True}
+            return {"success": False, "achievements": [], "total": 0, "message": str(e)}
+
+    async def get_achievement_progress(self, rom_id):
+        """Fetch user's achievement progress for a ROM from RomM.
+
+        Returns earned/total counts and per-achievement earned status.
+        Requires RA username configured in the RomM user profile.
+        """
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+
+        # Check cached RA username first, fetch from RomM if stale
+        ra_username = self._get_ra_username()
+        if not ra_username:
+            ra_username = await self._fetch_ra_username()
+        if not ra_username:
+            return {"success": False, "message": "No RA username configured in RomM", "earned": 0, "total": 0}
+
+        # Check progress cache
+        cached_progress = self._get_progress_cache_entry(rom_id_str)
+        if cached_progress:
+            self._log_debug(f"Achievement progress cache hit for rom_id={rom_id}")
+            return {"success": True, **cached_progress}
+
+        # Look up ra_id from registry
+        reg = self._state["shortcut_registry"].get(rom_id_str, {})
+        ra_id = reg.get("ra_id")
+        if not ra_id:
+            return {"success": True, "earned": 0, "total": 0, "earned_achievements": [], "no_ra_id": True}
+
+        # Ensure we have the achievement list
+        cheevos_result = await self.get_achievements(rom_id)
+        total = cheevos_result.get("total", 0)
+
+        # Fetch user progression from RomM
+        # RomM exposes user RA progression — try the user-specific endpoint
+        try:
+            # Fetch user profile from RomM — includes ra_progression and ra_username
+            # RomM 4.2+ has ra_progression on user schema
+            user_data = await self.loop.run_in_executor(
+                None, self._romm_request, "/api/users/me"
+            )
+            # Cache ra_username from this response to avoid separate fetch next time
+            fetched_username = (user_data.get("ra_username") or "").strip()
+            if fetched_username:
+                self._achievements_cache["_ra_user"] = {
+                    "username": fetched_username,
+                    "cached_at": time.time(),
+                }
+            ra_progression = user_data.get("ra_progression") or {}
+            results = ra_progression.get("results") or []
+
+            # Find progression for this game's ra_id
+            game_progress = None
+            for entry in results:
+                if entry.get("rom_ra_id") == ra_id:
+                    game_progress = entry
+                    break
+
+            if game_progress:
+                earned = game_progress.get("num_awarded", 0) or 0
+                earned_hardcore = game_progress.get("num_awarded_hardcore", 0) or 0
+                earned_achievements = game_progress.get("earned_achievements", [])
+
+                progress_data = {
+                    "earned": earned,
+                    "earned_hardcore": earned_hardcore,
+                    "total": game_progress.get("max_possible", total) or total,
+                    "earned_achievements": earned_achievements,
+                    "cached_at": time.time(),
+                }
+            else:
+                progress_data = {
+                    "earned": 0,
+                    "earned_hardcore": 0,
+                    "total": total,
+                    "earned_achievements": [],
+                    "cached_at": time.time(),
+                }
+
+            # Cache progress
+            if rom_id_str not in self._achievements_cache:
+                self._achievements_cache[rom_id_str] = {}
+            self._achievements_cache[rom_id_str]["user_progress"] = progress_data
+
+            return {"success": True, **{k: v for k, v in progress_data.items() if k != "cached_at"}}
+
+        except Exception as e:
+            decky.logger.warning(f"Failed to fetch achievement progress for rom_id={rom_id}: {e}")
+            # Return stale cache if available
+            stale_progress = self._achievements_cache.get(rom_id_str, {}).get("user_progress")
+            if stale_progress:
+                return {"success": True, **{k: v for k, v in stale_progress.items() if k != "cached_at"}, "stale": True}
+            return {"success": False, "earned": 0, "total": 0, "earned_achievements": [], "message": str(e)}
+
+    async def sync_achievements_after_session(self, rom_id):
+        """Post-session: force-refresh achievement progress from RomM.
+
+        Called after game session ends to pick up any achievements earned during gameplay.
+        Invalidates the progress cache and fetches fresh data.
+        """
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+
+        # Invalidate progress cache to force fresh fetch
+        if rom_id_str in self._achievements_cache and "user_progress" in self._achievements_cache[rom_id_str]:
+            del self._achievements_cache[rom_id_str]["user_progress"]
+
+        # Fetch fresh progress
+        result = await self.get_achievement_progress(rom_id)
+        if result.get("success"):
+            decky.logger.info(
+                f"Post-session achievement sync for rom_id={rom_id}: "
+                f"{result.get('earned', 0)}/{result.get('total', 0)} earned"
+            )
+        return result

--- a/py_modules/lib/state.py
+++ b/py_modules/lib/state.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         settings: dict
         _state: dict
         _metadata_cache: dict
+        _achievements_cache: dict
 
 
 class StateMixin:

--- a/py_modules/lib/sync.py
+++ b/py_modules/lib/sync.py
@@ -410,6 +410,7 @@ class SyncMixin:
                                     "platform_display_name": platform_name,
                                     "igdb_id": entry.get("igdb_id"),
                                     "sgdb_id": entry.get("sgdb_id"),
+                                    "ra_id": entry.get("ra_id"),
                                 })
                         await self._emit_progress("roms", current=len(all_roms),
                             message=f"{platform_name} unchanged ({pi}/{total_platforms})")
@@ -486,6 +487,7 @@ class SyncMixin:
                 "platform_slug": rom.get("platform_slug", ""),
                 "igdb_id": rom.get("igdb_id"),
                 "sgdb_id": rom.get("sgdb_id"),
+                "ra_id": rom.get("ra_id"),
                 "cover_path": "",
             })
 
@@ -659,7 +661,7 @@ class SyncMixin:
                 "platform_slug": pending.get("platform_slug", ""),
                 "cover_path": cover_path,
             }
-            for meta_key in ("igdb_id", "sgdb_id"):
+            for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
                 if pending.get(meta_key):
                     registry_entry[meta_key] = pending[meta_key]
             self._state["shortcut_registry"][rom_id_str] = registry_entry

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,5 @@
 import { callable } from "@decky/api";
-import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, RomMetadata, SaveSyncSettings, SaveStatus, PendingConflict, RomLookupResult, AvailableCore, RommErrorCode, SyncPreview } from "../types";
+import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, RomMetadata, SaveSyncSettings, SaveStatus, PendingConflict, RomLookupResult, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress } from "../types";
 
 export interface BackendResult {
   success: boolean;
@@ -20,6 +20,8 @@ export interface CachedGameDetail {
   metadata?: Record<string, unknown> | null;
   bios_status?: { needs_bios?: boolean; platform_slug: string; total: number; downloaded: number; all_downloaded: boolean; required_count?: number; required_downloaded?: number; active_core?: string; active_core_label?: string; available_cores?: AvailableCore[]; files?: Array<{ file_name: string; downloaded: boolean; local_path: string; required: boolean; description: string; classification: string; cores?: Record<string, { required: boolean }>; used_by_active?: boolean }> } | null;
   rom_file?: string;
+  ra_id?: number | null;
+  achievement_summary?: AchievementSummary | null;
 }
 
 const _cachedGameDetailRaw = callable<[number], CachedGameDetail>("get_cached_game_detail");
@@ -138,3 +140,8 @@ export const migrateRetroDeckFiles = callable<[string | null], MigrationResult>(
 export const deleteLocalSaves = callable<[number], { success: boolean; deleted_count: number; message: string }>("delete_local_saves");
 export const deletePlatformSaves = callable<[string], { success: boolean; deleted_count: number; message: string }>("delete_platform_saves");
 export const deletePlatformBios = callable<[string], { success: boolean; deleted_count: number; message: string }>("delete_platform_bios");
+
+// Achievements callables
+export const getAchievements = callable<[number], AchievementList>("get_achievements");
+export const getAchievementProgress = callable<[number], AchievementProgress>("get_achievement_progress");
+export const syncAchievementsAfterSession = callable<[number], AchievementProgress>("sync_achievements_after_session");

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useRef, FC, createElement } from "react";
-import { DialogButton } from "@decky/ui";
+import { DialogButton, Focusable, GamepadButton, ScrollPanelGroup } from "@decky/ui";
 // DialogButton is natively focusable by Steam's gamepad engine (unlike Focusable
 // wrappers around non-interactive content, which don't register in this injection
 // context). Style as content sections, not buttons.
@@ -27,9 +27,11 @@ import {
   getSaveStatus,
   getPendingConflicts,
   getArtworkBase64,
+  getAchievements,
+  getAchievementProgress,
   debugLog,
 } from "../api/backend";
-import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, PendingConflict } from "../types";
+import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, PendingConflict, Achievement, AchievementProgress, EarnedAchievement } from "../types";
 import { getMigrationState, onMigrationChange } from "../utils/migrationStore";
 
 interface RomMGameInfoPanelProps {
@@ -51,6 +53,11 @@ interface PanelState {
   saveStatus: SaveStatus | null;
   conflicts: PendingConflict[];
   error: boolean;
+  activeTab: string;
+  achievements: Achievement[];
+  achievementProgress: AchievementProgress | null;
+  achievementsLoading: boolean;
+  raId: number | null;
 }
 
 /** Format a Unix timestamp (seconds) as a release date string (e.g. "15 Mar 2003") */
@@ -92,6 +99,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     saveStatus: null,
     conflicts: [],
     error: false,
+    activeTab: "info",
+    achievements: [],
+    achievementProgress: null,
+    achievementsLoading: false,
+    raId: null,
   });
   const romIdRef = useRef<number | null>(null);
   const [migrationPending, setMigrationPending] = useState(getMigrationState().pending);
@@ -177,6 +189,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
             created_at: c.detected_at,
           })) as PendingConflict[];
 
+        // Store ra_id for tab visibility
+        const raId = (cached as any).ra_id ?? null;
+
         // Render immediately with cached data (metadata may be null — that's OK)
         setState({
           loading: false,
@@ -193,6 +208,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
           saveStatus,
           conflicts,
           error: false,
+          activeTab: "info",
+          achievements: [],
+          achievementProgress: null,
+          achievementsLoading: false,
+          raId,
         });
 
         // Phase 2: Background fetch for data not available in cache
@@ -315,10 +335,17 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     };
     window.addEventListener("romm_data_changed", onDataChanged);
 
+    const onTabSwitch = (e: Event) => {
+      const tab = (e as CustomEvent).detail?.tab;
+      if (tab) setState((prev) => ({ ...prev, activeTab: tab }));
+    };
+    window.addEventListener("romm_tab_switch", onTabSwitch);
+
     return () => {
       cancelled = true;
       window.removeEventListener("romm_rom_uninstalled", onUninstall);
       window.removeEventListener("romm_data_changed", onDataChanged);
+      window.removeEventListener("romm_tab_switch", onTabSwitch);
     };
   }, [appId]);
 
@@ -333,6 +360,42 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       });
     }
   }, [state.loading, state.error, state.romId]);
+
+  // Lazy-load achievements when the achievements tab becomes active
+  const achievementsLoadedRef = useRef(false);
+  useEffect(() => {
+    if (state.activeTab !== "achievements" || !state.raId || !state.romId) return;
+    if (achievementsLoadedRef.current) return;
+    achievementsLoadedRef.current = true;
+
+    let cancelled = false;
+    setState((prev) => ({ ...prev, achievementsLoading: true }));
+
+    async function loadAchievements() {
+      try {
+        const [listResult, progressResult] = await Promise.all([
+          getAchievements(state.romId!),
+          getAchievementProgress(state.romId!),
+        ]);
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          achievements: listResult.success ? listResult.achievements : [],
+          achievementProgress: progressResult.success ? progressResult : null,
+          achievementsLoading: false,
+        }));
+      } catch (e) {
+        debugLog(`Failed to load achievements: ${e}`);
+        if (!cancelled) {
+          achievementsLoadedRef.current = false;
+          setState((prev) => ({ ...prev, achievementsLoading: false }));
+        }
+      }
+    }
+
+    loadAchievements();
+    return () => { cancelled = true; };
+  }, [state.activeTab, state.raId, state.romId]);
 
   // --- Render helpers ---
 
@@ -756,6 +819,219 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     saveSyncSection = section("save-sync", "Save Sync", ...saveSyncChildren);
   }
 
+  // --- Tab bar ---
+  const tabs: { id: string; label: string; visible: boolean }[] = [
+    { id: "info", label: "GAME INFO", visible: true },
+    { id: "achievements", label: "ACHIEVEMENTS", visible: !!state.raId },
+    { id: "saves", label: "SAVES", visible: state.saveSyncEnabled },
+    { id: "bios", label: "BIOS", visible: !!state.biosStatus },
+  ];
+
+  const tabBar = createElement(Focusable as any, {
+    className: "romm-tab-bar",
+    "flow-children": "right",
+    "data-romm": "true",
+  },
+    ...tabs.filter((t) => t.visible).map((t) =>
+      createElement(DialogButton as any, {
+        key: `tab-${t.id}`,
+        className: `romm-tab ${state.activeTab === t.id ? "romm-tab-active" : ""}`,
+        onClick: () => setState((prev) => ({ ...prev, activeTab: t.id })),
+        style: {
+          background: "transparent",
+          border: "none",
+          borderBottom: state.activeTab === t.id ? "2px solid #1a9fff" : "2px solid transparent",
+          padding: "10px 16px",
+          minWidth: "auto",
+          width: "auto",
+        },
+        noFocusRing: false,
+      }, t.label),
+    ),
+  );
+
+  // --- Achievements tab content ---
+  let achievementsContent: ReturnType<typeof createElement> | null = null;
+  if (state.activeTab === "achievements") {
+    if (state.achievementsLoading) {
+      achievementsContent = createElement("div", { className: "romm-panel-loading" }, "Loading achievements...");
+    } else if (state.achievements.length === 0) {
+      achievementsContent = createElement("div", { className: "romm-panel-muted" }, "No achievements found for this game");
+    } else {
+      const progress = state.achievementProgress;
+      const earned = progress?.earned ?? 0;
+      const total = progress?.total ?? state.achievements.length;
+
+      // Build map from badge_id -> earned data (id in earned_achievements is badge_id)
+      const earnedMap = new Map<string, EarnedAchievement>();
+      for (const ea of (progress?.earned_achievements ?? [])) {
+        earnedMap.set(ea.id, ea);
+      }
+
+      // Sort: earned first, then by display_order
+      const sorted = [...state.achievements].sort((a, b) => {
+        const aEarned = earnedMap.has(a.badge_id) ? 0 : 1;
+        const bEarned = earnedMap.has(b.badge_id) ? 0 : 1;
+        if (aEarned !== bEarned) return aEarned - bEarned;
+        return (a.display_order || 0) - (b.display_order || 0);
+      });
+
+      const earnedList = sorted.filter((a) => earnedMap.has(a.badge_id));
+      const lockedList = sorted.filter((a) => !earnedMap.has(a.badge_id));
+
+      const formatCheevoDate = (dateStr: string) => {
+        // "2025-02-14 15:45:38" -> "2025-02-14 15:45"
+        return dateStr.replace(/:\d{2}$/, "");
+      };
+
+      // Generate unique sparkle positions per achievement using a simple seed hash
+      const makeHcSparkles = (seed: number) => {
+        // Simple deterministic pseudo-random from seed
+        const rng = (i: number) => {
+          let x = Math.sin(seed * 9301 + i * 4973) * 49297;
+          return x - Math.floor(x);
+        };
+        // 4 sparkles, positions along edges/corners with some spread outside
+        return Array.from({ length: 4 }, (_, i) => ({
+          top: `${Math.round(rng(i * 3) * 100)}%`,
+          left: `${Math.round(rng(i * 3 + 1) * 100)}%`,
+          dur: 2.2 + rng(i * 3 + 2) * 1.8, // 2.2–4.0s
+          delay: rng(i * 7 + 5) * 2.0,      // 0–2.0s
+        }));
+      };
+
+      const renderCheevoRow = (a: Achievement) => {
+        const earnedData = earnedMap.get(a.badge_id);
+        const isEarned = !!earnedData;
+        const isHardcore = !!(earnedData?.date_hardcore);
+
+        const rowClasses = [
+          "romm-cheevo-row",
+          isEarned ? "romm-cheevo-row-earned" : "",
+        ].filter(Boolean).join(" ");
+
+        const imgClasses = [
+          "romm-cheevo-badge-img",
+          isHardcore ? "romm-cheevo-badge-img-hc" : "",
+        ].filter(Boolean).join(" ");
+
+        // Date column for earned achievements — show both normal and HC dates
+        const dateChildren: ReturnType<typeof createElement>[] = [];
+        if (earnedData?.date) {
+          dateChildren.push(
+            createElement("span", { key: "date", className: "romm-cheevo-date" },
+              formatCheevoDate(earnedData.date)),
+          );
+        }
+        if (isHardcore && earnedData?.date_hardcore) {
+          dateChildren.push(
+            createElement("span", {
+              key: "hc-row",
+              style: { display: "inline-flex", alignItems: "center", gap: "4px" },
+            },
+              createElement("span", { className: "romm-cheevo-date" },
+                formatCheevoDate(earnedData.date_hardcore)),
+              createElement("span", { className: "romm-cheevo-hc-badge" }, "HC"),
+            ),
+          );
+        }
+
+        // Badge image — wrapped with sparkle container for HC achievements
+        const imgEl = createElement("img", {
+          className: imgClasses,
+          src: isEarned ? a.badge_url : (a.badge_url_lock || a.badge_url),
+          style: isEarned ? {} : { filter: "grayscale(0.7) opacity(0.6)" },
+        });
+
+        const badgeElement = isHardcore
+          ? createElement("div", { className: "romm-cheevo-img-wrap" },
+              imgEl,
+              createElement("span", { className: "romm-cheevo-img-sparkles" },
+                ...makeHcSparkles(a.ra_id).map((sp, i) =>
+                  createElement("span", {
+                    key: `hc-sp-${i}`,
+                    className: "romm-cheevo-img-sparkle-dot",
+                    style: {
+                      "--romm-sparkle-top": sp.top,
+                      "--romm-sparkle-left": sp.left,
+                      "--romm-sparkle-delay": `${sp.delay.toFixed(1)}s`,
+                      "--romm-sparkle-dur": `${sp.dur.toFixed(1)}s`,
+                    } as any,
+                  }),
+                ),
+              ),
+            )
+          : imgEl;
+
+        return createElement("div", {
+          key: `cheevo-${a.ra_id}`,
+          className: rowClasses,
+        },
+          badgeElement,
+          createElement("div", { className: "romm-cheevo-details" },
+            createElement("div", { className: "romm-cheevo-title" }, a.title),
+            createElement("div", { className: "romm-cheevo-desc" }, a.description),
+            a.num_awarded > 0
+              ? createElement("div", { className: "romm-cheevo-rarity" },
+                  `${a.num_awarded} players earned this`)
+              : null,
+          ),
+          dateChildren.length > 0
+            ? createElement("div", { className: "romm-cheevo-dates" }, ...dateChildren)
+            : null,
+          createElement("div", {
+            className: `romm-cheevo-points ${isEarned ? "" : "romm-cheevo-points-locked"}`,
+          }, `${a.points} pts`),
+        );
+      };
+
+      const cheevoChildren: ReturnType<typeof createElement>[] = [];
+
+      // Summary bar
+      cheevoChildren.push(
+        createElement("div", { key: "summary", className: "romm-cheevo-summary" },
+          createElement("span", { className: "romm-cheevo-summary-text" },
+            `${earned} / ${total} Achievements`),
+          progress?.earned_hardcore
+            ? createElement("span", { className: "romm-cheevo-summary-sub" },
+                `${progress.earned_hardcore} hardcore`)
+            : null,
+        ),
+      );
+
+      // Progress bar
+      const pct = total > 0 ? (earned / total) * 100 : 0;
+      cheevoChildren.push(
+        createElement("div", { key: "progress-bar", className: "romm-cheevo-progress-bar" },
+          createElement("div", {
+            className: "romm-cheevo-progress-fill",
+            style: { width: `${pct}%` },
+          }),
+        ),
+      );
+
+      // Earned section
+      if (earnedList.length > 0) {
+        cheevoChildren.push(
+          createElement("div", { key: "earned-title", className: "romm-cheevo-section-title" },
+            `Earned (${earnedList.length})`),
+        );
+        earnedList.forEach((a) => cheevoChildren.push(renderCheevoRow(a)));
+      }
+
+      // Locked section
+      if (lockedList.length > 0) {
+        cheevoChildren.push(
+          createElement("div", { key: "locked-title", className: "romm-cheevo-section-title" },
+            `Locked (${lockedList.length})`),
+        );
+        lockedList.forEach((a) => cheevoChildren.push(renderCheevoRow(a)));
+      }
+
+      achievementsContent = createElement("div", { className: "romm-cheevo-list" }, ...cheevoChildren);
+    }
+  }
+
   // --- Migration warning (when path change pending) ---
   const migrationWarning = migrationPending
     ? createElement("div", {
@@ -777,17 +1053,41 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       )
     : null;
 
-  // --- Assemble panel ---
-  // Root is a plain div — DialogButton sections inside are individually focusable.
-  return createElement("div", {
-    "data-romm": "true",
-    className: "romm-panel-container",
-    style: { paddingBottom: "48px" },
-  },
+  // --- Determine active tab content ---
+  let activeTabContent: ReturnType<typeof createElement> | null = null;
+  if (state.activeTab === "info") {
+    activeTabContent = createElement("div", { key: "tab-info" },
+      gameInfoSection,
+      romFileSection,
+    );
+  } else if (state.activeTab === "achievements") {
+    activeTabContent = achievementsContent
+      ? section("achievements", null, achievementsContent)
+      : null;
+  } else if (state.activeTab === "saves") {
+    activeTabContent = saveSyncSection;
+  } else if (state.activeTab === "bios") {
+    activeTabContent = biosSection;
+  }
+
+  return createElement("div", { "data-romm": "true" },
     migrationWarning,
-    gameInfoSection,
-    romFileSection,
-    saveSyncSection,
-    biosSection,
+    tabBar,
+    createElement(ScrollPanelGroup as any, {
+      focusable: false,
+      style: { flex: 1, minHeight: 0 },
+    },
+      createElement(Focusable as any, {
+        noFocusRing: true,
+        actionDescriptionMap: {
+          [GamepadButton.DIR_UP]: "Scroll Up",
+          [GamepadButton.DIR_DOWN]: "Scroll Down",
+        },
+        className: "romm-tab-content",
+        style: { paddingBottom: "48px" },
+      },
+        activeTabContent,
+      ),
+    ),
   );
 };

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -40,6 +40,7 @@ import {
   deleteLocalSaves,
   saveShortcutIcon,
   setGameCore,
+  getAchievementProgress,
   debugLog,
 } from "../api/backend";
 import type { AvailableCore, BiosStatus, SaveStatus } from "../types";
@@ -106,6 +107,9 @@ interface InfoState {
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
   availableCores: Array<{ core_so: string; label: string; is_default: boolean }>;
+  raId: number | null;
+  achievementEarned: number;
+  achievementTotal: number;
 }
 
 /** Format a Unix timestamp (seconds) as a human-readable date string */
@@ -217,8 +221,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     activeCoreLabel: null,
     activeCoreIsDefault: true,
     availableCores: [],
+    raId: null,
+    achievementEarned: 0,
+    achievementTotal: 0,
   });
-  const [connectionState, setConnectionState] = useState<ConnectionState>("checking");
+  const [, setConnectionState] = useState<ConnectionState>("checking");
   const [actionPending, setActionPending] = useState<string | null>(null);
   const romIdRef = useRef<number | null>(null);
 
@@ -311,6 +318,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
           activeCoreLabel,
           activeCoreIsDefault,
           availableCores,
+          raId: cached.ra_id ?? null,
+          achievementEarned: cached.achievement_summary?.earned ?? 0,
+          achievementTotal: cached.achievement_summary?.total ?? 0,
         }));
 
         // Auto-apply SGDB artwork on first visit (fire-and-forget)
@@ -325,6 +335,19 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         const metaStale = !metaCachedAt || (Date.now() / 1000 - metaCachedAt) > METADATA_TTL_SEC;
         if (romId && (!cached.metadata || metaStale)) {
           getRomMetadata(romId).catch((e) => debugLog(`Background metadata fetch error: ${e}`));
+        }
+
+        // Background: fetch achievement progress if ra_id exists but no summary cached
+        if (cached.ra_id && !cached.achievement_summary) {
+          getAchievementProgress(romId).then((result) => {
+            if (!cancelled && result.success) {
+              setInfo((prev) => ({
+                ...prev,
+                achievementEarned: result.earned,
+                achievementTotal: result.total,
+              }));
+            }
+          }).catch((e) => debugLog(`Background achievement progress fetch error: ${e}`));
         }
       } catch (e) {
         debugLog(`RomMPlaySection: loadCached error: ${e}`);
@@ -450,24 +473,6 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       createElement("div", { className: "romm-info-value" }, value),
     );
 
-  // Helper: info item with a colored status dot
-  const statusInfoItem = (key: string, header: string, value: string, color: string) =>
-    createElement("div", {
-      key,
-      className: "romm-info-item",
-    },
-      createElement("div", { className: "romm-info-header" }, header),
-      createElement("div", {
-        className: "romm-info-value",
-        style: { display: "flex", alignItems: "center", gap: "6px" },
-      },
-        createElement("span", {
-          className: "romm-status-dot",
-          style: { backgroundColor: color },
-        }),
-        value,
-      ),
-    );
 
   // --- Gear button action handlers ---
 
@@ -696,58 +701,90 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     infoItems.push(infoItem("playtime", "PLAYTIME", info.playtime));
   }
 
-  // Achievements (static placeholder)
-  infoItems.push(infoItem("achievements", "ACHIEVEMENTS", "Not available", "romm-info-muted"));
+  // Achievements badge (only when RA data available)
+  if (info.raId) {
+    const hasEarned = info.achievementEarned > 0;
+    const countLabel = info.achievementTotal > 0
+      ? `${info.achievementEarned}/${info.achievementTotal}`
+      : `${info.achievementEarned}`;
 
-  // Save Sync (only when enabled)
-  if (info.saveSyncEnabled && info.saveSyncStatus) {
-    const syncColor =
-      info.saveSyncStatus === "synced" ? "#5ba32b"
-        : info.saveSyncStatus === "conflict" ? "#d94126"
-          : "#8f98a0";
-    infoItems.push(statusInfoItem("save-sync", "SAVE SYNC", info.saveSyncLabel, syncColor));
-  }
+    // Generate sparkle dots at random fixed positions (only when earned > 0)
+    // Positions are deterministic per-index so they don't shift on re-render
+    const sparklePositions = [
+      { top: "5%", left: "80%" },
+      { top: "70%", left: "10%" },
+      { top: "15%", left: "35%" },
+      { top: "85%", left: "70%" },
+      { top: "45%", left: "90%" },
+    ];
+    const sparkleDurs = [2.4, 3.5, 2.8, 3.8, 3.1];
+    const sparkleDelays = [0, 0.9, 0.3, 1.6, 1.1];
+    const sparkleDots = hasEarned ? sparklePositions.map((pos, i) =>
+      createElement("span", {
+        key: `sparkle-${i}`,
+        className: "romm-sparkle-dot",
+        style: {
+          "--romm-sparkle-top": pos.top,
+          "--romm-sparkle-left": pos.left,
+          "--romm-sparkle-delay": `${sparkleDelays[i]}s`,
+          "--romm-sparkle-dur": `${sparkleDurs[i]}s`,
+        } as any,
+      }),
+    ) : [];
 
-  // BIOS (only when platform needs it)
-  if (info.biosNeeded && info.biosStatus) {
-    const biosColor =
-      info.biosStatus === "ok" ? "#5ba32b"
-        : info.biosStatus === "partial" ? "#d4a72c"
-          : "#d94126";
-    infoItems.push(statusInfoItem("bios", "BIOS", info.biosLabel, biosColor));
-  }
-
-  // Non-default core badge
-  if (info.activeCoreLabel && !info.activeCoreIsDefault) {
-    infoItems.push(infoItem("active-core", "NON-DEFAULT CORE", info.activeCoreLabel));
-  }
-
-  // RomM connection status
-  const connColor = connectionState === "connected" ? "#5ba32b"
-    : connectionState === "offline" ? "#8f98a0"
-      : "#1a9fff";
-  const connLabel = connectionState === "connected" ? "Online"
-    : connectionState === "offline" ? "Offline"
-      : "Checking...";
-  const connExtraClass = connectionState === "checking" ? "romm-info-checking" : "";
-  infoItems.push(
-    createElement("div", {
-      key: "romm-status",
-      className: `romm-info-item ${connExtraClass}`.trim(),
-    },
-      createElement("div", { className: "romm-info-header" }, "RomM"),
+    infoItems.push(
       createElement("div", {
-        className: "romm-info-value",
-        style: { display: "flex", alignItems: "center", gap: "6px" },
+        key: "achievements",
+        className: "romm-info-item romm-cheevo-badge",
+        onClick: () => {
+          window.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "achievements" } }));
+        },
       },
-        createElement("span", {
-          className: `romm-status-dot ${connectionState === "checking" ? "romm-status-dot-pulse" : ""}`.trim(),
-          style: { backgroundColor: connColor },
-        }),
-        connLabel,
+        createElement("div", { className: "romm-info-header" }, "ACHIEVEMENTS"),
+        createElement("div", {
+          className: "romm-cheevo-badge-sparkle",
+        },
+          // Trophy icon with sparkle container
+          createElement("span", { style: { position: "relative", display: "inline-block" } },
+            createElement("span", {
+              className: hasEarned ? "romm-cheevo-trophy" : "romm-cheevo-trophy-none",
+            }, "\uD83C\uDFC6"),
+            hasEarned ? createElement("span", { className: "romm-sparkle-container" }, ...sparkleDots) : null,
+          ),
+          createElement("span", { className: "romm-cheevo-count" }, countLabel),
+        ),
       ),
-    ),
-  );
+    );
+  }
+
+  // Save Sync moved to dedicated tab — no longer shown here
+
+  // BIOS warning (only when files are missing — OK status moved to tab)
+  if (info.biosNeeded && info.biosStatus && info.biosStatus !== "ok") {
+    const biosColor = info.biosStatus === "partial" ? "#d4a72c" : "#d94126";
+    infoItems.push(
+      createElement("div", {
+        key: "bios",
+        className: "romm-info-item",
+        onClick: () => {
+          window.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        },
+        style: { cursor: "pointer" },
+      },
+        createElement("div", { className: "romm-info-header" }, "BIOS"),
+        createElement("div", {
+          className: "romm-info-value",
+          style: { display: "flex", alignItems: "center", gap: "6px" },
+        },
+          createElement("span", {
+            className: "romm-status-dot",
+            style: { backgroundColor: biosColor },
+          }),
+          info.biosLabel,
+        ),
+      ),
+    );
+  }
 
   return createElement(Focusable, {
     "data-romm": "true",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -297,6 +297,52 @@ export interface DownloadProgressEvent {
   total_bytes: number;
 }
 
+export interface Achievement {
+  ra_id: number;
+  badge_id: string;
+  title: string;
+  description: string;
+  points: number;
+  badge_url: string;
+  badge_url_lock: string;
+  display_order: number;
+  type: string;
+  num_awarded: number;
+  num_awarded_hardcore: number;
+}
+
+export interface EarnedAchievement {
+  id: string;
+  date: string;
+  date_hardcore: string | null;
+}
+
+export interface AchievementSummary {
+  earned: number;
+  total: number;
+  earned_hardcore: number;
+}
+
+export interface AchievementList {
+  success: boolean;
+  achievements: Achievement[];
+  total: number;
+  no_ra_id?: boolean;
+  stale?: boolean;
+  message?: string;
+}
+
+export interface AchievementProgress {
+  success: boolean;
+  earned: number;
+  earned_hardcore?: number;
+  total: number;
+  earned_achievements: EarnedAchievement[];
+  no_ra_id?: boolean;
+  stale?: boolean;
+  message?: string;
+}
+
 export interface DownloadCompleteEvent {
   rom_id: number;
   rom_name: string;

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -15,6 +15,7 @@ import {
   getAppIdRomIdMap,
   getSaveSyncSettings,
   getPendingConflicts,
+  syncAchievementsAfterSession,
   logInfo,
   logError,
 } from "../api/backend";
@@ -103,6 +104,11 @@ async function handleGameStop(): Promise<void> {
   } catch (e) {
     logError(`Failed to record session end: ${e}`);
   }
+
+  // Post-session achievement sync (fire-and-forget, non-blocking)
+  syncAchievementsAfterSession(romId)
+    .then(() => logInfo(`Achievement sync complete for romId=${romId}`))
+    .catch((e) => logError(`Achievement sync failed for romId=${romId}: ${e}`));
 
   // Post-exit save sync (if enabled) — quick healthcheck first to avoid wasting retries
   try {

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -5,6 +5,8 @@ const ROMM_FOCUS_STYLES_ID = "romm-focus-styles";
 const ROMM_INFO_ITEMS_ID = "romm-info-items-styles";
 const ROMM_GAME_INFO_PANEL_ID = "romm-game-info-panel-styles";
 const ROMM_GEAR_BUTTONS_ID = "romm-gear-btn-styles";
+const ROMM_TABS_ID = "romm-tabs-styles";
+const ROMM_ACHIEVEMENTS_ID = "romm-achievements-styles";
 
 export function hideNativePlaySection(playSectionClass: string) {
   const sp = findSP();
@@ -378,6 +380,279 @@ export function hideNativePlaySection(playSectionClass: string) {
 }`;
     sp.window.document.head.appendChild(gearStyle);
   }
+
+  // Tab bar styles for game detail page tabs (GAME INFO | ACHIEVEMENTS | SAVES | BIOS)
+  if (!sp.window.document.getElementById(ROMM_TABS_ID)) {
+    const tabStyle = sp.window.document.createElement("style");
+    tabStyle.id = ROMM_TABS_ID;
+    tabStyle.textContent = `
+.romm-tab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+  padding: 0 2.8vw;
+  background: rgba(14, 20, 27, 0.33);
+}
+.romm-tab {
+  padding: 10px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #8f98a0;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  background: transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  white-space: nowrap;
+}
+.romm-tab:hover {
+  color: #dcdedf !important;
+}
+.romm-tab.gpfocus,
+.romm-tab:focus,
+.romm-tab.Focusable.gpfocus {
+  color: #dcdedf !important;
+  background: rgba(255,255,255,0.06) !important;
+  outline: none;
+  border-bottom-color: #1a9fff;
+}
+.romm-tab-active {
+  color: #dcdedf !important;
+  border-bottom-color: #1a9fff;
+}
+.romm-tab-content {
+  padding: 16px 2.8vw;
+  background: rgba(14, 20, 27, 0.33);
+}`;
+    sp.window.document.head.appendChild(tabStyle);
+  }
+
+  // Achievement badge sparkle + achievements tab styles
+  if (!sp.window.document.getElementById(ROMM_ACHIEVEMENTS_ID)) {
+    const cheevoStyle = sp.window.document.createElement("style");
+    cheevoStyle.id = ROMM_ACHIEVEMENTS_ID;
+    cheevoStyle.textContent = `
+@keyframes romm-gold-sparkle {
+  0%, 100% { opacity: 0; transform: scale(0); }
+  15% { opacity: 1; transform: scale(1.2); }
+  30% { opacity: 0.9; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1); }
+  80% { opacity: 0.4; transform: scale(0.6); }
+}
+.romm-cheevo-badge {
+  position: relative;
+  cursor: pointer;
+}
+.romm-cheevo-badge-sparkle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.romm-sparkle-container {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  right: -4px;
+  bottom: -4px;
+  pointer-events: none;
+  overflow: visible;
+}
+.romm-sparkle-dot {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: #fff8dc;
+  box-shadow: 0 0 2px 1px #ffd700, 0 0 4px 1px rgba(255, 215, 0, 0.5);
+  animation: romm-gold-sparkle var(--romm-sparkle-dur, 2s) ease-in-out infinite;
+  animation-delay: var(--romm-sparkle-delay, 0s);
+  top: var(--romm-sparkle-top, 50%);
+  left: var(--romm-sparkle-left, 50%);
+}
+.romm-cheevo-trophy {
+  color: #ffd700;
+  font-size: 14px;
+  filter: drop-shadow(0 0 2px rgba(255, 215, 0, 0.5));
+}
+.romm-cheevo-trophy-none {
+  color: #8f98a0;
+  font-size: 14px;
+  filter: none;
+}
+.romm-cheevo-count {
+  font-size: 13px;
+  font-weight: 500;
+  color: #dcdedf;
+}
+.romm-cheevo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.romm-cheevo-progress-bar {
+  height: 6px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  margin: 8px 0 16px 0;
+}
+.romm-cheevo-progress-fill {
+  height: 100%;
+  background: linear-gradient(to right, #ffd700, #ffaa00);
+  border-radius: 3px;
+  transition: width 0.4s ease-out;
+}
+.romm-cheevo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.03);
+  border-left: 3px solid transparent;
+}
+.romm-cheevo-row-earned {
+  background: rgba(255, 215, 0, 0.06);
+  border-left-color: #ffd700;
+}
+.romm-cheevo-img-wrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+}
+.romm-cheevo-img-sparkles {
+  position: absolute;
+  top: -5px;
+  left: -5px;
+  right: -5px;
+  bottom: -5px;
+  pointer-events: none;
+  overflow: visible;
+}
+.romm-cheevo-img-sparkle-dot {
+  position: absolute;
+  width: 2.5px;
+  height: 2.5px;
+  border-radius: 50%;
+  background: #fff8dc;
+  box-shadow: 0 0 2px 1px #ffd700, 0 0 5px 1px rgba(255, 215, 0, 0.5);
+  animation: romm-gold-sparkle var(--romm-sparkle-dur, 2.5s) ease-in-out infinite;
+  animation-delay: var(--romm-sparkle-delay, 0s);
+  top: var(--romm-sparkle-top, 50%);
+  left: var(--romm-sparkle-left, 50%);
+}
+.romm-cheevo-badge-img {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  object-fit: cover;
+  background: rgba(255,255,255,0.05);
+}
+.romm-cheevo-details {
+  flex: 1;
+  min-width: 0;
+}
+.romm-cheevo-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #dcdedf;
+  line-height: 1.3;
+}
+.romm-cheevo-desc {
+  font-size: 12px;
+  color: #8f98a0;
+  line-height: 1.4;
+  margin-top: 2px;
+}
+.romm-cheevo-points {
+  font-size: 11px;
+  color: #ffd700;
+  font-weight: 600;
+  flex-shrink: 0;
+  padding: 2px 8px;
+  background: rgba(255, 215, 0, 0.1);
+  border-radius: 3px;
+}
+.romm-cheevo-points-locked {
+  color: #8f98a0;
+  background: rgba(255,255,255,0.05);
+}
+.romm-cheevo-earned-label {
+  font-size: 10px;
+  color: #5ba32b;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.romm-cheevo-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #8f98a0;
+  margin: 12px 0 8px 0;
+}
+.romm-cheevo-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+.romm-cheevo-summary-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: #dcdedf;
+}
+.romm-cheevo-summary-sub {
+  font-size: 12px;
+  color: #8f98a0;
+}
+.romm-cheevo-rarity {
+  font-size: 10px;
+  color: #8f98a0;
+  white-space: nowrap;
+}
+.romm-cheevo-dates {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.romm-cheevo-date {
+  font-size: 10px;
+  color: #8f98a0;
+  white-space: nowrap;
+  padding: 2px 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+}
+.romm-cheevo-hc-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: #ffd700;
+  padding: 1px 5px;
+  background: rgba(255, 215, 0, 0.15);
+  border-radius: 3px;
+  box-shadow: 0 0 4px rgba(255, 215, 0, 0.3), 0 0 8px rgba(255, 215, 0, 0.15);
+  text-shadow: 0 0 4px rgba(255, 215, 0, 0.5);
+}
+.romm-cheevo-badge-img-hc {
+  box-shadow: 0 0 6px rgba(255, 215, 0, 0.4), 0 0 12px rgba(255, 215, 0, 0.2);
+  border: 1px solid rgba(255, 215, 0, 0.3);
+}`;
+    sp.window.document.head.appendChild(cheevoStyle);
+  }
 }
 
 export function showNativePlaySection() {
@@ -388,4 +663,6 @@ export function showNativePlaySection() {
   sp.window.document.getElementById(ROMM_INFO_ITEMS_ID)?.remove();
   sp.window.document.getElementById(ROMM_GAME_INFO_PANEL_ID)?.remove();
   sp.window.document.getElementById(ROMM_GEAR_BUTTONS_ID)?.remove();
+  sp.window.document.getElementById(ROMM_TABS_ID)?.remove();
+  sp.window.document.getElementById(ROMM_ACHIEVEMENTS_ID)?.remove();
 }

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,0 +1,1094 @@
+import pytest
+import time
+import asyncio
+from unittest.mock import patch, MagicMock
+
+# conftest.py patches decky before this import
+from main import Plugin
+
+
+@pytest.fixture
+def plugin():
+    p = Plugin()
+    p.settings = {
+        "romm_url": "http://romm.local",
+        "romm_user": "user",
+        "romm_pass": "pass",
+        "enabled_platforms": {},
+        "log_level": "warn",
+    }
+    p._sync_running = False
+    p._sync_cancel = False
+    p._sync_progress = {"running": False}
+    p._state = {
+        "shortcut_registry": {},
+        "installed_roms": {},
+        "last_sync": None,
+        "sync_stats": {},
+    }
+    p._pending_sync = {}
+    p._download_tasks = {}
+    p._download_queue = {}
+    p._download_in_progress = set()
+    p._metadata_cache = {}
+    p._achievements_cache = {}
+    return p
+
+
+# ── Sample data helpers ──────────────────────────────────────
+
+
+def _sample_achievements():
+    """Return a list of two sample RA achievements as they appear in ra_metadata."""
+    return [
+        {
+            "ra_id": 1001,
+            "title": "First Blood",
+            "description": "Defeat the first boss",
+            "points": 10,
+            "badge_url": "http://badges/1001.png",
+            "badge_url_lock": "http://badges/1001_lock.png",
+            "display_order": 1,
+            "type": "progression",
+            "num_awarded": 5000,
+            "num_awarded_hardcore": 2000,
+        },
+        {
+            "ra_id": 1002,
+            "title": "Completionist",
+            "description": "Find all secrets",
+            "points": 50,
+            "badge_url": "http://badges/1002.png",
+            "badge_url_lock": "http://badges/1002_lock.png",
+            "display_order": 2,
+            "type": "missable",
+            "num_awarded": 100,
+            "num_awarded_hardcore": 50,
+        },
+    ]
+
+
+def _sample_rom_data(achievements=None, use_merged=False):
+    """Build a mock RomM ROM detail response with ra_metadata."""
+    key = "merged_ra_metadata" if use_merged else "ra_metadata"
+    return {
+        "id": 42,
+        "ra_id": 9999,
+        key: {"achievements": achievements or _sample_achievements()},
+    }
+
+
+def _sample_user_data(ra_id, earned=5, total=10, earned_hardcore=3, ra_username="RetroPlayer"):
+    """Build a mock /api/users/me response with ra_progression and ra_username."""
+    return {
+        "ra_username": ra_username,
+        "ra_progression": {
+            "results": [
+                {
+                    "rom_ra_id": ra_id,
+                    "num_awarded": earned,
+                    "num_awarded_hardcore": earned_hardcore,
+                    "max_possible": total,
+                    "earned_achievements": [1001, 1002, 1003, 1004, 1005][:earned],
+                },
+            ],
+        },
+    }
+
+
+def _seed_ra_username_cache(plugin, username="RetroPlayer"):
+    """Pre-populate the RA username cache to simulate a known user."""
+    plugin._achievements_cache["_ra_user"] = {
+        "username": username,
+        "cached_at": time.time(),
+    }
+
+
+# ══════════════════════════════════════════════════════════════
+# _get_ra_username (reads from achievements cache, not settings)
+# ══════════════════════════════════════════════════════════════
+
+
+class TestGetRaUsername:
+    def test_returns_username_from_cache(self, plugin):
+        _seed_ra_username_cache(plugin, "RetroPlayer")
+        assert plugin._get_ra_username() == "RetroPlayer"
+
+    def test_returns_empty_when_no_cache(self, plugin):
+        assert plugin._get_ra_username() == ""
+
+    def test_returns_empty_when_cache_expired(self, plugin):
+        plugin._achievements_cache["_ra_user"] = {
+            "username": "RetroPlayer",
+            "cached_at": time.time() - (2 * 3600),  # 2h old > 1h TTL
+        }
+        assert plugin._get_ra_username() == ""
+
+    def test_returns_cached_when_fresh(self, plugin):
+        plugin._achievements_cache["_ra_user"] = {
+            "username": "JohnDoe",
+            "cached_at": time.time() - 1800,  # 30min old < 1h TTL
+        }
+        assert plugin._get_ra_username() == "JohnDoe"
+
+
+# ══════════════════════════════════════════════════════════════
+# _fetch_ra_username
+# ══════════════════════════════════════════════════════════════
+
+
+class TestFetchRaUsername:
+    @pytest.mark.asyncio
+    async def test_fetches_and_caches(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+        user_data = {"ra_username": "  RetroPlayer  "}
+
+        with patch.object(plugin, "_romm_request", return_value=user_data):
+            result = await plugin._fetch_ra_username()
+
+        assert result == "RetroPlayer"
+        assert plugin._achievements_cache["_ra_user"]["username"] == "RetroPlayer"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_ra_username_on_user(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+        user_data = {"ra_username": None}
+
+        with patch.object(plugin, "_romm_request", return_value=user_data):
+            result = await plugin._fetch_ra_username()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_api_error(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+
+        with patch.object(plugin, "_romm_request", side_effect=Exception("Network error")):
+            result = await plugin._fetch_ra_username()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_stale_cache_on_api_error(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+        plugin._achievements_cache["_ra_user"] = {
+            "username": "OldUser",
+            "cached_at": time.time() - (2 * 3600),  # expired
+        }
+
+        with patch.object(plugin, "_romm_request", side_effect=Exception("Network error")):
+            result = await plugin._fetch_ra_username()
+
+        assert result == "OldUser"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_ra_username(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+        user_data = {"ra_username": ""}
+
+        with patch.object(plugin, "_romm_request", return_value=user_data):
+            result = await plugin._fetch_ra_username()
+
+        assert result == ""
+
+
+# ══════════════════════════════════════════════════════════════
+# _extract_achievements_from_rom
+# ══════════════════════════════════════════════════════════════
+
+
+class TestExtractAchievementsFromRom:
+    def test_full_achievement_list(self, plugin):
+        rom_data = _sample_rom_data()
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert len(result) == 2
+        assert result[0]["ra_id"] == 1001
+        assert result[0]["title"] == "First Blood"
+        assert result[0]["description"] == "Defeat the first boss"
+        assert result[0]["points"] == 10
+        assert result[0]["badge_url"] == "http://badges/1001.png"
+        assert result[0]["badge_url_lock"] == "http://badges/1001_lock.png"
+        assert result[0]["display_order"] == 1
+        assert result[0]["type"] == "progression"
+        assert result[0]["num_awarded"] == 5000
+        assert result[0]["num_awarded_hardcore"] == 2000
+
+        assert result[1]["ra_id"] == 1002
+        assert result[1]["title"] == "Completionist"
+
+    def test_empty_ra_metadata(self, plugin):
+        rom_data = {"ra_metadata": {}}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert result == []
+
+    def test_none_ra_metadata(self, plugin):
+        rom_data = {"ra_metadata": None}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert result == []
+
+    def test_missing_ra_metadata_key(self, plugin):
+        rom_data = {"id": 1}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert result == []
+
+    def test_fallback_to_merged_ra_metadata(self, plugin):
+        """When ra_metadata is empty, falls back to merged_ra_metadata."""
+        rom_data = {
+            "ra_metadata": {},
+            "merged_ra_metadata": {"achievements": _sample_achievements()},
+        }
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert len(result) == 2
+        assert result[0]["ra_id"] == 1001
+
+    def test_fallback_to_merged_when_ra_metadata_is_none(self, plugin):
+        rom_data = {
+            "ra_metadata": None,
+            "merged_ra_metadata": {"achievements": _sample_achievements()},
+        }
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert len(result) == 2
+
+    def test_ra_metadata_takes_priority_over_merged(self, plugin):
+        """When ra_metadata has achievements, merged_ra_metadata is not used."""
+        rom_data = {
+            "ra_metadata": {"achievements": [_sample_achievements()[0]]},
+            "merged_ra_metadata": {"achievements": _sample_achievements()},
+        }
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert len(result) == 1
+        assert result[0]["ra_id"] == 1001
+
+    def test_missing_fields_get_defaults(self, plugin):
+        """Achievement entries with missing fields get default values."""
+        rom_data = {"ra_metadata": {"achievements": [{"ra_id": 2000}]}}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert len(result) == 1
+        a = result[0]
+        assert a["ra_id"] == 2000
+        assert a["title"] == ""
+        assert a["description"] == ""
+        assert a["points"] == 0
+        assert a["badge_url"] == ""
+        assert a["badge_url_lock"] == ""
+        assert a["display_order"] == 0
+        assert a["type"] == ""
+        assert a["num_awarded"] == 0
+        assert a["num_awarded_hardcore"] == 0
+
+    def test_empty_achievements_list(self, plugin):
+        rom_data = {"ra_metadata": {"achievements": []}}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert result == []
+
+    def test_achievements_none_in_metadata(self, plugin):
+        rom_data = {"ra_metadata": {"achievements": None}}
+        result = plugin._extract_achievements_from_rom(rom_data)
+        assert result == []
+
+
+# ══════════════════════════════════════════════════════════════
+# _get_achievements_cache_entry / _get_progress_cache_entry
+# ══════════════════════════════════════════════════════════════
+
+
+class TestAchievementsCacheEntry:
+    def test_returns_entry_when_fresh(self, plugin):
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1}],
+            "cached_at": time.time(),
+        }
+        result = plugin._get_achievements_cache_entry("42")
+        assert result is not None
+        assert result["achievements"] == [{"ra_id": 1}]
+
+    def test_returns_none_when_expired(self, plugin):
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1}],
+            "cached_at": time.time() - (25 * 3600),  # 25h old > 24h TTL
+        }
+        result = plugin._get_achievements_cache_entry("42")
+        assert result is None
+
+    def test_returns_none_when_missing(self, plugin):
+        result = plugin._get_achievements_cache_entry("42")
+        assert result is None
+
+    def test_returns_none_when_empty_entry(self, plugin):
+        plugin._achievements_cache["42"] = {}
+        result = plugin._get_achievements_cache_entry("42")
+        assert result is None
+
+    def test_boundary_exactly_at_ttl(self, plugin):
+        """Entry at exactly TTL age is considered expired."""
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1}],
+            "cached_at": time.time() - (24 * 3600 + 1),
+        }
+        result = plugin._get_achievements_cache_entry("42")
+        assert result is None
+
+
+class TestProgressCacheEntry:
+    def test_returns_entry_when_fresh(self, plugin):
+        plugin._achievements_cache["42"] = {
+            "user_progress": {
+                "earned": 5,
+                "total": 10,
+                "cached_at": time.time(),
+            },
+        }
+        result = plugin._get_progress_cache_entry("42")
+        assert result is not None
+        assert result["earned"] == 5
+
+    def test_returns_none_when_expired(self, plugin):
+        plugin._achievements_cache["42"] = {
+            "user_progress": {
+                "earned": 5,
+                "total": 10,
+                "cached_at": time.time() - (2 * 3600),  # 2h old > 1h TTL
+            },
+        }
+        result = plugin._get_progress_cache_entry("42")
+        assert result is None
+
+    def test_returns_none_when_missing(self, plugin):
+        result = plugin._get_progress_cache_entry("42")
+        assert result is None
+
+    def test_returns_none_when_no_user_progress_key(self, plugin):
+        plugin._achievements_cache["42"] = {"achievements": []}
+        result = plugin._get_progress_cache_entry("42")
+        assert result is None
+
+    def test_returns_none_when_user_progress_is_none(self, plugin):
+        plugin._achievements_cache["42"] = {"user_progress": None}
+        result = plugin._get_progress_cache_entry("42")
+        assert result is None
+
+
+# ══════════════════════════════════════════════════════════════
+# get_achievements
+# ══════════════════════════════════════════════════════════════
+
+
+class TestGetAchievements:
+    @pytest.mark.asyncio
+    async def test_happy_path_fetches_and_caches(self, plugin):
+        """Fetches from API, returns achievements, caches result."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999, "app_id": 100}
+        rom_data = _sample_rom_data()
+
+        with patch.object(plugin, "_romm_request", return_value=rom_data):
+            result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["total"] == 2
+        assert len(result["achievements"]) == 2
+        assert result["achievements"][0]["title"] == "First Blood"
+        # Verify cached
+        assert "42" in plugin._achievements_cache
+        assert len(plugin._achievements_cache["42"]["achievements"]) == 2
+        assert plugin._achievements_cache["42"]["ra_id"] == 9999
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_without_api_call(self, plugin):
+        """Returns cached data without calling _romm_request."""
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1001, "title": "Cached"}],
+            "cached_at": time.time(),
+        }
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            result = await plugin.get_achievements(42)
+
+        mock_req.assert_not_called()
+        assert result["success"] is True
+        assert result["total"] == 1
+        assert result["achievements"][0]["title"] == "Cached"
+
+    @pytest.mark.asyncio
+    async def test_cache_expired_refetches(self, plugin):
+        """Refetches from API when cache is older than TTL."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1001, "title": "Old"}],
+            "cached_at": time.time() - (25 * 3600),
+        }
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+
+        with patch.object(plugin, "_romm_request", return_value=rom_data):
+            result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["total"] == 2
+        assert result["achievements"][0]["title"] == "First Blood"
+
+    @pytest.mark.asyncio
+    async def test_no_ra_id_returns_empty(self, plugin):
+        """When no ra_id in registry, returns empty with no_ra_id flag."""
+        plugin._state["shortcut_registry"]["42"] = {"app_id": 100}
+
+        result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["achievements"] == []
+        assert result["total"] == 0
+        assert result["no_ra_id"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_registry_entry_returns_empty(self, plugin):
+        """When rom_id not in registry at all, returns empty with no_ra_id flag."""
+        result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["achievements"] == []
+        assert result["no_ra_id"] is True
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_stale_cache(self, plugin):
+        """On API error, returns stale cache if available."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._achievements_cache["42"] = {
+            "achievements": [{"ra_id": 1001, "title": "Stale"}],
+            "cached_at": time.time() - (25 * 3600),  # expired
+        }
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+
+        with patch.object(plugin, "_romm_request", side_effect=Exception("Connection refused")):
+            result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["stale"] is True
+        assert result["achievements"][0]["title"] == "Stale"
+
+    @pytest.mark.asyncio
+    async def test_api_error_no_cache_returns_error(self, plugin):
+        """On API error with no cache, returns error with empty list."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+
+        with patch.object(plugin, "_romm_request", side_effect=Exception("Connection refused")):
+            result = await plugin.get_achievements(42)
+
+        assert result["success"] is False
+        assert result["achievements"] == []
+        assert result["total"] == 0
+        assert "Connection refused" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_rom_id_cast_to_int(self, plugin):
+        """rom_id is cast to int, so string input works too."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+
+        with patch.object(plugin, "_romm_request", return_value=rom_data):
+            result = await plugin.get_achievements("42")
+
+        assert result["success"] is True
+        assert result["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_achievements_from_api(self, plugin):
+        """API returns ROM with no achievements."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = {"id": 42, "ra_metadata": {"achievements": []}}
+
+        with patch.object(plugin, "_romm_request", return_value=rom_data):
+            result = await plugin.get_achievements(42)
+
+        assert result["success"] is True
+        assert result["total"] == 0
+        assert result["achievements"] == []
+
+
+# ══════════════════════════════════════════════════════════════
+# get_achievement_progress
+# ══════════════════════════════════════════════════════════════
+
+
+class TestGetAchievementProgress:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, plugin):
+        """Fetches user progression, returns earned/total."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = _sample_user_data(ra_id=9999, earned=5, total=10, earned_hardcore=3)
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 5
+        assert result["total"] == 10
+        assert result["earned_hardcore"] == 3
+        assert len(result["earned_achievements"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_no_ra_username_fetches_from_romm(self, plugin):
+        """When no cached RA username, fetches from /api/users/me."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        # First call: _fetch_ra_username -> /api/users/me
+        # Second call: get_achievements -> /api/roms/42
+        # Third call: get_achievement_progress -> /api/users/me
+        user_data_with_username = _sample_user_data(ra_id=9999, earned=5, total=10)
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [
+                {"ra_username": "RetroPlayer"},  # _fetch_ra_username
+                rom_data,                         # get_achievements
+                user_data_with_username,           # progression fetch
+            ]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 5
+        # RA username should now be cached
+        assert plugin._achievements_cache["_ra_user"]["username"] == "RetroPlayer"
+
+    @pytest.mark.asyncio
+    async def test_no_ra_username_anywhere_returns_error(self, plugin):
+        """When no RA username in cache and RomM user has none, returns error."""
+        plugin.loop = asyncio.get_event_loop()
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+
+        with patch.object(plugin, "_romm_request", return_value={"ra_username": None}):
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is False
+        assert "No RA username" in result["message"]
+        assert result["earned"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_ra_id_returns_zeros(self, plugin):
+        """When no ra_id in registry, returns zeros with no_ra_id flag."""
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"app_id": 100}
+
+        result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 0
+        assert result["total"] == 0
+        assert result["no_ra_id"] is True
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, plugin):
+        """Returns cached progress without API call."""
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        plugin._achievements_cache["42"] = {
+            "user_progress": {
+                "earned": 3,
+                "earned_hardcore": 1,
+                "total": 10,
+                "earned_achievements": [1001, 1002, 1003],
+                "cached_at": time.time(),
+            },
+        }
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            result = await plugin.get_achievement_progress(42)
+
+        mock_req.assert_not_called()
+        assert result["success"] is True
+        assert result["earned"] == 3
+        assert result["total"] == 10
+
+    @pytest.mark.asyncio
+    async def test_game_not_found_in_progression(self, plugin):
+        """When the game's ra_id is not in progression results, returns zeros."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        # User data has progression for a different game
+        user_data = {"ra_username": "RetroPlayer", "ra_progression": {"results": [{"rom_ra_id": 1111, "num_awarded": 5}]}}
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 0
+        assert result["total"] == 2  # total from achievements list
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_stale_cache(self, plugin):
+        """On API error, returns stale progress cache if available."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        # Pre-populate achievements cache so get_achievements succeeds from cache
+        plugin._achievements_cache["42"] = {
+            "achievements": _sample_achievements(),
+            "cached_at": time.time(),
+            "user_progress": {
+                "earned": 2,
+                "earned_hardcore": 0,
+                "total": 10,
+                "earned_achievements": [1001, 1002],
+                "cached_at": time.time() - (2 * 3600),  # expired progress
+            },
+        }
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            # get_achievements cache hit, then /api/users/me fails
+            mock_req.side_effect = Exception("Network error")
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["stale"] is True
+        assert result["earned"] == 2
+
+    @pytest.mark.asyncio
+    async def test_api_error_no_cache_returns_error(self, plugin):
+        """On API error with no stale cache, returns error."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        # Pre-populate achievements cache so get_achievements succeeds
+        plugin._achievements_cache["42"] = {
+            "achievements": _sample_achievements(),
+            "cached_at": time.time(),
+        }
+
+        with patch.object(plugin, "_romm_request", side_effect=Exception("Network error")):
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is False
+        assert result["earned"] == 0
+        assert result["total"] == 0
+        assert "Network error" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_empty_ra_progression(self, plugin):
+        """User data with empty ra_progression returns zeros."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = {"ra_username": "RetroPlayer", "ra_progression": {"results": []}}
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 0
+        assert result["total"] == 2  # from achievement list count
+
+    @pytest.mark.asyncio
+    async def test_none_ra_progression(self, plugin):
+        """User data with None ra_progression returns zeros."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = {"ra_username": "RetroPlayer", "ra_progression": None}
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 0
+
+    @pytest.mark.asyncio
+    async def test_progress_caches_result(self, plugin):
+        """Successful progress fetch is cached in _achievements_cache."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = _sample_user_data(ra_id=9999, earned=7, total=10)
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            await plugin.get_achievement_progress(42)
+
+        cached = plugin._achievements_cache["42"]["user_progress"]
+        assert cached["earned"] == 7
+        assert cached["total"] == 10
+        assert "cached_at" in cached
+
+    @pytest.mark.asyncio
+    async def test_cached_at_not_in_response(self, plugin):
+        """The cached_at timestamp is not leaked into the response."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = _sample_user_data(ra_id=9999, earned=7, total=10)
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert "cached_at" not in result
+
+    @pytest.mark.asyncio
+    async def test_max_possible_fallback_to_total(self, plugin):
+        """When max_possible is None/0, falls back to total from achievements list."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = {
+            "ra_username": "RetroPlayer",
+            "ra_progression": {
+                "results": [
+                    {"rom_ra_id": 9999, "num_awarded": 1, "max_possible": 0},
+                ],
+            },
+        }
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        # Fallback: total should be len(achievements) = 2
+        assert result["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_none_num_awarded_treated_as_zero(self, plugin):
+        """When num_awarded is None in progression, treat as 0."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = {
+            "ra_username": "RetroPlayer",
+            "ra_progression": {
+                "results": [
+                    {
+                        "rom_ra_id": 9999,
+                        "num_awarded": None,
+                        "num_awarded_hardcore": None,
+                        "max_possible": 10,
+                    },
+                ],
+            },
+        }
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.get_achievement_progress(42)
+
+        assert result["earned"] == 0
+        assert result["earned_hardcore"] == 0
+
+    @pytest.mark.asyncio
+    async def test_caches_ra_username_from_users_me_response(self, plugin):
+        """The /api/users/me call in progress fetch also caches ra_username."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = _sample_user_data(ra_id=9999, earned=5, total=10, ra_username="NewUser")
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            await plugin.get_achievement_progress(42)
+
+        # RA username should have been updated from the users/me response
+        assert plugin._achievements_cache["_ra_user"]["username"] == "NewUser"
+
+
+# ══════════════════════════════════════════════════════════════
+# sync_achievements_after_session
+# ══════════════════════════════════════════════════════════════
+
+
+class TestSyncAchievementsAfterSession:
+    @pytest.mark.asyncio
+    async def test_invalidates_cache_and_refetches(self, plugin):
+        """Invalidates progress cache and fetches fresh data."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+
+        # Pre-populate cache with old progress
+        plugin._achievements_cache["42"] = {
+            "achievements": _sample_achievements(),
+            "cached_at": time.time(),
+            "user_progress": {
+                "earned": 1,
+                "total": 10,
+                "cached_at": time.time(),
+            },
+        }
+
+        user_data = _sample_user_data(ra_id=9999, earned=5, total=10)
+
+        with patch.object(plugin, "_romm_request", return_value=user_data):
+            result = await plugin.sync_achievements_after_session(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 5
+        # Old progress should have been replaced
+        assert plugin._achievements_cache["42"]["user_progress"]["earned"] == 5
+
+    @pytest.mark.asyncio
+    async def test_cache_cleared_before_refetch(self, plugin):
+        """Verifies that user_progress is deleted before get_achievement_progress is called."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        plugin._achievements_cache["42"] = {
+            "achievements": _sample_achievements(),
+            "cached_at": time.time(),
+            "user_progress": {
+                "earned": 1,
+                "total": 10,
+                "cached_at": time.time(),
+            },
+        }
+
+        call_order = []
+
+        original_get_progress = plugin.get_achievement_progress
+
+        async def spy_get_progress(rom_id):
+            # At the time get_achievement_progress is called, user_progress should be gone
+            entry = plugin._achievements_cache.get("42", {})
+            call_order.append("user_progress" not in entry)
+            return await original_get_progress(rom_id)
+
+        user_data = _sample_user_data(ra_id=9999, earned=5, total=10)
+
+        with patch.object(plugin, "get_achievement_progress", side_effect=spy_get_progress), \
+             patch.object(plugin, "_romm_request", return_value=user_data):
+            await plugin.sync_achievements_after_session(42)
+
+        assert call_order == [True], "user_progress should have been deleted before refetch"
+
+    @pytest.mark.asyncio
+    async def test_works_when_no_prior_cache(self, plugin):
+        """Works correctly when no prior cache exists."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        rom_data = _sample_rom_data()
+        user_data = _sample_user_data(ra_id=9999, earned=3, total=10)
+
+        with patch.object(plugin, "_romm_request") as mock_req:
+            mock_req.side_effect = [rom_data, user_data]
+            result = await plugin.sync_achievements_after_session(42)
+
+        assert result["success"] is True
+        assert result["earned"] == 3
+
+    @pytest.mark.asyncio
+    async def test_preserves_achievements_cache_on_invalidation(self, plugin):
+        """Invalidating progress cache preserves the achievements list cache."""
+        plugin.loop = asyncio.get_event_loop()
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {"ra_id": 9999}
+        plugin._achievements_cache["42"] = {
+            "achievements": _sample_achievements(),
+            "cached_at": time.time(),
+            "ra_id": 9999,
+            "user_progress": {
+                "earned": 1,
+                "total": 10,
+                "cached_at": time.time(),
+            },
+        }
+
+        user_data = _sample_user_data(ra_id=9999, earned=5, total=10)
+
+        with patch.object(plugin, "_romm_request", return_value=user_data):
+            await plugin.sync_achievements_after_session(42)
+
+        # Achievements list should still be cached
+        assert len(plugin._achievements_cache["42"]["achievements"]) == 2
+        assert plugin._achievements_cache["42"]["ra_id"] == 9999
+
+
+# ══════════════════════════════════════════════════════════════
+# Integration: get_cached_game_detail with achievements
+# ══════════════════════════════════════════════════════════════
+
+
+class TestGetCachedGameDetailAchievements:
+    @pytest.mark.asyncio
+    async def test_includes_ra_id_and_summary_with_cache(self, plugin):
+        """When ra_id exists, RA username cached, and progress cached: includes achievement_summary."""
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {
+            "ra_id": 9999,
+            "app_id": 100,
+            "name": "Test Game",
+            "platform_slug": "",
+        }
+        plugin._achievements_cache["42"] = {
+            "user_progress": {
+                "earned": 5,
+                "total": 10,
+                "earned_hardcore": 3,
+                "cached_at": time.time(),
+            },
+        }
+        plugin._save_sync_state = {"settings": {}, "saves": {}, "pending_conflicts": []}
+
+        result = await plugin.get_cached_game_detail(100)
+
+        assert result["found"] is True
+        assert result["ra_id"] == 9999
+        assert result["achievement_summary"] is not None
+        assert result["achievement_summary"]["earned"] == 5
+        assert result["achievement_summary"]["total"] == 10
+        assert result["achievement_summary"]["earned_hardcore"] == 3
+
+    @pytest.mark.asyncio
+    async def test_no_ra_username_returns_none_summary(self, plugin):
+        """When ra_id exists but no RA username cached, achievement_summary is None."""
+        plugin._state["shortcut_registry"]["42"] = {
+            "ra_id": 9999,
+            "app_id": 100,
+            "name": "Test Game",
+            "platform_slug": "",
+        }
+        plugin._save_sync_state = {"settings": {}, "saves": {}, "pending_conflicts": []}
+
+        result = await plugin.get_cached_game_detail(100)
+
+        assert result["found"] is True
+        assert result["ra_id"] == 9999
+        assert result["achievement_summary"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_ra_id_returns_none(self, plugin):
+        """When no ra_id in registry, ra_id is None and achievement_summary is None."""
+        plugin._state["shortcut_registry"]["42"] = {
+            "app_id": 100,
+            "name": "Test Game",
+            "platform_slug": "",
+        }
+        plugin._save_sync_state = {"settings": {}, "saves": {}, "pending_conflicts": []}
+
+        result = await plugin.get_cached_game_detail(100)
+
+        assert result["found"] is True
+        assert result["ra_id"] is None
+        assert result["achievement_summary"] is None
+
+    @pytest.mark.asyncio
+    async def test_ra_username_cached_but_no_progress(self, plugin):
+        """When RA username cached and ra_id exists but no progress cache, summary is None."""
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {
+            "ra_id": 9999,
+            "app_id": 100,
+            "name": "Test Game",
+            "platform_slug": "",
+        }
+        plugin._save_sync_state = {"settings": {}, "saves": {}, "pending_conflicts": []}
+
+        result = await plugin.get_cached_game_detail(100)
+
+        assert result["found"] is True
+        assert result["ra_id"] == 9999
+        assert result["achievement_summary"] is None
+
+    @pytest.mark.asyncio
+    async def test_expired_progress_cache_returns_none_summary(self, plugin):
+        """Expired progress cache returns None for achievement_summary."""
+        _seed_ra_username_cache(plugin)
+        plugin._state["shortcut_registry"]["42"] = {
+            "ra_id": 9999,
+            "app_id": 100,
+            "name": "Test Game",
+            "platform_slug": "",
+        }
+        plugin._achievements_cache["42"] = {
+            "user_progress": {
+                "earned": 5,
+                "total": 10,
+                "earned_hardcore": 3,
+                "cached_at": time.time() - (2 * 3600),  # expired
+            },
+        }
+        plugin._save_sync_state = {"settings": {}, "saves": {}, "pending_conflicts": []}
+
+        result = await plugin.get_cached_game_detail(100)
+
+        assert result["found"] is True
+        assert result["achievement_summary"] is None
+
+
+# ══════════════════════════════════════════════════════════════
+# Integration: sync captures ra_id in shortcuts_data / registry
+# ══════════════════════════════════════════════════════════════
+
+
+class TestSyncCapturesRaId:
+    def test_rom_with_ra_id_appears_in_registry(self, plugin):
+        """Registry entry includes ra_id when present in pending sync data."""
+        rom_id_str = "42"
+        pending = {
+            "rom_id": 42,
+            "name": "Test Game",
+            "platform_slug": "snes",
+            "igdb_id": 1234,
+            "sgdb_id": 5678,
+            "ra_id": 9999,
+        }
+        # Simulate what sync does when writing registry
+        registry_entry = {
+            "name": pending["name"],
+            "platform_slug": pending.get("platform_slug", ""),
+            "cover_path": "",
+        }
+        for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
+            if pending.get(meta_key):
+                registry_entry[meta_key] = pending[meta_key]
+        plugin._state["shortcut_registry"][rom_id_str] = registry_entry
+
+        assert plugin._state["shortcut_registry"]["42"]["ra_id"] == 9999
+
+    def test_rom_without_ra_id_not_in_registry(self, plugin):
+        """Registry entry does not include ra_id when not present in pending sync data."""
+        pending = {
+            "rom_id": 42,
+            "name": "Test Game",
+            "platform_slug": "snes",
+        }
+        registry_entry = {
+            "name": pending["name"],
+            "platform_slug": pending.get("platform_slug", ""),
+            "cover_path": "",
+        }
+        for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
+            if pending.get(meta_key):
+                registry_entry[meta_key] = pending[meta_key]
+        plugin._state["shortcut_registry"]["42"] = registry_entry
+
+        assert "ra_id" not in plugin._state["shortcut_registry"]["42"]
+
+    def test_ra_id_preserved_across_registry_updates(self, plugin):
+        """ra_id is preserved when registry entry is updated."""
+        plugin._state["shortcut_registry"]["42"] = {
+            "name": "Test Game",
+            "platform_slug": "snes",
+            "ra_id": 9999,
+            "app_id": 100,
+        }
+
+        # Simulate re-sync updating the entry
+        existing = plugin._state["shortcut_registry"]["42"]
+        existing["name"] = "Test Game (Updated)"
+        # ra_id should still be there
+        assert plugin._state["shortcut_registry"]["42"]["ra_id"] == 9999


### PR DESCRIPTION
## Summary
- RetroAchievements backend module (`achievements.py`): RA data fetch, user progress, caching
- Achievements tab in game detail page with earned/locked sections, sparkle animations, progress bar
- `ra_id` extraction during sync, post-session achievement refresh
- Full Phase 7 roadmap in PLAN.md

## Note
Controller scrolling in injected game detail panels has a known issue (scrolls briefly then stops, banner partially hidden on scroll-up). Root cause identified — will be fixed in a separate dedicated PR.