### PR TITLE
refactor(services): split LibraryService into focused sub-services

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -56,6 +56,7 @@ name = Services must not import other services
 type = independence
 modules =
     services.achievements
+    services.artwork
     services.downloads
     services.firmware
     services.game_detail
@@ -65,4 +66,5 @@ modules =
     services.playtime
     services.rom_removal
     services.saves
+    services.shortcut_removal
     services.steamgrid

--- a/main.py
+++ b/main.py
@@ -162,6 +162,8 @@ class Plugin:
         self._achievements_service = services["achievements_service"]
         self._migration_service = services["migration_service"]
         self._game_detail_service = services["game_detail_service"]
+        self._artwork_service = services["artwork_service"]
+        self._shortcut_removal_service = services["shortcut_removal_service"]
         self._firmware_service.load_bios_registry()
 
         # ── 5. Startup healing ──────────────────────────────────────────────
@@ -171,7 +173,7 @@ class Plugin:
         self._prune_stale_registry()
         self._save_sync_service.prune_orphaned_state()
         self._sgdb_service.prune_orphaned_artwork_cache()
-        self._sync_service.prune_orphaned_staging_artwork()
+        self._artwork_service.prune_orphaned_staging_artwork()
         self._download_service.cleanup_leftover_tmp_files()
 
         # ── 6. Background tasks ─────────────────────────────────────────────
@@ -463,16 +465,16 @@ class Plugin:
         return self._sync_service.get_registry_platforms()
 
     async def remove_platform_shortcuts(self, platform_slug):
-        return await self._sync_service.remove_platform_shortcuts(platform_slug)
+        return await self._shortcut_removal_service.remove_platform_shortcuts(platform_slug)
 
     async def remove_all_shortcuts(self):
-        return self._sync_service.remove_all_shortcuts()
+        return self._shortcut_removal_service.remove_all_shortcuts()
 
     async def report_removal_results(self, removed_rom_ids):
-        return await self._sync_service.report_removal_results(removed_rom_ids)
+        return await self._shortcut_removal_service.report_removal_results(removed_rom_ids)
 
     async def get_artwork_base64(self, rom_id):
-        return await self._sync_service.get_artwork_base64(rom_id)
+        return await self._artwork_service.get_artwork_base64(int(rom_id), self._sync_service.pending_sync)
 
     async def clear_sync_cache(self):
         return self._sync_service.clear_sync_cache()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -19,6 +19,7 @@ from adapters.romm.api_router import ApiRouter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
+from services.artwork import ArtworkService
 from services.downloads import DownloadService
 from services.firmware import FirmwareService
 from services.game_detail import GameDetailService
@@ -30,6 +31,7 @@ from services.protocols import RommApiProtocol
 from services.protocols import SteamConfigAdapter as SteamConfigProtocol
 from services.rom_removal import RomRemovalService
 from services.saves import SaveService
+from services.shortcut_removal import ShortcutRemovalService
 from services.steamgrid import SteamGridService
 
 
@@ -152,6 +154,27 @@ def wire_services(cfg: WiringConfig) -> dict:
         log_debug=cfg.log_debug,
     )
 
+    artwork_service = ArtworkService(
+        romm_api=cfg.romm_api,
+        steam_config=cfg.steam_config,
+        state=cfg.state,
+        loop=cfg.loop,
+        logger=cfg.logger,
+        emit=cfg.emit,
+        sync_state_ref=lambda: None,  # placeholder; overwritten below after LibraryService is created
+    )
+
+    shortcut_removal_service = ShortcutRemovalService(
+        romm_api=cfg.romm_api,
+        steam_config=cfg.steam_config,
+        state=cfg.state,
+        loop=cfg.loop,
+        logger=cfg.logger,
+        emit=cfg.emit,
+        save_state=cfg.save_state,
+        remove_artwork_files=artwork_service.remove_artwork_files,
+    )
+
     sync_service = LibraryService(
         romm_api=cfg.romm_api,
         steam_config=cfg.steam_config,
@@ -166,7 +189,11 @@ def wire_services(cfg: WiringConfig) -> dict:
         save_settings_to_disk=cfg.save_settings_to_disk,
         log_debug=cfg.log_debug,
         metadata_service=metadata_service,
+        artwork=artwork_service,
     )
+
+    # Wire sync_state_ref after sync_service is created (breaks circular dependency)
+    artwork_service._sync_state_ref = lambda: sync_service.sync_state
 
     download_service = DownloadService(
         romm_api=cfg.romm_api,
@@ -252,4 +279,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         "achievements_service": achievements_service,
         "migration_service": migration_service,
         "game_detail_service": game_detail_service,
+        "artwork_service": artwork_service,
+        "shortcut_removal_service": shortcut_removal_service,
     }

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -1,0 +1,47 @@
+"""Pure functions for building shortcut data dicts.
+
+No I/O, no imports from services, adapters, or lib.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
+    """Transform ROM list into shortcut data dicts for frontend AddShortcut calls."""
+    exe = os.path.join(plugin_dir, "bin", "romm-launcher")
+    start_dir = os.path.join(plugin_dir, "bin")
+    return [
+        {
+            "rom_id": rom["id"],
+            "name": rom["name"],
+            "fs_name": rom.get("fs_name", ""),
+            "exe": exe,
+            "start_dir": start_dir,
+            "launch_options": f"romm:{rom['id']}",
+            "platform_name": rom.get("platform_name", "Unknown"),
+            "platform_slug": rom.get("platform_slug", ""),
+            "igdb_id": rom.get("igdb_id"),
+            "sgdb_id": rom.get("sgdb_id"),
+            "ra_id": rom.get("ra_id"),
+            "cover_path": "",
+        }
+        for rom in roms
+    ]
+
+
+def build_registry_entry(pending: dict, app_id: int, cover_path: str) -> dict:
+    """Build a shortcut registry entry from pending sync data."""
+    entry = {
+        "app_id": app_id,
+        "name": pending.get("name", ""),
+        "fs_name": pending.get("fs_name", ""),
+        "platform_name": pending.get("platform_name", ""),
+        "platform_slug": pending.get("platform_slug", ""),
+        "cover_path": cover_path,
+    }
+    for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
+        if pending.get(meta_key):
+            entry[meta_key] = pending[meta_key]
+    return entry

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -1,0 +1,229 @@
+"""ArtworkService — cover art download, staging, and cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import pathlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
+
+    from services.protocols import RommApiProtocol, SteamConfigAdapter
+
+
+class ArtworkService:
+    """Manages artwork downloading, staging, finalisation, and cleanup."""
+
+    def __init__(
+        self,
+        *,
+        romm_api: RommApiProtocol,
+        steam_config: SteamConfigAdapter,
+        state: dict,
+        loop: asyncio.AbstractEventLoop,
+        logger: logging.Logger,
+        emit: Callable,
+        sync_state_ref: Callable,
+    ) -> None:
+        self._romm_api = romm_api
+        self._steam_config = steam_config
+        self._state = state
+        self._loop = loop
+        self._logger = logger
+        self._emit = emit
+        # A callable that returns the current SyncState value so artwork
+        # download can react to cancellation without importing library.py.
+        self._sync_state_ref = sync_state_ref
+
+    # ── Existing cover path check ──────────────────────────────────────────
+
+    def existing_cover_path(self, rom_id: int, grid: str) -> str | None:
+        """Return an existing cover path for *rom_id*, or ``None`` if a download is needed."""
+        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+
+        # If already synced and final artwork exists, reuse it
+        reg = self._state["shortcut_registry"].get(str(rom_id))
+        if reg and reg.get("app_id"):
+            final = os.path.join(grid, f"{reg['app_id']}p.png")
+            if os.path.exists(final):
+                return final
+
+        # If staging file already exists (e.g. retry), reuse it
+        if os.path.exists(staging):
+            return staging
+
+        return None
+
+    # ── Artwork download ───────────────────────────────────────────────────
+
+    async def download_artwork(
+        self,
+        all_roms: list[dict],
+        emit_progress: Callable,
+        is_cancelling: Callable,
+        progress_step: int = 4,
+        progress_total_steps: int = 6,
+    ) -> dict[int, str]:
+        """Download cover artwork to staging filenames (romm_{rom_id}_cover.png).
+
+        Decouples download from the final Steam app_id, which isn't known until
+        after AddShortcut. finalize_cover_path() renames to {app_id}p.png.
+        Returns dict of rom_id -> local cover path.
+        """
+        cover_paths: dict[int, str] = {}
+        grid = self._steam_config.grid_dir()
+        if not grid:
+            self._logger.warning("Cannot find grid directory, skipping artwork")
+            return cover_paths
+
+        total = len(all_roms)
+
+        for i, rom in enumerate(all_roms):
+            if is_cancelling():
+                return cover_paths
+
+            await emit_progress(
+                "applying",
+                current=i + 1,
+                total=total,
+                message=f"Downloading artwork {i + 1}/{total}",
+                step=progress_step,
+                total_steps=progress_total_steps,
+            )
+
+            cover_url = rom.get("path_cover_large") or rom.get("path_cover_small")
+            if not cover_url:
+                continue
+
+            rom_id = rom["id"]
+            existing = self.existing_cover_path(rom_id, grid)
+            if existing:
+                cover_paths[rom_id] = existing
+                continue
+
+            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+            try:
+                await self._loop.run_in_executor(None, self._romm_api.download_cover, cover_url, staging)
+                cover_paths[rom_id] = staging
+            except Exception as e:
+                self._logger.warning(f"Failed to download artwork for {rom['name']}: {e}")
+
+        return cover_paths
+
+    # ── Artwork finalisation ───────────────────────────────────────────────
+
+    def finalize_cover_path(self, grid: str | None, cover_path: str, app_id: int, rom_id_str: str) -> str:
+        """Rename staged artwork to final Steam app_id filename, return final path."""
+        if not grid or not cover_path:
+            return cover_path
+        final_path = os.path.join(grid, f"{app_id}p.png")
+        if cover_path != final_path and os.path.exists(cover_path):
+            try:
+                os.replace(cover_path, final_path)
+                return final_path
+            except OSError as e:
+                self._logger.warning(f"Failed to rename artwork for rom {rom_id_str}: {e}")
+        elif os.path.exists(final_path):
+            return final_path
+        return cover_path
+
+    # ── Artwork removal ────────────────────────────────────────────────────
+
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None:
+        """Remove all artwork files for a registry entry."""
+        removed = False
+        # Try cover_path first (stores the final renamed path)
+        cover_path = entry.get("cover_path", "")
+        if cover_path and os.path.exists(cover_path):
+            os.remove(cover_path)
+            removed = True
+        # Try {app_id}p.png (the standard Steam grid filename)
+        if not removed and entry.get("app_id"):
+            app_path = os.path.join(grid, f"{entry['app_id']}p.png")
+            if os.path.exists(app_path):
+                os.remove(app_path)
+                removed = True
+        # Fallback: legacy artwork_id format
+        if not removed:
+            artwork_id = entry.get("artwork_id")
+            if artwork_id:
+                art_path = os.path.join(grid, f"{artwork_id}p.png")
+                if os.path.exists(art_path):
+                    os.remove(art_path)
+        # Clean up any leftover staging file
+        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+        if os.path.exists(staging):
+            os.remove(staging)
+
+    # ── Artwork base64 query ───────────────────────────────────────────────
+
+    async def get_artwork_base64(self, rom_id: int, pending_sync: dict) -> dict:
+        """Return base64-encoded cover artwork for a single ROM."""
+        grid = self._steam_config.grid_dir()
+        if not grid:
+            return {"base64": None}
+
+        # Check pending sync data first (staging path)
+        pending = pending_sync.get(rom_id, {})
+        cover_path = pending.get("cover_path", "")
+
+        # Fall back to registry
+        if not cover_path:
+            reg = self._state["shortcut_registry"].get(str(rom_id), {})
+            cover_path = reg.get("cover_path", "")
+
+        # Try staging filename as last resort
+        if not cover_path:
+            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+            if os.path.exists(staging):
+                cover_path = staging
+
+        if cover_path and os.path.exists(cover_path):
+            try:
+                data = await self._loop.run_in_executor(None, lambda: pathlib.Path(cover_path).read_bytes())
+                return {"base64": base64.b64encode(data).decode("ascii")}
+            except Exception as e:
+                self._logger.warning(f"Failed to read artwork for rom {rom_id}: {e}")
+
+        return {"base64": None}
+
+    # ── Staging file housekeeping ──────────────────────────────────────────
+
+    def is_staging_file_orphaned(self, grid: str, registry: dict, rom_id: str) -> bool:
+        """Check if a staging artwork file is orphaned (not in registry or has final artwork)."""
+        if rom_id not in registry:
+            return True
+        app_id = registry[rom_id].get("app_id")
+        if app_id:
+            final = os.path.join(grid, f"{app_id}p.png")
+            return os.path.exists(final)
+        return False
+
+    def prune_orphaned_staging_artwork(self) -> None:
+        """Remove orphaned romm_{rom_id}_cover.png staging files from Steam grid dir."""
+        grid = self._steam_config.grid_dir()
+        if not grid or not os.path.isdir(grid):
+            return
+        registry = self._state.get("shortcut_registry", {})
+        pruned = []
+        for filename in os.listdir(grid):
+            if not filename.startswith("romm_") or not filename.endswith("_cover.png"):
+                continue
+            try:
+                rom_id = filename[len("romm_") : -len("_cover.png")]
+                int(rom_id)  # validate it's numeric
+            except (ValueError, IndexError):
+                continue
+            if not self.is_staging_file_orphaned(grid, registry, rom_id):
+                continue
+            try:
+                os.remove(os.path.join(grid, filename))
+                pruned.append(filename)
+            except OSError as e:
+                self._logger.warning(f"Failed to remove orphaned staging artwork {filename}: {e}")
+        if pruned:
+            self._logger.info(f"Pruned {len(pruned)} orphaned staging artwork file(s)")

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -1,20 +1,22 @@
 """LibraryService — library sync engine.
 
-Handles platform/ROM fetching, shortcut data preparation, artwork
-downloading, delta preview/apply, and shortcut registry management.
+Handles platform/ROM fetching, shortcut data preparation,
+delta preview/apply, and shortcut registry management.
+
+Artwork operations are delegated to ArtworkService via callbacks.
+Shortcut removal is delegated to ShortcutRemovalService.
 """
 
 from __future__ import annotations
 
 import asyncio
-import base64
-import os
-import pathlib
 import time
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+
+from domain.shortcut_data import build_registry_entry, build_shortcuts_data
 
 from lib.errors import classify_error
 
@@ -35,7 +37,7 @@ _SYNC_CANCELLED = "Sync cancelled"
 
 
 class LibraryService:
-    """Sync engine: fetch ROMs, prepare shortcuts, manage artwork + registry."""
+    """Sync engine: fetch ROMs, prepare shortcuts, manage registry."""
 
     def __init__(
         self,
@@ -53,6 +55,7 @@ class LibraryService:
         save_settings_to_disk: Callable,
         log_debug: Callable,
         metadata_service: Any = None,
+        artwork: Any = None,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
@@ -67,6 +70,7 @@ class LibraryService:
         self._save_settings_to_disk = save_settings_to_disk
         self._log_debug = log_debug
         self._metadata_service = metadata_service
+        self._artwork = artwork
 
         # Sync-specific state (owned by this service)
         self._sync_state = SyncState.IDLE
@@ -525,25 +529,7 @@ class LibraryService:
 
     def _build_shortcuts_data(self, all_roms):
         """Build shortcut data list from ROM list."""
-        exe = os.path.join(self._plugin_dir, "bin", "romm-launcher")
-        start_dir = os.path.join(self._plugin_dir, "bin")
-        return [
-            {
-                "rom_id": rom["id"],
-                "name": rom["name"],
-                "fs_name": rom.get("fs_name", ""),
-                "exe": exe,
-                "start_dir": start_dir,
-                "launch_options": f"romm:{rom['id']}",
-                "platform_name": rom.get("platform_name", "Unknown"),
-                "platform_slug": rom.get("platform_slug", ""),
-                "igdb_id": rom.get("igdb_id"),
-                "sgdb_id": rom.get("sgdb_id"),
-                "ra_id": rom.get("ra_id"),
-                "cover_path": "",
-            }
-            for rom in all_roms
-        ]
+        return build_shortcuts_data(all_roms, self._plugin_dir)
 
     async def _fetch_and_prepare(self):
         """Fetch platforms + ROMs, prepare shortcut data.
@@ -713,34 +699,15 @@ class LibraryService:
     # ── Sync results (called by frontend) ────────────────────
 
     def _finalize_cover_path(self, grid, cover_path, app_id, rom_id_str):
-        """Rename staged artwork to final Steam app_id filename, return final path."""
-        if not grid or not cover_path:
-            return cover_path
-        final_path = os.path.join(grid, f"{app_id}p.png")
-        if cover_path != final_path and os.path.exists(cover_path):
-            try:
-                os.replace(cover_path, final_path)
-                return final_path
-            except OSError as e:
-                self._logger.warning(f"Failed to rename artwork for rom {rom_id_str}: {e}")
-        elif os.path.exists(final_path):
-            return final_path
+        """Delegate to ArtworkService callback if available, else use local impl."""
+        if self._artwork.finalize_cover_path is not None:
+            return self._artwork.finalize_cover_path(grid, cover_path, app_id, rom_id_str)
+        # Fallback (no-op passthrough when callback not wired)
         return cover_path
 
     def _build_registry_entry(self, pending, app_id, cover_path):
         """Build a registry entry dict from pending sync data."""
-        entry = {
-            "app_id": app_id,
-            "name": pending.get("name", ""),
-            "fs_name": pending.get("fs_name", ""),
-            "platform_name": pending.get("platform_name", ""),
-            "platform_slug": pending.get("platform_slug", ""),
-            "cover_path": cover_path,
-        }
-        for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
-            if pending.get(meta_key):
-                entry[meta_key] = pending[meta_key]
-        return entry
+        return build_registry_entry(pending, app_id, cover_path)
 
     def _report_sync_results_io(self, rom_id_to_app_id, removed_rom_ids):
         """Sync helper for report_sync_results — artwork renames, state save in executor."""
@@ -821,71 +788,19 @@ class LibraryService:
         self._sync_state = SyncState.IDLE
         return {"success": True}
 
-    # ── Artwork ──────────────────────────────────────────────
-
-    def _existing_cover_path(self, rom_id: int, grid: str) -> str | None:
-        """Return an existing cover path for *rom_id*, or ``None`` if a download is needed."""
-        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-
-        # If already synced and final artwork exists, reuse it
-        reg = self._state["shortcut_registry"].get(str(rom_id))
-        if reg and reg.get("app_id"):
-            final = os.path.join(grid, f"{reg['app_id']}p.png")
-            if os.path.exists(final):
-                return final
-
-        # If staging file already exists (e.g. retry), reuse it
-        if os.path.exists(staging):
-            return staging
-
-        return None
+    # ── Artwork delegation ───────────────────────────────────
 
     async def _download_artwork(self, all_roms, progress_step=4, progress_total_steps=6):
-        """Download cover artwork to staging filenames (romm_{rom_id}_cover.png).
-
-        Decouples download from the final Steam app_id, which isn't known until
-        after AddShortcut. report_sync_results() renames to {app_id}p.png.
-        Returns dict of rom_id -> local cover path.
-        """
-        cover_paths = {}
-        grid = self._steam_config.grid_dir()
-        if not grid:
-            self._logger.warning("Cannot find grid directory, skipping artwork")
-            return cover_paths
-
-        total = len(all_roms)
-
-        for i, rom in enumerate(all_roms):
-            if self._sync_state == SyncState.CANCELLING:
-                return cover_paths
-
-            await self._emit_progress(
-                "applying",
-                current=i + 1,
-                total=total,
-                message=f"Downloading artwork {i + 1}/{total}",
-                step=progress_step,
-                total_steps=progress_total_steps,
+        """Delegate artwork download to ArtworkService callback."""
+        if self._artwork.download_artwork is not None:
+            return await self._artwork.download_artwork(
+                all_roms,
+                emit_progress=self._emit_progress,
+                is_cancelling=lambda: self._sync_state == SyncState.CANCELLING,
+                progress_step=progress_step,
+                progress_total_steps=progress_total_steps,
             )
-
-            cover_url = rom.get("path_cover_large") or rom.get("path_cover_small")
-            if not cover_url:
-                continue
-
-            rom_id = rom["id"]
-            existing = self._existing_cover_path(rom_id, grid)
-            if existing:
-                cover_paths[rom_id] = existing
-                continue
-
-            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-            try:
-                await self._loop.run_in_executor(None, self._romm_api.download_cover, cover_url, staging)
-                cover_paths[rom_id] = staging
-            except Exception as e:
-                self._logger.warning(f"Failed to download artwork for {rom['name']}: {e}")
-
-        return cover_paths
+        return {}
 
     # ── Registry queries ─────────────────────────────────────
 
@@ -900,153 +815,6 @@ class LibraryService:
         return {
             "platforms": [{"name": k, "slug": v["slug"], "count": v["count"]} for k, v in sorted(platforms.items())],
         }
-
-    def _find_platform_name_in_registry(self, platform_slug):
-        """Look up platform name from the shortcut registry by slug."""
-        for entry in self._state["shortcut_registry"].values():
-            if entry.get("platform_slug") == platform_slug:
-                return entry.get("platform_name")
-        return None
-
-    async def _find_platform_name_from_api(self, platform_slug):
-        """Look up platform name from the RomM API by slug."""
-        platforms = await self._loop.run_in_executor(None, self._romm_api.list_platforms)
-        for p in platforms:
-            if p.get("slug") == platform_slug:
-                return p.get("name", "")
-        return None
-
-    async def remove_platform_shortcuts(self, platform_slug):
-        """Return app_ids and rom_ids for a platform for the frontend to remove via SteamClient."""
-        try:
-            platform_name = self._find_platform_name_in_registry(platform_slug)
-            if not platform_name:
-                platform_name = await self._find_platform_name_from_api(platform_slug)
-
-            if not platform_name:
-                return {
-                    "success": False,
-                    "message": f"Platform '{platform_slug}' not found",
-                    "app_ids": [],
-                    "rom_ids": [],
-                }
-
-            app_ids = [
-                entry["app_id"]
-                for entry in self._state["shortcut_registry"].values()
-                if entry.get("platform_name") == platform_name and "app_id" in entry
-            ]
-            rom_ids = [
-                rom_id
-                for rom_id, entry in self._state["shortcut_registry"].items()
-                if entry.get("platform_name") == platform_name
-            ]
-
-            return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids, "platform_name": platform_name}
-        except Exception as e:
-            self._logger.error(f"Failed to get platform shortcuts: {e}")
-            return {"success": False, "message": f"Failed: {e}", "app_ids": [], "rom_ids": []}
-
-    def remove_all_shortcuts(self):
-        """Return app_ids and rom_ids for the frontend to remove via SteamClient."""
-        registry = self._state.get("shortcut_registry", {})
-        app_ids = [entry["app_id"] for entry in registry.values() if "app_id" in entry]
-        rom_ids = list(registry.keys())
-        return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids}
-
-    def _remove_artwork_files(self, grid, rom_id, entry):
-        """Remove all artwork files for a registry entry."""
-        removed = False
-        # Try cover_path first (stores the final renamed path)
-        cover_path = entry.get("cover_path", "")
-        if cover_path and os.path.exists(cover_path):
-            os.remove(cover_path)
-            removed = True
-        # Try {app_id}p.png (the standard Steam grid filename)
-        if not removed and entry.get("app_id"):
-            app_path = os.path.join(grid, f"{entry['app_id']}p.png")
-            if os.path.exists(app_path):
-                os.remove(app_path)
-                removed = True
-        # Fallback: legacy artwork_id format
-        if not removed:
-            artwork_id = entry.get("artwork_id")
-            if artwork_id:
-                art_path = os.path.join(grid, f"{artwork_id}p.png")
-                if os.path.exists(art_path):
-                    os.remove(art_path)
-        # Clean up any leftover staging file
-        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-        if os.path.exists(staging):
-            os.remove(staging)
-
-    def _report_removal_results_io(self, removed_rom_ids):
-        """Sync helper for report_removal_results — file deletions, state save in executor."""
-        # Clean up Steam Input config for removed shortcuts (always reset to default)
-        removed_app_ids = [
-            entry["app_id"]
-            for rom_id in removed_rom_ids
-            for entry in [self._state["shortcut_registry"].get(str(rom_id))]
-            if entry and entry.get("app_id")
-        ]
-        if removed_app_ids:
-            try:
-                self._steam_config.set_steam_input_config(removed_app_ids, mode="default")
-            except Exception as e:
-                self._logger.error(f"Failed to clean up Steam Input config: {e}")
-
-        grid = self._steam_config.grid_dir()
-        for rom_id in removed_rom_ids:
-            entry = self._state["shortcut_registry"].pop(str(rom_id), None)
-            if entry and grid:
-                self._remove_artwork_files(grid, rom_id, entry)
-
-        # Update sync_stats to reflect current registry
-        registry = self._state.get("shortcut_registry", {})
-        platforms = {e.get("platform_name", "") for e in registry.values()}
-        self._state["sync_stats"] = {
-            "platforms": len(platforms),
-            "roms": len(registry),
-        }
-        self._save_state()
-
-    async def report_removal_results(self, removed_rom_ids):
-        """Called by frontend after removing shortcuts via SteamClient."""
-        await self._loop.run_in_executor(None, self._report_removal_results_io, removed_rom_ids)
-        return {"success": True, "message": f"Removed {len(removed_rom_ids)} shortcuts"}
-
-    # ── Artwork queries ──────────────────────────────────────
-
-    async def get_artwork_base64(self, rom_id):
-        """Return base64-encoded cover artwork for a single ROM (callable from frontend)."""
-        rom_id = int(rom_id)
-        grid = self._steam_config.grid_dir()
-        if not grid:
-            return {"base64": None}
-
-        # Check pending sync data first (staging path)
-        pending = self._pending_sync.get(rom_id, {})
-        cover_path = pending.get("cover_path", "")
-
-        # Fall back to registry
-        if not cover_path:
-            reg = self._state["shortcut_registry"].get(str(rom_id), {})
-            cover_path = reg.get("cover_path", "")
-
-        # Try staging filename as last resort
-        if not cover_path:
-            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-            if os.path.exists(staging):
-                cover_path = staging
-
-        if cover_path and os.path.exists(cover_path):
-            try:
-                data = await self._loop.run_in_executor(None, lambda: pathlib.Path(cover_path).read_bytes())
-                return {"base64": base64.b64encode(data).decode("ascii")}
-            except Exception as e:
-                self._logger.warning(f"Failed to read artwork for rom {rom_id}: {e}")
-
-        return {"base64": None}
 
     # ── Cache / stats ────────────────────────────────────────
 
@@ -1080,40 +848,3 @@ class LibraryService:
                     "installed": installed,
                 }
         return None
-
-    # ── Housekeeping ─────────────────────────────────────────
-
-    def _is_staging_file_orphaned(self, grid, registry, rom_id):
-        """Check if a staging artwork file is orphaned (not in registry or has final artwork)."""
-        if rom_id not in registry:
-            return True
-        app_id = registry[rom_id].get("app_id")
-        if app_id:
-            final = os.path.join(grid, f"{app_id}p.png")
-            return os.path.exists(final)
-        return False
-
-    def prune_orphaned_staging_artwork(self):
-        """Remove orphaned romm_{rom_id}_cover.png staging files from Steam grid dir."""
-        grid = self._steam_config.grid_dir()
-        if not grid or not os.path.isdir(grid):
-            return
-        registry = self._state.get("shortcut_registry", {})
-        pruned = []
-        for filename in os.listdir(grid):
-            if not filename.startswith("romm_") or not filename.endswith("_cover.png"):
-                continue
-            try:
-                rom_id = filename[len("romm_") : -len("_cover.png")]
-                int(rom_id)  # validate it's numeric
-            except (ValueError, IndexError):
-                continue
-            if not self._is_staging_file_orphaned(grid, registry, rom_id):
-                continue
-            try:
-                os.remove(os.path.join(grid, filename))
-                pruned.append(filename)
-            except OSError as e:
-                self._logger.warning(f"Failed to remove orphaned staging artwork {filename}: {e}")
-        if pruned:
-            self._logger.info(f"Pruned {len(pruned)} orphaned staging artwork file(s)")

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -1,0 +1,131 @@
+"""ShortcutRemovalService — shortcut removal and state cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
+
+    from services.protocols import RommApiProtocol, SteamConfigAdapter
+
+
+class ShortcutRemovalService:
+    """Handles shortcut removal: identifies app_ids/rom_ids and cleans up state."""
+
+    def __init__(
+        self,
+        *,
+        romm_api: RommApiProtocol,
+        steam_config: SteamConfigAdapter,
+        state: dict,
+        loop: asyncio.AbstractEventLoop,
+        logger: logging.Logger,
+        emit: Callable,
+        save_state: Callable,
+        remove_artwork_files: Callable,
+    ) -> None:
+        self._romm_api = romm_api
+        self._steam_config = steam_config
+        self._state = state
+        self._loop = loop
+        self._logger = logger
+        self._emit = emit
+        self._save_state = save_state
+        self._remove_artwork_files = remove_artwork_files
+
+    # ── Registry helpers ───────────────────────────────────────────────────
+
+    def _find_platform_name_in_registry(self, platform_slug: str) -> str | None:
+        """Look up platform name from the shortcut registry by slug."""
+        for entry in self._state["shortcut_registry"].values():
+            if entry.get("platform_slug") == platform_slug:
+                return entry.get("platform_name")
+        return None
+
+    async def _find_platform_name_from_api(self, platform_slug: str) -> str | None:
+        """Look up platform name from the RomM API by slug."""
+        platforms = await self._loop.run_in_executor(None, self._romm_api.list_platforms)
+        for p in platforms:
+            if p.get("slug") == platform_slug:
+                return p.get("name", "")
+        return None
+
+    # ── Removal queries ────────────────────────────────────────────────────
+
+    def remove_all_shortcuts(self) -> dict:
+        """Return app_ids and rom_ids for the frontend to remove via SteamClient."""
+        registry = self._state.get("shortcut_registry", {})
+        app_ids = [entry["app_id"] for entry in registry.values() if "app_id" in entry]
+        rom_ids = list(registry.keys())
+        return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids}
+
+    async def remove_platform_shortcuts(self, platform_slug: str) -> dict:
+        """Return app_ids and rom_ids for a platform for the frontend to remove via SteamClient."""
+        try:
+            platform_name = self._find_platform_name_in_registry(platform_slug)
+            if not platform_name:
+                platform_name = await self._find_platform_name_from_api(platform_slug)
+
+            if not platform_name:
+                return {
+                    "success": False,
+                    "message": f"Platform '{platform_slug}' not found",
+                    "app_ids": [],
+                    "rom_ids": [],
+                }
+
+            app_ids = [
+                entry["app_id"]
+                for entry in self._state["shortcut_registry"].values()
+                if entry.get("platform_name") == platform_name and "app_id" in entry
+            ]
+            rom_ids = [
+                rom_id
+                for rom_id, entry in self._state["shortcut_registry"].items()
+                if entry.get("platform_name") == platform_name
+            ]
+
+            return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids, "platform_name": platform_name}
+        except Exception as e:
+            self._logger.error(f"Failed to get platform shortcuts: {e}")
+            return {"success": False, "message": f"Failed: {e}", "app_ids": [], "rom_ids": []}
+
+    # ── Removal results ────────────────────────────────────────────────────
+
+    def _report_removal_results_io(self, removed_rom_ids: list) -> None:
+        """Sync helper for report_removal_results — file deletions, state save in executor."""
+        # Clean up Steam Input config for removed shortcuts (always reset to default)
+        removed_app_ids = [
+            entry["app_id"]
+            for rom_id in removed_rom_ids
+            for entry in [self._state["shortcut_registry"].get(str(rom_id))]
+            if entry and entry.get("app_id")
+        ]
+        if removed_app_ids:
+            try:
+                self._steam_config.set_steam_input_config(removed_app_ids, mode="default")
+            except Exception as e:
+                self._logger.error(f"Failed to clean up Steam Input config: {e}")
+
+        grid = self._steam_config.grid_dir()
+        for rom_id in removed_rom_ids:
+            entry = self._state["shortcut_registry"].pop(str(rom_id), None)
+            if entry and grid:
+                self._remove_artwork_files(grid, rom_id, entry)
+
+        # Update sync_stats to reflect current registry
+        registry = self._state.get("shortcut_registry", {})
+        platforms = {e.get("platform_name", "") for e in registry.values()}
+        self._state["sync_stats"] = {
+            "platforms": len(platforms),
+            "roms": len(registry),
+        }
+        self._save_state()
+
+    async def report_removal_results(self, removed_rom_ids: list) -> dict:
+        """Called by frontend after removing shortcuts via SteamClient."""
+        await self._loop.run_in_executor(None, self._report_removal_results_io, removed_rom_ids)
+        return {"success": True, "message": f"Removed {len(removed_rom_ids)} shortcuts"}

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -1,0 +1,461 @@
+"""Tests for ArtworkService."""
+
+import asyncio
+import base64
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# conftest.py patches decky before this import
+import decky
+import pytest
+from adapters.steam_config import SteamConfigAdapter
+from services.artwork import ArtworkService
+
+
+@pytest.fixture
+def state():
+    return {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+
+
+@pytest.fixture
+def steam_config():
+    return SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
+
+
+@pytest.fixture
+def artwork_service(state, steam_config):
+    svc = ArtworkService(
+        romm_api=MagicMock(),
+        steam_config=steam_config,
+        state=state,
+        loop=asyncio.get_event_loop(),
+        logger=decky.logger,
+        emit=decky.emit,
+        sync_state_ref=lambda: None,
+    )
+    return svc
+
+
+@pytest.fixture(autouse=True)
+async def _set_event_loop(artwork_service):
+    artwork_service._loop = asyncio.get_event_loop()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _noop_emit_progress(*args, **kwargs):
+    pass
+
+
+def _not_cancelling():
+    return False
+
+
+# ── TestExistingCoverPath ─────────────────────────────────────────────────────
+
+
+class TestExistingCoverPath:
+    """Tests for existing_cover_path()."""
+
+    def test_returns_final_when_exists(self, artwork_service, state, tmp_path):
+        final = tmp_path / "99999p.png"
+        final.write_text("final")
+        state["shortcut_registry"]["42"] = {"app_id": 99999}
+
+        result = artwork_service.existing_cover_path(42, str(tmp_path))
+        assert result == str(final)
+
+    def test_returns_staging_when_exists(self, artwork_service, tmp_path):
+        staging = tmp_path / "romm_42_cover.png"
+        staging.write_text("staging")
+
+        result = artwork_service.existing_cover_path(42, str(tmp_path))
+        assert result == str(staging)
+
+    def test_returns_none_when_nothing_exists(self, artwork_service, tmp_path):
+        result = artwork_service.existing_cover_path(42, str(tmp_path))
+        assert result is None
+
+    def test_returns_none_when_registry_no_app_id(self, artwork_service, state, tmp_path):
+        state["shortcut_registry"]["42"] = {"name": "Game"}
+        result = artwork_service.existing_cover_path(42, str(tmp_path))
+        assert result is None
+
+
+# ── TestDownloadArtwork ───────────────────────────────────────────────────────
+
+
+class TestDownloadArtwork:
+    """Tests for download_artwork()."""
+
+    @pytest.mark.asyncio
+    async def test_download_uses_staging_filename(self, artwork_service, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock()
+        artwork_service._loop = mock_loop
+
+        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+
+        assert 42 in result
+        assert result[42].endswith("romm_42_cover.png")
+        call_args = mock_loop.run_in_executor.call_args[0]
+        assert "romm_42_cover.png" in call_args[3]
+
+    @pytest.mark.asyncio
+    async def test_skips_download_if_final_exists(self, artwork_service, state, steam_config, tmp_path):
+        """If {app_id}p.png exists from a prior sync, skip re-download."""
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock()
+        artwork_service._loop = mock_loop
+
+        final_art = grid_dir / "99999p.png"
+        final_art.write_text("fake")
+        state["shortcut_registry"]["42"] = {"app_id": 99999, "name": "Test"}
+
+        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+
+        assert result[42] == str(final_art)
+        mock_loop.run_in_executor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_download_if_staging_exists(self, artwork_service, steam_config, tmp_path):
+        """If staging file exists (e.g. retry), skip re-download."""
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock()
+        artwork_service._loop = mock_loop
+
+        staging = grid_dir / "romm_42_cover.png"
+        staging.write_text("fake")
+
+        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+
+        assert result[42] == str(staging)
+        mock_loop.run_in_executor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_grid_returns_empty(self, artwork_service, steam_config):
+        steam_config.grid_dir = lambda: None
+        roms = [{"id": 1, "name": "G", "path_cover_large": "/c.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_skips_rom_without_cover_url(self, artwork_service, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        roms = [{"id": 1, "name": "No Cover"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 1 not in result
+
+    @pytest.mark.asyncio
+    async def test_download_failure_logged(self, artwork_service, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Network error"))
+        artwork_service._loop = mock_loop
+
+        roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
+        )
+        assert 1 not in result
+
+    @pytest.mark.asyncio
+    async def test_cancelling_during_artwork(self, artwork_service, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
+        result = await artwork_service.download_artwork(
+            roms, emit_progress=_noop_emit_progress, is_cancelling=lambda: True
+        )
+        assert result == {}
+
+
+# ── TestFinalizeCoverPath ─────────────────────────────────────────────────────
+
+
+class TestFinalizeCoverPath:
+    """Tests for finalize_cover_path()."""
+
+    def test_renames_staging_to_final(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        staging = tmp_path / "romm_1_cover.png"
+        staging.write_text("cover data")
+
+        result = artwork_service.finalize_cover_path(grid, str(staging), 100001, "1")
+        expected = os.path.join(grid, "100001p.png")
+        assert result == expected
+        assert not staging.exists()
+        assert os.path.exists(expected)
+
+    def test_returns_existing_final(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        final = tmp_path / "100001p.png"
+        final.write_text("final data")
+
+        result = artwork_service.finalize_cover_path(grid, "/nonexistent/path.png", 100001, "1")
+        assert result == str(final)
+
+    def test_returns_cover_path_when_no_grid(self, artwork_service):
+        result = artwork_service.finalize_cover_path(None, "/some/path.png", 100001, "1")
+        assert result == "/some/path.png"
+
+    def test_returns_cover_path_when_empty(self, artwork_service, tmp_path):
+        result = artwork_service.finalize_cover_path(str(tmp_path), "", 100001, "1")
+        assert result == ""
+
+    def test_handles_rename_os_error(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        staging = tmp_path / "romm_1_cover.png"
+        staging.write_text("data")
+
+        with patch("os.replace", side_effect=OSError("perm denied")):
+            result = artwork_service.finalize_cover_path(grid, str(staging), 100001, "1")
+        assert result == str(staging)
+
+
+# ── TestRemoveArtworkFiles ────────────────────────────────────────────────────
+
+
+class TestRemoveArtworkFiles:
+    """Tests for remove_artwork_files()."""
+
+    def test_removes_cover_path(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        cover = tmp_path / "100001p.png"
+        cover.write_text("cover data")
+        entry = {"cover_path": str(cover), "app_id": 100001}
+        artwork_service.remove_artwork_files(grid, "42", entry)
+        assert not cover.exists()
+
+    def test_removes_app_id_fallback(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        art = tmp_path / "100001p.png"
+        art.write_text("data")
+        entry = {"cover_path": "", "app_id": 100001}
+        artwork_service.remove_artwork_files(grid, "42", entry)
+        assert not art.exists()
+
+    def test_removes_legacy_artwork_id(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        art = tmp_path / "12345p.png"
+        art.write_text("data")
+        entry = {"cover_path": "", "artwork_id": 12345}
+        artwork_service.remove_artwork_files(grid, "42", entry)
+        assert not art.exists()
+
+    def test_removes_staging_leftover(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        staging = tmp_path / "romm_42_cover.png"
+        staging.write_text("staging")
+        entry = {"cover_path": ""}
+        artwork_service.remove_artwork_files(grid, "42", entry)
+        assert not staging.exists()
+
+    def test_removes_all_types(self, artwork_service, tmp_path):
+        grid = str(tmp_path)
+        cover = tmp_path / "mycover.png"
+        cover.write_text("cover")
+        staging = tmp_path / "romm_42_cover.png"
+        staging.write_text("staging")
+        entry = {"cover_path": str(cover), "app_id": 100001}
+        artwork_service.remove_artwork_files(grid, "42", entry)
+        assert not cover.exists()
+        assert not staging.exists()
+
+
+# ── TestGetArtworkBase64 ──────────────────────────────────────────────────────
+
+
+class TestGetArtworkBase64:
+    """Tests for get_artwork_base64()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_base64_from_pending(self, artwork_service, steam_config, tmp_path):
+        steam_config.grid_dir = lambda: str(tmp_path)
+
+        cover = tmp_path / "romm_42_cover.png"
+        cover.write_bytes(b"fake png data")
+
+        pending_sync = {42: {"cover_path": str(cover)}}
+        result = await artwork_service.get_artwork_base64(42, pending_sync)
+        assert result["base64"] is not None
+        assert base64.b64decode(result["base64"]) == b"fake png data"
+
+    @pytest.mark.asyncio
+    async def test_returns_base64_from_registry(self, artwork_service, state, steam_config, tmp_path):
+        steam_config.grid_dir = lambda: str(tmp_path)
+
+        cover = tmp_path / "100001p.png"
+        cover.write_bytes(b"registry png")
+        state["shortcut_registry"]["42"] = {"cover_path": str(cover)}
+
+        result = await artwork_service.get_artwork_base64(42, {})
+        assert result["base64"] is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_base64_from_staging_fallback(self, artwork_service, steam_config, tmp_path):
+        steam_config.grid_dir = lambda: str(tmp_path)
+
+        staging = tmp_path / "romm_42_cover.png"
+        staging.write_bytes(b"staging png")
+
+        result = await artwork_service.get_artwork_base64(42, {})
+        assert result["base64"] is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_grid(self, artwork_service, steam_config):
+        steam_config.grid_dir = lambda: None
+        result = await artwork_service.get_artwork_base64(42, {})
+        assert result["base64"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_file_missing(self, artwork_service, steam_config, tmp_path):
+        steam_config.grid_dir = lambda: str(tmp_path)
+        result = await artwork_service.get_artwork_base64(42, {})
+        assert result["base64"] is None
+
+
+# ── TestIsStagingFileOrphaned ─────────────────────────────────────────────────
+
+
+class TestIsStagingFileOrphaned:
+    """Tests for is_staging_file_orphaned()."""
+
+    def test_orphaned_when_not_in_registry(self, artwork_service, tmp_path):
+        result = artwork_service.is_staging_file_orphaned(str(tmp_path), {}, "42")
+        assert result is True
+
+    def test_orphaned_when_final_exists(self, artwork_service, tmp_path):
+        final = tmp_path / "1001p.png"
+        final.write_text("final")
+        registry = {"42": {"app_id": 1001}}
+        result = artwork_service.is_staging_file_orphaned(str(tmp_path), registry, "42")
+        assert result is True
+
+    def test_not_orphaned_when_no_final(self, artwork_service, tmp_path):
+        registry = {"42": {"app_id": 1001}}
+        result = artwork_service.is_staging_file_orphaned(str(tmp_path), registry, "42")
+        assert result is False
+
+    def test_not_orphaned_when_no_app_id(self, artwork_service, tmp_path):
+        registry = {"42": {"name": "Game"}}
+        result = artwork_service.is_staging_file_orphaned(str(tmp_path), registry, "42")
+        assert result is False
+
+
+# ── TestPruneOrphanedStagingArtwork ──────────────────────────────────────────
+
+
+class TestPruneOrphanedStagingArtwork:
+    """Tests for prune_orphaned_staging_artwork()."""
+
+    def test_removes_staging_not_in_registry(self, artwork_service, state, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        staging = grid_dir / "romm_42_cover.png"
+        staging.write_text("fake")
+
+        steam_config.grid_dir = lambda: str(grid_dir)
+        state["shortcut_registry"] = {}
+
+        artwork_service.prune_orphaned_staging_artwork()
+        assert not staging.exists()
+
+    def test_removes_redundant_staging_with_final(self, artwork_service, state, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        staging = grid_dir / "romm_42_cover.png"
+        staging.write_text("fake staging")
+        final = grid_dir / "1001p.png"
+        final.write_text("fake final")
+
+        steam_config.grid_dir = lambda: str(grid_dir)
+        state["shortcut_registry"] = {"42": {"app_id": 1001, "name": "Game A"}}
+
+        artwork_service.prune_orphaned_staging_artwork()
+        assert not staging.exists()
+        assert final.exists()
+
+    def test_keeps_staging_when_no_final(self, artwork_service, state, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        staging = grid_dir / "romm_42_cover.png"
+        staging.write_text("fake staging")
+
+        steam_config.grid_dir = lambda: str(grid_dir)
+        state["shortcut_registry"] = {"42": {"app_id": 1001, "name": "Game A"}}
+
+        artwork_service.prune_orphaned_staging_artwork()
+        assert staging.exists()
+
+    def test_ignores_non_staging_files(self, artwork_service, state, steam_config, tmp_path):
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        final = grid_dir / "1001p.png"
+        final.write_text("final art")
+        other = grid_dir / "something_else.png"
+        other.write_text("other")
+
+        steam_config.grid_dir = lambda: str(grid_dir)
+        state["shortcut_registry"] = {}
+
+        artwork_service.prune_orphaned_staging_artwork()
+        assert final.exists()
+        assert other.exists()
+
+    def test_no_grid_dir_no_crash(self, artwork_service, state, steam_config):
+        steam_config.grid_dir = lambda: None
+        state["shortcut_registry"] = {}
+        artwork_service.prune_orphaned_staging_artwork()  # should not raise
+
+    def test_handles_os_error(self, artwork_service, state, steam_config, tmp_path, caplog):
+
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        staging = grid_dir / "romm_42_cover.png"
+        staging.write_text("fake")
+
+        steam_config.grid_dir = lambda: str(grid_dir)
+        state["shortcut_registry"] = {}
+
+        with caplog.at_level(logging.WARNING):
+            with patch("os.remove", side_effect=OSError("permission denied")):
+                artwork_service.prune_orphaned_staging_artwork()
+
+        assert staging.exists()
+        assert any("Failed to remove orphaned staging artwork" in r.message for r in caplog.records)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -157,7 +157,7 @@ class TestWireServices:
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(WiringConfig(**deps))
-        assert len(result) == 11
+        assert len(result) == 13
         assert "migration_service" in result
         assert "game_detail_service" in result
         assert "rom_removal_service" in result

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 from adapters.steam_config import SteamConfigAdapter
+from services.artwork import ArtworkService
 from services.library import LibraryService, SyncState
 from services.metadata import MetadataService
+from services.shortcut_removal import ShortcutRemovalService
 
 # conftest.py patches decky before this import
 from main import Plugin
@@ -35,6 +37,17 @@ def plugin():
     )
     p._metadata_service = metadata_service
 
+    artwork_service = ArtworkService(
+        romm_api=p._romm_api,
+        steam_config=steam_config,
+        state=p._state,
+        loop=asyncio.get_event_loop(),
+        logger=decky.logger,
+        emit=decky.emit,
+        sync_state_ref=lambda: None,
+    )
+    p._artwork_service = artwork_service
+
     p._sync_service = LibraryService(
         romm_api=p._romm_api,
         steam_config=steam_config,
@@ -49,6 +62,20 @@ def plugin():
         save_settings_to_disk=p._save_settings_to_disk,
         log_debug=p._log_debug,
         metadata_service=metadata_service,
+        artwork=artwork_service,
+    )
+
+    artwork_service._sync_state_ref = lambda: p._sync_service.sync_state
+
+    p._shortcut_removal_service = ShortcutRemovalService(
+        romm_api=p._romm_api,
+        steam_config=steam_config,
+        state=p._state,
+        loop=asyncio.get_event_loop(),
+        logger=decky.logger,
+        emit=decky.emit,
+        save_state=p._save_state,
+        remove_artwork_files=artwork_service.remove_artwork_files,
     )
     return p
 
@@ -58,6 +85,8 @@ async def _set_event_loop(plugin):
     """Ensure plugin.loop matches the running event loop for async tests."""
     plugin.loop = asyncio.get_event_loop()
     plugin._sync_service._loop = asyncio.get_event_loop()
+    plugin._artwork_service._loop = asyncio.get_event_loop()
+    plugin._shortcut_removal_service._loop = asyncio.get_event_loop()
     plugin._metadata_service._loop = asyncio.get_event_loop()
 
 
@@ -354,7 +383,7 @@ class TestRemovePlatformShortcuts:
                 {"id": 2, "slug": "snes", "name": "Super Nintendo"},
             ]
         )
-        plugin._sync_service._loop = mock_loop
+        plugin._shortcut_removal_service._loop = mock_loop
 
         plugin._state["shortcut_registry"] = {
             "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64"},
@@ -378,7 +407,7 @@ class TestRemovePlatformShortcuts:
                 {"id": 1, "slug": "n64", "name": "Nintendo 64"},
             ]
         )
-        plugin._sync_service._loop = mock_loop
+        plugin._shortcut_removal_service._loop = mock_loop
 
         result = await plugin.remove_platform_shortcuts("nonexistent")
         assert result["success"] is False
@@ -396,7 +425,7 @@ class TestRemovePlatformShortcuts:
                 {"id": 1, "slug": "n64", "name": "Nintendo 64"},
             ]
         )
-        plugin._sync_service._loop = mock_loop
+        plugin._shortcut_removal_service._loop = mock_loop
 
         plugin._state["shortcut_registry"] = {
             "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64"},
@@ -413,7 +442,7 @@ class TestRemovePlatformShortcuts:
 
         mock_loop = MagicMock()
         mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Server unreachable"))
-        plugin._sync_service._loop = mock_loop
+        plugin._shortcut_removal_service._loop = mock_loop
 
         plugin._state["shortcut_registry"] = {
             "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64", "platform_slug": "n64"},
@@ -424,75 +453,6 @@ class TestRemovePlatformShortcuts:
         assert result["success"] is True
         assert set(result["app_ids"]) == {1001, 1002}
         assert result["platform_name"] == "Nintendo 64"
-
-
-class TestArtworkStaging:
-    """Tests for the staging/rename artwork flow."""
-
-    @pytest.mark.asyncio
-    async def test_download_uses_staging_filename(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, MagicMock
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        plugin._sync_service._loop = mock_loop
-
-        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
-        result = await plugin._sync_service._download_artwork(roms)
-
-        assert 42 in result
-        assert result[42].endswith("romm_42_cover.png")
-        # Should have called _romm_download with staging path as dest arg
-        call_args = mock_loop.run_in_executor.call_args[0]
-        assert "romm_42_cover.png" in call_args[3]
-
-    @pytest.mark.asyncio
-    async def test_skips_download_if_final_exists(self, plugin, tmp_path):
-        """If {app_id}p.png exists from a prior sync, skip re-download."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        plugin._sync_service._loop = mock_loop
-
-        # Simulate existing final artwork from previous sync
-        final_art = grid_dir / "99999p.png"
-        final_art.write_text("fake")
-
-        plugin._state["shortcut_registry"]["42"] = {"app_id": 99999, "name": "Test"}
-
-        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
-        result = await plugin._sync_service._download_artwork(roms)
-
-        assert result[42] == str(final_art)
-        mock_loop.run_in_executor.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_skips_download_if_staging_exists(self, plugin, tmp_path):
-        """If staging file exists (e.g. retry), skip re-download."""
-        from unittest.mock import AsyncMock, MagicMock
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        plugin._sync_service._loop = mock_loop
-
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
-
-        roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
-        result = await plugin._sync_service._download_artwork(roms)
-
-        assert result[42] == str(staging)
-        mock_loop.run_in_executor.assert_not_called()
 
 
 class TestArtworkRenameOnSync:
@@ -748,100 +708,6 @@ class TestShortcutDataFormat:
         id_b = SteamConfigAdapter.generate_artwork_id(exe, "Game B")
 
         assert id_a != id_b, "Different games should have different artwork IDs"
-
-
-class TestPruneOrphanedStagingArtwork:
-    def test_removes_staging_not_in_registry(self, plugin, tmp_path):
-        """Staging file for a rom_id not in registry should be deleted."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
-
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._state["shortcut_registry"] = {}
-
-        plugin._sync_service.prune_orphaned_staging_artwork()
-        assert not staging.exists()
-
-    def test_removes_redundant_staging_with_final(self, plugin, tmp_path):
-        """Staging file should be removed when final {app_id}p.png exists."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake staging")
-        final = grid_dir / "1001p.png"
-        final.write_text("fake final")
-
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._state["shortcut_registry"] = {
-            "42": {"app_id": 1001, "name": "Game A"},
-        }
-
-        plugin._sync_service.prune_orphaned_staging_artwork()
-        assert not staging.exists()
-        assert final.exists()  # final artwork untouched
-
-    def test_keeps_staging_when_no_final(self, plugin, tmp_path):
-        """Staging file kept when rom is in registry but final artwork not yet created."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake staging")
-
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._state["shortcut_registry"] = {
-            "42": {"app_id": 1001, "name": "Game A"},
-        }
-
-        plugin._sync_service.prune_orphaned_staging_artwork()
-        assert staging.exists()
-
-    def test_ignores_non_staging_files(self, plugin, tmp_path):
-        """Non-staging files in grid dir should not be touched."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        final = grid_dir / "1001p.png"
-        final.write_text("final art")
-        other = grid_dir / "something_else.png"
-        other.write_text("other")
-
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._state["shortcut_registry"] = {}
-
-        plugin._sync_service.prune_orphaned_staging_artwork()
-        assert final.exists()
-        assert other.exists()
-
-    def test_no_grid_dir_no_crash(self, plugin):
-        """When _grid_dir() returns None, pruning should not crash."""
-        plugin._steam_config.grid_dir = lambda: None
-        plugin._state["shortcut_registry"] = {}
-
-        # Should not raise
-        plugin._sync_service.prune_orphaned_staging_artwork()
-
-    def test_handles_os_error(self, plugin, tmp_path, caplog):
-        """OSError during os.remove should log warning and not crash."""
-        import logging
-        from unittest.mock import patch
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
-
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._state["shortcut_registry"] = {}
-
-        with caplog.at_level(logging.WARNING):
-            with patch("os.remove", side_effect=OSError("permission denied")):
-                plugin._sync_service.prune_orphaned_staging_artwork()
-
-        # File still exists (os.remove was mocked to fail)
-        assert staging.exists()
-        # Warning should have been logged
-        assert any("Failed to remove orphaned staging artwork" in r.message for r in caplog.records)
 
 
 class TestClassifyRoms:
@@ -1994,241 +1860,6 @@ class TestBuildRegistryEntry:
         assert result["platform_slug"] == ""
 
 
-class TestFindPlatformNameInRegistry:
-    """Tests for _find_platform_name_in_registry() — lines 888-893."""
-
-    def test_finds_by_slug(self, plugin):
-        plugin._state["shortcut_registry"] = {
-            "1": {"platform_name": "Nintendo 64", "platform_slug": "n64"},
-            "2": {"platform_name": "Super Nintendo", "platform_slug": "snes"},
-        }
-        result = plugin._sync_service._find_platform_name_in_registry("n64")
-        assert result == "Nintendo 64"
-
-    def test_returns_none_when_not_found(self, plugin):
-        plugin._state["shortcut_registry"] = {
-            "1": {"platform_name": "Nintendo 64", "platform_slug": "n64"},
-        }
-        result = plugin._sync_service._find_platform_name_in_registry("gba")
-        assert result is None
-
-    def test_empty_registry(self, plugin):
-        result = plugin._sync_service._find_platform_name_in_registry("n64")
-        assert result is None
-
-
-class TestFindPlatformNameFromApi:
-    """Tests for _find_platform_name_from_api() — lines 895-901."""
-
-    @pytest.mark.asyncio
-    async def test_finds_by_slug(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"slug": "n64", "name": "Nintendo 64"},
-                {"slug": "snes", "name": "Super Nintendo"},
-            ]
-        )
-        plugin._sync_service._loop = mock_loop
-
-        result = await plugin._sync_service._find_platform_name_from_api("snes")
-        assert result == "Super Nintendo"
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_not_found(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value=[{"slug": "n64", "name": "Nintendo 64"}])
-        plugin._sync_service._loop = mock_loop
-
-        result = await plugin._sync_service._find_platform_name_from_api("gba")
-        assert result is None
-
-
-class TestIsStagingFileOrphaned:
-    """Tests for _is_staging_file_orphaned() — lines 1070-1078."""
-
-    def test_orphaned_when_not_in_registry(self, plugin, tmp_path):
-        result = plugin._sync_service._is_staging_file_orphaned(str(tmp_path), {}, "42")
-        assert result is True
-
-    def test_orphaned_when_final_exists(self, plugin, tmp_path):
-        final = tmp_path / "1001p.png"
-        final.write_text("final")
-        registry = {"42": {"app_id": 1001}}
-        result = plugin._sync_service._is_staging_file_orphaned(str(tmp_path), registry, "42")
-        assert result is True
-
-    def test_not_orphaned_when_no_final(self, plugin, tmp_path):
-        registry = {"42": {"app_id": 1001}}
-        result = plugin._sync_service._is_staging_file_orphaned(str(tmp_path), registry, "42")
-        assert result is False
-
-    def test_not_orphaned_when_no_app_id(self, plugin, tmp_path):
-        registry = {"42": {"name": "Game"}}
-        result = plugin._sync_service._is_staging_file_orphaned(str(tmp_path), registry, "42")
-        assert result is False
-
-
-class TestExistingCoverPath:
-    """Tests for _existing_cover_path() — lines 810-825."""
-
-    def test_returns_final_when_exists(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        final = tmp_path / "99999p.png"
-        final.write_text("final")
-        plugin._state["shortcut_registry"]["42"] = {"app_id": 99999}
-
-        result = plugin._sync_service._existing_cover_path(42, grid)
-        assert result == str(final)
-
-    def test_returns_staging_when_exists(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
-
-        result = plugin._sync_service._existing_cover_path(42, grid)
-        assert result == str(staging)
-
-    def test_returns_none_when_nothing_exists(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        result = plugin._sync_service._existing_cover_path(42, grid)
-        assert result is None
-
-    def test_returns_none_when_registry_no_app_id(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        plugin._state["shortcut_registry"]["42"] = {"name": "Game"}
-        result = plugin._sync_service._existing_cover_path(42, grid)
-        assert result is None
-
-
-class TestRemoveArtworkFiles:
-    """Tests for _remove_artwork_files() — lines 941-965."""
-
-    def test_removes_cover_path(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        cover = tmp_path / "100001p.png"
-        cover.write_text("cover data")
-        entry = {"cover_path": str(cover), "app_id": 100001}
-        plugin._sync_service._remove_artwork_files(grid, "42", entry)
-        assert not cover.exists()
-
-    def test_removes_app_id_fallback(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        art = tmp_path / "100001p.png"
-        art.write_text("data")
-        entry = {"cover_path": "", "app_id": 100001}
-        plugin._sync_service._remove_artwork_files(grid, "42", entry)
-        assert not art.exists()
-
-    def test_removes_legacy_artwork_id(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        art = tmp_path / "12345p.png"
-        art.write_text("data")
-        entry = {"cover_path": "", "artwork_id": 12345}
-        plugin._sync_service._remove_artwork_files(grid, "42", entry)
-        assert not art.exists()
-
-    def test_removes_staging_leftover(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
-        entry = {"cover_path": ""}
-        plugin._sync_service._remove_artwork_files(grid, "42", entry)
-        assert not staging.exists()
-
-    def test_removes_all_types(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        cover = tmp_path / "mycover.png"
-        cover.write_text("cover")
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
-        entry = {"cover_path": str(cover), "app_id": 100001}
-        plugin._sync_service._remove_artwork_files(grid, "42", entry)
-        assert not cover.exists()
-        assert not staging.exists()
-
-
-class TestRemovePlatformShortcutsException:
-    """Tests for exception handling in remove_platform_shortcuts — lines 930-932."""
-
-    @pytest.mark.asyncio
-    async def test_handles_exception(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("API Error"))
-        plugin._sync_service._loop = mock_loop
-
-        # No slug match in registry, forces API call which errors
-        result = await plugin._sync_service.remove_platform_shortcuts("broken")
-        assert result["success"] is False
-        assert result["app_ids"] == []
-        assert result["rom_ids"] == []
-
-
-class TestGetArtworkBase64:
-    """Tests for get_artwork_base64() — lines 1004-1033."""
-
-    @pytest.mark.asyncio
-    async def test_returns_base64_from_pending(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-
-        cover = tmp_path / "romm_42_cover.png"
-        cover.write_bytes(b"fake png data")
-
-        plugin._sync_service._pending_sync = {42: {"cover_path": str(cover)}}
-
-        result = await plugin._sync_service.get_artwork_base64(42)
-        assert result["base64"] is not None
-        import base64
-
-        assert base64.b64decode(result["base64"]) == b"fake png data"
-
-    @pytest.mark.asyncio
-    async def test_returns_base64_from_registry(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-
-        cover = tmp_path / "100001p.png"
-        cover.write_bytes(b"registry png")
-
-        plugin._state["shortcut_registry"]["42"] = {"cover_path": str(cover)}
-
-        result = await plugin._sync_service.get_artwork_base64(42)
-        assert result["base64"] is not None
-
-    @pytest.mark.asyncio
-    async def test_returns_base64_from_staging_fallback(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_bytes(b"staging png")
-
-        result = await plugin._sync_service.get_artwork_base64(42)
-        assert result["base64"] is not None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_no_grid(self, plugin):
-        plugin._steam_config.grid_dir = lambda: None
-
-        result = await plugin._sync_service.get_artwork_base64(42)
-        assert result["base64"] is None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_file_missing(self, plugin, tmp_path):
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-
-        result = await plugin._sync_service.get_artwork_base64(42)
-        assert result["base64"] is None
-
-
 class TestClearSyncCache:
     """Tests for clear_sync_cache() — lines 1037-1042."""
 
@@ -2278,57 +1909,6 @@ class TestReportSyncResultsCancelled:
         complete_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert len(complete_calls) == 1
         assert complete_calls[0][0][1]["cancelled"] is True
-
-
-class TestDownloadArtworkEdgeCases:
-    """Tests for _download_artwork edge cases — lines 837-870."""
-
-    @pytest.mark.asyncio
-    async def test_no_grid_returns_empty(self, plugin):
-        plugin._steam_config.grid_dir = lambda: None
-        result = await plugin._sync_service._download_artwork([{"id": 1, "name": "G", "path_cover_large": "/c.png"}])
-        assert result == {}
-
-    @pytest.mark.asyncio
-    async def test_skips_rom_without_cover_url(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock
-
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-        plugin._sync_service._emit_progress = AsyncMock()
-
-        roms = [{"id": 1, "name": "No Cover"}]
-        result = await plugin._sync_service._download_artwork(roms)
-        assert 1 not in result
-
-    @pytest.mark.asyncio
-    async def test_download_failure_logged(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, MagicMock
-
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Network error"))
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._emit_progress = AsyncMock()
-
-        roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
-        result = await plugin._sync_service._download_artwork(roms)
-        assert 1 not in result
-
-    @pytest.mark.asyncio
-    async def test_cancelling_during_artwork(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock
-
-        grid = str(tmp_path)
-        plugin._steam_config.grid_dir = lambda: grid
-        plugin._sync_service._sync_state = SyncState.CANCELLING
-        plugin._sync_service._emit_progress = AsyncMock()
-
-        roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
-        result = await plugin._sync_service._download_artwork(roms)
-        assert result == {}
 
 
 class TestDoSyncErrorHandling:

--- a/tests/test_shortcut_data.py
+++ b/tests/test_shortcut_data.py
@@ -1,0 +1,140 @@
+"""Tests for domain/shortcut_data.py pure functions."""
+
+import os
+
+from domain.shortcut_data import build_registry_entry, build_shortcuts_data
+
+
+class TestBuildShortcutsData:
+    """Tests for build_shortcuts_data()."""
+
+    def test_builds_correct_format(self):
+        plugin_dir = "/home/deck/homebrew/plugins/decky-romm-sync"
+        roms = [
+            {
+                "id": 1,
+                "name": "Game A",
+                "fs_name": "gamea.z64",
+                "platform_name": "N64",
+                "platform_slug": "n64",
+                "igdb_id": 100,
+                "sgdb_id": 200,
+                "ra_id": 300,
+            },
+            {"id": 2, "name": "Game B", "platform_name": "SNES", "platform_slug": "snes"},
+        ]
+        result = build_shortcuts_data(roms, plugin_dir)
+        assert len(result) == 2
+        assert result[0]["rom_id"] == 1
+        assert result[0]["name"] == "Game A"
+        assert result[0]["fs_name"] == "gamea.z64"
+        assert result[0]["launch_options"] == "romm:1"
+        assert result[0]["platform_name"] == "N64"
+        assert result[0]["platform_slug"] == "n64"
+        assert result[0]["igdb_id"] == 100
+        assert result[0]["sgdb_id"] == 200
+        assert result[0]["ra_id"] == 300
+        assert result[0]["cover_path"] == ""
+        assert result[0]["exe"] == os.path.join(plugin_dir, "bin", "romm-launcher")
+        assert result[0]["start_dir"] == os.path.join(plugin_dir, "bin")
+        assert result[1]["fs_name"] == ""
+
+    def test_empty_roms(self):
+        result = build_shortcuts_data([], "/some/dir")
+        assert result == []
+
+    def test_missing_optional_fields(self):
+        roms = [{"id": 5, "name": "Minimal"}]
+        result = build_shortcuts_data(roms, "/plugin")
+        assert result[0]["rom_id"] == 5
+        assert result[0]["platform_name"] == "Unknown"
+        assert result[0]["platform_slug"] == ""
+        assert result[0]["igdb_id"] is None
+        assert result[0]["sgdb_id"] is None
+
+    def test_exe_path_contains_romm_launcher(self):
+        plugin_dir = "/home/deck/homebrew/plugins/decky-romm-sync"
+        roms = [{"id": 1, "name": "Game"}]
+        result = build_shortcuts_data(roms, plugin_dir)
+        assert result[0]["exe"].endswith("/bin/romm-launcher")
+
+    def test_start_dir_is_parent_of_exe(self):
+        plugin_dir = "/home/deck/homebrew/plugins/decky-romm-sync"
+        roms = [{"id": 1, "name": "Game"}]
+        result = build_shortcuts_data(roms, plugin_dir)
+        assert result[0]["start_dir"] == os.path.dirname(result[0]["exe"])
+
+    def test_launch_options_format(self):
+        import re
+
+        pattern = r"^romm:\d+$"
+        roms = [{"id": i, "name": f"Game {i}"} for i in [1, 42, 99999]]
+        result = build_shortcuts_data(roms, "/plugin")
+        for item in result:
+            assert re.match(pattern, item["launch_options"])
+
+    def test_multiple_roms_each_has_required_fields(self):
+        required_fields = {"rom_id", "name", "exe", "start_dir", "launch_options", "platform_name", "platform_slug"}
+        roms = [{"id": i, "name": f"Game {i}"} for i in range(5)]
+        result = build_shortcuts_data(roms, "/plugin")
+        for item in result:
+            for field in required_fields:
+                assert field in item, f"Missing field '{field}' in shortcut data"
+
+
+class TestBuildRegistryEntry:
+    """Tests for build_registry_entry()."""
+
+    def test_builds_full_entry(self):
+        pending = {
+            "name": "Game A",
+            "fs_name": "gamea.z64",
+            "platform_name": "N64",
+            "platform_slug": "n64",
+            "igdb_id": 100,
+            "sgdb_id": 200,
+            "ra_id": 300,
+        }
+        result = build_registry_entry(pending, 100001, "/grid/100001p.png")
+        assert result["app_id"] == 100001
+        assert result["name"] == "Game A"
+        assert result["fs_name"] == "gamea.z64"
+        assert result["platform_name"] == "N64"
+        assert result["platform_slug"] == "n64"
+        assert result["cover_path"] == "/grid/100001p.png"
+        assert result["igdb_id"] == 100
+        assert result["sgdb_id"] == 200
+        assert result["ra_id"] == 300
+
+    def test_omits_none_meta_keys(self):
+        pending = {
+            "name": "Game B",
+            "fs_name": "",
+            "platform_name": "SNES",
+            "platform_slug": "snes",
+            "igdb_id": None,
+            "sgdb_id": None,
+            "ra_id": None,
+        }
+        result = build_registry_entry(pending, 100002, "")
+        assert "igdb_id" not in result
+        assert "sgdb_id" not in result
+        assert "ra_id" not in result
+
+    def test_missing_keys_default_to_empty(self):
+        pending = {}
+        result = build_registry_entry(pending, 100003, "")
+        assert result["name"] == ""
+        assert result["fs_name"] == ""
+        assert result["platform_name"] == ""
+        assert result["platform_slug"] == ""
+
+    def test_cover_path_stored(self):
+        pending = {"name": "Game", "platform_name": "N64", "platform_slug": "n64", "fs_name": ""}
+        result = build_registry_entry(pending, 99, "/grid/99p.png")
+        assert result["cover_path"] == "/grid/99p.png"
+
+    def test_empty_cover_path_stored(self):
+        pending = {"name": "Game", "platform_name": "N64", "platform_slug": "n64", "fs_name": ""}
+        result = build_registry_entry(pending, 99, "")
+        assert result["cover_path"] == ""

--- a/tests/test_shortcut_removal.py
+++ b/tests/test_shortcut_removal.py
@@ -1,0 +1,382 @@
+"""Tests for ShortcutRemovalService."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+# conftest.py patches decky before this import
+import decky
+import pytest
+from adapters.steam_config import SteamConfigAdapter
+from services.shortcut_removal import ShortcutRemovalService
+
+
+@pytest.fixture
+def state():
+    return {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+
+
+@pytest.fixture
+def steam_config():
+    return SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
+
+
+@pytest.fixture
+def remove_artwork_files_mock():
+    return MagicMock()
+
+
+@pytest.fixture
+def svc(state, steam_config, remove_artwork_files_mock):
+    service = ShortcutRemovalService(
+        romm_api=MagicMock(),
+        steam_config=steam_config,
+        state=state,
+        loop=asyncio.get_event_loop(),
+        logger=decky.logger,
+        emit=decky.emit,
+        save_state=MagicMock(),
+        remove_artwork_files=remove_artwork_files_mock,
+    )
+    return service
+
+
+@pytest.fixture(autouse=True)
+async def _set_event_loop(svc):
+    svc._loop = asyncio.get_event_loop()
+
+
+# ── TestRemoveAllShortcuts ────────────────────────────────────────────────────
+
+
+class TestRemoveAllShortcuts:
+    def test_returns_app_ids_and_rom_ids(self, svc, state):
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A"},
+            "20": {"app_id": 1002, "name": "Game B"},
+            "30": {"name": "Game C"},  # no app_id (edge case)
+        }
+        result = svc.remove_all_shortcuts()
+        assert result["success"] is True
+        assert set(result["app_ids"]) == {1001, 1002}
+        assert set(result["rom_ids"]) == {"10", "20", "30"}
+
+    def test_empty_registry(self, svc):
+        result = svc.remove_all_shortcuts()
+        assert result["success"] is True
+        assert result["app_ids"] == []
+        assert result["rom_ids"] == []
+
+    def test_does_not_modify_registry(self, svc, state):
+        """remove_all_shortcuts just returns data; registry cleared by report_removal_results."""
+        state["shortcut_registry"] = {"10": {"app_id": 1001, "name": "Game A"}}
+        svc.remove_all_shortcuts()
+        assert "10" in state["shortcut_registry"]
+
+
+# ── TestRemovePlatformShortcuts ───────────────────────────────────────────────
+
+
+class TestRemovePlatformShortcuts:
+    @pytest.mark.asyncio
+    async def test_returns_matching_platform_entries(self, svc, state):
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value=[
+                {"id": 1, "slug": "n64", "name": "Nintendo 64"},
+                {"id": 2, "slug": "snes", "name": "Super Nintendo"},
+            ]
+        )
+        svc._loop = mock_loop
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64"},
+            "20": {"app_id": 1002, "name": "Zelda OOT", "platform_name": "Nintendo 64"},
+            "30": {"app_id": 1003, "name": "DKC", "platform_name": "Super Nintendo"},
+        }
+
+        result = await svc.remove_platform_shortcuts("n64")
+        assert result["success"] is True
+        assert set(result["app_ids"]) == {1001, 1002}
+        assert set(result["rom_ids"]) == {"10", "20"}
+        assert result["platform_name"] == "Nintendo 64"
+
+    @pytest.mark.asyncio
+    async def test_platform_not_found(self, svc):
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(return_value=[{"id": 1, "slug": "n64", "name": "Nintendo 64"}])
+        svc._loop = mock_loop
+
+        result = await svc.remove_platform_shortcuts("nonexistent")
+        assert result["success"] is False
+        assert result["app_ids"] == []
+        assert result["rom_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_modify_registry(self, svc, state):
+        """remove_platform_shortcuts just returns data; registry cleared by report_removal_results."""
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(return_value=[{"id": 1, "slug": "n64", "name": "Nintendo 64"}])
+        svc._loop = mock_loop
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64"},
+        }
+
+        await svc.remove_platform_shortcuts("n64")
+        assert "10" in state["shortcut_registry"]
+
+    @pytest.mark.asyncio
+    async def test_works_offline_with_registry_slug(self, svc, state):
+        """When platform_slug is in the registry, no API call needed."""
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Server unreachable"))
+        svc._loop = mock_loop
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Mario 64", "platform_name": "Nintendo 64", "platform_slug": "n64"},
+            "20": {"app_id": 1002, "name": "Zelda OOT", "platform_name": "Nintendo 64", "platform_slug": "n64"},
+        }
+
+        result = await svc.remove_platform_shortcuts("n64")
+        assert result["success"] is True
+        assert set(result["app_ids"]) == {1001, 1002}
+        assert result["platform_name"] == "Nintendo 64"
+
+    @pytest.mark.asyncio
+    async def test_handles_exception(self, svc):
+        """Exception during API call returns failure response."""
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("API Error"))
+        svc._loop = mock_loop
+
+        result = await svc.remove_platform_shortcuts("broken")
+        assert result["success"] is False
+        assert result["app_ids"] == []
+        assert result["rom_ids"] == []
+
+
+# ── TestReportRemovalResults ──────────────────────────────────────────────────
+
+
+class TestReportRemovalResults:
+    @pytest.mark.asyncio
+    async def test_removes_entries_from_registry(self, svc, state, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A", "cover_path": ""},
+            "20": {"app_id": 1002, "name": "Game B", "cover_path": ""},
+        }
+
+        result = await svc.report_removal_results([10, 20])
+        assert result["success"] is True
+        assert state["shortcut_registry"] == {}
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_artwork_via_callback(self, svc, state, steam_config, remove_artwork_files_mock, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A", "cover_path": ""},
+        }
+
+        await svc.report_removal_results([10])
+        assert remove_artwork_files_mock.called
+
+    @pytest.mark.asyncio
+    async def test_partial_removal(self, svc, state, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A", "cover_path": ""},
+            "20": {"app_id": 1002, "name": "Game B", "cover_path": ""},
+        }
+
+        result = await svc.report_removal_results([10])
+        assert result["success"] is True
+        assert "10" not in state["shortcut_registry"]
+        assert "20" in state["shortcut_registry"]
+
+    @pytest.mark.asyncio
+    async def test_updates_sync_stats(self, svc, state, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A", "platform_name": "N64", "cover_path": ""},
+            "20": {"app_id": 1002, "name": "Game B", "platform_name": "SNES", "cover_path": ""},
+        }
+
+        await svc.report_removal_results([10, 20])
+        assert state["sync_stats"]["platforms"] == 0
+        assert state["sync_stats"]["roms"] == 0
+
+
+# ── TestRemovalCleansUpArtwork ────────────────────────────────────────────────
+
+
+class TestRemovalCleansUpArtwork:
+    """Tests for artwork cleanup via callback in report_removal_results."""
+
+    @pytest.mark.asyncio
+    async def test_removes_app_id_artwork(self, state, steam_config, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        art_file = grid_dir / "100001p.png"
+        art_file.write_text("fake")
+
+        state["shortcut_registry"] = {"10": {"app_id": 100001, "name": "Game A", "cover_path": ""}}
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        from services.artwork import ArtworkService
+
+        artwork_svc = ArtworkService(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            sync_state_ref=lambda: None,
+        )
+
+        svc = ShortcutRemovalService(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            save_state=MagicMock(),
+            remove_artwork_files=artwork_svc.remove_artwork_files,
+        )
+        svc._loop = asyncio.get_event_loop()
+
+        await svc.report_removal_results([10])
+        assert not art_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_removes_staging_leftover(self, state, steam_config, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+
+        grid_dir = tmp_path / "grid"
+        grid_dir.mkdir()
+        staging = grid_dir / "romm_10_cover.png"
+        staging.write_text("fake")
+
+        state["shortcut_registry"] = {"10": {"app_id": 100001, "name": "Game A", "cover_path": ""}}
+        steam_config.grid_dir = lambda: str(grid_dir)
+
+        from services.artwork import ArtworkService
+
+        artwork_svc = ArtworkService(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            sync_state_ref=lambda: None,
+        )
+
+        svc = ShortcutRemovalService(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            save_state=MagicMock(),
+            remove_artwork_files=artwork_svc.remove_artwork_files,
+        )
+        svc._loop = asyncio.get_event_loop()
+
+        await svc.report_removal_results([10])
+        assert not staging.exists()
+
+
+# ── TestFindPlatformNameInRegistry ────────────────────────────────────────────
+
+
+class TestFindPlatformNameInRegistry:
+    def test_finds_by_slug(self, svc, state):
+        state["shortcut_registry"] = {
+            "1": {"platform_name": "Nintendo 64", "platform_slug": "n64"},
+            "2": {"platform_name": "Super Nintendo", "platform_slug": "snes"},
+        }
+        result = svc._find_platform_name_in_registry("n64")
+        assert result == "Nintendo 64"
+
+    def test_returns_none_when_not_found(self, svc, state):
+        state["shortcut_registry"] = {"1": {"platform_name": "Nintendo 64", "platform_slug": "n64"}}
+        result = svc._find_platform_name_in_registry("gba")
+        assert result is None
+
+    def test_empty_registry(self, svc):
+        result = svc._find_platform_name_in_registry("n64")
+        assert result is None
+
+
+# ── TestFindPlatformNameFromApi ───────────────────────────────────────────────
+
+
+class TestFindPlatformNameFromApi:
+    @pytest.mark.asyncio
+    async def test_finds_by_slug(self, svc):
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value=[
+                {"slug": "n64", "name": "Nintendo 64"},
+                {"slug": "snes", "name": "Super Nintendo"},
+            ]
+        )
+        svc._loop = mock_loop
+
+        result = await svc._find_platform_name_from_api("snes")
+        assert result == "Super Nintendo"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self, svc):
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(return_value=[{"slug": "n64", "name": "Nintendo 64"}])
+        svc._loop = mock_loop
+
+        result = await svc._find_platform_name_from_api("gba")
+        assert result is None
+
+
+# ── TestReportRemovalSteamInputCleanup ────────────────────────────────────────
+
+
+class TestReportRemovalSteamInputCleanup:
+    @pytest.mark.asyncio
+    async def test_cleans_up_steam_input_config(self, svc, state, steam_config, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+        steam_config.grid_dir = lambda: None
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A"},
+        }
+
+        steam_config.set_steam_input_config = MagicMock()
+        await svc.report_removal_results([10])
+        steam_config.set_steam_input_config.assert_called_once_with([1001], mode="default")
+
+    @pytest.mark.asyncio
+    async def test_handles_steam_input_exception(self, svc, state, steam_config, tmp_path):
+        decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
+        steam_config.grid_dir = lambda: None
+
+        state["shortcut_registry"] = {
+            "10": {"app_id": 1001, "name": "Game A"},
+        }
+
+        steam_config.set_steam_input_config = MagicMock(side_effect=Exception("VDF write failed"))
+
+        # Should not raise
+        result = await svc.report_removal_results([10])
+        assert result["success"] is True


### PR DESCRIPTION
## Summary

- Extracts `ArtworkService` from LibraryService (cover download, staging, finalization, cleanup)
- Extracts `ShortcutRemovalService` (removal queries, post-removal state cleanup, artwork deletion)
- Extracts `domain/shortcut_data.py` with pure functions (`build_shortcuts_data`, `build_registry_entry`)
- LibraryService reduced from 1119L to ~650L, focused on sync orchestration
- Cross-service communication via callbacks + `artwork: Any` pattern (service independence maintained)
- Parameter count reduced from 16 to 14 (will drop further with #154 Protocols)

Closes #113

## Test plan

- [x] `python -m pytest tests/ -q` — 1260 passed
- [x] `ruff check` — all checks passed
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 5 contracts kept, 0 broken