### PR TITLE
fix: Tier 3 improvements — caching, serialization, cleanup

### DIFF
--- a/py_modules/lib/es_de_config.py
+++ b/py_modules/lib/es_de_config.py
@@ -7,9 +7,13 @@ import re
 import decky  # for DECKY_USER_HOME and logging
 
 
-# Module-level caches
+# Module-level caches (with mtime tracking for external-change invalidation)
 _es_systems_cache = None  # dict or None
+_es_systems_mtime = None  # float or None — mtime when cache was loaded
+_es_systems_path = None  # str or None — path that was cached
 _core_defaults_cache = None  # dict or None
+_core_defaults_mtime = None  # float or None
+_core_defaults_path = None  # str or None
 
 _CORE_SO_RE = re.compile(r"%CORE_RETROARCH%/([\w-]+_libretro)\.so")
 
@@ -24,9 +28,14 @@ _ES_SYSTEMS_CANDIDATES = [
 
 def _reset_cache():
     """Reset caches (for testing)."""
-    global _es_systems_cache, _core_defaults_cache
+    global _es_systems_cache, _es_systems_mtime, _es_systems_path
+    global _core_defaults_cache, _core_defaults_mtime, _core_defaults_path
     _es_systems_cache = None
+    _es_systems_mtime = None
+    _es_systems_path = None
     _core_defaults_cache = None
+    _core_defaults_mtime = None
+    _core_defaults_path = None
 
 
 def find_es_systems_xml():
@@ -152,16 +161,28 @@ def parse_es_systems(xml_path):
 
 
 def _load_core_defaults():
-    """Load the static core_defaults.json fallback."""
-    global _core_defaults_cache
-    if _core_defaults_cache is not None:
-        return _core_defaults_cache
+    """Load the static core_defaults.json fallback.
+
+    Re-reads from disk if the file's mtime has changed (handles plugin updates).
+    """
+    global _core_defaults_cache, _core_defaults_mtime, _core_defaults_path
 
     # Check plugin root first (Decky CLI moves defaults/ contents to root),
     # then defaults/ subdirectory (dev deploys via mise run deploy)
     root_path = os.path.join(decky.DECKY_PLUGIN_DIR, "core_defaults.json")
     dev_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "core_defaults.json")
     defaults_path = root_path if os.path.exists(root_path) else dev_path
+
+    try:
+        current_mtime = os.path.getmtime(defaults_path)
+    except OSError:
+        current_mtime = None
+
+    if (_core_defaults_cache is not None
+            and _core_defaults_path == defaults_path
+            and _core_defaults_mtime == current_mtime):
+        return _core_defaults_cache
+
     try:
         with open(defaults_path, "r") as f:
             data = json.load(f)
@@ -170,21 +191,39 @@ def _load_core_defaults():
         decky.logger.warning("es_de_config: failed to load core_defaults.json: %s", e)
         _core_defaults_cache = {}
 
+    _core_defaults_path = defaults_path
+    _core_defaults_mtime = current_mtime
     return _core_defaults_cache
 
 
 def _load_es_systems():
-    """Load and cache es_systems.xml parse result."""
-    global _es_systems_cache
-    if _es_systems_cache is not None:
-        return _es_systems_cache
+    """Load and cache es_systems.xml parse result.
+
+    Re-reads from disk if the file's mtime has changed (handles flatpak updates).
+    """
+    global _es_systems_cache, _es_systems_mtime, _es_systems_path
 
     xml_path = find_es_systems_xml()
     if xml_path:
+        try:
+            current_mtime = os.path.getmtime(xml_path)
+        except OSError:
+            current_mtime = None
+
+        if (_es_systems_cache is not None
+                and _es_systems_path == xml_path
+                and _es_systems_mtime == current_mtime):
+            return _es_systems_cache
+
         _es_systems_cache = parse_es_systems(xml_path)
+        _es_systems_path = xml_path
+        _es_systems_mtime = current_mtime
     else:
-        decky.logger.info("es_de_config: es_systems.xml not found, using core_defaults.json fallback")
+        if _es_systems_cache is None:
+            decky.logger.info("es_de_config: es_systems.xml not found, using core_defaults.json fallback")
         _es_systems_cache = {}
+        _es_systems_path = None
+        _es_systems_mtime = None
 
     return _es_systems_cache
 

--- a/py_modules/lib/retrodeck_config.py
+++ b/py_modules/lib/retrodeck_config.py
@@ -1,12 +1,28 @@
 """Centralized RetroDECK path resolution.
 
 Reads paths from retrodeck.json config, with fallback to ~/retrodeck/{subdir}.
-Each call reads fresh from disk (no caching) to handle config changes.
+Uses a 30-second TTL cache to avoid re-reading disk on every call during
+batch operations (e.g. 50-ROM save sync).
 """
 import json
 import os
+import time
 
 import decky
+
+_CACHE_TTL = 30  # seconds
+
+_cached_config = None
+_cache_time = 0.0
+_cache_config_path = None
+
+
+def _reset_cache():
+    """Reset the TTL cache (for testing)."""
+    global _cached_config, _cache_time, _cache_config_path
+    _cached_config = None
+    _cache_time = 0.0
+    _cache_config_path = None
 
 
 def _config_path():
@@ -18,16 +34,36 @@ def _config_path():
     )
 
 
+def _load_config():
+    """Load retrodeck.json with TTL caching."""
+    global _cached_config, _cache_time, _cache_config_path
+    config_path = _config_path()
+    now = time.monotonic()
+    if (_cached_config is not None
+            and _cache_config_path == config_path
+            and (now - _cache_time) < _CACHE_TTL):
+        return _cached_config
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        _cached_config = config
+        _cache_time = now
+        _cache_config_path = config_path
+        return config
+    except (OSError, json.JSONDecodeError):
+        _cached_config = None
+        _cache_config_path = config_path
+        _cache_time = now
+        return None
+
+
 def get_retrodeck_path(key, fallback_subdir):
     """Read a path from retrodeck.json paths.{key}, fallback to ~/retrodeck/{subdir}."""
-    try:
-        with open(_config_path(), "r") as f:
-            config = json.load(f)
+    config = _load_config()
+    if config:
         path = config.get("paths", {}).get(key, "")
         if path:
             return path
-    except (OSError, json.JSONDecodeError):
-        pass
     return os.path.join(decky.DECKY_USER_HOME, "retrodeck", fallback_subdir)
 
 

--- a/py_modules/lib/sgdb.py
+++ b/py_modules/lib/sgdb.py
@@ -110,11 +110,6 @@ class SgdbMixin:
                     pass
             return None
 
-    async def save_steamgriddb_key(self, api_key):
-        self.settings["steamgriddb_api_key"] = api_key
-        self._save_settings_to_disk()
-        return {"success": True}
-
     async def get_sgdb_artwork_base64(self, rom_id, asset_type_num):
         rom_id = int(rom_id)
         asset_type_num = int(asset_type_num)

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -37,7 +37,18 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
   const startPolling = () => {
     stopPolling();
     pollRef.current = setInterval(() => {
-      setLocalDownloads([...getDownloadState()]);
+      const current = getDownloadState();
+      // Un-clear rom_ids that have new active downloads (re-download case)
+      setCleared((prev) => {
+        const restarted = current.filter(
+          (d) => (d.status === "downloading" || d.status === "queued") && prev.has(d.rom_id),
+        );
+        if (restarted.length === 0) return prev;
+        const next = new Set(prev);
+        restarted.forEach((d) => next.delete(d.rom_id));
+        return next;
+      });
+      setLocalDownloads([...current]);
     }, 500);
   };
 

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -17,7 +17,7 @@ import type { RoutePatch } from "@decky/api";
 const rommAppIds = new Set<number>();
 
 // Tracks which appIds have already had their tree dumped (once per page load)
-const dumpedAppIds = new Set<number>();
+let treeDumped = false;
 
 /**
  * Recursively walk a React element tree and log each node.
@@ -114,8 +114,8 @@ export function registerGameDetailPatch() {
 
             // Diagnostic tree dump — runs once per appId per plugin load.
             // Logs the full InnerContainer structure for debugging tree changes.
-            if (isRomM && !dumpedAppIds.has(appId)) {
-              dumpedAppIds.add(appId);
+            if (isRomM && !treeDumped) {
+              treeDumped = true;
               debugLog(`===== DEEP TREE DUMP for appId=${appId} =====`);
               debugLog(`InnerContainer className: ${container.props.className}`);
 

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -34,6 +34,9 @@ let sessionStartTime: number | null = null;
 let suspendedAt: number | null = null;
 let totalPausedMs = 0;
 
+// Serialization chain — ensures lifecycle events don't interleave
+let lifecycleChain: Promise<void> = Promise.resolve();
+
 // Hook handles for cleanup
 let lifetimeHook: { unregister: () => void } | null = null;
 let suspendHook: { unregister: () => void } | null = null;
@@ -193,21 +196,27 @@ export async function initSessionManager(): Promise<void> {
 
   // Game lifecycle notifications
   lifetimeHook = SteamClient.GameSessions.RegisterForAppLifetimeNotifications(
-    async (update) => {
-      if (update.bRunning) {
-        // Game started — wait for Router.MainRunningApp to populate
-        await delay(500);
-        const running = typeof Router !== "undefined" ? Router.MainRunningApp : null;
-        const appId = running?.appid ?? update.unAppID;
-        if (appId) {
-          // Refresh map in case a sync happened since init
-          await refreshAppIdMap();
-          await handleGameStart(appId);
-        }
-      } else {
-        // Game stopped
-        await handleGameStop();
-      }
+    (update) => {
+      lifecycleChain = lifecycleChain
+        .then(async () => {
+          if (update.bRunning) {
+            // Game started — wait for Router.MainRunningApp to populate
+            await delay(500);
+            const running = typeof Router !== "undefined" ? Router.MainRunningApp : null;
+            const appId = running?.appid ?? update.unAppID;
+            if (appId) {
+              // Refresh map in case a sync happened since init
+              await refreshAppIdMap();
+              await handleGameStart(appId);
+            }
+          } else {
+            // Game stopped
+            await handleGameStop();
+          }
+        })
+        .catch((e) => {
+          logError(`Lifecycle event error: ${e}`);
+        });
     },
   );
 
@@ -240,6 +249,7 @@ export function destroySessionManager(): void {
   sessionStartTime = null;
   suspendedAt = null;
   totalPausedMs = 0;
+  lifecycleChain = Promise.resolve();
 
   logInfo("Session manager destroyed");
 }

--- a/tests/test_es_de_config.py
+++ b/tests/test_es_de_config.py
@@ -583,3 +583,60 @@ class TestGetActiveCoreWithGameOverride:
             # rom_filename provided but no per-game override: system override wins
             result = es_de_config.get_active_core("gba", rom_filename="Pokemon.gba")
             assert result == ("vbam_libretro", "VBA-M")
+
+
+class TestMtimeInvalidation:
+    """Test that caches invalidate when underlying files change on disk."""
+
+    def setup_method(self):
+        es_de_config._reset_cache()
+
+    def test_es_systems_reloads_on_mtime_change(self):
+        """_load_es_systems should re-parse if es_systems.xml mtime changes."""
+        xml_v1 = """\
+<?xml version="1.0"?>
+<systemList>
+  <system>
+    <name>gba</name>
+    <command label="mGBA">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mgba_libretro.so %ROM%</command>
+  </system>
+</systemList>
+"""
+        xml_v2 = """\
+<?xml version="1.0"?>
+<systemList>
+  <system>
+    <name>gba</name>
+    <command label="mGBA">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mgba_libretro.so %ROM%</command>
+    <command label="gpSP">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/gpsp_libretro.so %ROM%</command>
+  </system>
+</systemList>
+"""
+        path = _write_temp_xml(xml_v1)
+        try:
+            with mock.patch("lib.es_de_config.find_es_systems_xml", return_value=path):
+                result1 = es_de_config._load_es_systems()
+                assert len(result1["gba"]["cores"]) == 1
+
+                # Overwrite file (changes mtime)
+                import time
+                time.sleep(0.05)  # ensure mtime differs
+                with open(path, "w") as f:
+                    f.write(xml_v2)
+
+                result2 = es_de_config._load_es_systems()
+                assert len(result2["gba"]["cores"]) == 2
+        finally:
+            os.unlink(path)
+
+    def test_es_systems_cache_hit_when_unchanged(self):
+        """_load_es_systems should return cached result if mtime unchanged."""
+        path = _write_temp_xml(SAMPLE_ES_SYSTEMS_XML)
+        try:
+            with mock.patch("lib.es_de_config.find_es_systems_xml", return_value=path):
+                result1 = es_de_config._load_es_systems()
+                result2 = es_de_config._load_es_systems()
+                # Same object reference means cache was used
+                assert result1 is result2
+        finally:
+            os.unlink(path)

--- a/tests/test_retrodeck_config.py
+++ b/tests/test_retrodeck_config.py
@@ -8,6 +8,9 @@ from lib import retrodeck_config
 
 
 class TestGetBiosPath:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
     def test_from_config(self, tmp_path):
         import decky
         decky.DECKY_USER_HOME = str(tmp_path)
@@ -31,6 +34,9 @@ class TestGetBiosPath:
 
 
 class TestGetRomsPath:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
     def test_from_config(self, tmp_path):
         import decky
         decky.DECKY_USER_HOME = str(tmp_path)
@@ -54,6 +60,9 @@ class TestGetRomsPath:
 
 
 class TestGetSavesPath:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
     def test_from_config(self, tmp_path):
         import decky
         decky.DECKY_USER_HOME = str(tmp_path)
@@ -70,6 +79,9 @@ class TestGetSavesPath:
 
 
 class TestGetRetroDeckHome:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
     def test_from_config(self, tmp_path):
         import decky
         decky.DECKY_USER_HOME = str(tmp_path)
@@ -93,7 +105,85 @@ class TestGetRetroDeckHome:
         assert result == os.path.join(str(tmp_path), "retrodeck", "")
 
 
+class TestTTLCache:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
+    def test_cache_returns_same_result_without_rereading(self, tmp_path):
+        """Second call within TTL should return cached result."""
+        import decky
+        decky.DECKY_USER_HOME = str(tmp_path)
+
+        config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "retrodeck.json"
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/original/bios"}
+        }))
+
+        result1 = retrodeck_config.get_bios_path()
+        assert result1 == "/original/bios"
+
+        # Change file — should still return cached value within TTL
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/changed/bios"}
+        }))
+        result2 = retrodeck_config.get_bios_path()
+        assert result2 == "/original/bios"
+
+    def test_cache_expires_after_ttl(self, tmp_path, monkeypatch):
+        """After TTL expires, cache should re-read from disk."""
+        import decky
+        decky.DECKY_USER_HOME = str(tmp_path)
+
+        config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "retrodeck.json"
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/original/bios"}
+        }))
+
+        result1 = retrodeck_config.get_bios_path()
+        assert result1 == "/original/bios"
+
+        # Change file and expire cache by advancing monotonic time
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/changed/bios"}
+        }))
+        import time
+        original_monotonic = time.monotonic
+        monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + 31)
+        retrodeck_config._cache_time = 0  # force expiry
+
+        result2 = retrodeck_config.get_bios_path()
+        assert result2 == "/changed/bios"
+
+    def test_reset_cache_clears_state(self, tmp_path):
+        """_reset_cache() should clear all cached state."""
+        import decky
+        decky.DECKY_USER_HOME = str(tmp_path)
+
+        config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "retrodeck.json"
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/original/bios"}
+        }))
+
+        retrodeck_config.get_bios_path()
+        retrodeck_config._reset_cache()
+
+        config_file.write_text(json.dumps({
+            "paths": {"bios_path": "/new/bios"}
+        }))
+        result = retrodeck_config.get_bios_path()
+        assert result == "/new/bios"
+
+
 class TestEdgeCases:
+    def setup_method(self):
+        retrodeck_config._reset_cache()
+
     def test_fallback_when_key_missing(self, tmp_path):
         """Config exists but missing the requested path key."""
         import decky

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -2149,8 +2149,9 @@ class TestGetRetrodeckSavesPath:
         expected = os.path.join(str(tmp_path), "retrodeck", "saves")
         assert result == expected
 
-    def test_not_cached(self, plugin, tmp_path):
-        """Reads fresh every call (not cached)."""
+    def test_picks_up_changes_after_cache_reset(self, plugin, tmp_path):
+        """Reads fresh after TTL cache is reset."""
+        from lib import retrodeck_config as rc
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
         config_file = config_dir / "retrodeck.json"
@@ -2159,6 +2160,7 @@ class TestGetRetrodeckSavesPath:
         assert plugin._get_retrodeck_saves_path() == "/first/path"
 
         config_file.write_text(json.dumps({"paths": {"saves_path": "/second/path"}}))
+        rc._reset_cache()
         assert plugin._get_retrodeck_saves_path() == "/second/path"
 
 


### PR DESCRIPTION
## Summary

- **T3-7**: Serialize async game lifecycle events in `sessionManager.ts` via promise chain — prevents interleaving on rapid start/stop that could corrupt session state or lose playtime
- **T3-8**: Add 30s TTL cache to `retrodeck_config.py` — 50-ROM save sync drops from 50 disk reads to 1
- **T3-9**: Add mtime-based cache invalidation to `es_de_config.py` — flatpak/plugin updates picked up without plugin restart
- **T3-12**: Limit diagnostic tree dump to first RomM appId only (was once per appId, noisy with 100+ shortcuts)
- **T3-13**: Fix cleared downloads hidden on re-download in `DownloadQueue.tsx` — un-clear rom_ids when new active download arrives
- **T3-16**: Remove dead `save_steamgriddb_key()` duplicate in `sgdb.py`

## Test plan

- [x] 796 backend tests pass
- [x] Frontend builds clean (`pnpm build`)
- [x] Verify re-downloading a previously cleared ROM shows progress again
- [x] Verify rapid game start+stop doesn't interleave session events
- [x] Verify retrodeck config changes are picked up after 30s