### PR TITLE
feat(saves): device list + client_version reconciliation

### DIFF
--- a/main.py
+++ b/main.py
@@ -593,7 +593,10 @@ class Plugin:
                     self._romm_api.set_version(self._romm_version)
             except Exception as e:
                 decky.logger.debug(f"ensure_device_registered: heartbeat failed (non-fatal): {e}")
-        return self._save_sync_service.ensure_device_registered()
+        return await self._save_sync_service.ensure_device_registered()
+
+    async def list_devices(self):
+        return await self._save_sync_service.list_devices()
 
     async def get_save_status(self, rom_id):
         return await self._save_sync_service.get_save_status(rom_id)

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -178,16 +178,24 @@ class RommApi:
 
     # ── Devices ───────────────────────────────────────────────────────
 
-    def register_device(self, name: str, platform: str, client: str, version: str) -> dict:
+    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
         return self._client.post_json(
             "/api/devices",
             {
                 "name": name,
                 "platform": platform,
                 "client": client,
-                "version": version,
+                "client_version": client_version,
             },
         )
+
+    def list_devices(self) -> list[dict]:
+        result = self._client.request("/api/devices")
+        return result if isinstance(result, list) else []
+
+    def update_device(self, device_id: str, **fields) -> dict:
+        payload = {k: v for k, v in fields.items() if v is not None}
+        return self._client.put_json(f"/api/devices/{device_id}", payload)
 
     # ── Notes / Playtime ──────────────────────────────────────────────
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -255,10 +255,27 @@ class RommApiProtocol(Protocol):
         """
         ...
 
-    def register_device(self, name: str, platform: str, client: str, version: str) -> dict:
+    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
         """Register this client as a sync device on the RomM server.
 
         Returns device dict with id, name, created_at.
+        """
+        ...
+
+    def list_devices(self) -> list[dict]:
+        """List all devices registered with the RomM server for the current user.
+
+        Returns a list of device dicts from /api/devices.
+        """
+        ...
+
+    def update_device(self, device_id: str, **fields) -> dict:
+        """Update a registered device's metadata on the RomM server.
+
+        Currently the plugin only sends ``client_version`` via the reconciliation
+        loop; the server accepts additional fields per its OpenAPI schema (name,
+        platform, client, ip_address, mac_address, hostname, sync_enabled) but
+        they are not exercised by this plugin.
         """
         ...
 

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -56,6 +56,24 @@ if TYPE_CHECKING:
 _SYNC_DISABLED_MSG = "Save sync is disabled"
 
 
+def _compute_uploaded_by_us(
+    server_save: dict | None,
+    own_upload_ids: list[int] | None,
+) -> bool | None:
+    """Three-way uploader attribution flag.
+
+    Returns True/False when own_upload_ids is known for this ROM (we can tell
+    whether this installation POSTed the save), or None for legacy ROM state
+    without the ``own_upload_ids`` field (attribution unknown).
+    """
+    if server_save is None or own_upload_ids is None:
+        return None
+    sid = server_save.get("id")
+    if sid is None:
+        return None
+    return sid in own_upload_ids
+
+
 class SaveService:
     """Bidirectional save file sync between local RetroDECK and RomM server.
 
@@ -647,19 +665,8 @@ class SaveService:
             rom_id_str, filename, result, file_path, system, emulator_tag=emulator, core_so=core_so
         )
 
-        # Track saves we POSTed ourselves (new saves only, not updates).
-        # NOTE: This assumes POST = brand-new save. If RomM ever changes POST to
-        # upsert-by-filename semantics, this block would need revisiting.
         if is_post:
-            new_id = result.get("id")
-            if new_id is not None:
-                # _update_file_sync_state (called above) guarantees the key exists.
-                rom_state = self._save_sync_state["saves"].setdefault(rom_id_str, {"own_upload_ids": []})
-                own_ids: list[int] = rom_state.get("own_upload_ids", [])
-                if new_id not in own_ids:
-                    own_ids.append(new_id)
-                    rom_state["own_upload_ids"] = own_ids
-                    self.save_state()
+            self._record_own_upload(rom_id_str, result.get("id"))
 
         # Promote local slot to server after successful upload
         if slot:
@@ -680,6 +687,23 @@ class SaveService:
 
         self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
         return result
+
+    def _record_own_upload(self, rom_id_str: str, new_id: int | None) -> None:
+        """Track a save_id we POSTed ourselves for uploader attribution.
+
+        POST = brand-new save; PUT updates an existing tracked save without
+        changing ownership. Assumes POST is not upsert-by-filename on the
+        server — if RomM ever changes that, revisit this tracker.
+        """
+        if new_id is None:
+            return
+        rom_state = self._save_sync_state["saves"].setdefault(rom_id_str, {"own_upload_ids": []})
+        own_ids: list[int] = rom_state.get("own_upload_ids", [])
+        if new_id in own_ids:
+            return
+        own_ids.append(new_id)
+        rom_state["own_upload_ids"] = own_ids
+        self.save_state()
 
     def _sync_single_save_file(
         self,
@@ -1080,15 +1104,6 @@ class SaveService:
         raw_own_ids = save_state.get("own_upload_ids")
         own_upload_ids: list[int] | None = raw_own_ids if isinstance(raw_own_ids, list) else None
 
-        def _uploaded_by_us(server_save: dict | None) -> bool | None:
-            """Three-way flag: True/False if we know, None if attribution unknown."""
-            if server_save is None or own_upload_ids is None:
-                return None
-            sid = server_save.get("id")
-            if sid is None:
-                return None
-            return sid in own_upload_ids
-
         # Match local files to server saves (same domain logic as _sync_rom_saves).
         # device_id is required so _find_newer_in_slot can distinguish foreign
         # saves from our own.
@@ -1124,7 +1139,7 @@ class SaveService:
                         last_sync_at=files_state.get(m.filename, {}).get("last_sync_at"),
                         status=action,
                         server_device_id=server_device_id,
-                        uploaded_by_us=_uploaded_by_us(server),
+                        uploaded_by_us=_compute_uploaded_by_us(server, own_upload_ids),
                     )
                 )
             elif m.server_save:
@@ -1140,7 +1155,7 @@ class SaveService:
                         last_sync_at=None,
                         status="download",
                         server_device_id=server_device_id,
-                        uploaded_by_us=_uploaded_by_us(m.server_save),
+                        uploaded_by_us=_compute_uploaded_by_us(m.server_save, own_upload_ids),
                     )
                 )
             # Surface newer-in-slot warnings (another device uploaded a newer
@@ -1549,16 +1564,7 @@ class SaveService:
                 "latest_updated_at": (s.get("latest") or {}).get("updated_at"),
             }
 
-        # Keep local slots that are NOT on server
-        for name, info in persisted_slots.items():
-            if name not in merged:
-                if info.get("source") == "local":
-                    # Still local — keep it
-                    merged[name] = {"source": "local", "count": 0, "latest_updated_at": None}
-                # If it was "server" but is gone from server now — drop it
-                # (unless it's the active_slot)
-                elif info.get("source") == "server" and name == (active_slot or ""):
-                    merged[name] = {"source": "server", "count": 0, "latest_updated_at": None}
+        self._merge_persisted_slots(persisted_slots, merged, active_slot)
 
         # Persist merged slots in state
         game_entry = self._save_sync_state.setdefault("saves", {}).setdefault(rom_id_str, {})
@@ -1577,6 +1583,27 @@ class SaveService:
         ]
 
         return {"success": True, "slots": result_slots, "active_slot": active_slot}
+
+    @staticmethod
+    def _merge_persisted_slots(
+        persisted: dict[str, dict],
+        merged: dict[str, dict],
+        active_slot: str | None,
+    ) -> None:
+        """Add persisted local slots (or the active slot) that aren't on the server.
+
+        Mutates ``merged`` in place. Local slots are always kept. A persisted
+        server slot that's gone from the server is dropped unless it's the
+        active slot — we want to keep the UI functional until the user
+        explicitly switches away.
+        """
+        for name, info in persisted.items():
+            if name in merged:
+                continue
+            if info.get("source") == "local":
+                merged[name] = {"source": "local", "count": 0, "latest_updated_at": None}
+            elif info.get("source") == "server" and name == (active_slot or ""):
+                merged[name] = {"source": "server", "count": 0, "latest_updated_at": None}
 
     async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
         """Fetch server save files for a specific slot.

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -558,6 +558,7 @@ class SaveService:
                 "system": system,
                 "last_synced_core": core_so,
                 "active_slot": self._save_sync_state.get("settings", {}).get("default_slot", "default"),
+                "own_upload_ids": [],
             }
         save_entry = self._save_sync_state["saves"][rom_id_str]
         save_entry.setdefault("files", {})
@@ -635,6 +636,7 @@ class SaveService:
         game_state = self._save_sync_state.get("saves", {}).get(rom_id_str, {})
         slot = game_state.get("active_slot", "default") if device_id else None
 
+        is_post = save_id is None
         result = self._retry.with_retry(
             lambda: self._romm_api.upload_save(
                 int(rom_id), file_path, emulator, save_id, device_id=device_id, slot=slot
@@ -644,6 +646,20 @@ class SaveService:
         self._update_file_sync_state(
             rom_id_str, filename, result, file_path, system, emulator_tag=emulator, core_so=core_so
         )
+
+        # Track saves we POSTed ourselves (new saves only, not updates).
+        # NOTE: This assumes POST = brand-new save. If RomM ever changes POST to
+        # upsert-by-filename semantics, this block would need revisiting.
+        if is_post:
+            new_id = result.get("id")
+            if new_id is not None:
+                # _update_file_sync_state (called above) guarantees the key exists.
+                rom_state = self._save_sync_state["saves"].setdefault(rom_id_str, {"own_upload_ids": []})
+                own_ids: list[int] = rom_state.get("own_upload_ids", [])
+                if new_id not in own_ids:
+                    own_ids.append(new_id)
+                    rom_state["own_upload_ids"] = own_ids
+                    self.save_state()
 
         # Promote local slot to server after successful upload
         if slot:
@@ -1005,6 +1021,7 @@ class SaveService:
         last_sync_at: str | None,
         status: str,
         server_device_id: str | None = None,
+        uploaded_by_us: bool | None = None,
     ) -> dict:
         """Build a file status dict for the frontend."""
         server_device_syncs = server.get("device_syncs", []) if server else []
@@ -1042,6 +1059,7 @@ class SaveService:
             "status": status,
             "device_syncs": device_syncs,
             "is_current": is_current,
+            "uploaded_by_us": uploaded_by_us,
         }
 
     def _get_save_status_io(self, rom_id: int, server_saves: list[dict]) -> dict:
@@ -1057,6 +1075,19 @@ class SaveService:
 
         save_state = self._save_sync_state["saves"].get(rom_id_str, {})
         files_state = save_state.get("files", {})
+
+        # own_upload_ids: None means missing key (legacy entry — unknown attribution).
+        raw_own_ids = save_state.get("own_upload_ids")
+        own_upload_ids: list[int] | None = raw_own_ids if isinstance(raw_own_ids, list) else None
+
+        def _uploaded_by_us(server_save: dict | None) -> bool | None:
+            """Three-way flag: True/False if we know, None if attribution unknown."""
+            if server_save is None or own_upload_ids is None:
+                return None
+            sid = server_save.get("id")
+            if sid is None:
+                return None
+            return sid in own_upload_ids
 
         # Match local files to server saves (same domain logic as _sync_rom_saves).
         # device_id is required so _find_newer_in_slot can distinguish foreign
@@ -1093,6 +1124,7 @@ class SaveService:
                         last_sync_at=files_state.get(m.filename, {}).get("last_sync_at"),
                         status=action,
                         server_device_id=server_device_id,
+                        uploaded_by_us=_uploaded_by_us(server),
                     )
                 )
             elif m.server_save:
@@ -1108,6 +1140,7 @@ class SaveService:
                         last_sync_at=None,
                         status="download",
                         server_device_id=server_device_id,
+                        uploaded_by_us=_uploaded_by_us(m.server_save),
                     )
                 )
             # Surface newer-in-slot warnings (another device uploaded a newer
@@ -2184,6 +2217,11 @@ class SaveService:
             return []
         base_name = tracked_save.get("file_name_no_tags") or tracked_save.get("file_name", "")
 
+        # Resolve own_upload_ids for attribution — None means legacy state (unknown).
+        rom_state = self._save_sync_state["saves"].get(rom_id_str, {})
+        raw = rom_state.get("own_upload_ids")
+        own_upload_ids: list[int] | None = raw if isinstance(raw, list) else None
+
         # Filter to saves with the same base name, excluding the tracked one
         versions = [
             {
@@ -2193,6 +2231,7 @@ class SaveService:
                 "updated_at": s.get("updated_at", ""),
                 "file_size_bytes": s.get("file_size_bytes"),
                 "device_syncs": s.get("device_syncs", []),
+                "uploaded_by_us": (s["id"] in own_upload_ids) if own_upload_ids is not None else None,
             }
             for s in server_saves
             if (s.get("file_name_no_tags") or s.get("file_name", "")) == base_name and s.get("id") != tracked_id

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -1462,6 +1462,8 @@ class SaveService:
         msg = f"Uploaded {synced} save(s)"
         if errors:
             msg += f", {len(errors)} error(s)"
+        if conflicts:
+            msg += f", {len(conflicts)} conflict(s)"
         return {
             "success": len(errors) == 0,
             "message": msg,
@@ -1492,6 +1494,8 @@ class SaveService:
         msg = f"Synced {synced} save(s)"
         if errors:
             msg += f", {len(errors)} error(s)"
+        if conflicts:
+            msg += f", {len(conflicts)} conflict(s)"
         return {
             "success": len(errors) == 0,
             "message": msg,

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -1542,7 +1542,7 @@ class SaveService:
             merged[name] = {
                 "source": "server",
                 "count": s.get("count", 0),
-                "latest_updated_at": s.get("latest_updated_at"),
+                "latest_updated_at": (s.get("latest") or {}).get("updated_at"),
             }
 
         # Keep local slots that are NOT on server

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -1179,7 +1179,7 @@ class SaveService:
     # Public async API (callable endpoints)
     # ------------------------------------------------------------------
 
-    def ensure_device_registered(self) -> dict:
+    async def ensure_device_registered(self) -> dict:
         """Ensure this device is registered with the RomM server for save sync tracking."""
         if not self._is_save_sync_enabled():
             return {"success": False, "device_id": "", "device_name": "", "disabled": True}
@@ -1188,6 +1188,11 @@ class SaveService:
         has_device_id = self._save_sync_state.get("device_id")
         has_server_id = self._save_sync_state.get("server_device_id")
         if has_device_id and has_server_id:
+            with contextlib.suppress(Exception):
+                await self._loop.run_in_executor(
+                    None,
+                    lambda: self._romm_api.update_device(has_server_id, client_version=self._plugin_version),
+                )
             return {
                 "success": True,
                 "device_id": self._save_sync_state["device_id"],
@@ -1198,11 +1203,14 @@ class SaveService:
         hostname = socket.gethostname()
 
         try:
-            result = self._romm_api.register_device(
-                name=hostname,
-                platform="linux",
-                client="decky-romm-sync",
-                version=self._plugin_version,
+            result = await self._loop.run_in_executor(
+                None,
+                lambda: self._romm_api.register_device(
+                    name=hostname,
+                    platform="linux",
+                    client="decky-romm-sync",
+                    client_version=self._plugin_version,
+                ),
             )
             server_device_id = result.get("id") or result.get("device_id")
             if server_device_id:
@@ -1246,6 +1254,25 @@ class SaveService:
                 await self._emit("save_status_updated", result)
         except Exception as e:
             self._log_debug(f"Background save status check failed for rom {rom_id}: {e}")
+
+    async def list_devices(self) -> dict:
+        """List all devices registered with the RomM server for this user."""
+        if not self._is_save_sync_enabled():
+            return {"success": False, "devices": [], "disabled": True}
+        try:
+            own_id = self._get_server_device_id()
+            devices = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(lambda: self._romm_api.list_devices()),
+            )
+            own_id_str = str(own_id or "")
+            enriched = [
+                {**d, "is_current_device": bool(own_id_str) and (str(d.get("id") or "")) == own_id_str} for d in devices
+            ]
+            return {"success": True, "devices": enriched}
+        except Exception as e:
+            self._log_debug(f"list_devices failed: {e}")
+            return {"success": False, "devices": [], "error": "list_failed"}
 
     def check_core_change(self, rom_id: int) -> dict:
         """Check if emulator core changed since last sync for a ROM."""
@@ -1343,7 +1370,7 @@ class SaveService:
             return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
 
         if not self._save_sync_state.get("device_id"):
-            reg = self.ensure_device_registered()
+            reg = await self.ensure_device_registered()
             if not reg.get("success"):
                 return {"success": False, "message": _DEVICE_NOT_REGISTERED}
 
@@ -1384,7 +1411,7 @@ class SaveService:
             return {"success": False, "message": "Server offline", "synced": 0, "offline": True}
 
         if not self._save_sync_state.get("device_id"):
-            reg = self.ensure_device_registered()
+            reg = await self.ensure_device_registered()
             if not reg.get("success"):
                 return {"success": False, "message": _DEVICE_NOT_REGISTERED}
 
@@ -1422,7 +1449,7 @@ class SaveService:
         await self._refresh_save_sort_state("sync_rom_saves")
 
         if not self._save_sync_state.get("device_id"):
-            reg = self.ensure_device_registered()
+            reg = await self.ensure_device_registered()
             if not reg.get("success"):
                 return {"success": False, "message": _DEVICE_NOT_REGISTERED}
 
@@ -1951,7 +1978,7 @@ class SaveService:
         await self._refresh_save_sort_state("sync_all_saves")
 
         if not self._save_sync_state.get("device_id"):
-            reg = self.ensure_device_registered()
+            reg = await self.ensure_device_registered()
             if not reg.get("success"):
                 return {"success": False, "message": _DEVICE_NOT_REGISTERED}
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -251,6 +251,7 @@ export interface SaveVersionEntry {
   updated_at: string;
   file_size_bytes: number | null;
   device_syncs: Array<{ device_id: string; device_name: string; is_current: boolean; last_synced_at: string | null }>;
+  uploaded_by_us?: boolean | null;
 }
 
 export type RollbackStatus =

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -116,6 +116,33 @@ export const saveShortcutIcon = callable<[number, string], { success: boolean }>
 
 // Save sync callables
 export const ensureDeviceRegistered = callable<[], { success: boolean; device_id: string; device_name: string }>("ensure_device_registered");
+
+export interface RegisteredDevice {
+  id: string;
+  name: string | null;
+  platform: string | null;
+  client: string | null;
+  client_version: string | null;
+  last_seen: string | null;
+  created_at: string;
+  is_current_device: boolean;
+  user_id?: number;
+  ip_address?: string | null;
+  mac_address?: string | null;
+  hostname?: string | null;
+  sync_mode?: string | null;
+  sync_enabled?: boolean;
+  updated_at?: string | null;
+}
+
+export interface ListDevicesResponse {
+  success: boolean;
+  devices: RegisteredDevice[];
+  disabled?: boolean;
+  error?: string;
+}
+
+export const listDevices = callable<[], ListDevicesResponse>("list_devices");
 export const getSaveStatus = callable<[number], SaveStatus>("get_save_status");
 export const preLaunchSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: (PendingConflict | NewerInSlotConflict)[] }>("pre_launch_sync");
 export const postExitSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: (PendingConflict | NewerInSlotConflict)[]; offline?: boolean }>("post_exit_sync");

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -23,6 +23,7 @@ import {
   basicAppDetailsSectionStylerClasses,
 } from "@decky/ui";
 import { hideNativePlaySection, showNativePlaySection } from "../utils/styleInjector";
+import { hasAnySaveConflict } from "../utils/saveStatus";
 import {
   getCachedGameDetail,
   startDownload,
@@ -158,7 +159,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           setState("download");
         } else {
           // Check for conflicts from cached save status
-          const hasConflict = cached.save_status?.files?.some((f) => f.status === "conflict") ?? false;
+          const hasConflict = hasAnySaveConflict(cached.save_status);
           if (hasConflict) {
             debugLog(`CustomPlayButton: -> conflict (from cache)`);
             setState("conflict");

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -25,6 +25,7 @@ import {
 } from "@decky/ui";
 import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icons/fa";
 import { CustomPlayButton } from "./CustomPlayButton";
+import { hasAnySaveConflict } from "../utils/saveStatus";
 import {
   getCachedGameDetail,
   _cachedGameDetailCache,
@@ -174,7 +175,7 @@ function getBiosLevel(bios: BiosStatus): "ok" | "partial" | "missing" {
 
 /** Compute save sync display status and label from a SaveStatus response */
 function computeSaveSyncDisplay(saveStatus: SaveStatus | null): { status: "synced" | "conflict" | "none"; label: string } {
-  const hasConflict = saveStatus?.files?.some((f) => f.status === "conflict") ?? false;
+  const hasConflict = hasAnySaveConflict(saveStatus);
   if (hasConflict) return { status: "conflict", label: "Conflict" };
 
   const hasLocalFiles = saveStatus?.files?.some((f) => f.local_path || f.status === "synced" || f.status === "upload") ?? false;
@@ -457,7 +458,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       try {
         const saveStatus = await getSaveStatus(romId);
         if (isCancelled) return;
-        const hasConflict = saveStatus?.files?.some((f: { status: string }) => f.status === "conflict") ?? false;
+        const hasConflict = hasAnySaveConflict(saveStatus);
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
           detail: { type: "save_sync", rom_id: romId, has_conflict: hasConflict },
         }));

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -87,6 +87,31 @@ function attributionLabel(uploadedByUs: boolean | null | undefined): string | nu
   return null;
 }
 
+/**
+ * Format the per-save attribution+checkmark segment for the sync-time line.
+ *
+ * Combines device name, attribution label, and the trailing checkmark into
+ * one ready-to-render string, or null when nothing meaningful can be shown.
+ * Reused between `renderSaveFileRow` and `renderVersionRow`.
+ */
+function formatAttributionSegment(
+  uploadedByUs: boolean | null | undefined,
+  deviceName: string | null | undefined,
+): string | null {
+  const label = attributionLabel(uploadedByUs);
+  if (uploadedByUs === true) {
+    return deviceName ? `${deviceName} ${label} \u2713` : `${label} \u2713`;
+  }
+  if (uploadedByUs === false) {
+    // Intentionally no device name — lastSyncer is our own sync record, not the actual uploader
+    return `${label} \u2713`;
+  }
+  if (label === null) {
+    return deviceName ? `${deviceName} \u2713` : `\u2713`;
+  }
+  return null;
+}
+
 /** Map a save file status to color and label */
 function statusLabel(status: string, lastSyncAt: string | null): { color: string; label: string } {
   switch (status) {
@@ -230,21 +255,10 @@ const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
     if (v.emulator) headerParts.push(v.emulator);
     if (v.file_size_bytes != null) headerParts.push(formatBytes(v.file_size_bytes));
 
-    // Line 2: Last updated: <timestamp>[ · <device label> ✓]
-    // uploaded_by_us=true  → "<deviceName> (this device) ✓"
-    // uploaded_by_us=false → "(not this device) ✓"  (no device name — lastSyncer is our own record)
-    // uploaded_by_us=null  → "<deviceName> ✓" if device name known, else "✓"  (unknown / legacy)
+    // Line 2: Last updated: <timestamp>[ · <device label> ✓]  — see formatAttributionSegment
     const lastUpdatedParts: string[] = [formatTimestamp(v.updated_at)];
-    const attrLabel = attributionLabel(v.uploaded_by_us);
-    if (v.uploaded_by_us === true && deviceName) {
-      lastUpdatedParts.push(`${deviceName} ${attrLabel} \u2713`);
-    } else if (v.uploaded_by_us === true) {
-      lastUpdatedParts.push(`${attrLabel} \u2713`);
-    } else if (v.uploaded_by_us === false) {
-      lastUpdatedParts.push(`${attrLabel} \u2713`);
-    } else if (attrLabel === null) {
-      lastUpdatedParts.push(deviceName ? `${deviceName} \u2713` : `\u2713`);
-    }
+    const attrSegment = formatAttributionSegment(v.uploaded_by_us, deviceName);
+    if (attrSegment !== null) lastUpdatedParts.push(attrSegment);
 
     return createElement("div", {
       key: `ver-${v.id}`,
@@ -404,26 +418,10 @@ function renderSaveFileRow(
     style: { color, fontSize: "11px", fontWeight: 600 },
   }, label));
 
-  // Last synced value: "just now · <attribution> ✓"
-  // uploaded_by_us=true  → "<deviceName> (this device) ✓"
-  // uploaded_by_us=false → "(not this device) ✓"  (no device name)
-  // uploaded_by_us=null  → "<deviceName> ✓" if device name known, else "✓"  (unknown / legacy)
-  const lastSyncedPieces: string[] = [];
-  if (syncTime) {
-    lastSyncedPieces.push(formatRelativeTime(syncTime) || "Never");
-  } else {
-    lastSyncedPieces.push("Never");
-  }
-  const attrLabel = attributionLabel(f.uploaded_by_us);
-  if (f.uploaded_by_us === true && lastSyncer?.device_name) {
-    lastSyncedPieces.push(`${lastSyncer.device_name} ${attrLabel} \u2713`);
-  } else if (f.uploaded_by_us === true) {
-    lastSyncedPieces.push(`${attrLabel} \u2713`);
-  } else if (f.uploaded_by_us === false) {
-    lastSyncedPieces.push(`${attrLabel} \u2713`);
-  } else if (attrLabel === null) {
-    lastSyncedPieces.push(lastSyncer?.device_name ? `${lastSyncer.device_name} \u2713` : `\u2713`);
-  }
+  // Last synced value: "just now · <attribution> ✓" — see formatAttributionSegment
+  const lastSyncedPieces: string[] = [syncTime ? (formatRelativeTime(syncTime) || "Never") : "Never"];
+  const attrSegment = formatAttributionSegment(f.uploaded_by_us, lastSyncer?.device_name);
+  if (attrSegment !== null) lastSyncedPieces.push(attrSegment);
   if (f.is_current === false) {
     lastSyncedPieces.push("Newer version available on server");
   }

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -76,6 +76,17 @@ function pickLastSyncer(syncs: DeviceSyncInfo[] | undefined): DeviceSyncInfo | n
   }, null);
 }
 
+/**
+ * Return an attribution label based on the uploaded_by_us flag, or null if unknown.
+ * NOTE: "this device" is really "this plugin installation" — if state.json is
+ * copied to another machine, the label would incorrectly claim local ownership.
+ */
+function attributionLabel(uploadedByUs: boolean | null | undefined): string | null {
+  if (uploadedByUs === true) return "(this device)";
+  if (uploadedByUs === false) return "(not this device)";
+  return null;
+}
+
 /** Map a save file status to color and label */
 function statusLabel(status: string, lastSyncAt: string | null): { color: string; label: string } {
   switch (status) {
@@ -129,7 +140,6 @@ interface VersionHistoryPanelProps {
   filename: string;
   isOffline: boolean;
   onRestored: () => void;
-  ourDeviceId: string;
 }
 
 const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
@@ -138,7 +148,6 @@ const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
   filename,
   isOffline,
   onRestored,
-  ourDeviceId,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [versions, setVersions] = useState<SaveVersionEntry[] | null>(null);
@@ -221,11 +230,20 @@ const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
     if (v.emulator) headerParts.push(v.emulator);
     if (v.file_size_bytes != null) headerParts.push(formatBytes(v.file_size_bytes));
 
-    // Line 2: Last updated: <timestamp>[ · <device> (this/other device) ✓]
+    // Line 2: Last updated: <timestamp>[ · <device label> ✓]
+    // uploaded_by_us=true  → "<deviceName> (this device) ✓"
+    // uploaded_by_us=false → "(not this device) ✓"  (no device name — lastSyncer is our own record)
+    // uploaded_by_us=null  → "<deviceName> ✓" if device name known, else "✓"  (unknown / legacy)
     const lastUpdatedParts: string[] = [formatTimestamp(v.updated_at)];
-    if (deviceName) {
-      const deviceLabel = lastSyncer?.device_id === ourDeviceId ? "(this device)" : "(other device)";
-      lastUpdatedParts.push(`${deviceName} ${deviceLabel} \u2713`);
+    const attrLabel = attributionLabel(v.uploaded_by_us);
+    if (v.uploaded_by_us === true && deviceName) {
+      lastUpdatedParts.push(`${deviceName} ${attrLabel} \u2713`);
+    } else if (v.uploaded_by_us === true) {
+      lastUpdatedParts.push(`${attrLabel} \u2713`);
+    } else if (v.uploaded_by_us === false) {
+      lastUpdatedParts.push(`${attrLabel} \u2713`);
+    } else if (attrLabel === null) {
+      lastUpdatedParts.push(deviceName ? `${deviceName} \u2713` : `\u2713`);
     }
 
     return createElement("div", {
@@ -366,7 +384,6 @@ function renderSaveFileRow(
   f: SaveFileStatus,
   conflict: PendingConflict | undefined,
   lastSyncCheckAt: string | null,
-  ourDeviceId: string,
 ): ReturnType<typeof createElement> {
   const { color, label } = statusLabel(f.status, f.last_sync_at);
   const syncTime = lastSyncCheckAt || f.last_sync_at;
@@ -387,16 +404,25 @@ function renderSaveFileRow(
     style: { color, fontSize: "11px", fontWeight: 600 },
   }, label));
 
-  // Last synced value: "just now · steamdeck ✓"
+  // Last synced value: "just now · <attribution> ✓"
+  // uploaded_by_us=true  → "<deviceName> (this device) ✓"
+  // uploaded_by_us=false → "(not this device) ✓"  (no device name)
+  // uploaded_by_us=null  → "<deviceName> ✓" if device name known, else "✓"  (unknown / legacy)
   const lastSyncedPieces: string[] = [];
   if (syncTime) {
     lastSyncedPieces.push(formatRelativeTime(syncTime) || "Never");
   } else {
     lastSyncedPieces.push("Never");
   }
-  if (lastSyncer?.device_name) {
-    const deviceLabel = lastSyncer.device_id === ourDeviceId ? "(this device)" : "(other device)";
-    lastSyncedPieces.push(`${lastSyncer.device_name} ${deviceLabel} \u2713`);
+  const attrLabel = attributionLabel(f.uploaded_by_us);
+  if (f.uploaded_by_us === true && lastSyncer?.device_name) {
+    lastSyncedPieces.push(`${lastSyncer.device_name} ${attrLabel} \u2713`);
+  } else if (f.uploaded_by_us === true) {
+    lastSyncedPieces.push(`${attrLabel} \u2713`);
+  } else if (f.uploaded_by_us === false) {
+    lastSyncedPieces.push(`${attrLabel} \u2713`);
+  } else if (attrLabel === null) {
+    lastSyncedPieces.push(lastSyncer?.device_name ? `${lastSyncer.device_name} \u2713` : `\u2713`);
   }
   if (f.is_current === false) {
     lastSyncedPieces.push("Newer version available on server");
@@ -548,13 +574,12 @@ function renderActiveSlotBody(
   slot: string,
   isOffline: boolean,
   onVersionRestored: () => void,
-  ourDeviceId: string,
 ): (ReturnType<typeof createElement> | null)[] {
   if (saveStatus && saveStatus.files.length > 0) {
     return saveStatus.files.map((f) => {
       const conflict = conflicts.find((c) => c.filename === f.filename);
       return createElement("div", { key: f.filename },
-        renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at, ourDeviceId),
+        renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at),
         createElement(VersionHistoryPanel, {
           key: `vhp-${f.filename}`,
           romId,
@@ -562,7 +587,6 @@ function renderActiveSlotBody(
           filename: f.filename,
           isOffline,
           onRestored: onVersionRestored,
-          ourDeviceId,
         }),
       );
     });
@@ -649,7 +673,6 @@ interface SlotPanelProps {
   saveStatus: SaveStatus | null;
   conflicts: PendingConflict[];
   isOffline: boolean;
-  ourDeviceId: string;
   // Callbacks
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
   onVersionRestored: () => void;
@@ -664,7 +687,6 @@ const SlotPanel: FC<SlotPanelProps> = ({
   saveStatus,
   conflicts,
   isOffline,
-  ourDeviceId,
   onSlotSwitched,
   onVersionRestored,
   onSlotDeleted,
@@ -844,7 +866,7 @@ const SlotPanel: FC<SlotPanelProps> = ({
   let bodyChildren: (ReturnType<typeof createElement> | null)[] = [];
   if (expanded) {
     bodyChildren = isActive
-      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored, ourDeviceId)
+      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored)
       : renderInactiveSlotBody({ loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting });
   }
 
@@ -1014,8 +1036,6 @@ export const SavesTab: FC<SavesTabProps> = ({
     );
   };
 
-  const ourDeviceId = saveStatus?.device_id ?? "";
-
   // --- Legacy mode: show save files directly (not in a slot panel) ---
   let legacyFilesSection: ReturnType<typeof createElement> | null = null;
   if (activeSlot === null) {
@@ -1023,7 +1043,7 @@ export const SavesTab: FC<SavesTabProps> = ({
       legacyFilesSection = createElement("div", { key: "legacy-files", style: { marginBottom: "12px" } },
         ...saveStatus.files.map((f) => {
           const conflict = conflicts.find((c) => c.filename === f.filename);
-          return renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at, ourDeviceId);
+          return renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at);
         }),
       );
     } else {
@@ -1058,7 +1078,6 @@ export const SavesTab: FC<SavesTabProps> = ({
           saveStatus: isActive ? saveStatus : null,
           conflicts: isActive ? conflicts : [],
           isOffline,
-          ourDeviceId,
           onSlotSwitched,
           onVersionRestored: handleVersionRestored,
           onSlotDeleted: handleSlotDeleted,

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -129,6 +129,7 @@ interface VersionHistoryPanelProps {
   filename: string;
   isOffline: boolean;
   onRestored: () => void;
+  ourDeviceId: string;
 }
 
 const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
@@ -137,6 +138,7 @@ const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
   filename,
   isOffline,
   onRestored,
+  ourDeviceId,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [versions, setVersions] = useState<SaveVersionEntry[] | null>(null);
@@ -219,9 +221,12 @@ const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
     if (v.emulator) headerParts.push(v.emulator);
     if (v.file_size_bytes != null) headerParts.push(formatBytes(v.file_size_bytes));
 
-    // Line 2: Last updated: <timestamp>[ · <device>]
+    // Line 2: Last updated: <timestamp>[ · <device> (this/other device) ✓]
     const lastUpdatedParts: string[] = [formatTimestamp(v.updated_at)];
-    if (deviceName) lastUpdatedParts.push(`${deviceName} \u2713`);
+    if (deviceName) {
+      const deviceLabel = lastSyncer?.device_id === ourDeviceId ? "(this device)" : "(other device)";
+      lastUpdatedParts.push(`${deviceName} ${deviceLabel} \u2713`);
+    }
 
     return createElement("div", {
       key: `ver-${v.id}`,
@@ -361,6 +366,7 @@ function renderSaveFileRow(
   f: SaveFileStatus,
   conflict: PendingConflict | undefined,
   lastSyncCheckAt: string | null,
+  ourDeviceId: string,
 ): ReturnType<typeof createElement> {
   const { color, label } = statusLabel(f.status, f.last_sync_at);
   const syncTime = lastSyncCheckAt || f.last_sync_at;
@@ -389,7 +395,8 @@ function renderSaveFileRow(
     lastSyncedPieces.push("Never");
   }
   if (lastSyncer?.device_name) {
-    lastSyncedPieces.push(`${lastSyncer.device_name} \u2713`);
+    const deviceLabel = lastSyncer.device_id === ourDeviceId ? "(this device)" : "(other device)";
+    lastSyncedPieces.push(`${lastSyncer.device_name} ${deviceLabel} \u2713`);
   }
   if (f.is_current === false) {
     lastSyncedPieces.push("Newer version available on server");
@@ -541,12 +548,13 @@ function renderActiveSlotBody(
   slot: string,
   isOffline: boolean,
   onVersionRestored: () => void,
+  ourDeviceId: string,
 ): (ReturnType<typeof createElement> | null)[] {
   if (saveStatus && saveStatus.files.length > 0) {
     return saveStatus.files.map((f) => {
       const conflict = conflicts.find((c) => c.filename === f.filename);
       return createElement("div", { key: f.filename },
-        renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at),
+        renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at, ourDeviceId),
         createElement(VersionHistoryPanel, {
           key: `vhp-${f.filename}`,
           romId,
@@ -554,6 +562,7 @@ function renderActiveSlotBody(
           filename: f.filename,
           isOffline,
           onRestored: onVersionRestored,
+          ourDeviceId,
         }),
       );
     });
@@ -640,6 +649,7 @@ interface SlotPanelProps {
   saveStatus: SaveStatus | null;
   conflicts: PendingConflict[];
   isOffline: boolean;
+  ourDeviceId: string;
   // Callbacks
   onSlotSwitched: (newSlot: string, newStatus: SaveStatus) => void;
   onVersionRestored: () => void;
@@ -654,6 +664,7 @@ const SlotPanel: FC<SlotPanelProps> = ({
   saveStatus,
   conflicts,
   isOffline,
+  ourDeviceId,
   onSlotSwitched,
   onVersionRestored,
   onSlotDeleted,
@@ -833,7 +844,7 @@ const SlotPanel: FC<SlotPanelProps> = ({
   let bodyChildren: (ReturnType<typeof createElement> | null)[] = [];
   if (expanded) {
     bodyChildren = isActive
-      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored)
+      ? renderActiveSlotBody(saveStatus, conflicts, romId, slotName, isOffline, onVersionRestored, ourDeviceId)
       : renderInactiveSlotBody({ loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting });
   }
 
@@ -1003,6 +1014,8 @@ export const SavesTab: FC<SavesTabProps> = ({
     );
   };
 
+  const ourDeviceId = saveStatus?.device_id ?? "";
+
   // --- Legacy mode: show save files directly (not in a slot panel) ---
   let legacyFilesSection: ReturnType<typeof createElement> | null = null;
   if (activeSlot === null) {
@@ -1010,7 +1023,7 @@ export const SavesTab: FC<SavesTabProps> = ({
       legacyFilesSection = createElement("div", { key: "legacy-files", style: { marginBottom: "12px" } },
         ...saveStatus.files.map((f) => {
           const conflict = conflicts.find((c) => c.filename === f.filename);
-          return renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at);
+          return renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at, ourDeviceId);
         }),
       );
     } else {
@@ -1045,6 +1058,7 @@ export const SavesTab: FC<SavesTabProps> = ({
           saveStatus: isActive ? saveStatus : null,
           conflicts: isActive ? conflicts : [],
           isOffline,
+          ourDeviceId,
           onSlotSwitched,
           onVersionRestored: handleVersionRestored,
           onSlotDeleted: handleSlotDeleted,

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -811,11 +811,12 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
             </PanelSectionRow>
           )}
           {!devicesLoading && !devicesError && registeredDevices !== null && registeredDevices.map((device, i) => {
-            const clientLine = `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`;
-            const parts: string[] = [clientLine];
-            if (device.platform) parts.push(device.platform);
-            parts.push(`last seen ${formatRelativeTime(device.last_seen)}`);
-            parts.push(`ID ${String(device.id ?? "").slice(0, 8) || "—"}`);
+            const parts: string[] = [
+              `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`,
+              ...(device.platform ? [device.platform] : []),
+              `last seen ${formatRelativeTime(device.last_seen)}`,
+              `ID ${String(device.id ?? "").slice(0, 8) || "—"}`,
+            ];
             return (
               <PanelSectionRow key={device.id || `idx-${i}`}>
                 <Field

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -29,18 +29,34 @@ import {
   saveLogLevel,
   fixRetroarchInputDriver,
   ensureDeviceRegistered,
+  listDevices,
   getSaveSortMigrationStatus,
   migrateSaveSortFiles,
   dismissSaveSortMigration,
   logError,
 } from "../api/backend";
-import type { MigrationStatus, SaveSortMigrationStatus } from "../api/backend";
+import type { MigrationStatus, SaveSortMigrationStatus, RegisteredDevice } from "../api/backend";
 import { getMigrationState, setMigrationStatus, clearMigration, onMigrationChange } from "../utils/migrationStore";
 import { getSaveSortMigrationState, setSaveSortMigrationStatus as setStoreSaveSortStatus, clearSaveSortMigration, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
 import type { SaveSyncSettings as SaveSyncSettingsType, ConflictMode, RetroArchInputCheck } from "../types";
 
 // Module-level state survives component remounts (modal close can remount QAM)
 const pendingEdits: { url?: string; username?: string; password?: string } = {};
+
+/** Format a relative time string (e.g. "5m ago", "2h ago") from an ISO string */
+function formatRelativeTime(isoStr: string | null): string {
+  if (!isoStr) return "never";
+  const date = new Date(isoStr);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 1440) return `${Math.floor(diffMin / 60)}h ago`;
+  const d = date.getDate();
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${d} ${months[date.getMonth()]}`;
+}
 
 const MigrationConflictModal: FC<{
   conflictCount: number;
@@ -139,6 +155,11 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const [syncing, setSyncing] = useState(false);
   const [syncStatus, setSyncStatus] = useState("");
 
+  // Registered devices state
+  const [registeredDevices, setRegisteredDevices] = useState<RegisteredDevice[] | null>(null);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+  const [devicesError, setDevicesError] = useState<string | null>(null);
+
   // Controller state
   const [steamInputMode, setSteamInputMode] = useState("default");
   const [steamInputStatus, setSteamInputStatus] = useState("");
@@ -196,6 +217,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
               }
             })
             .catch(() => {});
+          loadDevices();
         }
       })
       .catch((e) => logError(`Failed to load save sync settings: ${e}`));
@@ -211,6 +233,29 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
     return () => { unsubMigration(); unsubSaveSort(); };
   }, []);
+
+  const loadDevices = () => {
+    setDevicesLoading(true);
+    setDevicesError(null);
+    listDevices()
+      .then((result) => {
+        if (result.success) {
+          setRegisteredDevices(result.devices);
+        } else if (result.disabled) {
+          setRegisteredDevices(null);
+        } else {
+          setDevicesError(result.error ?? "Failed to load devices");
+          setRegisteredDevices([]);
+        }
+      })
+      .catch((e: unknown) => {
+        setDevicesError(e instanceof Error ? e.message : "Failed to load devices");
+        setRegisteredDevices([]);
+      })
+      .finally(() => {
+        setDevicesLoading(false);
+      });
+  };
 
   // Auto-save connection fields when a modal edit is confirmed
   const autoSaveSettings = async (field: "url" | "username" | "password", newValue: string) => {
@@ -247,6 +292,12 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
           detail: { type: "save_sync_settings", save_sync_enabled: updated.save_sync_enabled },
         }));
+        if (updated.save_sync_enabled) {
+          loadDevices();
+        } else {
+          setRegisteredDevices(null);
+          setDevicesError(null);
+        }
       }
     } catch (e) {
       logError(`Failed to save settings: ${e}`);
@@ -742,6 +793,47 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
           </PanelSectionRow>
         )}
       </PanelSection>
+      {saveSyncEnabled && (devicesLoading || registeredDevices !== null) && (
+        <PanelSection title="Registered Devices">
+          {devicesLoading && (
+            <PanelSectionRow>
+              <Field label="Loading..." />
+            </PanelSectionRow>
+          )}
+          {!devicesLoading && devicesError && (
+            <PanelSectionRow>
+              <Field label="Could not load devices" description={devicesError} />
+            </PanelSectionRow>
+          )}
+          {!devicesLoading && !devicesError && registeredDevices !== null && registeredDevices.length === 0 && (
+            <PanelSectionRow>
+              <Field label="No devices registered" />
+            </PanelSectionRow>
+          )}
+          {!devicesLoading && !devicesError && registeredDevices !== null && registeredDevices.map((device, i) => {
+            const clientLine = `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`;
+            const parts: string[] = [clientLine];
+            if (device.platform) parts.push(device.platform);
+            parts.push(`last seen ${formatRelativeTime(device.last_seen)}`);
+            parts.push(`ID ${String(device.id ?? "").slice(0, 8) || "—"}`);
+            return (
+              <PanelSectionRow key={device.id || `idx-${i}`}>
+                <Field
+                  label={
+                    <span>
+                      {device.name ?? "(unnamed)"}
+                      {device.is_current_device && (
+                        <span style={{ color: "#6ab04c", marginLeft: "8px", fontSize: "12px" }}>(this device)</span>
+                      )}
+                    </span>
+                  }
+                  description={parts.join(" · ")}
+                />
+              </PanelSectionRow>
+            );
+          })}
+        </PanelSection>
+      )}
       <PanelSection title="Controller">
         <PanelSectionRow>
           <DropdownItem

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { updateDownload, getDownloadState } from "./utils/downloadStore";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
 import { registerMetadataPatches, unregisterMetadataPatches, applyAllPlaytime } from "./patches/metadataPatches";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
+import { hasAnySaveConflict } from "./utils/saveStatus";
 import { getAllMetadataCache, getAppIdRomIdMap, ensureDeviceRegistered, getSaveSyncSettings, getAllPlaytime, getMigrationStatus, getSaveSortMigrationStatus, testConnection, logError, logInfo } from "./api/backend";
 import { createOrUpdateCollections, createOrUpdateRomMCollections, clearPlatformCollection, getHostname } from "./utils/collections";
 import { setMigrationStatus } from "./utils/migrationStore";
@@ -336,7 +337,7 @@ export default definePlugin(() => {
   const saveStatusListener = addEventListener<[SaveStatus]>(
     "save_status_updated",
     (data: SaveStatus) => {
-      const hasConflict = data.files?.some((f) => f.status === "conflict") ?? false;
+      const hasConflict = hasAnySaveConflict(data);
       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
         detail: { type: "save_sync", rom_id: data.rom_id, save_status: data, has_conflict: hasConflict },
       }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -315,6 +315,7 @@ export interface SaveFileStatus {
   status: "skip" | "download" | "upload" | "conflict" | "synced" | "unknown";
   device_syncs?: DeviceSyncInfo[];
   is_current?: boolean;
+  uploaded_by_us?: boolean | null;
 }
 
 export interface PlaytimeEntry {

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -10,6 +10,7 @@ import { isRomMAppId } from "../patches/gameDetailPatch";
 import { getInstalledRom, getSaveStatus, getSaveSyncSettings, refreshMigrationState, logInfo, logError } from "../api/backend";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
+import { hasAnySaveConflict } from "./saveStatus";
 
 let gameActionHook: { unregister: () => void } | null = null;
 
@@ -54,7 +55,7 @@ export function registerLaunchInterceptor(): void {
           const settings = await getSaveSyncSettings();
           if (settings.conflict_mode === "ask_me") {
             const saveStatus = await getSaveStatus(rom.rom_id);
-            const hasConflict = saveStatus?.files?.some((f: any) => f.status === "conflict") ?? false;
+            const hasConflict = hasAnySaveConflict(saveStatus);
             if (hasConflict) {
               SteamClient.Apps.CancelGameAction(gameActionId);
               toaster.toast({

--- a/src/utils/saveStatus.ts
+++ b/src/utils/saveStatus.ts
@@ -1,0 +1,17 @@
+import type { PendingConflict } from "../types";
+
+/**
+ * Single source of truth for "does this save status require user action for a conflict?"
+ *
+ * Uses the `conflicts` array (canonical) rather than per-file `f.status === "conflict"`
+ * checks, which only catch three-way (file-level) conflicts and miss `newer_in_slot`
+ * (slot-level) conflicts that RomM surfaces when another device posts a parallel save.
+ *
+ * Accepts any object with an optional `conflicts` array, so it works with `SaveStatus`,
+ * `CachedGameDetail.save_status`, and `save_status_updated` emit-event payloads.
+ */
+export function hasAnySaveConflict(
+  status: { conflicts?: PendingConflict[] | null } | null | undefined,
+): boolean {
+  return (status?.conflicts?.length ?? 0) > 0;
+}

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -178,7 +178,7 @@ class TestListCollections:
 
 
 class TestRegisterDevice:
-    def test_posts_to_devices_endpoint(self):
+    def test_uses_client_version_key(self):
         api, client = _make_api()
         client.post_json.return_value = {
             "id": "abc-123",
@@ -186,16 +186,79 @@ class TestRegisterDevice:
             "created_at": "2026-01-01T00:00:00Z",
         }
         result = api.register_device("steamdeck", "linux", "decky-romm-sync", "0.13.0")
+        _name, payload = client.post_json.call_args[0]
+        assert payload["client_version"] == "0.13.0"
+        assert "version" not in payload
+        assert result["id"] == "abc-123"
+
+    def test_posts_to_devices_endpoint(self):
+        api, client = _make_api()
+        client.post_json.return_value = {
+            "id": "abc-123",
+            "name": "steamdeck",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        api.register_device("steamdeck", "linux", "decky-romm-sync", "0.13.0")
         client.post_json.assert_called_once_with(
             "/api/devices",
             {
                 "name": "steamdeck",
                 "platform": "linux",
                 "client": "decky-romm-sync",
-                "version": "0.13.0",
+                "client_version": "0.13.0",
             },
         )
+
+
+class TestListDevices:
+    def test_returns_array(self):
+        api, client = _make_api()
+        client.request.return_value = [
+            {"id": "abc-123", "name": "steamdeck"},
+            {"id": "def-456", "name": "laptop"},
+        ]
+        result = api.list_devices()
+        client.request.assert_called_once_with("/api/devices")
+        assert len(result) == 2
+        assert result[0]["id"] == "abc-123"
+
+    def test_handles_non_list_response(self):
+        api, client = _make_api()
+        client.request.return_value = {"error": "unexpected"}
+        result = api.list_devices()
+        assert result == []
+
+    def test_handles_none_response(self):
+        api, client = _make_api()
+        client.request.return_value = None
+        result = api.list_devices()
+        assert result == []
+
+
+class TestUpdateDevice:
+    def test_sends_put_with_filtered_payload(self):
+        api, client = _make_api()
+        client.put_json.return_value = {"id": "abc-123", "client_version": "0.14.0"}
+        result = api.update_device("abc-123", client_version="0.14.0", name=None)
+        client.put_json.assert_called_once_with(
+            "/api/devices/abc-123",
+            {"client_version": "0.14.0"},
+        )
         assert result["id"] == "abc-123"
+
+    def test_excludes_none_fields(self):
+        api, client = _make_api()
+        client.put_json.return_value = {"id": "abc-123"}
+        api.update_device("abc-123", name=None, client_version=None, sync_enabled=None)
+        _url, payload = client.put_json.call_args[0]
+        assert payload == {}
+
+    def test_url_contains_device_id(self):
+        api, client = _make_api()
+        client.put_json.return_value = {"id": "xyz-999"}
+        api.update_device("xyz-999", client_version="1.0.0")
+        url = client.put_json.call_args[0][0]
+        assert "xyz-999" in url
 
 
 class TestSetVersion:

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -111,14 +111,28 @@ class FakeSaveApi:
             self.saves.pop(sid, None)
         return {"deleted": len(save_ids)}
 
-    def register_device(self, name: str, platform: str, client: str, version: str) -> dict:
-        self.call_log.append(("register_device", (name, platform, client, version), {}))
+    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
+        self.call_log.append(("register_device", (name, platform, client, client_version), {}))
         self._check_fail()
         device_id = f"device-{self._next_device_id}"
         self._next_device_id += 1
         device = {"id": device_id, "name": name, "created_at": datetime.now(UTC).isoformat()}
         self._registered_devices.append(device)
         return device
+
+    def list_devices(self) -> list[dict]:
+        self.call_log.append(("list_devices", (), {}))
+        self._check_fail()
+        return list(self._registered_devices)
+
+    def update_device(self, device_id: str, **fields) -> dict:
+        self.call_log.append(("update_device", (device_id,), fields))
+        self._check_fail()
+        for device in self._registered_devices:
+            if str(device.get("id")) == str(device_id):
+                device.update({k: v for k, v in fields.items() if v is not None})
+                return dict(device)
+        return {"id": device_id, **{k: v for k, v in fields.items() if v is not None}}
 
     def download_save_content(
         self,

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -177,11 +177,12 @@ class FakeSaveApi:
                 slot = s.get("slot")
                 slots.setdefault(slot, []).append(s)
         return {
+            "total_count": sum(len(saves) for saves in slots.values()),
             "slots": [
                 {
                     "slot": slot_name,  # None for legacy saves (no slot) — preserve as-is
                     "count": len(saves),
-                    "latest_updated_at": max((s.get("updated_at", "") for s in saves), default=None),
+                    "latest": max(saves, key=lambda s: s.get("updated_at", "")),
                 }
                 for slot_name, saves in slots.items()
             ],

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -901,6 +901,32 @@ class TestSyncRomSaves:
         assert call_order.count("detect") == 1
         assert call_order.index("detect") < call_order.index("sync")
 
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_message_includes_conflict_count(self, tmp_path):
+        """Public sync_rom_saves must surface conflict count in its message.
+
+        Previously reported "Synced 0 save(s)" even with conflicts present,
+        which reads as success — user had no signal that manual intervention
+        was needed.
+        """
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+
+        # Stub _sync_rom_saves to return 1 conflict, 0 synced, 0 errors
+        def stub_sync(rom_id):
+            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+
+        svc._sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.sync_rom_saves(42)
+
+        # success is still True — conflicts are legitimate state, not technical failure
+        assert result["success"] is True
+        assert "1 conflict(s)" in result["message"]
+        assert result["synced"] == 0
+
 
 # ---------------------------------------------------------------------------
 # TestSyncAllSaves
@@ -992,6 +1018,31 @@ class TestSyncAllSaves:
         # detect fired exactly once, before any per-ROM sync ran.
         assert call_order.count("detect") == 1
         assert call_order.index("detect") < call_order.index("sync")
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_success_stays_true_with_only_conflicts(self, tmp_path):
+        """Regression guard: success flag reflects errors only, not conflicts.
+
+        Conflicts are a legitimate state requiring user resolution — not a
+        technical failure. Frontend distinguishes via conflicts count; success
+        flag must stay reserved for actual errors.
+        """
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+
+        # Stub internal sync to produce conflicts but no errors
+        def stub_sync(rom_id):
+            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+
+        svc._sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.sync_all_saves()
+
+        assert result["success"] is True
+        assert result["conflicts"] >= 1
+        assert "conflict(s)" in result["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -1182,6 +1233,29 @@ class TestPostExitSync:
 
         assert result["success"] is True
         assert result["synced"] == 1
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_message_includes_conflict_count(self, tmp_path):
+        """post_exit_sync must surface conflict count in its message.
+
+        Previously "Uploaded 0 save(s)" even with conflicts — user has no
+        signal that sync is blocked on manual resolution.
+        """
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+
+        def stub_sync(rom_id):
+            return (0, [], [{"type": "newer_in_slot", "rom_id": rom_id}])
+
+        svc._sync_rom_saves = stub_sync  # type: ignore[method-assign]
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is True
+        assert "1 conflict(s)" in result["message"]
+        assert result["synced"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -4449,6 +4449,53 @@ class TestListFileVersions:
         assert len(entry["device_syncs"]) == 1
         assert entry["device_syncs"][0]["device_name"] == "steamdeck"
 
+    @pytest.mark.asyncio
+    async def test_list_file_versions_populates_uploaded_by_us(self, tmp_path):
+        """uploaded_by_us is True for IDs in own_upload_ids, False for others."""
+        svc, fake = make_service(tmp_path)
+
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default", updated_at="2026-03-10T10:00:00Z")
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-03-05T10:00:00Z")
+        fake.saves[30] = _server_save(save_id=30, rom_id=42, slot="default", updated_at="2026-03-01T10:00:00Z")
+
+        svc._save_sync_state["saves"]["42"] = {
+            "system": "gba",
+            "active_slot": "default",
+            "own_upload_ids": [50],
+            "files": {
+                "pokemon.srm": {"tracked_save_id": 100},
+            },
+        }
+
+        result = await svc.list_file_versions(42, "default", "pokemon.srm")
+
+        assert len(result) == 2
+        by_id = {v["id"]: v for v in result}
+        assert by_id[50]["uploaded_by_us"] is True
+        assert by_id[30]["uploaded_by_us"] is False
+
+    @pytest.mark.asyncio
+    async def test_list_file_versions_legacy_state_returns_none(self, tmp_path):
+        """When rom state has no own_upload_ids key, uploaded_by_us is None for all versions."""
+        svc, fake = make_service(tmp_path)
+
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default", updated_at="2026-03-10T10:00:00Z")
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-03-05T10:00:00Z")
+
+        svc._save_sync_state["saves"]["42"] = {
+            "system": "gba",
+            "active_slot": "default",
+            # own_upload_ids key intentionally absent — legacy state
+            "files": {
+                "pokemon.srm": {"tracked_save_id": 100},
+            },
+        }
+
+        result = await svc.list_file_versions(42, "default", "pokemon.srm")
+
+        assert len(result) == 1
+        assert result[0]["uploaded_by_us"] is None
+
 
 # ---------------------------------------------------------------------------
 # TestRollbackToVersion
@@ -4878,3 +4925,162 @@ class TestDeleteSlot:
 
         assert result["success"] is False
         assert result["reason"] == "disabled"
+
+
+# ---------------------------------------------------------------------------
+# TestOwnUploadIds
+# ---------------------------------------------------------------------------
+
+
+class TestOwnUploadIds:
+    """Tests for own_upload_ids tracking and the uploaded_by_us flag."""
+
+    @pytest.mark.asyncio
+    async def test_post_upload_appends_own_upload_id(self, tmp_path):
+        """After a POST upload (new save), the returned save_id is added to own_upload_ids."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        # No pre-existing server save — this will be a POST (save_id=None)
+        await svc.sync_rom_saves(42)
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        returned_id = upload_calls[0][2]["save_id"]  # save_id kwarg from upload_save call
+        # The save_id passed to upload_save should be None (POST path)
+        assert returned_id is None
+
+        rom_state = svc._save_sync_state["saves"]["42"]
+        own_ids = rom_state.get("own_upload_ids", [])
+        assert len(own_ids) == 1
+        # The id in the list must match what fake returned
+        new_save_id = next(iter(fake.saves.values()))["id"]
+        assert new_save_id in own_ids
+
+    @pytest.mark.asyncio
+    async def test_post_upload_idempotent_in_own_list(self, tmp_path):
+        """Calling _do_upload_save twice with the same resulting save_id does not duplicate."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        save_file = _create_save(tmp_path)
+
+        # Pre-populate own_upload_ids with the id that fake will return (1000)
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {},
+            "system": "gba",
+            "active_slot": "default",
+            "own_upload_ids": [1000],
+        }
+        # Fake will return the same id=1000 because filename matches existing
+        fake.saves[1000] = _server_save(save_id=1000, rom_id=42)
+
+        # Call internal upload with no server_save (POST path)
+        svc._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=None)
+
+        rom_state = svc._save_sync_state["saves"]["42"]
+        # Should still have exactly one entry for that id
+        assert rom_state["own_upload_ids"].count(1000) == 1
+
+    @pytest.mark.asyncio
+    async def test_put_upload_does_not_touch_own_list(self, tmp_path):
+        """Updating an existing tracked save (PUT path) does not modify own_upload_ids."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        save_file = _create_save(tmp_path)
+
+        # Pre-existing server save (id=100) — upload_save called with save_id=100 → PUT
+        fake.saves[100] = _server_save(save_id=100, rom_id=42)
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "old"}},
+            "system": "gba",
+            "active_slot": "default",
+            "own_upload_ids": [99],  # pre-existing unrelated id
+        }
+
+        server_save = fake.saves[100]
+        svc._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=server_save)
+
+        rom_state = svc._save_sync_state["saves"]["42"]
+        # own_upload_ids must not have changed (100 not added, 99 still there)
+        assert rom_state["own_upload_ids"] == [99]
+
+    @pytest.mark.asyncio
+    async def test_get_save_status_flags_own_uploads(self, tmp_path):
+        """Save 26 (ours) gets uploaded_by_us=True; save 27 (foreign) gets uploaded_by_us=False."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        # Two server saves: 26 and 27
+        fake.saves[26] = _server_save(save_id=26, rom_id=42, filename="pokemon.srm")
+        fake.saves[27] = _server_save(save_id=27, rom_id=42, filename="pokemon2.srm")
+
+        # ROM state: own_upload_ids includes only 26
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {},
+            "system": "gba",
+            "active_slot": None,
+            "own_upload_ids": [26],
+        }
+
+        result = await svc.get_save_status(42)
+
+        files_by_id: dict[int, dict] = {f["server_save_id"]: f for f in result["files"] if f.get("server_save_id")}
+        assert files_by_id[26]["uploaded_by_us"] is True
+        assert files_by_id[27]["uploaded_by_us"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_save_status_legacy_rom_state_returns_none(self, tmp_path):
+        """When rom state exists but own_upload_ids key is absent, uploaded_by_us is None."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        fake.saves[26] = _server_save(save_id=26, rom_id=42, filename="pokemon.srm")
+
+        # Legacy state: own_upload_ids key is absent
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {},
+            "system": "gba",
+            "active_slot": None,
+            # no own_upload_ids key
+        }
+
+        result = await svc.get_save_status(42)
+
+        files_by_id = {f["server_save_id"]: f for f in result["files"] if f.get("server_save_id")}
+        assert files_by_id[26]["uploaded_by_us"] is None
+
+    @pytest.mark.asyncio
+    async def test_rollback_to_foreign_version_preserves_own_upload_ids(self, tmp_path):
+        """Rolling back to a foreign save (not in own_upload_ids) does not modify own_upload_ids."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+
+        save_file = _create_save(tmp_path)
+        local_hash = _file_md5(str(save_file))
+
+        # own save is 26, tracked is 26 (clean state)
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {
+                "pokemon.srm": {
+                    "tracked_save_id": 26,
+                    "last_sync_hash": local_hash,
+                }
+            },
+            "system": "gba",
+            "active_slot": "default",
+            "own_upload_ids": [26],
+        }
+        fake.saves[26] = _server_save(save_id=26, rom_id=42, slot="default")
+        # Foreign older version to roll back to
+        fake.saves[27] = _server_save(save_id=27, rom_id=42, slot="default", updated_at="2026-01-01T00:00:00Z")
+
+        result = await svc.rollback_to_version(42, "default", "pokemon.srm", 27)
+
+        assert result["status"] == "ok"
+        # own_upload_ids must be unchanged — 27 was not POSTed by us
+        rom_state = svc._save_sync_state["saves"]["42"]
+        assert rom_state["own_upload_ids"] == [26]

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -184,7 +184,7 @@ class TestDeviceRegistration:
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result["device_id"]
         assert result["device_name"]
@@ -199,7 +199,7 @@ class TestDeviceRegistration:
         svc._save_sync_state["device_name"] = "deck"
         svc._save_sync_state["server_device_id"] = "server-existing"
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["device_id"] == "existing"
         assert result["device_name"] == "deck"
         assert result["server_device_id"] == "server-existing"
@@ -208,7 +208,7 @@ class TestDeviceRegistration:
     async def test_disabled_returns_failure(self, tmp_path):
         svc, _ = make_service(tmp_path)
         # save_sync_enabled defaults to False
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["success"] is False
         assert result.get("disabled") is True
 
@@ -219,12 +219,13 @@ class TestDeviceRegistration:
 
 
 class TestDeviceRegistrationServer:
-    def test_registers_with_server(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_registers_with_server(self, tmp_path):
         """Calls register_device and stores server_device_id."""
         svc, fake = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result.get("server_device_id") is not None
         assert svc._save_sync_state["server_device_id"] == result["server_device_id"]
@@ -235,19 +236,21 @@ class TestDeviceRegistrationServer:
         assert reg_calls[0][1][1] == "linux"  # platform
         assert reg_calls[0][1][2] == "decky-romm-sync"  # client
 
-    def test_returns_failure_on_server_error(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_returns_failure_on_server_error(self, tmp_path):
         """If register_device fails, returns failure."""
         fake = FakeSaveApi()
         fake.fail_on_next(Exception("server error"))
         svc, _ = make_service(tmp_path, fake_api=fake)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["success"] is False
         assert result.get("error") == "registration_failed"
         assert svc._save_sync_state.get("server_device_id") is None
 
-    def test_returns_existing_with_server_device_id(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_returns_existing_with_server_device_id(self, tmp_path):
         """If already registered, returns existing IDs including server_device_id."""
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
@@ -255,11 +258,12 @@ class TestDeviceRegistrationServer:
         svc._save_sync_state["device_name"] = "deck"
         svc._save_sync_state["server_device_id"] = "server-id-123"
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["device_id"] == "existing-id"
         assert result.get("server_device_id") == "server-id-123"
 
-    def test_upgrades_local_uuid_to_server(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_upgrades_local_uuid_to_server(self, tmp_path):
         """Local-only UUID gets upgraded to server registration."""
         svc, fake = make_service(tmp_path)
         svc._save_sync_state["settings"]["save_sync_enabled"] = True
@@ -268,13 +272,126 @@ class TestDeviceRegistrationServer:
         svc._save_sync_state["device_name"] = "deck"
         svc._save_sync_state["server_device_id"] = None
 
-        result = svc.ensure_device_registered()
+        result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result.get("server_device_id") is not None
         assert svc._save_sync_state["server_device_id"] is not None
         # register_device was called
         reg_calls = [c for c in fake.call_log if c[0] == "register_device"]
         assert len(reg_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_ensure_device_registered_reconciles_client_version(self, tmp_path):
+        """Already-registered path calls update_device with current plugin_version."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "existing-id"
+        svc._save_sync_state["device_name"] = "deck"
+        svc._save_sync_state["server_device_id"] = "server-abc"
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        update_calls = [c for c in fake.call_log if c[0] == "update_device"]
+        assert len(update_calls) == 1
+        assert update_calls[0][1][0] == "server-abc"
+        assert update_calls[0][2].get("client_version") == "0.14.0"
+
+    @pytest.mark.asyncio
+    async def test_ensure_device_registered_reconcile_non_fatal(self, tmp_path):
+        """PUT raises, ensure_device_registered still returns success."""
+        fake = FakeSaveApi()
+        svc, _ = make_service(tmp_path, fake_api=fake)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "existing-id"
+        svc._save_sync_state["device_name"] = "deck"
+        svc._save_sync_state["server_device_id"] = "server-abc"
+
+        # Make update_device fail silently
+        fake.fail_on_next(Exception("network error"))
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        assert result["device_id"] == "existing-id"
+
+
+# ---------------------------------------------------------------------------
+# TestListDevices
+# ---------------------------------------------------------------------------
+
+
+class TestListDevices:
+    @pytest.mark.asyncio
+    async def test_list_devices_marks_own_device(self, tmp_path):
+        """own device_id present in state — is_current_device is True on matching entry."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["server_device_id"] = "device-1"
+
+        # Register two devices in fake
+        fake._registered_devices = [
+            {"id": "device-1", "name": "steamdeck"},
+            {"id": "device-2", "name": "laptop"},
+        ]
+
+        result = await svc.list_devices()
+
+        assert result["success"] is True
+        assert len(result["devices"]) == 2
+        own = next(d for d in result["devices"] if d["id"] == "device-1")
+        other = next(d for d in result["devices"] if d["id"] == "device-2")
+        assert own["is_current_device"] is True
+        assert other["is_current_device"] is False
+
+    @pytest.mark.asyncio
+    async def test_list_devices_save_sync_disabled(self, tmp_path):
+        """Returns disabled=True when save sync is off."""
+        svc, _ = make_service(tmp_path)
+        # save_sync_enabled defaults to False
+
+        result = await svc.list_devices()
+
+        assert result == {"success": False, "devices": [], "disabled": True}
+
+    @pytest.mark.asyncio
+    async def test_list_devices_adapter_error(self, tmp_path):
+        """Adapter raises — returns error response."""
+        fake = FakeSaveApi()
+        svc, _ = make_service(tmp_path, fake_api=fake)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+
+        fake.fail_on_next(Exception("server unavailable"))
+        result = await svc.list_devices()
+
+        assert result == {"success": False, "devices": [], "error": "list_failed"}
+
+    @pytest.mark.asyncio
+    async def test_list_devices_no_own_id_all_false(self, tmp_path):
+        """No server_device_id in state — all is_current_device are False."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["server_device_id"] = None
+
+        fake._registered_devices = [{"id": "device-1", "name": "steamdeck"}]
+        result = await svc.list_devices()
+
+        assert result["success"] is True
+        assert result["devices"][0]["is_current_device"] is False
+
+    @pytest.mark.asyncio
+    async def test_list_devices_handles_null_id(self, tmp_path):
+        """Device with id=None must not match own_id=None (avoid 'None'=='None' trap)."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["server_device_id"] = None
+
+        fake._registered_devices = [{"id": None, "name": "unknown"}]
+        result = await svc.list_devices()
+
+        assert result["success"] is True
+        # id=None and own_id=None must both resolve to "" — empty string never
+        # compares truthy, so is_current_device must be False
+        assert result["devices"][0]["is_current_device"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -2628,6 +2628,39 @@ class TestSaveSlots:
         assert result["active_slot"] == "default"
 
     @pytest.mark.asyncio
+    async def test_get_save_slots_latest_updated_at_from_server(self, tmp_path):
+        """latest_updated_at is populated from nested latest.updated_at, not a flat key."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state["server_device_id"] = "server-dev-1"
+
+        # Two saves in the default slot; the later one should win.
+        fake.saves[1] = {
+            "id": 1,
+            "rom_id": 123,
+            "file_name": "a.srm",
+            "updated_at": "2026-04-16T13:00:00",
+            "slot": "default",
+        }
+        fake.saves[2] = {
+            "id": 2,
+            "rom_id": 123,
+            "file_name": "b.srm",
+            "updated_at": "2026-04-17T20:00:00",
+            "slot": "default",
+        }
+
+        result = await svc.get_save_slots(123)
+        assert result["success"] is True
+        slot = next(s for s in result["slots"] if s["slot"] == "default")
+        assert slot["latest_updated_at"] == "2026-04-17T20:00:00"
+
+        # Also verify the value is persisted in state (not None)
+        persisted = svc._save_sync_state["saves"]["123"]["slots"]["default"]
+        assert persisted["latest_updated_at"] == "2026-04-17T20:00:00"
+
+    @pytest.mark.asyncio
     async def test_get_save_slots_disabled(self, tmp_path):
         svc, _ = make_service(tmp_path)
         result = await svc.get_save_slots(123)

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -217,6 +217,39 @@ class TestDeviceRegistration:
 
 
 # ============================================================================
+# List Devices (Plugin callable integration)
+# ============================================================================
+
+
+class TestListDevices:
+    """Tests for list_devices callable wired through Plugin."""
+
+    @pytest.mark.asyncio
+    async def test_list_devices_returns_devices(self, plugin):
+        """list_devices callable routes through save service and returns enriched list."""
+        plugin._fake_api._registered_devices = [
+            {"id": "device-1", "name": "steamdeck"},
+        ]
+        plugin._save_sync_state["server_device_id"] = "device-1"
+
+        result = await plugin.list_devices()
+
+        assert result["success"] is True
+        assert len(result["devices"]) == 1
+        assert result["devices"][0]["is_current_device"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_devices_disabled_when_sync_off(self, plugin):
+        """Returns disabled=True when save sync is disabled."""
+        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+
+        result = await plugin.list_devices()
+
+        assert result["success"] is False
+        assert result.get("disabled") is True
+
+
+# ============================================================================
 # Pre-Launch Sync (Plugin callable integration)
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- New read-only **Registered Devices** panel in Settings QAM — shows all devices under your RomM user with name, platform, client version, last seen, short UUID
- **SavesTab** now always appends `(this device)` / `(other device)` after the syncer name, so duplicate device names (e.g. two Steam Decks both registered as `steamdeck`) are unambiguous
- Fixes a silent bug: `register_device` was sending `{"version": ...}` but the RomM server expects `{"client_version": ...}` — it was silently dropped, leaving `client_version: null` in the DB
- Self-heals existing devices via reconciliation-on-startup (idempotent PUT), no migration needed
- Hardens the event loop: `ensure_device_registered` is now async + executor-wrapped, previously the sync HTTP calls could block QAM load up to 30s when RomM was unreachable

Block 2 of #197. Block 1 (slot deletion) shipped in #245.

## What changed

### Backend
- `RommApi.register_device` — key `version` → `client_version`, param renamed accordingly
- `RommApi.list_devices()` — new, wraps `GET /api/devices`
- `RommApi.update_device(device_id, **fields)` — new, wraps `PUT /api/devices/{id}` with None-field filtering so callers pass only what they want to update
- `SaveService.list_devices()` — new async callable, enriches each device with `is_current_device: bool` (compared against stored `server_device_id`)
- `SaveService.ensure_device_registered` — now `async def`; HTTP calls wrapped in `run_in_executor`; adds idempotent reconciliation PUT for `client_version` on the already-registered path
- `main.py` — new `list_devices` callable exposed to frontend
- `protocols.py` — updated `RommApiProtocol` + `SaveApiProtocol` signatures

### Frontend
- `src/api/backend.ts` — new `listDevices` callable + `RegisteredDevice` / `ListDevicesResponse` types
- `src/components/SettingsPage.tsx` — new `Registered Devices` panel between Save Sync and Controller sections, loads on mount and when save sync enables, hides when disabled
- `src/components/SavesTab.tsx` — always-label device attribution (never leave unlabeled)

### Tests
- +15 new tests (1719 total, up from 1703)
- `test_register_device_uses_client_version_key` — guards against regression
- `test_list_devices_*` — 4 scenarios (happy, empty, disabled, adapter error, null-id edge case)
- `test_update_device_*` — 3 scenarios
- `test_ensure_device_registered_reconciles_client_version` / `..._reconcile_non_fatal` — reconciliation behaviour + PUT failure resilience
- `TestListDevices` integration — wires through plugin class

## Rationale: reconciliation, not migration

`client_version` changes on every plugin upgrade. A schema migration (one-shot) would help once, then go stale. Reconciliation-on-startup is the right primitive: idempotent, no state bookkeeping, handles plugin upgrades automatically, and retroactively fixes the `client_version: null` rows left by the old bug. Cost: 1 PUT per plugin load.

## Upstream RomM findings

Documented in the new `upstream:romm`-labelled tracker (to be filed separately):
- Duplicate device names accepted despite `allow_duplicate: false` default (also with `allow_existing: false`)
- `PATCH /api/devices/{id}` returns 405 but `PUT` works — previously assumed server-side rename was impossible, it isn't
- Unknown payload fields on `POST /api/devices` are silently dropped (root cause of this bug)

## Test plan

- [x] `python -m pytest tests/ -q` — 1719 passed
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright` — 0 errors / 0 warnings / 0 notes
- [x] `PYTHONPATH=py_modules lint-imports` — 6/6 contracts kept
- [x] `pnpm build` — clean
- [x] Manual smoke test on Deck: open Settings, confirm Registered Devices panel lists own device + others with "(this device)" badge; open a save-synced game's SAVES tab, confirm "(this device)" / "(other device)" labels on save rows
- [x] Manual verify reconciliation: check RomM DB that `client_version` of own device is no longer null after next plugin load

## Related

- Issue #197 (parent)
- Issue #161 (separate QAM scroll investigation — extended with research notes during this PR)