### PR TITLE
feat(saves): show offline indicators in play section and saves tab (#221)

### DIFF
--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -23,7 +23,7 @@ import {
   showContextMenu,
   showModal,
 } from "@decky/ui";
-import { FaGamepad, FaCog, FaMicrochip } from "react-icons/fa";
+import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icons/fa";
 import { CustomPlayButton } from "./CustomPlayButton";
 import {
   getCachedGameDetail,
@@ -273,7 +273,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     achievementEarned: 0,
     achievementTotal: 0,
   });
-  const [, setConnectionState] = useState<ConnectionState>("checking");
+  const [connectionState, setConnectionState] = useState<ConnectionState>("checking");
   const [actionPending, setActionPending] = useState<string | null>(null);
   const romIdRef = useRef<number | null>(null);
 
@@ -739,6 +739,24 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
 
   // Build info items array
   const infoItems: ReturnType<typeof createElement>[] = [];
+
+  // Offline indicator (first — most prominent)
+  if (connectionState === "offline") {
+    infoItems.push(
+      createElement("div", {
+        key: "offline-indicator",
+        className: "romm-info-item",
+      },
+        createElement("div", { className: "romm-info-header" },
+          createElement(FaExclamationTriangle, { size: 12, color: "#ff8800" }),
+        ),
+        createElement("div", {
+          className: "romm-info-value",
+          style: { color: "#ff8800" },
+        }, "RomM offline"),
+      ),
+    );
+  }
 
   // Last Played
   if (info.lastPlayed) {

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -10,9 +10,10 @@
  * - New-slot modal opens inline (same as old NewSlotModal in parent).
  */
 
-import { useState, useRef, createElement, FC, ChangeEvent } from "react";
+import { useState, useEffect, useRef, createElement, FC, ChangeEvent } from "react";
 import { ConfirmModal, DialogButton, Focusable, TextField, showModal } from "@decky/ui";
 import { getSlotSaves, switchSlot, debugLog } from "../api/backend";
+import { getRommConnectionState } from "../utils/connectionState";
 import type { SaveStatus, PendingConflict, SaveSlotSummary, SaveFileStatus, SlotSaveFile, SwitchSlotResponse } from "../types";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 
@@ -488,6 +489,34 @@ export const SavesTab: FC<SavesTabProps> = ({
 }) => {
   const [newSlotError, setNewSlotError] = useState<string | null>(null);
   const newSlotErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isOffline, setIsOffline] = useState(getRommConnectionState() === "offline");
+
+  useEffect(() => {
+    const onConnectionChanged = (e: Event) => {
+      const connState = (e as CustomEvent).detail?.state;
+      setIsOffline(connState === "offline");
+    };
+    window.addEventListener("romm_connection_changed", onConnectionChanged);
+    return () => {
+      window.removeEventListener("romm_connection_changed", onConnectionChanged);
+    };
+  }, []);
+
+  // --- Offline banner ---
+  const offlineBanner = isOffline
+    ? createElement("div", {
+        key: "offline-banner",
+        style: {
+          padding: "8px",
+          background: "rgba(217, 65, 38, 0.15)",
+          borderRadius: "4px",
+          border: "1px solid rgba(217, 65, 38, 0.4)",
+          marginBottom: "12px",
+          fontSize: "12px",
+          color: "#d94126",
+        },
+      }, "RomM is offline \u2014 slot switching is disabled until the server is reachable. This prevents save sync conflicts.")
+    : null;
 
   // --- Legacy mode warning ---
   const legacyWarning = activeSlot === null
@@ -507,8 +536,11 @@ export const SavesTab: FC<SavesTabProps> = ({
 
   // --- Loading state ---
   if (slotsLoading) {
-    return createElement("div", { style: { fontSize: "13px", color: "#8f98a0", padding: "8px 0" } },
-      "Loading slots...");
+    return createElement(Focusable as any, { noFocusRing: true },
+      offlineBanner,
+      createElement("div", { style: { fontSize: "13px", color: "#8f98a0", padding: "8px 0" } },
+        "Loading slots..."),
+    );
   }
 
   // --- Sort slots: active first, then alphabetically ---
@@ -600,6 +632,7 @@ export const SavesTab: FC<SavesTabProps> = ({
     noFocusRing: true,
     style: { display: "flex", flexDirection: "column" as const, gap: "0" },
   },
+    offlineBanner,
     legacyWarning,
 
     // Legacy mode: show save files directly above slot panels

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -496,9 +496,9 @@ export const SavesTab: FC<SavesTabProps> = ({
       const connState = (e as CustomEvent).detail?.state;
       setIsOffline(connState === "offline");
     };
-    window.addEventListener("romm_connection_changed", onConnectionChanged);
+    globalThis.addEventListener("romm_connection_changed", onConnectionChanged);
     return () => {
-      window.removeEventListener("romm_connection_changed", onConnectionChanged);
+      globalThis.removeEventListener("romm_connection_changed", onConnectionChanged);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Adds a conditional offline info item in the RomM play section — a warning triangle with "RomM offline" label, shown as the first info item whenever the connection state is `offline`.
- Adds a red top banner in the saves tab that explains slot switching is disabled while RomM is unreachable. The banner is visible during the `slotsLoading` state too, so the offline state is communicated immediately on tab open.
- Subscribes to the existing `romm_connection_changed` event (same pattern as `CustomPlayButton`), no new backend calls or API changes.

Closes #221.

## Test plan
- [x] With RomM online: no offline indicator in play section, no red banner in saves tab
- [x] With RomM offline on tab open: offline indicator shown in play section, red banner shown at top of saves tab (also during "Loading slots...")
- [x] RomM goes from online to offline while saves tab is open: banner appears without reloading the tab
- [x] RomM recovers from offline to online: banner and indicator disappear
- [x] Slot switch attempt while offline still shows the existing inline error (unchanged behavior)
- [x] Playtime / BIOS / other play-section info items still render correctly alongside the offline indicator