### PR TITLE
refactor(domain): extract BIOS status computation from FirmwareService (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ py_modules/
         v47.py                            # SaveApiV47 — RomM 4.7.0 save API adapter
   models/                                 # Domain dataclasses (currently empty — types inlined in services)
   domain/
-    bios.py                               # BIOS status formatting for game detail page
+    bios.py                               # BIOS status formatting and computation
     es_de_config.py                       # CoreResolver + GamelistXmlEditor classes (core resolution, gamelist.xml)
     retrodeck_config.py                   # RetroDECK path resolution (roms, saves, BIOS, states)
     state_migrations.py                   # Schema migration functions for state files

--- a/py_modules/domain/bios.py
+++ b/py_modules/domain/bios.py
@@ -1,4 +1,4 @@
-"""Pure BIOS-status formatting for the game detail page."""
+"""Pure BIOS-status formatting and computation for the game detail page."""
 
 from __future__ import annotations
 
@@ -17,3 +17,87 @@ def format_bios_status(bios: dict, platform_slug: str) -> dict:
         "active_core_label": bios.get("active_core_label"),
         "available_cores": bios.get("available_cores", []),
     }
+
+
+def classify_firmware_file(
+    reg_entry: dict | None,
+    file_name: str,
+    active_core_so: str | None,
+) -> tuple[bool, str, str]:
+    """Classify a firmware file as required/optional/unknown based on active core.
+
+    Returns (is_required, classification, description).
+    """
+    if active_core_so and reg_entry and "cores" in reg_entry:
+        if active_core_so in reg_entry["cores"]:
+            is_required = reg_entry["cores"][active_core_so]["required"]
+        else:
+            is_required = False
+        description = reg_entry.get("description", file_name)
+        classification = "required" if is_required else "optional"
+    elif reg_entry:
+        is_required = reg_entry.get("required", True)
+        classification = "required" if is_required else "optional"
+        description = reg_entry.get("description", file_name)
+    else:
+        is_required = False
+        classification = "unknown"
+        description = file_name
+    return is_required, classification, description
+
+
+def build_cores_info(reg_entry: dict | None) -> dict:
+    """Build per-core info dict for frontend display."""
+    if not reg_entry or "cores" not in reg_entry:
+        return {}
+    return {
+        core_so_key: {"required": core_data.get("required", True)}
+        for core_so_key, core_data in reg_entry["cores"].items()
+    }
+
+
+def is_used_by_active_core(reg_entry: dict | None, active_core_so: str | None) -> bool:
+    """Check if a firmware file is used by the active core."""
+    if not active_core_so or not reg_entry or "cores" not in reg_entry:
+        return True
+    return active_core_so in reg_entry["cores"]
+
+
+def build_file_entry(
+    file_name: str,
+    downloaded: bool,
+    dest: str,
+    reg_entry: dict | None,
+    active_core_so: str | None,
+) -> dict:
+    """Build a single file status entry dict."""
+    is_required, classification, description = classify_firmware_file(reg_entry, file_name, active_core_so)
+    return {
+        "file_name": file_name,
+        "downloaded": downloaded,
+        "local_path": dest,
+        "required": is_required,
+        "description": description,
+        "classification": classification,
+        "cores": build_cores_info(reg_entry),
+        "used_by_active": is_used_by_active_core(reg_entry, active_core_so),
+    }
+
+
+def collect_firmware_status(
+    items: list[dict],
+    registry_platform: dict,
+    active_core_so: str | None,
+) -> list[dict]:
+    """Build file entry dicts for a list of pre-resolved firmware items.
+
+    Each item must have keys: file_name, downloaded, dest.
+    Looks up reg_entry from registry_platform by file_name and calls
+    build_file_entry for each item.
+    """
+    files = []
+    for item in items:
+        file_name = item["file_name"]
+        reg_entry = registry_platform.get(file_name)
+        files.append(build_file_entry(file_name, item["downloaded"], item["dest"], reg_entry, active_core_so))
+    return files

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from domain import es_de_config, retrodeck_config
+from domain.bios import collect_firmware_status
 
 from lib.errors import error_response
 
@@ -219,7 +220,16 @@ class FirmwareService:
         for slug in fw_slugs:
             registry_platform.update(self._bios_registry.get("platforms", {}).get(slug, {}))
 
-        files = self._collect_server_firmware(self._firmware_cache, fw_slugs, registry_platform, active_core_so)
+        items = [
+            {
+                "file_name": fw.get("file_name", ""),
+                "downloaded": os.path.exists(self._firmware_dest_path(fw)),
+                "dest": self._firmware_dest_path(fw),
+            }
+            for fw in self._firmware_cache
+            if self._firmware_slug(fw.get("file_path", "")) in fw_slugs
+        ]
+        files = collect_firmware_status(items, registry_platform, active_core_so)
 
         if not files:
             return {"needs_bios": False, "cached_at": self._firmware_cache_epoch}
@@ -481,79 +491,6 @@ class FirmwareService:
             msg += f" ({len(errors)} failed: {', '.join(errors)})"
         return {"success": True, "message": msg, "downloaded": downloaded}
 
-    def _classify_firmware_file(self, reg_entry, file_name, active_core_so):
-        """Classify a firmware file as required/optional/unknown based on active core."""
-        if active_core_so and reg_entry and "cores" in reg_entry:
-            if active_core_so in reg_entry["cores"]:
-                is_required = reg_entry["cores"][active_core_so]["required"]
-            else:
-                is_required = False
-            description = reg_entry.get("description", file_name)
-            classification = "required" if is_required else "optional"
-        elif reg_entry:
-            is_required = reg_entry.get("required", True)
-            classification = "required" if is_required else "optional"
-            description = reg_entry.get("description", file_name)
-        else:
-            is_required = False
-            classification = "unknown"
-            description = file_name
-        return is_required, classification, description
-
-    def _build_cores_info(self, reg_entry):
-        """Build per-core info dict for frontend display."""
-        if not reg_entry or "cores" not in reg_entry:
-            return {}
-        return {
-            core_so_key: {"required": core_data.get("required", True)}
-            for core_so_key, core_data in reg_entry["cores"].items()
-        }
-
-    def _is_used_by_active_core(self, reg_entry, active_core_so):
-        """Check if a firmware file is used by the active core."""
-        if not active_core_so or not reg_entry or "cores" not in reg_entry:
-            return True
-        return active_core_so in reg_entry["cores"]
-
-    def _build_file_entry(self, file_name, downloaded, dest, reg_entry, active_core_so):
-        """Build a single file status entry dict."""
-        is_required, classification, description = self._classify_firmware_file(reg_entry, file_name, active_core_so)
-        return {
-            "file_name": file_name,
-            "downloaded": downloaded,
-            "local_path": dest,
-            "required": is_required,
-            "description": description,
-            "classification": classification,
-            "cores": self._build_cores_info(reg_entry),
-            "used_by_active": self._is_used_by_active_core(reg_entry, active_core_so),
-        }
-
-    def _collect_server_firmware(self, firmware_list, fw_slugs, registry_platform, active_core_so):
-        """Collect file entries from server firmware list."""
-        files = []
-        for fw in firmware_list:
-            fw_slug = self._firmware_slug(fw.get("file_path", ""))
-            if not fw_slug or fw_slug not in fw_slugs:
-                continue
-            file_name = fw.get("file_name", "")
-            reg_entry = registry_platform.get(file_name)
-            dest = self._firmware_dest_path(fw)
-            downloaded = os.path.exists(dest)
-            files.append(self._build_file_entry(file_name, downloaded, dest, reg_entry, active_core_so))
-        return files
-
-    def _collect_registry_firmware(self, registry_platform, active_core_so):
-        """Collect file entries from registry (offline fallback)."""
-        bios_base = retrodeck_config.get_bios_path()
-        files = []
-        for file_name, reg_entry in registry_platform.items():
-            firmware_path = reg_entry.get("firmware_path", file_name)
-            dest = os.path.join(bios_base, firmware_path)
-            downloaded = os.path.exists(dest)
-            files.append(self._build_file_entry(file_name, downloaded, dest, reg_entry, active_core_so))
-        return files
-
     async def check_platform_bios(self, platform_slug, rom_filename=None):
         """Check if RomM has firmware for this platform and whether it's downloaded."""
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
@@ -566,11 +503,29 @@ class FirmwareService:
 
         try:
             firmware_list = await self._loop.run_in_executor(None, self._get_firmware_list)
-            files = self._collect_server_firmware(firmware_list, fw_slugs, registry_platform, active_core_so)
+            items = [
+                {
+                    "file_name": fw.get("file_name", ""),
+                    "downloaded": os.path.exists(self._firmware_dest_path(fw)),
+                    "dest": self._firmware_dest_path(fw),
+                }
+                for fw in firmware_list
+                if self._firmware_slug(fw.get("file_path", "")) in fw_slugs
+            ]
+            files = collect_firmware_status(items, registry_platform, active_core_so)
         except Exception:
             if not registry_platform:
                 return {"needs_bios": False}
-            files = self._collect_registry_firmware(registry_platform, active_core_so)
+            bios_base = retrodeck_config.get_bios_path()
+            registry_items = [
+                {
+                    "file_name": file_name,
+                    "downloaded": os.path.exists(os.path.join(bios_base, reg_entry.get("firmware_path", file_name))),
+                    "dest": os.path.join(bios_base, reg_entry.get("firmware_path", file_name)),
+                }
+                for file_name, reg_entry in registry_platform.items()
+            ]
+            files = collect_firmware_status(registry_items, registry_platform, active_core_so)
 
         if not files:
             return {"needs_bios": False}

--- a/tests/test_bios_domain.py
+++ b/tests/test_bios_domain.py
@@ -1,6 +1,13 @@
-"""Tests for domain.bios.format_bios_status."""
+"""Tests for domain.bios pure functions."""
 
-from domain.bios import format_bios_status
+from domain.bios import (
+    build_cores_info,
+    build_file_entry,
+    classify_firmware_file,
+    collect_firmware_status,
+    format_bios_status,
+    is_used_by_active_core,
+)
 
 
 class TestFormatBiosStatusFullDict:
@@ -102,3 +109,247 @@ class TestFormatBiosStatusNeedsBiosContext:
         bios = {"needs_bios": True, "server_count": 1}
         result = format_bios_status(bios, "gba")
         assert "needs_bios" not in result
+
+
+class TestClassifyFirmwareFile:
+    """Tests for classify_firmware_file pure function."""
+
+    def test_active_core_with_per_core_entry_required(self):
+        """Active core that requires the file returns required=True."""
+        reg_entry = {
+            "description": "GBA BIOS",
+            "required": True,
+            "cores": {"gpsp_libretro.so": {"required": True}, "mgba_libretro.so": {"required": False}},
+        }
+        is_required, classification, description = classify_firmware_file(reg_entry, "gba_bios.bin", "gpsp_libretro.so")
+        assert is_required is True
+        assert classification == "required"
+        assert description == "GBA BIOS"
+
+    def test_active_core_with_per_core_entry_optional(self):
+        """Active core that marks file optional returns required=False."""
+        reg_entry = {
+            "description": "GBA BIOS",
+            "required": True,
+            "cores": {"gpsp_libretro.so": {"required": True}, "mgba_libretro.so": {"required": False}},
+        }
+        is_required, classification, description = classify_firmware_file(reg_entry, "gba_bios.bin", "mgba_libretro.so")
+        assert is_required is False
+        assert classification == "optional"
+        assert description == "GBA BIOS"
+
+    def test_active_core_not_in_cores_dict(self):
+        """Active core absent from cores dict yields required=False."""
+        reg_entry = {
+            "description": "Some BIOS",
+            "required": True,
+            "cores": {"known_core.so": {"required": True}},
+        }
+        is_required, classification, description = classify_firmware_file(reg_entry, "some.bin", "unknown_core.so")
+        assert is_required is False
+        assert classification == "optional"
+
+    def test_no_active_core_uses_toplevel_required(self):
+        """Without active core, top-level required value is used."""
+        reg_entry = {"description": "DC BIOS", "required": True}
+        is_required, classification, description = classify_firmware_file(reg_entry, "dc_boot.bin", None)
+        assert is_required is True
+        assert classification == "required"
+        assert description == "DC BIOS"
+
+    def test_no_active_core_toplevel_optional(self):
+        """Without active core, top-level required=False yields optional."""
+        reg_entry = {"description": "DC Flash", "required": False}
+        is_required, classification, description = classify_firmware_file(reg_entry, "dc_flash.bin", None)
+        assert is_required is False
+        assert classification == "optional"
+
+    def test_no_reg_entry_yields_unknown(self):
+        """File not in registry yields unknown classification."""
+        is_required, classification, description = classify_firmware_file(None, "mystery.bin", None)
+        assert is_required is False
+        assert classification == "unknown"
+        assert description == "mystery.bin"
+
+    def test_no_reg_entry_with_active_core_yields_unknown(self):
+        """File not in registry with active core still yields unknown."""
+        is_required, classification, description = classify_firmware_file(None, "alien.bin", "some_core.so")
+        assert is_required is False
+        assert classification == "unknown"
+        assert description == "alien.bin"
+
+    def test_description_falls_back_to_file_name(self):
+        """reg_entry without description falls back to file_name."""
+        reg_entry = {"required": True}
+        _, _, description = classify_firmware_file(reg_entry, "bios.bin", None)
+        assert description == "bios.bin"
+
+
+class TestBuildCoresInfo:
+    """Tests for build_cores_info pure function."""
+
+    def test_with_cores_data_returns_formatted_dict(self):
+        """reg_entry with cores key produces per-core required dict."""
+        reg_entry = {
+            "cores": {
+                "mgba_libretro.so": {"required": False},
+                "gpsp_libretro.so": {"required": True},
+            }
+        }
+        result = build_cores_info(reg_entry)
+        assert result == {
+            "mgba_libretro.so": {"required": False},
+            "gpsp_libretro.so": {"required": True},
+        }
+
+    def test_no_reg_entry_returns_empty_dict(self):
+        """None reg_entry returns empty dict."""
+        assert build_cores_info(None) == {}
+
+    def test_reg_entry_without_cores_key_returns_empty_dict(self):
+        """reg_entry missing cores key returns empty dict."""
+        reg_entry = {"description": "Some BIOS", "required": True}
+        assert build_cores_info(reg_entry) == {}
+
+    def test_core_missing_required_defaults_to_true(self):
+        """Core entry without required key defaults to True."""
+        reg_entry = {"cores": {"some_core.so": {}}}
+        result = build_cores_info(reg_entry)
+        assert result["some_core.so"]["required"] is True
+
+
+class TestIsUsedByActiveCore:
+    """Tests for is_used_by_active_core pure function."""
+
+    def test_no_active_core_returns_true(self):
+        """No active core — file is considered used by all."""
+        reg_entry = {"cores": {"mgba_libretro.so": {"required": False}}}
+        assert is_used_by_active_core(reg_entry, None) is True
+
+    def test_no_reg_entry_returns_true(self):
+        """No registry entry — unknown file, considered used."""
+        assert is_used_by_active_core(None, "mgba_libretro.so") is True
+
+    def test_reg_entry_without_cores_returns_true(self):
+        """Registry entry without cores key — file used by all cores."""
+        reg_entry = {"description": "DC BIOS", "required": True}
+        assert is_used_by_active_core(reg_entry, "some_core.so") is True
+
+    def test_active_core_in_cores_returns_true(self):
+        """Active core present in cores dict — file is used by it."""
+        reg_entry = {"cores": {"mgba_libretro.so": {"required": False}}}
+        assert is_used_by_active_core(reg_entry, "mgba_libretro.so") is True
+
+    def test_active_core_not_in_cores_returns_false(self):
+        """Active core not in cores dict — file not used by it."""
+        reg_entry = {"cores": {"gpsp_libretro.so": {"required": True}}}
+        assert is_used_by_active_core(reg_entry, "mgba_libretro.so") is False
+
+
+class TestBuildFileEntry:
+    """Tests for build_file_entry pure function."""
+
+    def test_full_entry_with_reg_entry(self):
+        """Full entry is built correctly when reg_entry is present."""
+        reg_entry = {
+            "description": "Dreamcast BIOS",
+            "required": True,
+            "cores": {"dc_libretro.so": {"required": True}},
+        }
+        result = build_file_entry("dc_boot.bin", True, "/bios/dc/dc_boot.bin", reg_entry, None)
+        assert result["file_name"] == "dc_boot.bin"
+        assert result["downloaded"] is True
+        assert result["local_path"] == "/bios/dc/dc_boot.bin"
+        assert result["required"] is True
+        assert result["description"] == "Dreamcast BIOS"
+        assert result["classification"] == "required"
+        assert result["cores"] == {"dc_libretro.so": {"required": True}}
+        assert result["used_by_active"] is True
+
+    def test_no_reg_entry_yields_unknown(self):
+        """Without reg_entry, classification is unknown and required is False."""
+        result = build_file_entry("mystery.bin", False, "/bios/mystery.bin", None, None)
+        assert result["file_name"] == "mystery.bin"
+        assert result["downloaded"] is False
+        assert result["required"] is False
+        assert result["classification"] == "unknown"
+        assert result["description"] == "mystery.bin"
+        assert result["cores"] == {}
+        assert result["used_by_active"] is True
+
+    def test_downloaded_false_reflected(self):
+        """downloaded=False is reflected in the entry."""
+        reg_entry = {"description": "BIOS", "required": True}
+        result = build_file_entry("bios.bin", False, "/bios/bios.bin", reg_entry, None)
+        assert result["downloaded"] is False
+
+    def test_downloaded_true_reflected(self):
+        """downloaded=True is reflected in the entry."""
+        reg_entry = {"description": "BIOS", "required": True}
+        result = build_file_entry("bios.bin", True, "/bios/bios.bin", reg_entry, None)
+        assert result["downloaded"] is True
+
+    def test_active_core_not_in_cores_marks_not_used(self):
+        """File with cores dict where active_core is absent has used_by_active=False."""
+        reg_entry = {
+            "description": "GBA BIOS",
+            "required": True,
+            "cores": {"gpsp_libretro.so": {"required": True}},
+        }
+        result = build_file_entry("gba_bios.bin", False, "/bios/gba_bios.bin", reg_entry, "mgba_libretro.so")
+        assert result["used_by_active"] is False
+        assert result["required"] is False
+        assert result["classification"] == "optional"
+
+
+class TestCollectFirmwareStatus:
+    """Tests for collect_firmware_status pure function."""
+
+    def test_multiple_items_mix_of_registered_and_unknown(self):
+        """Mix of known and unknown files produces correct entries."""
+        registry_platform = {
+            "known.bin": {"description": "Known BIOS", "required": True},
+        }
+        items = [
+            {"file_name": "known.bin", "downloaded": True, "dest": "/bios/known.bin"},
+            {"file_name": "unknown.bin", "downloaded": False, "dest": "/bios/unknown.bin"},
+        ]
+        result = collect_firmware_status(items, registry_platform, None)
+        assert len(result) == 2
+
+        known = next(f for f in result if f["file_name"] == "known.bin")
+        unknown = next(f for f in result if f["file_name"] == "unknown.bin")
+
+        assert known["classification"] == "required"
+        assert known["downloaded"] is True
+        assert unknown["classification"] == "unknown"
+        assert unknown["downloaded"] is False
+
+    def test_empty_items_returns_empty_list(self):
+        """No items produces empty result."""
+        result = collect_firmware_status([], {"some.bin": {"required": True}}, None)
+        assert result == []
+
+    def test_registry_platform_lookup_by_file_name(self):
+        """reg_entry is looked up from registry_platform by file_name."""
+        registry_platform = {
+            "bios.bin": {"description": "My BIOS", "required": False},
+        }
+        items = [{"file_name": "bios.bin", "downloaded": False, "dest": "/bios/bios.bin"}]
+        result = collect_firmware_status(items, registry_platform, None)
+        assert result[0]["classification"] == "optional"
+        assert result[0]["description"] == "My BIOS"
+
+    def test_active_core_forwarded_to_classify(self):
+        """active_core_so is passed through to per-core classification."""
+        registry_platform = {
+            "gba_bios.bin": {
+                "description": "GBA BIOS",
+                "required": True,
+                "cores": {"mgba_libretro.so": {"required": False}},
+            }
+        }
+        items = [{"file_name": "gba_bios.bin", "downloaded": False, "dest": "/bios/gba_bios.bin"}]
+        result = collect_firmware_status(items, registry_platform, "mgba_libretro.so")
+        assert result[0]["required"] is False
+        assert result[0]["classification"] == "optional"


### PR DESCRIPTION
## Summary

- Extracts 6 BIOS status computation methods from `FirmwareService` into pure functions in `domain/bios.py`
- New domain functions: `classify_firmware_file`, `build_cores_info`, `is_used_by_active_core`, `build_file_entry`, `collect_firmware_status`
- `collect_firmware_status` unifies the old `_collect_server_firmware` and `_collect_registry_firmware` into one function
- FirmwareService stays as orchestrator: handles I/O (slug filtering, dest path resolution, file existence checks) then delegates to domain
- All existing integration tests pass unchanged

Closes #114

## Test plan

- [x] `python -m pytest tests/ -q` — 1133 passed (34 new domain function tests)
- [x] `ruff check` — all checks passed
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 5 contracts kept, 0 broken