### PR TITLE
feat(saves): auto-detect migration state across plugin lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,28 +114,8 @@ tests/
 
 ## Current State
 
-**Latest release**: v0.13.0 on main
-
-Working:
-- Full sync engine (fetch ROMs, create shortcuts, apply cover art)
-- On-demand ROM downloads with progress tracking
-- BIOS file management per platform with per-core annotations
-- Game detail page injection (custom PlaySection, GameInfoPanel, metadata)
-- SteamGridDB artwork (hero, logo, wide grid) — on-demand from game detail page
-- SGDB API key management with verify button
-- Per-platform sync toggles, per-platform removal
-- Steam collections
-- Toast notifications
-- Bidirectional save file sync (RetroArch .srm saves)
-- Three-way conflict detection with 4 resolution modes
-- Game session detection and playtime tracking (via RomM notes)
-- Save sync settings QAM page
-- Per-platform and per-game core switching (ES-DE gamelist.xml integration)
-- RetroDECK path migration (internal SSD ↔ SD card)
-- Native Steam metadata display (descriptions, genres, release date, controller support)
-- RetroAchievements integration with tabbed game detail page
-
-Roadmap and open work tracked on the [GitHub Projects board](https://github.com/users/danielcopper/projects/2).
+Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub Releases.
+Roadmap and open work: [GitHub Projects board](https://github.com/users/danielcopper/projects/2).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Reliability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Security](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Downloads](https://img.shields.io/github/downloads/danielcopper/decky-romm-sync/total.svg)](https://github.com/danielcopper/decky-romm-sync/releases)
-[![License](https://img.shields.io/github/license/danielcopper/decky-romm-sync)](LICENSE)
 
 # decky-romm-sync
 

--- a/main.py
+++ b/main.py
@@ -218,7 +218,10 @@ class Plugin:
     async def refresh_migration_state(self):
         self._migration_service.detect_retrodeck_path_change()
         self._migration_service.detect_save_sort_change()
-        return {"success": True}
+        return {
+            "retrodeck": await self._migration_service.get_migration_status(),
+            "save_sort": await self._migration_service.get_save_sort_migration_status(),
+        }
 
     async def _unload(self):  # Decky lifecycle — must be async
         self._sync_service.shutdown()

--- a/main.py
+++ b/main.py
@@ -215,6 +215,11 @@ class Plugin:
     async def dismiss_save_sort_migration(self):
         return self._migration_service.dismiss_save_sort_migration()
 
+    async def refresh_migration_state(self):
+        self._migration_service.detect_retrodeck_path_change()
+        self._migration_service.detect_save_sort_change()
+        return {"success": True}
+
     async def _unload(self):  # Decky lifecycle — must be async
         self._sync_service.shutdown()
         self._download_service.shutdown()

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from domain.save_extensions import get_save_extensions
@@ -216,27 +215,6 @@ class MigrationService:
             if os.path.exists(new_path) and os.path.exists(old_path):
                 conflict_set.add(label)
         return sorted(conflict_set)
-
-    @staticmethod
-    def _build_conflict_details(items: list) -> list[dict]:
-        """Return details for items where both source and destination exist."""
-        details = []
-        for label, old_path, new_path, _updater, _kind in items:
-            if os.path.exists(new_path) and os.path.exists(old_path):
-                old_stat = os.stat(old_path)
-                new_stat = os.stat(new_path)
-                details.append(
-                    {
-                        "filename": label,
-                        "old_path": old_path,
-                        "old_size": old_stat.st_size,
-                        "old_mtime": datetime.fromtimestamp(old_stat.st_mtime, tz=UTC).isoformat(),
-                        "new_path": new_path,
-                        "new_size": new_stat.st_size,
-                        "new_mtime": datetime.fromtimestamp(new_stat.st_mtime, tz=UTC).isoformat(),
-                    }
-                )
-        return sorted(details, key=lambda d: d["filename"])
 
     def _migrate_single_item(self, label, old_path, new_path, state_updater, kind, conflict_strategy, counts, errors):
         """Migrate a single file/directory item. Updates counts and errors in place."""
@@ -563,28 +541,77 @@ class MigrationService:
             return {"pending": False}
         return await self._loop.run_in_executor(None, self._get_save_sort_migration_status_io, old, new)
 
+    def _resolve_save_sort_conflict(
+        self,
+        label: str,
+        old_path: str,
+        new_path: str,
+        state_updater,
+        counts: dict,
+        count_key: str,
+        errors: list,
+    ) -> None:
+        """Newest-wins resolution for a save-sort conflict.
+
+        RetroArch does not migrate saves when its sort setting changes. If a
+        user flips ``sort_savefiles_enable`` mid-game via the Quick Menu and
+        then saves in-game, the new progress is written to the new layout
+        while the old location still holds pre-change content. The file at
+        the newer mtime contains actual user progress; the older one is
+        stale and must be cleaned up. Save-sync has already uploaded the
+        newest version to RomM before this runs, so even if local migration
+        fails the server still holds the authoritative copy.
+        """
+        try:
+            old_mtime = os.path.getmtime(old_path)
+            new_mtime = os.path.getmtime(new_path)
+        except OSError as e:
+            errors.append(f"{label}: {e}")
+            self._logger.error(f"Save-sort conflict mtime read failed: {old_path}: {e}")
+            return
+
+        if new_mtime >= old_mtime:
+            # Destination is newer — keep it, delete the stale orphan at old_path.
+            try:
+                os.remove(old_path)
+                state_updater()
+                counts[count_key] = counts.get(count_key, 0) + 1
+                self._logger.info(f"Save-sort conflict: kept newer {new_path}, removed stale {old_path}")
+            except OSError as e:
+                errors.append(f"{label}: {e}")
+                self._logger.error(f"Save-sort orphan cleanup failed: {old_path}: {e}")
+            return
+
+        # Source is newer — atomically overwrite destination.
+        try:
+            os.makedirs(os.path.dirname(new_path), exist_ok=True)
+            os.replace(old_path, new_path)
+            state_updater()
+            counts[count_key] = counts.get(count_key, 0) + 1
+            self._logger.info(f"Save-sort conflict: moved newer {old_path} -> {new_path}")
+        except OSError as e:
+            errors.append(f"{label}: {e}")
+            self._logger.error(f"Save-sort overwrite failed: {old_path}: {e}")
+
     def _migrate_save_sort_files_io(
         self, old_settings: dict, new_settings: dict, conflict_strategy: str | None
     ) -> dict:
+        # conflict_strategy is retained for backwards-compatibility with the
+        # callable signature but is unused for save-sort migration — conflicts
+        # are resolved in place via newest-wins (see _resolve_save_sort_conflict).
+        del conflict_strategy
         items = self._collect_save_sorting_items(old_settings, new_settings)
         if not items:
             self._state.pop("save_sort_settings_previous", None)
             self._save_state()
             return {"success": True, "message": "No save files to migrate", "saves_moved": 0}
-        if conflict_strategy is None:
-            conflict_details = self._build_conflict_details(items)
-            if conflict_details:
-                return {
-                    "success": False,
-                    "needs_confirmation": True,
-                    "conflict_count": len(conflict_details),
-                    "conflicts": conflict_details,
-                    "message": f"{len(conflict_details)} save file(s) exist at both old and new locations",
-                }
         counts: dict[str, int] = {"rom": 0, "bios": 0, "save": 0}
         errors: list[str] = []
-        for label, old_path, new_path, updater, kind in items:
-            self._migrate_single_item(label, old_path, new_path, updater, kind, conflict_strategy, counts, errors)
+        for label, old_path, new_path, updater, _kind in items:
+            if os.path.exists(old_path) and os.path.exists(new_path):
+                self._resolve_save_sort_conflict(label, old_path, new_path, updater, counts, "save", errors)
+            else:
+                self._migrate_single_item(label, old_path, new_path, updater, "save", None, counts, errors)
         if not errors:
             self._state.pop("save_sort_settings_previous", None)
             self._save_state()

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -166,7 +166,6 @@ export interface MigrationResult {
   needs_confirmation?: boolean;
   conflict_count?: number;
   conflicts?: string[] | ConflictDetail[];
-  conflict_details?: ConflictDetail[];
   roms_moved?: number;
   bios_moved?: number;
   saves_moved?: number;
@@ -186,7 +185,7 @@ export interface SaveSortMigrationStatus {
 export const getSaveSortMigrationStatus = callable<[], SaveSortMigrationStatus>("get_save_sort_migration_status");
 export const migrateSaveSortFiles = callable<[string | null], MigrationResult>("migrate_save_sort_files");
 export const dismissSaveSortMigration = callable<[], { success: boolean }>("dismiss_save_sort_migration");
-export const refreshMigrationState = callable<[], { success: boolean }>("refresh_migration_state");
+export const refreshMigrationState = callable<[], { retrodeck: MigrationStatus; save_sort: SaveSortMigrationStatus }>("refresh_migration_state");
 
 // Delete operations
 export const deleteLocalSaves = callable<[number], { success: boolean; deleted_count: number; message: string }>("delete_local_saves");

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -186,6 +186,7 @@ export interface SaveSortMigrationStatus {
 export const getSaveSortMigrationStatus = callable<[], SaveSortMigrationStatus>("get_save_sort_migration_status");
 export const migrateSaveSortFiles = callable<[string | null], MigrationResult>("migrate_save_sort_files");
 export const dismissSaveSortMigration = callable<[], { success: boolean }>("dismiss_save_sort_migration");
+export const refreshMigrationState = callable<[], { success: boolean }>("refresh_migration_state");
 
 // Delete operations
 export const deleteLocalSaves = callable<[number], { success: boolean; deleted_count: number; message: string }>("delete_local_saves");

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -27,8 +27,8 @@ import {
 } from "../api/backend";
 import { getSyncProgress } from "../utils/syncProgress";
 import { getDownloadState } from "../utils/downloadStore";
-import { getMigrationState, onMigrationChange } from "../utils/migrationStore";
-import { getSaveSortMigrationState, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
+import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
+import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
 import { requestSyncCancel } from "../utils/syncManager";
 import type { SyncProgress, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem } from "../types";
 import type { MigrationStatus } from "../api/backend";
@@ -111,7 +111,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   useEffect(() => {
-    refreshMigrationState().catch((e) => logError(`Failed to refresh migration state: ${e}`));
+    refreshMigrationState()
+      .then(({ retrodeck, save_sort }) => {
+        setMigrationStatus(retrodeck);
+        setSaveSortMigrationStatus(save_sort);
+      })
+      .catch((e) => logError(`Failed to refresh migration state: ${e}`));
     getSyncStats().then(setStats);
     testConnection().then((r) => setConnected(r.success));
     getSettings().then((s) => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -22,6 +22,8 @@ import {
   syncApplyDelta,
   syncCancelPreview,
   clearSyncCache,
+  refreshMigrationState,
+  logError,
 } from "../api/backend";
 import { getSyncProgress } from "../utils/syncProgress";
 import { getDownloadState } from "../utils/downloadStore";
@@ -109,6 +111,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   useEffect(() => {
+    refreshMigrationState().catch((e) => logError(`Failed to refresh migration state: ${e}`));
     getSyncStats().then(setStats);
     testConnection().then((r) => setConnected(r.success));
     getSettings().then((s) => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -31,6 +31,8 @@ import {
   getSaveSlots,
   isSaveTrackingConfigured,
   debugLog,
+  refreshMigrationState,
+  logError,
 } from "../api/backend";
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import { SavesTab } from "./SavesTab";
@@ -134,6 +136,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortPending(getSaveSortMigrationState().pending));
     return () => { unsub(); unsubSaveSort(); };
   }, []);
+
+  useEffect(() => {
+    refreshMigrationState().catch((e) => logError(`Failed to refresh migration state: ${e}`));
+  }, [appId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -37,8 +37,8 @@ import {
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import { SavesTab } from "./SavesTab";
 import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, PendingConflict, Achievement, AchievementProgress, EarnedAchievement, SaveSlotSummary } from "../types";
-import { getMigrationState, onMigrationChange } from "../utils/migrationStore";
-import { getSaveSortMigrationState, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
+import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
+import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 
 interface RomMGameInfoPanelProps {
@@ -138,7 +138,12 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   }, []);
 
   useEffect(() => {
-    refreshMigrationState().catch((e) => logError(`Failed to refresh migration state: ${e}`));
+    refreshMigrationState()
+      .then(({ retrodeck, save_sort }) => {
+        setMigrationStatus(retrodeck);
+        setSaveSortMigrationStatus(save_sort);
+      })
+      .catch((e) => logError(`Failed to refresh migration state: ${e}`));
   }, [appId]);
 
   useEffect(() => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
   dismissSaveSortMigration,
   logError,
 } from "../api/backend";
-import type { MigrationStatus, SaveSortMigrationStatus, ConflictDetail } from "../api/backend";
+import type { MigrationStatus, SaveSortMigrationStatus } from "../api/backend";
 import { getMigrationState, setMigrationStatus, clearMigration, onMigrationChange } from "../utils/migrationStore";
 import { getSaveSortMigrationState, setSaveSortMigrationStatus as setStoreSaveSortStatus, clearSaveSortMigration, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
 import type { SaveSyncSettings as SaveSyncSettingsType, ConflictMode, RetroArchInputCheck } from "../types";
@@ -61,59 +61,6 @@ const MigrationConflictModal: FC<{
         </DialogButton>
         <DialogButton onClick={() => { closeModal?.(); onChoice("skip"); }}>
           Skip
-        </DialogButton>
-        <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
-          Cancel
-        </DialogButton>
-      </div>
-    </div>
-  </ModalRoot>
-);
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" });
-}
-
-const SaveSortConflictModal: FC<{
-  conflicts: ConflictDetail[];
-  closeModal?: () => void;
-  onChoice: (strategy: "overwrite" | "skip") => void;
-}> = ({ conflicts, closeModal, onChoice }) => (
-  <ModalRoot closeModal={closeModal}>
-    <div style={{ padding: "16px", minWidth: "320px" }}>
-      <div style={{ fontSize: "16px", fontWeight: "bold", color: "#fff", marginBottom: "8px" }}>
-        Save Files Already Exist
-      </div>
-      <div style={{ fontSize: "13px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "12px" }}>
-        {conflicts.length} save file(s) exist at both the old and new location.
-      </div>
-      <div style={{ maxHeight: "240px", overflowY: "auto", marginBottom: "16px" }}>
-        {conflicts.map((c) => (
-          <div key={c.filename} style={{ marginBottom: "12px", padding: "8px", backgroundColor: "rgba(255,255,255,0.05)", borderRadius: "4px" }}>
-            <div style={{ fontSize: "13px", fontWeight: "bold", color: "#fff", marginBottom: "4px" }}>
-              {c.filename}
-            </div>
-            <div style={{ fontSize: "11px", color: "rgba(255,255,255,0.6)" }}>
-              Old: {formatBytes(c.old_size)}, {formatDate(c.old_mtime)}
-            </div>
-            <div style={{ fontSize: "11px", color: "rgba(255,255,255,0.6)" }}>
-              New: {formatBytes(c.new_size)}, {formatDate(c.new_mtime)}
-            </div>
-          </div>
-        ))}
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-        <DialogButton onClick={() => { closeModal?.(); onChoice("overwrite"); }}>
-          Overwrite (use old files)
-        </DialogButton>
-        <DialogButton onClick={() => { closeModal?.(); onChoice("skip"); }}>
-          Skip (keep new files)
         </DialogButton>
         <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
           Cancel
@@ -495,31 +442,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                 setSaveSortResult("");
                 try {
                   const result = await migrateSaveSortFiles(null);
-                  if (result.needs_confirmation) {
-                    setSaveSortMigrating(false);
-                    const details = (result.conflicts as ConflictDetail[] | undefined) ?? [];
-                    showModal(
-                      <SaveSortConflictModal
-                        conflicts={details}
-                        onChoice={async (strategy) => {
-                          setSaveSortMigrating(true);
-                          try {
-                            const r = await migrateSaveSortFiles(strategy);
-                            setSaveSortResult(r.message);
-                            if (r.success) {
-                              clearSaveSortMigration();
-                              toaster.toast({
-                                title: "RomM Sync",
-                                body: r.message || "Migration complete.",
-                              });
-                            }
-                          } catch { setSaveSortResult("Migration failed"); }
-                          setSaveSortMigrating(false);
-                        }}
-                      />
-                    );
-                    return;
-                  }
                   setSaveSortResult(result.message);
                   if (result.success) {
                     clearSaveSortMigration();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -298,28 +298,19 @@ export default definePlugin(() => {
     }
   );
 
-  const pathChangedListener = addEventListener<
-    [{ old_path: string; new_path: string }]
-  >("retrodeck_path_changed", (data) => {
-    setMigrationStatus({
-      pending: true,
-      old_path: data.old_path,
-      new_path: data.new_path,
-    });
-    toaster.toast({
-      title: "RomM Sync",
-      body: "RetroDECK location changed. Go to Settings to migrate files.",
-    });
-  });
+  const pathChangedListener = addEventListener<[{ old_path: string; new_path: string }]>(
+    "retrodeck_path_changed",
+    () => {
+      toaster.toast({
+        title: "RomM Sync",
+        body: "RetroDECK location changed. Go to Settings to migrate files.",
+      });
+    },
+  );
 
   const saveSortChangedListener = addEventListener<
     [{ old_settings: { sort_by_content: boolean; sort_by_core: boolean }; new_settings: { sort_by_content: boolean; sort_by_core: boolean } }]
-  >("save_sort_changed", (data) => {
-    setSaveSortMigrationStatus({
-      pending: true,
-      old_settings: data.old_settings,
-      new_settings: data.new_settings,
-    });
+  >("save_sort_changed", () => {
     toaster.toast({
       title: "RomM Sync",
       body: "RetroArch save sorting changed. Go to Settings to migrate save files.",

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -7,7 +7,9 @@
 
 import { toaster } from "@decky/api";
 import { isRomMAppId } from "../patches/gameDetailPatch";
-import { getInstalledRom, getSaveStatus, getSaveSyncSettings, logInfo, logError } from "../api/backend";
+import { getInstalledRom, getSaveStatus, getSaveSyncSettings, refreshMigrationState, logInfo, logError } from "../api/backend";
+import { setMigrationStatus } from "./migrationStore";
+import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 
 let gameActionHook: { unregister: () => void } | null = null;
 
@@ -18,6 +20,16 @@ export function registerLaunchInterceptor(): void {
 
       const appId = parseInt(appIdStr, 10);
       if (isNaN(appId) || !isRomMAppId(appId)) return;
+
+      // Fire-and-forget migration refresh — picks up RetroArch sort setting
+      // changes made via the in-game Quick Menu before the previous session.
+      // Must not block the launch: the user pressing Play means "launch now".
+      refreshMigrationState()
+        .then(({ retrodeck, save_sort }) => {
+          setMigrationStatus(retrodeck);
+          setSaveSortMigrationStatus(save_sort);
+        })
+        .catch((e) => logError(`Pre-launch migration refresh failed: ${e}`));
 
       // Check if ROM is installed
       try {

--- a/src/utils/migrationStore.ts
+++ b/src/utils/migrationStore.ts
@@ -2,9 +2,10 @@
  * Module-level migration state store.
  *
  * Updated by:
- *   - retrodeck_path_changed event from backend (listener in index.tsx)
- *   - getMigrationStatus() callable on plugin load
- *   - ConnectionSettings.tsx after successful migration
+ *   - plugin load init in index.tsx (getMigrationStatus callable)
+ *   - refreshMigrationState return value in MainPage, RomMGameInfoPanel,
+ *     launchInterceptor, sessionManager
+ *   - clearMigration() from SettingsPage after successful migration
  *
  * Read by:
  *   - MainPage.tsx and ConnectionSettings.tsx

--- a/src/utils/saveSortMigrationStore.ts
+++ b/src/utils/saveSortMigrationStore.ts
@@ -2,9 +2,10 @@
  * Module-level save sort migration state store.
  *
  * Updated by:
- *   - save_sort_changed event from backend (listener in index.tsx)
- *   - getSaveSortMigrationStatus() callable on plugin load
- *   - SettingsPage.tsx after successful migration
+ *   - plugin load init in index.tsx (getSaveSortMigrationStatus callable)
+ *   - refreshMigrationState return value in MainPage, RomMGameInfoPanel,
+ *     launchInterceptor, sessionManager
+ *   - clearSaveSortMigration() from SettingsPage after successful migration
  *
  * Read by:
  *   - MainPage.tsx, SettingsPage.tsx, RomMGameInfoPanel.tsx

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -13,9 +13,12 @@ import {
   recordSessionEnd,
   getAppIdRomIdMap,
   syncAchievementsAfterSession,
+  refreshMigrationState,
   logInfo,
   logError,
 } from "../api/backend";
+import { setMigrationStatus } from "./migrationStore";
+import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { isNewerInSlotConflict, isPendingConflict } from "../types";
 import type { PendingConflict, NewerInSlotConflict } from "../types";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
@@ -111,15 +114,19 @@ async function handleGameStop(): Promise<void> {
     .then(() => logInfo(`Achievement sync complete for romId=${romId}`))
     .catch((e) => logError(`Achievement sync failed for romId=${romId}: ${e}`));
 
-  // Post-exit save sync — backend handles settings check + connectivity
+  // Post-exit save sync — backend handles settings check + connectivity.
+  // IMPORTANT: save-sync MUST run before refreshMigrationState below. If the
+  // user changed RetroArch sort settings mid-game and we migrate first, the
+  // newest-wins resolver would delete the stale orphan locally — but since
+  // save-sync has not yet run, the newest progress would only live on disk.
+  // Uploading to RomM first gives us a safety net: even if local migration
+  // goes sideways, the server holds the authoritative latest version.
   try {
     const result = await postExitSync(romId);
     if (result.offline) {
       toaster.toast({ title: "RomM Save Sync", body: "Server offline — saves will sync next time" });
       window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-      return;
-    }
-    if (result.success) {
+    } else if (result.success) {
       if (result.synced && result.synced > 0) {
         toaster.toast({ title: "RomM Save Sync", body: "Saves uploaded to RomM" });
       }
@@ -133,6 +140,18 @@ async function handleGameStop(): Promise<void> {
   } catch (e) {
     logError(`Post-exit sync failed: ${e}`);
   }
+
+  // Post-game migration detection — runs AFTER save-sync above (ordering is
+  // load-bearing, see comment on the save-sync block). Runs unconditionally:
+  // refreshMigrationState only reads config files + state and emits events on
+  // genuine change — it does not touch user save files. Actual migration runs
+  // only when the user explicitly clicks the migrate button in Settings.
+  refreshMigrationState()
+    .then(({ retrodeck, save_sort }) => {
+      setMigrationStatus(retrodeck);
+      setSaveSortMigrationStatus(save_sort);
+    })
+    .catch((e) => logError(`Post-exit migration refresh failed: ${e}`));
 }
 
 function notifyConflicts(conflicts: (PendingConflict | NewerInSlotConflict)[]): void {

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -348,8 +348,9 @@ class TestMigrateSaveSortFiles:
         assert "save_sort_settings_previous" not in svc._state
 
     @pytest.mark.asyncio
-    async def test_conflicts_return_confirmation(self, tmp_path):
-        """Save at both old and new location — returns needs_confirmation without moving."""
+    async def test_conflict_destination_newer_deletes_old(self, tmp_path):
+        """Mid-game setting change edge case: newer file at destination wins,
+        stale orphan at old location is removed."""
         roms_path = tmp_path / "roms"
         saves_path = tmp_path / "saves"
         roms_path.mkdir()
@@ -359,15 +360,19 @@ class TestMigrateSaveSortFiles:
         rom_file.parent.mkdir(parents=True)
         rom_file.write_text("rom")
 
-        # Save exists at old location
+        # Old (stale) save at old location
         old_save_dir = saves_path / "gba"
         old_save_dir.mkdir(parents=True)
         old_save = old_save_dir / "Pokemon.srm"
-        old_save.write_text("old save")
+        old_save.write_text("stale pre-change")
 
-        # Save also exists at new location
+        # New (fresh) save at new location
         new_save = saves_path / "Pokemon.srm"
-        new_save.write_text("new save")
+        new_save.write_text("fresh in-game save")
+
+        # Make new_save newer than old_save
+        os.utime(str(old_save), (1_000_000, 1_000_000))
+        os.utime(str(new_save), (2_000_000, 2_000_000))
 
         installed_roms = {
             "1": {
@@ -392,23 +397,244 @@ class TestMigrateSaveSortFiles:
 
         result = await svc.migrate_save_sort_files()
 
+        assert result["success"] is True
+        assert result["saves_moved"] == 1
+        # Destination (newer) preserved unchanged, old orphan deleted.
+        assert new_save.read_text() == "fresh in-game save"
+        assert not old_save.exists()
+        assert "save_sort_settings_previous" not in svc._state
+
+    @pytest.mark.asyncio
+    async def test_conflict_source_newer_overwrites(self, tmp_path):
+        """Rare case: source is newer than destination — atomically overwrite."""
+        roms_path = tmp_path / "roms"
+        saves_path = tmp_path / "saves"
+        roms_path.mkdir()
+        saves_path.mkdir()
+
+        rom_file = roms_path / "gba" / "Pokemon.gba"
+        rom_file.parent.mkdir(parents=True)
+        rom_file.write_text("rom")
+
+        old_save_dir = saves_path / "gba"
+        old_save_dir.mkdir(parents=True)
+        old_save = old_save_dir / "Pokemon.srm"
+        old_save.write_text("newer save at source")
+
+        new_save = saves_path / "Pokemon.srm"
+        new_save.write_text("older stale at destination")
+
+        # Source newer than destination
+        os.utime(str(new_save), (1_000_000, 1_000_000))
+        os.utime(str(old_save), (2_000_000, 2_000_000))
+
+        installed_roms = {
+            "1": {
+                "system": "gba",
+                "file_path": str(rom_file),
+                "platform_slug": "gba",
+            }
+        }
+        old_settings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        svc, _ = _make_service(
+            tmp_path,
+            installed_roms=installed_roms,
+            state_overrides={
+                "installed_roms": installed_roms,
+                "save_sort_settings_previous": old_settings,
+                "save_sort_settings": new_settings,
+            },
+        )
+        svc._get_saves_path = lambda: str(saves_path)
+        svc._get_roms_path = lambda: str(roms_path)
+
+        result = await svc.migrate_save_sort_files()
+
+        assert result["success"] is True
+        assert result["saves_moved"] == 1
+        # New file was overwritten with the source contents, old removed.
+        assert new_save.read_text() == "newer save at source"
+        assert not old_save.exists()
+        assert "save_sort_settings_previous" not in svc._state
+
+    @pytest.mark.asyncio
+    async def test_conflict_mtime_read_oserror_records_error(self, tmp_path, monkeypatch):
+        """OSError during mtime read — conflict added to errors, no mutations."""
+        roms_path = tmp_path / "roms"
+        saves_path = tmp_path / "saves"
+        roms_path.mkdir()
+        saves_path.mkdir()
+
+        rom_file = roms_path / "gba" / "Pokemon.gba"
+        rom_file.parent.mkdir(parents=True)
+        rom_file.write_text("rom")
+
+        old_save_dir = saves_path / "gba"
+        old_save_dir.mkdir(parents=True)
+        old_save = old_save_dir / "Pokemon.srm"
+        old_save.write_text("old")
+        new_save = saves_path / "Pokemon.srm"
+        new_save.write_text("new")
+
+        installed_roms = {
+            "1": {
+                "system": "gba",
+                "file_path": str(rom_file),
+                "platform_slug": "gba",
+            }
+        }
+        old_settings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        svc, _ = _make_service(
+            tmp_path,
+            installed_roms=installed_roms,
+            state_overrides={
+                "installed_roms": installed_roms,
+                "save_sort_settings_previous": old_settings,
+                "save_sort_settings": new_settings,
+            },
+        )
+        svc._get_saves_path = lambda: str(saves_path)
+        svc._get_roms_path = lambda: str(roms_path)
+
+        real_getmtime = os.path.getmtime
+
+        def boom(path):
+            if path == str(old_save):
+                raise OSError("mtime read failed")
+            return real_getmtime(path)
+
+        monkeypatch.setattr("services.migration.os.path.getmtime", boom)
+
+        result = await svc.migrate_save_sort_files()
+
         assert result["success"] is False
-        assert result["needs_confirmation"] is True
-        assert result["conflict_count"] == 1
-        # conflicts is now a list of dicts with file details
-        conflicts = result["conflicts"]
-        assert len(conflicts) == 1
-        detail = conflicts[0]
-        assert detail["filename"] == "Pokemon.srm"
-        assert detail["old_size"] == len(b"old save")
-        assert detail["new_size"] == len(b"new save")
-        assert "old_mtime" in detail
-        assert "new_mtime" in detail
-        assert "old_path" in detail
-        assert "new_path" in detail
+        assert len(result["errors"]) == 1
+        assert "mtime read failed" in result["errors"][0]
         # Files untouched
-        assert old_save.exists()
-        assert new_save.read_text() == "new save"
+        assert old_save.read_text() == "old"
+        assert new_save.read_text() == "new"
+        # state_previous must be preserved when errors occur — users must still see
+        # the migration prompt on the next detect pass
+        assert "save_sort_settings_previous" in svc._state
+        assert svc._state["save_sort_settings_previous"] == old_settings
+
+    @pytest.mark.asyncio
+    async def test_conflict_remove_oserror_records_error(self, tmp_path, monkeypatch):
+        """Destination-wins cleanup fails — error recorded, no crash."""
+        roms_path = tmp_path / "roms"
+        saves_path = tmp_path / "saves"
+        roms_path.mkdir()
+        saves_path.mkdir()
+
+        rom_file = roms_path / "gba" / "Pokemon.gba"
+        rom_file.parent.mkdir(parents=True)
+        rom_file.write_text("rom")
+
+        old_save_dir = saves_path / "gba"
+        old_save_dir.mkdir(parents=True)
+        old_save = old_save_dir / "Pokemon.srm"
+        old_save.write_text("stale")
+        new_save = saves_path / "Pokemon.srm"
+        new_save.write_text("fresh")
+
+        os.utime(str(old_save), (1_000_000, 1_000_000))
+        os.utime(str(new_save), (2_000_000, 2_000_000))
+
+        installed_roms = {
+            "1": {
+                "system": "gba",
+                "file_path": str(rom_file),
+                "platform_slug": "gba",
+            }
+        }
+        old_settings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        svc, _ = _make_service(
+            tmp_path,
+            installed_roms=installed_roms,
+            state_overrides={
+                "installed_roms": installed_roms,
+                "save_sort_settings_previous": old_settings,
+                "save_sort_settings": new_settings,
+            },
+        )
+        svc._get_saves_path = lambda: str(saves_path)
+        svc._get_roms_path = lambda: str(roms_path)
+
+        def boom_remove(path):
+            raise OSError("remove failed")
+
+        monkeypatch.setattr("services.migration.os.remove", boom_remove)
+
+        result = await svc.migrate_save_sort_files()
+
+        assert result["success"] is False
+        assert len(result["errors"]) == 1
+        assert "remove failed" in result["errors"][0]
+        # state_previous must be preserved when errors occur — users must still see
+        # the migration prompt on the next detect pass
+        assert "save_sort_settings_previous" in svc._state
+        assert svc._state["save_sort_settings_previous"] == old_settings
+
+    @pytest.mark.asyncio
+    async def test_conflict_replace_oserror_records_error(self, tmp_path, monkeypatch):
+        """Source-wins overwrite fails — error recorded, no crash."""
+        roms_path = tmp_path / "roms"
+        saves_path = tmp_path / "saves"
+        roms_path.mkdir()
+        saves_path.mkdir()
+
+        rom_file = roms_path / "gba" / "Pokemon.gba"
+        rom_file.parent.mkdir(parents=True)
+        rom_file.write_text("rom")
+
+        old_save_dir = saves_path / "gba"
+        old_save_dir.mkdir(parents=True)
+        old_save = old_save_dir / "Pokemon.srm"
+        old_save.write_text("source newer")
+        new_save = saves_path / "Pokemon.srm"
+        new_save.write_text("destination older")
+
+        os.utime(str(new_save), (1_000_000, 1_000_000))
+        os.utime(str(old_save), (2_000_000, 2_000_000))
+
+        installed_roms = {
+            "1": {
+                "system": "gba",
+                "file_path": str(rom_file),
+                "platform_slug": "gba",
+            }
+        }
+        old_settings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        svc, _ = _make_service(
+            tmp_path,
+            installed_roms=installed_roms,
+            state_overrides={
+                "installed_roms": installed_roms,
+                "save_sort_settings_previous": old_settings,
+                "save_sort_settings": new_settings,
+            },
+        )
+        svc._get_saves_path = lambda: str(saves_path)
+        svc._get_roms_path = lambda: str(roms_path)
+
+        def boom_replace(src, dst):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr("services.migration.os.replace", boom_replace)
+
+        result = await svc.migrate_save_sort_files()
+
+        assert result["success"] is False
+        assert len(result["errors"]) == 1
+        assert "replace failed" in result["errors"][0]
+        # state_previous must be preserved when errors occur — users must still see
+        # the migration prompt on the next detect pass
+        assert "save_sort_settings_previous" in svc._state
+        assert svc._state["save_sort_settings_previous"] == old_settings
 
     @pytest.mark.asyncio
     async def test_clears_previous_on_success(self, tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -688,19 +688,45 @@ class TestPruneStaleRegistry:
 class TestRefreshMigrationState:
     @pytest.mark.asyncio
     async def test_calls_both_detect_methods(self, plugin):
+        from unittest.mock import AsyncMock
+
+        retrodeck_sentinel = {"pending": True, "old_path": "/a", "new_path": "/b"}
+        save_sort_sentinel = {"pending": True, "saves_count": 3}
         plugin._migration_service = MagicMock()
         plugin._migration_service.detect_retrodeck_path_change = MagicMock()
         plugin._migration_service.detect_save_sort_change = MagicMock()
+        plugin._migration_service.get_migration_status = AsyncMock(return_value=retrodeck_sentinel)
+        plugin._migration_service.get_save_sort_migration_status = AsyncMock(return_value=save_sort_sentinel)
         result = await plugin.refresh_migration_state()
         plugin._migration_service.detect_retrodeck_path_change.assert_called_once_with()
         plugin._migration_service.detect_save_sort_change.assert_called_once_with()
-        assert result == {"success": True}
+        assert result == {"retrodeck": retrodeck_sentinel, "save_sort": save_sort_sentinel}
 
     @pytest.mark.asyncio
     async def test_propagates_exceptions(self, plugin):
+        from unittest.mock import AsyncMock
+
         plugin._migration_service = MagicMock()
         plugin._migration_service.detect_retrodeck_path_change = MagicMock(side_effect=RuntimeError("boom"))
         plugin._migration_service.detect_save_sort_change = MagicMock()
+        plugin._migration_service.get_migration_status = AsyncMock(return_value={"pending": False})
+        plugin._migration_service.get_save_sort_migration_status = AsyncMock(return_value={"pending": False})
         with pytest.raises(RuntimeError, match="boom"):
             await plugin.refresh_migration_state()
         plugin._migration_service.detect_save_sort_change.assert_not_called()
+        plugin._migration_service.get_migration_status.assert_not_called()
+        plugin._migration_service.get_save_sort_migration_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_detect_order_preserved(self, plugin):
+        from unittest.mock import AsyncMock
+
+        plugin._migration_service = MagicMock()
+        manager = MagicMock()
+        plugin._migration_service.detect_retrodeck_path_change = manager.detect_retrodeck_path_change
+        plugin._migration_service.detect_save_sort_change = manager.detect_save_sort_change
+        plugin._migration_service.get_migration_status = AsyncMock(return_value={"pending": False})
+        plugin._migration_service.get_save_sort_migration_status = AsyncMock(return_value={"pending": False})
+        await plugin.refresh_migration_state()
+        ordered = [name for name, _args, _kwargs in manager.mock_calls]
+        assert ordered == ["detect_retrodeck_path_change", "detect_save_sort_change"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -683,3 +683,24 @@ class TestPruneStaleRegistry:
         # Should not crash, state file should NOT be written
         state_path = tmp_path / "state.json"
         assert not state_path.exists()
+
+
+class TestRefreshMigrationState:
+    @pytest.mark.asyncio
+    async def test_calls_both_detect_methods(self, plugin):
+        plugin._migration_service = MagicMock()
+        plugin._migration_service.detect_retrodeck_path_change = MagicMock()
+        plugin._migration_service.detect_save_sort_change = MagicMock()
+        result = await plugin.refresh_migration_state()
+        plugin._migration_service.detect_retrodeck_path_change.assert_called_once_with()
+        plugin._migration_service.detect_save_sort_change.assert_called_once_with()
+        assert result == {"success": True}
+
+    @pytest.mark.asyncio
+    async def test_propagates_exceptions(self, plugin):
+        plugin._migration_service = MagicMock()
+        plugin._migration_service.detect_retrodeck_path_change = MagicMock(side_effect=RuntimeError("boom"))
+        plugin._migration_service.detect_save_sort_change = MagicMock()
+        with pytest.raises(RuntimeError, match="boom"):
+            await plugin.refresh_migration_state()
+        plugin._migration_service.detect_save_sort_change.assert_not_called()


### PR DESCRIPTION
## Summary

Implements GitHub #229 — the plugin now re-runs migration detection at five lifecycle points instead of only at plugin startup, so users see the migration banner without having to fully reload Decky after changing RetroDECK paths or RetroArch save sorting settings.

The implementation went through a deliberate redesign during the test phase. The first iteration (commit `f9bcb5e`, kept for history) wired a simple `refresh_migration_state` callable into mount useEffects on MainPage and RomMGameInfoPanel. Live testing surfaced two issues that drove the rework:

1. The frontend event listeners for `save_sort_changed` / `retrodeck_path_changed` set the store with an incomplete payload (no `saves_count`), causing the banner to display "0 file(s) to migrate" — a pre-existing bug that the new mid-session detection made reachable
2. The mount-only trigger model missed the actual primary scenario: users change RetroArch sort settings via the in-game Quick Menu while a game is running, and we can only catch that AFTER game exit

The rework adopts a cleaner architecture and adds the lifecycle hooks the real-world flow requires.

## What changes

### Backend

- **`refresh_migration_state` is pull-based and authoritative** (`main.py`). Returns `{retrodeck, save_sort}` with full `MigrationStatus` / `SaveSortMigrationStatus` objects from `get_*_migration_status()`, not just `{success: true}`. Frontend consumes the return value directly to update stores. Single round-trip, single source of truth. Fixes the saves_count=0 bug by removing the buggy code path entirely (event listeners no longer update stores).

- **Newest-wins conflict resolution for save-sort migration** (`migration.py` `_resolve_save_sort_conflict`). When `_migrate_save_sort_files_io` finds a conflict (file exists at both old and new locations), it auto-resolves by mtime: if destination is newer, the orphan at old_path is removed via `os.remove`; if source is newer, the destination is overwritten via `os.replace`. The bulk `needs_confirmation` modal flow is dropped from the save-sort path. Retrodeck-path migration is **unchanged** — it keeps the strategy modal because ROMs/BIOS aren't progress files.

- **Rationale**: RetroArch does not migrate save files when its sort setting changes mid-game. When a user toggles `sort_savefiles_enable` via the Quick Menu and saves in-game, the new progress is written to the new layout while the old location still holds pre-change content. The file with the newer mtime contains actual user progress; the older one is stale.

### Frontend

- **Five detection trigger points** (all call the same `refresh_migration_state` callable):
  | When | Where | Why |
  |---|---|---|
  | Plugin load | `main.py` Phase 6 (existing) | Catches changes between plugin sessions |
  | QAM open | `MainPage.tsx` mount useEffect | Easy nav path to Settings if banner shows |
  | Game-detail open | `RomMGameInfoPanel.tsx` `useEffect([appId])` | Per-game refresh on browse |
  | Pre-game-launch | `launchInterceptor.ts` (new) | Catches changes between sessions made by external tooling |
  | Post-game-exit | `sessionManager.ts` after save-sync (new) | **Primary** — catches Quick Menu mid-game changes |

- **Event listeners reduced to toast-only** (`index.tsx`). `save_sort_changed` and `retrodeck_path_changed` listeners no longer call `set*MigrationStatus(...)`. Store updates come exclusively from the pull path now. This is what root-causes the saves_count=0 bug.

- **Post-game ordering** is documented as load-bearing in `sessionManager.ts`: save-sync runs first, then refresh runs unconditionally (including when offline). The comment block explains why this matters for the in-game-Quick-Menu edge case. **See known-issue note below.**

- **Settings page cleanup** (`SettingsPage.tsx`). Removed the now-dead `SaveSortConflictModal` component, its `formatBytes`/`formatDate` helpers, and the `needs_confirmation` branch in `migrateSaveSortFiles`. The retrodeck-path conflict modal flow is untouched.

### Tests

- New tests for `_resolve_save_sort_conflict` in `tests/services/test_migration_save_sort.py` covering: destination-newer happy path (orphan removed), source-newer happy path (overwrite), all three OSError paths (mtime read, `os.remove`, `os.replace`), state preservation on error
- Updated `tests/test_plugin.py` `TestRefreshMigrationState` for the new `{retrodeck, save_sort}` return shape, plus a new `test_detect_order_preserved` to lock in the call ordering

### Wiki

Already pushed to the wiki repo as a separate update (commit `6d9824c` and `45e664b` on `decky-romm-sync.wiki`). New section in `Save-File-Sync-Architecture.md` documenting the five trigger points, post-game ordering rationale, newest-wins resolution rules, and the unsupported `savefiles_in_content_dir` configuration.

## Known issues discovered during live testing — filed as separate

Both filed today after manual end-to-end testing of this PR's behavior. Neither blocks merge but both are high-quality follow-ups.

- **#238 (Ready)** — Race condition: post-game save-sync vs detect ordering can be violated by the `RomMGameInfoPanel` mount useEffect firing detect first. When that happens, save-sync looks at the new layout, finds nothing, downloads the older server version, and the subsequent newest-wins migration picks the (freshly-downloaded but content-old) server file by mtime. **Potential silent data loss** in a specific edge case. Forensic timeline + three fix proposals included in the issue. Recommend tackling this next.
- **#239 (Backlog)** — RetroArch's `savefiles_in_content_dir` ("Write Saves to Content Directory") setting is not handled by the plugin. RetroDECK default is off so most users aren't affected, but if enabled the plugin silently misses all saves. Minimum fix: detect-and-warn. Discovered while explaining the difference between RetroArch's similarly-named save sort settings.

## Closes

Closes #229

## Test plan

### Automated (already passing)
- [x] `python -m pytest tests/ -q` — 1736 passed
- [x] `ruff check py_modules main.py tests` — clean
- [x] `basedpyright py_modules main.py tests` — 0 errors, 0 warnings, 0 notes
- [x] `PYTHONPATH=py_modules lint-imports` — 6 contracts kept, 0 broken
- [x] `pnpm build` — clean, no warnings

### Manual end-to-end (done today on Steam Deck)
- [x] Plugin load detects pre-existing save-sort change → banner appears with correct count
- [x] User clicks migrate → migration runs, files move to new layout, success toast (#231) fires
- [x] Mid-game RetroArch Quick Menu setting change → post-game detect catches it → banner appears
- [x] Newest-wins conflict resolution removes the orphan at old path, keeps file at new path
- [x] Per-game core changes via the plugin's Settings page do not interfere with detection
- [x] Banner correctly shows count instead of "0 files to migrate" (the saves_count=0 bug is fixed)

### Reviewer test plan
- [ ] Review the `_resolve_save_sort_conflict` helper for OSError handling correctness
- [ ] Verify the post-game ordering comment in `sessionManager.ts` matches the documented intent
- [ ] Sanity-check the `[appId]` dependency on the RomMGameInfoPanel useEffect — this is the load-bearing per-game refresh trigger
- [ ] Confirm the SettingsPage cleanup didn't accidentally remove the success toast from #231