### PR TITLE
feat(saves): expand save file extensions for DS and Sega CD

### DIFF
--- a/py_modules/domain/save_extensions.py
+++ b/py_modules/domain/save_extensions.py
@@ -4,21 +4,21 @@ Provides the list of save file extensions to look for when syncing saves.
 The default covers RetroArch's standard .srm and .rtc extensions.
 Platform-specific overrides can expand or replace this list.
 
-Extension expansion (adding .sav, .mcr, .mcd, etc.) is tracked in #186.
+Extension mapping based on RetroDECK core audit — see wiki/Save-File-Extensions.
 
 No I/O, no service/adapter/lib imports. Pure functions only.
 """
 
 from __future__ import annotations
 
-_DEFAULT_EXTENSIONS: tuple[str, ...] = (".srm", ".rtc")
+_DEFAULT_EXTENSIONS: tuple[str, ...] = (".srm", ".rtc", ".sav")
 
 # Platform-specific overrides. Keys are RomM platform slugs.
 # Values completely replace the default list for that platform.
-# Populated incrementally as gameplay tests confirm actual extensions.
+# See wiki/Save-File-Extensions for the research behind these mappings.
 _PLATFORM_OVERRIDES: dict[str, tuple[str, ...]] = {
-    # Example (to be filled in #186):
-    # "n64": (".srm", ".rtc", ".eep", ".sra", ".fla", ".mpk"),
+    "nds": (".srm", ".rtc", ".sav", ".dsv"),  # DeSmuME native format
+    "segacd": (".srm", ".rtc", ".sav", ".brm"),  # Genesis Plus GX Sega CD BRAM
 }
 
 

--- a/tests/domain/test_save_extensions.py
+++ b/tests/domain/test_save_extensions.py
@@ -6,93 +6,82 @@ from unittest.mock import patch
 
 from domain.save_extensions import get_all_known_extensions, get_save_extensions
 
+_DEFAULTS = (".srm", ".rtc", ".sav")
+
 
 class TestGetSaveExtensionsDefault:
     """get_save_extensions returns defaults when no override exists."""
 
     def test_no_argument_returns_default(self):
-        """Calling with no argument returns the default extensions."""
         result = get_save_extensions()
-        assert result == (".srm", ".rtc")
+        assert result == _DEFAULTS
 
     def test_none_argument_returns_default(self):
-        """Passing None explicitly returns the default extensions."""
         result = get_save_extensions(None)
-        assert result == (".srm", ".rtc")
+        assert result == _DEFAULTS
 
     def test_known_platform_without_override_returns_default(self):
         """A real platform slug with no override returns the default."""
         result = get_save_extensions("gba")
-        assert result == (".srm", ".rtc")
+        assert result == _DEFAULTS
 
     def test_unknown_platform_returns_default(self):
-        """An unrecognised platform slug returns the default."""
         result = get_save_extensions("unknown_platform")
-        assert result == (".srm", ".rtc")
+        assert result == _DEFAULTS
 
 
 class TestGetSaveExtensionsWithOverride:
     """get_save_extensions respects platform-specific overrides."""
 
-    _N64_EXTS = (".srm", ".rtc", ".eep", ".sra", ".fla", ".mpk")
+    def test_nds_override_includes_dsv(self):
+        """NDS platform returns DeSmuME .dsv extension."""
+        result = get_save_extensions("nds")
+        assert ".dsv" in result
+        assert ".srm" in result
+        assert ".sav" in result
 
-    def test_override_platform_returns_override(self):
-        """A platform with an override returns that override instead of the default."""
-        with patch(
-            "domain.save_extensions._PLATFORM_OVERRIDES",
-            {"n64": self._N64_EXTS},
-        ):
-            result = get_save_extensions("n64")
-            assert result == self._N64_EXTS
+    def test_segacd_override_includes_brm(self):
+        """Sega CD platform returns Genesis Plus GX .brm extension."""
+        result = get_save_extensions("segacd")
+        assert ".brm" in result
+        assert ".srm" in result
 
     def test_non_override_platform_still_returns_default(self):
-        """Other platforms are unaffected when an override is present for a different one."""
-        with patch(
-            "domain.save_extensions._PLATFORM_OVERRIDES",
-            {"n64": self._N64_EXTS},
-        ):
-            result = get_save_extensions("gba")
-            assert result == (".srm", ".rtc")
+        """Platforms without overrides get defaults."""
+        result = get_save_extensions("gba")
+        assert result == _DEFAULTS
+        assert ".dsv" not in result
+        assert ".brm" not in result
+
+    def test_patched_override_replaces_defaults(self):
+        """A patched override completely replaces the default list."""
+        custom = (".foo", ".bar")
+        with patch("domain.save_extensions._PLATFORM_OVERRIDES", {"test": custom}):
+            result = get_save_extensions("test")
+            assert result == custom
 
 
 class TestGetAllKnownExtensions:
     """get_all_known_extensions covers defaults and all override extensions."""
 
     def test_contains_default_extensions(self):
-        """Result always contains the default .srm and .rtc extensions."""
         result = get_all_known_extensions()
         assert ".srm" in result
         assert ".rtc" in result
+        assert ".sav" in result
+
+    def test_contains_override_extensions(self):
+        """Real overrides (nds, segacd) are included."""
+        result = get_all_known_extensions()
+        assert ".dsv" in result
+        assert ".brm" in result
 
     def test_returns_tuple(self):
-        """Result is a tuple (immutable)."""
         assert isinstance(get_all_known_extensions(), tuple)
 
-    def test_with_patched_override_includes_override_extensions(self):
-        """Override extensions appear in the combined result."""
-        overrides = {"n64": (".srm", ".rtc", ".eep", ".mpk")}
-        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
-            result = get_all_known_extensions()
-            assert ".eep" in result
-            assert ".mpk" in result
-
-    def test_no_duplicates_when_override_repeats_defaults(self):
-        """Extensions shared between defaults and overrides are not duplicated."""
-        overrides = {"n64": (".srm", ".rtc", ".eep")}
-        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
-            result = get_all_known_extensions()
-            assert result.count(".srm") == 1
-            assert result.count(".rtc") == 1
-            assert result.count(".eep") == 1
-
-    def test_no_duplicates_across_multiple_overrides(self):
-        """Extensions shared across multiple platform overrides appear only once."""
-        overrides = {
-            "n64": (".srm", ".eep"),
-            "gba": (".srm", ".sav"),
-        }
-        with patch("domain.save_extensions._PLATFORM_OVERRIDES", overrides):
-            result = get_all_known_extensions()
-            assert result.count(".srm") == 1
-            assert ".eep" in result
-            assert ".sav" in result
+    def test_no_duplicates(self):
+        """Extensions shared between defaults and overrides appear only once."""
+        result = get_all_known_extensions()
+        assert result.count(".srm") == 1
+        assert result.count(".rtc") == 1
+        assert result.count(".sav") == 1


### PR DESCRIPTION
Partial fix for #196 (Extension Expansion part only — Save Path Change Detection is separate).

## Summary

- Add `.sav` to default extensions (gpsp GBA fallback, DeSmuME DS fallback)
- Add platform override for `nds`: `.dsv` (DeSmuME native format)
- Add platform override for `segacd`: `.brm` (Genesis Plus GX Sega CD BRAM)
- Extensions NOT added (with rationale from RetroDECK core audit):
  - `.eep`, `.sra`, `.fla`, `.mpk` — N64 standalone formats, Mupen64Plus packs all into `.srm`
  - `.mcr`, `.mcd` — PSX standalone formats, RetroArch cores use `.srm`
  - `.nv` — MAME NVRAM, different directory structure
  - `.bin` — Dreamcast VMU, tracked in #151

Research documented in [wiki/Save-File-Extensions](https://github.com/danielcopper/decky-romm-sync/wiki/Save-File-Extensions) and [issue comment](https://github.com/danielcopper/decky-romm-sync/issues/196#issuecomment-4145262478).

## Test plan

- [x] 12 unit tests covering defaults, NDS override, Sega CD override, fallback behavior, deduplication
- [x] Full suite: 1599 passed, ruff clean, basedpyright clean