### PR TITLE
feat: add performance instrumentation for sync pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -480,6 +480,9 @@ class Plugin:
     async def get_sync_progress(self):
         return self._sync_service.get_sync_progress()
 
+    async def get_perf_report(self):
+        return self._sync_service.get_perf_report()
+
     async def sync_heartbeat(self):
         return self._sync_service.sync_heartbeat()
 

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -53,6 +53,11 @@ class RommHttpAdapter:
         self._settings = settings
         self._plugin_dir = plugin_dir
         self._logger = logger
+        self._perf = None  # Optional PerfCollector, set via set_perf_collector()
+
+    def set_perf_collector(self, perf) -> None:
+        """Attach a PerfCollector instance to record HTTP metrics."""
+        self._perf = perf
 
     # ------------------------------------------------------------------
     # Platform map
@@ -182,6 +187,8 @@ class RommHttpAdapter:
                 if attempt < max_attempts - 1 and self.is_retryable(exc):
                     delay = base_delay * (3**attempt)
                     self._logger.info(f"Retry {attempt + 1}/{max_attempts} after {delay}s: {exc}")
+                    if self._perf is not None:
+                        self._perf.increment("http_retries")
                     time.sleep(delay)
                 else:
                     raise
@@ -191,6 +198,11 @@ class RommHttpAdapter:
     # HTTP request methods
     # ------------------------------------------------------------------
 
+    def _record_http(self, method: str, path: str, elapsed: float, status: int, nbytes: int) -> None:
+        """Record an HTTP request in the attached PerfCollector, if any."""
+        if self._perf is not None:
+            self._perf.record_http_request(method, path, elapsed, status, nbytes)
+
     def request(self, path: str):
         """GET a JSON resource from the RomM API."""
         url = self._settings["romm_url"].rstrip("/") + path
@@ -198,13 +210,21 @@ class RommHttpAdapter:
         def _do_request():
             req = urllib.request.Request(url, method="GET")
             req.add_header("Authorization", self.auth_header())
+            t0 = time.monotonic()
+            status = 0
+            nbytes = 0
             try:
                 with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
-                    return json.loads(resp.read().decode())
+                    data = resp.read()
+                    status = resp.status
+                    nbytes = len(data)
+                    return json.loads(data.decode())
             except RommApiError:
                 raise
             except Exception as exc:
                 raise self.translate_http_error(exc, url, "GET") from exc
+            finally:
+                self._record_http("GET", path, time.monotonic() - t0, status, nbytes)
 
         return self.with_retry(_do_request)
 
@@ -253,6 +273,9 @@ class RommHttpAdapter:
             req = urllib.request.Request(url, method="GET")
             req.add_header("Authorization", self.auth_header())
             ctx = self.ssl_context()
+            t0 = time.monotonic()
+            status = 0
+            nbytes = 0
             try:
                 with urllib.request.urlopen(req, context=ctx, timeout=self._CONNECT_TIMEOUT) as resp:
                     raw_sock = getattr(getattr(getattr(resp, "fp", None), "raw", None), "_sock", None)
@@ -261,11 +284,15 @@ class RommHttpAdapter:
                     total, downloaded = self._stream_to_file(
                         resp, dest_path, progress_callback, block_size=self._DOWNLOAD_BLOCK_SIZE, url=url
                     )
+                    status = resp.status
+                    nbytes = downloaded
                 self._validate_download(total, downloaded)
             except RommApiError:
                 raise
             except Exception as exc:
                 raise self.translate_http_error(exc, url, "GET") from exc
+            finally:
+                self._record_http("GET", path, time.monotonic() - t0, status, nbytes)
 
         return self.with_retry(_do_download)
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -247,6 +247,10 @@ def wire_services(cfg: WiringConfig) -> dict:
     # Resolve the circular dependency: point the box at the real sync_state getter.
     _sync_state_box[0] = lambda: sync_service.sync_state
 
+    # Wire PerfCollector from sync_service into the HTTP adapter so all
+    # HTTP requests are automatically recorded for performance analysis.
+    cfg.http_adapter.set_perf_collector(sync_service.perf)
+
     download_service = DownloadService(
         romm_api=cfg.romm_api,
         resolve_system=cfg.http_adapter.resolve_system,

--- a/py_modules/lib/perf.py
+++ b/py_modules/lib/perf.py
@@ -1,0 +1,291 @@
+"""Performance instrumentation for sync lifecycle measurement.
+
+Provides ``PerfCollector`` for phase timing, HTTP request tracking,
+counters, and gauges — and ``ETAEstimator`` for throughput-based
+remaining-time estimation.
+
+Both classes are pure Python with no external dependencies.
+
+Production usage
+~~~~~~~~~~~~~~~~
+Every sync automatically records perf data:
+  - Formatted report logged to Decky logs
+  - JSON written to ``<plugin_dir>/perf_report.json``
+  - Available via ``get_perf_report()`` RPC
+
+Ad-hoc baseline: ``python3 scripts/deck_perf_test.py``
+See that script's docstring for the full test methodology and
+representative platform selection rationale.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass
+class _HttpRecord:
+    """Single HTTP request measurement."""
+
+    method: str
+    path: str
+    elapsed: float
+    status: int
+    nbytes: int
+
+
+class PerfCollector:
+    """Collects performance metrics for a single sync cycle.
+
+    Usage::
+
+        perf = PerfCollector()
+        perf.start_sync()
+
+        with perf.time_phase("fetch_platforms"):
+            ...  # work
+
+        perf.record_http_request("GET", "/api/platforms", 0.42, 200, 1234)
+        perf.increment("platforms_fetched")
+        perf.set_gauge("fetch_concurrency", 4)
+
+        perf.end_sync()
+        print(perf.format_report())
+    """
+
+    def __init__(self) -> None:
+        self._sync_start: float = 0.0
+        self._sync_end: float = 0.0
+        self._phases: dict[str, float] = {}
+        self._phase_start: dict[str, float] = {}
+        self._http_requests: list[_HttpRecord] = []
+        self._counters: dict[str, int] = {}
+        self._gauges: dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Sync lifecycle
+    # ------------------------------------------------------------------
+
+    def start_sync(self) -> None:
+        """Begin a new sync cycle. Clears all prior data."""
+        self._sync_start = time.monotonic()
+        self._sync_end = 0.0
+        self._phases.clear()
+        self._phase_start.clear()
+        self._http_requests.clear()
+        self._counters.clear()
+        self._gauges.clear()
+
+    def end_sync(self) -> None:
+        """Mark sync cycle as finished."""
+        self._sync_end = time.monotonic()
+
+    @property
+    def wall_time(self) -> float:
+        """Total wall-clock seconds for the sync (0.0 if not finished)."""
+        if self._sync_end > 0 and self._sync_start > 0:
+            return self._sync_end - self._sync_start
+        return 0.0
+
+    # ------------------------------------------------------------------
+    # Phase timing
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def time_phase(self, name: str):
+        """Context manager that records the duration of a named phase.
+
+        Phases are cumulative — entering the same phase twice adds to
+        the previous total (useful for re-entrant phases).
+        """
+        t0 = time.monotonic()
+        try:
+            yield
+        finally:
+            elapsed = time.monotonic() - t0
+            self._phases[name] = self._phases.get(name, 0.0) + elapsed
+
+    # ------------------------------------------------------------------
+    # HTTP request tracking
+    # ------------------------------------------------------------------
+
+    def record_http_request(
+        self, method: str, path: str, elapsed: float, status: int, nbytes: int
+    ) -> None:
+        """Record a single HTTP request's measurements."""
+        self._http_requests.append(
+            _HttpRecord(method=method, path=path, elapsed=elapsed, status=status, nbytes=nbytes)
+        )
+
+    # ------------------------------------------------------------------
+    # Counters & gauges
+    # ------------------------------------------------------------------
+
+    def increment(self, name: str, amount: int = 1) -> None:
+        """Increment a named counter."""
+        self._counters[name] = self._counters.get(name, 0) + amount
+
+    def get_counter(self, name: str) -> int:
+        """Return current value of a counter (0 if not set)."""
+        return self._counters.get(name, 0)
+
+    def set_gauge(self, name: str, value: float) -> None:
+        """Set a named gauge to a point-in-time value."""
+        self._gauges[name] = value
+
+    def get_gauge(self, name: str) -> float:
+        """Return current value of a gauge (0.0 if not set)."""
+        return self._gauges.get(name, 0.0)
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+
+    def generate_report(self) -> dict:
+        """Return structured performance data as a dict."""
+        total_http = len(self._http_requests)
+        total_bytes = sum(r.nbytes for r in self._http_requests)
+        total_http_time = sum(r.elapsed for r in self._http_requests)
+
+        # Per-method breakdown
+        methods: dict[str, dict] = {}
+        for r in self._http_requests:
+            m = methods.setdefault(r.method, {"count": 0, "total_time": 0.0, "total_bytes": 0})
+            m["count"] += 1
+            m["total_time"] += r.elapsed
+            m["total_bytes"] += r.nbytes
+
+        # Error count (non-2xx)
+        errors = sum(1 for r in self._http_requests if r.status < 200 or r.status >= 300)
+
+        return {
+            "wall_time": round(self.wall_time, 3),
+            "phases": {k: round(v, 3) for k, v in self._phases.items()},
+            "http": {
+                "total_requests": total_http,
+                "total_bytes": total_bytes,
+                "total_time": round(total_http_time, 3),
+                "errors": errors,
+                "by_method": methods,
+            },
+            "counters": dict(self._counters),
+            "gauges": {k: round(v, 3) for k, v in self._gauges.items()},
+        }
+
+    def format_report(self) -> str:
+        """Return a human-readable performance summary."""
+        data = self.generate_report()
+        lines: list[str] = [f"Sync completed in {data['wall_time']:.1f}s"]
+        self._format_phases(data, lines)
+        self._format_http(data["http"], lines)
+        self._format_map(data["counters"], "Counters", lines)
+        self._format_map(data["gauges"], "Gauges", lines)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_phases(data: dict, lines: list[str]) -> None:
+        if not data["phases"]:
+            return
+        lines.append("  Phases:")
+        wall = data["wall_time"]
+        for name, secs in data["phases"].items():
+            pct = (secs / wall * 100) if wall > 0 else 0
+            lines.append(f"    {name}: {secs:.1f}s ({pct:.0f}%)")
+
+    @staticmethod
+    def _format_http(h: dict, lines: list[str]) -> None:
+        if h["total_requests"] == 0:
+            return
+        mb = h["total_bytes"] / (1024 * 1024)
+        lines.append(
+            f"  HTTP: {h['total_requests']} requests, "
+            f"{mb:.1f} MB, {h['total_time']:.1f}s cumulative"
+        )
+        if h["errors"] > 0:
+            lines.append(f"  HTTP errors: {h['errors']}")
+        for method, stats in h["by_method"].items():
+            lines.append(f"    {method}: {stats['count']} reqs, {stats['total_time']:.1f}s")
+
+    @staticmethod
+    def _format_map(mapping: dict, label: str, lines: list[str]) -> None:
+        if not mapping:
+            return
+        lines.append(f"  {label}:")
+        for name, val in mapping.items():
+            lines.append(f"    {name}: {val}")
+
+
+class ETAEstimator:
+    """Throughput-based ETA estimator using exponential moving average.
+
+    Parameters
+    ----------
+    alpha:
+        Smoothing factor (0–1). Higher = more weight on recent samples.
+        Default 0.3 balances responsiveness with stability.
+    min_samples:
+        Minimum number of ``update()`` calls before ``eta_seconds()``
+        returns a value (avoids wild early estimates).
+    """
+
+    def __init__(self, alpha: float = 0.3, min_samples: int = 3) -> None:
+        self._alpha = alpha
+        self._min_samples = min_samples
+        self._start: float = 0.0
+        self._samples: int = 0
+        self._ema_rate: float = 0.0  # items per second (smoothed)
+        self._last_update: float = 0.0
+        self._last_current: int = 0
+
+    def start(self) -> None:
+        """Reset and begin a new estimation cycle."""
+        self._start = time.monotonic()
+        self._samples = 0
+        self._ema_rate = 0.0
+        self._last_update = self._start
+        self._last_current = 0
+
+    def update(self, current: int) -> None:
+        """Record progress — *current* is the cumulative count of items processed."""
+        now = time.monotonic()
+        dt = now - self._last_update
+        if dt <= 0 or current <= self._last_current:
+            return  # skip duplicate or backward updates
+
+        dx = current - self._last_current
+        rate = dx / dt
+
+        if self._samples == 0:
+            self._ema_rate = rate
+        else:
+            self._ema_rate = self._alpha * rate + (1 - self._alpha) * self._ema_rate
+
+        self._last_update = now
+        self._last_current = current
+        self._samples += 1
+
+    def eta_seconds(self, current: int, total: int) -> float | None:
+        """Estimated seconds remaining, or ``None`` if too few samples."""
+        if self._samples < self._min_samples or self._ema_rate <= 0 or current >= total:
+            return None
+        remaining = total - current
+        return remaining / self._ema_rate
+
+    @property
+    def elapsed(self) -> float:
+        """Seconds since ``start()`` was called."""
+        if self._start <= 0:
+            return 0.0
+        return time.monotonic() - self._start
+
+    @property
+    def items_per_sec(self) -> float:
+        """Current smoothed throughput (items/sec). 0.0 if no samples yet."""
+        return self._ema_rate if self._samples > 0 else 0.0
+
+    @property
+    def samples(self) -> int:
+        """Number of update() calls recorded."""
+        return self._samples

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -81,9 +81,17 @@ class ArtworkService:
             return cover_paths
 
         total = len(all_roms)
+        artwork_downloaded = 0
+        artwork_skipped = 0
+        artwork_failed = 0
+        artwork_no_url = 0
+        log_interval = max(1, total // 10)  # Log every ~10%
+
+        self._logger.info(f"[Artwork] Starting: {total} ROMs to process")
 
         for i, rom in enumerate(all_roms):
             if is_cancelling():
+                self._logger.info(f"[Artwork] Cancelled at {i}/{total} (downloaded={artwork_downloaded}, skipped={artwork_skipped})")
                 return cover_paths
 
             await emit_progress(
@@ -97,21 +105,30 @@ class ArtworkService:
 
             cover_url = rom.get("path_cover_large") or rom.get("path_cover_small")
             if not cover_url:
+                artwork_no_url += 1
                 continue
 
             rom_id = rom["id"]
             existing = self.existing_cover_path(rom_id, grid)
             if existing:
                 cover_paths[rom_id] = existing
+                artwork_skipped += 1
                 continue
 
             staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
             try:
                 await self._loop.run_in_executor(None, self._romm_api.download_cover, cover_url, staging)
                 cover_paths[rom_id] = staging
+                artwork_downloaded += 1
             except Exception as e:
+                artwork_failed += 1
                 self._logger.warning(f"Failed to download artwork for {rom['name']}: {e}")
 
+            # Periodic progress log
+            if (i + 1) % log_interval == 0:
+                self._logger.info(f"[Artwork] {i + 1}/{total} processed (downloaded={artwork_downloaded}, skipped={artwork_skipped}, failed={artwork_failed})")
+
+        self._logger.info(f"[Artwork] Complete: {total} processed, {artwork_downloaded} downloaded, {artwork_skipped} skipped, {artwork_no_url} no URL, {artwork_failed} failed")
         return cover_paths
 
     # ── Artwork finalisation ───────────────────────────────────────────────

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from domain.shortcut_data import build_registry_entry, build_shortcuts_data
 from domain.sync_state import SyncState
 from lib.errors import RommUnsupportedError, classify_error
+from lib.perf import ETAEstimator, PerfCollector
 
 if TYPE_CHECKING:
     import logging
@@ -73,6 +74,10 @@ class LibraryService:
         self._metadata_service = metadata_service
         self._artwork = artwork
 
+        # Performance instrumentation
+        self._perf = PerfCollector()
+        self._eta = ETAEstimator()
+
         # Sync-specific state (owned by this service)
         self._sync_state = SyncState.IDLE
         self._sync_last_heartbeat = 0.0
@@ -102,6 +107,21 @@ class LibraryService:
         """Request graceful shutdown — cancels sync if running."""
         if self._sync_state == SyncState.RUNNING:
             self._sync_state = SyncState.CANCELLING
+
+    @property
+    def perf(self) -> PerfCollector:
+        """Expose PerfCollector for external wiring (e.g. http adapter)."""
+        return self._perf
+
+    def get_perf_report(self) -> dict:
+        """Return the performance report from the most recent sync."""
+        if self._perf.wall_time > 0:
+            return {
+                "success": True,
+                "report": self._perf.generate_report(),
+                "formatted": self._perf.format_report(),
+            }
+        return {"success": False, "message": "No performance data available"}
 
     # ── Platform & ROM fetching ──────────────────────────────
 
@@ -787,7 +807,8 @@ class LibraryService:
 
         # Phase 1: Fetch platforms
         await self._emit_progress("platforms", message="Fetching platforms...")
-        platforms = await self._fetch_enabled_platforms()
+        with self._perf.time_phase("fetch_platforms"):
+            platforms = await self._fetch_enabled_platforms()
         self._check_cancelling()
 
         # Phase 2: Fetch ROMs per platform (incremental if possible)
@@ -797,40 +818,46 @@ class LibraryService:
 
         all_roms: list[dict] = []
         total_platforms = len(platforms)
-        for pi, platform in enumerate(platforms, 1):
-            self._check_cancelling()
-            platform_name = platform.get("name", platform.get("display_name", "Unknown"))
-            platform_slug = platform.get("slug", "")
+        with self._perf.time_phase("fetch_roms"):
+            for pi, platform in enumerate(platforms, 1):
+                self._check_cancelling()
+                platform_name = platform.get("name", platform.get("display_name", "Unknown"))
+                platform_slug = platform.get("slug", "")
 
-            skipped = await self._try_incremental_skip(
-                platform, registry, last_sync, platform_name, platform_slug, all_roms, pi, total_platforms
-            )
-            if not skipped:
-                await self._full_fetch_platform_roms(
-                    platform["id"], platform_name, platform_slug, all_roms, pi, total_platforms
+                skipped = await self._try_incremental_skip(
+                    platform, registry, last_sync, platform_name, platform_slug, all_roms, pi, total_platforms
                 )
+                if not skipped:
+                    await self._full_fetch_platform_roms(
+                        platform["id"], platform_name, platform_slug, all_roms, pi, total_platforms
+                    )
 
         self._check_cancelling()
         self._logger.info(f"Fetched {len(all_roms)} ROMs from {len(platforms)} platforms")
+        self._perf.set_gauge("total_roms", len(all_roms))
+        self._perf.set_gauge("total_platforms", len(platforms))
 
         # Record which rom_ids came from platforms
         platform_rom_ids: set[int] = {r["id"] for r in all_roms}
 
         # Phase 3: Fetch collection ROMs (adds ROMs not already in all_roms)
-        collection_only_roms, collection_memberships = await self._fetch_collection_roms(platform_rom_ids)
+        with self._perf.time_phase("fetch_collections"):
+            collection_only_roms, collection_memberships = await self._fetch_collection_roms(platform_rom_ids)
         all_roms.extend(collection_only_roms)
 
         # Phase 4: Prepare shortcut data
-        shortcuts_data = self._build_shortcuts_data(all_roms)
+        with self._perf.time_phase("prepare_shortcuts"):
+            shortcuts_data = self._build_shortcuts_data(all_roms)
         self._check_cancelling()
 
         # Cache metadata from sync response
-        if self._metadata_service is not None:
-            for rom in all_roms:
-                rom_id_str = str(rom["id"])
-                self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
-                self._metadata_service.mark_metadata_dirty()
-            self._metadata_service.flush_metadata_if_dirty()
+        with self._perf.time_phase("cache_metadata"):
+            if self._metadata_service is not None:
+                for rom in all_roms:
+                    rom_id_str = str(rom["id"])
+                    self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
+                    self._metadata_service.mark_metadata_dirty()
+                self._metadata_service.flush_metadata_if_dirty()
         self._log_debug(f"Metadata cached for {len(all_roms)} ROMs")
 
         return all_roms, shortcuts_data, platforms, collection_memberships, platform_rom_ids
@@ -838,6 +865,7 @@ class LibraryService:
     # ── Full sync ────────────────────────────────────────────
 
     async def _do_sync(self):
+        self._perf.start_sync()
         try:
             try:
                 fetch_result = await self._fetch_and_prepare()
@@ -872,9 +900,10 @@ class LibraryService:
                     step=full_current_step,
                     total_steps=full_total_steps,
                 )
-                cover_paths = await self._download_artwork(
-                    all_roms, progress_step=full_current_step, progress_total_steps=full_total_steps
-                )
+                with self._perf.time_phase("download_artwork"):
+                    cover_paths = await self._download_artwork(
+                        all_roms, progress_step=full_current_step, progress_total_steps=full_total_steps
+                    )
             else:
                 cover_paths = {}
 
@@ -922,6 +951,8 @@ class LibraryService:
             )
 
             self._logger.info(f"Sync data emitted: {len(shortcuts_data)} shortcuts, {len(stale_rom_ids)} stale")
+            self._perf.set_gauge("shortcuts_emitted", len(shortcuts_data))
+            self._perf.set_gauge("stale_rom_ids", len(stale_rom_ids))
         except Exception as e:
             import traceback
 
@@ -936,6 +967,17 @@ class LibraryService:
             }
             self._loop.create_task(self._emit("sync_progress", self._sync_progress))
         finally:
+            self._perf.end_sync()
+            if self._perf.wall_time > 0:
+                self._logger.info(f"[PerfCollector] {self._perf.format_report()}")
+                try:
+                    import json as _json
+                    _perf_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "perf_report.json")
+                    with open(_perf_path, "w") as _f:
+                        _json.dump(self._perf.generate_report(), _f, indent=2)
+                    self._logger.info(f"[PerfCollector] Report saved to {_perf_path}")
+                except Exception as _e:
+                    self._logger.warning(f"[PerfCollector] Failed to save report: {_e}")
             if self._metadata_service is not None:
                 self._metadata_service.flush_metadata_if_dirty()
             self._sync_state = SyncState.IDLE

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 asyncio_mode = auto
 testpaths = tests
 addopts = --import-mode=importlib
+markers =
+    benchmark: marks tests that require a live RomM server (deselect with '-m "not benchmark"')

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import { DownloadQueue } from "./components/DownloadQueue";
 import { initSyncManager } from "./utils/syncManager";
 import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
-import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
+import { unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
 import { registerMetadataPatches, unregisterMetadataPatches, applyAllPlaytime } from "./patches/metadataPatches";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
 import { getAllMetadataCache, getAppIdRomIdMap, ensureDeviceRegistered, getSaveSyncSettings, getAllPlaytime, getMigrationStatus, getSaveSortMigrationStatus, logError, logInfo } from "./api/backend";
@@ -48,7 +48,9 @@ const QAMPanel: FC = () => {
 };
 
 export default definePlugin(() => {
-  registerGameDetailPatch();
+  // registerGameDetailPatch() intentionally removed — it calls
+  // routerHook.addPatch() which triggers Decky route re-renders that crash
+  // Steam's Library page (GetAppCountWithToolsFilter TypeError).
   registerLaunchInterceptor();
 
   // Load metadata cache, register store patches, and populate RomM app ID set.

--- a/tests/lib/test_perf.py
+++ b/tests/lib/test_perf.py
@@ -1,0 +1,398 @@
+"""Unit tests for PerfCollector and ETAEstimator."""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from lib.perf import ETAEstimator, PerfCollector
+
+
+# ═══════════════════════════════════════════════════════════════
+# PerfCollector
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestPerfCollectorLifecycle:
+    """start_sync / end_sync / wall_time basics."""
+
+    def test_wall_time_zero_before_sync(self):
+        perf = PerfCollector()
+        assert perf.wall_time == 0.0
+
+    def test_wall_time_zero_after_start_without_end(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        assert perf.wall_time == 0.0
+
+    def test_wall_time_positive_after_end(self):
+        perf = PerfCollector()
+        with patch("lib.perf.time.monotonic", side_effect=[100.0, 105.0]):
+            perf.start_sync()
+            perf.end_sync()
+        assert perf.wall_time == pytest.approx(5.0)
+
+    def test_start_sync_clears_prior_data(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.increment("x")
+        perf.set_gauge("y", 42)
+        perf.record_http_request("GET", "/a", 0.1, 200, 100)
+        with perf.time_phase("p"):
+            pass
+        perf.end_sync()
+
+        # Second sync should clear everything
+        perf.start_sync()
+        report = perf.generate_report()
+        assert report["counters"] == {}
+        assert report["gauges"] == {}
+        assert report["http"]["total_requests"] == 0
+        assert report["phases"] == {}
+
+
+class TestPerfCollectorPhases:
+    """time_phase context manager."""
+
+    def test_phase_records_duration(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        with perf.time_phase("test_phase"):
+            time.sleep(0.05)
+        perf.end_sync()
+        report = perf.generate_report()
+        assert "test_phase" in report["phases"]
+        assert report["phases"]["test_phase"] >= 0.03
+
+    def test_phase_is_cumulative(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        with perf.time_phase("reentrant"):
+            time.sleep(0.01)
+        with perf.time_phase("reentrant"):
+            time.sleep(0.01)
+        perf.end_sync()
+        report = perf.generate_report()
+        # Both entries combined; use loose threshold for CI timing variance
+        assert report["phases"]["reentrant"] >= 0.015
+
+    def test_multiple_phases(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        with perf.time_phase("alpha"):
+            pass
+        with perf.time_phase("beta"):
+            pass
+        perf.end_sync()
+        report = perf.generate_report()
+        assert "alpha" in report["phases"]
+        assert "beta" in report["phases"]
+
+    def test_phase_records_even_on_exception(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        with pytest.raises(ValueError):
+            with perf.time_phase("failing"):
+                raise ValueError("boom")
+        perf.end_sync()
+        assert "failing" in perf.generate_report()["phases"]
+
+
+class TestPerfCollectorHttp:
+    """HTTP request tracking."""
+
+    def test_record_single_request(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.record_http_request("GET", "/api/platforms", 0.5, 200, 4096)
+        perf.end_sync()
+        report = perf.generate_report()
+        assert report["http"]["total_requests"] == 1
+        assert report["http"]["total_bytes"] == 4096
+        assert report["http"]["total_time"] == 0.5
+        assert report["http"]["errors"] == 0
+
+    def test_record_multiple_methods(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.record_http_request("GET", "/a", 0.1, 200, 100)
+        perf.record_http_request("POST", "/b", 0.2, 201, 200)
+        perf.record_http_request("GET", "/c", 0.3, 200, 300)
+        perf.end_sync()
+        report = perf.generate_report()
+        assert report["http"]["total_requests"] == 3
+        assert report["http"]["total_bytes"] == 600
+        by_method = report["http"]["by_method"]
+        assert by_method["GET"]["count"] == 2
+        assert by_method["POST"]["count"] == 1
+
+    def test_error_counting(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.record_http_request("GET", "/ok", 0.1, 200, 100)
+        perf.record_http_request("GET", "/fail", 0.1, 500, 0)
+        perf.record_http_request("GET", "/auth", 0.1, 401, 0)
+        perf.record_http_request("GET", "/ok2", 0.1, 204, 50)
+        perf.end_sync()
+        report = perf.generate_report()
+        # 500 and 401 are errors (non-2xx)
+        assert report["http"]["errors"] == 2
+
+    def test_zero_status_counted_as_error(self):
+        """Status 0 (connection failure) should count as error."""
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.record_http_request("GET", "/fail", 0.1, 0, 0)
+        perf.end_sync()
+        assert perf.generate_report()["http"]["errors"] == 1
+
+
+class TestPerfCollectorCounters:
+    """Named counters."""
+
+    def test_increment_default(self):
+        perf = PerfCollector()
+        perf.increment("roms_fetched")
+        assert perf.get_counter("roms_fetched") == 1
+
+    def test_increment_custom_amount(self):
+        perf = PerfCollector()
+        perf.increment("bytes", 1024)
+        perf.increment("bytes", 2048)
+        assert perf.get_counter("bytes") == 3072
+
+    def test_get_counter_default(self):
+        perf = PerfCollector()
+        assert perf.get_counter("nonexistent") == 0
+
+
+class TestPerfCollectorGauges:
+    """Named gauges."""
+
+    def test_set_and_get_gauge(self):
+        perf = PerfCollector()
+        perf.set_gauge("concurrency", 4.0)
+        assert perf.get_gauge("concurrency") == 4.0
+
+    def test_gauge_overwrites(self):
+        perf = PerfCollector()
+        perf.set_gauge("x", 1.0)
+        perf.set_gauge("x", 99.0)
+        assert perf.get_gauge("x") == 99.0
+
+    def test_get_gauge_default(self):
+        perf = PerfCollector()
+        assert perf.get_gauge("nonexistent") == 0.0
+
+
+class TestPerfCollectorReport:
+    """generate_report() and format_report()."""
+
+    def test_generate_report_structure(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.end_sync()
+        report = perf.generate_report()
+        assert "wall_time" in report
+        assert "phases" in report
+        assert "http" in report
+        assert "counters" in report
+        assert "gauges" in report
+        assert "total_requests" in report["http"]
+        assert "total_bytes" in report["http"]
+        assert "errors" in report["http"]
+        assert "by_method" in report["http"]
+
+    def test_format_report_readable(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        with perf.time_phase("fetch"):
+            pass
+        perf.record_http_request("GET", "/api/roms", 0.5, 200, 10240)
+        perf.increment("platforms_fetched", 3)
+        perf.set_gauge("concurrency", 4)
+        perf.end_sync()
+
+        text = perf.format_report()
+        assert "Sync completed in" in text
+        assert "fetch:" in text
+        assert "HTTP:" in text
+        assert "GET:" in text
+        assert "platforms_fetched: 3" in text
+        assert "concurrency: 4" in text
+
+    def test_format_report_empty_sync(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.end_sync()
+        text = perf.format_report()
+        assert "Sync completed in" in text
+        # No phases, HTTP, counters, or gauges sections
+        assert "Phases:" not in text
+        assert "HTTP:" not in text
+
+    def test_format_report_shows_http_errors(self):
+        perf = PerfCollector()
+        perf.start_sync()
+        perf.record_http_request("GET", "/fail", 0.1, 500, 0)
+        perf.end_sync()
+        text = perf.format_report()
+        assert "HTTP errors: 1" in text
+
+
+# ═══════════════════════════════════════════════════════════════
+# ETAEstimator
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestETAEstimatorBasics:
+    """Core ETA behaviour."""
+
+    def test_eta_none_before_start(self):
+        eta = ETAEstimator()
+        assert eta.eta_seconds(0, 100) is None
+
+    def test_eta_none_with_few_samples(self):
+        eta = ETAEstimator(min_samples=3)
+        eta.start()
+        eta.update(10)
+        assert eta.eta_seconds(10, 100) is None  # only 1 sample
+
+    def test_eta_returns_value_after_min_samples(self):
+        eta = ETAEstimator(alpha=0.5, min_samples=2)
+        eta.start()
+        # Simulate two updates with controlled timing
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+
+            mock_time.return_value = 101.0
+            eta.update(10)  # 10 items in 1s = 10/s
+
+            mock_time.return_value = 102.0
+            eta.update(20)  # 10 items in 1s = 10/s
+
+        result = eta.eta_seconds(20, 100)
+        assert result is not None
+        assert result > 0
+
+    def test_eta_none_when_complete(self):
+        eta = ETAEstimator(min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+            mock_time.return_value = 101.0
+            eta.update(100)
+        assert eta.eta_seconds(100, 100) is None
+
+    def test_elapsed_zero_before_start(self):
+        eta = ETAEstimator()
+        assert eta.elapsed == 0.0
+
+    def test_elapsed_positive_after_start(self):
+        eta = ETAEstimator()
+        eta.start()
+        assert eta.elapsed >= 0
+
+    def test_items_per_sec_zero_before_update(self):
+        eta = ETAEstimator()
+        eta.start()
+        assert eta.items_per_sec == 0.0
+
+    def test_samples_count(self):
+        eta = ETAEstimator()
+        eta.start()
+        assert eta.samples == 0
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+            mock_time.return_value = 101.0
+            eta.update(10)
+            mock_time.return_value = 102.0
+            eta.update(20)
+        assert eta.samples == 2
+
+
+class TestETAEstimatorEdgeCases:
+    """Edge cases and invariants."""
+
+    def test_backward_update_ignored(self):
+        eta = ETAEstimator(min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+            mock_time.return_value = 101.0
+            eta.update(50)
+            mock_time.return_value = 102.0
+            eta.update(30)  # backward — should be ignored
+        assert eta.samples == 1
+
+    def test_duplicate_update_ignored(self):
+        eta = ETAEstimator(min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+            mock_time.return_value = 101.0
+            eta.update(50)
+            mock_time.return_value = 102.0
+            eta.update(50)  # same value — should be ignored
+        assert eta.samples == 1
+
+    def test_start_resets_state(self):
+        eta = ETAEstimator(min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+            mock_time.return_value = 101.0
+            eta.update(50)
+        assert eta.samples == 1
+
+        eta.start()
+        assert eta.samples == 0
+        assert eta.items_per_sec == 0.0
+
+    def test_ema_smoothing(self):
+        """With alpha=1.0, the EMA should equal the latest rate exactly."""
+        eta = ETAEstimator(alpha=1.0, min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+
+            mock_time.return_value = 101.0
+            eta.update(10)  # 10 items/sec
+
+            mock_time.return_value = 102.0
+            eta.update(30)  # 20 items in 1s = 20 items/sec
+
+        # alpha=1.0 means newest rate dominates
+        assert eta.items_per_sec == pytest.approx(20.0)
+
+    def test_eta_calculation_accuracy(self):
+        """With constant rate of 10 items/sec, ETA for 80 remaining should be ~8s."""
+        eta = ETAEstimator(alpha=1.0, min_samples=1)
+        eta.start()
+        with patch("lib.perf.time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+            eta._start = 100.0
+            eta._last_update = 100.0
+
+            mock_time.return_value = 101.0
+            eta.update(10)  # 10 items/sec
+
+            mock_time.return_value = 102.0
+            eta.update(20)  # 10 items/sec
+
+        result = eta.eta_seconds(20, 100)
+        assert result == pytest.approx(8.0)


### PR DESCRIPTION
## Summary
Add PerfCollector and ETAEstimator to measure sync performance across all pipeline phases. All changes are additive - zero behavioral modifications to existing sync logic.

## What's included
- **PerfCollector** - tracks per-phase timing, HTTP request counts, bytes transferred, error/retry counts
- **ETAEstimator** - provides estimated time remaining during long operations
- **Artwork progress logging** - reports downloaded/skipped/failed counts at ~10%% intervals
- **Per-platform ROM fetch timing** - individual timing for each platform's API pagination
- **get_perf_report RPC endpoint** - exposes collected metrics to the frontend
- **Auto-save perf_report.json** - written after each sync completes
- **35 unit tests** for PerfCollector and ETAEstimator

## Files changed
- `py_modules/lib/perf.py` - NEW: PerfCollector + ETAEstimator
- `py_modules/services/library.py` - phase timing wrappers, gauge counters
- `py_modules/adapters/romm/http.py` - HTTP request/byte tracking
- `py_modules/services/artwork.py` - progress logging
- `py_modules/bootstrap.py` - wires PerfCollector to HTTP adapter
- `main.py` - get_perf_report RPC endpoint
- `tests/lib/test_perf.py` - 35 unit tests
- `pytest.ini` - test configuration

## Testing
Tested on Steam Deck with 373 ROMs across Dreamcast platform + Metroid collection. Two successful end-to-end syncs confirmed all instrumentation works without affecting sync behavior.