### PR TITLE
feat(domain): save sync v2 domain logic (#183)

### DIFF
--- a/py_modules/domain/emulator_tag.py
+++ b/py_modules/domain/emulator_tag.py
@@ -1,0 +1,66 @@
+"""Emulator tag construction for RomM save uploads.
+
+The emulator tag determines the server-side folder path for saves:
+saves/{system}/{rom_id}/{emulator}/
+
+Format: retroarch-{core} where core is the libretro core name
+without the _libretro suffix, lowercased.
+
+No I/O, no service/adapter/lib imports. Pure functions only.
+"""
+
+from __future__ import annotations
+
+_LIBRETRO_SUFFIX = "_libretro"
+_FALLBACK = "retroarch"
+
+
+def build_emulator_tag(core_so: str | None) -> str:
+    """Build a RomM emulator tag from a RetroArch core .so name.
+
+    Parameters
+    ----------
+    core_so:
+        The libretro core name as found in ES-DE config, e.g. "mgba_libretro",
+        "snes9x_libretro", "swanstation_libretro".
+        May be None if core resolution failed.
+
+    Returns
+    -------
+    str
+        Emulator tag string, e.g. "retroarch-mgba", "retroarch-snes9x".
+        Returns "retroarch" as fallback when core_so is None or empty.
+
+    Rules:
+    - Strip "_libretro" suffix
+    - Lowercase
+    - Prepend "retroarch-"
+    - Fallback to "retroarch" if core_so is None/empty
+    """
+    if not core_so:
+        return _FALLBACK
+    core = core_so.lower()
+    if core.endswith(_LIBRETRO_SUFFIX):
+        core = core[: -len(_LIBRETRO_SUFFIX)]
+    return f"retroarch-{core}"
+
+
+def detect_core_change(stored_core: str | None, active_core: str | None) -> bool:
+    """Detect if the active RetroArch core has changed since last sync.
+
+    Parameters
+    ----------
+    stored_core:
+        The core_so name recorded at last sync, or None if never synced.
+    active_core:
+        The currently active core_so name, or None if unresolved.
+
+    Returns
+    -------
+    bool
+        True if the cores differ and both are non-None (actual change).
+        False if either is None (can't determine) or they match.
+    """
+    if stored_core is None or active_core is None:
+        return False
+    return stored_core != active_core

--- a/py_modules/domain/save_extensions.py
+++ b/py_modules/domain/save_extensions.py
@@ -1,0 +1,60 @@
+"""Per-platform save file extension configuration.
+
+Provides the list of save file extensions to look for when syncing saves.
+The default covers RetroArch's standard .srm and .rtc extensions.
+Platform-specific overrides can expand or replace this list.
+
+Extension expansion (adding .sav, .mcr, .mcd, etc.) is tracked in #186.
+
+No I/O, no service/adapter/lib imports. Pure functions only.
+"""
+
+from __future__ import annotations
+
+_DEFAULT_EXTENSIONS: tuple[str, ...] = (".srm", ".rtc")
+
+# Platform-specific overrides. Keys are RomM platform slugs.
+# Values completely replace the default list for that platform.
+# Populated incrementally as gameplay tests confirm actual extensions.
+_PLATFORM_OVERRIDES: dict[str, tuple[str, ...]] = {
+    # Example (to be filled in #186):
+    # "n64": (".srm", ".rtc", ".eep", ".sra", ".fla", ".mpk"),
+}
+
+
+def get_save_extensions(platform_slug: str | None = None) -> tuple[str, ...]:
+    """Return the save file extensions to search for a given platform.
+
+    Parameters
+    ----------
+    platform_slug:
+        RomM platform slug (e.g. "gba", "n64", "psx").
+        If None or not in overrides, returns the default extensions.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Tuple of file extensions including the leading dot (e.g. (".srm", ".rtc")).
+    """
+    if platform_slug is not None and platform_slug in _PLATFORM_OVERRIDES:
+        return _PLATFORM_OVERRIDES[platform_slug]
+    return _DEFAULT_EXTENSIONS
+
+
+def get_all_known_extensions() -> tuple[str, ...]:
+    """Return all unique extensions across defaults and all platform overrides.
+
+    Useful for broad file discovery or migration tooling.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for ext in _DEFAULT_EXTENSIONS:
+        if ext not in seen:
+            seen.add(ext)
+            result.append(ext)
+    for exts in _PLATFORM_OVERRIDES.values():
+        for ext in exts:
+            if ext not in seen:
+                seen.add(ext)
+                result.append(ext)
+    return tuple(result)

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -1,0 +1,83 @@
+"""Save file path resolution for RetroArch save directory layouts.
+
+Handles the various save directory structures created by RetroArch's
+sort_savefiles_by_content_enable and sort_savefiles_enable settings.
+
+No I/O, no service/adapter/lib imports. Pure functions only.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_save_dir(
+    rom_path: str,
+    saves_base: str,
+    system: str,
+    *,
+    sort_by_content: bool = True,
+    sort_by_core: bool = False,
+    core_name: str | None = None,
+) -> str:
+    """Resolve the save directory for a ROM.
+
+    Parameters
+    ----------
+    rom_path:
+        Relative ROM file path as stored in RomM (e.g. "gba/Game.gba" or
+        "psx/Game (USA)/Game.m3u").
+    saves_base:
+        Absolute path to the RetroArch saves root directory.
+    system:
+        Platform/system slug (e.g. "gba", "psx"). Used as fallback subdir.
+    sort_by_content:
+        If True, save subdir = last folder component of rom_path.
+        RetroDECK default: True.
+    sort_by_core:
+        If True, adds a core name subfolder inside the content dir.
+        RetroDECK default: False. Requires core_name.
+    core_name:
+        RetroArch core name (e.g. "mgba_libretro"). Required when sort_by_core=True.
+
+    Returns
+    -------
+    str
+        Absolute path to the directory where save files should be found/placed.
+    """
+    parts: list[str] = [saves_base]
+
+    if sort_by_content:
+        # Last folder component of the rom_path (i.e. the directory containing the ROM file)
+        rom_dir = os.path.dirname(rom_path)
+        content_dir = os.path.basename(rom_dir) if rom_dir else system
+        parts.append(content_dir)
+
+    if sort_by_core and core_name:
+        parts.append(core_name)
+
+    return os.path.join(*parts)
+
+
+def resolve_save_filename(rom_path: str, ext: str = ".srm") -> str:
+    """Derive the save filename from a ROM path.
+
+    Takes the ROM's basename, strips extension, appends save extension.
+    E.g. "gba/Pokemon.gba" -> "Pokemon.srm"
+    """
+    basename = os.path.basename(rom_path)
+    name, _ = os.path.splitext(basename)
+    return name + ext
+
+
+def detect_path_change(stored_path: str | None, resolved_path: str) -> bool:
+    """Detect if the save path has changed since last sync.
+
+    Useful for warning users when RetroArch settings change (e.g.
+    sort_by_content toggled) which would move where saves are expected.
+
+    Returns True if paths differ (or stored_path is None -- first sync).
+    """
+    if stored_path is None:
+        return True
+    return stored_path != resolved_path

--- a/py_modules/domain/save_sync.py
+++ b/py_modules/domain/save_sync.py
@@ -1,0 +1,85 @@
+"""Unified sync-action logic for save sync v2.
+
+Extends the existing conflict detection (save_conflicts.py) with
+RomM v4.7 device sync awareness (is_current flag from device_syncs).
+
+No I/O, no service/adapter/lib imports. Pure functions only.
+"""
+
+from __future__ import annotations
+
+from domain.save_conflicts import check_server_changes_fast, determine_action
+
+
+def check_server_changed_v47(device_sync_info: dict | None) -> bool | None:
+    """Check server change using v4.7 device_syncs info.
+
+    Parameters
+    ----------
+    device_sync_info:
+        A single device sync record from the server's device_syncs array,
+        or None if not available (v4.6 / no device registered).
+
+    Returns
+    -------
+    bool | None
+        True if server changed (is_current == False),
+        False if server unchanged (is_current == True),
+        None if indeterminate (no device_sync_info provided, or is_current is
+        absent/None).
+    """
+    if device_sync_info is None:
+        return None
+    is_current = device_sync_info.get("is_current")
+    if is_current is None:
+        return None
+    return not is_current
+
+
+def determine_sync_action(
+    local_changed: bool,
+    server_save: dict | None,
+    device_sync_info: dict | None = None,
+    file_state: dict | None = None,
+) -> str:
+    """Determine the sync action combining local and server change detection.
+
+    Parameters
+    ----------
+    local_changed:
+        Whether the local file has changed since last sync (caller computes this).
+    server_save:
+        Server save metadata dict, or None if no server save exists.
+    device_sync_info:
+        v4.7 device sync record (has "is_current" key), or None for v4.6 fallback.
+    file_state:
+        Per-file sync state dict (used for v4.6 fallback via check_server_changes_fast).
+        Only needed when device_sync_info is None.
+
+    Returns
+    -------
+    str
+        One of "skip", "upload", "download", "conflict", "initial_upload",
+        "initial_download".
+    """
+    # No server save at all
+    if server_save is None:
+        return "initial_upload" if local_changed else "skip"
+
+    # Server save exists — determine whether server has changed
+    server_changed: bool
+
+    # Priority 1: v4.7 device_sync_info
+    v47_result = check_server_changed_v47(device_sync_info)
+    if v47_result is not None:
+        server_changed = v47_result
+    else:
+        # Priority 2: v4.6 fast-path using file_state
+        if file_state is not None:
+            v46_result = check_server_changes_fast(file_state, server_save)
+            server_changed = v46_result if v46_result is not None else True
+        else:
+            # Priority 3: no info at all — safe default: assume server changed
+            server_changed = True
+
+    return determine_action(local_changed, server_changed)

--- a/tests/test_emulator_tag.py
+++ b/tests/test_emulator_tag.py
@@ -1,0 +1,57 @@
+"""Unit tests for domain.emulator_tag — pure emulator tag construction functions."""
+
+from __future__ import annotations
+
+from domain.emulator_tag import build_emulator_tag, detect_core_change
+
+# ---------------------------------------------------------------------------
+# TestBuildEmulatorTag
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEmulatorTag:
+    def test_normal_core_strips_libretro_suffix(self):
+        assert build_emulator_tag("mgba_libretro") == "retroarch-mgba"
+
+    def test_core_with_digits_strips_libretro_suffix(self):
+        assert build_emulator_tag("snes9x_libretro") == "retroarch-snes9x"
+
+    def test_swanstation_core(self):
+        assert build_emulator_tag("swanstation_libretro") == "retroarch-swanstation"
+
+    def test_none_input_returns_fallback(self):
+        assert build_emulator_tag(None) == "retroarch"
+
+    def test_empty_string_returns_fallback(self):
+        assert build_emulator_tag("") == "retroarch"
+
+    def test_core_without_libretro_suffix_passes_through(self):
+        # Shouldn't happen in practice but must not crash
+        assert build_emulator_tag("mgba") == "retroarch-mgba"
+
+    def test_uppercase_core_is_lowercased(self):
+        assert build_emulator_tag("MGBA_libretro") == "retroarch-mgba"
+
+
+# ---------------------------------------------------------------------------
+# TestDetectCoreChange
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCoreChange:
+    def test_same_core_returns_false(self):
+        assert detect_core_change("mgba_libretro", "mgba_libretro") is False
+
+    def test_different_cores_returns_true(self):
+        assert detect_core_change("mgba_libretro", "snes9x_libretro") is True
+
+    def test_stored_none_returns_false(self):
+        # First sync — no prior core recorded, can't determine change
+        assert detect_core_change(None, "mgba_libretro") is False
+
+    def test_active_none_returns_false(self):
+        # Core unresolved — can't determine change
+        assert detect_core_change("mgba_libretro", None) is False
+
+    def test_both_none_returns_false(self):
+        assert detect_core_change(None, None) is False

--- a/tests/test_save_extensions.py
+++ b/tests/test_save_extensions.py
@@ -1,0 +1,98 @@
+"""Tests for domain.save_extensions pure functions."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from domain.save_extensions import get_all_known_extensions, get_save_extensions
+
+
+class TestGetSaveExtensionsDefault:
+    """get_save_extensions returns defaults when no override exists."""
+
+    def test_no_argument_returns_default(self):
+        """Calling with no argument returns the default extensions."""
+        result = get_save_extensions()
+        assert result == (".srm", ".rtc")
+
+    def test_none_argument_returns_default(self):
+        """Passing None explicitly returns the default extensions."""
+        result = get_save_extensions(None)
+        assert result == (".srm", ".rtc")
+
+    def test_known_platform_without_override_returns_default(self):
+        """A real platform slug with no override returns the default."""
+        result = get_save_extensions("gba")
+        assert result == (".srm", ".rtc")
+
+    def test_unknown_platform_returns_default(self):
+        """An unrecognised platform slug returns the default."""
+        result = get_save_extensions("unknown_platform")
+        assert result == (".srm", ".rtc")
+
+
+class TestGetSaveExtensionsWithOverride:
+    """get_save_extensions respects platform-specific overrides."""
+
+    _N64_EXTS = (".srm", ".rtc", ".eep", ".sra", ".fla", ".mpk")
+
+    def test_override_platform_returns_override(self):
+        """A platform with an override returns that override instead of the default."""
+        with patch(
+            "domain.save_extensions._PLATFORM_OVERRIDES",
+            {"n64": self._N64_EXTS},
+        ):
+            result = get_save_extensions("n64")
+            assert result == self._N64_EXTS
+
+    def test_non_override_platform_still_returns_default(self):
+        """Other platforms are unaffected when an override is present for a different one."""
+        with patch(
+            "domain.save_extensions._PLATFORM_OVERRIDES",
+            {"n64": self._N64_EXTS},
+        ):
+            result = get_save_extensions("gba")
+            assert result == (".srm", ".rtc")
+
+
+class TestGetAllKnownExtensions:
+    """get_all_known_extensions covers defaults and all override extensions."""
+
+    def test_contains_default_extensions(self):
+        """Result always contains the default .srm and .rtc extensions."""
+        result = get_all_known_extensions()
+        assert ".srm" in result
+        assert ".rtc" in result
+
+    def test_returns_tuple(self):
+        """Result is a tuple (immutable)."""
+        assert isinstance(get_all_known_extensions(), tuple)
+
+    def test_with_patched_override_includes_override_extensions(self):
+        """Override extensions appear in the combined result."""
+        overrides = {"n64": (".srm", ".rtc", ".eep", ".mpk")}
+        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
+            result = get_all_known_extensions()
+            assert ".eep" in result
+            assert ".mpk" in result
+
+    def test_no_duplicates_when_override_repeats_defaults(self):
+        """Extensions shared between defaults and overrides are not duplicated."""
+        overrides = {"n64": (".srm", ".rtc", ".eep")}
+        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
+            result = get_all_known_extensions()
+            assert result.count(".srm") == 1
+            assert result.count(".rtc") == 1
+            assert result.count(".eep") == 1
+
+    def test_no_duplicates_across_multiple_overrides(self):
+        """Extensions shared across multiple platform overrides appear only once."""
+        overrides = {
+            "n64": (".srm", ".eep"),
+            "gba": (".srm", ".sav"),
+        }
+        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
+            result = get_all_known_extensions()
+            assert result.count(".srm") == 1
+            assert ".eep" in result
+            assert ".sav" in result

--- a/tests/test_save_path.py
+++ b/tests/test_save_path.py
@@ -1,0 +1,154 @@
+"""Tests for py_modules/domain/save_path.py"""
+
+from __future__ import annotations
+
+from domain.save_path import (
+    detect_path_change,
+    resolve_save_dir,
+    resolve_save_filename,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_save_dir
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSaveDir:
+    SAVES_BASE = "/saves"
+
+    def test_sort_by_content_simple_rom_path(self) -> None:
+        """gba/Game.gba → last folder is 'gba' → saves/gba"""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            sort_by_content=True,
+        )
+        assert result == "/saves/gba"
+
+    def test_sort_by_content_rom_in_subfolder(self) -> None:
+        """psx/Game (USA)/Game.m3u → last folder is 'Game (USA)' → saves/Game (USA)"""
+        result = resolve_save_dir(
+            rom_path="psx/Game (USA)/Game.m3u",
+            saves_base=self.SAVES_BASE,
+            system="psx",
+            sort_by_content=True,
+        )
+        assert result == "/saves/Game (USA)"
+
+    def test_sort_by_content_false_flat(self) -> None:
+        """sort_by_content=False → just saves_base, no subdir"""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            sort_by_content=False,
+        )
+        assert result == "/saves"
+
+    def test_sort_by_core_adds_core_subdir(self) -> None:
+        """sort_by_content=True + sort_by_core=True → saves/gba/mgba_libretro"""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            sort_by_content=True,
+            sort_by_core=True,
+            core_name="mgba_libretro",
+        )
+        assert result == "/saves/gba/mgba_libretro"
+
+    def test_sort_by_content_and_sort_by_core_together(self) -> None:
+        """Both flags True → saves/{content_dir}/{core}"""
+        result = resolve_save_dir(
+            rom_path="snes/Zelda.sfc",
+            saves_base=self.SAVES_BASE,
+            system="snes",
+            sort_by_content=True,
+            sort_by_core=True,
+            core_name="snes9x_libretro",
+        )
+        assert result == "/saves/snes/snes9x_libretro"
+
+    def test_sort_by_core_without_core_name_ignored(self) -> None:
+        """sort_by_core=True but core_name=None → no core subdir added"""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            sort_by_content=True,
+            sort_by_core=True,
+            core_name=None,
+        )
+        assert result == "/saves/gba"
+
+    def test_sort_by_content_uses_last_folder_not_system(self) -> None:
+        """When last folder differs from system slug, last folder wins."""
+        result = resolve_save_dir(
+            rom_path="psx/Crash (Europe)/Crash.m3u",
+            saves_base="/home/user/saves",
+            system="psx",
+            sort_by_content=True,
+        )
+        assert result == "/home/user/saves/Crash (Europe)"
+
+    def test_flat_with_sort_by_core_and_core_name(self) -> None:
+        """sort_by_content=False + sort_by_core=True → saves/{core} (no content subdir)"""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            sort_by_content=False,
+            sort_by_core=True,
+            core_name="mgba_libretro",
+        )
+        assert result == "/saves/mgba_libretro"
+
+
+# ---------------------------------------------------------------------------
+# resolve_save_filename
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSaveFilename:
+    def test_basic_rom_path(self) -> None:
+        """gba/Pokemon.gba → Pokemon.srm"""
+        assert resolve_save_filename("gba/Pokemon.gba") == "Pokemon.srm"
+
+    def test_default_extension_is_srm(self) -> None:
+        assert resolve_save_filename("snes/Zelda.sfc") == "Zelda.srm"
+
+    def test_custom_extension(self) -> None:
+        assert resolve_save_filename("gba/Game.gba", ext=".sav") == "Game.sav"
+
+    def test_spaces_in_name(self) -> None:
+        assert resolve_save_filename("psx/Crash Bandicoot (USA).bin") == "Crash Bandicoot (USA).srm"
+
+    def test_m3u_strips_m3u_extension(self) -> None:
+        """m3u playlists: strip .m3u, keep base name"""
+        assert resolve_save_filename("psx/Game (USA)/Game (USA).m3u") == "Game (USA).srm"
+
+    def test_rom_without_subdir(self) -> None:
+        """ROM path with no directory component"""
+        assert resolve_save_filename("Game.gba") == "Game.srm"
+
+
+# ---------------------------------------------------------------------------
+# detect_path_change
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPathChange:
+    def test_same_path_returns_false(self) -> None:
+        assert detect_path_change("/saves/gba", "/saves/gba") is False
+
+    def test_different_path_returns_true(self) -> None:
+        assert detect_path_change("/saves/gba", "/saves/Game (USA)") is True
+
+    def test_none_stored_returns_true(self) -> None:
+        """First sync — no stored path yet → treat as changed."""
+        assert detect_path_change(None, "/saves/gba") is True
+
+    def test_trailing_slash_difference(self) -> None:
+        """Paths with vs without trailing slash are different strings."""
+        assert detect_path_change("/saves/gba/", "/saves/gba") is True

--- a/tests/test_save_sync_domain.py
+++ b/tests/test_save_sync_domain.py
@@ -1,0 +1,200 @@
+"""Unit tests for domain.save_sync — v4.7-aware sync action logic."""
+
+from __future__ import annotations
+
+from domain.save_sync import check_server_changed_v47, determine_sync_action
+
+# ---------------------------------------------------------------------------
+# TestCheckServerChangedV47
+# ---------------------------------------------------------------------------
+
+
+class TestCheckServerChangedV47:
+    def test_none_input_returns_none(self):
+        assert check_server_changed_v47(None) is None
+
+    def test_is_current_true_returns_false(self):
+        assert check_server_changed_v47({"is_current": True}) is False
+
+    def test_is_current_false_returns_true(self):
+        assert check_server_changed_v47({"is_current": False}) is True
+
+    def test_missing_is_current_key_returns_none(self):
+        """A device_sync_info dict without is_current is treated as indeterminate."""
+        assert check_server_changed_v47({}) is None
+
+    def test_is_current_none_value_returns_none(self):
+        """is_current=None is treated as indeterminate."""
+        assert check_server_changed_v47({"is_current": None}) is None
+
+
+# ---------------------------------------------------------------------------
+# TestDetermineSyncAction
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineSyncAction:
+    # --- No server save ---
+
+    def test_no_server_save_not_changed_skips(self):
+        result = determine_sync_action(local_changed=False, server_save=None)
+        assert result == "skip"
+
+    def test_no_server_save_local_changed_initial_upload(self):
+        result = determine_sync_action(local_changed=True, server_save=None)
+        assert result == "initial_upload"
+
+    # --- Server save exists, v4.7 device_sync_info ---
+
+    def test_server_exists_neither_changed_skips(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        device_sync_info = {"is_current": True}
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=device_sync_info,
+        )
+        assert result == "skip"
+
+    def test_only_local_changed_uploads(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        device_sync_info = {"is_current": True}
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=device_sync_info,
+        )
+        assert result == "upload"
+
+    def test_only_server_changed_v47_downloads(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T08:00:00Z", "file_size_bytes": 2048}
+        device_sync_info = {"is_current": False}
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=device_sync_info,
+        )
+        assert result == "download"
+
+    def test_both_changed_v47_conflicts(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T08:00:00Z", "file_size_bytes": 2048}
+        device_sync_info = {"is_current": False}
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=device_sync_info,
+        )
+        assert result == "conflict"
+
+    # --- v4.6 fallback (device_sync_info=None, file_state provided) ---
+
+    def test_v46_fallback_server_unchanged_local_unchanged_skips(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        file_state = {
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "skip"
+
+    def test_v46_fallback_server_unchanged_local_changed_uploads(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        file_state = {
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "upload"
+
+    def test_v46_fallback_server_changed_local_unchanged_downloads(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T08:00:00Z", "file_size_bytes": 2048}
+        file_state = {
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "download"
+
+    def test_v46_fallback_both_changed_conflicts(self):
+        server_save = {"id": 1, "updated_at": "2026-02-17T08:00:00Z", "file_size_bytes": 2048}
+        file_state = {
+            "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+            "last_sync_server_size": 1024,
+        }
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "conflict"
+
+    # --- v4.6 indeterminate fallback (check_server_changes_fast returns None) ---
+
+    def test_v46_indeterminate_local_also_changed_conflicts(self):
+        """check_server_changes_fast returns None (timestamp changed) → assume server changed.
+        Both local and server changed → conflict."""
+        server_save = {"id": 1, "updated_at": "2026-02-17T10:00:00Z", "file_size_bytes": 1024}
+        # Timestamp changed → indeterminate
+        file_state = {"last_sync_server_updated_at": "2026-02-17T06:00:00Z"}
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "conflict"
+
+    def test_v46_indeterminate_only_server_changed_downloads(self):
+        """check_server_changes_fast returns None → assume server changed.
+        Only server changed → download."""
+        server_save = {"id": 1, "updated_at": "2026-02-17T10:00:00Z", "file_size_bytes": 1024}
+        file_state = {"last_sync_server_updated_at": "2026-02-17T06:00:00Z"}
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=file_state,
+        )
+        assert result == "download"
+
+    # --- Safe default: server_save exists, no device_sync_info, no file_state ---
+
+    def test_server_exists_no_sync_info_no_file_state_assumes_server_changed(self):
+        """No device_sync_info and no file_state → cannot determine server state.
+        Safe default: assume server changed. Local not changed → download."""
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        result = determine_sync_action(
+            local_changed=False,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=None,
+        )
+        assert result == "download"
+
+    def test_server_exists_no_sync_info_no_file_state_local_also_changed_conflicts(self):
+        """No device_sync_info and no file_state → assume server changed.
+        Local also changed → conflict."""
+        server_save = {"id": 1, "updated_at": "2026-02-17T06:00:00Z", "file_size_bytes": 1024}
+        result = determine_sync_action(
+            local_changed=True,
+            server_save=server_save,
+            device_sync_info=None,
+            file_state=None,
+        )
+        assert result == "conflict"


### PR DESCRIPTION
## Summary

- Add `domain/save_sync.py` — unified sync action logic with v4.7 `is_current` device sync awareness and v4.6 timestamp/hash fallback
- Add `domain/save_path.py` — RetroArch save directory layout resolution (`sort_by_content`, `sort_by_core`)
- Add `domain/emulator_tag.py` — RomM emulator tag construction (`retroarch-{core}` format)
- Add `domain/save_extensions.py` — per-platform save file extension config (default + override mechanism, expansion in #186)

Pure domain functions only — no I/O, no service/adapter imports. 60 new tests.

Closes #183
Depends on #187

## Test plan

- [x] 60 new unit tests all passing
- [x] Full suite: 1507 passed
- [x] ruff: 0 errors
- [x] basedpyright: 0 errors
- [x] import-linter: 6/6 contracts kept (layer boundaries clean)