### PR TITLE
fix(persistence): add file locking + schema versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ py_modules/
   domain/
     es_de_config.py                       # CoreResolver + GamelistXmlEditor classes (core resolution, gamelist.xml)
     retrodeck_config.py                   # RetroDECK path resolution (roms, saves, BIOS, states)
+    state_migrations.py                   # Schema migration functions for state files
   lib/
     errors.py                             # Exception hierarchy (RommApiError, classify_error)
   vdf/                                    # Vendored VDF library (binary VDF read/write)

--- a/main.py
+++ b/main.py
@@ -85,27 +85,17 @@ class Plugin:
         if pruned:
             self._save_state()
 
-    # -- settings loading with migrations --------------------------------------
-
-    def _load_settings(self):
-        self.settings = self._persistence.load_settings()
-        # Migrate old boolean setting
-        if "disable_steam_input" in self.settings:
-            if self.settings.pop("disable_steam_input"):
-                self.settings["steam_input_mode"] = "force_off"
-            self._save_settings_to_disk()
-        # Migrate old boolean debug_logging to log_level
-        if "debug_logging" in self.settings:
-            if self.settings.pop("debug_logging"):
-                self.settings.setdefault("log_level", "debug")
-            self._save_settings_to_disk()
-        self.settings.setdefault("log_level", "warn")
-
     async def _main(self):  # Decky lifecycle — must be async
         self.loop = asyncio.get_event_loop()
-        # ── Load settings (uses lazy _persistence property) ──
-        self._load_settings()
-        # ── Wire adapters from composition root ──
+
+        # ── 1. Load settings & run migrations ───────────────────────────────
+        from domain.state_migrations import migrate_settings, migrate_state
+
+        self.settings = self._persistence.load_settings()
+        self.settings = migrate_settings(self.settings)
+        self._save_settings_to_disk()
+
+        # ── 2. Wire adapters ────────────────────────────────────────────────
         adapters = bootstrap(
             settings_dir=decky.DECKY_PLUGIN_SETTINGS_DIR,
             runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
@@ -118,6 +108,8 @@ class Plugin:
         self._http_adapter = adapters["http_adapter"]
         self._romm_api = adapters["romm_api"]
         self._steam_config = adapters["steam_config"]
+
+        # ── 3. Load state ───────────────────────────────────────────────────
         self._state = {
             "shortcut_registry": {},
             "installed_roms": {},
@@ -129,12 +121,13 @@ class Plugin:
         self._metadata_cache = {}
         self._romm_version = None  # Detected on test_connection
         self._state = self._persistence.load_state(self._state)
+        self._state = migrate_state(self._state)
         self._metadata_cache = self._persistence.load_metadata_cache()
-        # ── Save sync state (owned by SaveService) ──
+
+        # ── 4. Wire services ────────────────────────────────────────────────
         from services.saves import SaveService
 
         self._save_sync_state = SaveService.make_default_state()
-        # ── Wire services (composition, uses live state refs) ──
         services = wire_services(
             WiringConfig(
                 http_adapter=self._http_adapter,
@@ -168,17 +161,18 @@ class Plugin:
         self._achievements_service = services["achievements_service"]
         self._migration_service = services["migration_service"]
         self._firmware_service.load_bios_registry()
-        # Load persisted state into the live dict
+
+        # ── 5. Startup healing ──────────────────────────────────────────────
         self._save_sync_service.init_state()
         self._save_sync_service.load_state()
-        # ── Startup state healing ──
         self._prune_stale_installed_roms()
         self._prune_stale_registry()
-        self._save_sync_service.prune_orphaned_state()  # services/saves.py
-        self._sgdb_service.prune_orphaned_artwork_cache()  # services/steamgrid.py
-        self._sync_service.prune_orphaned_staging_artwork()  # services/library.py
-        self._download_service.cleanup_leftover_tmp_files()  # services/downloads.py
-        # ── RetroDECK path change detection ──
+        self._save_sync_service.prune_orphaned_state()
+        self._sgdb_service.prune_orphaned_artwork_cache()
+        self._sync_service.prune_orphaned_staging_artwork()
+        self._download_service.cleanup_leftover_tmp_files()
+
+        # ── 6. Background tasks ─────────────────────────────────────────────
         self._migration_service.detect_retrodeck_path_change()
         self.loop.create_task(self._download_service.poll_download_requests())
         decky.logger.info("RomM Sync plugin loaded")

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -1,6 +1,8 @@
-"""Persistence adapter — pure I/O for settings, state, and metadata cache files.
+"""Persistence adapter — pure I/O for settings, state, and cache files.
 
-No business logic, no migration logic, no ``import decky``.
+Handles atomic writes, file locking, and schema version stamping.
+Migration logic lives in ``domain/state_migrations.py``.
+No ``import decky``.
 """
 
 import fcntl
@@ -10,6 +12,8 @@ import os
 
 _STATE_VERSION = 1
 _METADATA_CACHE_VERSION = 1
+_FIRMWARE_CACHE_VERSION = 1
+_SETTINGS_VERSION = 1
 _LOCK_EXT = ".lock"
 
 DEFAULT_SETTINGS: dict = {
@@ -20,8 +24,7 @@ DEFAULT_SETTINGS: dict = {
     "steam_input_mode": "default",
     "steamgriddb_api_key": "",
     "romm_allow_insecure_ssl": False,
-    # NOTE: log_level default is NOT here — it's applied in Plugin._load_settings()
-    # AFTER the debug_logging → log_level migration runs.
+    "log_level": "warn",
 }
 
 
@@ -46,6 +49,31 @@ class PersistenceAdapter:
         self._logger = logger
 
     # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _locked_write(self, path: str, data: dict) -> None:
+        """Atomic write of *data* to *path* under an exclusive file lock."""
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp_path = path + ".tmp"
+        lock_fd = os.open(path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(data, f, indent=2)
+                os.replace(tmp_path, path)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        finally:
+            os.close(lock_fd)
+
+    # ------------------------------------------------------------------
     # Settings
     # ------------------------------------------------------------------
 
@@ -53,7 +81,9 @@ class PersistenceAdapter:
         """Read ``settings.json``, apply defaults, and fix permissions.
 
         Migration logic (e.g. renaming old keys) is intentionally NOT
-        included here — that belongs in ``Plugin._load_settings()``.
+        included here — that belongs in ``domain/state_migrations.py``.
+        If the ``version`` key is absent the returned dict has ``version: 0``
+        to signal a pre-versioning file to callers.
         """
         settings_path = os.path.join(self._settings_dir, "settings.json")
         try:
@@ -65,6 +95,9 @@ class PersistenceAdapter:
         for key, default in DEFAULT_SETTINGS.items():
             settings.setdefault(key, default)
 
+        # Backfill version=0 to signal pre-versioning file to migration layer
+        settings.setdefault("version", 0)
+
         # Enforce 0600 on settings file (migrate from world-readable 0644)
         if os.path.exists(settings_path):
             current_mode = os.stat(settings_path).st_mode & 0o777
@@ -74,14 +107,10 @@ class PersistenceAdapter:
         return settings
 
     def save_settings(self, data: dict) -> None:
-        """Atomic write of *data* to ``settings.json`` with 0600 permissions."""
-        os.makedirs(self._settings_dir, exist_ok=True)
+        """Atomic write of *data* to ``settings.json`` with flock, stamping version."""
+        data["version"] = _SETTINGS_VERSION
         settings_path = os.path.join(self._settings_dir, "settings.json")
-        tmp_path = settings_path + ".tmp"
-        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2)
-        os.replace(tmp_path, settings_path)
+        self._locked_write(settings_path, data)
 
     # ------------------------------------------------------------------
     # State
@@ -109,80 +138,63 @@ class PersistenceAdapter:
         return state
 
     def save_state(self, data: dict) -> None:
-        """Atomic write of *data* to ``state.json`` with flock."""
-        os.makedirs(self._runtime_dir, exist_ok=True)
+        """Atomic write of *data* to ``state.json`` with flock, stamping version."""
+        data["version"] = _STATE_VERSION
         state_path = os.path.join(self._runtime_dir, "state.json")
-        tmp_path = state_path + ".tmp"
-        lock_fd = os.open(state_path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp_path, state_path)
-        finally:
-            os.close(lock_fd)
+        self._locked_write(state_path, data)
 
     # ------------------------------------------------------------------
     # Metadata cache
     # ------------------------------------------------------------------
 
     def load_metadata_cache(self) -> dict:
-        """Read ``metadata_cache.json`` with version check."""
+        """Read ``metadata_cache.json`` with version check.
+
+        Returns an empty cache dict if the file is missing, corrupt, or
+        has a version mismatch (stale/incompatible schema).
+        """
         cache_path = os.path.join(self._runtime_dir, "metadata_cache.json")
         try:
             with open(cache_path, "r") as f:
                 loaded = json.load(f)
             if not isinstance(loaded, dict):
-                loaded = {}
-            if "version" not in loaded:
-                loaded["version"] = _METADATA_CACHE_VERSION
+                return {"version": _METADATA_CACHE_VERSION}
+            if loaded.get("version") != _METADATA_CACHE_VERSION:
+                return {"version": _METADATA_CACHE_VERSION}
             return loaded
         except (FileNotFoundError, json.JSONDecodeError):
             return {"version": _METADATA_CACHE_VERSION}
 
     def save_metadata_cache(self, data: dict) -> None:
-        """Atomic write of *data* to ``metadata_cache.json`` with flock."""
-        os.makedirs(self._runtime_dir, exist_ok=True)
+        """Atomic write of *data* to ``metadata_cache.json`` with flock, stamping version."""
+        data["version"] = _METADATA_CACHE_VERSION
         cache_path = os.path.join(self._runtime_dir, "metadata_cache.json")
-        tmp_path = cache_path + ".tmp"
-        lock_fd = os.open(cache_path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp_path, cache_path)
-        finally:
-            os.close(lock_fd)
+        self._locked_write(cache_path, data)
 
     # ------------------------------------------------------------------
     # Firmware cache
     # ------------------------------------------------------------------
 
     def load_firmware_cache(self) -> dict:
-        """Read ``firmware_cache.json``."""
+        """Read ``firmware_cache.json`` with version check.
+
+        Returns an empty cache dict if the file is missing, corrupt, or
+        has a version mismatch (stale/incompatible schema).
+        """
         cache_path = os.path.join(self._runtime_dir, "firmware_cache.json")
         try:
             with open(cache_path, "r") as f:
                 loaded = json.load(f)
             if not isinstance(loaded, dict):
-                return {}
+                return {"version": _FIRMWARE_CACHE_VERSION}
+            if loaded.get("version") != _FIRMWARE_CACHE_VERSION:
+                return {"version": _FIRMWARE_CACHE_VERSION}
             return loaded
         except (FileNotFoundError, json.JSONDecodeError):
-            return {}
+            return {"version": _FIRMWARE_CACHE_VERSION}
 
     def save_firmware_cache(self, data: dict) -> None:
-        """Atomic write of *data* to ``firmware_cache.json`` with flock."""
-        os.makedirs(self._runtime_dir, exist_ok=True)
+        """Atomic write of *data* to ``firmware_cache.json`` with flock, stamping version."""
+        data["version"] = _FIRMWARE_CACHE_VERSION
         cache_path = os.path.join(self._runtime_dir, "firmware_cache.json")
-        tmp_path = cache_path + ".tmp"
-        lock_fd = os.open(cache_path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp_path, cache_path)
-        finally:
-            os.close(lock_fd)
+        self._locked_write(cache_path, data)

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -1,0 +1,27 @@
+"""Pure schema-migration functions for plugin state files.
+
+Each function accepts a raw dict (as loaded from disk) and returns
+the same dict promoted to the current schema version.  No I/O —
+reading and writing is the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+
+def migrate_settings(data: dict) -> dict:
+    """Bring *data* from any older settings schema to the current version."""
+    version = data.get("version", 0)
+    if version < 1:
+        # v0 → v1: rename deprecated boolean keys
+        if data.pop("disable_steam_input", None):
+            data["steam_input_mode"] = "force_off"
+        if data.pop("debug_logging", None):
+            data["log_level"] = "debug"
+        data["version"] = 1
+    return data
+
+
+def migrate_state(data: dict) -> dict:
+    """Bring *data* from any older state schema to the current version."""
+    # No migrations at v1 — infrastructure for future changes
+    return data

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -288,17 +288,18 @@ class TestLoadMetadataCache:
 
     def test_loads_from_disk(self, plugin, tmp_path):
         import decky
+        from adapters.persistence import _METADATA_CACHE_VERSION
 
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
 
-        cache_data = {"42": {"summary": "test", "cached_at": 100}}
+        rom_entry = {"summary": "test", "cached_at": 100}
+        cache_data = {"version": _METADATA_CACHE_VERSION, "42": rom_entry}
         cache_path = os.path.join(str(tmp_path), "metadata_cache.json")
         with open(cache_path, "w") as f:
             json.dump(cache_data, f)
 
         plugin._load_metadata_cache()
-        # version key is auto-added during load
-        assert plugin._metadata_cache["42"] == cache_data["42"]
+        assert plugin._metadata_cache["42"] == rom_entry
         assert "version" in plugin._metadata_cache
 
     def test_empty_when_file_missing(self, plugin, tmp_path):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,318 @@
+"""Tests for the PersistenceAdapter: locking, version stamping, and load edge cases."""
+
+import json
+import logging
+import os
+import threading
+
+import pytest
+from adapters.persistence import (
+    _FIRMWARE_CACHE_VERSION,
+    _METADATA_CACHE_VERSION,
+    _SETTINGS_VERSION,
+    _STATE_VERSION,
+    DEFAULT_SETTINGS,
+    PersistenceAdapter,
+)
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_persistence")
+
+
+@pytest.fixture
+def adapter(tmp_path, logger):
+    settings_dir = str(tmp_path / "settings")
+    runtime_dir = str(tmp_path / "runtime")
+    os.makedirs(settings_dir, exist_ok=True)
+    os.makedirs(runtime_dir, exist_ok=True)
+    return PersistenceAdapter(settings_dir=settings_dir, runtime_dir=runtime_dir, logger=logger)
+
+
+# ── Locking tests ──────────────────────────────────────────────────────────────
+
+
+class TestLocking:
+    def test_save_settings_creates_lock_file(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com"})
+        lock_path = os.path.join(adapter._settings_dir, "settings.json.lock")
+        assert os.path.exists(lock_path)
+
+    def test_save_settings_atomic_write(self, adapter):
+        data = {"romm_url": "http://example.com", "romm_user": "testuser"}
+        adapter.save_settings(data)
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path) as f:
+            loaded = json.load(f)
+        assert loaded["romm_url"] == "http://example.com"
+        assert loaded["romm_user"] == "testuser"
+
+    def test_save_state_creates_lock_file(self, adapter):
+        adapter.save_state({"shortcut_registry": {}})
+        lock_path = os.path.join(adapter._runtime_dir, "state.json.lock")
+        assert os.path.exists(lock_path)
+
+    def test_save_metadata_cache_creates_lock_file(self, adapter):
+        adapter.save_metadata_cache({"1": {"title": "Game"}})
+        lock_path = os.path.join(adapter._runtime_dir, "metadata_cache.json.lock")
+        assert os.path.exists(lock_path)
+
+    def test_save_firmware_cache_creates_lock_file(self, adapter):
+        adapter.save_firmware_cache({"snes": {"files": []}})
+        lock_path = os.path.join(adapter._runtime_dir, "firmware_cache.json.lock")
+        assert os.path.exists(lock_path)
+
+    def test_locked_write_concurrent(self, adapter):
+        """Two threads writing simultaneously — final file must be valid JSON."""
+        results = []
+        errors = []
+
+        def write_worker(value):
+            try:
+                adapter.save_settings({"romm_url": f"http://server{value}.com"})
+                results.append(value)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=write_worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Errors during concurrent writes: {errors}"
+        assert len(results) == 10
+
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path) as f:
+            loaded = json.load(f)
+        # The file must be valid JSON with the expected shape
+        assert "romm_url" in loaded
+        assert "version" in loaded
+
+
+# ── Version stamping on save ───────────────────────────────────────────────────
+
+
+class TestVersionStampingOnSave:
+    def test_save_settings_stamps_version(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com"})
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path) as f:
+            loaded = json.load(f)
+        assert loaded["version"] == _SETTINGS_VERSION
+
+    def test_save_state_stamps_version(self, adapter):
+        adapter.save_state({"shortcut_registry": {}})
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path) as f:
+            loaded = json.load(f)
+        assert loaded["version"] == _STATE_VERSION
+
+    def test_save_metadata_cache_stamps_version(self, adapter):
+        adapter.save_metadata_cache({"1": {"title": "Game"}})
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path) as f:
+            loaded = json.load(f)
+        assert loaded["version"] == _METADATA_CACHE_VERSION
+
+    def test_save_firmware_cache_stamps_version(self, adapter):
+        adapter.save_firmware_cache({"snes": {"files": []}})
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path) as f:
+            loaded = json.load(f)
+        assert loaded["version"] == _FIRMWARE_CACHE_VERSION
+
+
+# ── Version mismatch on load — caches discarded ──────────────────────────────
+
+
+class TestVersionMismatchOnLoad:
+    def test_load_metadata_cache_version_mismatch_discards(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"version": 999, "1": {"title": "stale"}}, f)
+        result = adapter.load_metadata_cache()
+        assert result == {"version": _METADATA_CACHE_VERSION}
+        assert "1" not in result
+
+    def test_load_firmware_cache_version_mismatch_discards(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"version": 999, "snes": {"files": []}}, f)
+        result = adapter.load_firmware_cache()
+        assert result == {"version": _FIRMWARE_CACHE_VERSION}
+        assert "snes" not in result
+
+    def test_load_firmware_cache_no_version_discards(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"snes": {"files": []}}, f)
+        result = adapter.load_firmware_cache()
+        assert result == {"version": _FIRMWARE_CACHE_VERSION}
+        assert "snes" not in result
+
+    def test_load_metadata_cache_no_version_discards(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"1": {"title": "stale"}}, f)
+        result = adapter.load_metadata_cache()
+        assert result == {"version": _METADATA_CACHE_VERSION}
+        assert "1" not in result
+
+
+# ── Loading edge cases ─────────────────────────────────────────────────────────
+
+
+class TestLoadingEdgeCases:
+    def test_load_settings_fresh_defaults(self, adapter):
+        result = adapter.load_settings()
+        for key, default_value in DEFAULT_SETTINGS.items():
+            assert result[key] == default_value
+        # Fresh install: no file → version backfilled to 0
+        assert result["version"] == 0
+
+    def test_load_settings_backfills_version_0(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump({"romm_url": "http://example.com"}, f)
+        os.chmod(settings_path, 0o600)
+        result = adapter.load_settings()
+        assert result["version"] == 0
+        assert result["romm_url"] == "http://example.com"
+
+    def test_load_settings_preserves_version(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump({"romm_url": "http://example.com", "version": 1}, f)
+        os.chmod(settings_path, 0o600)
+        result = adapter.load_settings()
+        assert result["version"] == 1
+
+    def test_load_settings_corrupt_json_returns_defaults(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            f.write("NOT_VALID_JSON{{{")
+        result = adapter.load_settings()
+        for key, default_value in DEFAULT_SETTINGS.items():
+            assert result[key] == default_value
+
+    def test_load_settings_applies_defaults_for_missing_keys(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump({"romm_url": "http://custom.com"}, f)
+        os.chmod(settings_path, 0o600)
+        result = adapter.load_settings()
+        assert result["romm_url"] == "http://custom.com"
+        assert result["steam_input_mode"] == "default"
+        assert result["romm_allow_insecure_ssl"] is False
+
+    def test_load_state_merges_defaults(self, adapter):
+        defaults = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None}
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"shortcut_registry": {"1": {"app_id": 123}}, "version": 1}, f)
+        result = adapter.load_state(defaults)
+        assert result["shortcut_registry"] == {"1": {"app_id": 123}}
+        assert result["installed_roms"] == {}
+        assert result["last_sync"] is None
+
+    def test_load_state_backfills_version(self, adapter):
+        defaults = {"shortcut_registry": {}}
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"shortcut_registry": {}}, f)
+        result = adapter.load_state(defaults)
+        assert result["version"] == _STATE_VERSION
+
+    def test_load_state_missing_file_returns_defaults(self, adapter):
+        defaults = {"shortcut_registry": {}, "installed_roms": {}}
+        result = adapter.load_state(defaults)
+        assert result["shortcut_registry"] == {}
+        assert result["installed_roms"] == {}
+        assert result["version"] == _STATE_VERSION
+
+    def test_load_state_corrupt_json_returns_defaults(self, adapter):
+        defaults = {"shortcut_registry": {}}
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path, "w") as f:
+            f.write("CORRUPT{{{")
+        result = adapter.load_state(defaults)
+        assert result["shortcut_registry"] == {}
+
+    def test_load_metadata_cache_missing_file_returns_empty(self, adapter):
+        result = adapter.load_metadata_cache()
+        assert result == {"version": _METADATA_CACHE_VERSION}
+
+    def test_load_firmware_cache_missing_file_returns_empty(self, adapter):
+        result = adapter.load_firmware_cache()
+        assert result == {"version": _FIRMWARE_CACHE_VERSION}
+
+    def test_load_metadata_cache_corrupt_json_returns_empty(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path, "w") as f:
+            f.write("CORRUPT{{{")
+        result = adapter.load_metadata_cache()
+        assert result == {"version": _METADATA_CACHE_VERSION}
+
+    def test_load_firmware_cache_corrupt_json_returns_empty(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path, "w") as f:
+            f.write("CORRUPT{{{")
+        result = adapter.load_firmware_cache()
+        assert result == {"version": _FIRMWARE_CACHE_VERSION}
+
+    def test_load_metadata_cache_valid_version_returns_data(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"version": _METADATA_CACHE_VERSION, "42": {"title": "Game"}}, f)
+        result = adapter.load_metadata_cache()
+        assert result["42"] == {"title": "Game"}
+        assert result["version"] == _METADATA_CACHE_VERSION
+
+    def test_load_firmware_cache_valid_version_returns_data(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump({"version": _FIRMWARE_CACHE_VERSION, "snes": {"files": []}}, f)
+        result = adapter.load_firmware_cache()
+        assert result["snes"] == {"files": []}
+        assert result["version"] == _FIRMWARE_CACHE_VERSION
+
+    def test_load_state_non_dict_json_returns_defaults(self, adapter):
+        defaults = {"shortcut_registry": {}}
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path, "w") as f:
+            json.dump([1, 2, 3], f)
+        result = adapter.load_state(defaults)
+        assert result["shortcut_registry"] == {}
+        assert result["version"] == _STATE_VERSION
+
+    def test_load_metadata_cache_non_dict_json_returns_empty(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump([1, 2, 3], f)
+        result = adapter.load_metadata_cache()
+        assert result == {"version": _METADATA_CACHE_VERSION}
+
+    def test_load_firmware_cache_non_dict_json_returns_empty(self, adapter):
+        cache_path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(cache_path, "w") as f:
+            json.dump([1, 2, 3], f)
+        result = adapter.load_firmware_cache()
+        assert result == {"version": _FIRMWARE_CACHE_VERSION}
+
+    def test_load_settings_fixes_permissions(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump({"romm_url": "http://example.com"}, f)
+        os.chmod(settings_path, 0o644)
+        adapter.load_settings()
+        mode = os.stat(settings_path).st_mode & 0o777
+        assert mode == 0o600
+
+    def test_save_settings_sets_permissions(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com"})
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        mode = os.stat(settings_path).st_mode & 0o777
+        assert mode == 0o600

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -245,28 +245,33 @@ class TestLogLevel:
 
     def test_migration_debug_logging_true(self, plugin, tmp_path):
         """Old debug_logging=True migrates to log_level='debug'."""
-        import decky
+        import logging
 
-        decky.DECKY_PLUGIN_SETTINGS_DIR = str(tmp_path)
-        # Write old-format settings
+        from adapters.persistence import PersistenceAdapter
+        from domain.state_migrations import migrate_settings
+
         settings_path = os.path.join(str(tmp_path), "settings.json")
         os.makedirs(str(tmp_path), exist_ok=True)
         with open(settings_path, "w") as f:
             json.dump({"debug_logging": True, "romm_url": ""}, f)
-        plugin._load_settings()
+        persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), logging.getLogger("test"))
+        plugin.settings = migrate_settings(persistence.load_settings())
         assert "debug_logging" not in plugin.settings
         assert plugin.settings["log_level"] == "debug"
 
     def test_migration_debug_logging_false(self, plugin, tmp_path):
         """Old debug_logging=False migrates to log_level='warn' (default)."""
-        import decky
+        import logging
 
-        decky.DECKY_PLUGIN_SETTINGS_DIR = str(tmp_path)
+        from adapters.persistence import PersistenceAdapter
+        from domain.state_migrations import migrate_settings
+
         settings_path = os.path.join(str(tmp_path), "settings.json")
         os.makedirs(str(tmp_path), exist_ok=True)
         with open(settings_path, "w") as f:
             json.dump({"debug_logging": False, "romm_url": ""}, f)
-        plugin._load_settings()
+        persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), logging.getLogger("test"))
+        plugin.settings = migrate_settings(persistence.load_settings())
         assert "debug_logging" not in plugin.settings
         assert plugin.settings["log_level"] == "warn"
 
@@ -307,14 +312,16 @@ class TestLogLevel:
 
 class TestInsecureSslSetting:
     def test_load_settings_defaults_false(self, plugin, tmp_path):
-        import decky
+        import logging
 
-        decky.DECKY_PLUGIN_SETTINGS_DIR = str(tmp_path)
+        from adapters.persistence import PersistenceAdapter
+
         settings_path = os.path.join(str(tmp_path), "settings.json")
         os.makedirs(str(tmp_path), exist_ok=True)
         with open(settings_path, "w") as f:
             json.dump({"romm_url": "https://romm.local"}, f)
-        plugin._load_settings()
+        persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), logging.getLogger("test"))
+        plugin.settings = persistence.load_settings()
         assert plugin.settings["romm_allow_insecure_ssl"] is False
 
     @pytest.mark.asyncio
@@ -368,9 +375,10 @@ class TestSettingsFilePermissions:
         assert mode == 0o600
 
     def test_load_settings_fixes_permissions(self, plugin, tmp_path):
-        import decky
+        import logging
 
-        decky.DECKY_PLUGIN_SETTINGS_DIR = str(tmp_path)
+        from adapters.persistence import PersistenceAdapter
+
         settings_path = tmp_path / "settings.json"
         import json as _json
 
@@ -378,7 +386,8 @@ class TestSettingsFilePermissions:
             _json.dump({"romm_url": "http://example.com"}, f)
         os.chmod(settings_path, 0o644)
         assert os.stat(settings_path).st_mode & 0o777 == 0o644
-        plugin._load_settings()
+        persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), logging.getLogger("test"))
+        persistence.load_settings()
         assert os.stat(settings_path).st_mode & 0o777 == 0o600
 
 

--- a/tests/test_state_migrations.py
+++ b/tests/test_state_migrations.py
@@ -1,0 +1,108 @@
+"""Tests for domain/state_migrations.py — pure migration functions."""
+
+from domain.state_migrations import migrate_settings, migrate_state
+
+
+class TestMigrateSettings:
+    def test_migrate_settings_v0_disable_steam_input_true(self):
+        data = {"version": 0, "disable_steam_input": True}
+        result = migrate_settings(data)
+        assert result["steam_input_mode"] == "force_off"
+        assert "disable_steam_input" not in result
+        assert result["version"] == 1
+
+    def test_migrate_settings_v0_disable_steam_input_false(self):
+        data = {"version": 0, "disable_steam_input": False}
+        result = migrate_settings(data)
+        assert "disable_steam_input" not in result
+        assert "steam_input_mode" not in result  # False → no override set
+        assert result["version"] == 1
+
+    def test_migrate_settings_v0_debug_logging_true(self):
+        data = {"version": 0, "debug_logging": True}
+        result = migrate_settings(data)
+        assert result["log_level"] == "debug"
+        assert "debug_logging" not in result
+        assert result["version"] == 1
+
+    def test_migrate_settings_v0_debug_logging_false(self):
+        data = {"version": 0, "debug_logging": False}
+        result = migrate_settings(data)
+        assert "debug_logging" not in result
+        assert "log_level" not in result  # False → no log_level override set
+        assert result["version"] == 1
+
+    def test_migrate_settings_v0_both_deprecated(self):
+        data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
+        result = migrate_settings(data)
+        assert result["steam_input_mode"] == "force_off"
+        assert result["log_level"] == "debug"
+        assert "disable_steam_input" not in result
+        assert "debug_logging" not in result
+        assert result["version"] == 1
+
+    def test_migrate_settings_v0_no_deprecated_keys(self):
+        data = {"version": 0, "romm_url": "http://example.com"}
+        result = migrate_settings(data)
+        assert result["romm_url"] == "http://example.com"
+        assert result["version"] == 1
+
+    def test_migrate_settings_v1_no_change(self):
+        data = {"version": 1, "romm_url": "http://example.com", "log_level": "warn"}
+        result = migrate_settings(data)
+        assert result == {"version": 1, "romm_url": "http://example.com", "log_level": "warn"}
+
+    def test_migrate_settings_fresh_empty(self):
+        data = {}
+        result = migrate_settings(data)
+        assert result["version"] == 1
+        assert "disable_steam_input" not in result
+        assert "debug_logging" not in result
+
+    def test_migrate_settings_missing_version_treated_as_v0(self):
+        data = {"romm_url": "http://example.com", "disable_steam_input": True}
+        result = migrate_settings(data)
+        assert result["steam_input_mode"] == "force_off"
+        assert result["version"] == 1
+
+    def test_migrate_settings_debug_logging_true_overrides_log_level(self):
+        """When debug_logging=True is being migrated, log_level is set to 'debug' unconditionally.
+
+        This handles the case where load_settings() has already applied the 'warn'
+        default before migration runs — the migration must win.
+        """
+        data = {"version": 0, "debug_logging": True, "log_level": "warn"}
+        result = migrate_settings(data)
+        assert result["log_level"] == "debug"
+        assert "debug_logging" not in result
+        assert result["version"] == 1
+
+    def test_migrate_settings_idempotent(self):
+        data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
+        result1 = migrate_settings(data.copy())
+        result2 = migrate_settings(result1.copy())
+        assert result1 == result2
+
+
+class TestMigrateState:
+    def test_migrate_state_passthrough(self):
+        data = {"version": 1, "shortcut_registry": {"1": {"app_id": 123}}}
+        result = migrate_state(data)
+        assert result is data  # returns same object unchanged
+
+    def test_migrate_state_empty_dict(self):
+        data = {}
+        result = migrate_state(data)
+        assert result == {}
+
+    def test_migrate_state_preserves_all_keys(self):
+        data = {
+            "version": 1,
+            "shortcut_registry": {},
+            "installed_roms": {},
+            "last_sync": "2024-01-01T00:00:00",
+            "sync_stats": {"platforms": 3, "roms": 42},
+        }
+        result = migrate_state(data)
+        assert result["sync_stats"]["roms"] == 42
+        assert result["last_sync"] == "2024-01-01T00:00:00"


### PR DESCRIPTION
## Summary

- Adds `fcntl.flock` to `save_settings()` — was the only unprotected write path (#120)
- Extracts `_locked_write()` helper to DRY the 4 identical lock+atomic-write patterns
- Adds schema version constants and stamping for `settings.json` and `firmware_cache.json` (#121)
- Discards caches on version mismatch (`metadata_cache`, `firmware_cache`) — rebuilt from server
- Creates `domain/state_migrations.py` with pure migration functions (Cosmic Python domain layer)
- Moves ad-hoc settings migration from `Plugin._load_settings()` into version-based flow
- Restructures `Plugin._main()` into 6 clearly separated sections
- Adds tmp file cleanup on write failure in `_locked_write()`

Closes #120
Closes #121

## Test plan

- [x] `python -m pytest tests/ -q` — 1099 passed (45 new tests)
- [x] `ruff check` — all checks passed
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 5 contracts kept, 0 broken