### PR TITLE
fix: retry app ID init on boot when backend isn't ready

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,32 +49,51 @@ export default definePlugin(() => {
   registerGameDetailPatch();
   registerLaunchInterceptor();
 
-  // Load metadata cache, register store patches, and populate RomM app ID set
-  (async () => {
+  // Load metadata cache, register store patches, and populate RomM app ID set.
+  // Retries with backoff if the backend isn't ready yet (e.g. boot without network).
+  const RETRY_DELAYS = [2000, 5000, 10000];
+  let initAttempt = 0;
+  let initDone = false;
+
+  async function loadAppIdsAndMetadata() {
+    const [cache, appIdMap] = await Promise.all([
+      getAllMetadataCache(),
+      getAppIdRomIdMap(),
+    ]);
+    registerMetadataPatches(cache, appIdMap);
+
+    for (const appIdStr of Object.keys(appIdMap)) {
+      const appId = parseInt(appIdStr, 10);
+      if (!isNaN(appId)) {
+        registerRomMAppId(appId);
+      }
+    }
+
     try {
-      const [cache, appIdMap] = await Promise.all([
-        getAllMetadataCache(),
-        getAppIdRomIdMap(),
-      ]);
-      registerMetadataPatches(cache, appIdMap);
-
-      // Populate the RomM app ID set for PlaySection hiding and launch interception
-      for (const appIdStr of Object.keys(appIdMap)) {
-        const appId = parseInt(appIdStr, 10);
-        if (!isNaN(appId)) {
-          registerRomMAppId(appId);
-        }
-      }
-
-      // Apply tracked playtime to Steam UI for all known apps
-      try {
-        const { playtime } = await getAllPlaytime();
-        applyAllPlaytime(playtime, appIdMap);
-      } catch (e) {
-        logError(`Failed to apply playtime: ${e}`);
-      }
+      const { playtime } = await getAllPlaytime();
+      applyAllPlaytime(playtime, appIdMap);
     } catch (e) {
-      logError(`Failed to load metadata cache: ${e}`);
+      logError(`Failed to apply playtime: ${e}`);
+    }
+
+    initDone = true;
+    logInfo(`App ID init succeeded (attempt ${initAttempt + 1})`);
+  }
+
+  (async () => {
+    while (!initDone && initAttempt <= RETRY_DELAYS.length) {
+      try {
+        await loadAppIdsAndMetadata();
+      } catch (e) {
+        if (initAttempt < RETRY_DELAYS.length) {
+          const delay = RETRY_DELAYS[initAttempt];
+          logError(`App ID init failed (attempt ${initAttempt + 1}), retrying in ${delay}ms: ${e}`);
+          await new Promise((r) => setTimeout(r, delay));
+        } else {
+          logError(`App ID init failed after ${initAttempt + 1} attempts, giving up: ${e}`);
+        }
+        initAttempt++;
+      }
     }
   })();
 


### PR DESCRIPTION
## Summary
- When Steam Deck boots (especially without network), the plugin backend may not be ready when the frontend loads
- `getAppIdRomIdMap()` fails silently, `rommAppIds` stays empty, and all RomM game detail pages show native Steam UI instead of our custom UI
- Add retry with backoff (2s, 5s, 10s) — up to 4 attempts total so the frontend recovers once the backend becomes available

## Root cause
`rommAppIds` (the set that gates whether `gameDetailPatch.tsx` replaces the native UI) is populated from a `callable()` to the Python backend. If that callable fails at boot, the set stays empty forever — the patch sees every game as non-RomM and returns the original React tree.

## Test plan
- [x] Boot Steam Deck with network → game detail pages show custom UI immediately
- [x] Boot Steam Deck without network → game detail pages show native UI initially, then custom UI after backend becomes available (within ~17s)
- [x] Check plugin logs for retry messages: `App ID init failed (attempt N), retrying in Xms`