### PR TITLE
refactor(domain): extract save conflict detection (#111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ py_modules/
     bios.py                               # BIOS status formatting for game detail page
     es_de_config.py                       # CoreResolver + GamelistXmlEditor classes (core resolution, gamelist.xml)
     retrodeck_config.py                   # RetroDECK path resolution (roms, saves, BIOS, states)
+    save_conflicts.py                     # Save file conflict detection and resolution logic
     state_migrations.py                   # Schema migration functions for state files
   lib/
     errors.py                             # Exception hierarchy (RommApiError, classify_error)
@@ -95,7 +96,7 @@ src/
   utils/                                  # Shortcut management, sync, downloads, collections, sessions
 bin/romm-launcher                         # Bash launcher for RetroDECK
 defaults/config.json                      # 149 platform slug → RetroDECK system mappings
-tests/test_*.py                           # Per-module backend tests (951 tests)
+tests/test_*.py                           # Per-module backend tests (1150 tests)
 tests/conftest.py                         # Mock decky module for test isolation
 ```
 

--- a/py_modules/domain/save_conflicts.py
+++ b/py_modules/domain/save_conflicts.py
@@ -1,0 +1,221 @@
+"""Pure save-file conflict detection and resolution logic.
+
+No I/O, no service/adapter/lib imports. All functions are stateless and
+operate only on the values passed to them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def check_local_changes(local_hash: str | None, last_sync_hash: str) -> bool:
+    """Return True if the local file has changed since the last sync.
+
+    Parameters
+    ----------
+    local_hash:
+        MD5 hex digest of the current local file (may be empty/None if missing).
+    last_sync_hash:
+        MD5 hex digest recorded at the last successful sync.
+    """
+    return local_hash != last_sync_hash
+
+
+def check_server_changes_fast(
+    file_state: dict,
+    server_save: dict,
+    last_sync_hash: str,
+) -> bool | None:
+    """Fast-path server-change detection using stored timestamp and size.
+
+    Returns
+    -------
+    False
+        Server is definitely unchanged (timestamp+size match AND last_sync_hash
+        is present so we have a valid baseline to compare against).
+    True
+        Server has definitely changed (size differs on a timestamp-matched save).
+    None
+        Indeterminate — timestamp changed (or no stored timestamp); the caller
+        must fall back to a slow-path hash comparison.
+    """
+    stored_updated_at = file_state.get("last_sync_server_updated_at")
+    stored_size = file_state.get("last_sync_server_size")
+    server_updated_at = server_save.get("updated_at", "")
+    server_size = server_save.get("file_size_bytes")
+
+    # Fast path: timestamp unchanged
+    if stored_updated_at and server_updated_at == stored_updated_at:
+        if stored_size is not None and server_size is not None and server_size != stored_size:
+            return True  # size changed despite same timestamp
+        return False  # unchanged
+
+    # Timestamp changed or no stored timestamp — indeterminate without hash
+    return None
+
+
+def determine_action(local_changed: bool, server_changed: bool) -> str:
+    """Decide the sync action from local and server change flags.
+
+    Returns
+    -------
+    str
+        One of ``"skip"``, ``"upload"``, ``"download"``, or ``"conflict"``.
+    """
+    if not local_changed and not server_changed:
+        return "skip"
+    if not local_changed:
+        return "download"
+    if not server_changed:
+        return "upload"
+    return "conflict"
+
+
+def detect_conflict_lightweight(
+    local_mtime: float,
+    local_size: int,
+    server_save: dict | None,
+    file_state: dict,
+) -> str:
+    """Timestamp-only conflict detection — no file hashing, no server downloads.
+
+    Parameters
+    ----------
+    local_mtime:
+        Modification time of the local save file (seconds since epoch).
+    local_size:
+        Size of the local save file in bytes.
+    server_save:
+        Server save metadata dict, or ``None`` if no server save exists.
+    file_state:
+        Per-file sync state from ``save_sync_state["saves"][rom_id]["files"][filename]``.
+
+    Returns
+    -------
+    str
+        One of ``"skip"``, ``"upload"``, ``"download"``, or ``"conflict"``.
+    """
+    last_sync_hash = file_state.get("last_sync_hash")
+
+    # Never synced — can't determine state without hashing
+    if not last_sync_hash:
+        return "conflict" if server_save else "upload"
+
+    # Local change: compare mtime against stored sync mtime
+    stored_local_mtime = file_state.get("last_sync_local_mtime")
+    if stored_local_mtime is not None:
+        local_changed = abs(local_mtime - stored_local_mtime) > 1.0
+    else:
+        # No stored mtime — fall back to size comparison
+        stored_local_size = file_state.get("last_sync_local_size")
+        local_changed = stored_local_size is not None and local_size != stored_local_size
+
+    # Server change detection
+    server_changed = False
+    if server_save:
+        stored_updated_at = file_state.get("last_sync_server_updated_at")
+        stored_size = file_state.get("last_sync_server_size")
+        server_updated_at = server_save.get("updated_at", "")
+        server_size = server_save.get("file_size_bytes")
+
+        if (stored_updated_at and server_updated_at != stored_updated_at) or (
+            stored_size is not None and server_size is not None and server_size != stored_size
+        ):
+            server_changed = True
+
+    return determine_action(local_changed, server_changed)
+
+
+def resolve_conflict_by_mode(
+    mode: str,
+    local_mtime: float,
+    server_save: dict,
+    tolerance: float = 60.0,
+) -> str:
+    """Apply a conflict resolution mode.
+
+    Parameters
+    ----------
+    mode:
+        One of ``"ask_me"``, ``"always_upload"``, ``"always_download"``,
+        or ``"newest_wins"``.
+    local_mtime:
+        Modification time of the local save file (seconds since epoch).
+    server_save:
+        Server save metadata dict (needs ``"updated_at"`` ISO-8601 string).
+    tolerance:
+        Clock-skew tolerance in seconds used by ``"newest_wins"`` mode.
+        Defaults to ``60``.
+
+    Returns
+    -------
+    str
+        One of ``"upload"``, ``"download"``, or ``"ask"``.
+    """
+    if mode == "always_upload":
+        return "upload"
+    if mode == "always_download":
+        return "download"
+    if mode == "ask_me":
+        return "ask"
+
+    # newest_wins (default fallback for unrecognised modes too)
+    server_updated = server_save.get("updated_at", "")
+    try:
+        server_dt = datetime.fromisoformat(server_updated.replace("Z", "+00:00"))
+        local_dt = datetime.fromtimestamp(local_mtime, tz=timezone.utc)
+        diff = abs((local_dt - server_dt).total_seconds())
+        if diff <= tolerance:
+            return "ask"
+        return "upload" if local_dt > server_dt else "download"
+    except (ValueError, TypeError):
+        return "ask"
+
+
+def build_conflict_dict(
+    rom_id: int,
+    filename: str,
+    local_info: dict | None,
+    local_hash: str | None,
+    server_save: dict,
+) -> dict:
+    """Build a conflict descriptor for the frontend.
+
+    Parameters
+    ----------
+    rom_id:
+        Integer ROM identifier.
+    filename:
+        Save filename (e.g. ``"pokemon.srm"``).
+    local_info:
+        Pre-computed local file metadata with keys ``"path"``, ``"mtime"``
+        (float seconds since epoch, or ``None``), and ``"size"`` (int, or
+        ``None``).  Pass ``None`` if no local file exists.
+    local_hash:
+        MD5 hex digest of the local file, or ``None``.
+    server_save:
+        Server save metadata dict.
+
+    Returns
+    -------
+    dict
+        Conflict descriptor ready for the frontend.
+    """
+    local_mtime_val: float | None = local_info.get("mtime") if local_info else None
+    return {
+        "rom_id": rom_id,
+        "filename": filename,
+        "local_path": local_info["path"] if local_info else None,
+        "local_hash": local_hash,
+        "local_mtime": (
+            datetime.fromtimestamp(local_mtime_val, tz=timezone.utc).isoformat()
+            if local_mtime_val is not None
+            else None
+        ),
+        "local_size": local_info.get("size") if local_info else None,
+        "server_save_id": server_save.get("id"),
+        "server_updated_at": server_save.get("updated_at", ""),
+        "server_size": server_save.get("file_size_bytes"),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -17,6 +17,15 @@ import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from domain.save_conflicts import (
+    build_conflict_dict,
+    check_local_changes,
+    check_server_changes_fast,
+    detect_conflict_lightweight,
+    determine_action,
+    resolve_conflict_by_mode,
+)
+
 from lib.errors import RommApiError, RommConflictError, classify_error
 from services.protocols import RommApiProtocol
 
@@ -259,24 +268,15 @@ class SaveService:
     # Conflict Detection
     # ------------------------------------------------------------------
 
-    def _check_local_changes(self, local_hash: str, last_sync_hash: str) -> bool:
-        """Compare local hash against baseline to detect local modifications."""
-        return local_hash != last_sync_hash
-
     def _check_server_changes(self, file_state: dict, server_save: dict, last_sync_hash: str) -> bool:
         """Compare server metadata/hash against baseline to detect server modifications."""
-        stored_updated_at = file_state.get("last_sync_server_updated_at")
-        stored_size = file_state.get("last_sync_server_size")
-        server_updated_at = server_save.get("updated_at", "")
-        server_size = server_save.get("file_size_bytes")
-
-        # Fast path: timestamp unchanged
-        if stored_updated_at and server_updated_at == stored_updated_at:
-            if stored_size is not None and server_size is not None and server_size != stored_size:
-                return True  # size changed
-            return False  # unchanged
+        fast = check_server_changes_fast(file_state, server_save, last_sync_hash)
+        if fast is not None:
+            return fast
 
         # Slow path: timestamp changed or no stored timestamp — download and hash
+        server_updated_at = server_save.get("updated_at", "")
+        server_size = server_save.get("file_size_bytes")
         try:
             server_hash = self._with_retry(self._get_server_save_hash, server_save)
         except Exception:
@@ -290,17 +290,6 @@ class SaveService:
             if server_size is not None:
                 file_state["last_sync_server_size"] = server_size
         return False
-
-    @staticmethod
-    def _determine_action(local_changed: bool, server_changed: bool) -> str:
-        """Decide skip/upload/download/conflict based on local and server change flags."""
-        if not local_changed and not server_changed:
-            return "skip"
-        if not local_changed:
-            return "download"
-        if not server_changed:
-            return "upload"
-        return "conflict"
 
     def _detect_conflict(self, rom_id: int, filename: str, local_hash: str, server_save: dict) -> str:
         """Hybrid conflict detection (no content_hash on RomM 4.6.1).
@@ -324,9 +313,9 @@ class SaveService:
                 return "skip" if local_hash == server_hash else "conflict"
             return "download"
 
-        local_changed = self._check_local_changes(local_hash, last_sync_hash)
+        local_changed = check_local_changes(local_hash, last_sync_hash)
         server_changed = self._check_server_changes(file_state, server_save, last_sync_hash)
-        result = self._determine_action(local_changed, server_changed)
+        result = determine_action(local_changed, server_changed)
 
         self._log_debug(
             f"_detect_conflict({rom_id}, {filename}): "
@@ -337,32 +326,11 @@ class SaveService:
         return result
 
     def _resolve_conflict_by_mode(self, local_mtime: float, server_save: dict) -> str:
-        """Apply configured conflict resolution mode.
-
-        Returns: ``"upload"``, ``"download"``, or ``"ask"``.
-        """
+        """Wrapper: apply configured conflict resolution mode via domain function."""
         settings = self._save_sync_state.get("settings", {})
         mode = settings.get("conflict_mode", "ask_me")
-
-        if mode == "always_upload":
-            return "upload"
-        if mode == "always_download":
-            return "download"
-        if mode == "ask_me":
-            return "ask"
-
-        # newest_wins (default)
         tolerance = settings.get("clock_skew_tolerance_sec", 60)
-        server_updated = server_save.get("updated_at", "")
-        try:
-            server_dt = datetime.fromisoformat(server_updated.replace("Z", "+00:00"))
-            local_dt = datetime.fromtimestamp(local_mtime, tz=timezone.utc)
-            diff = abs((local_dt - server_dt).total_seconds())
-            if diff <= tolerance:
-                return "ask"
-            return "upload" if local_dt > server_dt else "download"
-        except (ValueError, TypeError):
-            return "ask"
+        return resolve_conflict_by_mode(mode, local_mtime, server_save, tolerance)
 
     def _detect_conflict_lightweight(
         self,
@@ -371,39 +339,8 @@ class SaveService:
         server_save: dict | None,
         file_state: dict,
     ) -> str:
-        """Timestamp-only conflict detection. No file hashing or server downloads.
-
-        Returns: ``"skip"``, ``"download"``, ``"upload"``, or ``"conflict"``.
-        """
-        last_sync_hash = file_state.get("last_sync_hash")
-
-        # Never synced — can't determine state without hashing
-        if not last_sync_hash:
-            return "conflict" if server_save else "upload"
-
-        # Local change: compare mtime against stored sync mtime
-        stored_local_mtime = file_state.get("last_sync_local_mtime")
-        if stored_local_mtime is not None:
-            local_changed = abs(local_mtime - stored_local_mtime) > 1.0
-        else:
-            # No stored mtime — fall back to size comparison
-            stored_local_size = file_state.get("last_sync_local_size")
-            local_changed = stored_local_size is not None and local_size != stored_local_size
-
-        # Server change detection
-        server_changed = False
-        if server_save:
-            stored_updated_at = file_state.get("last_sync_server_updated_at")
-            stored_size = file_state.get("last_sync_server_size")
-            server_updated_at = server_save.get("updated_at", "")
-            server_size = server_save.get("file_size_bytes")
-
-            if (stored_updated_at and server_updated_at != stored_updated_at) or (
-                stored_size is not None and server_size is not None and server_size != stored_size
-            ):
-                server_changed = True
-
-        return self._determine_action(local_changed, server_changed)
+        """Wrapper: timestamp-only conflict detection via domain function."""
+        return detect_conflict_lightweight(local_mtime, local_size, server_save, file_state)
 
     def _update_file_sync_state(
         self, rom_id_str: str, filename: str, server_response: dict, local_path: str, system: str
@@ -477,31 +414,6 @@ class SaveService:
         self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str}")
         return result
 
-    @staticmethod
-    def _build_conflict_dict(
-        rom_id: int,
-        filename: str,
-        local: dict | None,
-        local_hash: str | None,
-        server: dict,
-    ) -> dict:
-        """Build a conflict descriptor for the frontend."""
-        local_mtime_val = os.path.getmtime(local["path"]) if local and os.path.isfile(local["path"]) else None
-        return {
-            "rom_id": rom_id,
-            "filename": filename,
-            "local_path": local["path"] if local else None,
-            "local_hash": local_hash,
-            "local_mtime": (
-                datetime.fromtimestamp(local_mtime_val, tz=timezone.utc).isoformat() if local_mtime_val else None
-            ),
-            "local_size": (os.path.getsize(local["path"]) if local and os.path.isfile(local["path"]) else None),
-            "server_save_id": server.get("id"),
-            "server_updated_at": server.get("updated_at", ""),
-            "server_size": server.get("file_size_bytes"),
-            "created_at": datetime.now(timezone.utc).isoformat(),
-        }
-
     def _sync_single_save_file(
         self,
         rom_id: int,
@@ -563,7 +475,13 @@ class SaveService:
                 return True
         except RommConflictError:
             if local and server:
-                conflicts.append(self._build_conflict_dict(rom_id, filename, local, local_hash, server))
+                local_path = local["path"]
+                local_info = {
+                    "path": local_path,
+                    "mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
+                    "size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
+                }
+                conflicts.append(build_conflict_dict(rom_id, filename, local_info, local_hash, server))
             else:
                 errors.append(f"{filename}: conflict without matching local+server")
         except RommApiError as e:
@@ -605,7 +523,13 @@ class SaveService:
 
         if action == "ask":
             if local and server:
-                conflicts.append(self._build_conflict_dict(rom_id, filename, local, local_hash, server))
+                local_path = local["path"]
+                local_info = {
+                    "path": local_path,
+                    "mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
+                    "size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
+                }
+                conflicts.append(build_conflict_dict(rom_id, filename, local_info, local_hash, server))
             return False
 
         t_action = time.time()
@@ -895,7 +819,7 @@ class SaveService:
             local_mtime = os.path.getmtime(lf["path"])
             local_size = os.path.getsize(lf["path"])
 
-            status = self._detect_conflict_lightweight(local_mtime, local_size, server, files_state.get(fn, {}))
+            status = detect_conflict_lightweight(local_mtime, local_size, server, files_state.get(fn, {}))
 
             file_statuses.append(
                 {

--- a/tests/test_save_conflicts.py
+++ b/tests/test_save_conflicts.py
@@ -1,0 +1,325 @@
+"""Unit tests for domain.save_conflicts — pure conflict detection functions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from domain.save_conflicts import (
+    build_conflict_dict,
+    check_local_changes,
+    check_server_changes_fast,
+    detect_conflict_lightweight,
+    determine_action,
+    resolve_conflict_by_mode,
+)
+
+# ---------------------------------------------------------------------------
+# TestCheckLocalChanges
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLocalChanges:
+    def test_same_hash_returns_false(self):
+        assert check_local_changes("abc123", "abc123") is False
+
+    def test_different_hash_returns_true(self):
+        assert check_local_changes("abc123", "def456") is True
+
+    def test_empty_local_hash_differs_from_baseline(self):
+        assert check_local_changes("", "abc123") is True
+
+    def test_both_empty_returns_false(self):
+        assert check_local_changes("", "") is False
+
+    def test_none_local_hash_differs_from_baseline(self):
+        assert check_local_changes(None, "abc123") is True
+
+    def test_none_local_hash_matches_none_baseline(self):
+        # Unusual edge case — both None means equal
+        assert check_local_changes(None, None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# TestCheckServerChangesFast
+# ---------------------------------------------------------------------------
+
+
+class TestCheckServerChangesFast:
+    def _file_state(self, updated_at="2026-02-17T06:00:00Z", size=1024):
+        return {
+            "last_sync_server_updated_at": updated_at,
+            "last_sync_server_size": size,
+        }
+
+    def _server_save(self, updated_at="2026-02-17T06:00:00Z", size=1024):
+        return {"updated_at": updated_at, "file_size_bytes": size}
+
+    def test_timestamp_and_size_match_returns_false(self):
+        file_state = self._file_state()
+        server_save = self._server_save()
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        assert result is False
+
+    def test_timestamp_matches_size_differs_returns_true(self):
+        file_state = self._file_state(size=1024)
+        server_save = self._server_save(size=2048)
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        assert result is True
+
+    def test_timestamp_changed_returns_none(self):
+        file_state = self._file_state(updated_at="2026-02-17T06:00:00Z")
+        server_save = self._server_save(updated_at="2026-02-17T12:00:00Z")
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        assert result is None
+
+    def test_no_stored_timestamp_returns_none(self):
+        file_state = {"last_sync_server_size": 1024}  # no last_sync_server_updated_at
+        server_save = self._server_save()
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        assert result is None
+
+    def test_empty_file_state_returns_none(self):
+        result = check_server_changes_fast({}, self._server_save(), "hash123")
+        assert result is None
+
+    def test_stored_size_none_timestamp_matches_returns_false(self):
+        """If stored_size is None (legacy), size check is skipped when timestamp matches."""
+        file_state = {"last_sync_server_updated_at": "2026-02-17T06:00:00Z", "last_sync_server_size": None}
+        server_save = self._server_save(size=2048)
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        # stored_size is None — condition `stored_size is not None and ...` is False -> unchanged
+        assert result is False
+
+    def test_server_size_none_timestamp_matches_returns_false(self):
+        """If server returns no size, size check is skipped."""
+        file_state = self._file_state(size=1024)
+        server_save = {"updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": None}
+        result = check_server_changes_fast(file_state, server_save, "hash123")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# TestDetermineAction
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineAction:
+    def test_neither_changed_skips(self):
+        assert determine_action(False, False) == "skip"
+
+    def test_only_server_changed_downloads(self):
+        assert determine_action(False, True) == "download"
+
+    def test_only_local_changed_uploads(self):
+        assert determine_action(True, False) == "upload"
+
+    def test_both_changed_conflicts(self):
+        assert determine_action(True, True) == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# TestDetectConflictLightweight
+# ---------------------------------------------------------------------------
+
+
+class TestDetectConflictLightweight:
+    def _server_save(self, updated_at="2026-02-17T06:00:00Z", size=1024):
+        return {"updated_at": updated_at, "file_size_bytes": size}
+
+    def test_never_synced_no_server_uploads(self):
+        result = detect_conflict_lightweight(1000.0, 1024, None, {})
+        assert result == "upload"
+
+    def test_never_synced_with_server_conflicts(self):
+        result = detect_conflict_lightweight(1000.0, 1024, self._server_save(), {})
+        assert result == "conflict"
+
+    def test_skip_when_unchanged(self):
+        file_state = {
+            "last_sync_hash": "abc",
+            "last_sync_local_mtime": 1000.0,
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = detect_conflict_lightweight(1000.0, 1024, self._server_save(), file_state)
+        assert result == "skip"
+
+    def test_local_only_changed_uploads(self):
+        file_state = {"last_sync_hash": "abc", "last_sync_local_mtime": 1000.0}
+        result = detect_conflict_lightweight(2000.0, 1024, None, file_state)
+        assert result == "upload"
+
+    def test_server_only_changed_downloads(self):
+        file_state = {
+            "last_sync_hash": "abc",
+            "last_sync_local_mtime": 1000.0,
+            "last_sync_server_updated_at": "2026-02-17T04:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        server = self._server_save(updated_at="2026-02-17T08:00:00Z")
+        result = detect_conflict_lightweight(1000.0, 1024, server, file_state)
+        assert result == "download"
+
+    def test_both_changed_conflicts(self):
+        file_state = {
+            "last_sync_hash": "abc",
+            "last_sync_local_mtime": 1000.0,
+            "last_sync_server_updated_at": "2026-02-17T04:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        server = self._server_save(updated_at="2026-02-17T08:00:00Z")
+        result = detect_conflict_lightweight(2000.0, 1024, server, file_state)
+        assert result == "conflict"
+
+    def test_no_server_save_only_local_changed_uploads(self):
+        file_state = {"last_sync_hash": "abc", "last_sync_local_mtime": 1000.0}
+        result = detect_conflict_lightweight(2000.0, 1024, None, file_state)
+        assert result == "upload"
+
+    def test_mtime_within_tolerance_unchanged(self):
+        """Mtime difference <= 1.0 second is treated as unchanged."""
+        file_state = {"last_sync_hash": "abc", "last_sync_local_mtime": 1000.0}
+        result = detect_conflict_lightweight(1000.5, 1024, None, file_state)
+        assert result == "skip"
+
+    def test_fallback_to_size_when_no_mtime(self):
+        """No stored mtime: size change counts as local changed."""
+        file_state = {"last_sync_hash": "abc", "last_sync_local_size": 1024}
+        result = detect_conflict_lightweight(1000.0, 2048, None, file_state)
+        assert result == "upload"
+
+    def test_fallback_size_unchanged_skips(self):
+        """No stored mtime, same size: local unchanged."""
+        file_state = {"last_sync_hash": "abc", "last_sync_local_size": 1024}
+        result = detect_conflict_lightweight(1000.0, 1024, None, file_state)
+        assert result == "skip"
+
+    def test_server_size_change_triggers_server_changed(self):
+        """Same timestamp but different size -> server changed."""
+        file_state = {
+            "last_sync_hash": "abc",
+            "last_sync_local_mtime": 1000.0,
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = detect_conflict_lightweight(1000.0, 1024, self._server_save(size=2048), file_state)
+        assert result == "download"
+
+
+# ---------------------------------------------------------------------------
+# TestResolveConflictByMode
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConflictByMode:
+    def _server_save(self, updated_at="2026-02-17T06:00:00Z"):
+        return {"updated_at": updated_at}
+
+    def test_ask_me_returns_ask(self):
+        result = resolve_conflict_by_mode("ask_me", 1000.0, self._server_save())
+        assert result == "ask"
+
+    def test_always_upload_returns_upload(self):
+        result = resolve_conflict_by_mode("always_upload", 1000.0, self._server_save())
+        assert result == "upload"
+
+    def test_always_download_returns_download(self):
+        result = resolve_conflict_by_mode("always_download", 1000.0, self._server_save())
+        assert result == "download"
+
+    def test_newest_wins_local_newer_uploads(self):
+        # Server updated at 2026-02-17T06:00:00Z
+        # local_mtime is after that
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        local_mtime = server_dt.timestamp() + 3600  # 1 hour later
+        result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
+        assert result == "upload"
+
+    def test_newest_wins_server_newer_downloads(self):
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        local_mtime = server_dt.timestamp() - 3600  # 1 hour earlier
+        result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
+        assert result == "download"
+
+    def test_newest_wins_within_tolerance_asks(self):
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        local_mtime = server_dt.timestamp() + 30  # 30s later, within 60s tolerance
+        result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
+        assert result == "ask"
+
+    def test_newest_wins_invalid_server_date_asks(self):
+        result = resolve_conflict_by_mode("newest_wins", 1000.0, {"updated_at": "not-a-date"}, tolerance=60)
+        assert result == "ask"
+
+    def test_newest_wins_missing_server_date_asks(self):
+        result = resolve_conflict_by_mode("newest_wins", 1000.0, {}, tolerance=60)
+        assert result == "ask"
+
+    def test_unknown_mode_falls_through_to_newest_wins(self):
+        """Unrecognised mode falls through to newest_wins logic."""
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        local_mtime = server_dt.timestamp() + 3600
+        result = resolve_conflict_by_mode("some_future_mode", local_mtime, self._server_save(), tolerance=60)
+        assert result == "upload"
+
+
+# ---------------------------------------------------------------------------
+# TestBuildConflictDict
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConflictDict:
+    def _server_save(self):
+        return {
+            "id": 100,
+            "updated_at": "2026-02-17T06:00:00Z",
+            "file_size_bytes": 1024,
+        }
+
+    def test_full_dict_structure(self):
+        local_mtime = datetime(2026, 2, 17, 5, 0, 0, tzinfo=timezone.utc).timestamp()
+        local_info = {"path": "/saves/pokemon.srm", "mtime": local_mtime, "size": 1024}
+        result = build_conflict_dict(42, "pokemon.srm", local_info, "abc123", self._server_save())
+
+        assert result["rom_id"] == 42
+        assert result["filename"] == "pokemon.srm"
+        assert result["local_path"] == "/saves/pokemon.srm"
+        assert result["local_hash"] == "abc123"
+        assert result["local_mtime"] == "2026-02-17T05:00:00+00:00"
+        assert result["local_size"] == 1024
+        assert result["server_save_id"] == 100
+        assert result["server_updated_at"] == "2026-02-17T06:00:00Z"
+        assert result["server_size"] == 1024
+        assert "created_at" in result
+
+    def test_no_local_info(self):
+        result = build_conflict_dict(42, "pokemon.srm", None, None, self._server_save())
+        assert result["local_path"] is None
+        assert result["local_hash"] is None
+        assert result["local_mtime"] is None
+        assert result["local_size"] is None
+
+    def test_local_mtime_none(self):
+        local_info = {"path": "/saves/pokemon.srm", "mtime": None, "size": 1024}
+        result = build_conflict_dict(42, "pokemon.srm", local_info, "abc123", self._server_save())
+        assert result["local_mtime"] is None
+
+    def test_missing_local_mtime_key(self):
+        """local_info without mtime key — treated as None."""
+        local_info = {"path": "/saves/pokemon.srm", "size": 1024}
+        result = build_conflict_dict(42, "pokemon.srm", local_info, "abc123", self._server_save())
+        assert result["local_mtime"] is None
+
+    def test_server_missing_optional_fields(self):
+        server = {"id": 99}
+        local_info = {"path": "/saves/pokemon.srm", "mtime": None, "size": 0}
+        result = build_conflict_dict(42, "pokemon.srm", local_info, "hash", server)
+        assert result["server_save_id"] == 99
+        assert result["server_updated_at"] == ""
+        assert result["server_size"] is None
+
+    def test_created_at_is_utc_iso(self):
+        local_info = {"path": "/saves/pokemon.srm", "mtime": None, "size": 0}
+        result = build_conflict_dict(1, "f.srm", local_info, None, self._server_save())
+        # Should parse without error
+        datetime.fromisoformat(result["created_at"])


### PR DESCRIPTION
## Summary

- Extracts 6 pure conflict detection functions from `SaveService` (1241L) into `domain/save_conflicts.py`
- New domain functions: `check_local_changes`, `check_server_changes_fast`, `determine_action`, `detect_conflict_lightweight`, `resolve_conflict_by_mode`, `build_conflict_dict`
- `check_server_changes_fast` handles the pure fast-path (timestamp/size comparison); slow-path (HTTP hash download) stays in SaveService
- `build_conflict_dict` receives pre-computed local metadata instead of doing `os.path` calls
- SaveService keeps I/O orchestration: hash downloads, upload/download, false-alarm caching

Closes #111

## Test plan

- [x] `python -m pytest tests/ -q` — 1150 passed (43 new domain function tests)
- [x] `ruff check` — all checks passed
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 5 contracts kept, 0 broken