### PR TITLE
feat(saves): save sync v2 service refactoring (#184)

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,6 +148,7 @@ class Plugin:
                 runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
                 emit=decky.emit,
                 get_saves_path=retrodeck_config.get_saves_path,
+                get_roms_path=retrodeck_config.get_roms_path,
                 save_state=self._save_state,
                 save_settings_to_disk=self._save_settings_to_disk,
                 save_metadata_cache=self._save_metadata_cache,

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -34,6 +34,7 @@ from services.protocols import (
     DebugLogger,
     EventEmitter,
     RommApiProtocol,
+    RomsPathProvider,
     SavesPathProvider,
     SettingsPersister,
     StatePersister,
@@ -71,6 +72,7 @@ class WiringConfig:
 
     # Callbacks
     get_saves_path: SavesPathProvider
+    get_roms_path: RomsPathProvider
     save_state: StatePersister
     save_settings_to_disk: SettingsPersister
     save_metadata_cache: StatePersister
@@ -127,6 +129,18 @@ def bootstrap(
     }
 
 
+def _read_plugin_version(plugin_dir: str) -> str:
+    """Read plugin version from package.json."""
+    import json
+    import os
+
+    try:
+        with open(os.path.join(plugin_dir, "package.json")) as f:
+            return json.load(f).get("version", "0.0.0")
+    except (OSError, json.JSONDecodeError):
+        return "0.0.0"
+
+
 def wire_services(cfg: WiringConfig) -> dict:
     """Create service instances after plugin state is initialised.
 
@@ -148,6 +162,9 @@ def wire_services(cfg: WiringConfig) -> dict:
         logger=cfg.logger,
         runtime_dir=cfg.runtime_dir,
         get_saves_path=cfg.get_saves_path,
+        get_roms_path=cfg.get_roms_path,
+        get_active_core=_es_de_config.get_active_core,
+        plugin_version=_read_plugin_version(cfg.plugin_dir),
     )
 
     playtime_service = PlaytimeService(

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -16,6 +16,7 @@ def resolve_save_dir(
     saves_base: str,
     system: str,
     *,
+    roms_base: str | None = None,
     sort_by_content: bool = True,
     sort_by_core: bool = False,
     core_name: str | None = None,
@@ -25,12 +26,17 @@ def resolve_save_dir(
     Parameters
     ----------
     rom_path:
-        Relative ROM file path as stored in RomM (e.g. "gba/Game.gba" or
+        ROM file path — absolute or relative (e.g. "gba/Game.gba",
+        "/home/deck/retrodeck/roms/gba/Game.gba", or
         "psx/Game (USA)/Game.m3u").
     saves_base:
         Absolute path to the RetroArch saves root directory.
     system:
         Platform/system slug (e.g. "gba", "psx"). Used as fallback subdir.
+    roms_base:
+        If provided, strip this absolute prefix from rom_path before
+        computing the content directory. Allows callers to pass absolute
+        ROM paths directly without pre-stripping.
     sort_by_content:
         If True, save subdir = last folder component of rom_path.
         RetroDECK default: True.
@@ -45,11 +51,21 @@ def resolve_save_dir(
     str
         Absolute path to the directory where save files should be found/placed.
     """
+    # Strip roms_base prefix if provided to get a relative path
+    effective_path = rom_path
+    if roms_base is not None:
+        norm_rom = os.path.normpath(rom_path)
+        norm_base = os.path.normpath(roms_base)
+        if norm_rom.startswith(norm_base + os.sep):
+            effective_path = norm_rom[len(norm_base) + 1 :]
+        elif norm_rom.startswith(norm_base):
+            effective_path = norm_rom[len(norm_base) :]
+
     parts: list[str] = [saves_base]
 
     if sort_by_content:
-        # Last folder component of the rom_path (i.e. the directory containing the ROM file)
-        rom_dir = os.path.dirname(rom_path)
+        # Last folder component of the effective_path (i.e. the directory containing the ROM file)
+        rom_dir = os.path.dirname(effective_path)
         content_dir = os.path.basename(rom_dir) if rom_dir else system
         parts.append(content_dir)
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -318,6 +318,18 @@ class SavesPathProvider(Protocol):
     def __call__(self) -> str: ...
 
 
+class RomsPathProvider(Protocol):
+    """Return the current RetroDECK roms directory path."""
+
+    def __call__(self) -> str: ...
+
+
+class CoreResolverFn(Protocol):
+    """Resolve the active RetroArch core for a system/game."""
+
+    def __call__(self, system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]: ...
+
+
 class SyncStateRef(Protocol):
     """Return the current sync state value (used by ArtworkService)."""
 

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from models.saves import SaveConflict
 
+from domain.emulator_tag import build_emulator_tag
 from domain.save_conflicts import (
     build_conflict_dict,
     check_local_changes,
@@ -29,8 +30,11 @@ from domain.save_conflicts import (
     determine_action,
     resolve_conflict_by_mode,
 )
+from domain.save_extensions import get_save_extensions
+from domain.save_path import resolve_save_dir
+from domain.save_sync import determine_sync_action
 from lib.errors import RommApiError, RommConflictError, classify_error
-from services.protocols import RetryStrategy, RommApiProtocol, SavesPathProvider
+from services.protocols import CoreResolverFn, RetryStrategy, RommApiProtocol, RomsPathProvider, SavesPathProvider
 
 _DEVICE_NOT_REGISTERED = "Device not registered"
 
@@ -63,6 +67,11 @@ class SaveService:
         ``save_sync_state.json`` persistence).
     get_saves_path:
         Callable returning the current RetroDECK saves directory.
+    get_roms_path:
+        Callable returning the current RetroDECK roms directory.
+    get_active_core:
+        Callable resolving the active RetroArch core for a system/game.
+        Returns ``(core_so, label)`` tuple; either may be None if unresolved.
     """
 
     def __init__(
@@ -76,6 +85,9 @@ class SaveService:
         logger: logging.Logger,
         runtime_dir: str,
         get_saves_path: SavesPathProvider,
+        get_roms_path: RomsPathProvider,
+        get_active_core: CoreResolverFn,
+        plugin_version: str = "0.0.0",
     ) -> None:
         self._romm_api = romm_api
         self._retry = retry
@@ -85,6 +97,9 @@ class SaveService:
         self._logger = logger
         self._runtime_dir = runtime_dir
         self._get_saves_path = get_saves_path
+        self._get_roms_path = get_roms_path
+        self._get_active_core = get_active_core
+        self._plugin_version = plugin_version
 
     # ------------------------------------------------------------------
     # Debug logging helper
@@ -92,6 +107,10 @@ class SaveService:
 
     def _log_debug(self, msg: str) -> None:
         self._logger.debug(msg)
+
+    def _get_server_device_id(self) -> str | None:
+        """Return the server device ID if registered, else None."""
+        return self._save_sync_state.get("server_device_id")
 
     # ------------------------------------------------------------------
     # State Management
@@ -104,6 +123,7 @@ class SaveService:
             "version": 1,
             "device_id": None,
             "device_name": None,
+            "server_device_id": None,
             "saves": {},
             "playtime": {},
             "settings": {
@@ -133,7 +153,7 @@ class SaveService:
             for key in ("saves", "playtime"):
                 if key in saved:
                     self._save_sync_state[key] = saved[key]
-            for key in ("version", "device_id", "device_name"):
+            for key in ("version", "device_id", "device_name", "server_device_id"):
                 if key in saved:
                     self._save_sync_state[key] = saved[key]
             if "settings" in saved:
@@ -177,10 +197,11 @@ class SaveService:
     # ROM / path helpers
     # ------------------------------------------------------------------
 
-    def _get_rom_save_info(self, rom_id: int) -> tuple[str, str, str] | None:
+    def _get_rom_save_info(self, rom_id: int) -> dict | None:
         """Get save-related info for an installed ROM.
 
-        Returns ``(system, rom_name, saves_dir)`` or ``None`` if not installed.
+        Returns dict with keys: system, rom_name, saves_dir, platform_slug, file_path
+        or None if not installed.
         """
         rom_id_str = str(int(rom_id))
         installed = self._state["installed_roms"].get(rom_id_str)
@@ -188,12 +209,32 @@ class SaveService:
             return None
         system = installed.get("system", "")
         file_path = installed.get("file_path", "")
+        platform_slug = installed.get("platform_slug", "")
         if not system or not file_path:
             return None
         rom_name = os.path.splitext(os.path.basename(file_path))[0]
+
+        # Use domain save path resolution.
+        # RetroDECK defaults: sort_by_content=True, sort_by_core=False
+        # TODO(#186): Read sort_savefiles_by_content_enable / sort_savefiles_enable from retroarch.cfg
         saves_base = self._get_saves_path()
-        saves_dir = os.path.join(saves_base, system)
-        return system, rom_name, saves_dir
+        roms_base = self._get_roms_path()
+        saves_dir = resolve_save_dir(
+            file_path,
+            saves_base,
+            system,
+            roms_base=roms_base,
+            sort_by_content=True,
+            sort_by_core=False,
+        )
+
+        return {
+            "system": system,
+            "rom_name": rom_name,
+            "saves_dir": saves_dir,
+            "platform_slug": platform_slug,
+            "file_path": file_path,
+        }
 
     # ------------------------------------------------------------------
     # File Helpers
@@ -209,18 +250,20 @@ class SaveService:
         return h.hexdigest()
 
     def _find_save_files(self, rom_id: int) -> list[dict]:
-        """Find local save files (.srm, .rtc) for a ROM.
+        """Find local save files for a ROM.
 
         Returns list of ``{"path": str, "filename": str}``.
         """
         info = self._get_rom_save_info(rom_id)
         if not info:
             return []
-        _system, rom_name, saves_dir = info
+        rom_name = info["rom_name"]
+        saves_dir = info["saves_dir"]
+        platform_slug = info["platform_slug"]
         if not os.path.isdir(saves_dir):
             return []
         results = []
-        for ext in (".srm", ".rtc"):
+        for ext in get_save_extensions(platform_slug):
             save_path = os.path.join(saves_dir, rom_name + ext)
             if os.path.isfile(save_path):
                 results.append({"path": save_path, "filename": rom_name + ext})
@@ -287,6 +330,20 @@ class SaveService:
                 file_state["last_sync_server_size"] = server_size
         return False
 
+    def _extract_device_sync_info(self, server_save: dict) -> dict | None:
+        """Extract this device's sync info from server save response.
+
+        Returns the device_syncs entry for our server_device_id, or None.
+        """
+        server_device_id = self._get_server_device_id()
+        if not server_device_id:
+            return None
+        device_syncs = server_save.get("device_syncs", [])
+        for sync in device_syncs:
+            if str(sync.get("device_id")) == server_device_id:
+                return sync
+        return None
+
     def _detect_conflict(self, rom_id: int, filename: str, local_hash: str | None, server_save: dict) -> str:
         """Hybrid conflict detection (no content_hash on RomM 4.6.1).
 
@@ -310,11 +367,24 @@ class SaveService:
             return "download"
 
         local_changed = check_local_changes(local_hash, last_sync_hash)
+
+        # v4.7: try device_syncs from server response
+        device_sync_info = self._extract_device_sync_info(server_save)
+        if device_sync_info is not None:
+            # Use v4.7 path — avoids expensive server hash download
+            result = determine_sync_action(local_changed, server_save, device_sync_info, file_state)
+            self._log_debug(
+                f"_detect_conflict({rom_id}, {filename}): v4.7 path "
+                f"local_changed={local_changed} is_current={device_sync_info.get('is_current')} → {result}"
+            )
+            return result
+
+        # v4.6 fallback: existing slow-path logic
         server_changed = self._check_server_changes(file_state, server_save, last_sync_hash)
         result = determine_action(local_changed, server_changed)
 
         self._log_debug(
-            f"_detect_conflict({rom_id}, {filename}): "
+            f"_detect_conflict({rom_id}, {filename}): v4.6 path "
             f"local_hash={local_hash[:8] if local_hash else None}… "
             f"baseline={last_sync_hash[:8] if last_sync_hash else None}… "
             f"local_changed={local_changed} server_changed={server_changed} → {result}"
@@ -339,17 +409,31 @@ class SaveService:
         return detect_conflict_lightweight(local_mtime, local_size, server_save, file_state)
 
     def _update_file_sync_state(
-        self, rom_id_str: str, filename: str, server_response: dict, local_path: str, system: str
+        self,
+        rom_id_str: str,
+        filename: str,
+        server_response: dict,
+        local_path: str,
+        system: str,
+        *,
+        emulator_tag: str | None = None,
+        core_so: str | None = None,
     ) -> None:
         """Update per-file sync tracking after a successful sync operation."""
         if rom_id_str not in self._save_sync_state["saves"]:
             self._save_sync_state["saves"][rom_id_str] = {
                 "files": {},
-                "emulator": "retroarch",
+                "emulator": emulator_tag or "retroarch",
                 "system": system,
+                "active_core": core_so,
+                "active_slot": "default",
             }
         save_entry = self._save_sync_state["saves"][rom_id_str]
         save_entry.setdefault("files", {})
+        if emulator_tag is not None:
+            save_entry["emulator"] = emulator_tag
+        if core_so is not None:
+            save_entry["active_core"] = core_so
 
         now = datetime.now(UTC).isoformat()
         local_hash = self._file_md5(local_path) if os.path.isfile(local_path) else ""
@@ -366,6 +450,7 @@ class SaveService:
             "last_sync_server_save_id": server_response.get("id"),
             "last_sync_server_size": server_response.get("file_size_bytes"),
             "local_mtime_at_last_sync": local_mtime,
+            "tracked_save_id": server_response.get("id"),
         }
 
     # ------------------------------------------------------------------
@@ -404,12 +489,27 @@ class SaveService:
         """Upload a local save file to server."""
         save_id = server_save.get("id") if server_save else None
 
+        # Resolve active core for emulator tag
+        installed = self._state["installed_roms"].get(rom_id_str, {})
+        rom_filename = os.path.basename(installed.get("file_path", "")) or None
+        core_so, _label = self._get_active_core(system, rom_filename)
+        emulator = build_emulator_tag(core_so)
+
+        # v4.7: pass device_id and slot
+        device_id = self._get_server_device_id()
+        game_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
+        slot = game_state.get("active_slot", "default") if device_id else None
+
         result = self._retry.with_retry(
-            lambda: self._romm_api.upload_save(int(rom_id), file_path, "retroarch", save_id)
+            lambda: self._romm_api.upload_save(
+                int(rom_id), file_path, emulator, save_id, device_id=device_id, slot=slot
+            )
         )
 
-        self._update_file_sync_state(rom_id_str, filename, result, file_path, system)
-        self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str}")
+        self._update_file_sync_state(
+            rom_id_str, filename, result, file_path, system, emulator_tag=emulator, core_so=core_so
+        )
+        self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
         return result
 
     def _sync_single_save_file(
@@ -580,12 +680,15 @@ class SaveService:
         if not info:
             self._log_debug(f"_sync_rom_saves({rom_id}): no save info, skipping")
             return 0, [], []
-        system, rom_name, saves_dir = info
+        system = info["system"]
+        rom_name = info["rom_name"]
+        saves_dir = info["saves_dir"]
 
         # Fetch server saves (with retry)
         t0 = time.time()
         try:
-            server_saves = self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id))
+            device_id = self._get_server_device_id()
+            server_saves = self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id, device_id=device_id))
         except Exception as e:
             self._logger.error(f"_sync_rom_saves({rom_id}): failed to list saves: {e}")
             _code, _msg = classify_error(e)
@@ -789,25 +892,54 @@ class SaveService:
     def ensure_device_registered(self) -> dict:
         """Ensure this device has a unique ID for save sync tracking.
 
-        Generates a local UUID on first use — no server registration needed.
+        v4.7+: Register with RomM server via register_device() API.
+        v4.6: Generate local UUID (no server registration).
         """
         if not self._is_save_sync_enabled():
             return {"success": False, "device_id": "", "device_name": "", "disabled": True}
 
+        # Already registered (either local or server)
         if self._save_sync_state.get("device_id"):
             return {
                 "success": True,
                 "device_id": self._save_sync_state["device_id"],
                 "device_name": self._save_sync_state.get("device_name", ""),
+                "server_device_id": self._save_sync_state.get("server_device_id"),
             }
 
         hostname = socket.gethostname()
-        device_id = str(uuid.uuid4())
 
+        # Try v4.7 server registration
+        if self._romm_api.supports_device_sync():
+            try:
+                result = self._romm_api.register_device(
+                    name=hostname,
+                    platform="linux",
+                    client="decky-romm-sync",
+                    version=self._plugin_version,
+                )
+                server_device_id = result.get("id") or result.get("device_id")
+                if server_device_id:
+                    self._save_sync_state["device_id"] = str(server_device_id)
+                    self._save_sync_state["device_name"] = hostname
+                    self._save_sync_state["server_device_id"] = str(server_device_id)
+                    self.save_state()
+                    self._logger.info(f"Device registered with server: {server_device_id} ({hostname})")
+                    return {
+                        "success": True,
+                        "device_id": str(server_device_id),
+                        "device_name": hostname,
+                        "server_device_id": str(server_device_id),
+                    }
+            except Exception as e:
+                self._logger.warning(f"Server device registration failed, falling back to local: {e}")
+
+        # v4.6 fallback or server registration failed
+        device_id = str(uuid.uuid4())
         self._save_sync_state["device_id"] = device_id
         self._save_sync_state["device_name"] = hostname
         self.save_state()
-        self._logger.info(f"Device ID generated: {device_id} ({hostname})")
+        self._logger.info(f"Device ID generated (local): {device_id} ({hostname})")
         return {"success": True, "device_id": device_id, "device_name": hostname}
 
     async def get_save_status(self, rom_id: int) -> dict:
@@ -816,9 +948,10 @@ class SaveService:
 
         server_saves: list[dict] = []
         try:
+            device_id = self._get_server_device_id()
             server_saves = await self._loop.run_in_executor(
                 None,
-                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id)),
+                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id, device_id=device_id)),
             )
         except Exception as e:
             self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
@@ -833,9 +966,10 @@ class SaveService:
 
         server_saves: list[dict] = []
         try:
+            device_id = self._get_server_device_id()
             server_saves = await self._loop.run_in_executor(
                 None,
-                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id)),
+                lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id, device_id=device_id)),
             )
         except Exception as e:
             self._log_debug(f"Lightweight save check failed for rom {rom_id}: {e}")
@@ -1069,7 +1203,8 @@ class SaveService:
         info = self._get_rom_save_info(rom_id)
         if not info:
             return {"success": False, "message": "ROM not installed"}
-        system, _rom_name, saves_dir = info
+        system = info["system"]
+        saves_dir = info["saves_dir"]
 
         try:
             result = await self._loop.run_in_executor(

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -25,6 +25,9 @@ class FakeSaveApi:
         self._next_note_id = 2000
         self._fail_on_next: Exception | None = None
         self.heartbeat_raises: Exception | None = None
+        self._supports_device_sync = False
+        self._registered_devices: list[dict] = []
+        self._next_device_id = 1
 
     def fail_on_next(self, exc: Exception) -> None:
         """Make the next call raise the given exception."""
@@ -103,10 +106,16 @@ class FakeSaveApi:
         raise NotImplementedError
 
     def supports_device_sync(self) -> bool:
-        return False
+        return self._supports_device_sync
 
     def register_device(self, name: str, platform: str, client: str, version: str) -> dict:
-        raise NotImplementedError
+        self.call_log.append(("register_device", (name, platform, client, version), {}))
+        self._check_fail()
+        device_id = f"device-{self._next_device_id}"
+        self._next_device_id += 1
+        device = {"id": device_id, "name": name, "created_at": datetime.now(UTC).isoformat()}
+        self._registered_devices.append(device)
+        return device
 
     def download_save_content(
         self,
@@ -137,7 +146,13 @@ class FakeSaveApi:
     ) -> list[dict]:
         self.call_log.append(("list_saves", (rom_id,), {"device_id": device_id, "slot": slot}))
         self._check_fail()
-        return [s for s in self.saves.values() if s.get("rom_id") == rom_id]
+        saves = [s for s in self.saves.values() if s.get("rom_id") == rom_id]
+        if device_id:
+            # Simulate server adding device_syncs when device_id is provided
+            for s in saves:
+                if "device_syncs" not in s:
+                    s["device_syncs"] = [{"device_id": device_id, "is_current": True}]
+        return saves
 
     def upload_save(
         self,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -127,6 +127,7 @@ class TestWireServices:
             "runtime_dir": str(tmp_path / "runtime"),
             "emit": AsyncMock(),
             "get_saves_path": MagicMock(return_value=str(tmp_path / "saves")),
+            "get_roms_path": MagicMock(return_value=str(tmp_path / "retrodeck" / "roms")),
             "save_state": MagicMock(),
             "save_settings_to_disk": MagicMock(),
             "save_metadata_cache": MagicMock(),

--- a/tests/test_cache_detail.py
+++ b/tests/test_cache_detail.py
@@ -86,6 +86,8 @@ def plugin(tmp_path):
         logger=logging.getLogger("test"),
         runtime_dir=str(tmp_path),
         get_saves_path=lambda: saves_path,
+        get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
+        get_active_core=lambda system_name, rom_filename=None: (None, None),
     )
     p._save_sync_service.init_state()
 

--- a/tests/test_save_path.py
+++ b/tests/test_save_path.py
@@ -104,6 +104,51 @@ class TestResolveSaveDir:
         )
         assert result == "/saves/mgba_libretro"
 
+    def test_resolve_save_dir_absolute_path_with_roms_base(self) -> None:
+        """Absolute ROM path + roms_base strips prefix → saves/gba"""
+        result = resolve_save_dir(
+            rom_path="/home/deck/retrodeck/roms/gba/pokemon.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            roms_base="/home/deck/retrodeck/roms",
+            sort_by_content=True,
+        )
+        assert result == "/saves/gba"
+
+    def test_resolve_save_dir_absolute_path_subfolder_with_roms_base(self) -> None:
+        """Multi-disc ROM in subfolder with absolute path → saves/Game (USA)"""
+        result = resolve_save_dir(
+            rom_path="/home/deck/retrodeck/roms/psx/Game (USA)/Game.m3u",
+            saves_base=self.SAVES_BASE,
+            system="psx",
+            roms_base="/home/deck/retrodeck/roms",
+            sort_by_content=True,
+        )
+        assert result == "/saves/Game (USA)"
+
+    def test_resolve_save_dir_roms_base_none_uses_path_as_is(self) -> None:
+        """When roms_base=None, rom_path is used as-is (old behaviour preserved)."""
+        result = resolve_save_dir(
+            rom_path="gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            roms_base=None,
+            sort_by_content=True,
+        )
+        assert result == "/saves/gba"
+
+    def test_resolve_save_dir_roms_base_no_match(self) -> None:
+        """When roms_base doesn't match the rom_path prefix, full path is used as-is."""
+        result = resolve_save_dir(
+            rom_path="/other/location/roms/gba/Game.gba",
+            saves_base=self.SAVES_BASE,
+            system="gba",
+            roms_base="/home/deck/retrodeck/roms",
+            sort_by_content=True,
+        )
+        # dirname of the full path is /other/location/roms/gba → basename is gba
+        assert result == "/saves/gba"
+
 
 # ---------------------------------------------------------------------------
 # resolve_save_filename

--- a/tests/test_save_service.py
+++ b/tests/test_save_service.py
@@ -43,6 +43,9 @@ def make_service(tmp_path, fake_api=None, **overrides) -> tuple["SaveService", "
         logger=logging.getLogger("test"),
         runtime_dir=str(tmp_path),
         get_saves_path=lambda: str(tmp_path / "saves"),
+        get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
+        get_active_core=lambda system_name, rom_filename=None: (None, None),
+        plugin_version="0.14.0",
     )
     defaults.update(overrides)
     svc = SaveService(**defaults)
@@ -188,6 +191,70 @@ class TestDeviceRegistration:
         result = svc.ensure_device_registered()
         assert result["success"] is False
         assert result.get("disabled") is True
+
+
+# ---------------------------------------------------------------------------
+# TestDeviceRegistrationV47
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceRegistrationV47:
+    def test_registers_with_server_on_v47(self, tmp_path):
+        """v4.7: calls register_device and stores server_device_id."""
+        fake = FakeSaveApi()
+        fake._supports_device_sync = True
+        svc, _ = make_service(tmp_path, fake_api=fake)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        result = svc.ensure_device_registered()
+        assert result["success"] is True
+        assert result.get("server_device_id") is not None
+        assert svc._save_sync_state["server_device_id"] == result["server_device_id"]
+        # Verify register_device was called
+        reg_calls = [c for c in fake.call_log if c[0] == "register_device"]
+        assert len(reg_calls) == 1
+        assert reg_calls[0][1][0]  # name (hostname)
+        assert reg_calls[0][1][1] == "linux"  # platform
+        assert reg_calls[0][1][2] == "decky-romm-sync"  # client
+
+    def test_falls_back_to_local_on_server_failure(self, tmp_path):
+        """v4.7: if register_device fails, falls back to local UUID."""
+        fake = FakeSaveApi()
+        fake._supports_device_sync = True
+        fake.fail_on_next(Exception("server error"))
+        svc, _ = make_service(tmp_path, fake_api=fake)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        result = svc.ensure_device_registered()
+        assert result["success"] is True
+        assert result["device_id"]  # got a local UUID
+        assert result.get("server_device_id") is None  # no server registration
+        assert svc._save_sync_state.get("server_device_id") is None
+
+    def test_v46_uses_local_uuid(self, tmp_path):
+        """v4.6: generates local UUID without server contact."""
+        svc, fake = make_service(tmp_path)  # default: supports_device_sync=False
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        result = svc.ensure_device_registered()
+        assert result["success"] is True
+        assert result["device_id"]
+        assert result.get("server_device_id") is None
+        # No register_device call
+        reg_calls = [c for c in fake.call_log if c[0] == "register_device"]
+        assert len(reg_calls) == 0
+
+    def test_returns_existing_with_server_device_id(self, tmp_path):
+        """If already registered, returns existing IDs including server_device_id."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "existing-id"
+        svc._save_sync_state["device_name"] = "deck"
+        svc._save_sync_state["server_device_id"] = "server-id-123"
+
+        result = svc.ensure_device_registered()
+        assert result["device_id"] == "existing-id"
+        assert result.get("server_device_id") == "server-id-123"
 
 
 # ---------------------------------------------------------------------------
@@ -1069,6 +1136,44 @@ class TestDeleteSaves:
         assert result["success"] is True
         assert result["deleted_count"] == 0
 
+
+# ---------------------------------------------------------------------------
+# TestEmulatorTag
+# ---------------------------------------------------------------------------
+
+
+class TestEmulatorTag:
+    def test_upload_uses_emulator_tag_from_core(self, tmp_path):
+        """When core resolver returns a core, upload uses retroarch-{core} tag."""
+        svc, fake = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+        )
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        svc._do_upload_save(42, str(tmp_path / "saves" / "gba" / "pokemon.srm"), "pokemon.srm", "42", "gba")
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        _name, args, _kwargs = upload_calls[0]
+        assert args[2] == "retroarch-mgba"  # emulator argument
+
+    def test_upload_uses_fallback_when_no_core(self, tmp_path):
+        """When core resolver returns None, upload falls back to 'retroarch'."""
+        svc, fake = make_service(tmp_path)  # default: get_active_core returns (None, None)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        svc._do_upload_save(42, str(tmp_path / "saves" / "gba" / "pokemon.srm"), "pokemon.srm", "42", "gba")
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        _name, args, _kwargs = upload_calls[0]
+        assert args[2] == "retroarch"
+
     @pytest.mark.asyncio
     async def test_delete_platform_saves(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -1134,7 +1239,11 @@ class TestFindSaveFiles:
             "rom_dir": str(tmp_path / "retrodeck" / "roms" / "psx" / "FF7"),
             "installed_at": "2026-01-01T00:00:00",
         }
-        _create_save(tmp_path, system="psx", rom_name="Final Fantasy VII")
+        # With sort_by_content=True, saves land in saves_base/{content_dir} where
+        # content_dir = last folder component of the ROM's directory = "FF7"
+        saves_dir = tmp_path / "saves" / "FF7"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        (saves_dir / "Final Fantasy VII.srm").write_bytes(b"\x00" * 1024)
 
         result = svc._find_save_files(55)
 
@@ -1352,10 +1461,9 @@ class TestGetRomSaveInfo:
         result = svc._get_rom_save_info(42)
 
         assert result is not None
-        system, rom_name, saves_dir = result
-        assert system == "gba"
-        assert rom_name == "pokemon"
-        assert saves_dir.endswith("saves/gba")
+        assert result["system"] == "gba"
+        assert result["rom_name"] == "pokemon"
+        assert result["saves_dir"].endswith("saves/gba")
 
     def test_returns_none_for_missing_rom(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -1421,6 +1529,83 @@ class TestUpdateFileSyncState:
         assert entry["last_sync_at"] is not None
         assert entry["last_sync_server_save_id"] == 200
 
+    def test_creates_entry_with_new_fields(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        save_file = _create_save(tmp_path)
+        server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}
+
+        svc._update_file_sync_state(
+            "42",
+            "pokemon.srm",
+            server_resp,
+            str(save_file),
+            "gba",
+            emulator_tag="retroarch-mgba",
+            core_so="mgba_libretro",
+        )
+
+        game_state = svc._save_sync_state["saves"]["42"]
+        assert game_state["emulator"] == "retroarch-mgba"
+        assert game_state["active_core"] == "mgba_libretro"
+        assert game_state["active_slot"] == "default"
+
+        file_state = game_state["files"]["pokemon.srm"]
+        assert file_state["tracked_save_id"] == 200
+        assert file_state["last_sync_server_save_id"] == 200
+
+    def test_updates_emulator_on_existing_entry(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        save_file = _create_save(tmp_path)
+        # Pre-populate with old emulator tag
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {},
+            "emulator": "retroarch",
+            "system": "gba",
+            "active_core": None,
+            "active_slot": "default",
+        }
+        server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}
+
+        svc._update_file_sync_state(
+            "42",
+            "pokemon.srm",
+            server_resp,
+            str(save_file),
+            "gba",
+            emulator_tag="retroarch-mgba",
+            core_so="mgba_libretro",
+        )
+
+        game_state = svc._save_sync_state["saves"]["42"]
+        assert game_state["emulator"] == "retroarch-mgba"
+        assert game_state["active_core"] == "mgba_libretro"
+
+    def test_core_so_none_does_not_overwrite(self, tmp_path):
+        """core_so=None should not reset an already-set active_core."""
+        svc, _ = make_service(tmp_path)
+        save_file = _create_save(tmp_path)
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {},
+            "emulator": "retroarch-mgba",
+            "system": "gba",
+            "active_core": "mgba_libretro",
+            "active_slot": "default",
+        }
+        server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}
+
+        svc._update_file_sync_state(
+            "42",
+            "pokemon.srm",
+            server_resp,
+            str(save_file),
+            "gba",
+            emulator_tag="retroarch",
+        )
+
+        # active_core unchanged because core_so=None
+        game_state = svc._save_sync_state["saves"]["42"]
+        assert game_state["active_core"] == "mgba_libretro"
+
 
 # ---------------------------------------------------------------------------
 # TestPruneOrphanedEdgeCase
@@ -1440,3 +1625,235 @@ class TestPruneOrphanedEdgeCase:
 
         assert svc._save_sync_state["saves"] == {}
         assert svc._save_sync_state["playtime"] == {}
+
+
+# ---------------------------------------------------------------------------
+# TestStateBackwardCompat
+# ---------------------------------------------------------------------------
+
+
+class TestStateBackwardCompat:
+    """Backward compat: old state files without new fields load and work."""
+
+    def test_old_state_without_server_device_id_loads_fine(self, tmp_path):
+        """Existing state files without server_device_id should load without errors."""
+        svc, _ = make_service(tmp_path)
+        # Simulate old state without server_device_id
+        svc._save_sync_state["device_id"] = "old-local-uuid"
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
+            "emulator": "retroarch",
+            "system": "gba",
+        }
+        # Remove the new field to simulate an old state file
+        del svc._save_sync_state["server_device_id"]
+        svc.save_state()
+
+        # Reload into fresh service
+        svc2, _ = make_service(tmp_path)
+        svc2.load_state()
+
+        # New field should be None (from init_state default)
+        assert svc2._save_sync_state.get("server_device_id") is None
+        # Old data preserved
+        assert svc2._save_sync_state["device_id"] == "old-local-uuid"
+        assert "42" in svc2._save_sync_state["saves"]
+
+    def test_old_per_game_entry_missing_new_fields_works_via_get(self, tmp_path):
+        """Per-game entries without active_core/active_slot still work via .get()."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["device_id"] = "old-local-uuid"
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
+            "emulator": "retroarch",
+            "system": "gba",
+        }
+        svc.save_state()
+
+        svc2, _ = make_service(tmp_path)
+        svc2.load_state()
+
+        game_state = svc2._save_sync_state["saves"]["42"]
+        assert game_state.get("active_core") is None
+        assert game_state.get("active_slot", "default") == "default"
+
+    def test_make_default_state_includes_server_device_id(self):
+        """make_default_state() must include server_device_id field."""
+        state = SaveService.make_default_state()
+        assert "server_device_id" in state
+        assert state["server_device_id"] is None
+
+    def test_load_state_restores_server_device_id(self, tmp_path):
+        """server_device_id saved to disk is restored on load_state."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["server_device_id"] = "romm-server-uuid"
+        svc.save_state()
+
+        svc2, _ = make_service(tmp_path)
+        svc2.load_state()
+        assert svc2._save_sync_state["server_device_id"] == "romm-server-uuid"
+
+    def test_state_stores_emulator_tag_and_core(self, tmp_path):
+        """After upload sync, state should contain emulator tag and core info."""
+        svc, _fake = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+        )
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+
+        svc._do_upload_save(42, str(save_path), "pokemon.srm", "42", "gba")
+
+        game_state = svc._save_sync_state["saves"]["42"]
+        assert game_state["emulator"] == "retroarch-mgba"
+        assert game_state["active_core"] == "mgba_libretro"
+        assert game_state.get("active_slot") == "default"
+
+        # Per-file should have tracked_save_id
+        file_state = game_state["files"]["pokemon.srm"]
+        assert file_state.get("tracked_save_id") is not None
+
+    def test_download_sets_tracked_save_id_in_file_state(self, tmp_path):
+        """After download sync, per-file state should contain tracked_save_id."""
+        svc, _ = make_service(tmp_path)
+        saves_dir = str(tmp_path / "saves" / "gba")
+        os.makedirs(saves_dir, exist_ok=True)
+        server_save = _server_save(save_id=99)
+
+        svc._do_download_save(server_save, saves_dir, "pokemon.srm", "42", "gba")
+
+        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
+        assert file_state.get("tracked_save_id") == 99
+        assert file_state.get("last_sync_server_save_id") == 99
+
+
+# ---------------------------------------------------------------------------
+# TestV47SyncFlow
+# ---------------------------------------------------------------------------
+
+
+class TestV47SyncFlow:
+    def test_list_saves_passes_device_id(self, tmp_path):
+        """v4.7: list_saves receives server_device_id."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "local-id"
+        svc._save_sync_state["server_device_id"] = "server-dev-123"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        svc._sync_rom_saves(42)
+
+        list_calls = [c for c in fake.call_log if c[0] == "list_saves"]
+        assert len(list_calls) >= 1
+        assert list_calls[0][2]["device_id"] == "server-dev-123"
+
+    def test_upload_passes_device_id_and_slot(self, tmp_path):
+        """v4.7: upload_save receives device_id and slot."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "local-id"
+        svc._save_sync_state["server_device_id"] = "server-dev-123"
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+
+        svc._do_upload_save(42, str(save_path), "pokemon.srm", "42", "gba")
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["device_id"] == "server-dev-123"
+        assert upload_calls[0][2]["slot"] == "default"
+
+    def test_v46_does_not_pass_device_id(self, tmp_path):
+        """v4.6: no device_id or slot passed to API calls."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "local-uuid"
+        # No server_device_id set
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        svc._sync_rom_saves(42)
+
+        list_calls = [c for c in fake.call_log if c[0] == "list_saves"]
+        assert list_calls[0][2]["device_id"] is None
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        if upload_calls:
+            assert upload_calls[0][2]["device_id"] is None
+            assert upload_calls[0][2]["slot"] is None
+
+    def test_v47_skip_when_is_current(self, tmp_path):
+        """v4.7: server says is_current=True, local unchanged → skip."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["server_device_id"] = "dev-1"
+        _install_rom(svc, tmp_path)
+        content = b"same content"
+        _create_save(tmp_path, content=content)
+        local_hash = hashlib.md5(content).hexdigest()
+
+        # Pre-populate sync state (simulating previous sync)
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {
+                "pokemon.srm": {
+                    "last_sync_hash": local_hash,
+                    "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                    "last_sync_server_save_id": 100,
+                    "last_sync_server_size": len(content),
+                }
+            }
+        }
+
+        # Set up server save with device_syncs showing is_current=True
+        fake.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T06:00:00Z",
+            "file_size_bytes": len(content),
+            "device_syncs": [{"device_id": "dev-1", "is_current": True}],
+        }
+
+        synced, errors, conflicts = svc._sync_rom_saves(42)
+        assert synced == 0
+        assert errors == []
+        assert conflicts == []
+
+    def test_v47_download_when_not_current(self, tmp_path):
+        """v4.7: server says is_current=False, local unchanged → download."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["server_device_id"] = "dev-1"
+        _install_rom(svc, tmp_path)
+        content = b"old content"
+        _create_save(tmp_path, content=content)
+        local_hash = hashlib.md5(content).hexdigest()
+
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {
+                "pokemon.srm": {
+                    "last_sync_hash": local_hash,
+                    "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                    "last_sync_server_save_id": 100,
+                    "last_sync_server_size": len(content),
+                }
+            }
+        }
+
+        # Server has newer save, device is not current
+        fake.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2026-02-17T08:00:00Z",
+            "file_size_bytes": 2048,
+            "device_syncs": [{"device_id": "dev-1", "is_current": False}],
+        }
+
+        synced, errors, _conflicts = svc._sync_rom_saves(42)
+        assert synced == 1
+        assert errors == []
+        # Verify download happened
+        assert 100 in fake.downloaded_files

--- a/tests/test_save_sync.py
+++ b/tests/test_save_sync.py
@@ -85,6 +85,8 @@ def plugin(tmp_path):
         logger=logging.getLogger("test"),
         runtime_dir=str(tmp_path),
         get_saves_path=lambda: saves_path,
+        get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
+        get_active_core=lambda system_name, rom_filename=None: (None, None),
     )
     p._save_sync_service.init_state()
 


### PR DESCRIPTION
## Summary

Refactors SaveService to use the new adapter (#187) and domain (#189) capabilities from Save Sync v2:

- **Save path resolution**: Wire `resolve_save_dir()` with `roms_base` parameter and `get_save_extensions()` — replaces hardcoded `saves/{system}/` and `.srm/.rtc`
- **Emulator tags**: Use `build_emulator_tag(active_core)` via `CoreResolverFn` protocol instead of hardcoded `"retroarch"`
- **State format**: Add `server_device_id`, `active_core`, `active_slot`, `tracked_save_id` — all backward-compat via `.get()` defaults
- **Device registration**: v4.7 calls `register_device()` API, v4.6 falls back to local UUID
- **Device sync**: Pass `device_id`/`slot` to `list_saves`/`upload_save` on v4.7
- **v4.7 conflict detection**: Use `determine_sync_action` with `device_syncs.is_current` — avoids expensive server hash downloads
- **Plugin version**: Read from `package.json` at bootstrap for device registration metadata

### Not in this PR (documented/deferred):
- `download_save_content` with device tracking (follow-up)
- retroarch.cfg reading for `sort_savefiles_*` settings (#186)
- Migration prompt for existing `slot=null` saves (#185)

Closes #184
Depends on #187, #189

## Test plan

- [x] 20 new tests (v4.7 device registration, sync flow, state backward compat, emulator tags)
- [x] Full suite: 1531 passed
- [x] ruff: 0 errors
- [x] basedpyright: 0 errors
- [x] import-linter: 6/6 contracts kept