### PR TITLE
feat(saves): show success toast on migration completion

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   showModal,
   ToggleField,
 } from "@decky/ui";
+import { toaster } from "@decky/api";
 import {
   getSettings,
   saveSettings,
@@ -425,7 +426,13 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                           try {
                             const r = await migrateRetroDeckFiles(strategy);
                             setMigrateResult(r.message);
-                            if (r.success) clearMigration();
+                            if (r.success) {
+                              clearMigration();
+                              toaster.toast({
+                                title: "RomM Sync",
+                                body: r.message || "Migration complete.",
+                              });
+                            }
                           } catch { setMigrateResult("Migration failed"); }
                           setMigrating(false);
                         }}
@@ -436,6 +443,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                   setMigrateResult(result.message);
                   if (result.success) {
                     clearMigration();
+                    toaster.toast({
+                      title: "RomM Sync",
+                      body: result.message || "Migration complete.",
+                    });
                   }
                 } catch {
                   setMigrateResult("Migration failed");
@@ -495,7 +506,13 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                           try {
                             const r = await migrateSaveSortFiles(strategy);
                             setSaveSortResult(r.message);
-                            if (r.success) clearSaveSortMigration();
+                            if (r.success) {
+                              clearSaveSortMigration();
+                              toaster.toast({
+                                title: "RomM Sync",
+                                body: r.message || "Migration complete.",
+                              });
+                            }
                           } catch { setSaveSortResult("Migration failed"); }
                           setSaveSortMigrating(false);
                         }}
@@ -506,6 +523,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                   setSaveSortResult(result.message);
                   if (result.success) {
                     clearSaveSortMigration();
+                    toaster.toast({
+                      title: "RomM Sync",
+                      body: result.message || "Migration complete.",
+                    });
                   }
                 } catch {
                   setSaveSortResult("Migration failed");


### PR DESCRIPTION
## Summary

- Add success toast notifications when either migration flow completes (RetroDECK path migration + RetroArch save-sort migration)
- Covers all four success branches: initial migration + conflict-resolution follow-up, for both flows
- Keeps Detect→Complete feedback symmetric with the existing detection toasts in `src/index.tsx`

Before this change, the only success signal was the migration banner disappearing and a `<Field>` appearing inside the SettingsPage — if the user navigated away after triggering migration, they got no feedback that the action succeeded. The title (`"RomM Sync"`) and body (`result.message` with a defensive `|| "Migration complete."` fallback) match the existing toast conventions in `src/index.tsx`.

Error toasts are intentionally out of scope — the existing `setMigrateResult("Migration failed")` Field-based error display is unchanged.

Closes #231

## Test plan

- [x] Trigger RetroDECK path migration with pending files → toast appears with backend message (e.g. `"Migrated N ROM(s), M BIOS, K save(s)"`)
- [x] Trigger save-sort migration with pending files → toast appears with backend message
- [x] Trigger migration flow that hits a conflict, pick a resolution strategy → success toast fires after the follow-up completes
- [x] Trigger migration when nothing needs migrating → toast fires with `"No files to migrate"` message (intentional per issue #231 — "toast on all successes")
- [x] Trigger a failure → no toast (existing `Field` error display unchanged)
- [x] Navigate away from SettingsPage immediately after triggering migration → toast still visible via global toaster