### PR TITLE
refactor(protocols): replace all callbacks with typed Protocol interfaces

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,17 @@
 import asyncio
+import contextlib
 import os
 import sys
+from typing import ClassVar
 
 plugin_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(plugin_dir, "py_modules"))
 sys.path.insert(0, plugin_dir)
 
 import decky
-from adapters.persistence import PersistenceAdapter
 from bootstrap import WiringConfig, bootstrap, wire_services
+
+from adapters.persistence import PersistenceAdapter
 from domain import retrodeck_config
 
 
@@ -18,7 +21,7 @@ class Plugin:
 
     # -- logging ---------------------------------------------------------------
 
-    LOG_LEVELS = {"debug": 0, "info": 1, "warn": 2, "error": 3}
+    LOG_LEVELS: ClassVar[dict] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
 
     def _log_debug(self, msg):
         """Log a message only when log_level allows debug messages."""
@@ -215,10 +218,8 @@ class Plugin:
 
         # Extract server version from heartbeat
         self._romm_version = None
-        try:
+        with contextlib.suppress(AttributeError, TypeError):
             self._romm_version = heartbeat.get("SYSTEM", {}).get("VERSION")
-        except (AttributeError, TypeError):
-            pass
         if self._romm_version:
             decky.logger.info(f"RomM server version: {self._romm_version}")
             self._romm_api.set_version(self._romm_version)
@@ -343,7 +344,7 @@ class Plugin:
         return {"success": True}
 
     async def get_cached_game_detail(self, app_id):
-        return await self._game_detail_service.get_cached_game_detail(app_id)
+        return self._game_detail_service.get_cached_game_detail(app_id)
 
     async def get_available_cores(self, platform_slug):
         """Return available RetroArch cores for a platform."""
@@ -584,7 +585,7 @@ class Plugin:
     # ── Metadata delegation to MetadataService ────────────────
 
     async def get_rom_metadata(self, rom_id):
-        return await self._metadata_service.get_rom_metadata(rom_id)
+        return self._metadata_service.get_rom_metadata(rom_id)
 
     async def get_all_metadata_cache(self):
         return self._metadata_service.get_all_metadata_cache()

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -5,6 +5,7 @@ Migration logic lives in ``domain/state_migrations.py``.
 No ``import decky``.
 """
 
+import contextlib
 import fcntl
 import json
 import logging
@@ -65,10 +66,8 @@ class PersistenceAdapter:
                     json.dump(data, f, indent=2)
                 os.replace(tmp_path, path)
             except Exception:
-                try:
+                with contextlib.suppress(OSError):
                     os.unlink(tmp_path)
-                except OSError:
-                    pass
                 raise
         finally:
             os.close(lock_fd)
@@ -87,7 +86,7 @@ class PersistenceAdapter:
         """
         settings_path = os.path.join(self._settings_dir, "settings.json")
         try:
-            with open(settings_path, "r") as f:
+            with open(settings_path) as f:
                 settings = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError):
             settings = {}
@@ -125,7 +124,7 @@ class PersistenceAdapter:
         state_path = os.path.join(self._runtime_dir, "state.json")
         state = dict(defaults)
         try:
-            with open(state_path, "r") as f:
+            with open(state_path) as f:
                 saved = json.load(f)
             if not isinstance(saved, dict):
                 saved = {}
@@ -155,7 +154,7 @@ class PersistenceAdapter:
         """
         cache_path = os.path.join(self._runtime_dir, "metadata_cache.json")
         try:
-            with open(cache_path, "r") as f:
+            with open(cache_path) as f:
                 loaded = json.load(f)
             if not isinstance(loaded, dict):
                 return {"version": _METADATA_CACHE_VERSION}
@@ -183,7 +182,7 @@ class PersistenceAdapter:
         """
         cache_path = os.path.join(self._runtime_dir, "firmware_cache.json")
         try:
-            with open(cache_path, "r") as f:
+            with open(cache_path) as f:
                 loaded = json.load(f)
             if not isinstance(loaded, dict):
                 return {"version": _FIRMWARE_CACHE_VERSION}

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -16,6 +16,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from pathlib import Path
+from typing import ClassVar
 
 from lib.certifi_bundle import ca_bundle as _ca_bundle
 from lib.errors import (
@@ -64,7 +65,7 @@ class RommHttpAdapter:
         root_path = os.path.join(self._plugin_dir, "config.json")
         dev_path = os.path.join(self._plugin_dir, "defaults", "config.json")
         config_path = root_path if os.path.exists(root_path) else dev_path
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             config = json.load(f)
         return config.get("platform_map", {})
 
@@ -109,7 +110,7 @@ class RommHttpAdapter:
 
     # Maps HTTP status codes to (error_class, custom_message_template_or_None).
     # None means use the default ``msg``.
-    _HTTP_STATUS_MAP: dict[int, tuple[type[RommApiError], str | None]] = {
+    _HTTP_STATUS_MAP: ClassVar[dict[int, tuple[type[RommApiError], str | None]]] = {
         400: (RommApiError, "Bad request ({method} {url})"),
         401: (RommAuthError, None),
         403: (RommForbiddenError, None),
@@ -164,9 +165,7 @@ class RommHttpAdapter:
         # Backward compat for non-RomM exceptions
         if isinstance(exc, urllib.error.HTTPError):
             return exc.code >= 500
-        if isinstance(exc, (urllib.error.URLError, ConnectionError, TimeoutError, OSError)):
-            return True
-        return False
+        return isinstance(exc, (urllib.error.URLError, ConnectionError, TimeoutError, OSError))
 
     def with_retry(self, fn, *args, max_attempts: int = 3, base_delay: int = 1, **kwargs):
         """Call fn(*args, **kwargs) with exponential backoff retry.
@@ -221,7 +220,7 @@ class RommHttpAdapter:
             while True:
                 try:
                     chunk = resp.read(block_size)
-                except (socket.timeout, TimeoutError) as exc:
+                except TimeoutError as exc:
                     raise RommTimeoutError(
                         "Download stalled: no data received within read timeout",
                         url=url,
@@ -239,9 +238,9 @@ class RommHttpAdapter:
     def _validate_download(total: int, downloaded: int) -> None:
         """Raise if the download was incomplete or empty."""
         if total > 0 and downloaded != total:
-            raise IOError(f"Download incomplete: got {downloaded} bytes, expected {total}")
+            raise OSError(f"Download incomplete: got {downloaded} bytes, expected {total}")
         if total == 0 and downloaded == 0:
-            raise IOError("Download produced 0 bytes (no Content-Length header and no data received)")
+            raise OSError("Download produced 0 bytes (no Content-Length header and no data received)")
 
     def download(self, path: str, dest: str, progress_callback=None):
         """Download a file from the RomM API to a local path."""

--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -123,7 +123,7 @@ class SteamConfigAdapter:
             return None, None
 
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 return vdf.load(f), path
         except Exception as e:
             self._logger.error(f"Failed to parse localconfig.vdf: {e}")
@@ -183,7 +183,7 @@ class SteamConfigAdapter:
         for candidate in candidates:
             cfg_path = os.path.expanduser(candidate)
             try:
-                with open(cfg_path, "r") as f:
+                with open(cfg_path) as f:
                     for line in f:
                         line = line.strip()
                         if line.startswith("input_driver"):
@@ -206,7 +206,7 @@ class SteamConfigAdapter:
             return {"success": False, "message": "No fix needed"}
         cfg_path = check["config_path"]
         try:
-            with open(cfg_path, "r") as f:
+            with open(cfg_path) as f:
                 lines = f.readlines()
             with open(cfg_path, "w") as f:
                 for line in lines:

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -12,12 +12,13 @@ import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 from adapters.persistence import PersistenceAdapter
 from adapters.romm.api_router import ApiRouter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain import es_de_config as _es_de_config
+from domain import retrodeck_config as _retrodeck_config
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService
 from services.downloads import DownloadService
@@ -27,7 +28,14 @@ from services.library import LibraryService
 from services.metadata import MetadataService
 from services.migration import MigrationService
 from services.playtime import PlaytimeService
-from services.protocols import RommApiProtocol
+from services.protocols import (
+    DebugLogger,
+    EventEmitter,
+    RommApiProtocol,
+    SavesPathProvider,
+    SettingsPersister,
+    StatePersister,
+)
 from services.protocols import SteamConfigAdapter as SteamConfigProtocol
 from services.rom_removal import RomRemovalService
 from services.saves import SaveService
@@ -56,16 +64,16 @@ class WiringConfig:
     logger: logging.Logger
     plugin_dir: str
     runtime_dir: str
-    emit: Any
+    emit: EventEmitter
 
     # Callbacks
-    get_saves_path: Callable
-    save_state: Callable
-    save_settings_to_disk: Callable
-    save_metadata_cache: Callable
-    save_firmware_cache: Callable
-    load_firmware_cache: Callable
-    log_debug: Callable
+    get_saves_path: SavesPathProvider
+    save_state: StatePersister
+    save_settings_to_disk: SettingsPersister
+    save_metadata_cache: StatePersister
+    save_firmware_cache: Callable[[dict], None]
+    load_firmware_cache: Callable[[], dict]
+    log_debug: DebugLogger
 
 
 def bootstrap(
@@ -97,6 +105,10 @@ def bootstrap(
     dict with keys ``persistence``, ``http_adapter``, and ``wire_services``
     (a factory callable for deferred service creation).
     """
+    # Configure domain modules with runtime paths/logger (removes decky coupling from domain).
+    _retrodeck_config.configure(user_home=user_home)
+    _es_de_config.configure(plugin_dir=plugin_dir, logger=logger)
+
     persistence = PersistenceAdapter(settings_dir, runtime_dir, logger)
     http_adapter = RommHttpAdapter(settings, plugin_dir, logger)
     romm_api = ApiRouter(http_adapter)
@@ -124,8 +136,7 @@ def wire_services(cfg: WiringConfig) -> dict:
     """
     save_sync_service = SaveService(
         romm_api=cfg.romm_api,
-        with_retry=cfg.http_adapter.with_retry,
-        is_retryable=cfg.http_adapter.is_retryable,
+        retry=cfg.http_adapter,
         state=cfg.state,
         save_sync_state=cfg.save_sync_state,
         loop=cfg.loop,
@@ -136,8 +147,7 @@ def wire_services(cfg: WiringConfig) -> dict:
 
     playtime_service = PlaytimeService(
         romm_api=cfg.romm_api,
-        with_retry=cfg.http_adapter.with_retry,
-        is_retryable=cfg.http_adapter.is_retryable,
+        retry=cfg.http_adapter,
         save_sync_state=cfg.save_sync_state,
         loop=cfg.loop,
         logger=cfg.logger,
@@ -154,6 +164,13 @@ def wire_services(cfg: WiringConfig) -> dict:
         log_debug=cfg.log_debug,
     )
 
+    # Mutable container to break the circular dependency:
+    # ArtworkService needs sync_state_ref but LibraryService isn't created yet.
+    # We put a mutable list with one element; after LibraryService is created we
+    # replace that element.  ArtworkService reads _sync_state_box[0]() so it always
+    # gets the live value without any post-construction attribute mutation.
+    _sync_state_box: list = [lambda: None]
+
     artwork_service = ArtworkService(
         romm_api=cfg.romm_api,
         steam_config=cfg.steam_config,
@@ -161,7 +178,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         loop=cfg.loop,
         logger=cfg.logger,
         emit=cfg.emit,
-        sync_state_ref=lambda: None,  # placeholder; overwritten below after LibraryService is created
+        sync_state_ref=lambda: _sync_state_box[0](),
     )
 
     shortcut_removal_service = ShortcutRemovalService(
@@ -192,8 +209,8 @@ def wire_services(cfg: WiringConfig) -> dict:
         artwork=artwork_service,
     )
 
-    # Wire sync_state_ref after sync_service is created (breaks circular dependency)
-    artwork_service._sync_state_ref = lambda: sync_service.sync_state
+    # Resolve the circular dependency: point the box at the real sync_state getter.
+    _sync_state_box[0] = lambda: sync_service.sync_state
 
     download_service = DownloadService(
         romm_api=cfg.romm_api,
@@ -236,7 +253,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         runtime_dir=cfg.runtime_dir,
         save_state=cfg.save_state,
         save_settings_to_disk=cfg.save_settings_to_disk,
-        pending_sync=sync_service.pending_sync,
+        get_pending_sync=lambda: sync_service.pending_sync,
     )
 
     achievements_service = AchievementsService(
@@ -253,7 +270,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         logger=cfg.logger,
         save_state=cfg.save_state,
         emit=cfg.emit,
-        firmware_service_bios_files_index=firmware_service.bios_files_index,
+        get_bios_files_index=lambda: firmware_service.bios_files_index,
     )
 
     game_detail_service = GameDetailService(
@@ -261,10 +278,8 @@ def wire_services(cfg: WiringConfig) -> dict:
         metadata_cache=cfg.metadata_cache,
         save_sync_state=cfg.save_sync_state,
         logger=cfg.logger,
-        check_platform_bios_cached=firmware_service.check_platform_bios_cached,
-        check_platform_bios=firmware_service.check_platform_bios,
-        get_ra_username=achievements_service.get_ra_username,
-        get_progress_cache_entry=achievements_service.get_progress_cache_entry,
+        bios_checker=firmware_service,
+        achievements=achievements_service,
     )
 
     return {

--- a/py_modules/domain/bios.py
+++ b/py_modules/domain/bios.py
@@ -29,10 +29,7 @@ def classify_firmware_file(
     Returns (is_required, classification, description).
     """
     if active_core_so and reg_entry and "cores" in reg_entry:
-        if active_core_so in reg_entry["cores"]:
-            is_required = reg_entry["cores"][active_core_so]["required"]
-        else:
-            is_required = False
+        is_required = reg_entry["cores"][active_core_so]["required"] if active_core_so in reg_entry["cores"] else False
         description = reg_entry.get("description", file_name)
         classification = "required" if is_required else "optional"
     elif reg_entry:

--- a/py_modules/domain/es_de_config.py
+++ b/py_modules/domain/es_de_config.py
@@ -4,9 +4,39 @@ import json
 import os
 import re
 
-import decky  # for DECKY_USER_HOME and logging
-
 _CORE_SO_RE = re.compile(r"%CORE_RETROARCH%/([\w-]+_libretro)\.so")
+
+# Module-level configuration — set via configure() during bootstrap.
+# Falls back to importing decky lazily if not configured (dev/test fallback).
+_logger = None
+_plugin_dir = None
+
+
+def configure(plugin_dir: str, logger) -> None:
+    """Configure module-level logger and plugin_dir.
+
+    Must be called once during bootstrap before the first use of CoreResolver
+    methods that load files from the plugin directory.
+    """
+    global _logger, _plugin_dir
+    _logger = logger
+    _plugin_dir = plugin_dir
+
+
+def _get_logger():
+    """Return the configured logger, raising if not configured."""
+    if _logger is not None:
+        return _logger
+    raise RuntimeError("es_de_config not configured — call configure() during bootstrap")
+
+
+def _get_plugin_dir():
+    """Return the configured plugin_dir, raising if not configured."""
+    if _plugin_dir is not None:
+        return _plugin_dir
+    raise RuntimeError("es_de_config not configured — call configure() during bootstrap")
+
+
 _GAMELIST_FILENAME = "gamelist.xml"
 
 _FLATPAK_SYSTEMS_DIR = (
@@ -86,7 +116,7 @@ class CoreResolver:
             if game_label:
                 resolved = self._resolve_label(system_name, system_info, game_label)
                 if resolved:
-                    decky.logger.debug(
+                    _get_logger().debug(
                         "es_de_config: per-game override for %s/%s -> %s",
                         system_name,
                         rom_filename,
@@ -148,7 +178,7 @@ class CoreResolver:
                 {"core_so": core_so, "label": label, "is_default": core_so == default_core}
                 for core_so, label in system_info["cores"].items()
             ]
-            decky.logger.debug(
+            _get_logger().debug(
                 "es_de_config: get_available_cores(%s) -> %d cores from es_systems.xml",
                 system_name,
                 len(cores),
@@ -164,14 +194,14 @@ class CoreResolver:
                 {"core_so": core_so, "label": label, "is_default": core_so == default_core}
                 for core_so, label in default_info["cores"].items()
             ]
-            decky.logger.debug(
+            _get_logger().debug(
                 "es_de_config: get_available_cores(%s) -> %d cores from core_defaults.json (fallback)",
                 system_name,
                 len(cores),
             )
             return cores
 
-        decky.logger.debug("es_de_config: get_available_cores(%s) -> no cores found", system_name)
+        _get_logger().debug("es_de_config: get_available_cores(%s) -> no cores found", system_name)
         return []
 
     def get_system_override(self, retrodeck_home, system_name):
@@ -257,9 +287,9 @@ class CoreResolver:
             game_path = game.get("path", "")
             # Normalize: strip leading "./" for comparison
             normalized = game_path.lstrip("./") if game_path else ""
-            if normalized == rom_filename or game_path == rom_filename or game_path == f"./{rom_filename}":
-                if game.get("altemulator"):
-                    return game["altemulator"]
+            path_matches = normalized == rom_filename or game_path == rom_filename or game_path == f"./{rom_filename}"
+            if path_matches and game.get("altemulator"):
+                return game["altemulator"]
 
         return None
 
@@ -366,14 +396,14 @@ class CoreResolver:
         try:
             from xml.parsers import expat
         except ImportError:
-            decky.logger.warning("es_de_config: xml.parsers.expat not available")
+            _get_logger().warning("es_de_config: xml.parsers.expat not available")
             return {}
 
         try:
             with open(xml_path, "rb") as f:
                 data = f.read()
         except OSError as e:
-            decky.logger.warning("es_de_config: failed to read %s: %s", xml_path, e)
+            _get_logger().warning("es_de_config: failed to read %s: %s", xml_path, e)
             return {}
 
         systems = {}
@@ -396,11 +426,11 @@ class CoreResolver:
         try:
             parser.Parse(data, True)
         except expat.ExpatError as e:
-            decky.logger.warning("es_de_config: failed to parse %s: %s", xml_path, e)
+            _get_logger().warning("es_de_config: failed to parse %s: %s", xml_path, e)
             return {}
 
         if state["root_tag"] != "systemList":
-            decky.logger.warning(
+            _get_logger().warning(
                 "es_de_config: unexpected root tag '%s' (expected 'systemList')",
                 state["root_tag"],
             )
@@ -417,8 +447,8 @@ class CoreResolver:
         """
         # Check plugin root first (Decky CLI moves defaults/ contents to root),
         # then defaults/ subdirectory (dev deploys via mise run deploy)
-        root_path = os.path.join(decky.DECKY_PLUGIN_DIR, "core_defaults.json")
-        dev_path = os.path.join(decky.DECKY_PLUGIN_DIR, "defaults", "core_defaults.json")
+        root_path = os.path.join(_get_plugin_dir(), "core_defaults.json")
+        dev_path = os.path.join(_get_plugin_dir(), "defaults", "core_defaults.json")
         defaults_path = root_path if os.path.exists(root_path) else dev_path
 
         try:
@@ -434,11 +464,11 @@ class CoreResolver:
             return self._core_defaults_cache
 
         try:
-            with open(defaults_path, "r") as f:
+            with open(defaults_path) as f:
                 data = json.load(f)
             self._core_defaults_cache = data.get("systems", {})
         except (OSError, json.JSONDecodeError) as e:
-            decky.logger.warning("es_de_config: failed to load core_defaults.json: %s", e)
+            _get_logger().warning("es_de_config: failed to load core_defaults.json: %s", e)
             self._core_defaults_cache = {}
 
         self._core_defaults_path = defaults_path
@@ -469,7 +499,7 @@ class CoreResolver:
             self._es_systems_mtime = current_mtime
         else:
             if self._es_systems_cache is None:
-                decky.logger.info("es_de_config: es_systems.xml not found, using core_defaults.json fallback")
+                _get_logger().info("es_de_config: es_systems.xml not found, using core_defaults.json fallback")
             self._es_systems_cache = {}
             self._es_systems_path = None
             self._es_systems_mtime = None
@@ -501,7 +531,7 @@ class GamelistXmlEditor:
         if raw:
             parsed = self.parse_gamelist_preserving(raw)
             if parsed is None:
-                decky.logger.warning("es_de_config: failed to parse %s for writing", path)
+                _get_logger().warning("es_de_config: failed to parse %s for writing", path)
                 return False
             games_xml = [g["raw_xml"] for g in parsed["games"]]
         else:
@@ -510,7 +540,7 @@ class GamelistXmlEditor:
         content = self.reconstruct_gamelist(core_label or None, games_xml)
         self.write_gamelist_atomic(path, content)
         action = "cleared" if not core_label else f"set to '{core_label}'"
-        decky.logger.info("es_de_config: system override for %s %s (%s)", system_name, action, path)
+        _get_logger().info("es_de_config: system override for %s %s (%s)", system_name, action, path)
         return True
 
     def set_game_override(self, retrodeck_home, system_name, rom_path, core_label):
@@ -526,7 +556,7 @@ class GamelistXmlEditor:
         if raw:
             parsed = self.parse_gamelist_preserving(raw)
             if parsed is None:
-                decky.logger.warning("es_de_config: failed to parse %s for writing", path)
+                _get_logger().warning("es_de_config: failed to parse %s for writing", path)
                 return False
             alt_label = parsed["alt_emulator_label"]
             games = parsed["games"]
@@ -545,21 +575,18 @@ class GamelistXmlEditor:
             else:
                 new_games_xml.append(game["raw_xml"])
 
-        if not found:
-            # Create new game entry
-            if core_label:
-                escaped_path = self.escape_xml(rom_path)
-                escaped_label = self.escape_xml(core_label)
-                game_xml = (
-                    f"<game>\n    <path>{escaped_path}</path>\n"
-                    f"    <altemulator>{escaped_label}</altemulator>\n  </game>"
-                )
-                new_games_xml.append(game_xml)
+        if not found and core_label:
+            escaped_path = self.escape_xml(rom_path)
+            escaped_label = self.escape_xml(core_label)
+            game_xml = (
+                f"<game>\n    <path>{escaped_path}</path>\n    <altemulator>{escaped_label}</altemulator>\n  </game>"
+            )
+            new_games_xml.append(game_xml)
 
         content = self.reconstruct_gamelist(alt_label, new_games_xml)
         self.write_gamelist_atomic(path, content)
         action = "cleared" if not core_label else f"set to '{core_label}'"
-        decky.logger.info("es_de_config: game override for %s [%s] %s (%s)", system_name, rom_path, action, path)
+        _get_logger().info("es_de_config: game override for %s [%s] %s (%s)", system_name, rom_path, action, path)
         return True
 
     def get_system_override(self, retrodeck_home, system_name):

--- a/py_modules/domain/retrodeck_config.py
+++ b/py_modules/domain/retrodeck_config.py
@@ -9,19 +9,38 @@ import json
 import os
 import time
 
-import decky
-
 _CACHE_TTL = 30  # seconds
 
 _cached_config = None
 _cache_time = 0.0
 _cache_config_path = None
 
+# Module-level configuration — set via configure() during bootstrap.
+# Falls back to importing decky lazily if not configured (dev/test fallback).
+_user_home = None
+
+
+def configure(user_home: str) -> None:
+    """Configure the user home path used for RetroDECK path resolution.
+
+    Must be called once during bootstrap before any path resolution functions
+    are used.
+    """
+    global _user_home
+    _user_home = user_home
+
+
+def _get_user_home() -> str:
+    """Return the configured user home, raising if not configured."""
+    if _user_home is not None:
+        return _user_home
+    raise RuntimeError("retrodeck_config not configured — call configure() during bootstrap")
+
 
 def _config_path():
-    """Return the path to retrodeck.json, using current DECKY_USER_HOME."""
+    """Return the path to retrodeck.json, using current user home."""
     return os.path.join(
-        decky.DECKY_USER_HOME,
+        _get_user_home(),
         ".var",
         "app",
         "net.retrodeck.retrodeck",
@@ -39,7 +58,7 @@ def _load_config():
     if _cached_config is not None and _cache_config_path == config_path and (now - _cache_time) < _CACHE_TTL:
         return _cached_config
     try:
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             config = json.load(f)
         _cached_config = config
         _cache_time = now
@@ -59,7 +78,7 @@ def get_retrodeck_path(key, fallback_subdir):
         path = config.get("paths", {}).get(key, "")
         if path:
             return path
-    return os.path.join(decky.DECKY_USER_HOME, "retrodeck", fallback_subdir)
+    return os.path.join(_get_user_home(), "retrodeck", fallback_subdir)
 
 
 def get_bios_path():

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -43,8 +43,8 @@ def build_m3u_content(disc_files: list[str]) -> str:
     return "\n".join(sorted_files) + "\n"
 
 
-def detect_launch_file(files: list[str]) -> str | None:
-    """Pick the best launch file from a list of absolute file paths.
+def detect_launch_file(files: list[tuple[str, int]]) -> str | None:
+    """Pick the best launch file from a list of (path, size) tuples.
 
     Priority order:
     1. M3U playlist
@@ -58,7 +58,8 @@ def detect_launch_file(files: list[str]) -> str | None:
     Parameters
     ----------
     files:
-        Absolute file paths to consider. If empty, returns None.
+        List of (absolute_path, size_in_bytes) tuples to consider.
+        If empty, returns None.
 
     Returns
     -------
@@ -68,34 +69,35 @@ def detect_launch_file(files: list[str]) -> str | None:
     if not files:
         return None
 
+    paths = [path for path, _size in files]
+
     # Prefer M3U > CUE
     for ext in (".m3u", ".cue"):
-        matches = [f for f in files if f.lower().endswith(ext)]
+        matches = [p for p in paths if p.lower().endswith(ext)]
         if matches:
             return matches[0]
 
     # WiiU: loadiine format has .rpx in code/ subdirectory
-    rpx_files = [f for f in files if f.lower().endswith(".rpx")]
+    rpx_files = [p for p in paths if p.lower().endswith(".rpx")]
     if rpx_files:
         return rpx_files[0]
 
     # WiiU disc images
     for ext in (".wud", ".wux", ".wua"):
-        matches = [f for f in files if f.lower().endswith(ext)]
+        matches = [p for p in paths if p.lower().endswith(ext)]
         if matches:
             return matches[0]
 
     # PS3: EBOOT.BIN in PS3_GAME/USRDIR/
-    eboot_files = [f for f in files if f.endswith("EBOOT.BIN")]
+    eboot_files = [p for p in paths if p.endswith("EBOOT.BIN")]
     if eboot_files:
         return eboot_files[0]
 
     # 3DS: prefer .3ds > .cia > .cxi
     for ext in (".3ds", ".cia", ".cxi"):
-        matches = [f for f in files if f.lower().endswith(ext)]
+        matches = [p for p in paths if p.lower().endswith(ext)]
         if matches:
             return matches[0]
 
-    import os
-
-    return max(files, key=os.path.getsize)
+    # Largest file by pre-computed size
+    return max(files, key=lambda t: t[1])[0]

--- a/py_modules/domain/save_conflicts.py
+++ b/py_modules/domain/save_conflicts.py
@@ -6,7 +6,7 @@ operate only on the values passed to them.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def check_local_changes(local_hash: str | None, last_sync_hash: str) -> bool:
@@ -25,7 +25,6 @@ def check_local_changes(local_hash: str | None, last_sync_hash: str) -> bool:
 def check_server_changes_fast(
     file_state: dict,
     server_save: dict,
-    last_sync_hash: str,
 ) -> bool | None:
     """Fast-path server-change detection using stored timestamp and size.
 
@@ -47,9 +46,7 @@ def check_server_changes_fast(
 
     # Fast path: timestamp unchanged
     if stored_updated_at and server_updated_at == stored_updated_at:
-        if stored_size is not None and server_size is not None and server_size != stored_size:
-            return True  # size changed despite same timestamp
-        return False  # unchanged
+        return stored_size is not None and server_size is not None and server_size != stored_size
 
     # Timestamp changed or no stored timestamp — indeterminate without hash
     return None
@@ -119,10 +116,9 @@ def detect_conflict_lightweight(
         server_updated_at = server_save.get("updated_at", "")
         server_size = server_save.get("file_size_bytes")
 
-        if (stored_updated_at and server_updated_at != stored_updated_at) or (
+        server_changed = (stored_updated_at and server_updated_at != stored_updated_at) or (
             stored_size is not None and server_size is not None and server_size != stored_size
-        ):
-            server_changed = True
+        )
 
     return determine_action(local_changed, server_changed)
 
@@ -164,7 +160,7 @@ def resolve_conflict_by_mode(
     server_updated = server_save.get("updated_at", "")
     try:
         server_dt = datetime.fromisoformat(server_updated.replace("Z", "+00:00"))
-        local_dt = datetime.fromtimestamp(local_mtime, tz=timezone.utc)
+        local_dt = datetime.fromtimestamp(local_mtime, tz=UTC)
         diff = abs((local_dt - server_dt).total_seconds())
         if diff <= tolerance:
             return "ask"
@@ -209,13 +205,11 @@ def build_conflict_dict(
         "local_path": local_info["path"] if local_info else None,
         "local_hash": local_hash,
         "local_mtime": (
-            datetime.fromtimestamp(local_mtime_val, tz=timezone.utc).isoformat()
-            if local_mtime_val is not None
-            else None
+            datetime.fromtimestamp(local_mtime_val, tz=UTC).isoformat() if local_mtime_val is not None else None
         ),
         "local_size": local_info.get("size") if local_info else None,
         "server_save_id": server_save.get("id"),
         "server_updated_at": server_save.get("updated_at", ""),
         "server_size": server_save.get("file_size_bytes"),
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
     }

--- a/py_modules/domain/sync_state.py
+++ b/py_modules/domain/sync_state.py
@@ -1,0 +1,9 @@
+"""SyncState enum — shared between LibraryService and consumers."""
+
+from enum import Enum
+
+
+class SyncState(Enum):
+    IDLE = "idle"
+    RUNNING = "running"
+    CANCELLING = "cancelling"

--- a/py_modules/services/achievements.py
+++ b/py_modules/services/achievements.py
@@ -12,9 +12,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol
+    from services.protocols import DebugLogger, RommApiProtocol
 
 
 class AchievementsService:
@@ -31,7 +30,7 @@ class AchievementsService:
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        log_debug: Callable,
+        log_debug: DebugLogger,
     ) -> None:
         self._romm_api = romm_api
         self._state = state

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol, SteamConfigAdapter
+    from services.protocols import EventEmitter, RommApiProtocol, SteamConfigAdapter, SyncStateRef
 
 
 class ArtworkService:
@@ -26,8 +26,8 @@ class ArtworkService:
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        emit: Callable,
-        sync_state_ref: Callable,
+        emit: EventEmitter,
+        sync_state_ref: SyncStateRef,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -19,14 +19,12 @@ from typing import TYPE_CHECKING
 
 from domain import retrodeck_config
 from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
-
 from lib.errors import error_response
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol
+    from services.protocols import EventEmitter, RommApiProtocol, StatePersister, SystemResolver
 
 _DOWNLOAD_QUEUE_MAX_TERMINAL = 50
 _ZIP_TMP_EXT = ".zip.tmp"
@@ -40,13 +38,13 @@ class DownloadService:
         self,
         *,
         romm_api: RommApiProtocol,
-        resolve_system: Callable,
+        resolve_system: SystemResolver,
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         runtime_dir: str,
-        emit: Callable,
-        save_state: Callable,
+        emit: EventEmitter,
+        save_state: StatePersister,
     ):
         self._romm_api = romm_api
         self._resolve_system = resolve_system
@@ -126,9 +124,9 @@ class DownloadService:
             if not os.path.isdir(system_path):
                 continue
             for filename in os.listdir(system_path):
-                if filename.endswith((_TMP_EXT, _ZIP_TMP_EXT)):
-                    if self._remove_tmp_file(os.path.join(system_path, filename)):
-                        cleaned += 1
+                full_path = os.path.join(system_path, filename)
+                if filename.endswith((_TMP_EXT, _ZIP_TMP_EXT)) and self._remove_tmp_file(full_path):
+                    cleaned += 1
         return cleaned
 
     def _clean_bios_tmp_files(self):
@@ -139,9 +137,8 @@ class DownloadService:
             return cleaned
         for root, _dirs, files in os.walk(bios_base):
             for filename in files:
-                if filename.endswith(_TMP_EXT):
-                    if self._remove_tmp_file(os.path.join(root, filename)):
-                        cleaned += 1
+                if filename.endswith(_TMP_EXT) and self._remove_tmp_file(os.path.join(root, filename)):
+                    cleaned += 1
         return cleaned
 
     def cleanup_leftover_tmp_files(self):
@@ -216,10 +213,7 @@ class DownloadService:
         os.makedirs(roms_dir, exist_ok=True)
         free_space = shutil.disk_usage(roms_dir).free
         buffer = 100 * 1024 * 1024
-        if rom_detail.get("has_multiple_files"):
-            required = file_size * 2 + buffer  # ZIP + extracted + buffer
-        else:
-            required = file_size + buffer
+        required = file_size * 2 + buffer if rom_detail.get("has_multiple_files") else file_size + buffer
         if file_size and free_space < required:
             self._download_in_progress.discard(rom_id)
             free_mb = free_space // (1024 * 1024)
@@ -451,10 +445,15 @@ class DownloadService:
 
     def _collect_and_detect_launch_file(self, extract_dir: str) -> str:
         """Find the best launch file in an extracted multi-file ROM directory."""
-        all_files = []
+        all_files: list[tuple[str, int]] = []
         for root, _dirs, files in os.walk(extract_dir):
             for f in files:
-                all_files.append(os.path.join(root, f))
+                path = os.path.join(root, f)
+                try:
+                    size = os.path.getsize(path)
+                except OSError:
+                    size = 0
+                all_files.append((path, size))
 
         result = detect_launch_file(all_files)
         return result if result is not None else extract_dir

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -10,12 +10,11 @@ import hashlib
 import json
 import os
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from domain import es_de_config, retrodeck_config
 from domain.bios import collect_firmware_status
-
 from lib.errors import error_response
 
 if TYPE_CHECKING:
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol
+    from services.protocols import RommApiProtocol, StatePersister
 
 _FIRMWARE_CACHE_TTL = 3600  # 1 hour
 
@@ -39,7 +38,7 @@ class FirmwareService:
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         plugin_dir: str,
-        save_state: Callable[[], None],
+        save_state: StatePersister,
         save_firmware_cache: Callable[[dict], None] | None = None,
         load_firmware_cache: Callable[[], dict] | None = None,
     ) -> None:
@@ -74,7 +73,7 @@ class FirmwareService:
         defaults_path = os.path.join(self._plugin_dir, "defaults", "bios_registry.json")
         registry_path = root_path if os.path.exists(root_path) else defaults_path
         try:
-            with open(registry_path, "r") as f:
+            with open(registry_path) as f:
                 self._bios_registry = json.load(f)
             # Build flat reverse index: {filename: {entry_data + "platform": slug}}
             for platform, files in self._bios_registry.get("platforms", {}).items():
@@ -369,7 +368,7 @@ class FirmwareService:
             "file_path": dest,
             "firmware_id": firmware_id,
             "platform_slug": self._firmware_slug(fw.get("file_path", "")),
-            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+            "downloaded_at": datetime.now(UTC).isoformat(),
         }
         self._save_state()
 

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -14,7 +14,8 @@ from domain.bios import format_bios_status
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable
+
+    from services.protocols import AchievementsReader, BiosChecker
 
 
 class GameDetailService:
@@ -27,20 +28,15 @@ class GameDetailService:
         metadata_cache: dict,
         save_sync_state: dict,
         logger: logging.Logger,
-        # Callbacks (cross-service, maintains independence)
-        check_platform_bios_cached: Callable,
-        check_platform_bios: Callable,
-        get_ra_username: Callable,
-        get_progress_cache_entry: Callable,
+        bios_checker: BiosChecker,
+        achievements: AchievementsReader,
     ) -> None:
         self._state = state
         self._metadata_cache = metadata_cache
         self._save_sync_state = save_sync_state
         self._logger = logger
-        self._check_platform_bios_cached = check_platform_bios_cached
-        self._check_platform_bios = check_platform_bios
-        self._get_ra_username = get_ra_username
-        self._get_progress_cache_entry = get_progress_cache_entry
+        self._bios_checker = bios_checker
+        self._achievements = achievements
 
     def _resolve_rom_by_app_id(self, app_id: int) -> tuple[int | None, dict | None]:
         """Reverse lookup: find rom_id by app_id in shortcut_registry."""
@@ -83,9 +79,9 @@ class GameDetailService:
 
     def _build_achievement_summary(self, rom_id_str: str, ra_id) -> dict | None:
         """Build cached achievement summary for badge rendering, or None."""
-        if not ra_id or not self._get_ra_username():
+        if not ra_id or not self._achievements.get_ra_username():
             return None
-        cached_progress = self._get_progress_cache_entry(rom_id_str)
+        cached_progress = self._achievements.get_progress_cache_entry(rom_id_str)
         if not cached_progress:
             return None
         return {
@@ -95,7 +91,7 @@ class GameDetailService:
             "cached_at": cached_progress.get("cached_at"),
         }
 
-    async def get_cached_game_detail(self, app_id) -> dict:
+    def get_cached_game_detail(self, app_id) -> dict:
         """Return cached + lightweight data for a game."""
         app_id = int(app_id)
 
@@ -126,7 +122,7 @@ class GameDetailService:
         # BIOS status from firmware cache (no HTTP — cache-only read)
         bios_status = None
         if platform_slug:
-            cached_bios = self._check_platform_bios_cached(platform_slug, rom_filename=rom_file or None)
+            cached_bios = self._bios_checker.check_platform_bios_cached(platform_slug, rom_filename=rom_file or None)
             if cached_bios and cached_bios.get("needs_bios"):
                 bios_status = format_bios_status(cached_bios, platform_slug)
                 bios_status["cached_at"] = cached_bios.get("cached_at")
@@ -166,7 +162,7 @@ class GameDetailService:
         rom_file = self._resolve_rom_file(rom_id_str, entry)
 
         try:
-            bios = await self._check_platform_bios(platform_slug, rom_filename=rom_file or None)
+            bios = await self._bios_checker.check_platform_bios(platform_slug, rom_filename=rom_file or None)
             if bios.get("needs_bios"):
                 return {"bios_status": format_bios_status(bios, platform_slug)}
         except Exception as e:

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -12,25 +12,26 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from datetime import datetime, timezone
-from enum import Enum
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from domain.shortcut_data import build_registry_entry, build_shortcuts_data
-
+from domain.sync_state import SyncState
 from lib.errors import classify_error
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol, SteamConfigAdapter
-
-
-class SyncState(Enum):
-    IDLE = "idle"
-    RUNNING = "running"
-    CANCELLING = "cancelling"
+    from services.protocols import (
+        ArtworkManager,
+        DebugLogger,
+        EventEmitter,
+        MetadataExtractor,
+        RommApiProtocol,
+        SettingsPersister,
+        StatePersister,
+        SteamConfigAdapter,
+    )
 
 
 _SYNC_CANCELLED = "Sync cancelled"
@@ -50,12 +51,12 @@ class LibraryService:
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         plugin_dir: str,
-        emit: Callable,
-        save_state: Callable,
-        save_settings_to_disk: Callable,
-        log_debug: Callable,
-        metadata_service: Any = None,
-        artwork: Any = None,
+        emit: EventEmitter,
+        save_state: StatePersister,
+        save_settings_to_disk: SettingsPersister,
+        log_debug: DebugLogger,
+        metadata_service: MetadataExtractor | None = None,
+        artwork: ArtworkManager | None = None,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
@@ -571,11 +572,12 @@ class LibraryService:
         self._check_cancelling()
 
         # Cache metadata from sync response
-        for rom in all_roms:
-            rom_id_str = str(rom["id"])
-            self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
-            self._metadata_service.mark_metadata_dirty()
-        self._metadata_service.flush_metadata_if_dirty()
+        if self._metadata_service is not None:
+            for rom in all_roms:
+                rom_id_str = str(rom["id"])
+                self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
+                self._metadata_service.mark_metadata_dirty()
+            self._metadata_service.flush_metadata_if_dirty()
         self._log_debug(f"Metadata cached for {len(all_roms)} ROMs")
 
         return all_roms, shortcuts_data, platforms
@@ -679,7 +681,8 @@ class LibraryService:
             }
             self._loop.create_task(self._emit("sync_progress", self._sync_progress))
         finally:
-            self._metadata_service.flush_metadata_if_dirty()
+            if self._metadata_service is not None:
+                self._metadata_service.flush_metadata_if_dirty()
             self._sync_state = SyncState.IDLE
             if self._sync_progress.get("phase") != "error" and self._sync_progress.get("running"):
                 self._start_safety_timeout()
@@ -700,7 +703,7 @@ class LibraryService:
 
     def _finalize_cover_path(self, grid, cover_path, app_id, rom_id_str):
         """Delegate to ArtworkService callback if available, else use local impl."""
-        if self._artwork.finalize_cover_path is not None:
+        if self._artwork is not None:
             return self._artwork.finalize_cover_path(grid, cover_path, app_id, rom_id_str)
         # Fallback (no-op passthrough when callback not wired)
         return cover_path
@@ -731,7 +734,7 @@ class LibraryService:
             except Exception as e:
                 self._logger.error(f"Failed to set Steam Input config: {e}")
 
-        self._state["last_sync"] = datetime.now(timezone.utc).isoformat()
+        self._state["last_sync"] = datetime.now(UTC).isoformat()
         self._save_state()
         self._pending_sync = {}
 
@@ -792,7 +795,7 @@ class LibraryService:
 
     async def _download_artwork(self, all_roms, progress_step=4, progress_total_steps=6):
         """Delegate artwork download to ArtworkService callback."""
-        if self._artwork.download_artwork is not None:
+        if self._artwork is not None:
             return await self._artwork.download_artwork(
                 all_roms,
                 emit_progress=self._emit_progress,

--- a/py_modules/services/metadata.py
+++ b/py_modules/services/metadata.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol
+    from services.protocols import DebugLogger, RommApiProtocol, StatePersister
 
 
 class MetadataService:
@@ -29,8 +28,8 @@ class MetadataService:
         metadata_cache: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        save_metadata_cache: Callable,
-        log_debug: Callable,
+        save_metadata_cache: StatePersister,
+        log_debug: DebugLogger,
     ) -> None:
         self._romm_api = romm_api
         self._state = state
@@ -76,7 +75,7 @@ class MetadataService:
             self._save_metadata_cache()
             self._metadata_dirty_count = 0
 
-    async def get_rom_metadata(self, rom_id):
+    def get_rom_metadata(self, rom_id):
         """Return cached metadata for a ROM.
 
         Metadata is populated during sync via the list API. This method

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
+    from services.protocols import EventEmitter, StatePersister
+
 
 class MigrationService:
     """Handles RetroDECK path change detection and file migration."""
@@ -27,16 +29,16 @@ class MigrationService:
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        save_state: Callable[[], None],
-        emit: Callable,
-        firmware_service_bios_files_index: dict,
+        save_state: StatePersister,
+        emit: EventEmitter,
+        get_bios_files_index: Callable[[], dict],
     ) -> None:
         self._state = state
         self._loop = loop
         self._logger = logger
         self._save_state = save_state
         self._emit = emit
-        self._firmware_bios_files_index = firmware_service_bios_files_index
+        self._get_bios_files_index = get_bios_files_index
 
     def detect_retrodeck_path_change(self) -> None:
         """Check if RetroDECK home path changed since last run."""
@@ -137,7 +139,7 @@ class MigrationService:
         if not os.path.isdir(old_bios):
             return items
         downloaded_bios = self._state.get("downloaded_bios", {})
-        for file_name, reg_entry in self._firmware_bios_files_index.items():
+        for file_name, reg_entry in self._get_bios_files_index().items():
             if file_name in downloaded_bios:
                 continue
             firmware_path = reg_entry.get("firmware_path", file_name)

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -6,16 +6,16 @@ No ``import decky``.
 
 from __future__ import annotations
 
+import contextlib
 import json
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
-from services.protocols import RommApiProtocol
+from services.protocols import RetryStrategy, RommApiProtocol, StatePersister
 
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
 
 class PlaytimeService:
@@ -25,10 +25,8 @@ class PlaytimeService:
     ----------
     romm_api:
         Protocol adapter for RomM HTTP operations.
-    with_retry:
-        Retry wrapper — ``fn(*args, **kwargs)`` with exponential backoff.
-    is_retryable:
-        Predicate: should the given exception trigger a retry?
+    retry:
+        Retry strategy — provides ``with_retry`` and ``is_retryable``.
     save_sync_state:
         Live reference to the save-sync state dict.  Playtime data lives
         in ``save_sync_state["playtime"]``.
@@ -46,16 +44,14 @@ class PlaytimeService:
         self,
         *,
         romm_api: RommApiProtocol,
-        with_retry: Callable[..., Any],
-        is_retryable: Callable[[Exception], bool],
+        retry: RetryStrategy,
         save_sync_state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        save_state: Callable[[], None],
+        save_state: StatePersister,
     ) -> None:
         self._romm_api = romm_api
-        self._with_retry = with_retry
-        self._is_retryable = is_retryable
+        self._retry = retry
         self._save_sync_state = save_sync_state
         self._loop = loop
         self._logger = logger
@@ -144,7 +140,7 @@ class PlaytimeService:
         device_name = self._save_sync_state.get("device_name", "")
 
         try:
-            note = self._with_retry(self._get_playtime_note, rom_id)
+            note = self._retry.with_retry(self._get_playtime_note, rom_id)
             server_seconds = 0
             note_id = None
 
@@ -159,14 +155,14 @@ class PlaytimeService:
 
             playtime_data = {
                 "seconds": new_total,
-                "updated": datetime.now(timezone.utc).isoformat(),
+                "updated": datetime.now(UTC).isoformat(),
                 "device": device_name,
             }
 
             if note_id:
-                self._with_retry(self._update_playtime_note, rom_id, note_id, playtime_data)
+                self._retry.with_retry(self._update_playtime_note, rom_id, note_id, playtime_data)
             else:
-                self._with_retry(self._create_playtime_note, rom_id, playtime_data)
+                self._retry.with_retry(self._create_playtime_note, rom_id, playtime_data)
 
             # Sync local state to the merged total
             entry["total_seconds"] = new_total
@@ -193,7 +189,7 @@ class PlaytimeService:
                 "offline_deltas": [],
             },
         )
-        entry["last_session_start"] = datetime.now(timezone.utc).isoformat()
+        entry["last_session_start"] = datetime.now(UTC).isoformat()
         self._save_state()
         return {"success": True}
 
@@ -211,7 +207,7 @@ class PlaytimeService:
 
         try:
             start = datetime.fromisoformat(entry["last_session_start"])
-            now = datetime.now(timezone.utc)
+            now = datetime.now(UTC)
             duration = (now - start).total_seconds()
 
             # Sanity check: clamp to 0-24h
@@ -225,10 +221,8 @@ class PlaytimeService:
             self._save_state()
 
             # Best-effort sync playtime to RomM server notes
-            try:
+            with contextlib.suppress(Exception):
                 await self._loop.run_in_executor(None, self._sync_playtime_to_romm, int(rom_id), int(duration))
-            except Exception:
-                pass  # Already logged inside _sync_playtime_to_romm
 
             return {
                 "success": True,
@@ -251,7 +245,7 @@ class PlaytimeService:
         try:
             note = await self._loop.run_in_executor(
                 None,
-                lambda: self._with_retry(self._get_playtime_note, rom_id),
+                lambda: self._retry.with_retry(self._get_playtime_note, rom_id),
             )
             if note:
                 server_data = self._parse_playtime_note_content(note.get("content", ""))

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from domain.sync_state import SyncState
+
 
 class SteamConfigAdapter(Protocol):
     """Protocol for Steam configuration operations."""
@@ -17,12 +19,6 @@ class SteamConfigAdapter(Protocol):
     def read_shortcuts(self) -> dict: ...
     def write_shortcuts(self, data: dict) -> None: ...
     def set_steam_input_config(self, app_ids: list, mode: str = "default") -> None: ...
-
-    @staticmethod
-    def generate_app_id(exe: str, appname: str) -> int: ...
-
-    @staticmethod
-    def generate_artwork_id(exe: str, appname: str) -> int: ...
 
 
 class RommApiProtocol(Protocol):
@@ -192,3 +188,106 @@ class RommApiProtocol(Protocol):
         PUT /api/roms/{rom_id}/notes/{note_id}.
         """
         ...
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure callback Protocols
+# ---------------------------------------------------------------------------
+
+
+class StatePersister(Protocol):
+    """Persist plugin state to disk (zero-argument callable)."""
+
+    def __call__(self) -> None: ...
+
+
+class SettingsPersister(Protocol):
+    """Persist settings to disk (zero-argument callable)."""
+
+    def __call__(self) -> None: ...
+
+
+class EventEmitter(Protocol):
+    """Emit named events with a data payload to the frontend."""
+
+    async def __call__(self, event: str, /, *args: object) -> None: ...
+
+
+class DebugLogger(Protocol):
+    """Log a debug/trace message string."""
+
+    def __call__(self, msg: str) -> None: ...
+
+
+class SystemResolver(Protocol):
+    """Resolve a RomM platform slug to a RetroDECK system path."""
+
+    def __call__(self, platform_slug: str, platform_fs_slug: str | None = None) -> str: ...
+
+
+class SavesPathProvider(Protocol):
+    """Return the current RetroDECK saves directory path."""
+
+    def __call__(self) -> str: ...
+
+
+class SyncStateRef(Protocol):
+    """Return the current sync state value (used by ArtworkService)."""
+
+    def __call__(self) -> SyncState: ...
+
+
+# ---------------------------------------------------------------------------
+# Multi-method cross-service Protocols
+# ---------------------------------------------------------------------------
+
+
+class RetryStrategy(Protocol):
+    """HTTP retry wrapper pair consumed by SaveService and PlaytimeService."""
+
+    def is_retryable(self, exc: Exception) -> bool: ...
+
+    def with_retry(self, fn: Any, *args: Any, max_attempts: int = 3, base_delay: int = 1, **kwargs: Any) -> Any: ...
+
+
+class BiosChecker(Protocol):
+    """BIOS status checking consumed by GameDetailService."""
+
+    def check_platform_bios_cached(self, platform_slug: str, rom_filename: str | None = None) -> dict | None: ...
+
+    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict: ...
+
+
+class AchievementsReader(Protocol):
+    """Achievement data access consumed by GameDetailService."""
+
+    def get_ra_username(self) -> str: ...
+
+    def get_progress_cache_entry(self, rom_id_str: str) -> dict | None: ...
+
+
+class MetadataExtractor(Protocol):
+    """Metadata extraction and cache flushing consumed by LibraryService."""
+
+    def extract_metadata(self, rom: dict) -> dict: ...
+
+    def mark_metadata_dirty(self) -> None: ...
+
+    def flush_metadata_if_dirty(self) -> None: ...
+
+
+class ArtworkManager(Protocol):
+    """Artwork operations consumed by LibraryService."""
+
+    async def download_artwork(
+        self,
+        all_roms: list[dict],
+        emit_progress: Any,
+        is_cancelling: Any,
+        progress_step: int = 4,
+        progress_total_steps: int = 6,
+    ) -> dict: ...
+
+    def finalize_cover_path(self, grid: str | None, cover_path: str, app_id: int, rom_id_str: str) -> str: ...
+
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -11,7 +11,8 @@ from domain import retrodeck_config
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable
+
+    from services.protocols import StatePersister
 
 
 class RomRemovalService:
@@ -24,8 +25,8 @@ class RomRemovalService:
         save_sync_state: dict,
         logger: logging.Logger,
         loop: asyncio.AbstractEventLoop,
-        save_state: Callable,
-        save_save_sync_state: Callable,
+        save_state: StatePersister,
+        save_save_sync_state: StatePersister,
     ):
         self._state = state
         self._save_sync_state = save_sync_state
@@ -44,9 +45,7 @@ class RomRemovalService:
         # Must be at least 2 levels deep (e.g. roms/gb/file.zip, not roms/gb/)
         rel = os.path.relpath(resolved, real_base)
         parts = rel.split(os.sep)
-        if len(parts) < 2:
-            return False
-        return True
+        return len(parts) >= 2
 
     def _delete_rom_files(self, installed: dict) -> None:
         """Delete ROM files for an installed entry. Handles both single-file and multi-file ROMs."""

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -6,6 +6,7 @@ No ``import decky`` — error utilities come from ``lib.errors``.
 
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import hashlib
 import json
@@ -14,8 +15,8 @@ import socket
 import tempfile
 import time
 import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from domain.save_conflicts import (
     build_conflict_dict,
@@ -25,16 +26,14 @@ from domain.save_conflicts import (
     determine_action,
     resolve_conflict_by_mode,
 )
-
 from lib.errors import RommApiError, RommConflictError, classify_error
-from services.protocols import RommApiProtocol
+from services.protocols import RetryStrategy, RommApiProtocol, SavesPathProvider
 
 _DEVICE_NOT_REGISTERED = "Device not registered"
 
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
 
 class SaveService:
@@ -44,10 +43,8 @@ class SaveService:
     ----------
     romm_api:
         Protocol adapter for all RomM save/notes HTTP operations.
-    with_retry:
-        Retry wrapper — ``fn(*args, **kwargs)`` with exponential backoff.
-    is_retryable:
-        Predicate: should the given exception trigger a retry?
+    retry:
+        Retry strategy — provides ``with_retry`` and ``is_retryable``.
     state:
         Live reference to the main plugin state dict (``installed_roms``,
         ``shortcut_registry``).
@@ -69,18 +66,16 @@ class SaveService:
         self,
         *,
         romm_api: RommApiProtocol,
-        with_retry: Callable[..., Any],
-        is_retryable: Callable[[Exception], bool],
+        retry: RetryStrategy,
         state: dict,
         save_sync_state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         runtime_dir: str,
-        get_saves_path: Callable[[], str],
+        get_saves_path: SavesPathProvider,
     ) -> None:
         self._romm_api = romm_api
-        self._with_retry = with_retry
-        self._is_retryable = is_retryable
+        self._retry = retry
         self._state = state
         self._save_sync_state = save_sync_state
         self._loop = loop
@@ -130,7 +125,7 @@ class SaveService:
         """Load save sync state from disk, merging with defaults."""
         path = os.path.join(self._runtime_dir, "save_sync_state.json")
         try:
-            with open(path, "r") as f:
+            with open(path) as f:
                 saved = json.load(f)
             for key in ("saves", "playtime"):
                 if key in saved:
@@ -254,15 +249,13 @@ class SaveService:
             return self._file_md5(tmp_path)
         except Exception as e:
             self._log_debug(f"Failed to hash server save {save_id}: {e}")
-            if self._is_retryable(e):
+            if self._retry.is_retryable(e):
                 raise
             return None
         finally:
             if tmp_path:
-                try:
+                with contextlib.suppress(OSError):
                     os.remove(tmp_path)
-                except OSError:
-                    pass
 
     # ------------------------------------------------------------------
     # Conflict Detection
@@ -270,7 +263,7 @@ class SaveService:
 
     def _check_server_changes(self, file_state: dict, server_save: dict, last_sync_hash: str) -> bool:
         """Compare server metadata/hash against baseline to detect server modifications."""
-        fast = check_server_changes_fast(file_state, server_save, last_sync_hash)
+        fast = check_server_changes_fast(file_state, server_save)
         if fast is not None:
             return fast
 
@@ -278,7 +271,7 @@ class SaveService:
         server_updated_at = server_save.get("updated_at", "")
         server_size = server_save.get("file_size_bytes")
         try:
-            server_hash = self._with_retry(self._get_server_save_hash, server_save)
+            server_hash = self._retry.with_retry(self._get_server_save_hash, server_save)
         except Exception:
             server_hash = None
         if server_hash and server_hash != last_sync_hash:
@@ -291,7 +284,7 @@ class SaveService:
                 file_state["last_sync_server_size"] = server_size
         return False
 
-    def _detect_conflict(self, rom_id: int, filename: str, local_hash: str, server_save: dict) -> str:
+    def _detect_conflict(self, rom_id: int, filename: str, local_hash: str | None, server_save: dict) -> str:
         """Hybrid conflict detection (no content_hash on RomM 4.6.1).
 
         Returns: ``"skip"``, ``"download"``, ``"upload"``, or ``"conflict"``.
@@ -305,7 +298,7 @@ class SaveService:
         if not last_sync_hash:
             if local_hash:
                 try:
-                    server_hash = self._with_retry(self._get_server_save_hash, server_save)
+                    server_hash = self._retry.with_retry(self._get_server_save_hash, server_save)
                 except Exception:
                     server_hash = None
                 if server_hash is None:
@@ -355,10 +348,10 @@ class SaveService:
         save_entry = self._save_sync_state["saves"][rom_id_str]
         save_entry.setdefault("files", {})
 
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         local_hash = self._file_md5(local_path) if os.path.isfile(local_path) else ""
         local_mtime = (
-            datetime.fromtimestamp(os.path.getmtime(local_path), tz=timezone.utc).isoformat()
+            datetime.fromtimestamp(os.path.getmtime(local_path), tz=UTC).isoformat()
             if os.path.isfile(local_path)
             else now
         )
@@ -382,7 +375,7 @@ class SaveService:
         os.makedirs(saves_dir, exist_ok=True)
         tmp_path = local_path + ".tmp"
 
-        self._with_retry(lambda: self._romm_api.download_save(server_save["id"], tmp_path))
+        self._retry.with_retry(lambda: self._romm_api.download_save(server_save["id"], tmp_path))
 
         # Backup existing local save before overwriting
         if os.path.isfile(local_path):
@@ -408,7 +401,9 @@ class SaveService:
         """Upload a local save file to server."""
         save_id = server_save.get("id") if server_save else None
 
-        result = self._with_retry(lambda: self._romm_api.upload_save(int(rom_id), file_path, "retroarch", save_id))
+        result = self._retry.with_retry(
+            lambda: self._romm_api.upload_save(int(rom_id), file_path, "retroarch", save_id)
+        )
 
         self._update_file_sync_state(rom_id_str, filename, result, file_path, system)
         self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str}")
@@ -450,6 +445,42 @@ class SaveService:
 
         return action, local_hash
 
+    def _handle_conflict_error(
+        self,
+        rom_id: int,
+        filename: str,
+        local: dict | None,
+        server: dict | None,
+        local_hash: str,
+        errors: list[str],
+        conflicts: list[dict],
+    ) -> None:
+        """Handle a RommConflictError by recording a conflict or error entry."""
+        if local and server:
+            local_path = local["path"]
+            local_info = {
+                "path": local_path,
+                "mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
+                "size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
+            }
+            conflicts.append(build_conflict_dict(rom_id, filename, local_info, local_hash, server))
+        else:
+            errors.append(f"{filename}: conflict without matching local+server")
+
+    def _handle_unexpected_error(
+        self,
+        e: Exception,
+        filename: str,
+        saves_dir: str,
+        errors: list[str],
+    ) -> None:
+        """Handle an unexpected exception by recording an error and cleaning up temp files."""
+        _code, _msg = classify_error(e)
+        errors.append(f"{filename}: {_msg}")
+        tmp = os.path.join(saves_dir, filename + ".tmp")
+        with contextlib.suppress(OSError):
+            os.remove(tmp)
+
     def _execute_sync_action(
         self,
         action: str,
@@ -474,28 +505,12 @@ class SaveService:
                 self._do_upload_save(rom_id, local["path"], filename, rom_id_str, system, server)
                 return True
         except RommConflictError:
-            if local and server:
-                local_path = local["path"]
-                local_info = {
-                    "path": local_path,
-                    "mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
-                    "size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
-                }
-                conflicts.append(build_conflict_dict(rom_id, filename, local_info, local_hash, server))
-            else:
-                errors.append(f"{filename}: conflict without matching local+server")
+            self._handle_conflict_error(rom_id, filename, local, server, local_hash, errors, conflicts)
         except RommApiError as e:
             _code, _msg = classify_error(e)
             errors.append(f"{filename}: {_msg}")
         except Exception as e:
-            _code, _msg = classify_error(e)
-            errors.append(f"{filename}: {_msg}")
-            tmp = os.path.join(saves_dir, filename + ".tmp")
-            if os.path.exists(tmp):
-                try:
-                    os.remove(tmp)
-                except OSError:
-                    pass
+            self._handle_unexpected_error(e, filename, saves_dir, errors)
         return False
 
     def _process_single_file_sync(
@@ -567,7 +582,7 @@ class SaveService:
         # Fetch server saves (with retry)
         t0 = time.time()
         try:
-            server_saves = self._with_retry(lambda: self._romm_api.list_saves(rom_id))
+            server_saves = self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id))
         except Exception as e:
             self._logger.error(f"_sync_rom_saves({rom_id}): failed to list saves: {e}")
             _code, _msg = classify_error(e)
@@ -610,7 +625,7 @@ class SaveService:
 
         # Record when this sync check ran (regardless of whether files transferred)
         save_entry = self._save_sync_state["saves"].setdefault(rom_id_str, {})
-        save_entry["last_sync_check_at"] = datetime.now(timezone.utc).isoformat()
+        save_entry["last_sync_check_at"] = datetime.now(UTC).isoformat()
 
         self._log_debug(
             f"[TIMING] _sync_rom_saves({rom_id}): TOTAL {time.time() - t_total:.3f}s"
@@ -682,7 +697,7 @@ class SaveService:
                     fn,
                     local_path=lf["path"],
                     local_hash=local_hash,
-                    local_mtime=datetime.fromtimestamp(os.path.getmtime(lf["path"]), tz=timezone.utc).isoformat(),
+                    local_mtime=datetime.fromtimestamp(os.path.getmtime(lf["path"]), tz=UTC).isoformat(),
                     local_size=os.path.getsize(lf["path"]),
                     server=server,
                     last_sync_at=files_state.get(fn, {}).get("last_sync_at"),
@@ -731,7 +746,7 @@ class SaveService:
             server_save_id = conflict.get("server_save_id")
             if not server_save_id:
                 return {"success": False, "message": "No server save ID"}
-            server_save = self._with_retry(lambda: self._romm_api.get_save_metadata(server_save_id))
+            server_save = self._retry.with_retry(lambda: self._romm_api.get_save_metadata(server_save_id))
             self._do_download_save(server_save, saves_dir, filename, rom_id_str, system)
         else:  # upload
             local_path = conflict.get("local_path")
@@ -739,11 +754,9 @@ class SaveService:
                 return {"success": False, "message": "Local file not found"}
             server_save = None
             if conflict.get("server_save_id"):
-                try:
+                with contextlib.suppress(Exception):
                     ssid = conflict["server_save_id"]
-                    server_save = self._with_retry(lambda: self._romm_api.get_save_metadata(ssid))
-                except Exception:
-                    pass
+                    server_save = self._retry.with_retry(lambda: self._romm_api.get_save_metadata(ssid))
             self._do_upload_save(rom_id, local_path, filename, rom_id_str, system, server_save)
         return None  # Success — caller handles state update
 
@@ -783,7 +796,7 @@ class SaveService:
         try:
             server_saves = await self._loop.run_in_executor(
                 None,
-                lambda: self._with_retry(lambda: self._romm_api.list_saves(rom_id)),
+                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id)),
             )
         except Exception as e:
             self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
@@ -800,7 +813,7 @@ class SaveService:
         try:
             server_saves = await self._loop.run_in_executor(
                 None,
-                lambda: self._with_retry(lambda: self._romm_api.list_saves(rom_id)),
+                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id)),
             )
         except Exception as e:
             self._log_debug(f"Lightweight save check failed for rom {rom_id}: {e}")
@@ -826,7 +839,7 @@ class SaveService:
                     "filename": fn,
                     "local_path": lf["path"],
                     "local_hash": None,
-                    "local_mtime": datetime.fromtimestamp(local_mtime, tz=timezone.utc).isoformat(),
+                    "local_mtime": datetime.fromtimestamp(local_mtime, tz=UTC).isoformat(),
                     "local_size": local_size,
                     "server_save_id": server.get("id") if server else None,
                     "server_updated_at": server.get("updated_at", "") if server else None,

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol, SteamConfigAdapter
+    from services.protocols import EventEmitter, RommApiProtocol, StatePersister, SteamConfigAdapter
 
 
 class ShortcutRemovalService:
@@ -23,9 +23,9 @@ class ShortcutRemovalService:
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        emit: Callable,
-        save_state: Callable,
-        remove_artwork_files: Callable,
+        emit: EventEmitter,
+        save_state: StatePersister,
+        remove_artwork_files: Callable[[str, str | int, dict], None],
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -7,15 +7,15 @@ to Steam grid directory, and orphaned artwork cache pruning.
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 import os
 import pathlib
 import ssl
 import struct
 import urllib.error
-import urllib.parse
 import urllib.request
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from lib.certifi_bundle import ca_bundle as _ca_bundle
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import RommApiProtocol, SteamConfigAdapter
+    from services.protocols import RommApiProtocol, SettingsPersister, StatePersister, SteamConfigAdapter
 
 
 _USER_AGENT = "decky-romm-sync/0.1"
@@ -43,9 +43,9 @@ class SteamGridService:
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         runtime_dir: str,
-        save_state: Callable[[], None],
-        save_settings_to_disk: Callable[[], None],
-        pending_sync: dict,
+        save_state: StatePersister,
+        save_settings_to_disk: SettingsPersister,
+        get_pending_sync: Callable[[], dict],
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
@@ -56,11 +56,11 @@ class SteamGridService:
         self._runtime_dir = runtime_dir
         self._save_state = save_state
         self._save_settings_to_disk = save_settings_to_disk
-        self._pending_sync = pending_sync
+        self._get_pending_sync = get_pending_sync
 
     # -- logging -----------------------------------------------------------
 
-    _LOG_LEVELS = {"debug": 0, "info": 1, "warn": 2, "error": 3}
+    _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
 
     def _log_debug(self, msg: str) -> None:
         configured = self._settings.get("log_level", "warn")
@@ -130,22 +130,19 @@ class SteamGridService:
             # S4423: false positive — Python 3.10+ defaults are TLS 1.2+ secure
             ctx = ssl.create_default_context(cafile=_ca_bundle())
             tmp_path = cached + ".tmp"
-            with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
-                with open(tmp_path, "wb") as f:
-                    while True:
-                        chunk = resp.read(8192)
-                        if not chunk:
-                            break
-                        f.write(chunk)
+            with urllib.request.urlopen(req, context=ctx, timeout=30) as resp, open(tmp_path, "wb") as f:
+                while True:
+                    chunk = resp.read(8192)
+                    if not chunk:
+                        break
+                    f.write(chunk)
             os.replace(tmp_path, cached)
             return cached
         except Exception as e:
             self._logger.warning(f"SGDB {asset_type} download failed for game {sgdb_game_id}: {e}")
             if os.path.exists(cached + ".tmp"):
-                try:
+                with contextlib.suppress(OSError):
                     os.remove(cached + ".tmp")
-                except OSError:
-                    pass
             return None
 
     # -- artwork base64 (callable) -----------------------------------------
@@ -167,7 +164,7 @@ class SteamGridService:
         igdb_id = reg.get("igdb_id")
 
         if not sgdb_id:
-            pending = self._pending_sync.get(rom_id, {})
+            pending = self._get_pending_sync().get(rom_id, {})
             sgdb_id = pending.get("sgdb_id")
             igdb_id = igdb_id or pending.get("igdb_id")
 
@@ -334,10 +331,8 @@ class SteamGridService:
         except Exception as e:
             self._logger.error(f"Failed to write icon file {icon_path}: {e}")
             if os.path.exists(tmp_path):
-                try:
+                with contextlib.suppress(OSError):
                     os.remove(tmp_path)
-                except OSError:
-                    pass
             return False
 
         # Update shortcuts.vdf icon field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,12 @@ pythonVersion = "3.12"
 extraPaths = ["py_modules"]
 stubPath = "typings"
 typeCheckingMode = "basic"
-exclude = ["py_modules/vdf", "tests", "scripts", ".venv"]
+exclude = ["py_modules/vdf", "scripts", ".venv"]
 reportMissingModuleSource = "none"
 reportMissingImports = "warning"
 reportRedeclaration = "none"
+reportUnusedParameter = "none"
+reportUnusedVariable = "warning"
 
 [tool.ruff]
 target-version = "py312"
@@ -14,14 +16,24 @@ line-length = 120
 extend-exclude = ["py_modules/vdf", "scripts"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "B",    # bugbear — common pitfalls
+    "SIM",  # simplify — unnecessary complexity
+    "UP",   # pyupgrade — modern Python syntax
+    "RUF",  # ruff-specific rules
+    "ARG",  # unused arguments
+]
 
 [tool.ruff.lint.per-file-ignores]
 "main.py" = ["E402"]
-"py_modules/lib/sync.py" = ["E402"]
+"tests/**" = ["ARG"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["lib"]
+known-first-party = ["lib", "domain", "services", "adapters"]
 known-third-party = ["decky"]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,49 @@ import logging
 import os
 import sys
 import tempfile
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 # Mirror Decky's sys.path setup: add py_modules/ so `from lib.xxx import` works
 _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(_project_root, "py_modules"))
 
+
+class _DeckyMock(MagicMock):
+    """MagicMock that keeps retrodeck_config and es_de_config in sync when
+    DECKY_USER_HOME or DECKY_PLUGIN_DIR are reassigned in tests.
+
+    Without this, tests that do ``decky.DECKY_USER_HOME = str(tmp_path)``
+    would update the mock attribute but not the domain module's cached value,
+    which is now stored via configure() rather than read lazily.
+    """
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name == "DECKY_USER_HOME":
+            try:
+                from domain import retrodeck_config
+
+                retrodeck_config.configure(user_home=value)
+                retrodeck_config._cached_config = None
+                retrodeck_config._cache_time = 0.0
+                retrodeck_config._cache_config_path = None
+            except Exception:
+                pass
+        elif name == "DECKY_PLUGIN_DIR":
+            try:
+                from domain import es_de_config
+
+                logger = super().__getattribute__("logger")
+                es_de_config.configure(plugin_dir=value, logger=logger)
+            except Exception:
+                pass
+
+
 # Create mock decky module before any imports of main
-mock_decky = MagicMock()
+mock_decky = _DeckyMock()
 mock_decky.DECKY_PLUGIN_DIR = _project_root
 mock_decky.DECKY_PLUGIN_SETTINGS_DIR = tempfile.mkdtemp()
 mock_decky.DECKY_PLUGIN_RUNTIME_DIR = tempfile.mkdtemp()
@@ -19,3 +54,42 @@ mock_decky.logger = logging.getLogger("test_romm")
 mock_decky.emit = AsyncMock()
 
 sys.modules["decky"] = mock_decky
+
+
+def _make_testable_plugin():
+    """Return a TestablePlugin instance with test-only attributes declared."""
+    # Import here to ensure decky mock is already installed
+    from main import Plugin
+
+    class TestablePlugin(Plugin):
+        """Plugin subclass that declares test-only attributes for type safety."""
+
+        _fake_api: Any
+        _resolve_system: Any
+
+    return TestablePlugin()
+
+
+@pytest.fixture(autouse=True)
+def _reset_retrodeck_config_user_home():
+    """Reset retrodeck_config and es_de_config module-level state between every test.
+
+    Calls configure() with the mock decky values so that services using these
+    modules work without explicit configure() calls in test bodies.
+    Tests that need a specific user_home can set decky.DECKY_USER_HOME = str(tmp_path),
+    which will automatically call retrodeck_config.configure() via _DeckyMock.
+    """
+    from domain import es_de_config, retrodeck_config
+
+    # Reset to defaults at the start of each test
+    mock_decky.DECKY_USER_HOME = os.path.expanduser("~")
+    mock_decky.DECKY_PLUGIN_DIR = _project_root
+    retrodeck_config._cached_config = None
+    retrodeck_config._cache_time = 0.0
+    retrodeck_config._cache_config_path = None
+    es_de_config.configure(plugin_dir=_project_root, logger=logging.getLogger("test_romm"))
+    yield
+    retrodeck_config._user_home = None
+    retrodeck_config._cached_config = None
+    retrodeck_config._cache_time = 0.0
+    retrodeck_config._cache_config_path = None

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from typing import Any
 
 
 class FakeSaveApi:
-    """In-memory fake that satisfies RommApiProtocol save/note methods without HTTP."""
+    """In-memory fake that satisfies RommApiProtocol save/note methods without HTTP.
+
+    Only save, note, and download_save methods are implemented.
+    ROM, firmware, and platform methods raise NotImplementedError — use MagicMock()
+    when those methods are needed.
+    """
 
     def __init__(self) -> None:
         self.saves: dict[int, dict] = {}  # save_id -> save dict
@@ -29,6 +35,62 @@ class FakeSaveApi:
             self._fail_on_next = None
             raise exc
 
+    # ------------------------------------------------------------------
+    # Unimplemented RommApiProtocol methods (use MagicMock for these)
+    # ------------------------------------------------------------------
+
+    def set_version(self, version: str) -> None:
+        raise NotImplementedError
+
+    def heartbeat(self) -> dict:
+        raise NotImplementedError
+
+    def list_platforms(self) -> list[dict]:
+        raise NotImplementedError
+
+    def get_current_user(self) -> dict:
+        raise NotImplementedError
+
+    def get_rom(self, rom_id: int) -> dict:
+        raise NotImplementedError
+
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+        raise NotImplementedError
+
+    def list_roms_updated_after(
+        self,
+        platform_id: int,
+        updated_after: str,
+        limit: int = 1,
+        offset: int = 0,
+    ) -> dict:
+        raise NotImplementedError
+
+    def download_rom_content(
+        self,
+        rom_id: int,
+        filename: str,
+        dest: str,
+        progress_callback: Any = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def download_cover(self, cover_url: str, dest: str) -> None:
+        raise NotImplementedError
+
+    def list_firmware(self) -> list[dict]:
+        raise NotImplementedError
+
+    def get_firmware(self, firmware_id: int) -> dict:
+        raise NotImplementedError
+
+    def download_firmware(self, firmware_id: int, filename: str, dest: str) -> None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Implemented save/note methods
+    # ------------------------------------------------------------------
+
     def list_saves(self, rom_id: int) -> list[dict]:
         self.call_log.append(("list_saves", (rom_id,), {}))
         self._check_fail()
@@ -47,7 +109,7 @@ class FakeSaveApi:
         import os
 
         filename = os.path.basename(file_path)
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         size = os.path.getsize(file_path) if os.path.isfile(file_path) else 0
 
         if save_id and save_id in self.saves:
@@ -82,6 +144,7 @@ class FakeSaveApi:
                 }
                 self.saves[save_id] = entry
 
+        assert save_id is not None
         self.uploaded_files[save_id] = file_path
         return dict(entry)
 

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,15 +1,16 @@
 import asyncio
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.achievements import AchievementsService
-from services.game_detail import GameDetailService
-from services.library import LibraryService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.achievements import AchievementsService
+from services.game_detail import GameDetailService
+from services.library import LibraryService
 
 
 @pytest.fixture
@@ -58,16 +59,17 @@ def plugin():
         logger=decky.logger,
         log_debug=p._log_debug,
     )
+    bios_checker = MagicMock()
+    bios_checker.check_platform_bios_cached.return_value = None
+    bios_checker.check_platform_bios = AsyncMock(return_value={"needs_bios": False})
     p._save_sync_state = {"settings": {}, "saves": {}}
     p._game_detail_service = GameDetailService(
         state=p._state,
         metadata_cache=p._metadata_cache,
         save_sync_state=p._save_sync_state,
         logger=decky.logger,
-        check_platform_bios_cached=MagicMock(return_value=None),
-        check_platform_bios=MagicMock(return_value={"needs_bios": False}),
-        get_ra_username=p._achievements_service.get_ra_username,
-        get_progress_cache_entry=p._achievements_service.get_progress_cache_entry,
+        bios_checker=bios_checker,
+        achievements=p._achievements_service,
     )
     return p
 
@@ -152,9 +154,7 @@ def _seed_ra_username_cache(svc, username="RetroPlayer"):
     }
 
 
-# ══════════════════════════════════════════════════════════════
-# get_ra_username (reads from achievements cache, not settings)
-# ══════════════════════════════════════════════════════════════
+# --- get_ra_username (reads from achievements cache, not settings) ---
 
 
 class TestGetRaUsername:
@@ -180,9 +180,7 @@ class TestGetRaUsername:
         assert svc.get_ra_username() == "JohnDoe"
 
 
-# ══════════════════════════════════════════════════════════════
-# _fetch_ra_username
-# ══════════════════════════════════════════════════════════════
+# --- _fetch_ra_username ---
 
 
 class TestFetchRaUsername:
@@ -234,9 +232,7 @@ class TestFetchRaUsername:
         assert result == ""
 
 
-# ══════════════════════════════════════════════════════════════
-# _extract_achievements_from_rom
-# ══════════════════════════════════════════════════════════════
+# --- _extract_achievements_from_rom ---
 
 
 class TestExtractAchievementsFromRom:
@@ -329,9 +325,7 @@ class TestExtractAchievementsFromRom:
         assert result == []
 
 
-# ══════════════════════════════════════════════════════════════
-# _get_achievements_cache_entry / get_progress_cache_entry
-# ══════════════════════════════════════════════════════════════
+# --- _get_achievements_cache_entry / get_progress_cache_entry ---
 
 
 class TestAchievementsCacheEntry:
@@ -439,9 +433,7 @@ class TestProgressCacheEntry:
         assert result["cached_at"] < time.time() - 1700
 
 
-# ══════════════════════════════════════════════════════════════
-# get_achievements
-# ══════════════════════════════════════════════════════════════
+# --- get_achievements ---
 
 
 class TestGetAchievements:
@@ -572,9 +564,7 @@ class TestGetAchievements:
         assert result["achievements"] == []
 
 
-# ══════════════════════════════════════════════════════════════
-# get_achievement_progress
-# ══════════════════════════════════════════════════════════════
+# --- get_achievement_progress ---
 
 
 class TestGetAchievementProgress:
@@ -856,9 +846,7 @@ class TestGetAchievementProgress:
         assert svc._achievements_cache["_ra_user"]["username"] == "NewUser"
 
 
-# ══════════════════════════════════════════════════════════════
-# sync_achievements_after_session
-# ══════════════════════════════════════════════════════════════
+# --- sync_achievements_after_session ---
 
 
 class TestSyncAchievementsAfterSession:
@@ -963,9 +951,7 @@ class TestSyncAchievementsAfterSession:
         assert svc._achievements_cache["42"]["ra_id"] == 9999
 
 
-# ══════════════════════════════════════════════════════════════
-# Integration: get_cached_game_detail with achievements
-# ══════════════════════════════════════════════════════════════
+# --- Integration: get_cached_game_detail with achievements ---
 
 
 class TestGetCachedGameDetailAchievements:
@@ -1002,6 +988,7 @@ class TestGetCachedGameDetailAchievements:
     @pytest.mark.asyncio
     async def test_no_ra_username_returns_none_summary(self, svc, plugin):
         """When ra_id exists but no RA username cached, achievement_summary is None."""
+        _ = svc
         plugin._state["shortcut_registry"]["42"] = {
             "ra_id": 9999,
             "app_id": 100,
@@ -1020,6 +1007,7 @@ class TestGetCachedGameDetailAchievements:
     @pytest.mark.asyncio
     async def test_no_ra_id_returns_none(self, svc, plugin):
         """When no ra_id in registry, ra_id is None and achievement_summary is None."""
+        _ = svc
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 100,
             "name": "Test Game",
@@ -1080,9 +1068,7 @@ class TestGetCachedGameDetailAchievements:
         assert result["achievement_summary"] is None
 
 
-# ══════════════════════════════════════════════════════════════
-# Integration: sync captures ra_id in shortcuts_data / registry
-# ══════════════════════════════════════════════════════════════
+# --- Integration: sync captures ra_id in shortcuts_data / registry ---
 
 
 class TestSyncCapturesRaId:

--- a/tests/test_artwork.py
+++ b/tests/test_artwork.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # conftest.py patches decky before this import
 import decky
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
+from domain.sync_state import SyncState
 from services.artwork import ArtworkService
 
 
@@ -32,7 +34,7 @@ def artwork_service(state, steam_config):
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
         emit=decky.emit,
-        sync_state_ref=lambda: None,
+        sync_state_ref=lambda: SyncState.IDLE,
     )
     return svc
 
@@ -45,7 +47,7 @@ async def _set_event_loop(artwork_service):
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-async def _noop_emit_progress(*args, **kwargs):
+async def _noop_emit_progress(*_args, **_kwargs):
     pass
 
 
@@ -453,9 +455,8 @@ class TestPruneOrphanedStagingArtwork:
         steam_config.grid_dir = lambda: str(grid_dir)
         state["shortcut_registry"] = {}
 
-        with caplog.at_level(logging.WARNING):
-            with patch("os.remove", side_effect=OSError("permission denied")):
-                artwork_service.prune_orphaned_staging_artwork()
+        with caplog.at_level(logging.WARNING), patch("os.remove", side_effect=OSError("permission denied")):
+            artwork_service.prune_orphaned_staging_artwork()
 
         assert staging.exists()
         assert any("Failed to remove orphaned staging artwork" in r.message for r in caplog.records)

--- a/tests/test_bios_domain.py
+++ b/tests/test_bios_domain.py
@@ -145,7 +145,7 @@ class TestClassifyFirmwareFile:
             "required": True,
             "cores": {"known_core.so": {"required": True}},
         }
-        is_required, classification, description = classify_firmware_file(reg_entry, "some.bin", "unknown_core.so")
+        is_required, classification, _ = classify_firmware_file(reg_entry, "some.bin", "unknown_core.so")
         assert is_required is False
         assert classification == "optional"
 
@@ -160,7 +160,7 @@ class TestClassifyFirmwareFile:
     def test_no_active_core_toplevel_optional(self):
         """Without active core, top-level required=False yields optional."""
         reg_entry = {"description": "DC Flash", "required": False}
-        is_required, classification, description = classify_firmware_file(reg_entry, "dc_flash.bin", None)
+        is_required, classification, _ = classify_firmware_file(reg_entry, "dc_flash.bin", None)
         assert is_required is False
         assert classification == "optional"
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,11 +4,12 @@ import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
+from bootstrap import WiringConfig, bootstrap, wire_services
+
 from adapters.persistence import PersistenceAdapter
 from adapters.romm.api_router import ApiRouter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
-from bootstrap import WiringConfig, bootstrap, wire_services
 from services.achievements import AchievementsService
 from services.downloads import DownloadService
 from services.firmware import FirmwareService

--- a/tests/test_cache_detail.py
+++ b/tests/test_cache_detail.py
@@ -5,8 +5,12 @@ import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from adapters.steam_config import SteamConfigAdapter
+
+# conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
+from conftest import _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
+
+from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
 from services.firmware import FirmwareService
 from services.game_detail import GameDetailService
@@ -14,17 +18,21 @@ from services.library import LibraryService
 from services.playtime import PlaytimeService
 from services.saves import SaveService
 
-# conftest.py patches decky before this import
-from main import Plugin
-
 
 def _no_retry(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_retry():
+    retry = MagicMock()
+    retry.with_retry.side_effect = _no_retry
+    retry.is_retryable.return_value = False
+    return retry
+
+
 @pytest.fixture
 def plugin(tmp_path):
-    p = Plugin()
+    p = _make_testable_plugin()
     p.settings = {
         "romm_url": "http://romm.local",
         "romm_user": "user",
@@ -71,8 +79,7 @@ def plugin(tmp_path):
 
     p._save_sync_service = SaveService(
         romm_api=fake_api,
-        with_retry=_no_retry,
-        is_retryable=lambda e: isinstance(e, ConnectionError),
+        retry=_make_retry(),
         state=p._state,
         save_sync_state=p._save_sync_state,
         loop=asyncio.get_event_loop(),
@@ -84,8 +91,7 @@ def plugin(tmp_path):
 
     p._playtime_service = PlaytimeService(
         romm_api=fake_api,
-        with_retry=_no_retry,
-        is_retryable=lambda e: isinstance(e, ConnectionError),
+        retry=_make_retry(),
         save_sync_state=p._save_sync_state,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
@@ -124,10 +130,8 @@ def game_detail_service(plugin):
         metadata_cache=plugin._metadata_cache,
         save_sync_state=plugin._save_sync_state,
         logger=logging.getLogger("test"),
-        check_platform_bios_cached=plugin._firmware_service.check_platform_bios_cached,
-        check_platform_bios=plugin._firmware_service.check_platform_bios,
-        get_ra_username=plugin._achievements_service.get_ra_username,
-        get_progress_cache_entry=plugin._achievements_service.get_progress_cache_entry,
+        bios_checker=plugin._firmware_service,
+        achievements=plugin._achievements_service,
     )
 
 
@@ -207,7 +211,7 @@ class TestGetCachedGameDetailFound:
             "cached_at": 100,
         }
 
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["found"] is True
         assert result["rom_id"] == 123
@@ -230,14 +234,14 @@ class TestGetCachedGameDetailNotFound:
     @pytest.mark.asyncio
     async def test_not_found(self, game_detail_service):
         """Unknown app_id returns found=False."""
-        result = await game_detail_service.get_cached_game_detail(12345)
+        result = game_detail_service.get_cached_game_detail(12345)
         assert result == {"found": False}
 
     @pytest.mark.asyncio
     async def test_not_found_empty_registry(self, plugin, game_detail_service):
         """Empty registry returns found=False."""
         plugin._state["shortcut_registry"] = {}
-        result = await game_detail_service.get_cached_game_detail(1)
+        result = game_detail_service.get_cached_game_detail(1)
         assert result == {"found": False}
 
     @pytest.mark.asyncio
@@ -249,7 +253,7 @@ class TestGetCachedGameDetailNotFound:
             "platform_slug": "nes",
             "platform_name": "NES",
         }
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
         assert result == {"found": False}
 
 
@@ -265,7 +269,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_slug": "snes",
             "platform_name": "Super Nintendo",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert result["save_status"] is None
 
@@ -278,7 +282,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_slug": "snes",
             "platform_name": "Super Nintendo",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert result["metadata"] is None
 
@@ -291,7 +295,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_slug": "snes",
             "platform_name": "Super Nintendo",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert "pending_conflicts" not in result
 
@@ -305,7 +309,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_name": "Super Nintendo",
         }
         plugin._save_sync_state["settings"]["save_sync_enabled"] = False
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["save_sync_enabled"] is False
 
     @pytest.mark.asyncio
@@ -314,7 +318,7 @@ class TestGetCachedGameDetailPartialData:
         plugin._state["shortcut_registry"]["10"] = {
             "app_id": 50000,
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert result["rom_name"] == ""
         assert result["platform_slug"] == ""
@@ -337,7 +341,7 @@ class TestGetCachedGameDetailInstalled:
             "rom_id": 10,
             "file_path": "/roms/game.sfc",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["installed"] is True
 
     @pytest.mark.asyncio
@@ -349,7 +353,7 @@ class TestGetCachedGameDetailInstalled:
             "platform_slug": "snes",
             "platform_name": "SNES",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["installed"] is False
 
 
@@ -365,7 +369,7 @@ class TestGetCachedGameDetailConflictFiltering:
             "platform_slug": "snes",
             "platform_name": "SNES",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert "pending_conflicts" not in result
 
     @pytest.mark.asyncio
@@ -377,7 +381,7 @@ class TestGetCachedGameDetailConflictFiltering:
             "platform_slug": "snes",
             "platform_name": "SNES",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert "save_sync_enabled" in result
 
@@ -390,7 +394,7 @@ class TestGetCachedGameDetailConflictFiltering:
             "platform_slug": "snes",
             "platform_name": "SNES",
         }
-        result = await game_detail_service.get_cached_game_detail("50000")
+        result = game_detail_service.get_cached_game_detail("50000")
         assert result["found"] is True
         assert result["rom_id"] == 10
 
@@ -413,7 +417,7 @@ class TestGetCachedGameDetailBiosFromCache:
             "platform_name": "GBA",
         }
         # firmware cache is empty by default (None)
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["found"] is True
         assert result["bios_status"] is None
 
@@ -446,13 +450,13 @@ class TestGetCachedGameDetailBiosFromCache:
             patch("domain.es_de_config.get_available_cores", return_value=[]),
             patch("domain.retrodeck_config.get_bios_path", return_value=str(tmp_path)),
         ):
-            result = await game_detail_service.get_cached_game_detail(50000)
+            result = game_detail_service.get_cached_game_detail(50000)
 
         assert result["found"] is True
         bs = result["bios_status"]
         assert bs is not None
         assert bs["platform_slug"] == "gba"
-        assert bs["cached_at"] == 99.0
+        assert bs["cached_at"] == pytest.approx(99.0)
         assert bs["total"] == 1
         assert bs["downloaded"] == 0
 
@@ -463,7 +467,7 @@ class TestGetCachedGameDetailBiosFromCache:
             "app_id": 50000,
             "name": "Game",
         }
-        result = await game_detail_service.get_cached_game_detail(50000)
+        result = game_detail_service.get_cached_game_detail(50000)
         assert result["bios_status"] is None
 
     @pytest.mark.asyncio
@@ -482,7 +486,7 @@ class TestGetCachedGameDetailBiosFromCache:
         plugin._firmware_service._firmware_cache_epoch = 50.0
 
         with patch("domain.es_de_config.get_active_core", return_value=(None, None)):
-            result = await game_detail_service.get_cached_game_detail(50000)
+            result = game_detail_service.get_cached_game_detail(50000)
 
         assert result["bios_status"] is None
 
@@ -523,7 +527,7 @@ class TestGetBiosStatusFound:
                 "available_cores": [],
             }
         )
-        game_detail_service._check_platform_bios = mock_check
+        game_detail_service._bios_checker.check_platform_bios = mock_check
 
         result = await game_detail_service.get_bios_status(42)
         bs = result["bios_status"]
@@ -545,7 +549,7 @@ class TestGetBiosStatusFound:
             "platform_slug": "gba",
             "platform_name": "GBA",
         }
-        game_detail_service._check_platform_bios = AsyncMock(return_value={"needs_bios": False})
+        game_detail_service._bios_checker.check_platform_bios = AsyncMock(return_value={"needs_bios": False})
 
         result = await game_detail_service.get_bios_status(42)
         assert result["bios_status"] is None
@@ -572,7 +576,7 @@ class TestGetBiosStatusFound:
             captured_args["rom_filename"] = rom_filename
             return {"needs_bios": False}
 
-        game_detail_service._check_platform_bios = capture_check
+        game_detail_service._bios_checker.check_platform_bios = capture_check
 
         await game_detail_service.get_bios_status(42)
         assert captured_args["rom_filename"] == "installed_file.gba"
@@ -822,7 +826,7 @@ class TestAchievementSummaryCachedAt:
             "cached_at": time.time(),
         }
 
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["achievement_summary"] is not None
         assert result["achievement_summary"]["earned"] == 5
@@ -856,7 +860,7 @@ class TestAchievementSummaryCachedAt:
             "cached_at": time.time(),
         }
 
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
 
         # cached_at should be the storage time, not a fresh timestamp
         assert result["achievement_summary"]["cached_at"] == storage_time
@@ -873,7 +877,7 @@ class TestAchievementSummaryCachedAt:
             "ra_id": 555,
         }
 
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["achievement_summary"] is None
 
@@ -892,6 +896,6 @@ class TestAchievementSummaryCachedAt:
             "cached_at": time.time(),
         }
 
-        result = await game_detail_service.get_cached_game_detail(99999)
+        result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["achievement_summary"] is None

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -4,18 +4,19 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
+from conftest import _make_testable_plugin
+
 from adapters.steam_config import SteamConfigAdapter
 from services.downloads import DownloadService
 from services.library import LibraryService
 from services.rom_removal import RomRemovalService
 
-# conftest.py patches decky before this import
-from main import Plugin
-
 
 @pytest.fixture
 def plugin():
-    p = Plugin()
+    p = _make_testable_plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
@@ -479,7 +480,7 @@ class TestPollDownloadRequestsIO:
         assert result[0]["rom_id"] == 42
         assert result[1]["rom_id"] == 99
         # File should be cleared
-        with open(str(requests_path), "r") as f:
+        with open(str(requests_path)) as f:
             remaining = json.load(f)
         assert remaining == []
 
@@ -514,7 +515,7 @@ class TestDownloadRequestPolling:
 
         with patch.object(plugin, "start_download", new_callable=AsyncMock) as mock_start:
             # Call internal logic directly: read file, process, clear
-            with open(requests_path, "r") as f:
+            with open(requests_path) as f:
                 requests = json.load(f)
             with open(requests_path, "w") as f:
                 json.dump([], f)
@@ -535,13 +536,13 @@ class TestDownloadRequestPolling:
         requests_path.write_text(json.dumps([{"rom_id": 1}, {"rom_id": 2}]))
 
         # Simulate the cleanup logic from _poll_download_requests
-        with open(requests_path, "r") as f:
+        with open(requests_path) as f:
             requests = json.load(f)
         with open(requests_path, "w") as f:
             json.dump([], f)
 
         # Verify file was cleared
-        with open(requests_path, "r") as f:
+        with open(requests_path) as f:
             remaining = json.load(f)
         assert remaining == []
         assert len(requests) == 2
@@ -946,9 +947,11 @@ class TestDoDownloadCancelled:
         plugin._download_service._loop = asyncio.get_event_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
-        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download_cancel):
-            with pytest.raises(asyncio.CancelledError):
-                await plugin._download_service._do_download(42, rom_detail, target_path, "n64")
+        with (
+            patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download_cancel),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64")
 
         assert plugin._download_service._download_queue[42]["status"] == "cancelled"
         assert not os.path.exists(target_path)

--- a/tests/test_es_de_config.py
+++ b/tests/test_es_de_config.py
@@ -2,9 +2,11 @@
 
 import os
 import tempfile
+from typing import ClassVar
 from unittest import mock
 
 import pytest
+
 from domain import es_de_config
 
 # conftest.py patches decky before this import
@@ -14,7 +16,11 @@ from main import Plugin  # noqa: F401
 
 @pytest.fixture(autouse=True)
 def _reset_es_de_cache():
-    """Reset CoreResolver singleton caches between tests."""
+    """Reset CoreResolver singleton caches between tests and ensure module is configured."""
+    import logging
+
+    plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    es_de_config.configure(plugin_dir=plugin_dir, logger=logging.getLogger("test_es_de"))
     es_de_config._resolver.reset_cache()
 
 
@@ -71,6 +77,7 @@ class TestFindEsSystemsXml:
     def test_finds_xml_in_linux_path(self, mock_exists):
         mock_exists.return_value = True
         result = es_de_config.find_es_systems_xml()
+        assert result is not None
         assert result == es_de_config._ES_SYSTEMS_CANDIDATES[0]
         assert "linux" in result
 
@@ -79,6 +86,7 @@ class TestFindEsSystemsXml:
         # linux/ doesn't exist, unix/ does
         mock_exists.side_effect = [False, True]
         result = es_de_config.find_es_systems_xml()
+        assert result is not None
         assert result == es_de_config._ES_SYSTEMS_CANDIDATES[1]
         assert "unix" in result
 
@@ -222,7 +230,7 @@ class TestGetSystemOverride:
 
 
 class TestGetActiveCore:
-    GBA_SYSTEM_INFO = {
+    GBA_SYSTEM_INFO: ClassVar[dict] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",
@@ -290,7 +298,7 @@ class TestGetActiveCore:
 
 
 class TestGetAvailableCores:
-    GBA_SYSTEM_INFO = {
+    GBA_SYSTEM_INFO: ClassVar[dict] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",
@@ -366,7 +374,7 @@ class TestSetSystemOverride:
             assert result == "gpSP"
 
             # Game entry should be preserved
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "some_game.gba" in content
 
@@ -399,7 +407,7 @@ class TestSetGameOverride:
             es_de_config.set_game_override(tmpdir, "gba", "./Pokemon.gba", "gpSP")
 
             gamelist_path = os.path.join(tmpdir, "ES-DE", "gamelists", "gba", "gamelist.xml")
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "Pokemon.gba" in content
             assert "gpSP" in content
@@ -415,7 +423,7 @@ class TestSetGameOverride:
 
             es_de_config.set_game_override(tmpdir, "gba", "./some_game.gba", "gpSP")
 
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "gpSP" in content
             assert "Some Game" in content  # preserved
@@ -426,14 +434,14 @@ class TestSetGameOverride:
             es_de_config.set_game_override(tmpdir, "gba", "./Pokemon.gba", "gpSP")
 
             gamelist_path = os.path.join(tmpdir, "ES-DE", "gamelists", "gba", "gamelist.xml")
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "<altemulator>" in content
 
             # Clear it
             es_de_config.set_game_override(tmpdir, "gba", "./Pokemon.gba", None)
 
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "<altemulator>" not in content
             assert "Pokemon.gba" in content  # game entry still there
@@ -451,7 +459,7 @@ class TestSetGameOverride:
             assert result == "VBA-M"
 
             gamelist_path = os.path.join(tmpdir, "ES-DE", "gamelists", "gba", "gamelist.xml")
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "gpSP" in content
             assert "VBA-M" in content
@@ -472,7 +480,7 @@ class TestSetGameOverride:
 
             # Read gamelist — should have both games
             gamelist_path = os.path.join(tmpdir, "ES-DE", "gamelists", "gba", "gamelist.xml")
-            with open(gamelist_path, "r") as f:
+            with open(gamelist_path) as f:
                 content = f.read()
             assert "Pokemon.gba" in content
             assert "Zelda.gba" in content
@@ -513,7 +521,7 @@ class TestGetGameOverride:
 class TestGetActiveCoreWithGameOverride:
     """Test that get_active_core reads per-game overrides when rom_filename is provided."""
 
-    GBA_SYSTEM_INFO = {
+    GBA_SYSTEM_INFO: ClassVar[dict] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -4,12 +4,13 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.firmware import FirmwareService
-from services.library import LibraryService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.firmware import FirmwareService
+from services.library import LibraryService
 
 
 @pytest.fixture
@@ -275,7 +276,7 @@ class TestDownloadFirmware:
 
         with (
             patch.object(plugin._romm_api, "get_firmware", return_value=fw_detail),
-            patch.object(plugin._romm_api, "download_firmware", side_effect=IOError("Connection reset")),
+            patch.object(plugin._romm_api, "download_firmware", side_effect=OSError("Connection reset")),
         ):
             result = await fw.download_firmware(10)
 
@@ -1184,12 +1185,12 @@ class TestPerCoreFiltering:
         assert result["active_core"] == "gpsp_libretro"
         assert result["active_core_label"] == "gpSP"
         # gpSP requires gba_bios.bin
-        gba_file = [f for f in result["files"] if f["file_name"] == "gba_bios.bin"][0]
+        gba_file = next(f for f in result["files"] if f["file_name"] == "gba_bios.bin")
         assert gba_file["required"] is True
         assert gba_file["classification"] == "required"
         assert gba_file["used_by_active"] is True
         # gb_bios not used by gpSP
-        gb_file = [f for f in result["files"] if f["file_name"] == "gb_bios.bin"][0]
+        gb_file = next(f for f in result["files"] if f["file_name"] == "gb_bios.bin")
         assert gb_file["used_by_active"] is False
         assert gb_file["cores"] == {"gambatte_libretro": {"required": False}, "mgba_libretro": {"required": False}}
         # required_count should only count files used by active core
@@ -1369,9 +1370,9 @@ class TestPerCoreFiltering:
         assert "gba_bios.bin" in file_names
         assert "gb_bios.bin" in file_names  # present but not used by active
         # Check used_by_active flags
-        gba_file = [f for f in result["files"] if f["file_name"] == "gba_bios.bin"][0]
+        gba_file = next(f for f in result["files"] if f["file_name"] == "gba_bios.bin")
         assert gba_file["used_by_active"] is True
-        gb_file = [f for f in result["files"] if f["file_name"] == "gb_bios.bin"][0]
+        gb_file = next(f for f in result["files"] if f["file_name"] == "gb_bios.bin")
         assert gb_file["used_by_active"] is False
 
 
@@ -1457,7 +1458,7 @@ class TestDownloadFirmwarePostIORegistryHash:
 
         fw_data = {"file_name": "bad.bin", "file_path": "bios/test/bad.bin", "md5_hash": ""}
         with patch("services.firmware.retrodeck_config.get_bios_path", return_value=str(bios_dir)):
-            md5_match, reg_hash_valid = fw._download_firmware_post_io(fw_data, 2, dest, tmp_path_file)
+            _md5_match, reg_hash_valid = fw._download_firmware_post_io(fw_data, 2, dest, tmp_path_file)
 
         assert reg_hash_valid is False
 
@@ -1629,7 +1630,7 @@ class TestFirmwareListCache:
 class TestCheckPlatformBiosCached:
     """Tests for check_platform_bios_cached — cache-only BIOS status read."""
 
-    def _make_service(self, firmware_cache=None, firmware_cache_at=0, bios_registry=None, state=None):
+    def _make_service(self, firmware_cache=None, firmware_cache_at: float = 0, bios_registry=None, state=None):
         import logging
 
         fw = FirmwareService(
@@ -1696,6 +1697,7 @@ class TestCheckPlatformBiosCached:
         ):
             result = fw.check_platform_bios_cached("gba")
 
+        assert result is not None
         assert result["needs_bios"] is True
         assert result["cached_at"] == 42.0
         assert result["server_count"] == 1

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -3,14 +3,16 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.artwork import ArtworkService
-from services.library import LibraryService, SyncState
-from services.metadata import MetadataService
-from services.shortcut_removal import ShortcutRemovalService
+from domain.sync_state import SyncState
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.artwork import ArtworkService
+from services.library import LibraryService
+from services.metadata import MetadataService
+from services.shortcut_removal import ShortcutRemovalService
 
 
 @pytest.fixture
@@ -44,7 +46,7 @@ def plugin():
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
         emit=decky.emit,
-        sync_state_ref=lambda: None,
+        sync_state_ref=lambda: SyncState.IDLE,
     )
     p._artwork_service = artwork_service
 
@@ -766,7 +768,7 @@ class TestClassifyRoms:
             self._make_sd(1, "Game A", fs_name="gamea.z64"),
             self._make_sd(2, "Game B", fs_name="gameb.z64"),
         ]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, unchanged_ids, stale, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert new == []
         assert changed == []
         assert set(unchanged_ids) == {1, 2}
@@ -795,7 +797,7 @@ class TestClassifyRoms:
             self._make_sd(2, "New Name", fs_name="gameb.z64"),  # changed (name)
             self._make_sd(3, "Game C", fs_name="gamec.z64"),  # new
         ]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(new) == 1
         assert new[0]["rom_id"] == 3
         assert len(changed) == 1
@@ -813,7 +815,7 @@ class TestClassifyRoms:
         # Must also set fs_name in registry to match
         plugin._state["shortcut_registry"]["1"]["fs_name"] = ""
         plugin._state["shortcut_registry"]["1"]["platform_slug"] = "n64"
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
         assert 99 in stale
         assert disabled == 0  # N64 is in fetched_platform_names
 
@@ -823,7 +825,7 @@ class TestClassifyRoms:
             "1": {"app_id": 1001, "name": "Game A", "platform_name": "SNES"},
         }
         sd = []  # nothing fetched
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
         assert 1 in stale
         assert disabled == 1  # SNES is not in {"N64"}
 
@@ -839,7 +841,7 @@ class TestClassifyRoms:
             },
         }
         sd = [self._make_sd(1, "New Title")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(changed) == 1
         assert changed[0]["existing_app_id"] == 1001
         assert new == []
@@ -857,7 +859,7 @@ class TestClassifyRoms:
             },
         }
         sd = [self._make_sd(1, "Game A", platform_name="N64")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        _, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(changed) == 1
         assert changed[0]["rom_id"] == 1
 
@@ -873,7 +875,7 @@ class TestClassifyRoms:
             },
         }
         sd = [self._make_sd(1, "Game A", fs_name="new.z64")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        _, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(changed) == 1
         assert changed[0]["rom_id"] == 1
 
@@ -889,7 +891,7 @@ class TestClassifyRoms:
             },
         }
         sd = [self._make_sd(1, "Game A", igdb_id=999, sgdb_id=888)]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert unchanged_ids == [1]
         assert changed == []
         assert new == []
@@ -900,7 +902,7 @@ class TestClassifyRoms:
             "1": {"name": "Game A", "platform_name": "N64"},
         }
         sd = [self._make_sd(1, "Game A")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(new) == 1
         assert new[0]["rom_id"] == 1
         assert changed == []
@@ -927,7 +929,7 @@ class TestClassifyRoms:
             },
         }
         sd = [self._make_sd(1, "Game A")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        new, changed, unchanged_ids, stale, _ = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(new) == 0
         assert len(changed) == 0
         assert len(stale) == 0
@@ -941,7 +943,7 @@ class TestClassifyRoms:
         }
         sd = []  # nothing fetched
         # Neither GBA nor SNES in fetched set
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
+        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
         assert len(stale) == 2
         assert disabled == 2
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,15 +1,17 @@
 import asyncio
+import http.client
 import json
 import os
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.library import LibraryService
-from services.metadata import MetadataService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.library import LibraryService
+from services.metadata import MetadataService
 
 
 @pytest.fixture
@@ -288,6 +290,7 @@ class TestLoadMetadataCache:
 
     def test_loads_from_disk(self, plugin, tmp_path):
         import decky
+
         from adapters.persistence import _METADATA_CACHE_VERSION
 
         decky.DECKY_PLUGIN_RUNTIME_DIR = str(tmp_path)
@@ -384,7 +387,7 @@ class TestSyncMetadataCapture:
         # Verify disk cache
         cache_path = os.path.join(str(tmp_path), "metadata_cache.json")
         assert os.path.exists(cache_path)
-        with open(cache_path, "r") as f:
+        with open(cache_path) as f:
             disk_cache = json.load(f)
         assert "1" in disk_cache
         assert "2" in disk_cache
@@ -426,7 +429,7 @@ class TestSyncMetadataCapture:
 
         # Verify on disk too
         cache_path = os.path.join(str(tmp_path), "metadata_cache.json")
-        with open(cache_path, "r") as f:
+        with open(cache_path) as f:
             disk_cache = json.load(f)
         assert "99" in disk_cache
         assert "1" in disk_cache
@@ -460,7 +463,7 @@ class TestGetRomMetadata404:
             url="http://example.com/api/roms/999",
             code=404,
             msg="Not Found",
-            hdrs={},
+            hdrs=http.client.HTTPMessage(),
             fp=None,
         )
 
@@ -496,7 +499,7 @@ class TestGetRomMetadata404:
             url="http://example.com/api/roms/999",
             code=404,
             msg="Not Found",
-            hdrs={},
+            hdrs=http.client.HTTPMessage(),
             fp=None,
         )
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -3,13 +3,14 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.firmware import FirmwareService
-from services.library import LibraryService
-from services.migration import MigrationService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.firmware import FirmwareService
+from services.library import LibraryService
+from services.migration import MigrationService
 
 
 @pytest.fixture
@@ -63,7 +64,7 @@ def plugin():
         logger=decky.logger,
         save_state=p._save_state,
         emit=decky.emit,
-        firmware_service_bios_files_index=p._firmware_service.bios_files_index,
+        get_bios_files_index=lambda: p._firmware_service.bios_files_index,
     )
     return p
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -6,6 +6,7 @@ import os
 import threading
 
 import pytest
+
 from adapters.persistence import (
     _FIRMWARE_CACHE_VERSION,
     _METADATA_CACHE_VERSION,

--- a/tests/test_playtime_service.py
+++ b/tests/test_playtime_service.py
@@ -3,33 +3,41 @@
 import asyncio
 import json
 import logging
-from datetime import datetime, timedelta, timezone
-
-import pytest
-from fakes.fake_save_api import FakeSaveApi
-from services.playtime import PlaytimeService
-
-from lib.errors import RommApiError
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+from unittest.mock import MagicMock
+
+import pytest
+from fakes.fake_save_api import FakeSaveApi
+
+from lib.errors import RommApiError
+from services.playtime import PlaytimeService
 
 
 def _no_retry(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_retry():
+    retry = MagicMock()
+    retry.with_retry.side_effect = _no_retry
+    retry.is_retryable.return_value = False
+    return retry
+
+
 def make_service(tmp_path=None, fake_api=None, **overrides):
     """Create a PlaytimeService with sensible defaults."""
     fake = fake_api or FakeSaveApi()
-    state = {"playtime": {}}
-    saved = []
+    state: dict[str, Any] = {"playtime": {}}
+    saved: list[bool] = []
 
-    defaults = dict(
+    defaults: dict[str, Any] = dict(
         romm_api=fake,
-        with_retry=_no_retry,
-        is_retryable=lambda e: False,
+        retry=_make_retry(),
         save_sync_state=state,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
@@ -57,13 +65,13 @@ class TestRecordSession:
 
     @pytest.mark.asyncio
     async def test_end_records_duration(self):
-        svc, fake, state, saved = make_service()
+        svc, _, state, _ = make_service()
 
         # Start session
         svc.record_session_start(42)
 
         # Backdate session start by 60 seconds
-        start = datetime.now(timezone.utc) - timedelta(seconds=60)
+        start = datetime.now(UTC) - timedelta(seconds=60)
         state["playtime"]["42"]["last_session_start"] = start.isoformat()
 
         result = await svc.record_session_end(42)
@@ -80,17 +88,17 @@ class TestRecordSession:
 
     @pytest.mark.asyncio
     async def test_multiple_sessions_accumulate(self):
-        svc, fake, state, _ = make_service()
+        svc, _, state, _ = make_service()
 
         # Session 1
         svc.record_session_start(42)
-        start = datetime.now(timezone.utc) - timedelta(seconds=30)
+        start = datetime.now(UTC) - timedelta(seconds=30)
         state["playtime"]["42"]["last_session_start"] = start.isoformat()
         await svc.record_session_end(42)
 
         # Session 2
         svc.record_session_start(42)
-        start = datetime.now(timezone.utc) - timedelta(seconds=45)
+        start = datetime.now(UTC) - timedelta(seconds=45)
         state["playtime"]["42"]["last_session_start"] = start.isoformat()
         result2 = await svc.record_session_end(42)
 
@@ -155,7 +163,7 @@ class TestSyncPlaytime:
     @pytest.mark.asyncio
     async def test_merge_takes_max(self):
         """new_total = max(local_total, server_seconds + session_duration)"""
-        svc, fake, state, saved = make_service()
+        svc, fake, state, _ = make_service()
         state["playtime"]["42"] = {
             "total_seconds": 300,
             "session_count": 3,
@@ -259,7 +267,7 @@ class TestPlaytimeNotes:
         assert note["id"] == 2
 
     def test_get_playtime_note_missing(self):
-        svc, fake, _, _ = make_service()
+        svc, _, _, _ = make_service()
         note = svc._get_playtime_note(42)
         assert note is None
 
@@ -327,11 +335,11 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     async def test_session_clamps_to_24h(self):
-        svc, fake, state, _ = make_service()
+        svc, _, state, _ = make_service()
         svc.record_session_start(42)
 
         # Backdate by 25 hours
-        start = datetime.now(timezone.utc) - timedelta(hours=25)
+        start = datetime.now(UTC) - timedelta(hours=25)
         state["playtime"]["42"]["last_session_start"] = start.isoformat()
 
         result = await svc.record_session_end(42)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,12 +4,13 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.library import LibraryService
-from services.steamgrid import SteamGridService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.library import LibraryService
+from services.steamgrid import SteamGridService
 
 
 @pytest.fixture
@@ -51,7 +52,7 @@ def plugin():
         runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
         save_state=MagicMock(),
         save_settings_to_disk=MagicMock(),
-        pending_sync=p._sync_service._pending_sync,
+        get_pending_sync=lambda: p._sync_service._pending_sync,
     )
     return p
 
@@ -516,7 +517,7 @@ class TestAtomicSettingsWrite:
         plugin._save_settings_to_disk()
 
         settings_path = tmp_path / "settings.json"
-        with open(settings_path, "r") as f:
+        with open(settings_path) as f:
             data = json.load(f)
         assert data["romm_url"] == "http://example.com"
         assert data["romm_user"] == "user"
@@ -545,13 +546,12 @@ class TestAtomicSettingsWrite:
 
         # Now simulate a crash during json.dump
         plugin.settings = {"romm_url": "http://corrupted.com"}
-        with patch("json.dump", side_effect=OSError("disk full")):
-            with pytest.raises(OSError):
-                plugin._save_settings_to_disk()
+        with patch("json.dump", side_effect=OSError("disk full")), pytest.raises(OSError):
+            plugin._save_settings_to_disk()
 
         # Original file should still be intact
         settings_path = tmp_path / "settings.json"
-        with open(settings_path, "r") as f:
+        with open(settings_path) as f:
             data = json.load(f)
         assert data["romm_url"] == "http://original.com"
 

--- a/tests/test_retrodeck_config.py
+++ b/tests/test_retrodeck_config.py
@@ -9,17 +9,16 @@ from domain import retrodeck_config
 
 @pytest.fixture(autouse=True)
 def _reset_retrodeck_cache():
-    """Reset retrodeck_config module-level cache between tests."""
+    """Reset retrodeck_config module-level cache and configured user home between tests."""
     retrodeck_config._cached_config = None
     retrodeck_config._cache_time = 0.0
     retrodeck_config._cache_config_path = None
+    retrodeck_config._user_home = None
 
 
 class TestGetBiosPath:
     def test_from_config(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -30,9 +29,7 @@ class TestGetBiosPath:
         assert result == "/run/media/deck/SD/retrodeck/bios"
 
     def test_fallback_when_config_missing(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         result = retrodeck_config.get_bios_path()
         assert result == os.path.join(str(tmp_path), "retrodeck", "bios")
@@ -40,9 +37,7 @@ class TestGetBiosPath:
 
 class TestGetRomsPath:
     def test_from_config(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -53,9 +48,7 @@ class TestGetRomsPath:
         assert result == "/run/media/deck/SD/retrodeck/roms"
 
     def test_fallback_when_config_missing(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         result = retrodeck_config.get_roms_path()
         assert result == os.path.join(str(tmp_path), "retrodeck", "roms")
@@ -63,9 +56,7 @@ class TestGetRomsPath:
 
 class TestGetSavesPath:
     def test_from_config(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -78,9 +69,7 @@ class TestGetSavesPath:
 
 class TestGetRetroDeckHome:
     def test_from_config(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -91,9 +80,7 @@ class TestGetRetroDeckHome:
         assert result == "/run/media/deck/SD/retrodeck"
 
     def test_fallback_when_config_missing(self, tmp_path):
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         result = retrodeck_config.get_retrodeck_home()
         # fallback_subdir is "" for home, so returns ~/retrodeck/
@@ -103,9 +90,7 @@ class TestGetRetroDeckHome:
 class TestTTLCache:
     def test_cache_returns_same_result_without_rereading(self, tmp_path):
         """Second call within TTL should return cached result."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -122,9 +107,7 @@ class TestTTLCache:
 
     def test_cache_expires_after_ttl(self, tmp_path, monkeypatch):
         """After TTL expires, cache should re-read from disk."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -147,9 +130,7 @@ class TestTTLCache:
 
     def test_cache_reset_allows_new_values(self, tmp_path):
         """After cache reset (via fixture), new config values are picked up."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -171,9 +152,7 @@ class TestTTLCache:
 class TestEdgeCases:
     def test_fallback_when_key_missing(self, tmp_path):
         """Config exists but missing the requested path key."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -185,9 +164,7 @@ class TestEdgeCases:
 
     def test_fallback_when_json_malformed(self, tmp_path):
         """Corrupt JSON falls back gracefully."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -199,9 +176,7 @@ class TestEdgeCases:
 
     def test_fallback_when_path_empty_string(self, tmp_path):
         """Key exists but value is empty string — should fallback."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)
@@ -213,9 +188,7 @@ class TestEdgeCases:
 
     def test_no_paths_key_in_config(self, tmp_path):
         """Config exists but has no 'paths' key at all."""
-        import decky
-
-        decky.DECKY_USER_HOME = str(tmp_path)
+        retrodeck_config.configure(user_home=str(tmp_path))
 
         config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
         config_dir.mkdir(parents=True)

--- a/tests/test_rom_files.py
+++ b/tests/test_rom_files.py
@@ -8,6 +8,18 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
 
 
+def _with_sizes(paths: list[str]) -> list[tuple[str, int]]:
+    """Helper: convert a list of file paths to (path, size) tuples for detect_launch_file."""
+    result = []
+    for p in paths:
+        try:
+            size = os.path.getsize(p)
+        except OSError:
+            size = 0
+        result.append((p, size))
+    return result
+
+
 class TestNeedsM3u:
     def test_two_disc_files_returns_true(self):
         assert needs_m3u(["disc1.cue", "disc2.cue"]) is True
@@ -82,7 +94,7 @@ class TestDetectLaunchFile:
         cue = str(tmp_path / "disc1.cue")
         open(m3u, "w").close()
         open(cue, "w").close()
-        result = detect_launch_file([m3u, cue])
+        result = detect_launch_file(_with_sizes([m3u, cue]))
         assert result == m3u
 
     def test_prefers_cue_over_bin(self, tmp_path):
@@ -91,14 +103,14 @@ class TestDetectLaunchFile:
         open(cue, "w").close()
         with open(binf, "wb") as f:
             f.write(b"\x00" * 1000)
-        result = detect_launch_file([cue, binf])
+        result = detect_launch_file(_with_sizes([cue, binf]))
         assert result == cue
 
     def test_rpx_returned_when_no_m3u_or_cue(self, tmp_path):
         rpx = str(tmp_path / "code" / "game.rpx")
         os.makedirs(os.path.dirname(rpx))
         open(rpx, "w").close()
-        result = detect_launch_file([rpx])
+        result = detect_launch_file(_with_sizes([rpx]))
         assert result == rpx
 
     def test_m3u_beats_rpx(self, tmp_path):
@@ -107,7 +119,7 @@ class TestDetectLaunchFile:
         os.makedirs(os.path.dirname(rpx))
         open(m3u, "w").close()
         open(rpx, "w").close()
-        result = detect_launch_file([m3u, rpx])
+        result = detect_launch_file(_with_sizes([m3u, rpx]))
         assert result == m3u
 
     def test_wux_disc_image(self, tmp_path):
@@ -116,21 +128,21 @@ class TestDetectLaunchFile:
         with open(wux, "wb") as f:
             f.write(b"\x00" * 1000)
         open(txt, "w").close()
-        result = detect_launch_file([wux, txt])
+        result = detect_launch_file(_with_sizes([wux, txt]))
         assert result == wux
 
     def test_wud_disc_image(self, tmp_path):
         wud = str(tmp_path / "game.wud")
         with open(wud, "wb") as f:
             f.write(b"\x00" * 1000)
-        result = detect_launch_file([wud])
+        result = detect_launch_file(_with_sizes([wud]))
         assert result == wud
 
     def test_wua_disc_image(self, tmp_path):
         wua = str(tmp_path / "game.wua")
         with open(wua, "wb") as f:
             f.write(b"\x00" * 1000)
-        result = detect_launch_file([wua])
+        result = detect_launch_file(_with_sizes([wua]))
         assert result == wua
 
     def test_eboot_bin_ps3(self, tmp_path):
@@ -138,7 +150,7 @@ class TestDetectLaunchFile:
         os.makedirs(os.path.dirname(eboot))
         with open(eboot, "wb") as f:
             f.write(b"\x00" * 500)
-        result = detect_launch_file([eboot])
+        result = detect_launch_file(_with_sizes([eboot]))
         assert result == eboot
 
     def test_3ds_preferred_over_cia(self, tmp_path):
@@ -148,7 +160,7 @@ class TestDetectLaunchFile:
             f.write(b"\x00" * 100)
         with open(cia, "wb") as f:
             f.write(b"\x00" * 100)
-        result = detect_launch_file([rom_3ds, cia])
+        result = detect_launch_file(_with_sizes([rom_3ds, cia]))
         assert result == rom_3ds
 
     def test_cia_preferred_over_cxi(self, tmp_path):
@@ -158,7 +170,7 @@ class TestDetectLaunchFile:
             f.write(b"\x00" * 100)
         with open(cxi, "wb") as f:
             f.write(b"\x00" * 100)
-        result = detect_launch_file([cia, cxi])
+        result = detect_launch_file(_with_sizes([cia, cxi]))
         assert result == cia
 
     def test_falls_back_to_largest_file(self, tmp_path):
@@ -168,17 +180,17 @@ class TestDetectLaunchFile:
             f.write(b"\x00" * 100)
         with open(large, "wb") as f:
             f.write(b"\x00" * 10000)
-        result = detect_launch_file([small, large])
+        result = detect_launch_file(_with_sizes([small, large]))
         assert result == large
 
     def test_single_file_returned_directly(self, tmp_path):
         f = str(tmp_path / "game.z64")
         with open(f, "wb") as fh:
             fh.write(b"\x00" * 100)
-        assert detect_launch_file([f]) == f
+        assert detect_launch_file(_with_sizes([f])) == f
 
     def test_case_insensitive_extension_matching(self, tmp_path):
         m3u = str(tmp_path / "GAME.M3U")
         open(m3u, "w").close()
-        result = detect_launch_file([m3u])
+        result = detect_launch_file(_with_sizes([m3u]))
         assert result == m3u

--- a/tests/test_rom_removal.py
+++ b/tests/test_rom_removal.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 sys.path.insert(0, os.path.dirname(__file__))
 
 # conftest.py patches decky before this import
-from services.rom_removal import RomRemovalService  # noqa: E402
+from services.rom_removal import RomRemovalService
 
 
 @pytest.fixture
@@ -416,9 +416,8 @@ class TestUninstallAllRoms:
         }
 
         # Make deletion fail
-        with patch("shutil.rmtree", side_effect=OSError("perm")):
-            with patch("os.remove", side_effect=OSError("perm")):
-                result = await service.uninstall_all_roms()
+        with patch("shutil.rmtree", side_effect=OSError("perm")), patch("os.remove", side_effect=OSError("perm")):
+            result = await service.uninstall_all_roms()
 
         assert result["success"] is True
         assert "errors" in result["message"]

--- a/tests/test_romm_api_base.py
+++ b/tests/test_romm_api_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.romm.api_base import RommApiBase
 
 

--- a/tests/test_romm_api_router.py
+++ b/tests/test_romm_api_router.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from adapters.romm.api_router import ApiRouter
 
+from adapters.romm.api_router import ApiRouter
 from lib.errors import RommUnsupportedError
 
 
@@ -202,7 +202,7 @@ class TestGetattr:
 
     def test_unknown_attr_is_romm_api_error(self, router):
         with pytest.raises(RommUnsupportedError) as exc_info:
-            router.nonexistent
+            _ = router.nonexistent
         assert exc_info.value.min_version == "unknown"
 
 

--- a/tests/test_romm_http.py
+++ b/tests/test_romm_http.py
@@ -1,14 +1,13 @@
 import asyncio
-import socket
+import http.client
 import ssl
 import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
-from services.library import LibraryService
-
 from lib.errors import (
     RommApiError,
     RommAuthError,
@@ -23,6 +22,7 @@ from lib.errors import (
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.library import LibraryService
 
 
 @pytest.fixture
@@ -305,7 +305,7 @@ class TestTranslateHttpError:
     """Tests for _translate_http_error method."""
 
     def test_401_becomes_auth_error(self, plugin):
-        exc = urllib.error.HTTPError("http://romm.local/api/test", 401, "Unauthorized", {}, None)
+        exc = urllib.error.HTTPError("http://romm.local/api/test", 401, "Unauthorized", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/test", "GET")
         assert isinstance(result, RommAuthError)
         assert result.status_code == 401
@@ -314,44 +314,44 @@ class TestTranslateHttpError:
         assert "401" in str(result)
 
     def test_403_becomes_forbidden_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 403, "Forbidden", {}, None)
+        exc = urllib.error.HTTPError("url", 403, "Forbidden", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x", "POST")
         assert isinstance(result, RommForbiddenError)
         assert result.status_code == 403
 
     def test_404_becomes_not_found_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 404, "Not Found", {}, None)
+        exc = urllib.error.HTTPError("url", 404, "Not Found", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommNotFoundError)
         assert result.status_code == 404
 
     def test_409_becomes_conflict_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 409, "Conflict", {}, None)
+        exc = urllib.error.HTTPError("url", 409, "Conflict", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x", "PUT")
         assert isinstance(result, RommConflictError)
         assert result.status_code == 409
 
     def test_500_becomes_server_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 500, "Internal Server Error", {}, None)
+        exc = urllib.error.HTTPError("url", 500, "Internal Server Error", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommServerError)
         assert result.status_code == 500
 
     def test_502_becomes_server_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 502, "Bad Gateway", {}, None)
+        exc = urllib.error.HTTPError("url", 502, "Bad Gateway", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommServerError)
         assert result.status_code == 502
 
     def test_429_becomes_server_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 429, "Too Many Requests", {}, None)
+        exc = urllib.error.HTTPError("url", 429, "Too Many Requests", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommServerError)
         assert result.status_code == 429
         assert "Rate limited" in str(result)
 
     def test_other_4xx_becomes_generic_api_error(self, plugin):
-        exc = urllib.error.HTTPError("url", 418, "I'm a Teapot", {}, None)
+        exc = urllib.error.HTTPError("url", 418, "I'm a Teapot", http.client.HTTPMessage(), None)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommApiError)
         assert not isinstance(result, RommServerError)
@@ -369,7 +369,7 @@ class TestTranslateHttpError:
         assert isinstance(result, RommSSLError)
 
     def test_url_error_wrapping_timeout_becomes_timeout_error(self, plugin):
-        timeout_exc = socket.timeout("timed out")
+        timeout_exc = TimeoutError("timed out")
         exc = urllib.error.URLError(timeout_exc)
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommTimeoutError)
@@ -386,7 +386,7 @@ class TestTranslateHttpError:
         assert isinstance(result, RommSSLError)
 
     def test_direct_socket_timeout(self, plugin):
-        exc = socket.timeout("timed out")
+        exc = TimeoutError("timed out")
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x")
         assert isinstance(result, RommTimeoutError)
 
@@ -422,47 +422,46 @@ class TestRommRequestErrors:
 
     def test_401_raises_auth_error(self, plugin):
         _setup_plugin(plugin)
-        exc = urllib.error.HTTPError("http://romm.local/api/test", 401, "Unauthorized", {}, None)
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with pytest.raises(RommAuthError) as exc_info:
-                plugin._http_adapter.request("/api/test")
+        exc = urllib.error.HTTPError("http://romm.local/api/test", 401, "Unauthorized", http.client.HTTPMessage(), None)
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommAuthError) as exc_info:
+            plugin._http_adapter.request("/api/test")
         assert exc_info.value.status_code == 401
 
     def test_connection_refused_raises_connection_error(self, plugin):
         _setup_plugin(plugin)
-        with patch("urllib.request.urlopen", side_effect=ConnectionRefusedError("refused")):
-            with pytest.raises(RommConnectionError):
-                plugin._http_adapter.request("/api/test")
+        with (
+            patch("urllib.request.urlopen", side_effect=ConnectionRefusedError("refused")),
+            pytest.raises(RommConnectionError),
+        ):
+            plugin._http_adapter.request("/api/test")
 
     def test_timeout_raises_timeout_error(self, plugin):
         _setup_plugin(plugin)
-        with patch("urllib.request.urlopen", side_effect=socket.timeout("timed out")):
-            with pytest.raises(RommTimeoutError):
-                plugin._http_adapter.request("/api/test")
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")), pytest.raises(RommTimeoutError):
+            plugin._http_adapter.request("/api/test")
 
     def test_500_raises_server_error(self, plugin):
         _setup_plugin(plugin)
-        exc = urllib.error.HTTPError("http://romm.local/api/test", 500, "Internal Server Error", {}, None)
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with pytest.raises(RommServerError) as exc_info:
-                plugin._http_adapter.request("/api/test")
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/test", 500, "Internal Server Error", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommServerError) as exc_info:
+            plugin._http_adapter.request("/api/test")
         assert exc_info.value.status_code == 500
 
     def test_preserves_cause_chain(self, plugin):
         _setup_plugin(plugin)
         original = ConnectionRefusedError("refused")
-        with patch("urllib.request.urlopen", side_effect=original):
-            with pytest.raises(RommConnectionError) as exc_info:
-                plugin._http_adapter.request("/api/test")
+        with patch("urllib.request.urlopen", side_effect=original), pytest.raises(RommConnectionError) as exc_info:
+            plugin._http_adapter.request("/api/test")
         assert exc_info.value.__cause__ is original
 
     def test_already_translated_error_not_rewrapped(self, plugin):
         """If a nested call already raised RommApiError, don't re-translate."""
         _setup_plugin(plugin)
         original_err = RommAuthError("already translated")
-        with patch("urllib.request.urlopen", side_effect=original_err):
-            with pytest.raises(RommAuthError) as exc_info:
-                plugin._http_adapter.request("/api/test")
+        with patch("urllib.request.urlopen", side_effect=original_err), pytest.raises(RommAuthError) as exc_info:
+            plugin._http_adapter.request("/api/test")
         assert str(exc_info.value) == "already translated"
 
 
@@ -471,16 +470,14 @@ class TestRommJsonRequestErrors:
 
     def test_404_raises_not_found(self, plugin):
         _setup_plugin(plugin)
-        exc = urllib.error.HTTPError("http://romm.local/api/saves", 404, "Not Found", {}, None)
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with pytest.raises(RommNotFoundError):
-                plugin._http_adapter.post_json("/api/saves", {"data": 1})
+        exc = urllib.error.HTTPError("http://romm.local/api/saves", 404, "Not Found", http.client.HTTPMessage(), None)
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommNotFoundError):
+            plugin._http_adapter.post_json("/api/saves", {"data": 1})
 
     def test_timeout_raises_timeout_error(self, plugin):
         _setup_plugin(plugin)
-        with patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")):
-            with pytest.raises(RommTimeoutError):
-                plugin._http_adapter.put_json("/api/saves/1", {"data": 1})
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")), pytest.raises(RommTimeoutError):
+            plugin._http_adapter.put_json("/api/saves/1", {"data": 1})
 
 
 class TestRommDownloadErrors:
@@ -488,11 +485,12 @@ class TestRommDownloadErrors:
 
     def test_403_raises_forbidden(self, plugin, tmp_path):
         _setup_plugin(plugin)
-        exc = urllib.error.HTTPError("http://romm.local/assets/rom.zip", 403, "Forbidden", {}, None)
+        exc = urllib.error.HTTPError(
+            "http://romm.local/assets/rom.zip", 403, "Forbidden", http.client.HTTPMessage(), None
+        )
         dest = str(tmp_path / "rom.zip")
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with pytest.raises(RommForbiddenError):
-                plugin._http_adapter.download("/assets/rom.zip", dest)
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommForbiddenError):
+            plugin._http_adapter.download("/assets/rom.zip", dest)
 
 
 class TestRommUploadMultipartErrors:
@@ -502,10 +500,9 @@ class TestRommUploadMultipartErrors:
         _setup_plugin(plugin)
         save_file = tmp_path / "test.srm"
         save_file.write_bytes(b"data")
-        exc = urllib.error.HTTPError("http://romm.local/api/saves", 409, "Conflict", {}, None)
-        with patch("urllib.request.urlopen", side_effect=exc):
-            with pytest.raises(RommConflictError):
-                plugin._http_adapter.upload_multipart("/api/saves", str(save_file))
+        exc = urllib.error.HTTPError("http://romm.local/api/saves", 409, "Conflict", http.client.HTTPMessage(), None)
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommConflictError):
+            plugin._http_adapter.upload_multipart("/api/saves", str(save_file))
 
 
 # ============================================================================
@@ -519,13 +516,13 @@ class TestRetryLogic:
     def test_is_retryable_5xx(self, plugin):
         """HTTP 500/502/503 are retryable."""
         for code in (500, 502, 503):
-            exc = urllib.error.HTTPError("url", code, "err", {}, None)
+            exc = urllib.error.HTTPError("url", code, "err", http.client.HTTPMessage(), None)
             assert RommHttpAdapter.is_retryable(exc) is True
 
     def test_is_not_retryable_4xx(self, plugin):
         """HTTP 400/401/404/409 are NOT retryable."""
         for code in (400, 401, 403, 404, 409):
-            exc = urllib.error.HTTPError("url", code, "err", {}, None)
+            exc = urllib.error.HTTPError("url", code, "err", http.client.HTTPMessage(), None)
             assert RommHttpAdapter.is_retryable(exc) is False
 
     def test_is_retryable_connection_errors(self, plugin):
@@ -590,14 +587,13 @@ class TestRetryLogic:
     def test_retry_exhausted_raises(self, plugin):
         """All attempts fail -> raises last exception."""
         fn = MagicMock(side_effect=ConnectionError("refused"))
-        with patch("time.sleep"):
-            with pytest.raises(ConnectionError):
-                plugin._http_adapter.with_retry(fn, max_attempts=3, base_delay=0)
+        with patch("time.sleep"), pytest.raises(ConnectionError):
+            plugin._http_adapter.with_retry(fn, max_attempts=3, base_delay=0)
         assert fn.call_count == 3
 
     def test_retry_no_retry_on_4xx(self, plugin):
         """4xx errors raise immediately without retry."""
-        err = urllib.error.HTTPError("url", 404, "not found", {}, None)
+        err = urllib.error.HTTPError("url", 404, "not found", http.client.HTTPMessage(), None)
         fn = MagicMock(side_effect=err)
         with pytest.raises(urllib.error.HTTPError):
             plugin._http_adapter.with_retry(fn, max_attempts=3, base_delay=0)
@@ -909,7 +905,7 @@ class TestTranslateUnwrapped:
         assert isinstance(err, RommSSLError)
 
     def test_socket_timeout(self):
-        err = RommHttpAdapter._translate_unwrapped(socket.timeout("timed out"), "/api", "GET")
+        err = RommHttpAdapter._translate_unwrapped(TimeoutError("timed out"), "/api", "GET")
         assert isinstance(err, RommTimeoutError)
 
     def test_timeout_error(self):
@@ -1014,7 +1010,7 @@ class TestDownloadTimeout:
         resp = MagicMock()
         resp.headers = {"Content-Length": "65536"}
         # First read returns data, second raises socket.timeout
-        resp.read.side_effect = [b"x" * 256, socket.timeout("timed out")]
+        resp.read.side_effect = [b"x" * 256, TimeoutError("timed out")]
 
         dest = tmp_path / "rom.zip"
         with pytest.raises(RommTimeoutError, match="stalled"):
@@ -1090,15 +1086,18 @@ class TestDownloadTimeout:
             call_count += 1
             if call_count == 1:
                 return b"x" * 65536
-            raise socket.timeout("no data")
+            raise TimeoutError("no data")
 
         mock_resp.read = _read
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            with pytest.raises(RommTimeoutError, match="stalled") as exc_info:
-                adapter.download("/roms/big.zip", dest)
+        with (
+            patch("urllib.request.urlopen", return_value=mock_resp),
+            pytest.raises(RommTimeoutError, match="stalled") as exc_info,
+        ):
+            adapter.download("/roms/big.zip", dest)
+        assert exc_info.value.url is not None
         assert "romm.local" in exc_info.value.url
 
     def test_large_download_succeeds_with_slow_chunks(self, tmp_path):
@@ -1119,24 +1118,29 @@ class TestDownloadTimeout:
         with patch("urllib.request.urlopen", return_value=mock_resp):
             adapter.download("/roms/game.zip", dest)
 
-        assert open(dest, "rb").read() == data
+        with open(dest, "rb") as f:
+            assert f.read() == data
 
     def test_connection_timeout_still_works(self, tmp_path):
         """socket.timeout raised by urlopen (connection phase) -> RommTimeoutError."""
         adapter = self._make_adapter()
         dest = str(tmp_path / "rom.zip")
 
-        with patch("urllib.request.urlopen", side_effect=socket.timeout("connection timed out")):
-            with pytest.raises(RommTimeoutError):
-                adapter.download("/roms/game.zip", dest)
+        with (
+            patch("urllib.request.urlopen", side_effect=TimeoutError("connection timed out")),
+            pytest.raises(RommTimeoutError),
+        ):
+            adapter.download("/roms/game.zip", dest)
 
     def test_connection_timeout_via_urlerror(self, tmp_path):
         """URLError-wrapped socket.timeout (real urllib path) -> RommTimeoutError."""
         adapter = self._make_adapter()
         dest = str(tmp_path / "rom.zip")
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError(socket.timeout("connection timed out"))):
-            with pytest.raises(RommTimeoutError):
-                adapter.download("/roms/game.zip", dest)
+        with (
+            patch("urllib.request.urlopen", side_effect=urllib.error.URLError(TimeoutError("connection timed out"))),
+            pytest.raises(RommTimeoutError),
+        ):
+            adapter.download("/roms/game.zip", dest)
 
     def test_download_sets_read_timeout_on_socket(self, tmp_path):
         """After urlopen succeeds, settimeout(_READ_TIMEOUT) is called on the raw socket."""
@@ -1184,4 +1188,5 @@ class TestDownloadTimeout:
         with patch("urllib.request.urlopen", return_value=mock_resp):
             adapter.download("/roms/game.zip", dest)  # should not raise
 
-        assert open(dest, "rb").read() == data
+        with open(dest, "rb") as f:
+            assert f.read() == data

--- a/tests/test_save_conflicts.py
+++ b/tests/test_save_conflicts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from domain.save_conflicts import (
     build_conflict_dict,
@@ -57,36 +57,36 @@ class TestCheckServerChangesFast:
     def test_timestamp_and_size_match_returns_false(self):
         file_state = self._file_state()
         server_save = self._server_save()
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         assert result is False
 
     def test_timestamp_matches_size_differs_returns_true(self):
         file_state = self._file_state(size=1024)
         server_save = self._server_save(size=2048)
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         assert result is True
 
     def test_timestamp_changed_returns_none(self):
         file_state = self._file_state(updated_at="2026-02-17T06:00:00Z")
         server_save = self._server_save(updated_at="2026-02-17T12:00:00Z")
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         assert result is None
 
     def test_no_stored_timestamp_returns_none(self):
         file_state = {"last_sync_server_size": 1024}  # no last_sync_server_updated_at
         server_save = self._server_save()
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         assert result is None
 
     def test_empty_file_state_returns_none(self):
-        result = check_server_changes_fast({}, self._server_save(), "hash123")
+        result = check_server_changes_fast({}, self._server_save())
         assert result is None
 
     def test_stored_size_none_timestamp_matches_returns_false(self):
         """If stored_size is None (legacy), size check is skipped when timestamp matches."""
         file_state = {"last_sync_server_updated_at": "2026-02-17T06:00:00Z", "last_sync_server_size": None}
         server_save = self._server_save(size=2048)
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         # stored_size is None — condition `stored_size is not None and ...` is False -> unchanged
         assert result is False
 
@@ -94,7 +94,7 @@ class TestCheckServerChangesFast:
         """If server returns no size, size check is skipped."""
         file_state = self._file_state(size=1024)
         server_save = {"updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": None}
-        result = check_server_changes_fast(file_state, server_save, "hash123")
+        result = check_server_changes_fast(file_state, server_save)
         assert result is False
 
 
@@ -230,19 +230,19 @@ class TestResolveConflictByMode:
     def test_newest_wins_local_newer_uploads(self):
         # Server updated at 2026-02-17T06:00:00Z
         # local_mtime is after that
-        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=UTC)
         local_mtime = server_dt.timestamp() + 3600  # 1 hour later
         result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
         assert result == "upload"
 
     def test_newest_wins_server_newer_downloads(self):
-        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=UTC)
         local_mtime = server_dt.timestamp() - 3600  # 1 hour earlier
         result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
         assert result == "download"
 
     def test_newest_wins_within_tolerance_asks(self):
-        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=UTC)
         local_mtime = server_dt.timestamp() + 30  # 30s later, within 60s tolerance
         result = resolve_conflict_by_mode("newest_wins", local_mtime, self._server_save(), tolerance=60)
         assert result == "ask"
@@ -257,7 +257,7 @@ class TestResolveConflictByMode:
 
     def test_unknown_mode_falls_through_to_newest_wins(self):
         """Unrecognised mode falls through to newest_wins logic."""
-        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=timezone.utc)
+        server_dt = datetime(2026, 2, 17, 6, 0, 0, tzinfo=UTC)
         local_mtime = server_dt.timestamp() + 3600
         result = resolve_conflict_by_mode("some_future_mode", local_mtime, self._server_save(), tolerance=60)
         assert result == "upload"
@@ -277,7 +277,7 @@ class TestBuildConflictDict:
         }
 
     def test_full_dict_structure(self):
-        local_mtime = datetime(2026, 2, 17, 5, 0, 0, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 5, 0, 0, tzinfo=UTC).timestamp()
         local_info = {"path": "/saves/pokemon.srm", "mtime": local_mtime, "size": 1024}
         result = build_conflict_dict(42, "pokemon.srm", local_info, "abc123", self._server_save())
 

--- a/tests/test_save_service.py
+++ b/tests/test_save_service.py
@@ -5,13 +5,15 @@ import hashlib
 import logging
 import os
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from fakes.fake_save_api import FakeSaveApi
-from services.saves import SaveService
 
 from lib.errors import RommApiError
+from services.saves import SaveService
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -22,13 +24,19 @@ def _no_retry(fn, *a, **kw):
     return fn(*a, **kw)
 
 
-def make_service(tmp_path, fake_api=None, **overrides):
+def _make_retry():
+    retry = MagicMock()
+    retry.with_retry.side_effect = _no_retry
+    retry.is_retryable.return_value = False
+    return retry
+
+
+def make_service(tmp_path, fake_api=None, **overrides) -> tuple["SaveService", "FakeSaveApi"]:
     """Create a SaveService with sensible defaults for testing."""
-    fake = fake_api or FakeSaveApi()
-    defaults = dict(
+    fake: FakeSaveApi = fake_api or FakeSaveApi()
+    defaults: dict[str, Any] = dict(
         romm_api=fake,
-        with_retry=_no_retry,
-        is_retryable=lambda e: False,
+        retry=_make_retry(),
         state={"shortcut_registry": {}, "installed_roms": {}},
         save_sync_state=SaveService.make_default_state(),
         loop=asyncio.get_event_loop(),
@@ -39,7 +47,7 @@ def make_service(tmp_path, fake_api=None, **overrides):
     defaults.update(overrides)
     svc = SaveService(**defaults)
     svc.init_state()
-    return svc, defaults.get("romm_api", fake) if fake_api is None else fake
+    return svc, fake
 
 
 def _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba"):
@@ -189,7 +197,7 @@ class TestDeviceRegistration:
 
 class TestConflictDetection:
     def test_skip_when_unchanged(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         content = b"save data"
         local_hash = hashlib.md5(content).hexdigest()
 
@@ -208,7 +216,7 @@ class TestConflictDetection:
         assert result == "skip"
 
     def test_upload_when_local_changed(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         old_hash = hashlib.md5(b"old").hexdigest()
         new_hash = hashlib.md5(b"new data").hexdigest()
 
@@ -227,7 +235,7 @@ class TestConflictDetection:
         assert result == "upload"
 
     def test_download_when_server_changed(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         local_hash = hashlib.md5(b"save data").hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -250,7 +258,7 @@ class TestConflictDetection:
         assert result == "download"
 
     def test_conflict_when_both_changed(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         old_hash = hashlib.md5(b"baseline").hexdigest()
         new_local = hashlib.md5(b"local edit").hexdigest()
 
@@ -270,7 +278,7 @@ class TestConflictDetection:
 
     def test_never_synced_same_hash_skips(self, tmp_path):
         """When never synced but local and server have same content -> skip."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         # FakeSaveApi.download_save writes 1024 zero bytes
         content = b"\x00" * 1024
         local_hash = hashlib.md5(content).hexdigest()
@@ -281,7 +289,7 @@ class TestConflictDetection:
 
     def test_never_synced_different_hash_conflicts(self, tmp_path):
         """When never synced and hashes differ -> conflict."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         local_hash = hashlib.md5(b"different content").hexdigest()
 
         server = _server_save()
@@ -300,7 +308,7 @@ class TestConflictDetection:
 
     def test_no_local_file_downloads(self, tmp_path):
         """No local file (local_hash=None), server has save -> download."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
 
         server = _server_save()
         result = svc._detect_conflict(42, "pokemon.srm", None, server)
@@ -308,7 +316,7 @@ class TestConflictDetection:
 
     def test_server_size_change_fast_path(self, tmp_path):
         """Same timestamp but different size -> detects server changed."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         local_hash = hashlib.md5(b"save data").hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -338,7 +346,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_timestamp_changed_content_identical_skips(self, tmp_path):
         """Server timestamp changed but content hash matches baseline -> skip."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         # FakeSaveApi.download_save writes 1024 zero bytes by default
         baseline_hash = hashlib.md5(b"\x00" * 1024).hexdigest()
 
@@ -359,7 +367,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_false_alarm_updates_stored_metadata(self, tmp_path):
         """After false alarm, stored server_updated_at and server_size are updated."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         baseline_hash = hashlib.md5(b"\x00" * 1024).hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -381,7 +389,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_local_changed_server_content_unchanged_uploads(self, tmp_path):
         """Local changed + server timestamp changed but server content unchanged -> upload."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         baseline_hash = hashlib.md5(b"\x00" * 1024).hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -401,7 +409,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_no_stored_timestamp_triggers_slow_path(self, tmp_path):
         """No stored server_updated_at -> triggers slow path (download + hash)."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         baseline_hash = hashlib.md5(b"\x00" * 1024).hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -462,7 +470,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_fast_path_timestamp_and_size_match(self, tmp_path):
         """Both timestamp and size match stored -> skip."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         local_hash = hashlib.md5(b"save data").hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -481,7 +489,7 @@ class TestConflictDetectionFalseAlarm:
 
     def test_fast_path_stored_size_none(self, tmp_path):
         """stored_size is None (legacy), timestamp matches -> skip (size check skipped)."""
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         local_hash = hashlib.md5(b"save data").hexdigest()
 
         svc._save_sync_state["saves"]["42"] = {
@@ -586,7 +594,7 @@ class TestSyncRomSaves:
         ss = _server_save()
         fake.saves[100] = ss
 
-        synced, errors, conflicts = svc._sync_rom_saves(42)
+        synced, errors, _ = svc._sync_rom_saves(42)
         assert synced == 1
         assert errors == []
         # Verify the file was downloaded
@@ -621,7 +629,7 @@ class TestSyncRomSaves:
 
     def test_rom_not_installed(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        synced, errors, conflicts = svc._sync_rom_saves(999)
+        synced, errors, _ = svc._sync_rom_saves(999)
         assert synced == 0
         assert errors == []
 
@@ -630,7 +638,7 @@ class TestSyncRomSaves:
         _install_rom(svc, tmp_path)
         fake.fail_on_next(RommApiError("Server error"))
 
-        synced, errors, conflicts = svc._sync_rom_saves(42)
+        synced, errors, _ = svc._sync_rom_saves(42)
         assert synced == 0
         assert len(errors) == 1
         assert "Failed to fetch saves" in errors[0]
@@ -644,7 +652,7 @@ class TestSyncRomSaves:
 class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_syncs_multiple_roms(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
         svc._save_sync_state["device_id"] = "test-device"
 
@@ -741,7 +749,7 @@ class TestPreLaunchSync:
 class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_uploads_changed_saves(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
         svc._save_sync_state["device_id"] = "test-device"
         _install_rom(svc, tmp_path)
@@ -770,7 +778,7 @@ class TestPostExitSync:
 
     @pytest.mark.asyncio
     async def test_auto_registers_device(self, tmp_path):
-        svc, fake = make_service(tmp_path)
+        svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
         # No device_id set
         _install_rom(svc, tmp_path)
@@ -1138,7 +1146,7 @@ class TestResolveConflictByMode:
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["conflict_mode"] = "newest_wins"
         server = _server_save(updated_at="2026-02-17T10:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 14, 0, 0, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 14, 0, 0, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 
@@ -1148,7 +1156,7 @@ class TestResolveConflictByMode:
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["conflict_mode"] = "newest_wins"
         server = _server_save(updated_at="2026-02-17T14:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 10, 0, 0, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 
@@ -1159,7 +1167,7 @@ class TestResolveConflictByMode:
         svc._save_sync_state["settings"]["conflict_mode"] = "newest_wins"
         svc._save_sync_state["settings"]["clock_skew_tolerance_sec"] = 60
         server = _server_save(updated_at="2026-02-17T12:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 12, 0, 30, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 12, 0, 30, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 
@@ -1180,7 +1188,7 @@ class TestClockSkewBoundary:
         svc._save_sync_state["settings"]["clock_skew_tolerance_sec"] = 60
 
         server = _server_save(updated_at="2026-02-17T12:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 12, 1, 0, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 12, 1, 0, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 
@@ -1192,7 +1200,7 @@ class TestClockSkewBoundary:
         svc._save_sync_state["settings"]["clock_skew_tolerance_sec"] = 60
 
         server = _server_save(updated_at="2026-02-17T12:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 12, 1, 1, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 12, 1, 1, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 
@@ -1204,7 +1212,7 @@ class TestClockSkewBoundary:
         svc._save_sync_state["settings"]["clock_skew_tolerance_sec"] = 0
 
         server = _server_save(updated_at="2026-02-17T12:00:00Z")
-        local_mtime = datetime(2026, 2, 17, 12, 0, 1, tzinfo=timezone.utc).timestamp()
+        local_mtime = datetime(2026, 2, 17, 12, 0, 1, tzinfo=UTC).timestamp()
 
         result = svc._resolve_conflict_by_mode(local_mtime, server)
 

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -1,28 +1,36 @@
 import asyncio
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
+from conftest import _make_testable_plugin
+from fakes.fake_save_api import FakeSaveApi
+
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
-from fakes.fake_save_api import FakeSaveApi
 from services.library import LibraryService
 from services.playtime import PlaytimeService
 from services.saves import SaveService
-
-# conftest.py patches decky before this import
-from main import Plugin
 
 
 def _no_retry(fn, *a, **kw):
     return fn(*a, **kw)
 
 
+def _make_retry():
+    retry = MagicMock()
+    retry.with_retry.side_effect = _no_retry
+    retry.is_retryable.return_value = False
+    return retry
+
+
 @pytest.fixture
 def plugin(tmp_path):
-    p = Plugin()
+    p = _make_testable_plugin()
     p.settings = {
         "romm_url": "http://romm.local",
         "romm_user": "user",
@@ -70,8 +78,7 @@ def plugin(tmp_path):
 
     p._save_sync_service = SaveService(
         romm_api=fake_api,
-        with_retry=_no_retry,
-        is_retryable=lambda e: isinstance(e, ConnectionError),
+        retry=_make_retry(),
         state=p._state,
         save_sync_state=p._save_sync_state,
         loop=asyncio.get_event_loop(),
@@ -83,8 +90,7 @@ def plugin(tmp_path):
 
     p._playtime_service = PlaytimeService(
         romm_api=fake_api,
-        with_retry=_no_retry,
-        is_retryable=lambda e: isinstance(e, ConnectionError),
+        retry=_make_retry(),
         save_sync_state=p._save_sync_state,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
@@ -264,7 +270,7 @@ class TestPlaytimeTracking:
     async def test_session_end_calculates_delta(self, plugin):
         """record_session_end computes correct duration."""
         plugin._save_sync_state.setdefault("playtime", {})
-        start_time = datetime.now(timezone.utc) - timedelta(seconds=600)
+        start_time = datetime.now(UTC) - timedelta(seconds=600)
         plugin._save_sync_state["playtime"]["42"] = {
             "total_seconds": 0,
             "session_count": 0,
@@ -282,7 +288,7 @@ class TestPlaytimeTracking:
     @pytest.mark.asyncio
     async def test_delta_accumulated(self, plugin):
         """Playtime delta added to existing total."""
-        start_time = datetime.now(timezone.utc) - timedelta(seconds=300)
+        start_time = datetime.now(UTC) - timedelta(seconds=300)
         plugin._save_sync_state["playtime"] = {
             "42": {
                 "total_seconds": 1000,
@@ -301,7 +307,7 @@ class TestPlaytimeTracking:
     @pytest.mark.asyncio
     async def test_session_count_incremented(self, plugin):
         """Session count goes up on end."""
-        start_time = datetime.now(timezone.utc) - timedelta(seconds=10)
+        start_time = datetime.now(UTC) - timedelta(seconds=10)
         plugin._save_sync_state["playtime"] = {
             "42": {
                 "total_seconds": 0,
@@ -326,7 +332,7 @@ class TestPlaytimeTracking:
     @pytest.mark.asyncio
     async def test_session_start_clears_on_end(self, plugin):
         """last_session_start is cleared after session end."""
-        start_time = datetime.now(timezone.utc) - timedelta(seconds=10)
+        start_time = datetime.now(UTC) - timedelta(seconds=10)
         plugin._save_sync_state["playtime"] = {
             "42": {
                 "total_seconds": 0,
@@ -344,7 +350,7 @@ class TestPlaytimeTracking:
     @pytest.mark.asyncio
     async def test_duration_clamped_to_24h(self, plugin):
         """Duration clamped to max 24 hours."""
-        start_time = datetime.now(timezone.utc) - timedelta(hours=48)
+        start_time = datetime.now(UTC) - timedelta(hours=48)
         plugin._save_sync_state["playtime"] = {
             "42": {
                 "total_seconds": 0,

--- a/tests/test_shortcut_removal.py
+++ b/tests/test_shortcut_removal.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock
 # conftest.py patches decky before this import
 import decky
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
+from domain.sync_state import SyncState
 from services.shortcut_removal import ShortcutRemovalService
 
 
@@ -241,7 +243,7 @@ class TestRemovalCleansUpArtwork:
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             emit=decky.emit,
-            sync_state_ref=lambda: None,
+            sync_state_ref=lambda: SyncState.IDLE,
         )
 
         svc = ShortcutRemovalService(
@@ -280,7 +282,7 @@ class TestRemovalCleansUpArtwork:
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             emit=decky.emit,
-            sync_state_ref=lambda: None,
+            sync_state_ref=lambda: SyncState.IDLE,
         )
 
         svc = ShortcutRemovalService(

--- a/tests/test_steam_config.py
+++ b/tests/test_steam_config.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import vdf
+
 from adapters.steam_config import SteamConfigAdapter
 
 
@@ -222,7 +223,7 @@ class TestSetSteamInputConfig:
         adapter.set_steam_input_config([12345], mode="force_on")
         # Re-read and verify
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         assert result["UserLocalConfigStore"]["Apps"]["12345"]["UseSteamControllerConfig"] == "2"
 
@@ -231,7 +232,7 @@ class TestSetSteamInputConfig:
         adapter = self._make_adapter_with_localconfig(tmp_path, data)
         adapter.set_steam_input_config([99], mode="force_off")
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         assert result["UserLocalConfigStore"]["Apps"]["99"]["UseSteamControllerConfig"] == "0"
 
@@ -240,7 +241,7 @@ class TestSetSteamInputConfig:
         adapter = self._make_adapter_with_localconfig(tmp_path, data)
         adapter.set_steam_input_config([42], mode="default")
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         # Key removed, but app entry remains because it has other keys
         assert "UseSteamControllerConfig" not in result["UserLocalConfigStore"]["Apps"]["42"]
@@ -250,7 +251,7 @@ class TestSetSteamInputConfig:
         adapter = self._make_adapter_with_localconfig(tmp_path, data)
         adapter.set_steam_input_config([42], mode="default")
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         assert "42" not in result["UserLocalConfigStore"]["Apps"]
 
@@ -265,7 +266,7 @@ class TestSetSteamInputConfig:
         adapter = self._make_adapter_with_localconfig(tmp_path, data)
         adapter.set_steam_input_config([42], mode="force_on")
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         assert result["UserLocalConfigStore"]["Apps"]["42"]["UseSteamControllerConfig"] == "2"
 
@@ -295,7 +296,7 @@ class TestSetSteamInputConfig:
         adapter = self._make_adapter_with_localconfig(tmp_path, data)
         adapter.set_steam_input_config([100, 200, 300], mode="force_on")
         userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
-        with open(str(userdata / "config" / "localconfig.vdf"), "r") as f:
+        with open(str(userdata / "config" / "localconfig.vdf")) as f:
             result = vdf.load(f)
         for app_id in ["100", "200", "300"]:
             assert result["UserLocalConfigStore"]["Apps"][app_id]["UseSteamControllerConfig"] == "2"
@@ -398,18 +399,17 @@ class TestFixRetroarchInputDriver:
         cfg_path = tmp_path / "retroarch.cfg"
         cfg_path.write_text('input_driver = "x"\n')
         adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
-        with patch("adapters.steam_config.os.path.expanduser", return_value=str(cfg_path)):
-            # check_retroarch_input_driver opens the file once (read),
-            # fix_retroarch_input_driver opens it twice more (read lines, write).
-            # Let the first two opens succeed, then fail on write.
-            with patch(
+        with (
+            patch("adapters.steam_config.os.path.expanduser", return_value=str(cfg_path)),
+            patch(
                 "builtins.open",
                 side_effect=[
-                    open(str(cfg_path), "r"),  # check_retroarch_input_driver read
-                    open(str(cfg_path), "r"),  # fix_retroarch_input_driver read lines
+                    open(str(cfg_path)),  # check_retroarch_input_driver read
+                    open(str(cfg_path)),  # fix_retroarch_input_driver read lines
                     OSError("nope"),  # fix_retroarch_input_driver write
                 ],
-            ):
-                result = adapter.fix_retroarch_input_driver()
+            ),
+        ):
+            result = adapter.fix_retroarch_input_driver()
         assert result["success"] is False
         assert "failed" in result["message"].lower()

--- a/tests/test_steamgrid.py
+++ b/tests/test_steamgrid.py
@@ -1,13 +1,15 @@
 import asyncio
+import http.client
 from unittest.mock import MagicMock
 
 import pytest
+
 from adapters.steam_config import SteamConfigAdapter
-from services.library import LibraryService
-from services.steamgrid import SteamGridService
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.library import LibraryService
+from services.steamgrid import SteamGridService
 
 
 @pytest.fixture
@@ -49,7 +51,7 @@ def plugin():
         runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
         save_state=MagicMock(),
         save_settings_to_disk=MagicMock(),
-        pending_sync=p._sync_service._pending_sync,
+        get_pending_sync=lambda: p._sync_service._pending_sync,
     )
     return p
 
@@ -133,7 +135,9 @@ class TestVerifySgdbApiKey:
 
         with patch(
             "urllib.request.urlopen",
-            side_effect=urllib.error.HTTPError("https://steamgriddb.com", 401, "Unauthorized", {}, None),
+            side_effect=urllib.error.HTTPError(
+                "https://steamgriddb.com", 401, "Unauthorized", http.client.HTTPMessage(), None
+            ),
         ):
             result = await plugin.verify_sgdb_api_key("bad-key")
 
@@ -149,7 +153,9 @@ class TestVerifySgdbApiKey:
 
         with patch(
             "urllib.request.urlopen",
-            side_effect=urllib.error.HTTPError("https://steamgriddb.com", 403, "Forbidden", {}, None),
+            side_effect=urllib.error.HTTPError(
+                "https://steamgriddb.com", 403, "Forbidden", http.client.HTTPMessage(), None
+            ),
         ):
             result = await plugin.verify_sgdb_api_key("bad-key")
 
@@ -251,7 +257,9 @@ class TestVerifySgdbApiKey:
 
         with patch(
             "urllib.request.urlopen",
-            side_effect=urllib.error.HTTPError("https://steamgriddb.com", 500, "Internal Server Error", {}, None),
+            side_effect=urllib.error.HTTPError(
+                "https://steamgriddb.com", 500, "Internal Server Error", http.client.HTTPMessage(), None
+            ),
         ):
             result = await plugin.verify_sgdb_api_key("some-key")
 


### PR DESCRIPTION
## Summary

Major architecture cleanup — the foundation for all future development.

**Protocols:**
- 13 new Protocol interfaces in `services/protocols.py` (BiosChecker, AchievementsReader, ArtworkManager, MetadataExtractor, RetryStrategy, StatePersister, EventEmitter, SettingsPersister, DebugLogger, SystemResolver, SavesPathProvider, SyncStateRef, CachePersistence)
- All 13 services migrated from bare `Callable`/`Any` to typed Protocols
- GameDetailService: 8→6 params, LibraryService: 14→12 params

**Domain purity:**
- Removed `import decky` from `es_de_config.py` and `retrodeck_config.py` (configure() injection)
- Lazy fallback replaced with `RuntimeError` on unconfigured access
- Moved `SyncState` enum to `domain/sync_state.py`

**Bug fix:**
- Fixed SteamGridService stale `pending_sync` dict reference (functional bug)

**Code quality:**
- Expanded ruff rules: B (bugbear), SIM (simplify), UP (pyupgrade), RUF, ARG
- Fixed all 92 new violations across source + tests
- basedpyright now checks tests (0 errors) — TestablePlugin + FakeSaveApi Protocol conformance
- Converted async-without-await service methods to sync

Closes #154

## Test plan

- [x] `python -m pytest tests/ -q` — 1260 passed
- [x] `ruff check` — 0 errors (expanded ruleset)
- [x] `basedpyright` — 0 errors, 0 warnings (including tests)
- [x] `lint-imports` — 5 contracts kept, 0 broken
- [x] Architecture review: 2 rounds × 3 reviewers — all findings fixed