### PR TITLE
feat: v47 SaveApi adapter + VersionRouter + bug fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,6 +50,7 @@ class Plugin(
         )
         self._persistence = adapters["persistence"]
         self._http_client = adapters["http_client"]
+        self._version_router = adapters["version_router"]
         self._sync_state = SyncState.IDLE
         self._sync_last_heartbeat = 0.0
         self._sync_progress = {
@@ -409,6 +410,9 @@ class Plugin(
             pass
         if self._romm_version:
             decky.logger.info(f"RomM server version: {self._romm_version}")
+            router = getattr(self, "_version_router", None)
+            if router:
+                router.set_version(self._romm_version)
 
         # Test authenticated access
         try:
@@ -694,11 +698,8 @@ class Plugin(
 
     async def post_exit_sync(self, rom_id):
         save_svc = getattr(self, "_save_sync_service", None)
-        play_svc = getattr(self, "_playtime_service", None)
-        if save_svc and play_svc:
-            result = await save_svc.post_exit_sync(rom_id)
-            await play_svc.record_session_end(rom_id)
-            return result
+        if save_svc:
+            return await save_svc.post_exit_sync(rom_id)
         return await SaveSyncMixin.post_exit_sync(self, rom_id)
 
     async def sync_rom_saves(self, rom_id):

--- a/py_modules/adapters/romm/save_api/v47.py
+++ b/py_modules/adapters/romm/save_api/v47.py
@@ -1,0 +1,36 @@
+"""SaveApi adapter for RomM >= 4.7.0.
+
+What's improved vs v46:
+- Native GET /api/saves/{id}/content endpoint for downloads (no metadata
+  round-trip needed).
+
+What's postponed (and why):
+- content_hash: field exists in schema but is null on real 4.7.0 servers.
+  Still requires download-and-hash for change detection.
+- device_id / device tracking: accepted by server but adds registration
+  overhead with no functional benefit yet.
+
+FROZEN ADAPTER WARNING
+──────────────────────
+This file represents the RomM 4.7.0 API surface as it exists today.
+Do NOT add features from future RomM versions (4.7.1, 4.8, etc.) here.
+Create a new adapter file instead (e.g. v471.py, v48.py) — users on
+RomM 4.7.0 must remain supported with this exact behavior.
+"""
+
+from __future__ import annotations
+
+from adapters.romm.save_api.v46 import SaveApiV46
+
+
+class SaveApiV47(SaveApiV46):
+    """Concrete ``SaveApiProtocol`` for RomM >= 4.7.0.
+
+    Inherits everything from v46 except ``download_save``, which uses
+    the native ``/content`` endpoint instead of the metadata+download_path
+    workaround.
+    """
+
+    async def download_save(self, save_id: int, dest_path: str) -> None:
+        """Download via GET /api/saves/{id}/content (native 4.7.0 endpoint)."""
+        self._client.download(f"/api/saves/{save_id}/content", dest_path)

--- a/py_modules/adapters/romm/version_router.py
+++ b/py_modules/adapters/romm/version_router.py
@@ -1,0 +1,74 @@
+"""Proxy that delegates to the correct SaveApi adapter based on detected RomM server version.
+
+Defaults to v46 (safe fallback). Call ``set_version()`` after
+``test_connection()`` detects the server version.
+"""
+
+from __future__ import annotations
+
+from adapters.romm.client import RommHttpClient
+from adapters.romm.save_api.v46 import SaveApiV46
+from adapters.romm.save_api.v47 import SaveApiV47
+
+
+def _parse_version(version: str) -> tuple[int, ...] | None:
+    """Parse a dotted version string into a tuple of ints, or None on failure."""
+    try:
+        return tuple(int(p) for p in version.split("."))
+    except (ValueError, AttributeError):
+        return None
+
+
+_V47_THRESHOLD = (4, 7, 0)
+
+
+class VersionRouter:
+    """Selects the correct SaveApi adapter based on detected RomM version."""
+
+    def __init__(self, client: RommHttpClient) -> None:
+        self._v46 = SaveApiV46(client)
+        self._v47 = SaveApiV47(client)
+        self._active = self._v46
+
+    def set_version(self, version: str) -> None:
+        """Switch adapter based on version string.
+
+        ``>= 4.7.0`` or ``"development"`` → v47, otherwise v46.
+        """
+        if version == "development":
+            self._active = self._v47
+            return
+        parsed = _parse_version(version)
+        if parsed is not None and parsed >= _V47_THRESHOLD:
+            self._active = self._v47
+        else:
+            self._active = self._v46
+
+    # -- Delegate all SaveApiProtocol methods to self._active --
+
+    async def list_saves(self, rom_id: int) -> list[dict]:
+        return await self._active.list_saves(rom_id)
+
+    async def upload_save(
+        self,
+        rom_id: int,
+        file_path: str,
+        emulator: str,
+        save_id: int | None = None,
+    ) -> dict:
+        return await self._active.upload_save(rom_id, file_path, emulator, save_id)
+
+    async def download_save(self, save_id: int, dest_path: str) -> None:
+        return await self._active.download_save(save_id, dest_path)
+
+    async def get_save_metadata(self, save_id: int) -> dict:
+        return await self._active.get_save_metadata(save_id)
+
+    async def get_rom_detail(self, rom_id: int) -> dict:
+        return await self._active.get_rom_detail(rom_id)
+
+    async def create_note(self, rom_id: int, data: dict) -> dict:
+        return await self._active.create_note(rom_id, data)
+
+    async def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+        return await self._active.update_note(rom_id, note_id, data)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from adapters.persistence import PersistenceAdapter
 from adapters.romm.client import RommHttpClient
-from adapters.romm.save_api.v46 import SaveApiV46
+from adapters.romm.version_router import VersionRouter
 from services.playtime import PlaytimeService
 from services.save_sync import SaveSyncService
 
@@ -49,12 +49,13 @@ def bootstrap(
     """
     persistence = PersistenceAdapter(settings_dir, runtime_dir, logger)
     http_client = RommHttpClient(settings, plugin_dir, logger)
-    save_api = SaveApiV46(http_client)
+    version_router = VersionRouter(http_client)
 
     return {
         "persistence": persistence,
         "http_client": http_client,
-        "save_api": save_api,
+        "save_api": version_router,
+        "version_router": version_router,
     }
 
 

--- a/py_modules/services/save_sync.py
+++ b/py_modules/services/save_sync.py
@@ -889,11 +889,15 @@ class SaveSyncService:
 
     async def post_exit_sync(self, rom_id: int) -> dict:
         """Upload changed saves after game exit."""
+        self._logger.info("post_exit_sync called for rom_id=%d", rom_id)
+
         if not self._is_save_sync_enabled():
+            self._logger.info("post_exit_sync skipped: save sync disabled")
             return {"success": True, "message": "Save sync disabled", "synced": 0}
 
         settings = self._save_sync_state.get("settings", {})
         if not settings.get("sync_after_exit", True):
+            self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
             return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
 
         if not self._save_sync_state.get("device_id"):
@@ -903,6 +907,14 @@ class SaveSyncService:
 
         synced, errors, conflicts = await self._loop.run_in_executor(None, self._sync_rom_saves, rom_id)
         self.save_state()
+
+        self._logger.info(
+            "post_exit_sync complete for rom_id=%d: synced=%d, errors=%d, conflicts=%d",
+            rom_id,
+            synced,
+            len(errors),
+            len(conflicts),
+        )
 
         msg = f"Uploaded {synced} save(s)"
         if errors:

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -215,8 +215,12 @@ export async function initSessionManager(): Promise<void> {
   );
 
   // Suspend/resume for accurate playtime
-  suspendHook = SteamClient.System.RegisterForOnSuspendRequest(handleSuspend);
-  resumeHook = SteamClient.System.RegisterForOnResumeFromSuspend(handleResume);
+  try {
+    suspendHook = SteamClient.System.RegisterForOnSuspendRequest(handleSuspend);
+    resumeHook = SteamClient.System.RegisterForOnResumeFromSuspend(handleResume);
+  } catch (e) {
+    console.warn("[romm-sync] Suspend/resume hooks unavailable:", e);
+  }
 
   logInfo("Session manager initialized");
 }

--- a/tests/test_save_api_v47.py
+++ b/tests/test_save_api_v47.py
@@ -1,0 +1,56 @@
+"""Tests for SaveApiV47 adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from adapters.romm.save_api.v47 import SaveApiV47
+
+
+@pytest.fixture()
+def mock_client():
+    client = MagicMock()
+    client.download = MagicMock()
+    client.request = MagicMock(return_value=[])
+    client.upload_multipart = MagicMock(return_value={})
+    client.post_json = MagicMock(return_value={})
+    client.put_json = MagicMock(return_value={})
+    return client
+
+
+@pytest.fixture()
+def api(mock_client):
+    return SaveApiV47(mock_client)
+
+
+@pytest.mark.asyncio()
+async def test_download_save_uses_content_endpoint(api, mock_client):
+    """download_save should use /api/saves/{id}/content directly."""
+    await api.download_save(42, "/tmp/test.srm")
+    mock_client.download.assert_called_once_with("/api/saves/42/content", "/tmp/test.srm")
+
+
+@pytest.mark.asyncio()
+async def test_list_saves_inherited(api, mock_client):
+    """list_saves is inherited from v46 and works the same."""
+    mock_client.request.return_value = [{"id": 1, "rom_id": 5}]
+    result = await api.list_saves(5)
+    assert result == [{"id": 1, "rom_id": 5}]
+    mock_client.request.assert_called_once_with("/api/saves?rom_id=5")
+
+
+@pytest.mark.asyncio()
+async def test_get_save_metadata_inherited(api, mock_client):
+    """get_save_metadata is inherited from v46."""
+    mock_client.request.return_value = {"id": 10, "file_name": "test.srm"}
+    result = await api.get_save_metadata(10)
+    assert result == {"id": 10, "file_name": "test.srm"}
+
+
+@pytest.mark.asyncio()
+async def test_upload_save_inherited(api, mock_client):
+    """upload_save is inherited from v46."""
+    mock_client.upload_multipart.return_value = {"id": 1}
+    result = await api.upload_save(5, "/tmp/test.srm", "retroarch")
+    assert result == {"id": 1}

--- a/tests/test_version_router.py
+++ b/tests/test_version_router.py
@@ -1,0 +1,139 @@
+"""Tests for VersionRouter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from adapters.romm.save_api.v46 import SaveApiV46
+from adapters.romm.save_api.v47 import SaveApiV47
+from adapters.romm.version_router import VersionRouter
+
+
+@pytest.fixture()
+def mock_client():
+    client = MagicMock()
+    client.download = MagicMock()
+    client.request = MagicMock(return_value=[])
+    client.upload_multipart = MagicMock(return_value={})
+    client.post_json = MagicMock(return_value={})
+    client.put_json = MagicMock(return_value={})
+    return client
+
+
+@pytest.fixture()
+def router(mock_client):
+    return VersionRouter(mock_client)
+
+
+# -- Version switching --
+
+
+def test_default_is_v46(router):
+    assert isinstance(router._active, SaveApiV46)
+
+
+def test_set_version_470_switches_to_v47(router):
+    router.set_version("4.7.0")
+    assert isinstance(router._active, SaveApiV47)
+
+
+def test_set_version_461_stays_v46(router):
+    router.set_version("4.6.1")
+    assert isinstance(router._active, SaveApiV46)
+
+
+def test_set_version_460_stays_v46(router):
+    router.set_version("4.6.0")
+    assert isinstance(router._active, SaveApiV46)
+
+
+def test_set_version_480_uses_v47(router):
+    router.set_version("4.8.0")
+    assert isinstance(router._active, SaveApiV47)
+
+
+def test_set_version_development_uses_v47(router):
+    router.set_version("development")
+    assert isinstance(router._active, SaveApiV47)
+
+
+def test_set_version_empty_stays_v46(router):
+    router.set_version("")
+    assert isinstance(router._active, SaveApiV46)
+
+
+def test_set_version_garbage_stays_v46(router):
+    router.set_version("not-a-version")
+    assert isinstance(router._active, SaveApiV46)
+
+
+def test_set_version_can_be_called_multiple_times(router):
+    router.set_version("4.7.0")
+    assert isinstance(router._active, SaveApiV47)
+    router.set_version("4.6.1")
+    assert isinstance(router._active, SaveApiV46)
+    router.set_version("development")
+    assert isinstance(router._active, SaveApiV47)
+
+
+# -- Delegation --
+
+
+@pytest.mark.asyncio()
+async def test_download_save_delegates_v46(router, mock_client):
+    """Default (v46) download goes through metadata workaround."""
+    mock_client.request.return_value = {"download_path": "/saves/test.srm"}
+    await router.download_save(1, "/tmp/test.srm")
+    # v46 fetches metadata first
+    mock_client.request.assert_called_with("/api/saves/1")
+
+
+@pytest.mark.asyncio()
+async def test_download_save_delegates_v47(router, mock_client):
+    """After set_version(4.7.0), download uses /content endpoint."""
+    router.set_version("4.7.0")
+    await router.download_save(1, "/tmp/test.srm")
+    mock_client.download.assert_called_once_with("/api/saves/1/content", "/tmp/test.srm")
+
+
+@pytest.mark.asyncio()
+async def test_list_saves_delegates(router, mock_client):
+    mock_client.request.return_value = [{"id": 1}]
+    result = await router.list_saves(5)
+    assert result == [{"id": 1}]
+
+
+@pytest.mark.asyncio()
+async def test_upload_save_delegates(router, mock_client):
+    mock_client.upload_multipart.return_value = {"id": 1}
+    result = await router.upload_save(5, "/tmp/test.srm", "retroarch")
+    assert result == {"id": 1}
+
+
+@pytest.mark.asyncio()
+async def test_get_save_metadata_delegates(router, mock_client):
+    mock_client.request.return_value = {"id": 10}
+    result = await router.get_save_metadata(10)
+    assert result == {"id": 10}
+
+
+@pytest.mark.asyncio()
+async def test_get_rom_detail_delegates(router, mock_client):
+    mock_client.request.return_value = {"id": 5, "name": "Test ROM"}
+    result = await router.get_rom_detail(5)
+    assert result == {"id": 5, "name": "Test ROM"}
+
+
+@pytest.mark.asyncio()
+async def test_create_note_delegates(router, mock_client):
+    mock_client.post_json.return_value = {"id": 1}
+    result = await router.create_note(5, {"body": "test"})
+    assert result == {"id": 1}
+
+
+@pytest.mark.asyncio()
+async def test_update_note_delegates(router, mock_client):
+    mock_client.put_json.return_value = {"id": 1}
+    result = await router.update_note(5, 1, {"body": "updated"})
+    assert result == {"id": 1}


### PR DESCRIPTION
## Summary
- **SaveApiV47**: minimal adapter inheriting v46, overrides `download_save` to use native `/api/saves/{id}/content` endpoint (no metadata round-trip). Frozen adapter — future RomM improvements go into new adapter files.
- **VersionRouter**: proxy implementing SaveApiProtocol, selects v46/v47 based on detected server version (>= 4.7.0 or "development" → v47, else v46)
- **Fix: duplicate playtime tracking** — `post_exit_sync` in main.py called `record_session_end` redundantly (frontend already calls it separately)
- **Fix: missing post_exit_sync logging** — added entry/skip/completion log lines to SaveSyncService
- **Fix: RegisterForOnSuspendRequest crash** — Steam renamed/removed this API; wrapped in try/catch so session manager initializes cleanly

## Test plan
- [x] 904 tests pass (883 existing + 21 new router/v47 tests)
- [x] Manual: plugin loads without RegisterForOnSuspendRequest error
- [x] Manual: post_exit_sync logging visible after game session
- [x] Manual: save sync works end-to-end on RomM 4.7.0 server