### PR TITLE
fix(saves): resolve corename via retroarch .info for sort-by-core save paths

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -184,6 +184,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         get_saves_path=cfg.get_saves_path,
         get_roms_path=cfg.get_roms_path,
         get_active_core=_es_de_config.get_active_core,
+        get_core_name=cfg.get_core_name,
         plugin_version=_read_plugin_version(cfg.plugin_dir),
         emit=cfg.emit,
     )

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -34,6 +34,7 @@ from domain.save_path import resolve_save_dir
 from domain.save_sync import determine_sync_action, match_local_to_server_saves
 from lib.errors import RommApiError, RommConflictError, classify_error
 from services.protocols import (
+    CoreNameProviderFn,
     CoreResolverFn,
     RetryStrategy,
     RommApiProtocol,
@@ -84,6 +85,17 @@ class SaveService:
     get_active_core:
         Callable resolving the active RetroArch core for a system/game.
         Returns ``(core_so, label)`` tuple; either may be None if unresolved.
+        This is an ES-DE question (``which core runs this ROM?``).
+    get_core_name:
+        Callable returning the RetroArch canonical ``corename`` field from
+        a core's ``.info`` file for a given ``core_so`` (e.g. ``"mgba_libretro"``
+        → ``"mGBA"``). Optional. When ``sort_savefiles_enable`` is active on
+        RetroArch, this is the authoritative name used for the per-core save
+        subdirectory — it is NOT the same as the ES-DE UI label returned by
+        ``get_active_core`` (see the Config-Source-Parsers wiki page for the
+        one-parser-per-source rationale). When ``None`` or when resolution
+        fails at runtime, SaveService warns and falls back to the parent
+        directory path; see ``_resolve_retroarch_corename``.
     get_retroarch_save_sorting:
         Callable returning ``(sort_by_content, sort_by_core)`` booleans from retroarch.cfg.
     """
@@ -104,6 +116,7 @@ class SaveService:
         get_saves_path: SavesPathProvider,
         get_roms_path: RomsPathProvider,
         get_active_core: CoreResolverFn,
+        get_core_name: CoreNameProviderFn | None = None,
         plugin_version: str = "0.0.0",
         emit: EventEmitter | None = None,
     ) -> None:
@@ -118,6 +131,7 @@ class SaveService:
         self._get_saves_path = get_saves_path
         self._get_roms_path = get_roms_path
         self._get_active_core = get_active_core
+        self._get_core_name = get_core_name
         self._plugin_version = plugin_version
         self._emit = emit
 
@@ -225,6 +239,35 @@ class SaveService:
     # ROM / path helpers
     # ------------------------------------------------------------------
 
+    def _resolve_retroarch_corename(self, system: str, rom_filename: str) -> str | None:
+        """Resolve the RetroArch ``corename`` for a system/ROM.
+
+        Asks ES-DE (via ``get_active_core``) **which** core is active for
+        this ROM, then asks the RetroArch ``.info`` parser (via
+        ``get_core_name``) **what** RetroArch calls that core in its own
+        subsystem — which is the authoritative name used for per-core save
+        subdirectories when ``sort_savefiles_enable`` is active.
+
+        One parser per source: the ES-DE label (second element of the
+        ``get_active_core`` tuple) is NOT a valid substitute for the
+        RetroArch corename. See the Config-Source-Parsers wiki page and
+        the reference implementation in ``MigrationService``.
+
+        Returns ``None`` when either callback is missing, the active core
+        cannot be determined, or the ``.info`` file doesn't yield a
+        usable corename. Callers are responsible for choosing the right
+        behavior when ``None`` is returned (e.g. warn and fall back for
+        critical-path SaveService flows; skip and warn for one-shot
+        migrations).
+        """
+        if self._get_active_core is None or self._get_core_name is None:
+            return None
+        core_so, _label = self._get_active_core(system, rom_filename)
+        if not core_so:
+            return None
+        corename = self._get_core_name(core_so)
+        return corename or None
+
     def _get_rom_save_info(self, rom_id: int) -> dict | None:
         """Get save-related info for an installed ROM.
 
@@ -252,6 +295,29 @@ class SaveService:
             sort_by_core = sort_state.get("sort_by_core", False)
         else:
             sort_by_content, sort_by_core = True, False  # RetroDECK defaults
+
+        # When sort-by-core is active, RetroArch writes per-core subdirs named
+        # by the .info ``corename`` field. Resolve it via the dedicated parser.
+        # See docs: Config-Source-Parsers wiki page ("one parser per source").
+        # Decision: warn-and-fallback (not fail-loud like MigrationService).
+        # SaveService is the critical-path sync flow — every game launch
+        # depends on it. Fail-loud would take down save sync entirely on any
+        # .info hiccup. MigrationService can afford strictness (one-shot),
+        # SaveService cannot (continuous). See issue #232 for history.
+        core_name: str | None = None
+        if sort_by_core:
+            core_name = self._resolve_retroarch_corename(system, os.path.basename(file_path))
+            if core_name is None:
+                self._logger.warning(
+                    "SaveService: unable to resolve RetroArch corename for "
+                    "%s/%s while sort_by_core is enabled. Falling back to the "
+                    "parent save directory, which will not match what RetroArch "
+                    "reads at runtime. Check that the core's .info file is "
+                    "readable under the RetroDECK Flatpak cores directory.",
+                    system,
+                    os.path.basename(file_path),
+                )
+
         saves_dir = resolve_save_dir(
             file_path,
             saves_base,
@@ -259,6 +325,7 @@ class SaveService:
             roms_base=roms_base,
             sort_by_content=sort_by_content,
             sort_by_core=sort_by_core,
+            core_name=core_name,
         )
 
         return {

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -96,8 +96,6 @@ class SaveService:
         one-parser-per-source rationale). When ``None`` or when resolution
         fails at runtime, SaveService warns and falls back to the parent
         directory path; see ``_resolve_retroarch_corename``.
-    get_retroarch_save_sorting:
-        Callable returning ``(sort_by_content, sort_by_core)`` booleans from retroarch.cfg.
     """
 
     _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
@@ -239,7 +237,7 @@ class SaveService:
     # ROM / path helpers
     # ------------------------------------------------------------------
 
-    def _resolve_retroarch_corename(self, system: str, rom_filename: str) -> str | None:
+    def _resolve_retroarch_corename(self, system: str, rom_filename: str) -> tuple[str | None, str | None]:
         """Resolve the RetroArch ``corename`` for a system/ROM.
 
         Asks ES-DE (via ``get_active_core``) **which** core is active for
@@ -253,20 +251,24 @@ class SaveService:
         RetroArch corename. See the Config-Source-Parsers wiki page and
         the reference implementation in ``MigrationService``.
 
-        Returns ``None`` when either callback is missing, the active core
-        cannot be determined, or the ``.info`` file doesn't yield a
-        usable corename. Callers are responsible for choosing the right
-        behavior when ``None`` is returned (e.g. warn and fall back for
-        critical-path SaveService flows; skip and warn for one-shot
-        migrations).
+        Returns ``(corename, core_so)``. Either element may be ``None``
+        when resolution fails at that step: ``core_so`` is ``None`` when
+        ES-DE cannot determine the active core, ``corename`` is ``None``
+        when ``.info`` parsing returns nothing (or when ``get_core_name``
+        is not injected). Returning the tuple — rather than just
+        ``corename`` — lets callers include ``core_so`` in diagnostic
+        logs so users can identify which ``.info`` file is at fault.
+        Callers choose their own fallback strategy (e.g. warn and fall
+        back for critical-path SaveService flows; skip and warn for
+        one-shot migrations).
         """
-        if self._get_active_core is None or self._get_core_name is None:
-            return None
+        if self._get_core_name is None:
+            return (None, None)
         core_so, _label = self._get_active_core(system, rom_filename)
         if not core_so:
-            return None
+            return (None, None)
         corename = self._get_core_name(core_so)
-        return corename or None
+        return (corename or None, core_so)
 
     def _get_rom_save_info(self, rom_id: int) -> dict | None:
         """Get save-related info for an installed ROM.
@@ -306,16 +308,19 @@ class SaveService:
         # SaveService cannot (continuous). See issue #232 for history.
         core_name: str | None = None
         if sort_by_core:
-            core_name = self._resolve_retroarch_corename(system, os.path.basename(file_path))
+            rom_filename = os.path.basename(file_path)
+            core_name, core_so = self._resolve_retroarch_corename(system, rom_filename)
             if core_name is None:
                 self._logger.warning(
                     "SaveService: unable to resolve RetroArch corename for "
-                    "%s/%s while sort_by_core is enabled. Falling back to the "
-                    "parent save directory, which will not match what RetroArch "
-                    "reads at runtime. Check that the core's .info file is "
-                    "readable under the RetroDECK Flatpak cores directory.",
+                    "%s/%s (core_so=%s) while sort_by_core is enabled. "
+                    "Falling back to the parent save directory, which will "
+                    "not match what RetroArch reads at runtime. Check that "
+                    "the core's .info file is readable under the RetroDECK "
+                    "Flatpak cores directory.",
                     system,
-                    os.path.basename(file_path),
+                    rom_filename,
+                    core_so if core_so else "unresolved",
                 )
 
         saves_dir = resolve_save_dir(

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -1600,7 +1600,11 @@ class TestGetRomSaveInfo:
         assert "Snes9x - Current" not in result["saves_dir"]
 
     def test_sort_by_core_falls_back_when_corename_none(self, tmp_path, caplog):
-        """sort_by_core=True but corename unresolvable → warn + fall back to parent dir."""
+        """sort_by_core=True but corename unresolvable → warn + fall back to parent dir.
+
+        The warning must include ``core_so=mgba_libretro`` so a user can identify
+        which ``.info`` file the parser failed on.
+        """
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
@@ -1615,10 +1619,17 @@ class TestGetRomSaveInfo:
         assert result is not None
         assert result["saves_dir"].endswith("saves/gba")
         assert "/mGBA" not in result["saves_dir"]
-        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+        warnings = [rec.message for rec in caplog.records if "unable to resolve RetroArch corename" in rec.message]
+        assert warnings, "expected fallback warning"
+        assert "core_so=mgba_libretro" in warnings[0]
 
     def test_sort_by_core_falls_back_when_get_core_name_missing(self, tmp_path, caplog):
-        """Constructed without get_core_name → still warns and falls back."""
+        """Constructed without get_core_name → still warns and falls back.
+
+        When ``get_core_name`` is not injected, the helper short-circuits before
+        calling ``get_active_core``, so ``core_so`` is never resolved and the log
+        records ``core_so=unresolved`` for that case.
+        """
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
@@ -1632,10 +1643,16 @@ class TestGetRomSaveInfo:
 
         assert result is not None
         assert result["saves_dir"].endswith("saves/gba")
-        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+        warnings = [rec.message for rec in caplog.records if "unable to resolve RetroArch corename" in rec.message]
+        assert warnings, "expected fallback warning"
+        assert "core_so=unresolved" in warnings[0]
 
     def test_sort_by_core_falls_back_when_active_core_unresolved(self, tmp_path, caplog):
-        """sort_by_core=True but get_active_core returns (None, None) → warn + fall back."""
+        """sort_by_core=True but get_active_core returns (None, None) → warn + fall back.
+
+        When ES-DE cannot determine the active core, ``core_so`` is ``None`` and
+        the log records ``core_so=unresolved``.
+        """
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: (None, None),
@@ -1649,33 +1666,41 @@ class TestGetRomSaveInfo:
 
         assert result is not None
         assert result["saves_dir"].endswith("saves/gba")
-        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+        warnings = [rec.message for rec in caplog.records if "unable to resolve RetroArch corename" in rec.message]
+        assert warnings, "expected fallback warning"
+        assert "core_so=unresolved" in warnings[0]
 
     def test_resolve_retroarch_corename_happy_path(self, tmp_path):
-        """Direct test of the helper: both callbacks resolve → corename returned."""
+        """Direct test of the helper: both callbacks resolve → (corename, core_so) tuple returned."""
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x - Current"),
             get_core_name=lambda core_so: "Snes9x",
         )
-        assert svc._resolve_retroarch_corename("snes", "mario.sfc") == "Snes9x"
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") == ("Snes9x", "snes9x_libretro")
 
-    def test_resolve_retroarch_corename_returns_none_when_core_so_empty(self, tmp_path):
+    def test_resolve_retroarch_corename_returns_none_tuple_when_core_so_empty(self, tmp_path):
+        """ES-DE returns (None, None) → helper returns (None, None)."""
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             get_core_name=lambda core_so: "Snes9x",
         )
-        assert svc._resolve_retroarch_corename("snes", "mario.sfc") is None
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") == (None, None)
 
-    def test_resolve_retroarch_corename_returns_none_when_empty_string(self, tmp_path):
-        """Empty-string corename from .info is treated as None (dead branch in domain guard)."""
+    def test_resolve_retroarch_corename_preserves_core_so_when_corename_empty(self, tmp_path):
+        """Empty corename with resolved core_so → (None, core_so).
+
+        The core_so is preserved in the second element so the caller can log
+        which ``.info`` file failed diagnostically. The first element is None
+        because the empty-string corename is treated as "no usable value".
+        """
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
             get_core_name=lambda core_so: "",
         )
-        assert svc._resolve_retroarch_corename("snes", "mario.sfc") is None
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") == (None, "snes9x_libretro")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -1546,6 +1546,137 @@ class TestGetRomSaveInfo:
 
         assert result is None
 
+    # ------------------------------------------------------------------
+    # Regression tests for issue #232 — SaveService must resolve the
+    # RetroArch ``corename`` via the .info parser when sort_by_core is
+    # active, and must fall back with a warning when it cannot.
+    # ------------------------------------------------------------------
+
+    def test_default_sort_only_by_content_no_core_subdir(self, tmp_path):
+        """sort_by_core=False (RetroDECK default) → no core subdir."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
+
+        result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/gba")
+        assert "/mGBA" not in result["saves_dir"]
+
+    def test_sort_by_core_appends_retroarch_corename(self, tmp_path):
+        """sort_by_core=True with resolvable corename → saves_dir ends in /{system}/{corename}."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/gba/mGBA")
+
+    def test_sort_by_core_uses_corename_not_es_de_label(self, tmp_path):
+        """The RetroArch .info corename (``Snes9x``) must be used, not the ES-DE label (``Snes9x - Current``)."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x - Current"),
+            get_core_name=lambda core_so: "Snes9x",
+        )
+        _install_rom(svc, tmp_path, system="snes", file_name="mario.sfc")
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/snes/Snes9x")
+        assert "Snes9x - Current" not in result["saves_dir"]
+
+    def test_sort_by_core_falls_back_when_corename_none(self, tmp_path, caplog):
+        """sort_by_core=True but corename unresolvable → warn + fall back to parent dir."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: None,  # .info unreadable / field missing
+        )
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        with caplog.at_level("WARNING"):
+            result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/gba")
+        assert "/mGBA" not in result["saves_dir"]
+        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+
+    def test_sort_by_core_falls_back_when_get_core_name_missing(self, tmp_path, caplog):
+        """Constructed without get_core_name → still warns and falls back."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            # get_core_name intentionally omitted (defaults to None)
+        )
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        with caplog.at_level("WARNING"):
+            result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/gba")
+        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+
+    def test_sort_by_core_falls_back_when_active_core_unresolved(self, tmp_path, caplog):
+        """sort_by_core=True but get_active_core returns (None, None) → warn + fall back."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: (None, None),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        with caplog.at_level("WARNING"):
+            result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        assert result["saves_dir"].endswith("saves/gba")
+        assert any("unable to resolve RetroArch corename" in rec.message for rec in caplog.records)
+
+    def test_resolve_retroarch_corename_happy_path(self, tmp_path):
+        """Direct test of the helper: both callbacks resolve → corename returned."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x - Current"),
+            get_core_name=lambda core_so: "Snes9x",
+        )
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") == "Snes9x"
+
+    def test_resolve_retroarch_corename_returns_none_when_core_so_empty(self, tmp_path):
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: (None, None),
+            get_core_name=lambda core_so: "Snes9x",
+        )
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") is None
+
+    def test_resolve_retroarch_corename_returns_none_when_empty_string(self, tmp_path):
+        """Empty-string corename from .info is treated as None (dead branch in domain guard)."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
+            get_core_name=lambda core_so: "",
+        )
+        assert svc._resolve_retroarch_corename("snes", "mario.sfc") is None
+
 
 # ---------------------------------------------------------------------------
 # TestUploadSpecialChars

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -198,3 +198,17 @@ class TestWireServices:
         # Callback is stored as _get_core_name on the service
         assert migration_service._get_core_name is get_core_name_mock
         deps["loop"].close()
+
+    def test_save_sync_service_receives_get_core_name(self, tmp_path):
+        """Regression test for #232: SaveService must receive get_core_name.
+
+        Without this callback, SaveService cannot resolve the RetroArch
+        .info ``corename`` when ``sort_by_core`` is active, and silently
+        builds save paths that RetroArch will not read.
+        """
+        deps = self._make_deps(tmp_path)
+        get_core_name_mock = deps["get_core_name"]
+        result = wire_services(WiringConfig(**deps))
+        save_sync_service = result["save_sync_service"]
+        assert save_sync_service._get_core_name is get_core_name_mock
+        deps["loop"].close()


### PR DESCRIPTION
Closes #232. Discovered during live-testing of PR #227 (#208). This is the second shoe dropping on the one-parser-per-source compliance work.

## The bug

`SaveService._get_rom_save_info` called `domain.save_path.resolve_save_dir` with `sort_by_core` from state but **without** the resolved `core_name`. The domain function's guard `if sort_by_core and core_name:` then silently skipped the core subdir branch, so every save path fell back to `{saves_base}/{system}/` instead of `{saves_base}/{system}/{corename}/` whenever a user had `sort_savefiles_enable = true` in their `retroarch.cfg`.

Live-reproduced on a real Steam Deck: a user restored a Mario Golf GBA save via the game detail panel's version history UI. RetroArch respected the sort setting and read from `saves/gba/mGBA/` at runtime, but the restore wrote to `saves/gba/` — the restored file was effectively orphaned and the game loaded the pre-restore save.

The `RetroArchCoreInfoAdapter` and `CoreNameProviderFn` protocol were already added by #208 (PR #227) — the migration flow was fixed, but the audit didn't extend to `SaveService`. Every save-sync flow on every game launch (pre-launch sync, post-exit sync, rollback, slot switching, status checks) routes through `_get_rom_save_info`, so this single callsite silently corrupted every operation.

## The audit

Grepped every `resolve_save_dir` call site across `py_modules` and `tests`:

- `services/migration.py:516/:525` — already passes `core_name` via `_resolve_retroarch_corename`. Correct (fixed by #208).
- `services/saves.py:255` — missing `core_name`. **The bug.** Fixed here.
- `tests/domain/test_save_path.py` — pure-function unit tests, not bugs.

Also checked for manual `os.path.join(saves_base, system, ...)` patterns bypassing `resolve_save_dir` — none found. Every downstream save flow in `saves.py` reads `saves_dir` from the dict returned by `_get_rom_save_info`, so fixing this one site repairs all consumers transitively.

## The fix

- `SaveService.__init__` takes a new optional `get_core_name: CoreNameProviderFn | None = None` callback, matching the pattern established by `MigrationService` in #208.
- New `_resolve_retroarch_corename(system, rom_filename) -> str | None` helper on `SaveService`, structurally mirroring the one on `MigrationService` but returning just `str | None` since `SaveService` doesn't need `core_so` for diagnostics.
- `_get_rom_save_info` now resolves `core_name` via the helper when `sort_by_core` is active, then passes it to `resolve_save_dir`. When `sort_by_core` is `False`, behavior is unchanged.
- `bootstrap.py` wires `get_core_name=cfg.get_core_name` into `SaveService` alongside the existing `MigrationService` wiring. The callback was already threaded through `WiringConfig` and `main.py` for #208, so no new infrastructure is needed.

## None-handling: warn-and-fallback, intentionally different from MigrationService

`MigrationService` fails loud when `.info` lookup returns `None`: it logs a warning and skips the affected files. That's acceptable because migration is a one-shot operation — a user can re-run it, and not migrating is safer than migrating to the wrong place.

`SaveService` cannot afford the same strictness. It runs on the continuous critical path: every game launch triggers pre-launch sync, every game exit triggers post-exit sync, and rollback/slot-switch runs during active play. Halting save sync entirely on any `.info` read hiccup would turn a diagnostic problem into a silent feature outage.

So this PR adopts **warn-and-fallback**: when `core_name` cannot be resolved with `sort_by_core=True`, SaveService logs a WARNING with enough context (system, rom filename, and the fact that sort_by_core is active) and falls back to the parent-dir path. The warning is loud enough to surface in logs for diagnosis while keeping the sync flow alive. The asymmetry with MigrationService is documented in a code comment so future readers don't "harmonize" the two services.

## Wiki update

Separate commit on the wiki repo (master): `docs(wiki): add "Known consumer gaps" section to Config-Source-Parsers`. Adds a new section with a case study of the #208 → #232 sequence, a five-item consumer checklist for reviewers, and a historical-examples table linking both issues. The goal is to make consumer-compliance audits an explicit reviewer responsibility, not just parser-side guidance.

## Test plan

- [x] Added `TestGetRomSaveInfo::test_default_sort_only_by_content_no_core_subdir` — `sort_by_core=False` (RetroDECK default) still produces `saves/gba` with no core subdir, guarding against over-correction.
- [x] Added `test_sort_by_core_appends_retroarch_corename` — happy path: `sort_by_core=True`, both callbacks resolve, `saves_dir` ends in `saves/gba/mGBA`.
- [x] Added `test_sort_by_core_uses_corename_not_es_de_label` — explicitly verifies the Snes9x / `Snes9x - Current` asymmetry from the wiki: the `.info` corename wins, the ES-DE label is not leaked into the path.
- [x] Added `test_sort_by_core_falls_back_when_corename_none` — `.info` unreadable or field missing → warn + fall back to parent dir.
- [x] Added `test_sort_by_core_falls_back_when_get_core_name_missing` — `SaveService` constructed without `get_core_name` at all → warn + fall back (backwards-compat for tests that don't wire the new callback).
- [x] Added `test_sort_by_core_falls_back_when_active_core_unresolved` — `get_active_core` returns `(None, None)` → warn + fall back.
- [x] Added three direct unit tests for `_resolve_retroarch_corename`: happy path, empty `core_so`, empty-string corename.
- [x] Added `TestWireServices::test_save_sync_service_receives_get_core_name` — bootstrap wiring regression test.
- [x] Full test suite green: **1729 passed** (`python -m pytest tests/ -q`).
- [x] Coverage on `services/saves.py`: 89% (unchanged by this PR; new lines are all covered by the new tests).
- [x] Ruff: **All checks passed**.
- [x] basedpyright (`py_modules main.py tests`): **0 errors, 0 warnings, 0 notes**.
- [x] import-linter: **6 kept, 0 broken**.
- [x] Frontend build: clean (no frontend changes).