### PR TITLE
feat(saves): slot deletion with server capabilities system

### DIFF
--- a/main.py
+++ b/main.py
@@ -606,6 +606,12 @@ class Plugin:
     async def switch_slot(self, rom_id, new_slot):
         return await self._save_sync_service.switch_slot(rom_id, new_slot)
 
+    async def get_slot_delete_info(self, rom_id, slot):
+        return await self._save_sync_service.get_slot_delete_info(rom_id, slot)
+
+    async def delete_slot(self, rom_id, slot):
+        return await self._save_sync_service.delete_slot(rom_id, slot)
+
     async def is_save_tracking_configured(self, rom_id):
         return self._save_sync_service.is_save_tracking_configured(rom_id)
 
@@ -640,6 +646,19 @@ class Plugin:
     async def delete_platform_saves(self, platform_slug):
         return self._save_sync_service.delete_platform_saves(platform_slug)
 
+    async def get_server_capabilities(self):
+        # All v4.7+ features share the same gate today. When a feature
+        # requires a different minimum version, add a dedicated
+        # service-level check and map it here.
+        v47 = self._save_sync_service.supports_version_history()
+        return {
+            "device_sync": v47,
+            "version_history": v47,
+            "slot_deletion": v47,
+            "device_management": v47,
+        }
+
+    # Deprecated: use get_server_capabilities instead. Kept for backward compat.
     async def saves_supports_version_history(self):
         return self._save_sync_service.supports_version_history()
 

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -2445,23 +2445,32 @@ class SaveService:
     # Slot deletion
     # ------------------------------------------------------------------
 
+    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[str, dict, dict[str, dict]]:
+        """Shared validation for slot delete operations.
+
+        Returns an error dict on failure, or a (rom_id_str, save_state, slots_dict)
+        tuple on success.
+        """
+        if not self._is_save_sync_enabled():
+            return {"success": False, "reason": "disabled"}
+        if not self._get_rom_save_info(rom_id):
+            return {"success": False, "reason": "not_installed"}
+        rom_id_str = str(rom_id)
+        save_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
+        slots_dict: dict[str, dict] = save_state.get("slots", {})
+        if slot not in slots_dict:
+            return {"success": False, "reason": "not_found"}
+        return rom_id_str, save_state, slots_dict
+
     async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
         """Return info about what deleting a slot would do, for the confirmation modal."""
         rom_id = int(rom_id)
         slot = str(slot).strip() if slot else ""
 
-        if not self._is_save_sync_enabled():
-            return {"success": False, "reason": "disabled"}
-
-        if not self._get_rom_save_info(rom_id):
-            return {"success": False, "reason": "not_installed"}
-
-        rom_id_str = str(rom_id)
-        save_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
-        slots_dict: dict[str, dict] = save_state.get("slots", {})
-
-        if slot not in slots_dict:
-            return {"success": False, "reason": "not_found"}
+        result = self._validate_slot_operation(rom_id, slot)
+        if isinstance(result, dict):
+            return result
+        _rom_id_str, save_state, slots_dict = result
 
         slot_info = slots_dict[slot]
         source = slot_info.get("source", "server")
@@ -2535,18 +2544,10 @@ class SaveService:
         rom_id = int(rom_id)
         slot = str(slot).strip() if slot else ""
 
-        if not self._is_save_sync_enabled():
-            return {"success": False, "reason": "disabled"}
-
-        if not self._get_rom_save_info(rom_id):
-            return {"success": False, "reason": "not_installed"}
-
-        rom_id_str = str(rom_id)
-        save_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
-        slots_dict: dict[str, dict] = save_state.get("slots", {})
-
-        if slot not in slots_dict:
-            return {"success": False, "reason": "not_found"}
+        result = self._validate_slot_operation(rom_id, slot)
+        if isinstance(result, dict):
+            return result
+        _rom_id_str, save_state, slots_dict = result
 
         effective_active = save_state.get("active_slot") or ""
         if slot == effective_active:

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -2531,7 +2531,7 @@ class SaveService:
                     ),
                 )
             return {"success": True, "count": len(save_ids), "ids": set(save_ids)}
-        except (RommApiError, Exception) as e:
+        except Exception as e:
             self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
             return {
                 "success": False,

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -2440,3 +2440,150 @@ class SaveService:
             "deleted_count": total_deleted,
             "message": f"Deleted {total_deleted} save file(s) from {rom_count} ROM(s)",
         }
+
+    # ------------------------------------------------------------------
+    # Slot deletion
+    # ------------------------------------------------------------------
+
+    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
+        """Return info about what deleting a slot would do, for the confirmation modal."""
+        rom_id = int(rom_id)
+        slot = str(slot).strip() if slot else ""
+
+        if not self._is_save_sync_enabled():
+            return {"success": False, "reason": "disabled"}
+
+        if not self._get_rom_save_info(rom_id):
+            return {"success": False, "reason": "not_installed"}
+
+        rom_id_str = str(rom_id)
+        save_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
+        slots_dict: dict[str, dict] = save_state.get("slots", {})
+
+        if slot not in slots_dict:
+            return {"success": False, "reason": "not_found"}
+
+        slot_info = slots_dict[slot]
+        source = slot_info.get("source", "server")
+        active_slot = save_state.get("active_slot")
+        is_active = slot == (active_slot or "")
+
+        # Server save count
+        server_save_ids: list[int] = []
+        if source == "server":
+            device_id = self._get_server_device_id()
+            try:
+                server_saves: list[dict] = await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(
+                        lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                    ),
+                )
+                server_save_ids = [s["id"] for s in server_saves]
+            except Exception as e:
+                self._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
+
+        # Local tracked files pointing to server saves in this slot
+        files_state = save_state.get("files", {})
+        local_filenames: list[str] = []
+        if server_save_ids:
+            id_set = set(server_save_ids)
+            for filename, fstate in files_state.items():
+                if fstate.get("tracked_save_id") in id_set:
+                    local_filenames.append(filename)
+
+        return {
+            "success": True,
+            "slot": slot,
+            "source": source,
+            "server_save_count": len(server_save_ids),
+            "server_save_ids": server_save_ids,
+            "local_file_count": len(local_filenames),
+            "local_filenames": local_filenames,
+            "is_active": is_active,
+        }
+
+    async def delete_slot(self, rom_id: int, slot: str) -> dict:
+        """Delete a save slot and all its saves (local state + server if applicable)."""
+        rom_id = int(rom_id)
+        slot = str(slot).strip() if slot else ""
+
+        if not self._is_save_sync_enabled():
+            return {"success": False, "reason": "disabled"}
+
+        if not self._get_rom_save_info(rom_id):
+            return {"success": False, "reason": "not_installed"}
+
+        rom_id_str = str(rom_id)
+        save_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
+        slots_dict: dict[str, dict] = save_state.get("slots", {})
+
+        if slot not in slots_dict:
+            return {"success": False, "reason": "not_found"}
+
+        active_slot = save_state.get("active_slot")
+        if slot == (active_slot or ""):
+            return {
+                "success": False,
+                "reason": "active_slot",
+                "message": "Cannot delete the active slot. Switch to a different slot first.",
+            }
+
+        slot_info = slots_dict[slot]
+        source = slot_info.get("source", "server")
+
+        deleted_server_saves = 0
+        cleaned_files = 0
+        deleted_ids: set[int] = set()
+
+        # Delete server saves if this is a server-backed slot
+        if source == "server":
+            device_id = self._get_server_device_id()
+            try:
+                server_saves: list[dict] = await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(
+                        lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                    ),
+                )
+                save_ids = [s["id"] for s in server_saves]
+                if save_ids:
+                    await self._loop.run_in_executor(
+                        None,
+                        lambda: self._retry.with_retry(
+                            lambda: self._romm_api.delete_server_saves(save_ids),
+                        ),
+                    )
+                    deleted_ids = set(save_ids)
+                    deleted_server_saves = len(save_ids)
+            except RommApiError as e:
+                self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
+                return {
+                    "success": False,
+                    "reason": "server_error",
+                    "message": f"Failed to delete server saves: {e}",
+                }
+            except Exception as e:
+                self._logger.warning(f"delete_slot: unexpected error for slot '{slot}': {e}")
+                return {
+                    "success": False,
+                    "reason": "server_error",
+                    "message": f"Failed to delete server saves: {e}",
+                }
+
+        # Clean up local state
+        files_state = save_state.get("files", {})
+        if deleted_ids:
+            to_remove = [fn for fn, fs in files_state.items() if fs.get("tracked_save_id") in deleted_ids]
+            for fn in to_remove:
+                del files_state[fn]
+                cleaned_files += 1
+
+        del slots_dict[slot]
+        self.save_state()
+
+        return {
+            "success": True,
+            "deleted_server_saves": deleted_server_saves,
+            "cleaned_files": cleaned_files,
+        }

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -2503,6 +2503,33 @@ class SaveService:
             "is_active": is_active,
         }
 
+    async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict:
+        """Delete all server saves in a slot. Returns result dict with count and IDs."""
+        device_id = self._get_server_device_id()
+        try:
+            server_saves: list[dict] = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                ),
+            )
+            save_ids = [s["id"] for s in server_saves]
+            if save_ids:
+                await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(
+                        lambda: self._romm_api.delete_server_saves(save_ids),
+                    ),
+                )
+            return {"success": True, "count": len(save_ids), "ids": set(save_ids)}
+        except (RommApiError, Exception) as e:
+            self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
+            return {
+                "success": False,
+                "reason": "server_error",
+                "message": f"Failed to delete server saves: {e}",
+            }
+
     async def delete_slot(self, rom_id: int, slot: str) -> dict:
         """Delete a save slot and all its saves (local state + server if applicable)."""
         rom_id = int(rom_id)
@@ -2521,8 +2548,8 @@ class SaveService:
         if slot not in slots_dict:
             return {"success": False, "reason": "not_found"}
 
-        active_slot = save_state.get("active_slot")
-        if slot == (active_slot or ""):
+        effective_active = save_state.get("active_slot") or ""
+        if slot == effective_active:
             return {
                 "success": False,
                 "reason": "active_slot",
@@ -2536,42 +2563,14 @@ class SaveService:
         cleaned_files = 0
         deleted_ids: set[int] = set()
 
-        # Delete server saves if this is a server-backed slot
         if source == "server":
-            device_id = self._get_server_device_id()
-            try:
-                server_saves: list[dict] = await self._loop.run_in_executor(
-                    None,
-                    lambda: self._retry.with_retry(
-                        lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
-                    ),
-                )
-                save_ids = [s["id"] for s in server_saves]
-                if save_ids:
-                    await self._loop.run_in_executor(
-                        None,
-                        lambda: self._retry.with_retry(
-                            lambda: self._romm_api.delete_server_saves(save_ids),
-                        ),
-                    )
-                    deleted_ids = set(save_ids)
-                    deleted_server_saves = len(save_ids)
-            except RommApiError as e:
-                self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
-                return {
-                    "success": False,
-                    "reason": "server_error",
-                    "message": f"Failed to delete server saves: {e}",
-                }
-            except Exception as e:
-                self._logger.warning(f"delete_slot: unexpected error for slot '{slot}': {e}")
-                return {
-                    "success": False,
-                    "reason": "server_error",
-                    "message": f"Failed to delete server saves: {e}",
-                }
+            result = await self._delete_server_slot_saves(rom_id, slot)
+            if not result["success"]:
+                return result
+            deleted_server_saves = result["count"]
+            deleted_ids = result["ids"]
 
-        # Clean up local state
+        # Clean up tracked file entries pointing to deleted saves
         files_state = save_state.get("files", {})
         if deleted_ids:
             to_remove = [fn for fn, fs in files_state.items() if fs.get("tracked_save_id") in deleted_ids]

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -131,6 +131,31 @@ export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSl
 export const setGameSlot = callable<[number, string], { success: boolean; active_slot?: string; message?: string }>("set_game_slot");
 export const getSlotSaves = callable<[number, string], SlotSavesResponse>("get_slot_saves");
 export const switchSlot = callable<[number, string], SwitchSlotResponse>("switch_slot");
+
+export interface SlotDeleteInfo {
+  success: boolean;
+  slot?: string;
+  source?: "server" | "local";
+  server_save_count?: number;
+  server_save_ids?: number[];
+  local_file_count?: number;
+  local_filenames?: string[];
+  is_active?: boolean;
+  reason?: string;
+  message?: string;
+}
+
+export interface DeleteSlotResult {
+  success: boolean;
+  deleted_server_saves?: number;
+  cleaned_files?: number;
+  reason?: string;
+  message?: string;
+}
+
+export const getSlotDeleteInfo = callable<[number, string], SlotDeleteInfo>("get_slot_delete_info");
+export const deleteSlot = callable<[number, string], DeleteSlotResult>("delete_slot");
+
 export const isSaveTrackingConfigured = callable<[number], { configured: boolean; active_slot: string | null }>("is_save_tracking_configured");
 export const getSaveSetupInfo = callable<[number], SaveSetupInfo>("get_save_setup_info");
 export const confirmSlotChoice = callable<[number, string, string | null], { success: boolean; needs_conflict_resolution?: boolean; message: string }>("confirm_slot_choice");
@@ -192,7 +217,17 @@ export const deleteLocalSaves = callable<[number], { success: boolean; deleted_c
 export const deletePlatformSaves = callable<[string], { success: boolean; deleted_count: number; message: string }>("delete_platform_saves");
 export const deletePlatformBios = callable<[string], { success: boolean; deleted_count: number; message: string }>("delete_platform_bios");
 
-// Save version history callables (v4.7+ only — gated by supportsVersionHistory)
+// Server capabilities — fetched once by RomMGameInfoPanel and passed to children
+export interface ServerCapabilities {
+  device_sync: boolean;
+  version_history: boolean;
+  slot_deletion: boolean;
+  device_management: boolean;
+}
+
+export const getServerCapabilities = callable<[], ServerCapabilities>("get_server_capabilities");
+
+// Save version history callables (v4.7+ only — gated by capabilities.version_history)
 export interface SaveVersionEntry {
   id: number;
   file_name: string;

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -287,11 +287,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         }
 
         // Server capabilities (for save sync feature gating)
+        const handleCaps = (caps: ServerCapabilities) => {
+          if (!cancelled) setState((prev) => ({ ...prev, capabilities: caps }));
+        };
         if (cached.save_sync_enabled) {
-          const capsFetch = getServerCapabilities().then((caps) => {
-            if (!cancelled) setState((prev) => ({ ...prev, capabilities: caps }));
-          }).catch(() => {});
-          bgPromises.push(capsFetch);
+          bgPromises.push(getServerCapabilities().then(handleCaps).catch(() => {}));
         }
 
         await Promise.all(bgPromises);

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -288,13 +288,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
 
         // Server capabilities (for save sync feature gating)
         if (cached.save_sync_enabled) {
-          bgPromises.push(
-            getServerCapabilities().then((caps) => {
-              if (!cancelled) {
-                setState((prev) => ({ ...prev, capabilities: caps }));
-              }
-            }).catch(() => {}),
-          );
+          const capsFetch = getServerCapabilities().then((caps) => {
+            if (!cancelled) setState((prev) => ({ ...prev, capabilities: caps }));
+          }).catch(() => {});
+          bgPromises.push(capsFetch);
         }
 
         await Promise.all(bgPromises);

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -30,10 +30,12 @@ import {
   getAchievementProgress,
   getSaveSlots,
   isSaveTrackingConfigured,
+  getServerCapabilities,
   debugLog,
   refreshMigrationState,
   logError,
 } from "../api/backend";
+import type { ServerCapabilities } from "../api/backend";
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import { SavesTab } from "./SavesTab";
 import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, PendingConflict, Achievement, AchievementProgress, EarnedAchievement, SaveSlotSummary } from "../types";
@@ -69,6 +71,7 @@ interface PanelState {
   activeSlot: string | null;
   availableSlots: SaveSlotSummary[];
   slotsLoading: boolean;
+  capabilities: ServerCapabilities;
 }
 
 /** Format a Unix timestamp (seconds) as a release date string (e.g. "15 Mar 2003") */
@@ -102,6 +105,13 @@ function refreshSlotState(
 }
 
 export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
+  const defaultCapabilities: ServerCapabilities = {
+    device_sync: false,
+    version_history: false,
+    slot_deletion: false,
+    device_management: false,
+  };
+
   const [state, setState] = useState<PanelState>({
     loading: true,
     romId: null,
@@ -126,6 +136,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     activeSlot: "default",
     availableSlots: [],
     slotsLoading: false,
+    capabilities: defaultCapabilities,
   });
   const romIdRef = useRef<number | null>(null);
   const [migrationPending, setMigrationPending] = useState(getMigrationState().pending);
@@ -231,6 +242,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
           activeSlot: "default",
           availableSlots: [],
           slotsLoading: false,
+          capabilities: defaultCapabilities,
         });
 
         // Check if save slot tracking is configured for this game
@@ -269,6 +281,17 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
             getRomMetadata(romId).then((meta) => {
               if (!cancelled && meta) {
                 setState((prev) => ({ ...prev, metadata: meta }));
+              }
+            }).catch(() => {}),
+          );
+        }
+
+        // Server capabilities (for save sync feature gating)
+        if (cached.save_sync_enabled) {
+          bgPromises.push(
+            getServerCapabilities().then((caps) => {
+              if (!cancelled) {
+                setState((prev) => ({ ...prev, capabilities: caps }));
               }
             }).catch(() => {}),
           );
@@ -1015,6 +1038,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         activeSlot: state.activeSlot,
         availableSlots: state.availableSlots,
         slotsLoading: state.slotsLoading,
+        capabilities: state.capabilities,
         onSlotSwitched: (newSlot, newStatus) => {
           setState((prev) => ({
             ...prev,

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -287,14 +287,16 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         }
 
         // Server capabilities (for save sync feature gating)
-        const handleCaps = (caps: ServerCapabilities) => {
-          if (!cancelled) setState((prev) => ({ ...prev, capabilities: caps }));
-        };
+        let fetchedCaps: ServerCapabilities | null = null;
         if (cached.save_sync_enabled) {
-          bgPromises.push(getServerCapabilities().then(handleCaps).catch(() => {}));
+          bgPromises.push(getServerCapabilities().then((c) => { fetchedCaps = c; }).catch(() => {}));
         }
 
         await Promise.all(bgPromises);
+
+        if (!cancelled && fetchedCaps) {
+          setState((prev) => ({ ...prev, capabilities: fetchedCaps! }));
+        }
       } catch (e) {
         debugLog(`RomMGameInfoPanel: loadData error: ${e}`);
         if (!cancelled) setState((prev) => ({ ...prev, loading: false, error: true }));

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -566,18 +566,21 @@ function renderActiveSlotBody(
     "No save files tracked yet")];
 }
 
-function renderInactiveSlotBody(
-  loadingSlot: boolean,
-  slotFiles: SlotSaveFile[] | null,
-  switching: boolean,
-  switchError: string | null,
-  isOffline: boolean,
-  handleActivate: () => void,
-  handleDelete: () => void,
-  deleting: boolean,
-  slotSource: "server" | "local",
-  capabilities: ServerCapabilities,
-): (ReturnType<typeof createElement> | null)[] {
+interface InactiveSlotBodyOpts {
+  loadingSlot: boolean;
+  slotFiles: SlotSaveFile[] | null;
+  switching: boolean;
+  switchError: string | null;
+  isOffline: boolean;
+  handleActivate: () => void;
+  handleDelete: () => void;
+  deleting: boolean;
+  slotSource: "server" | "local";
+  capabilities: ServerCapabilities;
+}
+
+function renderInactiveSlotBody(opts: InactiveSlotBodyOpts): (ReturnType<typeof createElement> | null)[] {
+  const { loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting, slotSource, capabilities } = opts;
   const children: (ReturnType<typeof createElement> | null)[] = [];
 
   if (loadingSlot) {
@@ -593,6 +596,8 @@ function renderInactiveSlotBody(
 
   // Delete button: always shown for local-only slots, requires slot_deletion capability for server slots
   const showDeleteButton = slotSource === "local" || capabilities.slot_deletion;
+  const activateLabel = switching ? "Switching..." : "Activate Slot";
+  const deleteLabel = deleting ? "Deleting..." : "Delete Slot";
 
   children.push(
     createElement(Focusable as any, {
@@ -607,7 +612,7 @@ function renderInactiveSlotBody(
         onFocus: scrollFocusedToCenter,
         disabled: switching || isOffline,
         onClick: handleActivate,
-      }, switching ? "Switching..." : "Activate Slot"),
+      }, activateLabel),
       showDeleteButton
         ? createElement(DialogButton as any, {
             key: "delete-btn",
@@ -616,7 +621,7 @@ function renderInactiveSlotBody(
             onFocus: scrollFocusedToCenter,
             disabled: deleting || switching,
             onClick: handleDelete,
-          }, deleting ? "Loading..." : "Delete Slot")
+          }, deleteLabel)
         : null,
     ),
     isOffline
@@ -841,7 +846,7 @@ const SlotPanel: FC<SlotPanelProps> = ({
   if (expanded) {
     bodyChildren = isActive
       ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, capabilities, isOffline, onVersionRestored)
-      : renderInactiveSlotBody(loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting, slot.source, capabilities);
+      : renderInactiveSlotBody({ loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting, slotSource: slot.source, capabilities });
   }
 
   const bodyEl = expanded

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -13,8 +13,8 @@
 import { useState, useEffect, useRef, createElement, FC, ChangeEvent } from "react";
 import { ConfirmModal, DialogButton, Focusable, TextField, showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
-import { getSlotSaves, switchSlot, debugLog, savesSupportsVersionHistory, savesListFileVersions, savesRollbackToVersion } from "../api/backend";
-import type { SaveVersionEntry, RollbackStatus } from "../api/backend";
+import { getSlotSaves, switchSlot, debugLog, savesListFileVersions, savesRollbackToVersion, getSlotDeleteInfo, deleteSlot } from "../api/backend";
+import type { ServerCapabilities, SaveVersionEntry, RollbackStatus, SlotDeleteInfo } from "../api/backend";
 import { getRommConnectionState } from "../utils/connectionState";
 import type { SaveStatus, PendingConflict, SaveSlotSummary, SaveFileStatus, SlotSaveFile, SwitchSlotResponse, DeviceSyncInfo } from "../types";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
@@ -29,6 +29,7 @@ interface SavesTabProps {
   activeSlot: string | null;
   availableSlots: SaveSlotSummary[];
   slotsLoading: boolean;
+  capabilities: ServerCapabilities;
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
 }
 
@@ -539,7 +540,7 @@ function renderActiveSlotBody(
   conflicts: PendingConflict[],
   romId: number,
   slot: string,
-  supportsVersionHistory: boolean,
+  capabilities: ServerCapabilities,
   isOffline: boolean,
   onVersionRestored: () => void,
 ): (ReturnType<typeof createElement> | null)[] {
@@ -548,7 +549,7 @@ function renderActiveSlotBody(
       const conflict = conflicts.find((c) => c.filename === f.filename);
       return createElement("div", { key: f.filename },
         renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at),
-        supportsVersionHistory
+        capabilities.version_history
           ? createElement(VersionHistoryPanel, {
               key: `vhp-${f.filename}`,
               romId,
@@ -572,6 +573,10 @@ function renderInactiveSlotBody(
   switchError: string | null,
   isOffline: boolean,
   handleActivate: () => void,
+  handleDelete: () => void,
+  deleting: boolean,
+  slotSource: "server" | "local",
+  capabilities: ServerCapabilities,
 ): (ReturnType<typeof createElement> | null)[] {
   const children: (ReturnType<typeof createElement> | null)[] = [];
 
@@ -586,8 +591,15 @@ function renderInactiveSlotBody(
       "No saves in this slot"));
   }
 
+  // Delete button: always shown for local-only slots, requires slot_deletion capability for server slots
+  const showDeleteButton = slotSource === "local" || capabilities.slot_deletion;
+
   children.push(
-    createElement("div", { key: "activate-row", style: { marginTop: "10px" } },
+    createElement(Focusable as any, {
+      key: "activate-row",
+      "flow-children": "right",
+      style: { marginTop: "10px", display: "flex", gap: "8px", alignItems: "center" },
+    },
       createElement(DialogButton as any, {
         key: "activate-btn",
         style: { padding: "4px 12px", minWidth: "auto", fontSize: "12px", width: "auto" },
@@ -596,19 +608,29 @@ function renderInactiveSlotBody(
         disabled: switching || isOffline,
         onClick: handleActivate,
       }, switching ? "Switching..." : "Activate Slot"),
-      isOffline
-        ? createElement("div", {
-            key: "offline-hint",
-            style: { fontSize: "11px", color: "#8f98a0", fontStyle: "italic" as const, marginTop: "4px" },
-          }, "Offline \u2014 slot switching unavailable")
-        : null,
-      switchError
-        ? createElement("div", {
-            key: "switch-error",
-            style: { fontSize: "11px", color: "#d94126", marginTop: "4px" },
-          }, switchError)
+      showDeleteButton
+        ? createElement(DialogButton as any, {
+            key: "delete-btn",
+            style: { padding: "4px 12px", minWidth: "auto", fontSize: "12px", width: "auto", color: "#d94126" },
+            noFocusRing: false,
+            onFocus: scrollFocusedToCenter,
+            disabled: deleting || switching,
+            onClick: handleDelete,
+          }, deleting ? "Loading..." : "Delete Slot")
         : null,
     ),
+    isOffline
+      ? createElement("div", {
+          key: "offline-hint",
+          style: { fontSize: "11px", color: "#8f98a0", fontStyle: "italic" as const, marginTop: "4px" },
+        }, "Offline \u2014 slot switching unavailable")
+      : null,
+    switchError
+      ? createElement("div", {
+          key: "switch-error",
+          style: { fontSize: "11px", color: "#d94126", marginTop: "4px" },
+        }, switchError)
+      : null,
   );
 
   return children;
@@ -622,11 +644,12 @@ interface SlotPanelProps {
   // Active slot data (only set when isActive === true)
   saveStatus: SaveStatus | null;
   conflicts: PendingConflict[];
-  supportsVersionHistory: boolean;
+  capabilities: ServerCapabilities;
   isOffline: boolean;
   // Callbacks
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
   onVersionRestored: () => void;
+  onSlotDeleted: () => void;
 }
 
 const SlotPanel: FC<SlotPanelProps> = ({
@@ -636,16 +659,18 @@ const SlotPanel: FC<SlotPanelProps> = ({
   defaultExpanded,
   saveStatus,
   conflicts,
-  supportsVersionHistory,
+  capabilities,
   isOffline,
   onSlotSwitched,
   onVersionRestored,
+  onSlotDeleted,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [slotFiles, setSlotFiles] = useState<SlotSaveFile[] | null>(null);
   const [loadingSlot, setLoadingSlot] = useState(false);
   const [switching, setSwitching] = useState(false);
   const [switchError, setSwitchError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const switchErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const slotName = slot.slot;
@@ -696,6 +721,61 @@ const SlotPanel: FC<SlotPanelProps> = ({
       switchErrorTimerRef.current = setTimeout(() => setSwitchError(null), 5000);
     } finally {
       setSwitching(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      const info: SlotDeleteInfo = await getSlotDeleteInfo(romId, slotName);
+      if (!info.success) {
+        if (info.reason === "active_slot" || info.is_active) {
+          toaster.toast({ title: "RomM Sync", body: "Cannot delete the active slot. Switch to a different slot first." });
+        } else {
+          toaster.toast({ title: "RomM Sync", body: info.message ?? "Cannot delete this slot" });
+        }
+        return;
+      }
+
+      // Build confirmation message
+      const lines: string[] = [];
+      if (info.source === "server" && (info.server_save_count ?? 0) > 0) {
+        const n = info.server_save_count ?? 0;
+        lines.push(`This will permanently delete ${n} save${n === 1 ? "" : "s"} from slot '${info.slot}' on the RomM server.`);
+      } else {
+        lines.push(`This will remove slot '${info.slot}' from your local configuration.`);
+      }
+      if ((info.local_file_count ?? 0) > 0) {
+        const n = info.local_file_count ?? 0;
+        lines.push(`${n} tracked file${n === 1 ? "" : "s"} will be unlinked.`);
+      }
+      lines.push("This cannot be undone.");
+
+      showModal(createElement(ConfirmModal, {
+        strTitle: "Delete Slot",
+        strDescription: lines.join("\n\n"),
+        strOKButtonText: "Delete",
+        strCancelButtonText: "Cancel",
+        onOK: async () => {
+          try {
+            const result = await deleteSlot(romId, slotName);
+            if (result.success) {
+              toaster.toast({ title: "RomM Sync", body: `Slot '${slotName}' deleted` });
+              onSlotDeleted();
+            } else {
+              toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
+            }
+          } catch (e) {
+            debugLog(`SavesTab: deleteSlot error: ${e}`);
+            toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
+          }
+        },
+      }));
+    } catch (e) {
+      debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`);
+      toaster.toast({ title: "RomM Sync", body: "Failed to load slot info" });
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -760,8 +840,8 @@ const SlotPanel: FC<SlotPanelProps> = ({
   let bodyChildren: (ReturnType<typeof createElement> | null)[] = [];
   if (expanded) {
     bodyChildren = isActive
-      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, supportsVersionHistory, isOffline, onVersionRestored)
-      : renderInactiveSlotBody(loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate);
+      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, capabilities, isOffline, onVersionRestored)
+      : renderInactiveSlotBody(loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting, slot.source, capabilities);
   }
 
   const bodyEl = expanded
@@ -788,29 +868,25 @@ export const SavesTab: FC<SavesTabProps> = ({
   activeSlot,
   availableSlots,
   slotsLoading,
+  capabilities,
   onSlotSwitched,
 }) => {
   const [newSlotError, setNewSlotError] = useState<string | null>(null);
   const newSlotErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isOffline, setIsOffline] = useState(getRommConnectionState() === "offline");
-  const [supportsVersionHistory, setSupportsVersionHistory] = useState(false);
   // Bumped to invalidate VersionHistoryPanel caches after a restore
   const [versionHistoryKey, setVersionHistoryKey] = useState(0);
-
-  useEffect(() => {
-    // Skip while offline — preserve last-known capability so we don't flicker
-    // the UI off if the server is briefly unreachable. Re-fetches on reconnect
-    // via the isOffline dep.
-    if (isOffline) return;
-    savesSupportsVersionHistory()
-      .then((supported) => setSupportsVersionHistory(!!supported))
-      .catch(() => setSupportsVersionHistory(false));
-  }, [isOffline]);
 
   const handleVersionRestored = () => {
     setVersionHistoryKey((k) => k + 1);
     // Trigger parent refresh of saveStatus so the tracked save row reflects
     // the new tracked_save_id / server fields without leaving the page.
+    globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
+      detail: { type: "save_sync", rom_id: romId },
+    }));
+  };
+
+  const handleSlotDeleted = () => {
     globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
       detail: { type: "save_sync", rom_id: romId },
     }));
@@ -976,10 +1052,11 @@ export const SavesTab: FC<SavesTabProps> = ({
           defaultExpanded: isActive,
           saveStatus: isActive ? saveStatus : null,
           conflicts: isActive ? conflicts : [],
-          supportsVersionHistory,
+          capabilities,
           isOffline,
           onSlotSwitched,
           onVersionRestored: handleVersionRestored,
+          onSlotDeleted: handleSlotDeleted,
         });
       }),
 

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -170,6 +170,8 @@ class FakeSaveApi:
         self.call_log.append(("list_saves", (rom_id,), {"device_id": device_id, "slot": slot}))
         self._check_fail()
         saves = [s for s in self.saves.values() if s.get("rom_id") == rom_id]
+        if slot is not None:
+            saves = [s for s in saves if s.get("slot") == slot]
         if device_id:
             # Simulate server adding device_syncs when device_id is provided
             for s in saves:

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -4591,3 +4591,247 @@ class TestRollbackToVersion:
         result = await svc.rollback_to_version(42, "default", "pokemon.srm", 50)
 
         assert result["status"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# TestDeleteSlot
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSlot:
+    """Tests for SaveService.delete_slot and get_slot_delete_info."""
+
+    def _setup_state_with_slots(
+        self,
+        svc,
+        tmp_path,
+        *,
+        active_slot="default",
+        extra_slots=None,
+        files_state=None,
+    ):
+        """Set up a ROM with slot state for deletion tests."""
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        _install_rom(svc, tmp_path)
+
+        slots = {
+            "default": {"source": "server", "count": 1, "latest_updated_at": "2026-03-24T10:00:00"},
+        }
+        if extra_slots:
+            slots.update(extra_slots)
+
+        svc._save_sync_state["saves"]["42"] = {
+            "active_slot": active_slot,
+            "slot_confirmed": True,
+            "slots": slots,
+            "files": files_state or {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_server_slot(self, tmp_path):
+        """Server slot returns save count and tracked file info."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"save1": {"source": "server", "count": 3, "latest_updated_at": None}},
+            files_state={
+                "pokemon.srm": {"tracked_save_id": 10, "last_sync_hash": "abc"},
+                "zelda.srm": {"tracked_save_id": 11, "last_sync_hash": "def"},
+                "unrelated.srm": {"tracked_save_id": 99, "last_sync_hash": "ghi"},
+            },
+        )
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, filename="pokemon.srm", slot="save1")
+        fake.saves[11] = _server_save(save_id=11, rom_id=42, filename="zelda.srm", slot="save1")
+        fake.saves[12] = _server_save(save_id=12, rom_id=42, filename="extra.srm", slot="save1")
+
+        result = await svc.get_slot_delete_info(42, "save1")
+
+        assert result["success"] is True
+        assert result["server_save_count"] == 3
+        assert set(result["server_save_ids"]) == {10, 11, 12}
+        assert result["local_file_count"] == 2
+        assert set(result["local_filenames"]) == {"pokemon.srm", "zelda.srm"}
+        assert result["is_active"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_local_only_slot(self, tmp_path):
+        """Local-only slot returns zero server saves."""
+        svc, _fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"local1": {"source": "local", "count": 0, "latest_updated_at": None}},
+        )
+
+        result = await svc.get_slot_delete_info(42, "local1")
+
+        assert result["success"] is True
+        assert result["source"] == "local"
+        assert result["server_save_count"] == 0
+        assert result["local_file_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_active_slot(self, tmp_path):
+        """Info for the active slot still returns data (is_active=True)."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(svc, tmp_path, active_slot="default")
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default")
+
+        result = await svc.get_slot_delete_info(42, "default")
+
+        assert result["success"] is True
+        assert result["is_active"] is True
+        assert result["server_save_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_nonexistent_slot(self, tmp_path):
+        """Non-existent slot returns not_found."""
+        svc, _fake = make_service(tmp_path)
+        self._setup_state_with_slots(svc, tmp_path)
+
+        result = await svc.get_slot_delete_info(42, "nonexistent")
+
+        assert result["success"] is False
+        assert result["reason"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_server_saves_success(self, tmp_path):
+        """Deleting a server slot removes server saves and cleans up state."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"save1": {"source": "server", "count": 2, "latest_updated_at": None}},
+            files_state={
+                "pokemon.srm": {"tracked_save_id": 10, "last_sync_hash": "abc"},
+                "zelda.srm": {"tracked_save_id": 11, "last_sync_hash": "def"},
+            },
+        )
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, filename="pokemon.srm", slot="save1")
+        fake.saves[11] = _server_save(save_id=11, rom_id=42, filename="zelda.srm", slot="save1")
+
+        result = await svc.delete_slot(42, "save1")
+
+        assert result["success"] is True
+        assert result["deleted_server_saves"] == 2
+        assert result["cleaned_files"] == 2
+        # Slot removed from state
+        assert "save1" not in svc._save_sync_state["saves"]["42"]["slots"]
+        # File entries cleaned
+        assert "pokemon.srm" not in svc._save_sync_state["saves"]["42"]["files"]
+        assert "zelda.srm" not in svc._save_sync_state["saves"]["42"]["files"]
+        # delete_server_saves called with correct IDs
+        delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
+        assert len(delete_calls) == 1
+        assert set(delete_calls[0][1][0]) == {10, 11}
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_local_only_success(self, tmp_path):
+        """Deleting a local-only slot skips server calls."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"local1": {"source": "local", "count": 0, "latest_updated_at": None}},
+        )
+
+        result = await svc.delete_slot(42, "local1")
+
+        assert result["success"] is True
+        assert result["deleted_server_saves"] == 0
+        assert "local1" not in svc._save_sync_state["saves"]["42"]["slots"]
+        # No server calls made
+        delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
+        assert len(delete_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_blocks_active_slot(self, tmp_path):
+        """Cannot delete the active slot."""
+        svc, _fake = make_service(tmp_path)
+        self._setup_state_with_slots(svc, tmp_path, active_slot="default")
+
+        result = await svc.delete_slot(42, "default")
+
+        assert result["success"] is False
+        assert result["reason"] == "active_slot"
+        # Slot still exists
+        assert "default" in svc._save_sync_state["saves"]["42"]["slots"]
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_server_error(self, tmp_path):
+        """Server error leaves slot intact (no partial cleanup)."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"save1": {"source": "server", "count": 1, "latest_updated_at": None}},
+        )
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, filename="pokemon.srm", slot="save1")
+        # First list_saves call succeeds, then delete_server_saves fails
+        original_delete = fake.delete_server_saves
+
+        def fail_delete(save_ids):
+            raise RommApiError(500, "Server error")
+
+        fake.delete_server_saves = fail_delete
+
+        result = await svc.delete_slot(42, "save1")
+
+        assert result["success"] is False
+        assert result["reason"] == "server_error"
+        # Slot NOT removed from state (rollback on failure)
+        assert "save1" in svc._save_sync_state["saves"]["42"]["slots"]
+
+        fake.delete_server_saves = original_delete
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_cleans_up_tracked_files(self, tmp_path):
+        """Only file entries pointing to deleted saves are removed; unrelated entries preserved."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"save1": {"source": "server", "count": 2, "latest_updated_at": None}},
+            files_state={
+                "pokemon.srm": {"tracked_save_id": 10, "last_sync_hash": "abc"},
+                "zelda.srm": {"tracked_save_id": 11, "last_sync_hash": "def"},
+                "unrelated.srm": {"tracked_save_id": 99, "last_sync_hash": "ghi"},
+            },
+        )
+        fake.saves[10] = _server_save(save_id=10, rom_id=42, filename="pokemon.srm", slot="save1")
+        fake.saves[11] = _server_save(save_id=11, rom_id=42, filename="zelda.srm", slot="save1")
+
+        result = await svc.delete_slot(42, "save1")
+
+        assert result["success"] is True
+        files = svc._save_sync_state["saves"]["42"]["files"]
+        assert "pokemon.srm" not in files
+        assert "zelda.srm" not in files
+        assert "unrelated.srm" in files
+        assert files["unrelated.srm"]["tracked_save_id"] == 99
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_not_installed_rom(self, tmp_path):
+        """ROM not installed returns failure."""
+        svc, _fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        # Don't install any ROM
+
+        result = await svc.delete_slot(42, "default")
+
+        assert result["success"] is False
+        assert result["reason"] == "not_installed"
+
+    @pytest.mark.asyncio
+    async def test_delete_slot_sync_disabled(self, tmp_path):
+        """Save sync disabled returns failure."""
+        svc, _fake = make_service(tmp_path)
+        # save_sync_enabled defaults to False
+
+        result = await svc.delete_slot(42, "default")
+
+        assert result["success"] is False
+        assert result["reason"] == "disabled"

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -1075,6 +1075,33 @@ async def test_delete_platform_saves(plugin, tmp_path):
 # ============================================================================
 
 
+class TestGetServerCapabilitiesCallable:
+    """Integration tests for the get_server_capabilities callable."""
+
+    @pytest.mark.asyncio
+    async def test_returns_all_false_on_v46(self, plugin):
+        """get_server_capabilities returns all-false dict on v4.6."""
+        result = await plugin.get_server_capabilities()
+        assert result == {
+            "device_sync": False,
+            "version_history": False,
+            "slot_deletion": False,
+            "device_management": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_returns_all_true_on_v47(self, plugin):
+        """get_server_capabilities returns all-true dict when device sync is supported."""
+        plugin._fake_api._supports_device_sync = True
+        result = await plugin.get_server_capabilities()
+        assert result == {
+            "device_sync": True,
+            "version_history": True,
+            "slot_deletion": True,
+            "device_management": True,
+        }
+
+
 class TestSavesVersionHistoryCallables:
     """Integration tests for the three version history callables."""
 


### PR DESCRIPTION
## Summary

- **Slot Deletion**: Users can delete save slots (local-only and server-backed) with a confirmation modal showing exact save counts. Active slot cannot be deleted (must switch away first), which implicitly prevents deleting the last remaining slot.
- **Server Capabilities System**: Single `getServerCapabilities()` callable returns feature flags based on RomM server version. Frontend fetches once on mount and gates UI features accordingly. Replaces the ad-hoc `savesSupportsVersionHistory` pattern.
- **Gamepad Navigation Fix**: Activate/Delete buttons use `Focusable` with `flow-children="right"` for proper DPad left/right navigation.

## What changed

### Backend
- `SaveService.get_slot_delete_info(rom_id, slot)` — returns slot metadata for the confirmation modal
- `SaveService.delete_slot(rom_id, slot)` — performs deletion (server bulk delete + local state cleanup)
- `get_server_capabilities` callable in `main.py` builds feature-flag dict from `supports_version_history()` (composition root, not service layer)
- `FakeSaveApi.list_saves` now filters by `slot` parameter (was silently ignoring it)

### Frontend
- Delete button in inactive slot body (`SavesTab.tsx`), gated by `capabilities.slot_deletion` for server slots
- `ConfirmModal` with exact save counts and local/server distinction
- `RomMGameInfoPanel` fetches capabilities on mount, passes to `SavesTab` as prop
- `Focusable` wrapper with `flow-children="right"` for button row gamepad navigation

### Capabilities flags
All four flags gate on v4.7+ today (individually extensible for future version bumps):
- `device_sync` / `version_history` / `slot_deletion` / `device_management`

## Architecture note

`get_server_capabilities()` lives in `main.py` (composition root), NOT on SaveService. It's an orchestration concern — mapping server version to product-level feature flags. SaveService keeps `supports_version_history()` for internal backend use.

## Test plan

- [x] 1769 tests passed, ruff + basedpyright + lint-imports (6/6) + pnpm build all clean
- [x] 11 new unit tests in `TestDeleteSlot` (server/local slots, active-slot block, server error rollback, file cleanup, edge cases)
- [x] 4 new capability tests (v4.6 all-false, v4.7 all-true, at both service and plugin level)
- [x] Manual smoke test on Steam Deck: deleted default slot, verified server saves removed, local state cleaned, save file restored and re-uploaded on next sync
- [x] Capability gating tested with raised threshold (4.9) — version history and delete buttons correctly hidden
- [x] Gamepad DPad left/right navigation between Activate and Delete buttons verified

## Related

Block 1 of #197 (Multi-Device & Slot Management). Does NOT close #197 — Blocks 2 and 3 remain.

See also: #244 (Drop v4.6 support — will simplify capabilities to all-true)