### PR TITLE
fix(saves): close post-exit sync race during pending save-sort migration

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -172,6 +172,29 @@ def wire_services(cfg: WiringConfig) -> dict:
     dict with keys ``save_sync_service``, ``playtime_service``,
     ``sync_service``, ``download_service``, and ``firmware_service``.
     """
+    # MigrationService is constructed before SaveService so that
+    # save_sync_service can receive a bound reference to
+    # ``migration_service.detect_save_sort_change``. SaveService must observe
+    # fresh sort state before computing saves_dir (#238).
+    # ``get_bios_files_index`` is a lambda that defers the ``firmware_service``
+    # lookup to call time, so it is safe to reference here even though
+    # ``firmware_service`` is constructed later in this function.
+    migration_service = MigrationService(
+        state=cfg.state,
+        loop=cfg.loop,
+        logger=cfg.logger,
+        save_state=cfg.save_state,
+        emit=cfg.emit,
+        get_bios_files_index=lambda: firmware_service.bios_files_index,
+        get_retrodeck_home=cfg.get_retrodeck_home,
+        get_saves_path=cfg.get_saves_path,
+        get_bios_path=cfg.get_bios_path,
+        get_retroarch_save_sorting=cfg.get_retroarch_save_sorting,
+        get_roms_path=cfg.get_roms_path,
+        get_active_core=_es_de_config.get_active_core,
+        get_core_name=cfg.get_core_name,
+    )
+
     save_sync_service = SaveService(
         romm_api=cfg.romm_api,
         retry=cfg.http_adapter,
@@ -187,6 +210,8 @@ def wire_services(cfg: WiringConfig) -> dict:
         get_core_name=cfg.get_core_name,
         plugin_version=_read_plugin_version(cfg.plugin_dir),
         emit=cfg.emit,
+        # SaveService must observe fresh sort state before computing saves_dir (#238).
+        detect_sort_change=migration_service.detect_save_sort_change,
     )
 
     playtime_service = PlaytimeService(
@@ -311,22 +336,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         loop=cfg.loop,
         logger=cfg.logger,
         log_debug=cfg.log_debug,
-    )
-
-    migration_service = MigrationService(
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        save_state=cfg.save_state,
-        emit=cfg.emit,
-        get_bios_files_index=lambda: firmware_service.bios_files_index,
-        get_retrodeck_home=cfg.get_retrodeck_home,
-        get_saves_path=cfg.get_saves_path,
-        get_bios_path=cfg.get_bios_path,
-        get_retroarch_save_sorting=cfg.get_retroarch_save_sorting,
-        get_roms_path=cfg.get_roms_path,
-        get_active_core=_es_de_config.get_active_core,
-        get_core_name=cfg.get_core_name,
     )
 
     game_detail_service = GameDetailService(

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -7,6 +7,7 @@ Also detects RetroArch save sorting setting changes and migrates affected save f
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 from typing import TYPE_CHECKING
@@ -15,7 +16,6 @@ from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
 
 if TYPE_CHECKING:
-    import asyncio
     import logging
     from collections.abc import Callable
 
@@ -393,7 +393,16 @@ class MigrationService:
     # ---------------------------------------------------------------------------
 
     def detect_save_sort_change(self) -> None:
-        """Check if RetroArch save sorting settings changed since last run."""
+        """Check if RetroArch save sorting settings changed since last run.
+
+        May be called from a worker thread (via
+        ``SaveService._refresh_save_sort_state`` → ``run_in_executor``) or
+        from the loop thread. Use ``asyncio.run_coroutine_threadsafe`` to
+        schedule the emit coroutine: it is explicitly thread-safe and
+        also works correctly when invoked from the loop thread itself.
+        ``loop.create_task`` is NOT thread-safe and races with loop
+        internals on CPython (#238 review).
+        """
         if self._get_retroarch_save_sorting is None:
             return
         sort_by_content, sort_by_core = self._get_retroarch_save_sorting()
@@ -409,11 +418,15 @@ class MigrationService:
         self._state["save_sort_settings"] = current
         self._save_state()
         self._logger.warning(f"RetroArch save sorting changed: {stored} -> {current}")
-        self._loop.create_task(
+        # Fire-and-forget: thread-safe schedule of the emit coroutine on
+        # the plugin event loop. We deliberately do not await or .result()
+        # the future — this mirrors the previous create_task semantics.
+        asyncio.run_coroutine_threadsafe(
             self._emit(
                 "save_sort_changed",
                 {"old_settings": stored, "new_settings": current},
-            )
+            ),
+            self._loop,
         )
 
     def _resolve_retroarch_corename(self, system: str, rom_filename: str) -> tuple[str | None, str | None]:

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -48,6 +48,7 @@ _NO_MIGRATION = object()  # sentinel: no slot migration requested
 if TYPE_CHECKING:
     import asyncio
     import logging
+    from collections.abc import Callable
 
     from domain.save_sync import MatchedSave
     from services.protocols import EventEmitter
@@ -96,6 +97,19 @@ class SaveService:
         one-parser-per-source rationale). When ``None`` or when resolution
         fails at runtime, SaveService warns and falls back to the parent
         directory path; see ``_resolve_retroarch_corename``.
+    detect_sort_change:
+        Optional synchronous callback that refreshes save-sort state from
+        the live RetroArch config (wired to
+        ``MigrationService.detect_save_sort_change`` in ``bootstrap``).
+        Save-sync MUST see fresh save-sort state before computing
+        ``saves_dir`` — otherwise a direct-Steam-launch with no pre-launch
+        detect trigger would silently download stale server content to the
+        wrong layout and destroy real user progress during the subsequent
+        migration (#238). ``pre_launch_sync`` and ``post_exit_sync`` invoke
+        this callback once at their entry point. ``None`` disables the
+        call (used only in unit tests where state is seeded explicitly);
+        failures are logged and swallowed so save-sync degrades
+        gracefully to the previously-known state.
     """
 
     _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
@@ -117,6 +131,7 @@ class SaveService:
         get_core_name: CoreNameProviderFn | None = None,
         plugin_version: str = "0.0.0",
         emit: EventEmitter | None = None,
+        detect_sort_change: Callable[[], None] | None = None,
     ) -> None:
         self._romm_api = romm_api
         self._retry = retry
@@ -132,6 +147,7 @@ class SaveService:
         self._get_core_name = get_core_name
         self._plugin_version = plugin_version
         self._emit = emit
+        self._detect_sort_change = detect_sort_change
 
     # ------------------------------------------------------------------
     # Debug logging helper
@@ -289,9 +305,14 @@ class SaveService:
 
         # Use domain save path resolution.
         # Read sort settings from state (populated by MigrationService at startup).
+        # When a save-sort migration is pending, prefer the *previous* layout:
+        # RetroArch caches its runtime save-path at game-load time, so the
+        # session that just ended still wrote to the old directory. Reading
+        # the current settings here would point sync at the wrong location
+        # and risk downloading stale server content to the new layout (#238).
         saves_base = self._get_saves_path()
         roms_base = self._get_roms_path()
-        sort_state = self._state.get("save_sort_settings")
+        sort_state = self._pending_sort_settings() or self._state.get("save_sort_settings")
         if sort_state:
             sort_by_content = sort_state.get("sort_by_content", True)
             sort_by_core = sort_state.get("sort_by_core", False)
@@ -341,9 +362,21 @@ class SaveService:
             "file_path": file_path,
         }
 
+    def _pending_sort_settings(self) -> dict | None:
+        """Return previous save-sort settings if a migration is pending, else None.
+
+        Rejects empty dicts to avoid the half-state where ``_get_rom_save_info``'s
+        ``or`` fallback would treat ``{}`` as "no pending migration" (and read
+        current settings) while ``_is_save_sort_changed`` would treat the same
+        ``{}`` as "pending" (and gate sync). Both call sites must agree on
+        what counts as pending — see #238 review finding 3.
+        """
+        prev = self._state.get("save_sort_settings_previous")
+        return prev if prev else None
+
     def _is_save_sort_changed(self) -> bool:
         """Check if a save sort migration is pending (detected by MigrationService)."""
-        return self._state.get("save_sort_settings_previous") is not None
+        return self._pending_sort_settings() is not None
 
     # ------------------------------------------------------------------
     # File Helpers
@@ -902,7 +935,22 @@ class SaveService:
         errors: list[str] = []
         conflicts: list[SaveConflict | dict] = []
 
+        # During a pending save-sort migration the local layout is ambiguous —
+        # the session that just ended may have written to the previous layout,
+        # while the new layout may hold stale or no content. Downloading the
+        # server copy in that window would land a file with mtime=now at the
+        # new layout, which the mtime-naive migration resolver would then
+        # prefer over the real user progress at the previous layout (#238).
+        # Upload-only mode during pending migration keeps sync as a safety net
+        # without risking data loss. Downloads resume once the user resolves
+        # the migration.
+        pending_migration = self._is_save_sort_changed()
+
         for m in match_result.matched:
+            if pending_migration and m.local_file is None and m.server_save is not None:
+                self._log_debug(f"_sync_rom_saves({rom_id}): skipping server_only {m.filename} — migration pending")
+                continue
+
             # Check for newer-in-slot before normal sync
             if self._check_newer_in_slot(m, files_state, rom_id, save_state, conflicts):
                 continue  # Skip normal sync
@@ -1244,10 +1292,41 @@ class SaveService:
             "new_label": active_label or (active_core.replace("_libretro", "") if active_core else None),
         }
 
+    async def _refresh_save_sort_state(self, where: str) -> None:
+        """Refresh save-sort state from the live RetroArch config.
+
+        Save-sync must observe fresh save-sort state before computing
+        ``saves_dir``. This call ensures ``detect_save_sort_change`` has
+        run at least once before we read state, closing the race where
+        another frontend detect trigger arrives after our backend entry
+        point. Without this, a direct-Steam-launch with no pre-detect
+        would silently download stale server content to the wrong
+        layout and destroy real user progress during the subsequent
+        migration (#238).
+
+        Graceful degradation: if detect fails (e.g. retroarch.cfg is
+        temporarily unreadable) we log and continue with the
+        previously-known state — save-sync must not abort because of a
+        config read error.
+        """
+        if self._detect_sort_change is None:
+            return
+        try:
+            await self._loop.run_in_executor(None, self._detect_sort_change)
+        except Exception as e:
+            self._logger.warning(
+                "%s: detect_sort_change failed (%s) — proceeding with stale state",
+                where,
+                e,
+            )
+
     async def pre_launch_sync(self, rom_id: int) -> dict:
         """Download newer saves from server before game launch."""
         if not self._is_save_sync_enabled():
             return {"success": True, "message": "Save sync disabled", "synced": 0}
+
+        # Refresh save-sort state before the migration gate — see #238.
+        await self._refresh_save_sort_state("pre_launch_sync")
 
         if self._is_save_sort_changed():
             return {
@@ -1293,6 +1372,9 @@ class SaveService:
             self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
             return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
 
+        # Refresh save-sort state before _sync_rom_saves reads saves_dir — see #238.
+        await self._refresh_save_sort_state("post_exit_sync")
+
         try:
             await self._loop.run_in_executor(None, self._romm_api.heartbeat)
         except Exception:
@@ -1330,6 +1412,12 @@ class SaveService:
         """Bidirectional sync for a single ROM (manual trigger from game detail)."""
         if not self._is_save_sync_enabled():
             return {"success": False, "message": _SYNC_DISABLED_MSG, "synced": 0}
+
+        # Refresh save-sort state before _sync_rom_saves reads saves_dir — see #238.
+        # Manual sync paths must observe fresh sort state too: a user could
+        # edit retroarch.cfg outside of a session and then trigger a manual
+        # sync before any detect has fired.
+        await self._refresh_save_sort_state("sync_rom_saves")
 
         if not self._save_sync_state.get("device_id"):
             reg = self.ensure_device_registered()
@@ -1853,6 +1941,12 @@ class SaveService:
         """Manual full sync of all ROMs with shortcuts (both directions)."""
         if not self._is_save_sync_enabled():
             return {"success": False, "message": _SYNC_DISABLED_MSG, "synced": 0, "conflicts": 0}
+
+        # Refresh save-sort state before _sync_rom_saves reads saves_dir — see #238.
+        # Manual sync paths must observe fresh sort state too: a user could
+        # edit retroarch.cfg outside of a session and then trigger a manual
+        # sync before any detect has fired.
+        await self._refresh_save_sort_state("sync_all_saves")
 
         if not self._save_sync_state.get("device_id"):
             reg = self.ensure_device_registered()

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -876,6 +876,17 @@ class SaveService:
             "slot": slot,
         }
 
+    @staticmethod
+    def _should_skip_server_only_during_migration(m, pending_migration: bool) -> bool:
+        """Return True if this match is a server-only download that must be skipped during pending migration.
+
+        During a pending save-sort migration we run in upload-only mode so that
+        no freshly-downloaded file lands on disk with ``mtime=now`` — otherwise
+        the mtime-naive migration resolver could prefer the stale download over
+        the real user progress at the other layout (#238).
+        """
+        return pending_migration and m.local_file is None and m.server_save is not None
+
     def _sync_rom_saves(self, rom_id: int) -> tuple[int, list[str], list[SaveConflict | dict]]:
         """Sync saves for a single ROM (always bidirectional).
 
@@ -947,7 +958,7 @@ class SaveService:
         pending_migration = self._is_save_sort_changed()
 
         for m in match_result.matched:
-            if pending_migration and m.local_file is None and m.server_save is not None:
+            if self._should_skip_server_only_during_migration(m, pending_migration):
                 self._log_debug(f"_sync_rom_saves({rom_id}): skipping server_only {m.filename} — migration pending")
                 continue
 

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -887,6 +887,19 @@ class SaveService:
         """
         return pending_migration and m.local_file is None and m.server_save is not None
 
+    def _log_match_debug(self, m, rom_id: int) -> None:
+        """Emit a debug line describing how a single match will be handled.
+
+        Extracted from ``_sync_rom_saves`` so the per-match log-line ternaries
+        don't inflate the parent's cognitive complexity (Sonar S3776).
+        """
+        method_label = f" [{m.match_method}]" if m.match_method not in ("filename", "local_only") else ""
+        local_label = "yes" if m.local_file else "no"
+        server_label = m.server_save.get("id") if m.server_save else "none"
+        self._log_debug(
+            f"_sync_rom_saves({rom_id}): {m.filename}{method_label} local={local_label} server={server_label}"
+        )
+
     def _sync_rom_saves(self, rom_id: int) -> tuple[int, list[str], list[SaveConflict | dict]]:
         """Sync saves for a single ROM (always bidirectional).
 
@@ -966,11 +979,7 @@ class SaveService:
             if self._check_newer_in_slot(m, files_state, rom_id, save_state, conflicts):
                 continue  # Skip normal sync
 
-            method_label = f" [{m.match_method}]" if m.match_method not in ("filename", "local_only") else ""
-            self._log_debug(
-                f"_sync_rom_saves({rom_id}): {m.filename}{method_label} "
-                f"local={'yes' if m.local_file else 'no'} server={m.server_save.get('id') if m.server_save else 'none'}"
-            )
+            self._log_match_debug(m, rom_id)
             if self._process_single_file_sync(
                 rom_id, rom_id_str, m.filename, m.local_file, m.server_save, saves_dir, system, errors, conflicts
             ):

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -114,13 +114,10 @@ async function handleGameStop(): Promise<void> {
     .then(() => logInfo(`Achievement sync complete for romId=${romId}`))
     .catch((e) => logError(`Achievement sync failed for romId=${romId}: ${e}`));
 
-  // Post-exit save sync — backend handles settings check + connectivity.
-  // IMPORTANT: save-sync MUST run before refreshMigrationState below. If the
-  // user changed RetroArch sort settings mid-game and we migrate first, the
-  // newest-wins resolver would delete the stale orphan locally — but since
-  // save-sync has not yet run, the newest progress would only live on disk.
-  // Uploading to RomM first gives us a safety net: even if local migration
-  // goes sideways, the server holds the authoritative latest version.
+  // Post-exit save sync — backend reads the previous save-sort layout when a
+  // migration is pending (#238), so this call is order-independent wrt
+  // refreshMigrationState below. The ordering here is incidental, not
+  // load-bearing.
   try {
     const result = await postExitSync(romId);
     if (result.offline) {
@@ -141,11 +138,10 @@ async function handleGameStop(): Promise<void> {
     logError(`Post-exit sync failed: ${e}`);
   }
 
-  // Post-game migration detection — runs AFTER save-sync above (ordering is
-  // load-bearing, see comment on the save-sync block). Runs unconditionally:
-  // refreshMigrationState only reads config files + state and emits events on
-  // genuine change — it does not touch user save files. Actual migration runs
-  // only when the user explicitly clicks the migrate button in Settings.
+  // Post-game migration detection — runs unconditionally. refreshMigrationState
+  // only reads config files + state and emits events on genuine change; it
+  // does not touch user save files. Actual migration runs only when the user
+  // explicitly clicks the migrate button in Settings.
   refreshMigrationState()
     .then(({ retrodeck, save_sort }) => {
       setMigrationStatus(retrodeck);

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -605,3 +605,112 @@ class TestMigrateSaveFiles:
 
         assert status["pending"] is True
         assert status["saves_count"] == 1
+
+
+class TestResolveSaveSortConflict:
+    """Regression lock for _resolve_save_sort_conflict's mtime-naive behavior.
+
+    This test documents current mtime-naive behavior. It is deliberately NOT a
+    semantic "correctness" test — #238 works around this limitation
+    structurally at the save-sync layer (SaveService reads the previous
+    layout when a migration is pending and skips server_only downloads so
+    the mtime-naive resolver never sees a freshly-downloaded stale file).
+    If you improve the resolver to be hash-aware, delete or rewrite this
+    test rather than bypass it.
+    """
+
+    def test_resolve_save_sort_conflict_newest_mtime_wins_regression(self, plugin, tmp_path):
+        """Newer mtime wins; older file is removed. Freezes current behavior (#238)."""
+        # Stale file at the "old" path (older mtime).
+        old_path = str(tmp_path / "old_saves" / "game.srm")
+        new_path = str(tmp_path / "new_saves" / "game.srm")
+        os.makedirs(os.path.dirname(old_path))
+        os.makedirs(os.path.dirname(new_path))
+        with open(old_path, "wb") as f:
+            f.write(b"stale content")
+        with open(new_path, "wb") as f:
+            f.write(b"fresh content")
+
+        # Force deterministic mtimes: old is older, new is newer.
+        old_mtime = 1_700_000_000.0
+        new_mtime = 1_700_000_500.0
+        os.utime(old_path, (old_mtime, old_mtime))
+        os.utime(new_path, (new_mtime, new_mtime))
+
+        counts: dict[str, int] = {}
+        errors: list = []
+        state_updates: list[str] = []
+
+        plugin._migration_service._resolve_save_sort_conflict(
+            label="gba/game.srm",
+            old_path=old_path,
+            new_path=new_path,
+            state_updater=lambda: state_updates.append("called"),
+            counts=counts,
+            count_key="save",
+            errors=errors,
+        )
+
+        # New (newer mtime) is kept; old (stale) is removed.
+        assert os.path.exists(new_path)
+        assert not os.path.exists(old_path)
+        with open(new_path, "rb") as f:
+            assert f.read() == b"fresh content"
+        assert counts["save"] == 1
+        assert state_updates == ["called"]
+        assert errors == []
+
+
+class TestDetectSaveSortChangeThreadSafety:
+    """Regression tests for #238 review finding 1: ``detect_save_sort_change``
+    is called from a worker thread (via ``SaveService._refresh_save_sort_state``
+    → ``run_in_executor``) and must schedule the emit coroutine in a
+    thread-safe manner. ``loop.create_task`` is NOT thread-safe — it must
+    be ``asyncio.run_coroutine_threadsafe``.
+    """
+
+    async def test_detect_save_sort_change_is_thread_safe_when_called_from_executor(self, plugin):
+        """detect_save_sort_change must be safe to call from a worker thread (#238).
+
+        Drive the call via ``loop.run_in_executor`` and verify the emit
+        coroutine is scheduled on the loop and runs without exception.
+        Before the fix, this would call ``loop.create_task`` from a
+        worker thread, which is undefined behavior.
+        """
+        loop = asyncio.get_event_loop()
+        plugin._migration_service._loop = loop
+
+        # Initial state: a populated OLD layout. Detect should observe a
+        # change and emit ``save_sort_changed``.
+        plugin._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
+        plugin._migration_service._get_retroarch_save_sorting = MagicMock(return_value=(True, True))
+
+        # Capture emit calls. Use an asyncio.Queue so the test can await
+        # the emission from the loop thread regardless of which thread
+        # scheduled it.
+        emit_queue: asyncio.Queue = asyncio.Queue()
+
+        async def fake_emit(event_name: str, payload: dict) -> None:
+            await emit_queue.put((event_name, payload))
+
+        plugin._migration_service._emit = fake_emit
+
+        # Run detect_save_sort_change on a worker thread.
+        await loop.run_in_executor(None, plugin._migration_service.detect_save_sort_change)
+
+        # Wait (with a generous timeout) for the emit coroutine that was
+        # scheduled via run_coroutine_threadsafe to actually run.
+        event = await asyncio.wait_for(emit_queue.get(), timeout=2.0)
+        assert event[0] == "save_sort_changed"
+        assert event[1]["old_settings"] == {"sort_by_content": True, "sort_by_core": False}
+        assert event[1]["new_settings"] == {"sort_by_content": True, "sort_by_core": True}
+
+        # State is updated via the shared dict — visible to whoever holds it.
+        assert plugin._state["save_sort_settings_previous"] == {
+            "sort_by_content": True,
+            "sort_by_core": False,
+        }
+        assert plugin._state["save_sort_settings"] == {
+            "sort_by_content": True,
+            "sort_by_core": True,
+        }

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -98,28 +98,39 @@ class TestDetectSaveSortChange:
     def test_change_emits_event(self, tmp_path):
         """Settings changed — emits event, stores old + new."""
         old = {"sort_by_content": True, "sort_by_core": False}
+        # AsyncMock returns a coroutine when called — required because
+        # detect_save_sort_change schedules the emit coroutine via
+        # asyncio.run_coroutine_threadsafe, which validates that its
+        # first arg is an actual coroutine (#238 review finding 1).
         svc, save_state_mock = _make_service(
             tmp_path,
             sort_settings=(False, True),
             state_overrides={"save_sort_settings": old},
         )
+        svc._emit = AsyncMock()
 
-        _tasks = []
+        # Stub run_coroutine_threadsafe at the module level so we can
+        # observe scheduling without needing a running event loop. The
+        # stub closes the coroutine to avoid "never awaited" warnings.
+        scheduled: list = []
 
-        def _close_task(coro):
+        def fake_schedule(coro, loop):
             coro.close()
-            _tasks.append(coro)
+            scheduled.append(coro)
             return MagicMock()
 
-        mock_loop = MagicMock()
-        mock_loop.create_task = _close_task
-        svc._loop = mock_loop
+        import services.migration as migration_module
 
-        svc.detect_save_sort_change()
+        original = migration_module.asyncio.run_coroutine_threadsafe
+        migration_module.asyncio.run_coroutine_threadsafe = fake_schedule  # type: ignore[assignment]
+        try:
+            svc.detect_save_sort_change()
+        finally:
+            migration_module.asyncio.run_coroutine_threadsafe = original  # type: ignore[assignment]
 
         assert svc._state["save_sort_settings"] == {"sort_by_content": False, "sort_by_core": True}
         assert svc._state["save_sort_settings_previous"] == old
-        assert len(_tasks) == 1
+        assert len(scheduled) == 1
         save_state_mock.assert_called_once()
 
     def test_no_callback_noop(self, tmp_path):

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -687,6 +687,120 @@ class TestSyncRomSaves:
         assert len(errors) == 1
         assert "Failed to fetch saves" in errors[0]
 
+    # ------------------------------------------------------------------
+    # Regression tests for issue #238 — pending-migration handling.
+    # Rule 2: skip server_only downloads while a save-sort migration is
+    # pending so the mtime-naive resolver cannot prefer freshly-downloaded
+    # stale server content over real user progress at the other layout.
+    # ------------------------------------------------------------------
+
+    def test_sync_rom_saves_skips_server_only_downloads_during_pending_migration(self, tmp_path):
+        """server_only matches must be skipped while migration is pending (#238)."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        # Mark migration pending — detect has fired, user hasn't resolved yet.
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
+        svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+        # Server has a save, no local file anywhere.
+        ss = _server_save()
+        fake.saves[100] = ss
+
+        synced, errors, conflicts = svc._sync_rom_saves(42)
+
+        assert synced == 0
+        assert errors == []
+        assert conflicts == []
+        # No download was initiated.
+        assert fake.downloaded_files == {}
+        # No file landed on disk under either layout.
+        saves_dir = tmp_path / "saves" / "gba"
+        assert not (saves_dir / "pokemon.srm").exists()
+
+    def test_sync_rom_saves_uploads_local_only_during_pending_migration(self, tmp_path):
+        """local_only matches must still upload during pending migration (#238)."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
+        svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+        # Local save at the (previous == current, same layout) location.
+        _create_save(tmp_path, content=b"user progress")
+
+        synced, errors, conflicts = svc._sync_rom_saves(42)
+
+        assert synced == 1
+        assert errors == []
+        assert conflicts == []
+        # Upload went through.
+        assert any(c[0] == "upload_save" for c in fake.call_log)
+
+    def test_sync_rom_saves_resolves_matched_pairs_during_pending_migration(self, tmp_path):
+        """matched pairs (local + server) must still resolve normally during pending migration (#238)."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        # Force local-wins so we get a deterministic upload instead of
+        # landing in "ask" mode (default "ask_me" for a fresh ROM with no
+        # baseline hash).
+        svc._save_sync_state["settings"]["conflict_mode"] = "local_wins"
+        _install_rom(svc, tmp_path)
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
+        svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+
+        # Local file is freshly modified — definitively newer than server.
+        save_path = _create_save(tmp_path, content=b"new user progress")
+        fresh_mtime = time.time()
+        os.utime(str(save_path), (fresh_mtime, fresh_mtime))
+
+        # Server save is old.
+        ss = _server_save(updated_at="2020-01-01T00:00:00Z")
+        fake.saves[100] = ss
+
+        synced, errors, _conflicts = svc._sync_rom_saves(42)
+
+        # The entry was NOT skipped (i.e. the pending_migration + server_only
+        # branch did not fire for a matched pair). Normal sync logic ran —
+        # local_wins forces an upload.
+        assert errors == []
+        assert synced == 1
+        assert any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_invokes_detect_sort_change_before_sync(self, tmp_path):
+        """Manual sync_rom_saves must also refresh save-sort state first (#238).
+
+        Without the detect-first call, a user editing retroarch.cfg outside
+        of a session and then triggering manual sync would race the same
+        way that direct-Steam-launch does — sync would compute saves_dir
+        from stale state and risk landing stale server content at the
+        wrong layout.
+        """
+        call_order: list[str] = []
+
+        def fake_detect() -> None:
+            call_order.append("detect")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        orig_sync = svc._sync_rom_saves
+
+        def wrapped_sync(rom_id):
+            call_order.append("sync")
+            return orig_sync(rom_id)
+
+        svc._sync_rom_saves = wrapped_sync  # type: ignore[method-assign]
+
+        result = await svc.sync_rom_saves(42)
+
+        assert result["success"] is True
+        # detect fired exactly once, before sync ran.
+        assert call_order.count("detect") == 1
+        assert call_order.index("detect") < call_order.index("sync")
+
 
 # ---------------------------------------------------------------------------
 # TestSyncAllSaves
@@ -746,6 +860,39 @@ class TestSyncAllSaves:
         assert result["synced"] >= 1
         assert len(result["errors"]) >= 1
 
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_invokes_detect_sort_change_before_sync(self, tmp_path):
+        """Manual sync_all_saves must also refresh save-sort state first (#238).
+
+        Same race as sync_rom_saves but for the bulk path: detect must
+        fire once at the top of the method, before any per-ROM sync runs.
+        """
+        call_order: list[str] = []
+
+        def fake_detect() -> None:
+            call_order.append("detect")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        orig_sync = svc._sync_rom_saves
+
+        def wrapped_sync(rom_id):
+            call_order.append("sync")
+            return orig_sync(rom_id)
+
+        svc._sync_rom_saves = wrapped_sync  # type: ignore[method-assign]
+
+        result = await svc.sync_all_saves()
+
+        assert result["success"] is True
+        # detect fired exactly once, before any per-ROM sync ran.
+        assert call_order.count("detect") == 1
+        assert call_order.index("detect") < call_order.index("sync")
+
 
 # ---------------------------------------------------------------------------
 # TestPreLaunchSync
@@ -783,6 +930,34 @@ class TestPreLaunchSync:
 
         result = await svc.pre_launch_sync(42)
         assert result["synced"] == 0
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_invokes_detect_sort_change_before_migration_gate(self, tmp_path):
+        """detect_sort_change is called before the _is_save_sort_changed gate (#238)."""
+        order: list[str] = []
+
+        def fake_detect() -> None:
+            # Simulate detect discovering a pending migration.
+            order.append("detect")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+
+        # Track when _is_save_sort_changed is consulted.
+        orig_gate = svc._is_save_sort_changed
+
+        def wrapped_gate():
+            order.append("gate")
+            return orig_gate()
+
+        svc._is_save_sort_changed = wrapped_gate  # type: ignore[method-assign]
+
+        await svc.pre_launch_sync(42)
+
+        assert "detect" in order
+        assert "gate" in order
+        assert order.index("detect") < order.index("gate")
 
 
 # ---------------------------------------------------------------------------
@@ -831,6 +1006,82 @@ class TestPostExitSync:
         result = await svc.post_exit_sync(42)
         assert result["success"] is True
         assert svc._save_sync_state["device_id"] is not None
+
+    # ------------------------------------------------------------------
+    # Regression tests for issue #238 — detect-first invariant.
+    #
+    # Save-sync must refresh save-sort state via detect_sort_change
+    # before computing saves_dir, so that Rule 1 / Rule 2 engage even
+    # when a direct-Steam-launch race delivers post_exit_sync before
+    # refreshMigrationState. See #238.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_invokes_detect_sort_change_before_sync(self, tmp_path):
+        """detect_sort_change is called exactly once before the sync path runs (#238)."""
+        call_order: list[str] = []
+
+        def fake_detect() -> None:
+            call_order.append("detect")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        # Patch _sync_rom_saves to record call ordering.
+        orig_sync = svc._sync_rom_saves
+
+        def wrapped_sync(rom_id):
+            call_order.append("sync")
+            return orig_sync(rom_id)
+
+        svc._sync_rom_saves = wrapped_sync  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is True
+        # detect fired exactly once, before sync ran.
+        assert call_order.count("detect") == 1
+        assert call_order.index("detect") < call_order.index("sync")
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_continues_when_detect_sort_change_raises(self, tmp_path, caplog):
+        """If detect_sort_change raises, save-sync logs a warning and proceeds (#238)."""
+
+        def boom() -> None:
+            raise RuntimeError("cfg file unreadable")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=boom)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        with caplog.at_level(logging.WARNING, logger="test"):
+            result = await svc.post_exit_sync(42)
+
+        assert result["success"] is True
+        # Sync still ran despite detect failure.
+        assert result["synced"] == 1
+        # Warning was logged.
+        assert any("detect_sort_change failed" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_works_when_detect_sort_change_is_none(self, tmp_path):
+        """Default detect_sort_change=None: post_exit_sync still runs without error (#238)."""
+        svc, _ = make_service(tmp_path)  # detect_sort_change not passed → None
+        assert svc._detect_sort_change is None
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is True
+        assert result["synced"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -1545,6 +1796,83 @@ class TestGetRomSaveInfo:
         result = svc._get_rom_save_info(42)
 
         assert result is None
+
+    # ------------------------------------------------------------------
+    # Regression tests for issue #238 — Rule 1: when a save-sort migration
+    # is pending, prefer save_sort_settings_previous so sync reads the
+    # layout RetroArch actually wrote to during the session that just
+    # ended.
+    # ------------------------------------------------------------------
+
+    def test_get_rom_save_info_prefers_previous_sort_settings_when_migration_pending(self, tmp_path):
+        """Pending migration: previous (OLD) sort settings override current (NEW) (#238)."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        # NEW layout (what settings currently say):
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+        # OLD layout (what the session actually wrote to):
+        svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+
+        result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        # OLD layout: no /mGBA subdir.
+        assert result["saves_dir"].endswith("saves/gba")
+        assert "/mGBA" not in result["saves_dir"]
+
+    def test_get_rom_save_info_uses_current_sort_settings_when_no_pending_migration(self, tmp_path):
+        """No pending migration: use current sort settings (#238)."""
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        # Only save_sort_settings is present — no pending migration key at all.
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+        assert "save_sort_settings_previous" not in svc._state
+
+        result = svc._get_rom_save_info(42)
+
+        assert result is not None
+        # CURRENT layout: /mGBA subdir is appended because sort_by_core=True.
+        assert result["saves_dir"].endswith("saves/gba/mGBA")
+
+    def test_pending_sort_settings_rejects_empty_dict_half_state(self, tmp_path):
+        """Empty-dict ``save_sort_settings_previous`` must NOT count as pending (#238 review).
+
+        Freezes the contract: ``_get_rom_save_info`` and
+        ``_is_save_sort_changed`` must agree on what counts as pending.
+        Before ``_pending_sort_settings`` was introduced, a literal
+        empty dict at ``save_sort_settings_previous`` would put the
+        service in a half-state — ``_get_rom_save_info`` would fall
+        back to current settings (``{} or current``), but
+        ``_is_save_sort_changed`` would treat the same ``{}`` as
+        pending (``is not None``). This test locks in the agreement.
+        """
+        svc, _ = make_service(
+            tmp_path,
+            get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
+            get_core_name=lambda core_so: "mGBA",
+        )
+        _install_rom(svc, tmp_path)
+        # Half-state input: empty previous, populated current (NEW).
+        svc._state["save_sort_settings_previous"] = {}
+        svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
+
+        # Both call sites must agree there is NO pending migration.
+        assert svc._is_save_sort_changed() is False
+        assert svc._pending_sort_settings() is None
+
+        result = svc._get_rom_save_info(42)
+        assert result is not None
+        # Reads CURRENT settings (NEW layout), not the empty previous —
+        # mGBA subdir is appended because sort_by_core=True.
+        assert result["saves_dir"].endswith("saves/gba/mGBA")
 
     # ------------------------------------------------------------------
     # Regression tests for issue #232 — SaveService must resolve the

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -212,3 +212,69 @@ class TestWireServices:
         save_sync_service = result["save_sync_service"]
         assert save_sync_service._get_core_name is get_core_name_mock
         deps["loop"].close()
+
+    def test_save_sync_service_receives_migration_detect_sort_change(self, tmp_path):
+        """Regression test for #238: SaveService must receive
+        ``migration_service.detect_save_sort_change`` via its
+        ``detect_sort_change`` constructor parameter.
+
+        Without this wiring, post_exit_sync could run with stale sort
+        state and download stale server content to the wrong layout,
+        causing real user progress to be destroyed during the next
+        migration step.
+        """
+        deps = self._make_deps(tmp_path)
+        result = wire_services(WiringConfig(**deps))
+        save_sync_service = result["save_sync_service"]
+        migration_service = result["migration_service"]
+        # Bound method equality: same function + same bound instance.
+        # ``is`` fails because Python creates a fresh bound method object
+        # on each attribute access.
+        assert save_sync_service._detect_sort_change == migration_service.detect_save_sort_change
+        # Also check it's the actual migration instance, not some other.
+        assert save_sync_service._detect_sort_change.__self__ is migration_service  # type: ignore[union-attr]
+        deps["loop"].close()
+
+    def test_save_sync_and_migration_share_state_reference(self, tmp_path):
+        """Regression test for #238: SaveService and MigrationService must
+        observe the same state dict by reference.
+
+        Without shared state, ``detect_save_sort_change`` would mutate
+        MigrationService's local copy while SaveService reads its own
+        stale copy — defeating the detect-first invariant.
+        """
+        deps = self._make_deps(tmp_path)
+        result = wire_services(WiringConfig(**deps))
+        save_sync_service = result["save_sync_service"]
+        migration_service = result["migration_service"]
+        assert save_sync_service._state is deps["state"]
+        assert migration_service._state is deps["state"]
+        assert save_sync_service._state is migration_service._state
+        deps["loop"].close()
+
+    def test_save_sync_detect_sort_change_mutates_shared_state(self, tmp_path):
+        """Functional check for #238: invoking the wired detect callback
+        from SaveService updates state that SaveService subsequently
+        reads.
+
+        The wired callback writes current sort settings into
+        ``_state["save_sort_settings"]`` on first run. SaveService and
+        MigrationService must see that write through the same live dict.
+        """
+        deps = self._make_deps(tmp_path)
+        # The default mock returns (True, False); no prior state seeded.
+        assert "save_sort_settings" not in deps["state"]
+        result = wire_services(WiringConfig(**deps))
+        save_sync_service = result["save_sync_service"]
+
+        # Invoke the bound detect callback SaveService received.
+        save_sync_service._detect_sort_change()  # type: ignore[misc]
+
+        # State now has the current sort settings written through the
+        # shared dict — SaveService will read this on its next
+        # _get_rom_save_info call.
+        assert deps["state"]["save_sort_settings"] == {
+            "sort_by_content": True,
+            "sort_by_core": False,
+        }
+        deps["loop"].close()

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import logging
+import os
+import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +15,7 @@ from fakes.fake_save_api import FakeSaveApi
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.library import LibraryService
+from services.migration import MigrationService
 from services.playtime import PlaytimeService
 from services.saves import SaveService
 
@@ -246,6 +249,241 @@ class TestPostExitSync:
 
         assert result["synced"] == 0
         assert "disabled" in result["message"].lower()
+
+    # ------------------------------------------------------------------
+    # Regression tests for issue #238 — post-exit sync must not blow away
+    # user progress when a save-sort migration is pending.
+    #
+    # The two scenarios cover:
+    #  1. Mid-session sort change: save was written to the previous layout
+    #     during the session that just ended; Rule 1 ensures sync reads
+    #     that layout so local progress is uploaded before anything can
+    #     touch it.
+    #  2. NEW-from-start: the session ran entirely under the new layout
+    #     (user changed retroarch.cfg outside of a session then launched
+    #     directly via Steam), detect fires at session end, and Rule 2
+    #     must prevent sync from downloading stale server content to
+    #     the (empty) previous layout — otherwise the mtime-naive
+    #     migration resolver would pick that fresh download over the real
+    #     user progress at the new layout.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_mid_session_sort_change_preserves_user_progress(self, plugin, tmp_path):
+        """Mid-session sort change: save at previous layout must be uploaded, no stale download (#238)."""
+        _install_rom(plugin, tmp_path)
+        # Force local_wins so a conflict (fresh local vs stale server) cleanly
+        # resolves to an upload rather than dropping into ask_me.
+        plugin._save_sync_state["settings"]["conflict_mode"] = "local_wins"
+        # Session just ended: user flipped sort_by_content mid-game.
+        # PREVIOUS layout (OLD) — where RetroArch actually wrote the save:
+        #   saves/gba/pokemon.srm (sort_by_content=True)
+        # CURRENT layout (NEW) — where the current settings would look:
+        #   saves/pokemon.srm (sort_by_content=False)
+        plugin._state["save_sort_settings"] = {"sort_by_content": False, "sort_by_core": False}
+        plugin._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+
+        # Real user progress at PREVIOUS layout — this is the byte content we
+        # must protect at all costs.
+        prev_save_path = tmp_path / "retrodeck" / "saves" / "gba" / "pokemon.srm"
+        prev_save_path.parent.mkdir(parents=True, exist_ok=True)
+        prev_save_path.write_bytes(b"USER_PROGRESS_NEW")
+        # Ensure local mtime is newer than server (local_wins compares mtimes).
+        fresh = time.time()
+        os.utime(str(prev_save_path), (fresh, fresh))
+
+        # Server has an older, stale save — must NOT end up on disk.
+        plugin._fake_api.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2020-01-01T00:00:00Z",
+            "file_size_bytes": len(b"SERVER_STALE"),
+            "emulator": "retroarch",
+            "download_path": "/saves/pokemon.srm",
+        }
+        plugin._fake_api.uploaded_files[100] = str(tmp_path / "server_stale.srm")
+        (tmp_path / "server_stale.srm").write_bytes(b"SERVER_STALE")
+
+        result = await plugin.post_exit_sync(42)
+
+        assert result["success"] is True
+        # Local progress at PREVIOUS path was uploaded.
+        upload_calls = [c for c in plugin._fake_api.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        uploaded_path = upload_calls[0][1][1]
+        assert uploaded_path == str(prev_save_path)
+        with open(uploaded_path, "rb") as f:
+            assert f.read() == b"USER_PROGRESS_NEW"
+
+        # PREVIOUS path still has the real user progress, byte-identical.
+        assert prev_save_path.exists()
+        assert prev_save_path.read_bytes() == b"USER_PROGRESS_NEW"
+
+        # No file landed at the NEW layout (no stale download).
+        new_save_path = tmp_path / "retrodeck" / "saves" / "pokemon.srm"
+        assert not new_save_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_new_from_start_skips_stale_download(self, plugin, tmp_path):
+        """NEW-from-start edge: sync must not download stale server content to previous layout (#238)."""
+        _install_rom(plugin, tmp_path)
+        # Detect just fired at session end. Session ran entirely under the
+        # NEW layout because the user had already flipped the setting before
+        # launching.
+        plugin._state["save_sort_settings"] = {"sort_by_content": False, "sort_by_core": False}
+        plugin._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
+
+        # Real user progress at the NEW layout (where the session wrote).
+        new_save_path = tmp_path / "retrodeck" / "saves" / "pokemon.srm"
+        new_save_path.parent.mkdir(parents=True, exist_ok=True)
+        new_save_path.write_bytes(b"ACTUAL_USER_PROGRESS")
+
+        # Server has a stale save from a previous device.
+        plugin._fake_api.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2020-01-01T00:00:00Z",
+            "file_size_bytes": len(b"STALE_SERVER_CONTENT"),
+            "emulator": "retroarch",
+            "download_path": "/saves/pokemon.srm",
+        }
+        plugin._fake_api.uploaded_files[100] = str(tmp_path / "server_stale.srm")
+        (tmp_path / "server_stale.srm").write_bytes(b"STALE_SERVER_CONTENT")
+
+        # Nothing at the PREVIOUS layout path before sync.
+        prev_save_path = tmp_path / "retrodeck" / "saves" / "gba" / "pokemon.srm"
+        assert not prev_save_path.exists()
+
+        result = await plugin.post_exit_sync(42)
+
+        assert result["success"] is True
+        # No download happened (Rule 2 skipped server_only).
+        assert plugin._fake_api.downloaded_files == {}
+        # No file created at the PREVIOUS layout path.
+        assert not prev_save_path.exists()
+        # NEW layout file is untouched — byte-identical to what we wrote.
+        assert new_save_path.exists()
+        assert new_save_path.read_bytes() == b"ACTUAL_USER_PROGRESS"
+        # No upload either — previous layout is empty (nothing to upload).
+        upload_calls = [c for c in plugin._fake_api.call_log if c[0] == "upload_save"]
+        assert upload_calls == []
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_detects_stale_state_and_skips_stale_download_c2(self, plugin, tmp_path):
+        """End-to-end C2 regression (#238).
+
+        Race scenario: user changes retroarch.cfg outside of a session
+        (plugin hasn't detected yet — state still has stale OLD
+        settings, no ``previous``). User launches directly via Steam
+        (no pre-launch detect). Session runs under NEW layout. Session
+        ends. ``post_exit_sync`` arrives at the backend BEFORE
+        ``refresh_migration_state`` does.
+
+        Previous behavior: Rule 2 wouldn't engage because ``previous``
+        wasn't set yet — sync would compute ``saves_dir`` from the
+        stale OLD settings, find it empty, match the server save as
+        ``server_only``, download the stale content to the OLD path,
+        and the later migration resolver would prefer the
+        freshly-downloaded stale file over the real NEW-layout user
+        progress.
+
+        Fix: ``post_exit_sync`` calls ``detect_save_sort_change`` at
+        the top, which populates ``save_sort_settings_previous``. Rule
+        1 then returns the OLD layout for ``_get_rom_save_info``, and
+        Rule 2 skips the ``server_only`` match. Real user progress at
+        the NEW path stays untouched.
+        """
+        _install_rom(plugin, tmp_path)
+
+        # Preconditions:
+        # - Plugin state thinks save sort is still "sort_by_content only"
+        #   (this is what detect LAST wrote — before the user flipped cfg).
+        # - No ``previous`` key at all — detect has never seen the change.
+        plugin._state["save_sort_settings"] = {
+            "sort_by_content": True,
+            "sort_by_core": False,
+        }
+        assert "save_sort_settings_previous" not in plugin._state
+
+        # Real user progress at the NEW layout (where the session wrote).
+        # NEW layout: sort_by_content=True + sort_by_core=True adds /mGBA.
+        # Simplify: simulate NEW = sort_by_content=False (no gba/ subdir).
+        new_save_path = tmp_path / "retrodeck" / "saves" / "pokemon.srm"
+        new_save_path.parent.mkdir(parents=True, exist_ok=True)
+        new_save_path.write_bytes(b"ACTUAL_USER_PROGRESS")
+
+        # Server has stale content from an earlier device/session.
+        plugin._fake_api.saves[100] = {
+            "id": 100,
+            "rom_id": 42,
+            "file_name": "pokemon.srm",
+            "updated_at": "2020-01-01T00:00:00Z",
+            "file_size_bytes": len(b"STALE_SERVER_CONTENT"),
+            "emulator": "retroarch",
+            "download_path": "/saves/pokemon.srm",
+        }
+        stale_upload = tmp_path / "server_stale.srm"
+        stale_upload.write_bytes(b"STALE_SERVER_CONTENT")
+        plugin._fake_api.uploaded_files[100] = str(stale_upload)
+
+        # Wire a REAL MigrationService on the SAME state dict as the
+        # plugin's SaveService, then point SaveService's
+        # ``detect_sort_change`` at the real bound method.
+        # ``get_retroarch_save_sorting`` reports the CURRENT on-disk cfg
+        # (NEW: sort_by_content=False, sort_by_core=False) — the mismatch
+        # with state is what detect will discover.
+        real_migration = MigrationService(
+            state=plugin._state,
+            loop=asyncio.get_event_loop(),
+            logger=logging.getLogger("test"),
+            save_state=plugin._save_state,
+            emit=MagicMock(),
+            get_bios_files_index=lambda: {},
+            get_retroarch_save_sorting=lambda: (False, False),
+        )
+        # Sanity: same state object — mutations through migration will be
+        # visible to SaveService on the next state read.
+        assert real_migration._state is plugin._save_sync_service._state
+
+        plugin._save_sync_service._detect_sort_change = real_migration.detect_save_sort_change
+
+        # Nothing at the PREVIOUS (OLD: sort_by_content=True → gba/) path.
+        prev_save_path = tmp_path / "retrodeck" / "saves" / "gba" / "pokemon.srm"
+        assert not prev_save_path.exists()
+
+        result = await plugin.post_exit_sync(42)
+
+        assert result["success"] is True
+
+        # 1. detect fired inside post_exit_sync and populated
+        #    ``save_sort_settings_previous`` on the shared state dict.
+        assert plugin._state["save_sort_settings_previous"] == {
+            "sort_by_content": True,
+            "sort_by_core": False,
+        }
+        assert plugin._state["save_sort_settings"] == {
+            "sort_by_content": False,
+            "sort_by_core": False,
+        }
+
+        # 2. NO file was written to the OLD layout path (no stale download).
+        assert not prev_save_path.exists()
+        # FakeSaveApi records any download — confirm none happened.
+        assert plugin._fake_api.downloaded_files == {}
+
+        # 3. The file at NEW layout path is byte-identical to what the
+        #    session wrote — not touched, not overwritten.
+        assert new_save_path.exists()
+        assert new_save_path.read_bytes() == b"ACTUAL_USER_PROGRESS"
+
+        # 4. No upload either: Rule 1 points sync at the OLD layout
+        #    (empty), so there's nothing to upload from there. The real
+        #    NEW-layout save will be picked up after the user resolves
+        #    the migration via the Settings UI.
+        upload_calls = [c for c in plugin._fake_api.call_log if c[0] == "upload_save"]
+        assert upload_calls == []
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes a silent save data-loss race (#238) that triggered when RetroArch's `sort_savefiles_enable` or `sort_savefiles_by_content_enable` was changed mid-session. The forensic timeline: `refreshMigrationState` from `RomMGameInfoPanel` remount updated state to the new layout before `postExitSync` read it, save sync looked in the wrong directory, downloaded stale server content with `mtime=now`, and the newest-wins migration resolver later picked the fresh-but-stale download over the real local progress.

Three structural guards close the race:

- **Rule 1** — `_get_rom_save_info` reads `save_sort_settings_previous` in preference to `save_sort_settings` during pending migration. RetroArch caches its runtime save path at load time, so the just-ended session wrote to the previous layout.
- **Rule 2** — `_sync_rom_saves` skips `server_only` matches during pending migration. Upload-only mode prevents stale downloads from creating files the `mtime` resolver could later mispick.
- **Detect-first invariant** — `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves` and `sync_all_saves` call `detect_save_sort_change` via an injected callback before reading state, closing the "detect has not fired yet" race for direct-Steam launches that bypass `launchInterceptor`.

Combined, these three guards close all four race sub-scenarios:

| | Detect wins race | post_exit wins race |
|---|---|---|
| **Mid-session change** | B — Rule 1 | A — detect-first + Rule 1 |
| **NEW-from-start (direct Steam)** | C1 — Rule 1 + Rule 2 | C2 — detect-first + Rule 1 + Rule 2 |

## Related cleanups

- `MigrationService.detect_save_sort_change` uses `asyncio.run_coroutine_threadsafe` instead of `loop.create_task` to schedule the `save_sort_changed` emit. The method is now invoked from worker threads via `run_in_executor`, where `create_task` is not thread-safe.
- New `_pending_sort_settings` helper unifies empty-dict handling between `_get_rom_save_info` and `_is_save_sort_changed` (they previously disagreed on `{}` — `or` falsy vs `is not None`).
- Stale load-bearing-ordering comment in `sessionManager.ts handleGameStop` replaced with an accurate description of the new invariant. The call order inside `handleGameStop` is no longer load-bearing — save-sync is order-independent w.r.t. detect.

## Scope decision: `_resolve_save_sort_conflict` stays mtime-naive

The secondary cause in #238 is that `_resolve_save_sort_conflict` uses pure `mtime` comparison, which is fooled by freshly-downloaded files. Rather than making it hash-aware, this PR fixes the problem structurally at the save-sync layer: if save-sync never writes stale downloads to disk during pending migration, the mtime resolver can no longer be deceived. A regression test in `tests/services/test_migration.py` freezes the current mtime-naive behavior and documents that future changes there should be intentional.

## Test plan

- [x] Full backend test suite: **1756 passed**, 0 failed, 3 pre-existing warnings unrelated to this PR
- [x] `ruff check`, `basedpyright`, `lint-imports` (6/6 contracts), `pnpm build` all clean
- [x] Manual smoke test on Steam Deck: mid-session `sort_by_core` toggle on Mario Golf (mGBA core). Log trace confirmed Rule 1 reads previous layout, real user progress uploaded to RomM, migration performed clean `os.replace` with no conflict, next pre-launch sync correctly used new layout
- [x] Regression confirmation: the C2 integration test was dry-run without the detect-first wiring and verified to fail, proving it catches the newly-closed race

### New tests
- `tests/services/test_saves.py` — 12 new unit tests covering Rules 1 & 2, detect-first injection, manual sync paths, empty-dict half-state rejection
- `tests/services/test_migration.py` — thread-safety test for detect-from-executor, mtime-resolver regression test
- `tests/test_bootstrap.py` — 3 wiring tests (service construction order, shared state reference, bound method identity)
- `tests/test_plugin_saves.py` — 3 integration tests (mid-session, NEW-from-start, C2 stale-state) using real `MigrationService` wired onto shared state

## Closes

Closes #238