### PR TITLE
refactor(services): extract RomRemovalService + domain rom_files

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -63,5 +63,6 @@ modules =
     services.metadata
     services.migration
     services.playtime
+    services.rom_removal
     services.saves
     services.steamgrid

--- a/main.py
+++ b/main.py
@@ -155,6 +155,7 @@ class Plugin:
         self._playtime_service = services["playtime_service"]
         self._sync_service = services["sync_service"]
         self._download_service = services["download_service"]
+        self._rom_removal_service = services["rom_removal_service"]
         self._firmware_service = services["firmware_service"]
         self._sgdb_service = services["sgdb_service"]
         self._metadata_service = services["metadata_service"]
@@ -500,10 +501,16 @@ class Plugin:
         return self._download_service.get_installed_rom(rom_id)
 
     async def remove_rom(self, rom_id):
-        return await self._download_service.remove_rom(rom_id)
+        result = await self._rom_removal_service.remove_rom(rom_id)
+        if result.get("success"):
+            self._download_service._download_queue.pop(int(rom_id), None)
+        return result
 
     async def uninstall_all_roms(self):
-        return await self._download_service.uninstall_all_roms()
+        result = await self._rom_removal_service.uninstall_all_roms()
+        if result.get("success"):
+            self._download_service._download_queue.clear()
+        return result
 
     # ── Save Sync / Playtime delegation to services ──────────
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -28,6 +28,7 @@ from services.migration import MigrationService
 from services.playtime import PlaytimeService
 from services.protocols import RommApiProtocol
 from services.protocols import SteamConfigAdapter as SteamConfigProtocol
+from services.rom_removal import RomRemovalService
 from services.saves import SaveService
 from services.steamgrid import SteamGridService
 
@@ -171,11 +172,18 @@ def wire_services(cfg: WiringConfig) -> dict:
         romm_api=cfg.romm_api,
         resolve_system=cfg.http_adapter.resolve_system,
         state=cfg.state,
-        save_sync_state=cfg.save_sync_state,
         loop=cfg.loop,
         logger=cfg.logger,
         runtime_dir=cfg.runtime_dir,
         emit=cfg.emit,
+        save_state=cfg.save_state,
+    )
+
+    rom_removal_service = RomRemovalService(
+        state=cfg.state,
+        save_sync_state=cfg.save_sync_state,
+        logger=cfg.logger,
+        loop=cfg.loop,
         save_state=cfg.save_state,
         save_save_sync_state=save_sync_service.save_state,
     )
@@ -237,6 +245,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         "playtime_service": playtime_service,
         "sync_service": sync_service,
         "download_service": download_service,
+        "rom_removal_service": rom_removal_service,
         "firmware_service": firmware_service,
         "sgdb_service": sgdb_service,
         "metadata_service": metadata_service,

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -1,0 +1,101 @@
+"""ROM file format logic — pure decision/content functions.
+
+These functions contain no I/O. File discovery and writing remain
+in the calling service. The functions operate on file lists passed
+as parameters.
+"""
+
+from __future__ import annotations
+
+_DISC_EXTENSIONS = (".cue", ".chd", ".iso")
+
+
+def needs_m3u(disc_files: list[str]) -> bool:
+    """Return True if an M3U playlist should be generated.
+
+    Decides based on the number of disc files found. An M3U is needed
+    when there are 2 or more disc files (multi-disc ROM).
+
+    Parameters
+    ----------
+    disc_files:
+        Relative paths of disc files (.cue, .chd, .iso) found in the
+        extraction directory. Must already exclude any existing .m3u files.
+    """
+    return len(disc_files) >= 2
+
+
+def build_m3u_content(disc_files: list[str]) -> str:
+    """Build M3U playlist content string for the given disc files.
+
+    Parameters
+    ----------
+    disc_files:
+        Relative paths to disc files, sorted in playlist order.
+
+    Returns
+    -------
+    str
+        M3U playlist content with newline-separated entries and a
+        trailing newline.
+    """
+    sorted_files = sorted(disc_files)
+    return "\n".join(sorted_files) + "\n"
+
+
+def detect_launch_file(files: list[str]) -> str | None:
+    """Pick the best launch file from a list of absolute file paths.
+
+    Priority order:
+    1. M3U playlist
+    2. CUE sheet
+    3. WiiU: .rpx (loadiine format in code/ subdirectory)
+    4. WiiU disc images: .wud, .wux, .wua
+    5. PS3: EBOOT.BIN
+    6. 3DS: .3ds > .cia > .cxi
+    7. Largest file by size
+
+    Parameters
+    ----------
+    files:
+        Absolute file paths to consider. If empty, returns None.
+
+    Returns
+    -------
+    str | None
+        Absolute path to the best launch file, or None if ``files`` is empty.
+    """
+    if not files:
+        return None
+
+    # Prefer M3U > CUE
+    for ext in (".m3u", ".cue"):
+        matches = [f for f in files if f.lower().endswith(ext)]
+        if matches:
+            return matches[0]
+
+    # WiiU: loadiine format has .rpx in code/ subdirectory
+    rpx_files = [f for f in files if f.lower().endswith(".rpx")]
+    if rpx_files:
+        return rpx_files[0]
+
+    # WiiU disc images
+    for ext in (".wud", ".wux", ".wua"):
+        matches = [f for f in files if f.lower().endswith(ext)]
+        if matches:
+            return matches[0]
+
+    # PS3: EBOOT.BIN in PS3_GAME/USRDIR/
+    eboot_files = [f for f in files if f.endswith("EBOOT.BIN")]
+    if eboot_files:
+        return eboot_files[0]
+
+    # 3DS: prefer .3ds > .cia > .cxi
+    for ext in (".3ds", ".cia", ".cxi"):
+        matches = [f for f in files if f.lower().endswith(ext)]
+        if matches:
+            return matches[0]
+
+    import os
+
+    return max(files, key=os.path.getsize)

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -1,7 +1,7 @@
 """DownloadService — ROM download engine.
 
 Handles ROM downloads (single and multi-file), disk space checks,
-download queue management, ROM removal, and partial download cleanup.
+download queue management, and partial download cleanup.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from domain import retrodeck_config
+from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
 
 from lib.errors import error_response
 
@@ -33,7 +34,7 @@ _TMP_EXT = ".tmp"
 
 
 class DownloadService:
-    """ROM download engine: downloads, queue management, ROM removal."""
+    """ROM download engine: downloads and queue management."""
 
     def __init__(
         self,
@@ -41,24 +42,20 @@ class DownloadService:
         romm_api: RommApiProtocol,
         resolve_system: Callable,
         state: dict,
-        save_sync_state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         runtime_dir: str,
         emit: Callable,
         save_state: Callable,
-        save_save_sync_state: Callable,
     ):
         self._romm_api = romm_api
         self._resolve_system = resolve_system
         self._state = state
-        self._save_sync_state = save_sync_state
         self._loop = loop
         self._logger = logger
         self._runtime_dir = runtime_dir
         self._emit = emit
         self._save_state = save_state
-        self._save_save_sync_state = save_save_sync_state
 
         # Owned state
         self._download_in_progress: set = set()
@@ -290,9 +287,9 @@ class DownloadService:
                     os.replace(old_path, new_path)
                     self._logger.info(f"Renamed URL-encoded dir: {dname} -> {decoded}")
         # Auto-generate M3U if missing and multiple disc files exist
-        self._maybe_generate_m3u(extract_dir, rom_detail)
+        self._maybe_generate_m3u_io(extract_dir, rom_detail)
         # Detect launch file: prefer M3U > CUE > largest file
-        launch_file = self._detect_launch_file(extract_dir)
+        launch_file = self._collect_and_detect_launch_file(extract_dir)
 
         # Register as installed
         installed_entry = {
@@ -325,11 +322,8 @@ class DownloadService:
         self._save_state()
         return target_path
 
-    async def _do_download(self, rom_id, rom_detail, target_path, system):
-        file_name = rom_detail.get("fs_name", f"rom_{rom_id}")
-        rom_name = rom_detail.get("name", file_name)
-        platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
-        has_multiple = rom_detail.get("has_multiple_files", False)
+    def _make_progress_callback(self, rom_id, rom_name, platform_name, file_name):
+        """Build a throttled progress callback for a download."""
         last_emit = [0.0]  # mutable container for closure
         last_log = [0.0]
 
@@ -368,6 +362,15 @@ class DownloadService:
                     },
                 ),
             )
+
+        return progress_callback
+
+    async def _do_download(self, rom_id, rom_detail, target_path, system):
+        file_name = rom_detail.get("fs_name", f"rom_{rom_id}")
+        rom_name = rom_detail.get("name", file_name)
+        platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
+        has_multiple = rom_detail.get("has_multiple_files", False)
+        progress_callback = self._make_progress_callback(rom_id, rom_name, platform_name, file_name)
 
         try:
             self._logger.info(f"Download starting: {rom_name} (rom_id={rom_id}, multi={has_multiple}) -> {target_path}")
@@ -420,10 +423,10 @@ class DownloadService:
             self._download_in_progress.discard(rom_id)
             self._prune_download_queue()
 
-    def _maybe_generate_m3u(self, extract_dir, rom_detail):
+    def _maybe_generate_m3u_io(self, extract_dir: str, rom_detail: dict) -> None:
         """Auto-generate an M3U playlist if none exists and multiple disc files are found."""
         # Check if an M3U already exists (search recursively)
-        for root, _dirs, files in os.walk(extract_dir):
+        for _root, _dirs, files in os.walk(extract_dir):
             for f in files:
                 if f.lower().endswith(".m3u"):
                     return
@@ -437,56 +440,24 @@ class DownloadService:
                     rel_path = os.path.relpath(os.path.join(root, f), extract_dir)
                     disc_files.append(rel_path)
 
-        if len(disc_files) < 2:
+        if not needs_m3u(disc_files):
             return
-
-        # Sort naturally (Disc 1, Disc 2, etc.)
-        disc_files.sort()
 
         rom_name = rom_detail.get("fs_name_no_ext", rom_detail.get("name", "playlist"))
         m3u_path = os.path.join(extract_dir, f"{rom_name}.m3u")
         with open(m3u_path, "w") as f:
-            f.write("\n".join(disc_files) + "\n")
+            f.write(build_m3u_content(disc_files))
         self._logger.info(f"Auto-generated M3U playlist: {m3u_path}")
 
-    def _detect_launch_file(self, extract_dir):
+    def _collect_and_detect_launch_file(self, extract_dir: str) -> str:
         """Find the best launch file in an extracted multi-file ROM directory."""
         all_files = []
         for root, _dirs, files in os.walk(extract_dir):
             for f in files:
                 all_files.append(os.path.join(root, f))
 
-        # Prefer M3U > CUE
-        for ext in (".m3u", ".cue"):
-            matches = [f for f in all_files if f.lower().endswith(ext)]
-            if matches:
-                return matches[0]
-
-        # WiiU: loadiine format has .rpx in code/ subdirectory
-        rpx_files = [f for f in all_files if f.lower().endswith(".rpx")]
-        if rpx_files:
-            return rpx_files[0]
-
-        # WiiU disc images
-        for ext in (".wud", ".wux", ".wua"):
-            matches = [f for f in all_files if f.lower().endswith(ext)]
-            if matches:
-                return matches[0]
-
-        # PS3: EBOOT.BIN in PS3_GAME/USRDIR/
-        eboot_files = [f for f in all_files if f.endswith("EBOOT.BIN")]
-        if eboot_files:
-            return eboot_files[0]
-
-        # 3DS: prefer .3ds > .cia > .cxi
-        for ext in (".3ds", ".cia", ".cxi"):
-            matches = [f for f in all_files if f.lower().endswith(ext)]
-            if matches:
-                return matches[0]
-
-        if all_files:
-            return max(all_files, key=os.path.getsize)
-        return extract_dir
+        result = detect_launch_file(all_files)
+        return result if result is not None else extract_dir
 
     def _cleanup_partial_download(self, target_path, has_multiple, file_name):
         """Clean up partial download files. Each step is independent so one failure doesn't block others."""
@@ -523,102 +494,3 @@ class DownloadService:
 
     def get_installed_rom(self, rom_id):
         return self._state["installed_roms"].get(str(int(rom_id)))
-
-    def _is_safe_rom_path(self, path):
-        """Check that a path is safely contained within the roms base directory."""
-        roms_base = retrodeck_config.get_roms_path()
-        resolved = os.path.realpath(path)
-        real_base = os.path.realpath(roms_base)
-        if not resolved.startswith(real_base + os.sep):
-            return False
-        # Must be at least 2 levels deep (e.g. roms/gb/file.zip, not roms/gb/)
-        rel = os.path.relpath(resolved, real_base)
-        parts = rel.split(os.sep)
-        if len(parts) < 2:
-            return False
-        return True
-
-    def _delete_rom_files(self, installed):
-        """Delete ROM files for an installed entry. Handles both single-file and multi-file ROMs."""
-        rom_dir = installed.get("rom_dir", "")
-        file_path = installed.get("file_path", "")
-
-        if rom_dir and os.path.isdir(rom_dir):
-            if not self._is_safe_rom_path(rom_dir):
-                self._logger.error(f"Refusing to delete path outside roms directory: {rom_dir}")
-                return
-            shutil.rmtree(rom_dir)
-        elif file_path:
-            if not self._is_safe_rom_path(file_path):
-                self._logger.error(f"Refusing to delete path outside roms directory: {file_path}")
-                return
-            if os.path.isdir(file_path):
-                shutil.rmtree(file_path)
-            elif os.path.exists(file_path):
-                os.remove(file_path)
-
-    def _remove_rom_io(self, rom_id_str, installed):
-        """Sync helper for remove_rom — file deletion + state update in executor."""
-        self._delete_rom_files(installed)
-
-        del self._state["installed_roms"][rom_id_str]
-        # Clean save sync state for removed ROM
-        save_changed = False
-        if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
-            save_changed = True
-        if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
-            save_changed = True
-        if save_changed:
-            self._save_save_sync_state()
-        self._save_state()
-
-    async def remove_rom(self, rom_id):
-        rom_id_str = str(int(rom_id))
-        installed = self._state["installed_roms"].get(rom_id_str)
-        if not installed:
-            return {"success": False, "message": "ROM not installed"}
-
-        try:
-            await self._loop.run_in_executor(None, self._remove_rom_io, rom_id_str, installed)
-        except Exception as e:
-            self._logger.error(f"Failed to delete ROM files: {e}")
-            return {"success": False, "message": "Failed to delete ROM files"}
-
-        self._download_queue.pop(int(rom_id), None)
-        return {"success": True, "message": "ROM removed"}
-
-    def _uninstall_all_roms_io(self):
-        """Sync helper for uninstall_all_roms — bulk file deletion + state update in executor."""
-        count = 0
-        errors = []
-        successfully_deleted = []
-        for rom_id_str, installed in self._state["installed_roms"].items():
-            try:
-                self._delete_rom_files(installed)
-                count += 1
-                successfully_deleted.append(rom_id_str)
-            except Exception as e:
-                errors.append(f"{rom_id_str}: {e}")
-                self._logger.error(f"Failed to delete ROM {rom_id_str}: {e}")
-
-        for rom_id_str in successfully_deleted:
-            self._state["installed_roms"].pop(rom_id_str, None)
-        # Clean save sync state for all removed ROMs
-        save_changed = False
-        for rom_id_str in successfully_deleted:
-            if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
-                save_changed = True
-            if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
-                save_changed = True
-        if save_changed:
-            self._save_save_sync_state()
-        self._save_state()
-        return count, errors
-
-    async def uninstall_all_roms(self):
-        count, errors = await self._loop.run_in_executor(None, self._uninstall_all_roms_io)
-        self._download_queue.clear()
-        msg = f"Removed {count} ROMs"
-        if errors:
-            msg += f" ({len(errors)} errors)"
-        return {"success": True, "message": msg, "removed_count": count}

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -1,0 +1,134 @@
+"""RomRemovalService — ROM file deletion and state cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+from domain import retrodeck_config
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
+
+
+class RomRemovalService:
+    """Handles physical deletion of installed ROM files and state cleanup."""
+
+    def __init__(
+        self,
+        *,
+        state: dict,
+        save_sync_state: dict,
+        logger: logging.Logger,
+        loop: asyncio.AbstractEventLoop,
+        save_state: Callable,
+        save_save_sync_state: Callable,
+    ):
+        self._state = state
+        self._save_sync_state = save_sync_state
+        self._logger = logger
+        self._loop = loop
+        self._save_state = save_state
+        self._save_save_sync_state = save_save_sync_state
+
+    def _is_safe_rom_path(self, path: str) -> bool:
+        """Check that a path is safely contained within the roms base directory."""
+        roms_base = retrodeck_config.get_roms_path()
+        resolved = os.path.realpath(path)
+        real_base = os.path.realpath(roms_base)
+        if not resolved.startswith(real_base + os.sep):
+            return False
+        # Must be at least 2 levels deep (e.g. roms/gb/file.zip, not roms/gb/)
+        rel = os.path.relpath(resolved, real_base)
+        parts = rel.split(os.sep)
+        if len(parts) < 2:
+            return False
+        return True
+
+    def _delete_rom_files(self, installed: dict) -> None:
+        """Delete ROM files for an installed entry. Handles both single-file and multi-file ROMs."""
+        rom_dir = installed.get("rom_dir", "")
+        file_path = installed.get("file_path", "")
+
+        if rom_dir and os.path.isdir(rom_dir):
+            if not self._is_safe_rom_path(rom_dir):
+                self._logger.error(f"Refusing to delete path outside roms directory: {rom_dir}")
+                return
+            shutil.rmtree(rom_dir)
+        elif file_path:
+            if not self._is_safe_rom_path(file_path):
+                self._logger.error(f"Refusing to delete path outside roms directory: {file_path}")
+                return
+            if os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+            elif os.path.exists(file_path):
+                os.remove(file_path)
+
+    def _remove_rom_io(self, rom_id_str: str, installed: dict) -> None:
+        """Sync helper for remove_rom — file deletion + state update in executor."""
+        self._delete_rom_files(installed)
+
+        del self._state["installed_roms"][rom_id_str]
+        # Clean save sync state for removed ROM
+        save_changed = False
+        if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
+            save_changed = True
+        if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
+            save_changed = True
+        if save_changed:
+            self._save_save_sync_state()
+        self._save_state()
+
+    async def remove_rom(self, rom_id: int | str) -> dict:
+        """Remove a single installed ROM: delete files and clean state."""
+        rom_id_str = str(int(rom_id))
+        installed = self._state["installed_roms"].get(rom_id_str)
+        if not installed:
+            return {"success": False, "message": "ROM not installed"}
+
+        try:
+            await self._loop.run_in_executor(None, self._remove_rom_io, rom_id_str, installed)
+        except Exception as e:
+            self._logger.error(f"Failed to delete ROM files: {e}")
+            return {"success": False, "message": "Failed to delete ROM files"}
+
+        return {"success": True, "message": "ROM removed"}
+
+    def _uninstall_all_roms_io(self) -> tuple[int, list[str]]:
+        """Sync helper for uninstall_all_roms — bulk file deletion + state update in executor."""
+        count = 0
+        errors: list[str] = []
+        successfully_deleted: list[str] = []
+        for rom_id_str, installed in self._state["installed_roms"].items():
+            try:
+                self._delete_rom_files(installed)
+                count += 1
+                successfully_deleted.append(rom_id_str)
+            except Exception as e:
+                errors.append(f"{rom_id_str}: {e}")
+                self._logger.error(f"Failed to delete ROM {rom_id_str}: {e}")
+
+        for rom_id_str in successfully_deleted:
+            self._state["installed_roms"].pop(rom_id_str, None)
+        # Clean save sync state for all removed ROMs
+        save_changed = False
+        for rom_id_str in successfully_deleted:
+            if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
+                save_changed = True
+            if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
+                save_changed = True
+        if save_changed:
+            self._save_save_sync_state()
+        self._save_state()
+        return count, errors
+
+    async def uninstall_all_roms(self) -> dict:
+        """Remove all installed ROMs: delete files and clear state."""
+        count, errors = await self._loop.run_in_executor(None, self._uninstall_all_roms_io)
+        msg = f"Removed {count} ROMs"
+        if errors:
+            msg += f" ({len(errors)} errors)"
+        return {"success": True, "message": msg, "removed_count": count}

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -154,10 +154,11 @@ class TestWireServices:
         assert result["sync_service"]._state is deps["state"]
         deps["loop"].close()
 
-    def test_returns_ten_services(self, tmp_path):
+    def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(WiringConfig(**deps))
-        assert len(result) == 10
+        assert len(result) == 11
         assert "migration_service" in result
         assert "game_detail_service" in result
+        assert "rom_removal_service" in result
         deps["loop"].close()

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -7,6 +7,7 @@ import pytest
 from adapters.steam_config import SteamConfigAdapter
 from services.downloads import DownloadService
 from services.library import LibraryService
+from services.rom_removal import RomRemovalService
 
 # conftest.py patches decky before this import
 from main import Plugin
@@ -46,11 +47,17 @@ def plugin():
         romm_api=p._romm_api,
         resolve_system=p._resolve_system,
         state=p._state,
-        save_sync_state=p._save_sync_state,
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
         runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
         emit=decky.emit,
+        save_state=MagicMock(),
+    )
+    p._rom_removal_service = RomRemovalService(
+        state=p._state,
+        save_sync_state=p._save_sync_state,
+        logger=decky.logger,
+        loop=asyncio.get_event_loop(),
         save_state=MagicMock(),
         save_save_sync_state=MagicMock(),
     )
@@ -62,6 +69,7 @@ async def _set_event_loop(plugin):
     """Ensure plugin.loop matches the running event loop for async tests."""
     plugin.loop = asyncio.get_event_loop()
     plugin._download_service._loop = asyncio.get_event_loop()
+    plugin._rom_removal_service._loop = asyncio.get_event_loop()
 
 
 class TestStartDownload:
@@ -184,7 +192,7 @@ class TestGetDownloadQueue:
         result = await plugin.get_download_queue()
         assert len(result["downloads"]) == 1
         assert result["downloads"][0]["status"] == "downloading"
-        assert result["downloads"][0]["progress"] == 0.5
+        assert result["downloads"][0]["progress"] == pytest.approx(0.5)
 
     @pytest.mark.asyncio
     async def test_returns_completed_downloads(self, plugin):
@@ -320,21 +328,21 @@ class TestDetectLaunchFile:
         (tmp_path / "disc1.cue").write_text("cue data")
         (tmp_path / "disc1.bin").write_bytes(b"\x00" * 1000)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".m3u")
 
     def test_falls_back_to_cue(self, plugin, tmp_path):
         (tmp_path / "disc1.cue").write_text("cue data")
         (tmp_path / "disc1.bin").write_bytes(b"\x00" * 1000)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".cue")
 
     def test_falls_back_to_largest(self, plugin, tmp_path):
         (tmp_path / "small.bin").write_bytes(b"\x00" * 100)
         (tmp_path / "large.bin").write_bytes(b"\x00" * 10000)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith("large.bin")
 
     def test_wiiu_rpx_in_code_subdir(self, plugin, tmp_path):
@@ -344,26 +352,26 @@ class TestDetectLaunchFile:
         (tmp_path / "meta" / "meta.xml").parent.mkdir()
         (tmp_path / "meta" / "meta.xml").write_text("<xml/>")
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".rpx")
 
     def test_wiiu_disc_image(self, plugin, tmp_path):
         (tmp_path / "game.wux").write_bytes(b"\x00" * 1000)
         (tmp_path / "readme.txt").write_text("info")
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".wux")
 
     def test_wiiu_wud_format(self, plugin, tmp_path):
         (tmp_path / "game.wud").write_bytes(b"\x00" * 1000)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".wud")
 
     def test_wiiu_wua_format(self, plugin, tmp_path):
         (tmp_path / "game.wua").write_bytes(b"\x00" * 1000)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".wua")
 
     def test_ps3_eboot_bin(self, plugin, tmp_path):
@@ -372,21 +380,21 @@ class TestDetectLaunchFile:
         (usrdir / "EBOOT.BIN").write_bytes(b"\x00" * 500)
         (tmp_path / "PS3_GAME" / "PARAM.SFO").write_bytes(b"\x00" * 100)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith("EBOOT.BIN")
 
     def test_3ds_prefers_3ds_over_cia(self, plugin, tmp_path):
         (tmp_path / "game.3ds").write_bytes(b"\x00" * 500)
         (tmp_path / "game.cia").write_bytes(b"\x00" * 500)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".3ds")
 
     def test_3ds_falls_back_to_cia(self, plugin, tmp_path):
         (tmp_path / "game.cia").write_bytes(b"\x00" * 500)
         (tmp_path / "game.cxi").write_bytes(b"\x00" * 500)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".cia")
 
     def test_m3u_still_preferred_over_platform_specific(self, plugin, tmp_path):
@@ -396,7 +404,7 @@ class TestDetectLaunchFile:
         code_dir.mkdir()
         (code_dir / "game.rpx").write_bytes(b"\x00" * 500)
 
-        result = plugin._download_service._detect_launch_file(str(tmp_path))
+        result = plugin._download_service._collect_and_detect_launch_file(str(tmp_path))
         assert result.endswith(".m3u")
 
 
@@ -603,7 +611,7 @@ class TestMaybeGenerateM3u:
         (tmp_path / "Game - Disc 2.bin").write_bytes(b"\x00" * 1000)
 
         rom_detail = {"fs_name_no_ext": "Final Fantasy VII", "name": "Final Fantasy VII"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         m3u_path = tmp_path / "Final Fantasy VII.m3u"
         assert m3u_path.exists()
@@ -619,7 +627,7 @@ class TestMaybeGenerateM3u:
         (tmp_path / "Game (Disc 2).chd").write_bytes(b"\x00" * 100)
 
         rom_detail = {"fs_name_no_ext": "Game", "name": "Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         m3u_path = tmp_path / "Game.m3u"
         assert m3u_path.exists()
@@ -633,7 +641,7 @@ class TestMaybeGenerateM3u:
         (tmp_path / "disc2.cue").write_text("cue 2")
 
         rom_detail = {"fs_name_no_ext": "Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         # Only the original M3U should exist, unchanged
         assert (tmp_path / "existing.m3u").read_text() == "original content"
@@ -645,7 +653,7 @@ class TestMaybeGenerateM3u:
         (tmp_path / "game.bin").write_bytes(b"\x00" * 1000)
 
         rom_detail = {"fs_name_no_ext": "Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         assert not (tmp_path / "Game.m3u").exists()
 
@@ -655,7 +663,7 @@ class TestMaybeGenerateM3u:
         (tmp_path / "d2.chd").write_bytes(b"\x00" * 100)
 
         rom_detail = {"name": "My Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         assert (tmp_path / "My Game.m3u").exists()
 
@@ -686,7 +694,7 @@ class TestDoDownloadSingleFile:
             "has_multiple_files": False,
         }
 
-        def fake_download(rom_id, filename, dest, progress_callback=None):
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
             with open(dest, "wb") as f:
                 f.write(b"\x00" * 512)
 
@@ -751,7 +759,7 @@ class TestDoDownloadMultiFile:
             "has_multiple_files": True,
         }
 
-        def fake_download(rom_id, filename, dest, progress_callback=None):
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
             with open(dest, "wb") as f:
                 f.write(zip_bytes)
 
@@ -932,7 +940,7 @@ class TestDoDownloadCancelled:
             "has_multiple_files": False,
         }
 
-        def fake_download_cancel(rom_id, filename, dest, progress_callback=None):
+        def fake_download_cancel(_rom_id, _filename, dest, _progress_callback=None):
             raise asyncio.CancelledError()
 
         plugin._download_service._loop = asyncio.get_event_loop()
@@ -972,7 +980,7 @@ class TestDoDownloadZipFailure:
             "has_multiple_files": True,
         }
 
-        def fake_download(rom_id, filename, dest, progress_callback=None):
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
             # Write invalid data (not a real zip)
             with open(dest, "wb") as f:
                 f.write(b"not a zip file")
@@ -1035,7 +1043,7 @@ class TestMaybeGenerateM3uMixedFormats:
         (tmp_path / "disc2.chd").write_bytes(b"\x00" * 100)
 
         rom_detail = {"fs_name_no_ext": "Mixed Game", "name": "Mixed Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         m3u_path = tmp_path / "Mixed Game.m3u"
         assert m3u_path.exists()
@@ -1060,7 +1068,7 @@ class TestMaybeGenerateM3uSpecialCharacters:
             (tmp_path / name).write_text("cue data")
 
         rom_detail = {"fs_name_no_ext": "Game", "name": "Game"}
-        plugin._download_service._maybe_generate_m3u(str(tmp_path), rom_detail)
+        plugin._download_service._maybe_generate_m3u_io(str(tmp_path), rom_detail)
 
         m3u_path = tmp_path / "Game.m3u"
         assert m3u_path.exists()
@@ -1167,7 +1175,7 @@ class TestUrlEncodedFilenameRename:
             "has_multiple_files": True,
         }
 
-        def fake_download(rom_id, filename, dest, progress_callback=None):
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
             with open(dest, "wb") as f:
                 f.write(zip_bytes)
 
@@ -1218,7 +1226,7 @@ class TestUrlEncodedFilenameRename:
             "has_multiple_files": True,
         }
 
-        def fake_download(rom_id, filename, dest, progress_callback=None):
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
             with open(dest, "wb") as f:
                 f.write(zip_bytes)
 
@@ -1341,9 +1349,9 @@ class TestRemoveRomCleansSaveSyncState:
             "playtime": {"42": {"total_seconds": 3600}, "99": {"total_seconds": 7200}},
             "settings": {"save_sync_enabled": False},
         }
-        plugin._download_service._save_sync_state = save_sync_state
+        plugin._rom_removal_service._save_sync_state = save_sync_state
         save_calls = []
-        plugin._download_service._save_save_sync_state = lambda: save_calls.append(1)
+        plugin._rom_removal_service._save_save_sync_state = lambda: save_calls.append(1)
 
         result = await plugin.remove_rom(42)
         assert result["success"] is True
@@ -1379,9 +1387,9 @@ class TestRemoveRomCleansSaveSyncState:
             "playtime": {"1": {"total_seconds": 100}, "2": {"total_seconds": 200}},
             "settings": {"save_sync_enabled": False},
         }
-        plugin._download_service._save_sync_state = save_sync_state
+        plugin._rom_removal_service._save_sync_state = save_sync_state
         save_calls = []
-        plugin._download_service._save_save_sync_state = lambda: save_calls.append(1)
+        plugin._rom_removal_service._save_save_sync_state = lambda: save_calls.append(1)
 
         result = await plugin.uninstall_all_roms()
         assert result["success"] is True

--- a/tests/test_rom_files.py
+++ b/tests/test_rom_files.py
@@ -1,0 +1,184 @@
+"""Tests for domain.rom_files — pure M3U and launch file detection functions."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
+
+from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
+
+
+class TestNeedsM3u:
+    def test_two_disc_files_returns_true(self):
+        assert needs_m3u(["disc1.cue", "disc2.cue"]) is True
+
+    def test_three_disc_files_returns_true(self):
+        assert needs_m3u(["disc1.chd", "disc2.chd", "disc3.chd"]) is True
+
+    def test_single_disc_file_returns_false(self):
+        assert needs_m3u(["game.cue"]) is False
+
+    def test_empty_list_returns_false(self):
+        assert needs_m3u([]) is False
+
+    def test_boundary_exactly_two(self):
+        assert needs_m3u(["a.iso", "b.iso"]) is True
+
+    def test_boundary_exactly_one(self):
+        assert needs_m3u(["a.iso"]) is False
+
+
+class TestBuildM3uContent:
+    def test_two_files_sorted(self):
+        content = build_m3u_content(["disc2.cue", "disc1.cue"])
+        lines = content.strip().split("\n")
+        assert lines[0] == "disc1.cue"
+        assert lines[1] == "disc2.cue"
+
+    def test_trailing_newline(self):
+        content = build_m3u_content(["disc1.cue", "disc2.cue"])
+        assert content.endswith("\n")
+
+    def test_single_file(self):
+        content = build_m3u_content(["game.cue"])
+        assert content.strip() == "game.cue"
+        assert content.endswith("\n")
+
+    def test_already_sorted_list_unchanged(self):
+        files = ["disc1.cue", "disc2.cue", "disc3.cue"]
+        content = build_m3u_content(files)
+        lines = content.strip().split("\n")
+        assert lines == ["disc1.cue", "disc2.cue", "disc3.cue"]
+
+    def test_special_characters_preserved(self):
+        files = ["Game (Disc 1) [Japan].cue", "Game (Disc 2) [Japan].cue"]
+        content = build_m3u_content(files)
+        lines = content.strip().split("\n")
+        assert "Game (Disc 1) [Japan].cue" in lines
+        assert "Game (Disc 2) [Japan].cue" in lines
+
+    def test_sorting_is_applied(self):
+        files = ["b.cue", "c.cue", "a.cue"]
+        content = build_m3u_content(files)
+        lines = content.strip().split("\n")
+        assert lines == ["a.cue", "b.cue", "c.cue"]
+
+    def test_mixed_formats_sorted_together(self):
+        files = ["disc2.chd", "disc1.cue"]
+        content = build_m3u_content(files)
+        lines = content.strip().split("\n")
+        assert len(lines) == 2
+        # Both present, sorted alphabetically
+        assert "disc1.cue" in lines
+        assert "disc2.chd" in lines
+
+
+class TestDetectLaunchFile:
+    def test_empty_list_returns_none(self):
+        assert detect_launch_file([]) is None
+
+    def test_prefers_m3u_over_cue(self, tmp_path):
+        m3u = str(tmp_path / "game.m3u")
+        cue = str(tmp_path / "disc1.cue")
+        open(m3u, "w").close()
+        open(cue, "w").close()
+        result = detect_launch_file([m3u, cue])
+        assert result == m3u
+
+    def test_prefers_cue_over_bin(self, tmp_path):
+        cue = str(tmp_path / "disc1.cue")
+        binf = str(tmp_path / "disc1.bin")
+        open(cue, "w").close()
+        with open(binf, "wb") as f:
+            f.write(b"\x00" * 1000)
+        result = detect_launch_file([cue, binf])
+        assert result == cue
+
+    def test_rpx_returned_when_no_m3u_or_cue(self, tmp_path):
+        rpx = str(tmp_path / "code" / "game.rpx")
+        os.makedirs(os.path.dirname(rpx))
+        open(rpx, "w").close()
+        result = detect_launch_file([rpx])
+        assert result == rpx
+
+    def test_m3u_beats_rpx(self, tmp_path):
+        m3u = str(tmp_path / "game.m3u")
+        rpx = str(tmp_path / "code" / "game.rpx")
+        os.makedirs(os.path.dirname(rpx))
+        open(m3u, "w").close()
+        open(rpx, "w").close()
+        result = detect_launch_file([m3u, rpx])
+        assert result == m3u
+
+    def test_wux_disc_image(self, tmp_path):
+        wux = str(tmp_path / "game.wux")
+        txt = str(tmp_path / "readme.txt")
+        with open(wux, "wb") as f:
+            f.write(b"\x00" * 1000)
+        open(txt, "w").close()
+        result = detect_launch_file([wux, txt])
+        assert result == wux
+
+    def test_wud_disc_image(self, tmp_path):
+        wud = str(tmp_path / "game.wud")
+        with open(wud, "wb") as f:
+            f.write(b"\x00" * 1000)
+        result = detect_launch_file([wud])
+        assert result == wud
+
+    def test_wua_disc_image(self, tmp_path):
+        wua = str(tmp_path / "game.wua")
+        with open(wua, "wb") as f:
+            f.write(b"\x00" * 1000)
+        result = detect_launch_file([wua])
+        assert result == wua
+
+    def test_eboot_bin_ps3(self, tmp_path):
+        eboot = str(tmp_path / "PS3_GAME" / "USRDIR" / "EBOOT.BIN")
+        os.makedirs(os.path.dirname(eboot))
+        with open(eboot, "wb") as f:
+            f.write(b"\x00" * 500)
+        result = detect_launch_file([eboot])
+        assert result == eboot
+
+    def test_3ds_preferred_over_cia(self, tmp_path):
+        rom_3ds = str(tmp_path / "game.3ds")
+        cia = str(tmp_path / "game.cia")
+        with open(rom_3ds, "wb") as f:
+            f.write(b"\x00" * 100)
+        with open(cia, "wb") as f:
+            f.write(b"\x00" * 100)
+        result = detect_launch_file([rom_3ds, cia])
+        assert result == rom_3ds
+
+    def test_cia_preferred_over_cxi(self, tmp_path):
+        cia = str(tmp_path / "game.cia")
+        cxi = str(tmp_path / "game.cxi")
+        with open(cia, "wb") as f:
+            f.write(b"\x00" * 100)
+        with open(cxi, "wb") as f:
+            f.write(b"\x00" * 100)
+        result = detect_launch_file([cia, cxi])
+        assert result == cia
+
+    def test_falls_back_to_largest_file(self, tmp_path):
+        small = str(tmp_path / "small.bin")
+        large = str(tmp_path / "large.bin")
+        with open(small, "wb") as f:
+            f.write(b"\x00" * 100)
+        with open(large, "wb") as f:
+            f.write(b"\x00" * 10000)
+        result = detect_launch_file([small, large])
+        assert result == large
+
+    def test_single_file_returned_directly(self, tmp_path):
+        f = str(tmp_path / "game.z64")
+        with open(f, "wb") as fh:
+            fh.write(b"\x00" * 100)
+        assert detect_launch_file([f]) == f
+
+    def test_case_insensitive_extension_matching(self, tmp_path):
+        m3u = str(tmp_path / "GAME.M3U")
+        open(m3u, "w").close()
+        result = detect_launch_file([m3u])
+        assert result == m3u

--- a/tests/test_rom_removal.py
+++ b/tests/test_rom_removal.py
@@ -1,0 +1,424 @@
+"""Tests for RomRemovalService — ROM file deletion and state cleanup."""
+
+import asyncio
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+# conftest.py patches decky before this import
+from services.rom_removal import RomRemovalService  # noqa: E402
+
+
+@pytest.fixture
+def state():
+    return {"installed_roms": {}}
+
+
+@pytest.fixture
+def save_sync_state():
+    return {"saves": {}, "playtime": {}, "settings": {}}
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_rom_removal")
+
+
+@pytest.fixture
+def service(state, save_sync_state, logger):
+    return RomRemovalService(
+        state=state,
+        save_sync_state=save_sync_state,
+        logger=logger,
+        loop=asyncio.new_event_loop(),
+        save_state=MagicMock(),
+        save_save_sync_state=MagicMock(),
+    )
+
+
+@pytest.fixture(autouse=True)
+async def _sync_loop(service):
+    """Keep service loop in sync with the running event loop."""
+    service._loop = asyncio.get_event_loop()
+
+
+class TestIsSafeRomPath:
+    def test_path_inside_roms_dir_is_safe(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        safe = str(tmp_path / "retrodeck" / "roms" / "n64" / "game.z64")
+        assert service._is_safe_rom_path(safe) is True
+
+    def test_path_outside_roms_dir_is_not_safe(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        outside = str(tmp_path / "evil" / "game.z64")
+        assert service._is_safe_rom_path(outside) is False
+
+    def test_roms_base_itself_is_not_safe(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        # Only 1 level deep — must be at least 2
+        base = str(tmp_path / "retrodeck" / "roms" / "n64")
+        assert service._is_safe_rom_path(base) is False
+
+    def test_etc_passwd_is_not_safe(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        assert service._is_safe_rom_path("/etc/passwd") is False
+
+
+class TestDeleteRomFiles:
+    def test_deletes_single_file(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom = tmp_path / "retrodeck" / "roms" / "n64" / "game.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_bytes(b"\x00" * 100)
+
+        service._delete_rom_files({"file_path": str(rom)})
+        assert not rom.exists()
+
+    def test_deletes_rom_dir(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom_dir = tmp_path / "retrodeck" / "roms" / "psx" / "FF7"
+        rom_dir.mkdir(parents=True)
+        (rom_dir / "disc1.cue").write_text("cue")
+        (rom_dir / "disc1.bin").write_bytes(b"\x00" * 100)
+
+        service._delete_rom_files({"file_path": str(rom_dir / "FF7.m3u"), "rom_dir": str(rom_dir)})
+        assert not rom_dir.exists()
+
+    def test_refuses_file_outside_roms_dir(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        evil = tmp_path / "evil" / "important.txt"
+        evil.parent.mkdir(parents=True)
+        evil.write_text("do not delete")
+
+        service._delete_rom_files({"file_path": str(evil)})
+        assert evil.exists()
+
+    def test_refuses_rom_dir_outside_roms_dir(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        evil_dir = tmp_path / "evil"
+        evil_dir.mkdir(parents=True)
+        (evil_dir / "file.txt").write_text("important")
+
+        service._delete_rom_files({"rom_dir": str(evil_dir), "file_path": ""})
+        assert evil_dir.exists()
+
+    def test_missing_file_no_crash(self, service, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        # File doesn't exist — should not raise
+        service._delete_rom_files({"file_path": str(tmp_path / "retrodeck" / "roms" / "n64" / "gone.z64")})
+
+    def test_empty_paths_no_crash(self, service):
+        # No file_path, no rom_dir
+        service._delete_rom_files({"file_path": "", "rom_dir": ""})
+
+
+class TestRemoveRom:
+    @pytest.mark.asyncio
+    async def test_removes_file_and_clears_state(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom = tmp_path / "retrodeck" / "roms" / "n64" / "zelda.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"]["42"] = {"rom_id": 42, "file_path": str(rom), "system": "n64"}
+
+        result = await service.remove_rom(42)
+        assert result["success"] is True
+        assert not rom.exists()
+        assert "42" not in state["installed_roms"]
+
+    @pytest.mark.asyncio
+    async def test_returns_error_if_not_installed(self, service):
+        result = await service.remove_rom(999)
+        assert result["success"] is False
+        assert "not installed" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_rom_id(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom = tmp_path / "retrodeck" / "roms" / "n64" / "game.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"]["7"] = {"rom_id": 7, "file_path": str(rom), "system": "n64"}
+
+        result = await service.remove_rom("7")
+        assert result["success"] is True
+        assert "7" not in state["installed_roms"]
+
+    @pytest.mark.asyncio
+    async def test_file_already_gone_cleans_state(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        state["installed_roms"]["42"] = {
+            "rom_id": 42,
+            "file_path": str(tmp_path / "retrodeck" / "roms" / "n64" / "gone.z64"),
+            "system": "n64",
+        }
+
+        result = await service.remove_rom(42)
+        assert result["success"] is True
+        assert "42" not in state["installed_roms"]
+
+    @pytest.mark.asyncio
+    async def test_cleans_save_sync_state(self, service, state, save_sync_state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom = tmp_path / "retrodeck" / "roms" / "n64" / "zelda.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"]["42"] = {"rom_id": 42, "file_path": str(rom), "system": "n64"}
+        save_sync_state["saves"]["42"] = {"last_sync": "2024-01-01"}
+        save_sync_state["playtime"]["42"] = {"total_seconds": 3600}
+        # Add another ROM's state that should be preserved
+        save_sync_state["saves"]["99"] = {"last_sync": "2024-02-01"}
+        save_sync_state["playtime"]["99"] = {"total_seconds": 7200}
+
+        save_calls: list[int] = []
+        service._save_save_sync_state = lambda: save_calls.append(1)
+
+        result = await service.remove_rom(42)
+        assert result["success"] is True
+        assert "42" not in save_sync_state["saves"]
+        assert "42" not in save_sync_state["playtime"]
+        assert "99" in save_sync_state["saves"]
+        assert "99" in save_sync_state["playtime"]
+        assert len(save_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_save_sync_call_if_no_matching_state(self, service, state, save_sync_state, tmp_path):
+        _ = save_sync_state  # fixture ensures shared dict is initialized
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom = tmp_path / "retrodeck" / "roms" / "n64" / "zelda.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"]["42"] = {"rom_id": 42, "file_path": str(rom), "system": "n64"}
+        # No matching save/playtime state for ROM 42
+
+        save_calls: list[int] = []
+        service._save_save_sync_state = lambda: save_calls.append(1)
+
+        await service.remove_rom(42)
+        assert len(save_calls) == 0  # not called if nothing changed
+
+    @pytest.mark.asyncio
+    async def test_removes_rom_dir(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom_dir = tmp_path / "retrodeck" / "roms" / "psx" / "FF7"
+        rom_dir.mkdir(parents=True)
+        (rom_dir / "FF7.m3u").write_text("disc1.cue")
+        (rom_dir / "disc1.cue").write_text("cue")
+        (rom_dir / "disc1.bin").write_bytes(b"\x00" * 100)
+
+        state["installed_roms"]["42"] = {
+            "rom_id": 42,
+            "file_path": str(rom_dir / "FF7.m3u"),
+            "rom_dir": str(rom_dir),
+            "system": "psx",
+        }
+
+        result = await service.remove_rom(42)
+        assert result["success"] is True
+        assert not rom_dir.exists()
+        # Parent system dir should still exist
+        assert (tmp_path / "retrodeck" / "roms" / "psx").exists()
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        evil = tmp_path / "etc" / "passwd"
+        evil.parent.mkdir(parents=True)
+        evil.write_text("root:x:0:0")
+
+        state["installed_roms"]["99"] = {"rom_id": 99, "file_path": str(evil), "system": "n64"}
+
+        await service.remove_rom(99)
+        assert evil.exists()
+        assert "99" not in state["installed_roms"]
+
+
+class TestUninstallAllRoms:
+    @pytest.mark.asyncio
+    async def test_removes_all_installed(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        file_a = roms_dir / "game_a.z64"
+        file_b = roms_dir / "game_b.z64"
+        file_a.write_bytes(b"\x00" * 100)
+        file_b.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": str(file_a), "system": "n64"},
+            "2": {"rom_id": 2, "file_path": str(file_b), "system": "n64"},
+        }
+
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert result["removed_count"] == 2
+        assert not file_a.exists()
+        assert not file_b.exists()
+        assert state["installed_roms"] == {}
+
+    @pytest.mark.asyncio
+    async def test_clears_state_even_if_files_missing(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/nonexistent.z64", "system": "n64"},
+        }
+
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert state["installed_roms"] == {}
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_state(self, service, state, tmp_path):
+        _ = state  # fixture ensures shared dict is initialized
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert result["removed_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cleans_save_sync_state(self, service, state, save_sync_state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        file_a = roms_dir / "game_a.z64"
+        file_b = roms_dir / "game_b.z64"
+        file_a.write_bytes(b"\x00" * 100)
+        file_b.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": str(file_a), "system": "n64"},
+            "2": {"rom_id": 2, "file_path": str(file_b), "system": "n64"},
+        }
+        save_sync_state["saves"] = {"1": {"last_sync": "2024-01-01"}, "2": {"last_sync": "2024-02-01"}}
+        save_sync_state["playtime"] = {"1": {"total_seconds": 100}, "2": {"total_seconds": 200}}
+
+        save_calls: list[int] = []
+        service._save_save_sync_state = lambda: save_calls.append(1)
+
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert save_sync_state["saves"] == {}
+        assert save_sync_state["playtime"] == {}
+        assert len(save_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_deletes_rom_directories(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        rom_dir = tmp_path / "retrodeck" / "roms" / "psx" / "FF7"
+        rom_dir.mkdir(parents=True)
+        (rom_dir / "disc1.bin").write_bytes(b"\x00" * 100)
+
+        state["installed_roms"] = {
+            "1": {
+                "rom_id": 1,
+                "file_path": str(rom_dir / "FF7.m3u"),
+                "rom_dir": str(rom_dir),
+                "system": "psx",
+            },
+        }
+
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert result["removed_count"] == 1
+        assert not rom_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_outside_roms_dir_skipped_state_still_cleared(self, service, state, save_sync_state, tmp_path):
+        _ = save_sync_state  # fixture ensures shared dict is initialized
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        good_file = roms_dir / "game_a.z64"
+        good_file.write_bytes(b"\x00" * 100)
+
+        bad_file = tmp_path / "outside" / "game_b.z64"
+        bad_file.parent.mkdir(parents=True)
+        bad_file.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": str(good_file), "system": "n64"},
+            "2": {"rom_id": 2, "file_path": str(bad_file), "system": "snes"},
+        }
+
+        result = await service.uninstall_all_roms()
+        assert result["success"] is True
+        assert not good_file.exists()
+        assert bad_file.exists()  # not deleted (outside roms dir)
+        # State is cleared for successfully deleted ROMs
+        assert state["installed_roms"] == {}
+
+    @pytest.mark.asyncio
+    async def test_message_includes_error_count(self, service, state, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        rom = roms_dir / "game.z64"
+        rom.write_bytes(b"\x00" * 100)
+
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": str(rom), "system": "n64"},
+        }
+
+        # Make deletion fail
+        with patch("shutil.rmtree", side_effect=OSError("perm")):
+            with patch("os.remove", side_effect=OSError("perm")):
+                result = await service.uninstall_all_roms()
+
+        assert result["success"] is True
+        assert "errors" in result["message"]


### PR DESCRIPTION
## Summary

- Extracts ROM removal logic from DownloadService into dedicated `RomRemovalService` (delete, uninstall, path traversal safety)
- Extracts pure M3U/launch-file logic into `domain/rom_files.py` (`needs_m3u`, `build_m3u_content`, `detect_launch_file`)
- Extracts `_make_progress_callback` from `_do_download` to reduce cognitive complexity (Sonar S3776)
- Fixes pre-existing test warnings (unused params, float equality)

Closes #112

## Test plan

- [x] `python -m pytest tests/ -q` — 1228 passed, 0 warnings
- [x] `ruff check` — all checks passed
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 5 contracts kept, 0 broken