### PR TITLE
chore: remove deprecated getPendingConflicts callable (#116)

### DIFF
--- a/main.py
+++ b/main.py
@@ -556,9 +556,6 @@ class Plugin:
     async def resolve_conflict(self, rom_id, filename, resolution, server_save_id=None, local_path=None):
         return await self._save_sync_service.resolve_conflict(rom_id, filename, resolution, server_save_id, local_path)
 
-    async def get_pending_conflicts(self):
-        return self._save_sync_service.get_pending_conflicts()
-
     async def get_save_sync_settings(self):
         return self._save_sync_service.get_save_sync_settings()
 

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -1092,10 +1092,6 @@ class SaveService:
             self._logger.error(f"Conflict resolution failed: {e}")
             return {"success": False, "message": "Conflict resolution failed"}
 
-    def get_pending_conflicts(self) -> dict:
-        """Deprecated — conflicts are now returned inline from sync operations."""
-        return {"conflicts": []}
-
     def get_save_sync_settings(self) -> dict:
         """Return current save sync settings."""
         return self._save_sync_state.get(

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -124,8 +124,6 @@ export const postExitSync = callable<[number], { success: boolean; message: stri
 export const syncRomSaves = callable<[number], { success: boolean; message: string; synced: number; errors?: string[] }>("sync_rom_saves");
 export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>("sync_all_saves");
 export const resolveConflict = callable<[number, string, string, number, string], { success: boolean; message: string }>("resolve_conflict");
-/** @deprecated Conflicts are now returned inline from sync operations. Always returns empty. */
-export const getPendingConflicts = callable<[], { conflicts: PendingConflict[] }>("get_pending_conflicts");
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const recordSessionEnd = callable<[number], { success: boolean; duration_sec?: number; total_seconds?: number; session_count?: number; message?: string }>("record_session_end");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -532,20 +532,6 @@ class TestPendingConflicts:
     """Tests for conflict queue management."""
 
     @pytest.mark.asyncio
-    async def test_get_pending_conflicts_deprecated_stub(self, plugin):
-        """Deprecated stub always returns empty list."""
-        result = await plugin.get_pending_conflicts()
-
-        assert result["conflicts"] == []
-
-    @pytest.mark.asyncio
-    async def test_get_empty_conflicts(self, plugin):
-        """Returns empty list (deprecated stub)."""
-        result = await plugin.get_pending_conflicts()
-
-        assert result["conflicts"] == []
-
-    @pytest.mark.asyncio
     async def test_resolve_invalid_resolution(self, plugin):
         """Invalid resolution string is rejected."""
         result = await plugin.resolve_conflict(42, "pokemon.srm", "invalid")


### PR DESCRIPTION
## Summary

Removes the deprecated `getPendingConflicts` callable that was superseded by inline `conflicts` arrays in `get_save_status()` and `get_cached_game_detail()` responses (PR #175).

### Removed
- `main.py`: `get_pending_conflicts` callable
- `saves.py`: `get_pending_conflicts()` method
- `backend.ts`: `getPendingConflicts` export
- `test_save_sync.py`: 2 deprecated stub tests

No frontend code was calling this — it was already dead code.

## Test plan
- [x] 1398 tests pass
- [x] `pnpm build` clean
- [x] ruff, basedpyright clean
- [x] `grep` confirms zero remaining references

Closes #116.