### PR TITLE
fix(launcher): redesign romm-launcher — single responsibility, no shell interpolation

### DIFF
--- a/bin/romm-launcher
+++ b/bin/romm-launcher
@@ -1,6 +1,7 @@
 #!/bin/bash
 # romm-launcher — Steam shortcut launcher for RomM Sync plugin
 # Called by Steam with LaunchOptions as argument: romm:{rom_id}
+# Resolves ROM file path from state.json and launches via RetroDECK.
 
 set -euo pipefail
 
@@ -18,7 +19,7 @@ fi
 
 ROM_ID="${BASH_REMATCH[1]}"
 
-# Data dir for state.json (Decky stores runtime data in data/, not settings/)
+# Resolve data directory (Decky runtime dir or well-known fallbacks)
 DATA_DIR=""
 for candidate in \
     "${DECKY_PLUGIN_RUNTIME_DIR:-}" \
@@ -31,62 +32,36 @@ for candidate in \
 done
 
 if [[ -z "$DATA_DIR" ]]; then
-    DATA_DIR="$HOME/homebrew/data/decky-romm-sync"
-    mkdir -p "$DATA_DIR"
+    echo "Data directory not found" >&2
+    exit 1
 fi
 
 STATE_FILE="$DATA_DIR/state.json"
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo "State file not found: $STATE_FILE" >&2
+    exit 1
+fi
 
-# Check if ROM is installed by reading state.json
-if [[ -f "$STATE_FILE" ]]; then
-    # Use python3 to parse JSON (always available)
-    ROM_INFO=$(python3 -c "
-import json, sys
-with open('$STATE_FILE') as f:
+# Resolve ROM file path from state.json
+export ROMM_STATE_FILE="$STATE_FILE"
+export ROMM_ROM_ID="$ROM_ID"
+
+ROM_PATH=$(python3 -c "
+import json, os, sys
+with open(os.environ['ROMM_STATE_FILE']) as f:
     state = json.load(f)
-installed = state.get('installed_roms', {})
-rom = installed.get('$ROM_ID')
-if rom:
-    print(rom.get('system', ''))
-    print(rom.get('file_path', ''))
-else:
+rom = state.get('installed_roms', {}).get(os.environ['ROMM_ROM_ID'])
+if not rom:
     sys.exit(1)
-" 2>/dev/null) || ROM_INFO=""
+path = rom.get('file_path') or ''
+if not path:
+    sys.exit(1)
+print(path)
+") || { echo "ROM $ROM_ID not found in state" >&2; exit 1; }
+
+if [[ -z "$ROM_PATH" || ! -e "$ROM_PATH" ]]; then
+    echo "ROM file not found: ${ROM_PATH:-<empty>}" >&2
+    exit 1
 fi
 
-if [[ -n "${ROM_INFO:-}" ]]; then
-    ROM_PATH=$(echo "$ROM_INFO" | tail -1)
-
-    if [[ -e "$ROM_PATH" ]]; then
-        # Launch with RetroDECK (auto-detects system from roms/{system}/ path)
-        exec flatpak run net.retrodeck.retrodeck "$ROM_PATH"
-    else
-        echo "ROM file missing: $ROM_PATH — queueing download" >&2
-    fi
-    # Fall through to download request if ROM file is missing
-fi
-
-# ROM not installed — request download
-REQUESTS_FILE="$DATA_DIR/download_requests.json"
-
-python3 -c "
-import json, os, fcntl
-path = '$REQUESTS_FILE'
-try:
-    with open(path, 'r') as f:
-        requests = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
-    requests = []
-requests.append({'rom_id': $ROM_ID, 'timestamp': $(date +%s)})
-with open(path, 'w') as f:
-    fcntl.flock(f, fcntl.LOCK_EX)
-    json.dump(requests, f)
-    fcntl.flock(f, fcntl.LOCK_UN)
-"
-
-# Try to show a notification
-if command -v notify-send &>/dev/null; then
-    notify-send "RomM Sync" "Download queued for ROM #$ROM_ID. Play again when complete."
-fi
-
-exit 0
+exec flatpak run net.retrodeck.retrodeck "$ROM_PATH"


### PR DESCRIPTION
## Summary
- Remove download queue logic from romm-launcher (duplicated — GameDetailPage handles this)
- Replace shell-to-Python string interpolation with `export` + `os.environ[]`
- Remove `notify-send` (no longer queueing downloads)
- Remove `mkdir -p` fallback (exit with error if plugin data dir missing)
- Guard against `None` file_path values
- Let Python stderr through (removed `2>/dev/null`) for better diagnostics

93 lines → 68 lines. Single responsibility: parse `romm:<id>` → resolve path from state.json → `exec flatpak` or `exit 1`.

Closes #118

## Test plan
- [ ] Launch an installed ROM from game detail page — should launch the game via RetroArch
- [ ] Launch an installed ROM directly from Steam Library — should launch the game via RetroArch
- [ ] Launch a non-installed ROM — should exit with error, no crash
- [ ] Verify after SD card migration — launcher resolves new path from updated state.json
- [ ] Install fresh via Decky store — verify `bin/romm-launcher` has +x permission (Decky Loader applies chmod 755 recursively post-install)