### PR TITLE
fix: move HC badge before date in achievement list

### DIFF
--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -916,9 +916,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
               key: "hc-row",
               style: { display: "inline-flex", alignItems: "center", gap: "4px" },
             },
+              createElement("span", { className: "romm-cheevo-hc-badge" }, "HC"),
               createElement("span", { className: "romm-cheevo-date" },
                 formatCheevoDate(earnedData.date_hardcore)),
-              createElement("span", { className: "romm-cheevo-hc-badge" }, "HC"),
             ),
           );
         }


### PR DESCRIPTION
## Summary
- Move the hardcore (HC) badge label to appear before the earned date instead of after
- Before: `2025-02-22 12:48 HC`
- After: `HC 2025-02-22 12:48`

## Test plan
- [x] Open a game with hardcore achievements earned
- [x] Verify HC badge appears before the date on each hardcore row