### PR TITLE
fix(saves): filter server saves by active_slot in matching logic

### DIFF
--- a/py_modules/domain/save_sync.py
+++ b/py_modules/domain/save_sync.py
@@ -273,10 +273,18 @@ def match_local_to_server_saves(
     """
     result = MatchResult()
 
+    # Filter server saves to active slot (when slot is configured).
+    # Saves with slot=None (v4.6 / pre-slot) are included in any active slot.
+    # Treat empty string same as None (legacy/no-slot mode).
+    if active_slot:
+        filtered_saves = [ss for ss in server_saves if ss.get("slot") == active_slot or ss.get("slot") is None]
+    else:
+        filtered_saves = server_saves
+
     # Build indexes
     server_by_id: dict[int, dict] = {}
     server_by_name: dict[str, dict] = {}
-    for ss in server_saves:
+    for ss in filtered_saves:
         sid = ss.get("id")
         if sid is not None:
             server_by_id[sid] = ss
@@ -290,12 +298,13 @@ def match_local_to_server_saves(
     for lf in sorted(local_files, key=lambda x: x["filename"]):
         file_state = files_state.get(lf["filename"], {})
         matched = _match_single_local_file(
-            lf, server_by_id, server_by_name, server_saves, active_slot, file_state, result, device_id
+            lf, server_by_id, server_by_name, filtered_saves, active_slot, file_state, result, device_id
         )
         result.matched.append(matched)
 
     # --- Pass 2: Server-only saves (not matched by any local file) ---
-    result.matched.extend(_collect_server_only_saves(server_saves, result.matched_server_ids, local_by_name, rom_name))
+    server_only = _collect_server_only_saves(filtered_saves, result.matched_server_ids, local_by_name, rom_name)
+    result.matched.extend(server_only)
 
     return result
 

--- a/tests/domain/test_save_matching.py
+++ b/tests/domain/test_save_matching.py
@@ -7,7 +7,7 @@ def _local(fn="pokemon.srm", path="/saves/gba/pokemon.srm"):
     return {"filename": fn, "path": path}
 
 
-def _server(sid, fn="pokemon.srm", slot="default", updated="2026-03-24T15:00:00", **kw):
+def _server(sid, fn="pokemon.srm", slot: str | None = "default", updated="2026-03-24T15:00:00", **kw):
     return {"id": sid, "file_name": fn, "slot": slot, "updated_at": updated, "file_size_bytes": 1024, **kw}
 
 
@@ -157,8 +157,8 @@ class TestOlderVersionSkipping:
         server_only = [m for m in result.matched if m.match_method == "server_only"]
         assert len(server_only) == 0
 
-    def test_different_slot_not_skipped(self):
-        """Save in different slot should NOT be skipped."""
+    def test_different_slot_filtered_out(self):
+        """Save in different slot should be filtered out entirely."""
         local = [_local(fn="pokemon.srm")]
         server = [
             _server(10, fn="pokemon.srm", slot="default", updated="2026-03-24T15:00:00"),
@@ -175,9 +175,7 @@ class TestOlderVersionSkipping:
 
         result = match_local_to_server_saves(local, server, files_state, "default")
         server_only = [m for m in result.matched if m.match_method == "server_only"]
-        assert len(server_only) == 1
-        assert server_only[0].server_save is not None
-        assert server_only[0].server_save["id"] == 20
+        assert len(server_only) == 0
 
 
 class TestLocalOnly:
@@ -287,3 +285,77 @@ class TestNewerSaveInSlot:
         matched = result.matched[0]
         assert matched.newer_save_in_slot is not None
         assert matched.newer_save_in_slot["id"] == 30
+
+
+class TestSlotFiltering:
+    """Tests for active_slot filtering in match_local_to_server_saves."""
+
+    def test_filename_match_filtered_by_active_slot(self):
+        """Save with matching filename but in wrong slot should not match."""
+        local = [_local()]
+        server = [_server(10, fn="pokemon.srm", slot="default")]
+        result = match_local_to_server_saves(local, server, {}, "other")
+        assert result.matched[0].match_method == "local_only"
+        assert result.matched[0].server_save is None
+
+    def test_tracked_id_filtered_by_active_slot(self):
+        """Tracked save in wrong slot should not match."""
+        local = [_local()]
+        server = [_server(42, fn="pokemon [ts].srm", slot="default")]
+        files_state = {"pokemon.srm": {"tracked_save_id": 42}}
+        result = match_local_to_server_saves(local, server, files_state, "other")
+        assert result.matched[0].match_method == "local_only"
+        assert result.matched[0].server_save is None
+
+    def test_server_only_filtered_by_active_slot(self):
+        """Server-only saves from other slots should not appear."""
+        server = [
+            _server(10, fn="pokemon.srm", slot="default", file_name_no_tags="pokemon", file_extension="srm"),
+            _server(20, fn="zelda.srm", slot="portable", file_name_no_tags="zelda", file_extension="srm"),
+        ]
+        result = match_local_to_server_saves([], server, {}, "default")
+        server_only = [m for m in result.matched if m.match_method == "server_only"]
+        assert len(server_only) == 1
+        assert server_only[0].server_save is not None
+        assert server_only[0].server_save["id"] == 10
+
+    def test_null_slot_server_save_visible_from_any_active_slot(self):
+        """Server save with slot=None should match from any active slot (v4.6 compat)."""
+        local = [_local()]
+        server = [_server(10, fn="pokemon.srm", slot=None)]
+        result = match_local_to_server_saves(local, server, {}, "desktop")
+        assert result.matched[0].match_method == "filename"
+        assert result.matched[0].server_save is not None
+        assert result.matched[0].server_save["id"] == 10
+
+    def test_active_slot_none_shows_all_saves(self):
+        """When active_slot is None (legacy), all saves are visible regardless of slot."""
+        local = [_local()]
+        server = [_server(10, fn="pokemon.srm", slot="default")]
+        result = match_local_to_server_saves(local, server, {}, None)
+        assert result.matched[0].match_method == "filename"
+        assert result.matched[0].server_save is not None
+        assert result.matched[0].server_save["id"] == 10
+
+    def test_active_slot_empty_string_shows_all_saves(self):
+        """Empty string active_slot (UI sends '' for no-slot) treated same as None."""
+        local = [_local()]
+        server = [_server(10, fn="pokemon.srm", slot="default")]
+        result = match_local_to_server_saves(local, server, {}, "")
+        assert result.matched[0].match_method == "filename"
+        assert result.matched[0].server_save is not None
+        assert result.matched[0].server_save["id"] == 10
+
+    def test_newer_in_slot_only_from_active_slot(self):
+        """Newer-in-slot detection should not flag saves from other slots."""
+        local = [_local()]
+        server = [
+            _server(18, fn="pokemon [old].srm", slot="default", updated="2026-03-24T15:00:00"),
+            _server(25, fn="pokemon [new].srm", slot="default", updated="2026-03-25T10:00:00"),
+            _server(30, fn="pokemon [portable].srm", slot="portable", updated="2026-03-26T10:00:00"),
+        ]
+        files_state = {"pokemon.srm": {"tracked_save_id": 18}}
+        result = match_local_to_server_saves(local, server, files_state, "default")
+        matched = result.matched[0]
+        assert matched.newer_save_in_slot is not None
+        assert matched.newer_save_in_slot["id"] == 25  # from default, not 30 from portable

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -1046,6 +1046,24 @@ class TestSaveStatus:
         assert file_status["device_syncs"][0]["device_name"] == "my-deck"
         assert file_status["is_current"] is True
 
+    @pytest.mark.asyncio
+    async def test_save_status_filters_by_active_slot(self, tmp_path):
+        """Saves from a different slot should not appear in status."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        # Server save in slot "default", but active_slot is "other"
+        ss = _server_save(slot="default")
+        fake.saves[100] = ss
+        svc._save_sync_state["saves"]["42"] = {"active_slot": "other", "files": {}}
+
+        result = await svc.get_save_status(42)
+        # Local file exists → should show as upload (local-only), not synced against wrong slot
+        assert len(result["files"]) == 1
+        assert result["files"][0]["status"] == "upload"
+        assert result["files"][0]["server_save_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # TestCheckSaveStatusBackground
@@ -2861,8 +2879,8 @@ class TestOlderVersionSkipping:
         assert len(newer_conflicts) == 1
         assert newer_conflicts[0]["newer_save_id"] == 20
 
-    def test_different_slot_not_skipped(self, tmp_path):
-        """Saves in a different slot should never be skipped."""
+    def test_different_slot_filtered_out(self, tmp_path):
+        """Saves in a different slot should be filtered out entirely."""
         svc, fake = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
         svc._save_sync_state["device_id"] = "dev-1"
@@ -2876,7 +2894,7 @@ class TestOlderVersionSkipping:
             updated_at="2026-03-24T15:00:00",
             slot="default",
         )
-        # Unmatched in slot=portable — older timestamp but different slot
+        # Unmatched in slot=portable — filtered out by active_slot
         fake.saves[20] = _server_save(
             save_id=20,
             filename="pokemon [old].srm",
@@ -2903,10 +2921,9 @@ class TestOlderVersionSkipping:
         }
 
         _synced, _errors, _conflicts = svc._sync_rom_saves(42)
-        # pokemon [old].srm in slot=portable should NOT be skipped
+        # pokemon [old].srm in slot=portable is filtered out — no download
         download_calls = [c for c in fake.call_log if c[0] == "download_save"]
-        assert len(download_calls) == 1
-        assert download_calls[0][1][0] == 20
+        assert len(download_calls) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #200

## Summary

- `match_local_to_server_saves()` built indexes from **all** server saves regardless of slot — Priority 1 (tracked_save_id) and Priority 2 (filename) matched saves from any slot, causing wrong status when switching slots
- Filter `server_saves` by `active_slot` before building indexes so all matching priorities and server-only collection only see saves in the active slot
- Null-slot saves (v4.6 backward compat) pass through any active slot
- Empty string and `None` active_slot preserve legacy unfiltered behavior

## Test plan

- [x] 7 new domain tests in `TestSlotFiltering` (filename, tracked_id, server_only filtering, null-slot compat, None legacy, empty-string legacy, newer-in-slot scoping)
- [x] 1 new integration test `test_save_status_filters_by_active_slot`
- [x] 2 updated tests (`test_different_slot_not_skipped` → `test_different_slot_filtered_out`) in domain + service
- [x] Full suite: 1598 passed, ruff clean, basedpyright clean