### PR TITLE
fix(migration): block all ops during pending RetroDECK path migration

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
+from lib.migration_gate import migration_blocked
 
 
 class Plugin:
@@ -70,6 +71,11 @@ class Plugin:
         (boot-time race), and a naive os.path.exists() check would wipe every
         entry that lives on the card. The next plugin reload, with the
         filesystem ready, will run the prune normally.
+
+        Entries living under a pending migration's previous home are also
+        preserved — RetroDECK has moved away from that path so the files
+        won't exist there, but the user hasn't migrated yet and the entries
+        must survive until they do.
         """
         retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
         if not retrodeck_home or not os.path.exists(retrodeck_home):
@@ -78,10 +84,18 @@ class Plugin:
             )
             return
 
+        pending_migration_home = self._state.get("retrodeck_home_path_previous", "")
+        pending_prefix = (pending_migration_home + os.sep) if pending_migration_home else ""
+
         pruned = []
         for rom_id, entry in list(self._state["installed_roms"].items()):  # list(): dict mutated below
             file_path = entry.get("file_path", "")
             rom_dir = entry.get("rom_dir", "")
+            if pending_prefix and (file_path.startswith(pending_prefix) or rom_dir.startswith(pending_prefix)):
+                decky.logger.info(
+                    f"Skipping prune of {rom_id} ({file_path}): pending migration from {pending_migration_home}"
+                )
+                continue
             if (file_path and os.path.exists(file_path)) or (rom_dir and os.path.exists(rom_dir)):
                 continue
             decky.logger.info(f"Pruned stale installed_roms entry: {rom_id} ({file_path})")
@@ -199,6 +213,9 @@ class Plugin:
         # ── 5. Startup healing ──────────────────────────────────────────────
         self._save_sync_service.init_state()
         self._save_sync_service.load_state()
+        # Detect retrodeck path changes BEFORE pruning so the prune can skip
+        # entries living under a pending migration's previous home.
+        self._migration_service.detect_retrodeck_path_change()
         self._prune_stale_installed_roms()
         self._prune_stale_registry()
         self._save_sync_service.prune_orphaned_state()
@@ -207,7 +224,6 @@ class Plugin:
         self._download_service.cleanup_leftover_tmp_files()
 
         # ── 6. Background tasks ─────────────────────────────────────────────
-        self._migration_service.detect_retrodeck_path_change()
         self._migration_service.detect_save_sort_change()
         self.loop.create_task(self._download_service.poll_download_requests())
         decky.logger.info("RomM Sync plugin loaded")
@@ -228,6 +244,9 @@ class Plugin:
 
     async def dismiss_save_sort_migration(self):
         return self._migration_service.dismiss_save_sort_migration()
+
+    async def dismiss_retrodeck_migration(self):
+        return self._migration_service.dismiss_retrodeck_migration()
 
     async def refresh_migration_state(self):
         self._migration_service.detect_retrodeck_path_change()
@@ -431,6 +450,7 @@ class Plugin:
         es_de_config.set_system_override(retrodeck_home, platform_slug, core_label or None)
         es_de_config._resolver.reset_cache()
 
+    @migration_blocked
     async def set_system_core(self, platform_slug, core_label):
         """Set system-wide core override. Pass empty string to reset to default."""
         retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
@@ -452,6 +472,7 @@ class Plugin:
         es_de_config.set_game_override(retrodeck_home, platform_slug, rom_path, core_label or None)
         es_de_config._resolver.reset_cache()
 
+    @migration_blocked
     async def set_game_core(self, platform_slug, rom_path, core_label):
         """Set per-game core override. Pass empty string to reset to platform default."""
         retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
@@ -474,12 +495,15 @@ class Plugin:
     async def get_firmware_status(self):
         return await self._firmware_service.get_firmware_status()
 
+    @migration_blocked
     async def download_firmware(self, firmware_id):
         return await self._firmware_service.download_firmware(firmware_id)
 
+    @migration_blocked
     async def download_all_firmware(self, platform_slug):
         return await self._firmware_service.download_all_firmware(platform_slug)
 
+    @migration_blocked
     async def download_required_firmware(self, platform_slug):
         return await self._firmware_service.download_required_firmware(platform_slug)
 
@@ -489,6 +513,7 @@ class Plugin:
     async def get_bios_status(self, rom_id):
         return await self._game_detail_service.get_bios_status(rom_id)
 
+    @migration_blocked
     async def delete_platform_bios(self, platform_slug):
         return await self._firmware_service.delete_platform_bios(platform_slug)
 
@@ -497,18 +522,22 @@ class Plugin:
     async def get_platforms(self):
         return await self._sync_service.get_platforms()
 
+    @migration_blocked
     async def save_platform_sync(self, platform_id, enabled):
         return self._sync_service.save_platform_sync(platform_id, enabled)
 
+    @migration_blocked
     async def set_all_platforms_sync(self, enabled):
         return await self._sync_service.set_all_platforms_sync(enabled)
 
     async def get_collections(self):
         return await self._sync_service.get_collections()
 
+    @migration_blocked
     async def save_collection_sync(self, collection_id, enabled):
         return self._sync_service.save_collection_sync(collection_id, enabled)
 
+    @migration_blocked
     async def set_all_collections_sync(self, enabled, category=None):
         return await self._sync_service.set_all_collections_sync(enabled, category)
 
@@ -517,6 +546,7 @@ class Plugin:
         self._save_settings_to_disk()
         return {"success": True}
 
+    @migration_blocked
     async def start_sync(self):
         return self._sync_service.start_sync()
 
@@ -529,9 +559,11 @@ class Plugin:
     async def sync_heartbeat(self):
         return self._sync_service.sync_heartbeat()
 
+    @migration_blocked
     async def sync_preview(self):
         return await self._sync_service.sync_preview()
 
+    @migration_blocked
     async def sync_apply_delta(self, preview_id):
         return await self._sync_service.sync_apply_delta(preview_id)
 
@@ -544,9 +576,11 @@ class Plugin:
     async def get_registry_platforms(self):
         return self._sync_service.get_registry_platforms()
 
+    @migration_blocked
     async def remove_platform_shortcuts(self, platform_slug):
         return await self._shortcut_removal_service.remove_platform_shortcuts(platform_slug)
 
+    @migration_blocked
     async def remove_all_shortcuts(self):
         return self._shortcut_removal_service.remove_all_shortcuts()
 
@@ -556,6 +590,7 @@ class Plugin:
     async def get_artwork_base64(self, rom_id):
         return await self._artwork_service.get_artwork_base64(int(rom_id), self._sync_service.pending_sync)
 
+    @migration_blocked
     async def clear_sync_cache(self):
         return self._sync_service.clear_sync_cache()
 
@@ -567,6 +602,7 @@ class Plugin:
 
     # ── Download delegation to DownloadService ──────────────
 
+    @migration_blocked
     async def start_download(self, rom_id):
         return await self._download_service.start_download(rom_id)
 
@@ -576,18 +612,21 @@ class Plugin:
     async def get_download_queue(self):
         return self._download_service.get_download_queue()
 
+    @migration_blocked
     async def clear_completed_downloads(self):
         return self._download_service.clear_completed_downloads()
 
     async def get_installed_rom(self, rom_id):
         return self._download_service.get_installed_rom(rom_id)
 
+    @migration_blocked
     async def remove_rom(self, rom_id):
         result = await self._rom_removal_service.remove_rom(rom_id)
         if result.get("success"):
             self._download_service._download_queue.pop(int(rom_id), None)
         return result
 
+    @migration_blocked
     async def uninstall_all_roms(self):
         result = await self._rom_removal_service.uninstall_all_roms()
         if result.get("success"):
@@ -618,30 +657,36 @@ class Plugin:
     async def check_core_change(self, rom_id):
         return self._save_sync_service.check_core_change(rom_id)
 
+    @migration_blocked
     async def pre_launch_sync(self, rom_id):
         return await self._save_sync_service.pre_launch_sync(rom_id)
 
+    @migration_blocked
     async def post_exit_sync(self, rom_id):
         return await self._save_sync_service.post_exit_sync(rom_id)
 
+    @migration_blocked
     async def sync_rom_saves(self, rom_id):
         return await self._save_sync_service.sync_rom_saves(rom_id)
 
     async def get_save_slots(self, rom_id):
         return await self._save_sync_service.get_save_slots(rom_id)
 
+    @migration_blocked
     async def set_game_slot(self, rom_id, slot):
         return self._save_sync_service.set_game_slot(rom_id, slot)
 
     async def get_slot_saves(self, rom_id, slot):
         return await self._save_sync_service.get_slot_saves(rom_id, slot)
 
+    @migration_blocked
     async def switch_slot(self, rom_id, new_slot):
         return await self._save_sync_service.switch_slot(rom_id, new_slot)
 
     async def get_slot_delete_info(self, rom_id, slot):
         return await self._save_sync_service.get_slot_delete_info(rom_id, slot)
 
+    @migration_blocked
     async def delete_slot(self, rom_id, slot):
         return await self._save_sync_service.delete_slot(rom_id, slot)
 
@@ -651,6 +696,7 @@ class Plugin:
     async def get_save_setup_info(self, rom_id):
         return await self._save_sync_service.get_save_setup_info(rom_id)
 
+    @migration_blocked
     async def confirm_slot_choice(self, rom_id, chosen_slot, migrate_from_slot="__no_migration__"):
         from services.saves import _NO_MIGRATION
 
@@ -658,27 +704,33 @@ class Plugin:
         actual = _NO_MIGRATION if migrate_from_slot in ("__no_migration__", None) else migrate_from_slot
         return await self._save_sync_service.confirm_slot_choice(rom_id, chosen_slot, actual)
 
+    @migration_blocked
     async def sync_all_saves(self):
         return await self._save_sync_service.sync_all_saves()
 
+    @migration_blocked
     async def resolve_sync_conflict(self, rom_id, filename, action):
         return await self._save_sync_service.resolve_sync_conflict(rom_id, filename, action)
 
     async def get_save_sync_settings(self):
         return self._save_sync_service.get_save_sync_settings()
 
+    @migration_blocked
     async def update_save_sync_settings(self, settings):
         return self._save_sync_service.update_save_sync_settings(settings)
 
+    @migration_blocked
     async def delete_local_saves(self, rom_id):
         return self._save_sync_service.delete_local_saves(rom_id)
 
+    @migration_blocked
     async def delete_platform_saves(self, platform_slug):
         return self._save_sync_service.delete_platform_saves(platform_slug)
 
     async def saves_list_file_versions(self, rom_id, slot, filename):
         return await self._save_sync_service.list_file_versions(rom_id, slot, filename)
 
+    @migration_blocked
     async def saves_rollback_to_version(self, rom_id, slot, save_id):
         return await self._save_sync_service.rollback_to_version(rom_id, slot, save_id)
 

--- a/main.py
+++ b/main.py
@@ -63,6 +63,14 @@ class Plugin:
 
     # -- pruning ---------------------------------------------------------------
 
+    def _is_pending_migration_path(self, file_path: str, rom_dir: str) -> bool:
+        """True when an installed_roms entry lives under the pre-migration home."""
+        pending = self._state.get("retrodeck_home_path_previous", "")
+        if not pending:
+            return False
+        prefix = pending + os.sep
+        return file_path.startswith(prefix) or rom_dir.startswith(prefix)
+
     def _prune_stale_installed_roms(self):
         """Remove installed_roms entries whose files no longer exist on disk.
 
@@ -84,17 +92,12 @@ class Plugin:
             )
             return
 
-        pending_migration_home = self._state.get("retrodeck_home_path_previous", "")
-        pending_prefix = (pending_migration_home + os.sep) if pending_migration_home else ""
-
         pruned = []
         for rom_id, entry in list(self._state["installed_roms"].items()):  # list(): dict mutated below
             file_path = entry.get("file_path", "")
             rom_dir = entry.get("rom_dir", "")
-            if pending_prefix and (file_path.startswith(pending_prefix) or rom_dir.startswith(pending_prefix)):
-                decky.logger.info(
-                    f"Skipping prune of {rom_id} ({file_path}): pending migration from {pending_migration_home}"
-                )
+            if self._is_pending_migration_path(file_path, rom_dir):
+                decky.logger.info(f"Skipping prune of {rom_id} ({file_path}): pending migration")
                 continue
             if (file_path and os.path.exists(file_path)) or (rom_dir and os.path.exists(rom_dir)):
                 continue

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -211,6 +211,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         emit=cfg.emit,
         # SaveService must observe fresh sort state before computing saves_dir (#238).
         detect_sort_change=migration_service.detect_save_sort_change,
+        is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
     )
 
     playtime_service = PlaytimeService(
@@ -291,6 +292,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         save_state=cfg.save_state,
         get_roms_path=cfg.get_roms_path,
         get_bios_path=cfg.get_bios_path,
+        is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
     )
 
     rom_removal_service = RomRemovalService(

--- a/py_modules/lib/migration_gate.py
+++ b/py_modules/lib/migration_gate.py
@@ -1,0 +1,37 @@
+"""Decorator that blocks Decky callables while a RetroDECK migration is pending.
+
+The decorated method must be ``async def`` (every Decky callable is). The wrapped
+method's owner class must expose a ``_migration_service`` attribute with an
+``is_retrodeck_migration_pending() -> bool`` method.
+
+Tests can introspect blocked callables via the
+``_migration_blocked`` attribute attached to the wrapper.
+
+Lives in ``lib/`` to stay outside the services/adapters/domain dependency
+graph (per import-linter contracts).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+
+def migration_blocked(method):
+    """Block this Decky callable when ``is_retrodeck_migration_pending()`` is True."""
+
+    @functools.wraps(method)
+    async def wrapper(self, *args: Any, **kwargs: Any):
+        # Defensive: skip the gate cleanly if _migration_service is missing
+        # (e.g. tests that haven't wired it). Prefer no-op over AttributeError.
+        service = getattr(self, "_migration_service", None)
+        if service is not None and service.is_retrodeck_migration_pending():
+            return {
+                "success": False,
+                "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+                "blocked_by_migration": True,
+            }
+        return await method(self, *args, **kwargs)
+
+    wrapper._migration_blocked = True  # type: ignore[attr-defined]
+    return wrapper

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -22,6 +22,7 @@ from lib.errors import error_response
 
 if TYPE_CHECKING:
     import logging
+    from collections.abc import Callable
 
     from services.protocols import (
         BiosPathProvider,
@@ -53,6 +54,7 @@ class DownloadService:
         save_state: StatePersister,
         get_roms_path: RomsPathProvider | None = None,
         get_bios_path: BiosPathProvider | None = None,
+        is_retrodeck_migration_pending: Callable[[], bool] | None = None,
     ):
         self._romm_api = romm_api
         self._resolve_system = resolve_system
@@ -64,6 +66,7 @@ class DownloadService:
         self._save_state = save_state
         self._get_roms_path = get_roms_path
         self._get_bios_path = get_bios_path
+        self._is_retrodeck_migration_pending = is_retrodeck_migration_pending
 
         # Owned state
         self._download_in_progress: set = set()
@@ -181,6 +184,12 @@ class DownloadService:
         while True:
             try:
                 await asyncio.sleep(2)
+                # Pause polling while a RetroDECK migration is pending — must
+                # short-circuit BEFORE _poll_download_requests_io reads + clears
+                # the request file, otherwise queued requests would be silently
+                # dropped on the floor.
+                if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+                    continue
                 requests = await self._loop.run_in_executor(None, self._poll_download_requests_io, requests_path)
                 if not requests:
                     continue

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -87,6 +87,28 @@ class MigrationService:
             self._save_state()
             return
 
+        # Auto-clear: user reverted RetroDECK to the previous home before migrating.
+        # The "previous" path is now the live one — no migration needed, drop the marker.
+        if current_home == self._state.get("retrodeck_home_path_previous"):
+            previous = self._state.get("retrodeck_home_path_previous", "")
+            self._state.pop("retrodeck_home_path_previous", None)
+            self._state["retrodeck_home_path"] = current_home
+            self._save_state()
+            self._logger.info(f"RetroDECK home reverted to previous path; clearing migration marker: {current_home}")
+            # Notify the frontend so any pending migration UI can dismiss itself.
+            # ``cleared: True`` lets the listener distinguish from the path-change emit.
+            self._loop.create_task(
+                self._emit(
+                    "retrodeck_path_changed",
+                    {
+                        "old_path": previous,
+                        "new_path": current_home,
+                        "cleared": True,
+                    },
+                )
+            )
+            return
+
         old_home = stored_home
 
         # Path changed — store both old and new, emit event
@@ -103,6 +125,16 @@ class MigrationService:
                 },
             )
         )
+
+    def is_retrodeck_migration_pending(self) -> bool:
+        """Return True if a RetroDECK home path migration is pending."""
+        return bool(self._state.get("retrodeck_home_path_previous"))
+
+    def dismiss_retrodeck_migration(self) -> dict:
+        """Dismiss the RetroDECK path migration warning without migrating files."""
+        self._state.pop("retrodeck_home_path_previous", None)
+        self._save_state()
+        return {"success": True}
 
     def _collect_rom_items(self, old_home, new_home):
         """Collect ROM migration items from installed_roms state."""

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -147,6 +147,7 @@ class SaveService:
         plugin_version: str = "0.0.0",
         emit: EventEmitter | None = None,
         detect_sort_change: Callable[[], None] | None = None,
+        is_retrodeck_migration_pending: Callable[[], bool] | None = None,
     ) -> None:
         self._romm_api = romm_api
         self._retry = retry
@@ -163,6 +164,7 @@ class SaveService:
         self._plugin_version = plugin_version
         self._emit = emit
         self._detect_sort_change = detect_sort_change
+        self._is_retrodeck_migration_pending = is_retrodeck_migration_pending
         # Per-rom lock dict — serializes concurrent sync operations on the
         # same rom_id (pre_launch_sync, post_exit_sync, manual sync, resolve).
         self._rom_sync_locks: dict[int, asyncio.Lock] = {}
@@ -1480,6 +1482,20 @@ class SaveService:
             if not self._is_save_sync_enabled():
                 return {"success": True, "message": "Save sync disabled", "synced": 0}
 
+            # Defense in depth: block pre_launch_sync if a future caller bypasses
+            # the @migration_blocked decorator at the public callable. saves_dir
+            # would otherwise resolve under the new home and silently desync from
+            # files still living at the old home. Internal _sync_rom_saves callers
+            # (sync_all_saves, rollback_to_version) are protected by the decorator
+            # on their own public callables — this guard is for pre_launch_sync.
+            if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+                return {
+                    "success": False,
+                    "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+                    "synced": 0,
+                    "blocked_by_migration": True,
+                }
+
             # Refresh save-sort state before the migration gate — see #238.
             await self._refresh_save_sort_state("pre_launch_sync")
 
@@ -1523,6 +1539,18 @@ class SaveService:
             if not self._is_save_sync_enabled():
                 self._logger.info("post_exit_sync skipped: save sync disabled")
                 return {"success": True, "message": "Save sync disabled", "synced": 0}
+
+            # Defense in depth: same rationale as pre_launch_sync — internal
+            # _sync_rom_saves callers are protected by @migration_blocked on
+            # their public callables; this guard covers post_exit_sync only.
+            if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+                self._logger.info("post_exit_sync skipped: retrodeck migration pending")
+                return {
+                    "success": False,
+                    "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+                    "synced": 0,
+                    "blocked_by_migration": True,
+                }
 
             settings = self._save_sync_state.get("settings", {})
             if not settings.get("sync_after_exit", True):

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -6,6 +6,8 @@ export interface BackendResult {
   message: string;
   error_code?: RommErrorCode;
   romm_version?: string;
+  /** Set when a callable was rejected because a RetroDECK migration is pending. */
+  blocked_by_migration?: boolean;
 }
 
 export interface CachedGameDetail {
@@ -224,6 +226,7 @@ export interface MigrationResult {
 
 export const getMigrationStatus = callable<[], MigrationStatus>("get_migration_status");
 export const migrateRetroDeckFiles = callable<[string | null], MigrationResult>("migrate_retrodeck_files");
+export const dismissRetrodeckMigration = callable<[], { success: boolean }>("dismiss_retrodeck_migration");
 
 export interface SaveSortMigrationStatus {
   pending: boolean;

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -32,6 +32,7 @@ import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrat
 import { requestSyncCancel } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
+import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import type { SyncProgress, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem } from "../types";
 import type { MigrationStatus } from "../api/backend";
 
@@ -320,6 +321,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     return <VersionErrorCard message={versionError} compact />;
   }
 
+  if (migration.pending) {
+    return <MigrationBlockedPage migration={migration} />;
+  }
+
   return (
     <>
       <PanelSection title="Status">
@@ -380,25 +385,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </DialogButton>
             </Field>
           </PanelSectionRow>
-        )}
-        {migration.pending && (
-          <>
-            <PanelSectionRow>
-              <div style={{ padding: "8px 12px", backgroundColor: "rgba(212, 167, 44, 0.15)", borderLeft: "3px solid #d4a72c", borderRadius: "4px" }}>
-                <div style={{ fontSize: "13px", fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" }}>
-                  {"\u26A0\uFE0F"} RetroDECK location changed
-                </div>
-                <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)" }}>
-                  {(migration.roms_count ?? 0) + (migration.bios_count ?? 0) + (migration.saves_count ?? 0)} file(s) need migration ({migration.roms_count ?? 0} ROMs, {migration.bios_count ?? 0} BIOS, {migration.saves_count ?? 0} saves)
-                </div>
-              </div>
-            </PanelSectionRow>
-            <PanelSectionRow>
-              <ButtonItem layout="below" onClick={() => onNavigate("settings")}>
-                Go to Settings
-              </ButtonItem>
-            </PanelSectionRow>
-          </>
         )}
         {saveSortMigration.pending && (
           <>

--- a/src/components/MigrationBlockedCard.tsx
+++ b/src/components/MigrationBlockedCard.tsx
@@ -1,5 +1,5 @@
 import { FC, createElement } from "react";
-import { FaExclamationTriangle } from "react-icons/fa";
+import { WarningCard } from "./WarningCard";
 
 interface MigrationBlockedCardProps {
   /** Compact mode for narrow contexts (QAM panel). */
@@ -7,49 +7,9 @@ interface MigrationBlockedCardProps {
 }
 
 /** Polished warning card shown on the game detail page when a RetroDECK migration is pending. */
-export const MigrationBlockedCard: FC<MigrationBlockedCardProps> = ({ compact = false }) => {
-  return createElement(
-    "div",
-    {
-      style: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: compact ? "24px 16px" : "40px 32px",
-        gap: "14px",
-        textAlign: "center",
-        background: "rgba(14, 20, 27, 0.55)",
-        border: "1px solid rgba(255, 170, 0, 0.35)",
-        borderRadius: "6px",
-        margin: compact ? "8px 4px" : "24px 2.8vw",
-      },
-    },
-    createElement(FaExclamationTriangle, {
-      style: { color: "#ffaa00", fontSize: compact ? "28px" : "42px" },
-    }),
-    createElement(
-      "div",
-      {
-        style: {
-          fontSize: compact ? "15px" : "19px",
-          fontWeight: 600,
-          color: "rgba(255, 255, 255, 0.95)",
-        },
-      },
-      "RetroDECK Migration Required",
-    ),
-    createElement(
-      "div",
-      {
-        style: {
-          fontSize: compact ? "12px" : "14px",
-          color: "rgba(255, 255, 255, 0.75)",
-          maxWidth: compact ? "100%" : "680px",
-          lineHeight: 1.5,
-        },
-      },
-      "Open the plugin QAM to migrate files or dismiss the migration before playing.",
-    ),
-  );
-};
+export const MigrationBlockedCard: FC<MigrationBlockedCardProps> = ({ compact = false }) =>
+  createElement(WarningCard, {
+    title: "RetroDECK Migration Required",
+    message: "Open the plugin QAM to migrate files or dismiss the migration before playing.",
+    compact,
+  });

--- a/src/components/MigrationBlockedCard.tsx
+++ b/src/components/MigrationBlockedCard.tsx
@@ -1,0 +1,55 @@
+import { FC, createElement } from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
+
+interface MigrationBlockedCardProps {
+  /** Compact mode for narrow contexts (QAM panel). */
+  compact?: boolean;
+}
+
+/** Polished warning card shown on the game detail page when a RetroDECK migration is pending. */
+export const MigrationBlockedCard: FC<MigrationBlockedCardProps> = ({ compact = false }) => {
+  return createElement(
+    "div",
+    {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: compact ? "24px 16px" : "40px 32px",
+        gap: "14px",
+        textAlign: "center",
+        background: "rgba(14, 20, 27, 0.55)",
+        border: "1px solid rgba(255, 170, 0, 0.35)",
+        borderRadius: "6px",
+        margin: compact ? "8px 4px" : "24px 2.8vw",
+      },
+    },
+    createElement(FaExclamationTriangle, {
+      style: { color: "#ffaa00", fontSize: compact ? "28px" : "42px" },
+    }),
+    createElement(
+      "div",
+      {
+        style: {
+          fontSize: compact ? "15px" : "19px",
+          fontWeight: 600,
+          color: "rgba(255, 255, 255, 0.95)",
+        },
+      },
+      "RetroDECK Migration Required",
+    ),
+    createElement(
+      "div",
+      {
+        style: {
+          fontSize: compact ? "12px" : "14px",
+          color: "rgba(255, 255, 255, 0.75)",
+          maxWidth: compact ? "100%" : "680px",
+          lineHeight: 1.5,
+        },
+      },
+      "Open the plugin QAM to migrate files or dismiss the migration before playing.",
+    ),
+  );
+};

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -1,0 +1,156 @@
+import { FC, useEffect, useState } from "react";
+import {
+  PanelSection,
+  PanelSectionRow,
+  ButtonItem,
+  Field,
+  ConfirmModal,
+  showModal,
+} from "@decky/ui";
+import { toaster } from "@decky/api";
+import {
+  migrateRetroDeckFiles,
+  dismissRetrodeckMigration,
+} from "../api/backend";
+import type { MigrationStatus } from "../api/backend";
+import {
+  getMigrationState,
+  onMigrationChange,
+  clearMigration,
+} from "../utils/migrationStore";
+import { MigrationConflictModal } from "./MigrationConflictModal";
+
+/**
+ * Subscribe to migration state changes.
+ * Returns the current migration status.
+ */
+export function useMigrationStatus(): MigrationStatus {
+  const [status, setStatus] = useState<MigrationStatus>(getMigrationState());
+  useEffect(() => onMigrationChange(() => setStatus(getMigrationState())), []);
+  return status;
+}
+
+interface MigrationBlockedPageProps {
+  migration: MigrationStatus;
+}
+
+export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration }) => {
+  const [migrating, setMigrating] = useState(false);
+  const [migrateResult, setMigrateResult] = useState("");
+
+  const runMigration = async (strategy: "overwrite" | "skip" | null) => {
+    setMigrating(true);
+    setMigrateResult("");
+    try {
+      const result = await migrateRetroDeckFiles(strategy);
+      if (result.needs_confirmation) {
+        setMigrating(false);
+        showModal(
+          <MigrationConflictModal
+            conflictCount={result.conflict_count ?? 0}
+            onChoice={(s) => { runMigration(s); }}
+          />,
+        );
+        return;
+      }
+      setMigrateResult(result.message);
+      if (result.success) {
+        clearMigration();
+        toaster.toast({
+          title: "RomM Sync",
+          body: result.message || "Migration complete.",
+        });
+      }
+    } catch {
+      setMigrateResult("Migration failed");
+    }
+    setMigrating(false);
+  };
+
+  const handleMigrate = () => { runMigration(null); };
+
+  const handleDismiss = () => {
+    showModal(
+      <ConfirmModal
+        strTitle="Dismiss Migration?"
+        strDescription={
+          "This will accept that some ROMs and saves remain at the old location. " +
+          "The plugin will continue with the new path. Save data may be inconsistent " +
+          "across sessions. Are you sure?"
+        }
+        strOKButtonText="Dismiss"
+        strCancelButtonText="Cancel"
+        onOK={async () => {
+          try {
+            const result = await dismissRetrodeckMigration();
+            if (result.success) {
+              clearMigration();
+              toaster.toast({
+                title: "RomM Sync",
+                body: "Migration dismissed.",
+              });
+            }
+          } catch {
+            setMigrateResult("Dismiss failed");
+          }
+        }}
+      />,
+    );
+  };
+
+  return (
+    <PanelSection title="RetroDECK Migration Required">
+      <PanelSectionRow>
+        <div
+          style={{
+            padding: "8px 12px",
+            backgroundColor: "rgba(212, 167, 44, 0.15)",
+            borderLeft: "3px solid #d4a72c",
+            borderRadius: "4px",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "13px",
+              fontWeight: "bold",
+              color: "#d4a72c",
+              marginBottom: "6px",
+            }}
+          >
+            {"⚠️"} RetroDECK location changed
+          </div>
+          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "4px" }}>
+            From: {migration.old_path ?? "unknown"}
+          </div>
+          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "4px" }}>
+            To: {migration.new_path ?? "unknown"}
+          </div>
+          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.9)" }}>
+            {migration.roms_count ?? 0} ROM(s), {migration.bios_count ?? 0} BIOS,{" "}
+            {migration.saves_count ?? 0} save(s) to migrate
+          </div>
+        </div>
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" disabled={migrating} onClick={handleMigrate}>
+          {migrating ? "Migrating..." : "Migrate Files"}
+        </ButtonItem>
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" disabled={migrating} onClick={handleDismiss}>
+          Dismiss
+        </ButtonItem>
+      </PanelSectionRow>
+      {migrateResult && (
+        <PanelSectionRow>
+          <Field label={migrateResult} />
+        </PanelSectionRow>
+      )}
+      <PanelSectionRow>
+        <div style={{ fontSize: "11px", color: "rgba(255, 255, 255, 0.55)", padding: "4px 0" }}>
+          Or revert RetroDECK to its previous location — the plugin will detect it automatically.
+        </div>
+      </PanelSectionRow>
+    </PanelSection>
+  );
+};

--- a/src/components/MigrationConflictModal.tsx
+++ b/src/components/MigrationConflictModal.tsx
@@ -1,0 +1,36 @@
+import { FC } from "react";
+import { ModalRoot, DialogButton } from "@decky/ui";
+
+interface MigrationConflictModalProps {
+  conflictCount: number;
+  closeModal?: () => void;
+  onChoice: (strategy: "overwrite" | "skip") => void;
+}
+
+export const MigrationConflictModal: FC<MigrationConflictModalProps> = ({
+  conflictCount,
+  closeModal,
+  onChoice,
+}) => (
+  <ModalRoot closeModal={closeModal}>
+    <div style={{ padding: "16px", minWidth: "320px" }}>
+      <div style={{ fontSize: "16px", fontWeight: "bold", color: "#fff", marginBottom: "8px" }}>
+        Files Already Exist
+      </div>
+      <div style={{ fontSize: "13px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "16px" }}>
+        {conflictCount} file(s) already exist at the destination.
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        <DialogButton onClick={() => { closeModal?.(); onChoice("overwrite"); }}>
+          Overwrite
+        </DialogButton>
+        <DialogButton onClick={() => { closeModal?.(); onChoice("skip"); }}>
+          Skip
+        </DialogButton>
+        <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
+          Cancel
+        </DialogButton>
+      </div>
+    </div>
+  </ModalRoot>
+);

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -41,6 +41,7 @@ import { getMigrationState, onMigrationChange, setMigrationStatus } from "../uti
 import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
+import { MigrationBlockedCard } from "./MigrationBlockedCard";
 
 interface RomMGameInfoPanelProps {
   appId: number;
@@ -132,11 +133,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     slotsLoading: false,
   });
   const romIdRef = useRef<number | null>(null);
-  const [migrationPending, setMigrationPending] = useState(getMigrationState().pending);
+  const [migration, setMigration] = useState(getMigrationState());
   const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);
 
   useEffect(() => {
-    const unsub = onMigrationChange(() => setMigrationPending(getMigrationState().pending));
+    const unsub = onMigrationChange(() => setMigration(getMigrationState()));
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortPending(getSaveSortMigrationState().pending));
     return () => { unsub(); unsubSaveSort(); };
   }, []);
@@ -477,6 +478,15 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       "div",
       { "data-romm": "true" },
       createElement(VersionErrorCard, { message: versionError }),
+    );
+  }
+
+  // --- Pending RetroDECK migration — block the page until resolved ---
+  if (migration.pending) {
+    return createElement(
+      "div",
+      { "data-romm": "true" },
+      createElement(MigrationBlockedCard, {}),
     );
   }
 
@@ -956,27 +966,6 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     }
   }
 
-  // --- Migration warning (when path change pending) ---
-  const migrationWarning = migrationPending
-    ? createElement("div", {
-        key: "migration-warning",
-        style: {
-          padding: "8px 12px",
-          marginBottom: "12px",
-          backgroundColor: "rgba(212, 167, 44, 0.15)",
-          borderLeft: "3px solid #d4a72c",
-          borderRadius: "4px",
-        },
-      },
-        createElement("div", {
-          style: { fontSize: "13px", fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" },
-        }, "\u26A0\uFE0F RetroDECK location changed"),
-        createElement("div", {
-          style: { fontSize: "12px", color: "rgba(255, 255, 255, 0.7)" },
-        }, "File paths may be incorrect. Go to Settings to migrate files."),
-      )
-    : null;
-
   const saveSortWarning = saveSortPending
     ? createElement("div", {
         key: "save-sort-warning",
@@ -1046,7 +1035,6 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   }
 
   return createElement("div", { "data-romm": "true" },
-    migrationWarning,
     saveSortWarning,
     tabBar,
     createElement(Focusable as any, {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -200,6 +200,7 @@ function computeSaveSyncDisplay(saveStatus: SaveStatus | null): { status: "synce
 
 import { setRommConnectionState, setVersionError } from "../utils/connectionState";
 import { useVersionError } from "./VersionErrorCard";
+import { useMigrationStatus } from "./MigrationBlockedPage";
 
 /** Extract BIOS fields from a bios_status response into an InfoState partial. */
 function extractBiosInfo(b: BiosStatus): Partial<InfoState> {
@@ -250,6 +251,7 @@ function refreshBiosInBackground(
 export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
+  const migration = useMigrationStatus();
 
   // Read playtime from Steam's own overview synchronously (already written by metadataPatches)
   // This avoids an unnecessary render from setting it inside the async effect.
@@ -751,6 +753,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
 
   // Version mismatch — render nothing (VersionErrorCard is shown in RomMGameInfoPanel instead)
   if (versionError) {
+    return null;
+  }
+
+  // Pending RetroDECK migration — render nothing (MigrationBlockedCard is shown in RomMGameInfoPanel instead)
+  if (migration.pending) {
     return null;
   }
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -8,7 +8,6 @@ import {
   DropdownItem,
   DialogButton,
   ConfirmModal,
-  ModalRoot,
   showModal,
   ToggleField,
 } from "@decky/ui";
@@ -21,8 +20,6 @@ import {
   verifySgdbApiKey,
   saveSteamInputSetting,
   applySteamInputSetting,
-  getMigrationStatus,
-  migrateRetroDeckFiles,
   getSaveSyncSettings,
   updateSaveSyncSettings,
   syncAllSaves,
@@ -35,8 +32,7 @@ import {
   dismissSaveSortMigration,
   logError,
 } from "../api/backend";
-import type { MigrationStatus, SaveSortMigrationStatus, RegisteredDevice } from "../api/backend";
-import { getMigrationState, setMigrationStatus, clearMigration, onMigrationChange } from "../utils/migrationStore";
+import type { SaveSortMigrationStatus, RegisteredDevice } from "../api/backend";
 import { getSaveSortMigrationState, setSaveSortMigrationStatus as setStoreSaveSortStatus, clearSaveSortMigration, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
 import type { SaveSyncSettings as SaveSyncSettingsType, ConflictMode, RetroArchInputCheck } from "../types";
 
@@ -57,34 +53,6 @@ function formatRelativeTime(isoStr: string | null): string {
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
   return `${d} ${months[date.getMonth()]}`;
 }
-
-const MigrationConflictModal: FC<{
-  conflictCount: number;
-  closeModal?: () => void;
-  onChoice: (strategy: "overwrite" | "skip") => void;
-}> = ({ conflictCount, closeModal, onChoice }) => (
-  <ModalRoot closeModal={closeModal}>
-    <div style={{ padding: "16px", minWidth: "320px" }}>
-      <div style={{ fontSize: "16px", fontWeight: "bold", color: "#fff", marginBottom: "8px" }}>
-        Files Already Exist
-      </div>
-      <div style={{ fontSize: "13px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "16px" }}>
-        {conflictCount} file(s) already exist at the destination.
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-        <DialogButton onClick={() => { closeModal?.(); onChoice("overwrite"); }}>
-          Overwrite
-        </DialogButton>
-        <DialogButton onClick={() => { closeModal?.(); onChoice("skip"); }}>
-          Skip
-        </DialogButton>
-        <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
-          Cancel
-        </DialogButton>
-      </div>
-    </div>
-  </ModalRoot>
-);
 
 const SHARED_ACCOUNT_NAMES = new Set(["admin", "romm", "user", "guest", "root"]);
 
@@ -166,11 +134,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const [retroarchWarning, setRetroarchWarning] = useState<RetroArchInputCheck | null>(null);
   const [retroarchFixStatus, setRetroarchFixStatus] = useState("");
 
-  // Migration state
-  const [migration, setMigration] = useState<MigrationStatus>(getMigrationState());
-  const [migrating, setMigrating] = useState(false);
-  const [migrateResult, setMigrateResult] = useState("");
-
   // Save sort migration state
   const [saveSortMigration, setSaveSortMigration] = useState<SaveSortMigrationStatus>(getSaveSortMigrationState());
   const [saveSortMigrating, setSaveSortMigrating] = useState(false);
@@ -197,14 +160,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setStatus("Failed to load settings");
     });
 
-    // Load fresh migration status with file counts
-    getMigrationStatus().then((s) => {
-      if (s.pending) {
-        setMigrationStatus(s);
-        setMigration(s);
-      }
-    }).catch(() => {});
-
     // Load save sync settings and conflicts
     getSaveSyncSettings()
       .then((settings) => {
@@ -229,9 +184,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       }
     }).catch(() => {});
 
-    const unsubMigration = onMigrationChange(() => setMigration(getMigrationState()));
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
-    return () => { unsubMigration(); unsubSaveSort(); };
+    return () => { unsubSaveSort(); };
   }, []);
 
   const loadDevices = () => {
@@ -382,81 +336,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
           </ButtonItem>
         </PanelSectionRow>
       </PanelSection>
-      {migration.pending && (
-        <PanelSection title="Path Migration">
-          <PanelSectionRow>
-            <div style={{ padding: "8px 12px", backgroundColor: "rgba(212, 167, 44, 0.15)", borderLeft: "3px solid #d4a72c", borderRadius: "4px" }}>
-              <div style={{ fontSize: "13px", fontWeight: "bold", color: "#d4a72c", marginBottom: "6px" }}>
-                {"\u26A0\uFE0F"} RetroDECK location changed
-              </div>
-              <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "4px" }}>
-                From: {migration.old_path ?? "unknown"}
-              </div>
-              <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", marginBottom: "4px" }}>
-                To: {migration.new_path ?? "unknown"}
-              </div>
-              <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.9)" }}>
-                {migration.roms_count ?? 0} ROM(s), {migration.bios_count ?? 0} BIOS, {migration.saves_count ?? 0} save(s) to migrate
-              </div>
-            </div>
-          </PanelSectionRow>
-          <PanelSectionRow>
-            <ButtonItem
-              layout="below"
-              disabled={migrating}
-              onClick={async () => {
-                setMigrating(true);
-                setMigrateResult("");
-                try {
-                  const result = await migrateRetroDeckFiles(null);
-                  if (result.needs_confirmation) {
-                    setMigrating(false);
-                    showModal(
-                      <MigrationConflictModal
-                        conflictCount={result.conflict_count ?? 0}
-                        onChoice={async (strategy) => {
-                          setMigrating(true);
-                          try {
-                            const r = await migrateRetroDeckFiles(strategy);
-                            setMigrateResult(r.message);
-                            if (r.success) {
-                              clearMigration();
-                              toaster.toast({
-                                title: "RomM Sync",
-                                body: r.message || "Migration complete.",
-                              });
-                            }
-                          } catch { setMigrateResult("Migration failed"); }
-                          setMigrating(false);
-                        }}
-                      />
-                    );
-                    return;
-                  }
-                  setMigrateResult(result.message);
-                  if (result.success) {
-                    clearMigration();
-                    toaster.toast({
-                      title: "RomM Sync",
-                      body: result.message || "Migration complete.",
-                    });
-                  }
-                } catch {
-                  setMigrateResult("Migration failed");
-                }
-                setMigrating(false);
-              }}
-            >
-              {migrating ? "Migrating..." : "Migrate Files"}
-            </ButtonItem>
-          </PanelSectionRow>
-          {migrateResult && (
-            <PanelSectionRow>
-              <Field label={migrateResult} />
-            </PanelSectionRow>
-          )}
-        </PanelSection>
-      )}
       {saveSortMigration.pending && (
         <PanelSection title="Save Sort Migration">
           <PanelSectionRow>

--- a/src/components/VersionErrorCard.tsx
+++ b/src/components/VersionErrorCard.tsx
@@ -1,6 +1,6 @@
 import { FC, createElement, useEffect, useState } from "react";
-import { FaExclamationTriangle } from "react-icons/fa";
 import { getVersionError, onVersionErrorChange } from "../utils/connectionState";
+import { WarningCard } from "./WarningCard";
 
 /**
  * Subscribe to version error state changes.
@@ -19,49 +19,5 @@ interface VersionErrorCardProps {
 }
 
 /** Polished error card shown when server version is below plugin minimum. */
-export const VersionErrorCard: FC<VersionErrorCardProps> = ({ message, compact = false }) => {
-  return createElement(
-    "div",
-    {
-      style: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: compact ? "24px 16px" : "40px 32px",
-        gap: "14px",
-        textAlign: "center",
-        background: "rgba(14, 20, 27, 0.55)",
-        border: "1px solid rgba(255, 170, 0, 0.35)",
-        borderRadius: "6px",
-        margin: compact ? "8px 4px" : "24px 2.8vw",
-      },
-    },
-    createElement(FaExclamationTriangle, {
-      style: { color: "#ffaa00", fontSize: compact ? "28px" : "42px" },
-    }),
-    createElement(
-      "div",
-      {
-        style: {
-          fontSize: compact ? "15px" : "19px",
-          fontWeight: 600,
-          color: "rgba(255, 255, 255, 0.95)",
-        },
-      },
-      "RomM Server Update Required",
-    ),
-    createElement(
-      "div",
-      {
-        style: {
-          fontSize: compact ? "12px" : "14px",
-          color: "rgba(255, 255, 255, 0.75)",
-          maxWidth: compact ? "100%" : "680px",
-          lineHeight: 1.5,
-        },
-      },
-      message,
-    ),
-  );
-};
+export const VersionErrorCard: FC<VersionErrorCardProps> = ({ message, compact = false }) =>
+  createElement(WarningCard, { title: "RomM Server Update Required", message, compact });

--- a/src/components/WarningCard.tsx
+++ b/src/components/WarningCard.tsx
@@ -1,0 +1,57 @@
+import { FC, createElement } from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
+
+interface WarningCardProps {
+  title: string;
+  message: string;
+  /** Compact mode for narrow contexts (QAM panel). */
+  compact?: boolean;
+}
+
+/** Shared warning card layout: amber-bordered panel with icon, title and message. */
+export const WarningCard: FC<WarningCardProps> = ({ title, message, compact = false }) => {
+  return createElement(
+    "div",
+    {
+      style: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: compact ? "24px 16px" : "40px 32px",
+        gap: "14px",
+        textAlign: "center",
+        background: "rgba(14, 20, 27, 0.55)",
+        border: "1px solid rgba(255, 170, 0, 0.35)",
+        borderRadius: "6px",
+        margin: compact ? "8px 4px" : "24px 2.8vw",
+      },
+    },
+    createElement(FaExclamationTriangle, {
+      style: { color: "#ffaa00", fontSize: compact ? "28px" : "42px" },
+    }),
+    createElement(
+      "div",
+      {
+        style: {
+          fontSize: compact ? "15px" : "19px",
+          fontWeight: 600,
+          color: "rgba(255, 255, 255, 0.95)",
+        },
+      },
+      title,
+    ),
+    createElement(
+      "div",
+      {
+        style: {
+          fontSize: compact ? "12px" : "14px",
+          color: "rgba(255, 255, 255, 0.75)",
+          maxWidth: compact ? "100%" : "680px",
+          lineHeight: 1.5,
+        },
+      },
+      message,
+    ),
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,16 +131,13 @@ export default definePlugin(() => {
     }
   })();
 
-  // Check for pending RetroDECK path migration on startup
+  // Check for pending RetroDECK path migration on startup. The QAM block page
+  // and game-detail card surface this to the user — no toast needed.
   (async () => {
     try {
       const status = await getMigrationStatus();
       if (status.pending) {
         setMigrationStatus(status);
-        toaster.toast({
-          title: "RomM Sync",
-          body: "RetroDECK location changed. Go to Settings to migrate files.",
-        });
       }
     } catch (e) {
       logError(`Failed to check migration status: ${e}`);
@@ -315,13 +312,20 @@ export default definePlugin(() => {
     }
   );
 
-  const pathChangedListener = addEventListener<[{ old_path: string; new_path: string }]>(
+  const pathChangedListener = addEventListener<[{ old_path: string; new_path: string; cleared?: boolean }]>(
     "retrodeck_path_changed",
-    () => {
-      toaster.toast({
-        title: "RomM Sync",
-        body: "RetroDECK location changed. Go to Settings to migrate files.",
-      });
+    (data) => {
+      // Backend auto-clears the migration when the new path matches a previous
+      // RetroDECK home (round-trip / branch reset). Drop the pending block so
+      // all subscribers re-render without the migration UI.
+      if (data.cleared) {
+        setMigrationStatus({ pending: false });
+        return;
+      }
+      // Path actually changed — refetch authoritative status (file counts).
+      getMigrationStatus()
+        .then((status) => setMigrationStatus(status))
+        .catch((e) => logError(`Failed to refresh migration status: ${e}`));
     },
   );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,6 +152,7 @@ export interface SyncPreview {
   changed_names: string[];
   preview_id: string;
   message?: string;
+  blocked_by_migration?: boolean;
 }
 
 export interface SyncChangedItem extends SyncAddItem {
@@ -235,6 +236,7 @@ export interface FirmwareDownloadResult {
   file_path?: string;
   md5_match?: boolean | null;
   downloaded?: number;
+  blocked_by_migration?: boolean;
 }
 
 export interface RomMetadata {

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -8,7 +8,7 @@
 import { toaster } from "@decky/api";
 import { isRomMAppId } from "../patches/gameDetailPatch";
 import { getInstalledRom, getSaveStatus, getSaveSyncSettings, refreshMigrationState, logInfo, logError } from "../api/backend";
-import { setMigrationStatus } from "./migrationStore";
+import { getMigrationState, setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { hasAnySaveConflict } from "./saveStatus";
 
@@ -22,9 +22,23 @@ export function registerLaunchInterceptor(): void {
       const appId = parseInt(appIdStr, 10);
       if (isNaN(appId) || !isRomMAppId(appId)) return;
 
+      // Block launch if a RetroDECK migration is pending. Backend also blocks
+      // via @migration_blocked, but cancelling the Steam action here prevents
+      // Steam from even trying to start the game.
+      if (getMigrationState().pending) {
+        SteamClient.Apps.CancelGameAction(gameActionId);
+        toaster.toast({
+          title: "RomM Sync",
+          body: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+        });
+        return;
+      }
+
       // Fire-and-forget migration refresh — picks up RetroArch sort setting
       // changes made via the in-game Quick Menu before the previous session.
       // Must not block the launch: the user pressing Play means "launch now".
+      // Exception: pending RetroDECK migration is handled above as an explicit
+      // block, because the alternative is silent save-data loss.
       refreshMigrationState()
         .then(({ retrodeck, save_sort }) => {
           setMigrationStatus(retrodeck);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,13 @@ sys.modules["decky"] = mock_decky
 
 
 def _make_testable_plugin():
-    """Return a TestablePlugin instance with test-only attributes declared."""
+    """Return a TestablePlugin instance with test-only attributes declared.
+
+    Pre-populates ``_migration_service`` with a non-pending MagicMock so the
+    ``@migration_blocked`` decorator does not raise AttributeError in tests
+    that don't otherwise wire migration state. Tests that exercise the
+    block can override ``is_retrodeck_migration_pending`` per-test.
+    """
     # Import here to ensure decky mock is already installed
     from main import Plugin
 
@@ -60,7 +66,10 @@ def _make_testable_plugin():
         _fake_api: Any
         _resolve_system: Any
 
-    return TestablePlugin()
+    instance = TestablePlugin()
+    instance._migration_service = MagicMock()
+    instance._migration_service.is_retrodeck_migration_pending.return_value = False
+    return instance
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lib/test_migration_gate.py
+++ b/tests/lib/test_migration_gate.py
@@ -1,0 +1,155 @@
+"""Direct unit tests for the @migration_blocked decorator.
+
+The decorator wraps Decky callables on Plugin so they short-circuit with a
+blocked-dict whenever ``self._migration_service.is_retrodeck_migration_pending()``
+is True. Tests use a minimal fake class with a ``_migration_service`` attribute
+to keep them independent from the full Plugin.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.migration_gate import migration_blocked
+
+
+class _FakeMigrationService:
+    def __init__(self, pending: bool):
+        self._pending = pending
+
+    def is_retrodeck_migration_pending(self) -> bool:
+        return self._pending
+
+
+class _FakeOwner:
+    def __init__(self, pending: bool, ret=None, raise_exc: BaseException | None = None):
+        self._migration_service = _FakeMigrationService(pending)
+        self._ret = ret
+        self._raise = raise_exc
+        self.calls: list[tuple[tuple, dict]] = []
+
+    @migration_blocked
+    async def do_thing(self, *args, **kwargs):
+        """Demo docstring used to verify @functools.wraps preservation."""
+        self.calls.append((args, kwargs))
+        if self._raise is not None:
+            raise self._raise
+        return self._ret
+
+
+class TestMigrationBlockedDecorator:
+    @pytest.mark.asyncio
+    async def test_returns_blocked_dict_when_pending(self):
+        owner = _FakeOwner(pending=True, ret={"success": True, "data": "real"})
+        result = await owner.do_thing()
+        assert result == {
+            "success": False,
+            "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+            "blocked_by_migration": True,
+        }
+        assert owner.calls == []  # wrapped method NOT invoked
+
+    @pytest.mark.asyncio
+    async def test_passes_args_kwargs_when_not_pending(self):
+        owner = _FakeOwner(pending=False, ret={"success": True})
+        await owner.do_thing(1, 2, key="value")
+        assert owner.calls == [((1, 2), {"key": "value"})]
+
+    @pytest.mark.asyncio
+    async def test_preserves_inner_return_value_when_not_pending(self):
+        sentinel = {"success": True, "payload": [1, 2, 3]}
+        owner = _FakeOwner(pending=False, ret=sentinel)
+        result = await owner.do_thing()
+        assert result is sentinel  # exact pass-through, no mutation
+
+    def test_marks_wrapper_with_migration_blocked_attribute(self):
+        assert getattr(_FakeOwner.do_thing, "_migration_blocked", False) is True
+
+    @pytest.mark.asyncio
+    async def test_works_on_async_def_method(self):
+        """Ensures the wrapper awaits correctly — would TypeError otherwise."""
+        owner = _FakeOwner(pending=False, ret="awaited-value")
+        result = await owner.do_thing()
+        assert result == "awaited-value"
+
+    @pytest.mark.asyncio
+    async def test_blocked_dict_overrides_non_dict_inner_return(self):
+        """Contract: when pending, the wrapper ALWAYS returns the blocked-dict
+        regardless of the inner method's return type. Documented behavior so
+        callers can branch on ``blocked_by_migration`` uniformly."""
+
+        class _OwnerWithTupleReturn:
+            def __init__(self):
+                self._migration_service = _FakeMigrationService(pending=True)
+
+            @migration_blocked
+            async def returns_tuple(self):
+                return (1, 2, 3)
+
+        class _OwnerWithNoneReturn:
+            def __init__(self):
+                self._migration_service = _FakeMigrationService(pending=True)
+
+            @migration_blocked
+            async def returns_none(self):
+                return None
+
+        class _OwnerWithListReturn:
+            def __init__(self):
+                self._migration_service = _FakeMigrationService(pending=True)
+
+            @migration_blocked
+            async def returns_list(self):
+                return [1, 2, 3]
+
+        for owner_cls, attr in (
+            (_OwnerWithTupleReturn, "returns_tuple"),
+            (_OwnerWithNoneReturn, "returns_none"),
+            (_OwnerWithListReturn, "returns_list"),
+        ):
+            result = await getattr(owner_cls(), attr)()
+            assert isinstance(result, dict)
+            assert result["blocked_by_migration"] is True
+            assert result["success"] is False
+
+    def test_preserves_function_metadata_via_wraps(self):
+        """@functools.wraps copies __name__ and __doc__ onto the wrapper so
+        introspection (and test reporters) see the original method."""
+        assert _FakeOwner.do_thing.__name__ == "do_thing"
+        assert _FakeOwner.do_thing.__doc__ == ("Demo docstring used to verify @functools.wraps preservation.")
+
+    @pytest.mark.asyncio
+    async def test_decorator_no_op_when_migration_service_missing(self):
+        """Defensive path: if _migration_service is absent, the wrapper must
+        still call through to the wrapped method instead of raising."""
+
+        class _OwnerWithoutService:
+            @migration_blocked
+            async def do(self):
+                return "ok"
+
+        result = await _OwnerWithoutService().do()
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_returns_blocked_dict_using_mock_service(self):
+        """Mock-based variant of the pending check — confirms the wrapper
+        uses ``is_retrodeck_migration_pending`` exactly once per call."""
+
+        class _Owner:
+            def __init__(self, svc):
+                self._migration_service = svc
+
+            @migration_blocked
+            async def do(self):
+                return "real-call"
+
+        svc = MagicMock()
+        svc.is_retrodeck_migration_pending.return_value = True
+        owner = _Owner(svc)
+        result = cast(dict[str, Any], await owner.do())
+        assert result["blocked_by_migration"] is True
+        svc.is_retrodeck_migration_pending.assert_called_once_with()

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -571,6 +571,53 @@ class TestDownloadRequestPolling:
         assert len(requests) == 2
 
 
+class TestPollDownloadRequestsMigrationPause:
+    """Verify the poll loop pauses (does NOT read+clear the request file)
+    while a RetroDECK migration is pending — would otherwise drop queued
+    download requests on the floor (#251)."""
+
+    @pytest.mark.asyncio
+    async def test_poll_download_requests_pauses_when_migration_pending(self, plugin, tmp_path):
+        plugin._download_service._runtime_dir = str(tmp_path)
+        plugin._download_service._is_retrodeck_migration_pending = lambda: True
+
+        requests_path = tmp_path / "download_requests.json"
+        original_payload = [{"rom_id": 42}, {"rom_id": 99}]
+        requests_path.write_text(json.dumps(original_payload))
+
+        # Stub asyncio.sleep so we can run a single iteration deterministically:
+        # first call sleeps normally (returns immediately), second call cancels
+        # the loop so we exit after one pass.
+        sleep_calls = [0]
+
+        async def fake_sleep(_seconds):
+            sleep_calls[0] += 1
+            if sleep_calls[0] >= 2:
+                raise asyncio.CancelledError()
+
+        # Track whether the request file IO was invoked.
+        io_called = [False]
+        original_io = plugin._download_service._poll_download_requests_io
+
+        def tracking_io(path):
+            io_called[0] = True
+            return original_io(path)
+
+        plugin._download_service._poll_download_requests_io = tracking_io
+
+        with (
+            patch("services.downloads.asyncio.sleep", side_effect=fake_sleep),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await plugin._download_service.poll_download_requests()
+
+        # IO must NOT have been called while migration was pending.
+        assert io_called[0] is False
+        # Request file must still hold its original contents — not truncated.
+        with open(requests_path) as f:
+            assert json.load(f) == original_payload
+
+
 class TestMultiFileRomDeletion:
     @pytest.mark.asyncio
     async def test_remove_rom_deletes_rom_dir(self, plugin, tmp_path):

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -80,6 +80,10 @@ def plugin():
         save_state=p._save_state,
         remove_artwork_files=artwork_service.remove_artwork_files,
     )
+    # Default migration service mock — no migration pending. Tests that need
+    # to exercise the @migration_blocked gate override this.
+    p._migration_service = MagicMock()
+    p._migration_service.is_retrodeck_migration_pending.return_value = False
     return p
 
 

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -177,6 +177,117 @@ class TestPathChangeDetection:
         mock_loop.create_task.assert_not_called()
         assert plugin._state["retrodeck_home_path"] == ""
 
+    def test_detect_path_change_auto_clears_when_reverted_to_previous(self, plugin, tmp_path):
+        """User reverted RetroDECK to the previous home — drop the marker, no event."""
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        old_home = str(tmp_path / "old_retrodeck")
+        new_home = str(tmp_path / "new_retrodeck")
+        os.makedirs(old_home, exist_ok=True)
+
+        plugin._state["retrodeck_home_path"] = new_home
+        plugin._state["retrodeck_home_path_previous"] = old_home
+
+        mock_loop = MagicMock()
+        plugin._migration_service._loop = mock_loop
+
+        plugin._migration_service._get_retrodeck_home = MagicMock(return_value=old_home)
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        assert plugin._state["retrodeck_home_path"] == old_home
+        assert "retrodeck_home_path_previous" not in plugin._state
+
+    def test_detect_path_change_auto_clear_emits_cleared_event(self, plugin, tmp_path):
+        """Auto-clear MUST emit retrodeck_path_changed with cleared=True so the
+        frontend listener can dismiss any pending migration UI."""
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        old_home = str(tmp_path / "old_retrodeck")
+        new_home = str(tmp_path / "new_retrodeck")
+        os.makedirs(old_home, exist_ok=True)
+
+        plugin._state["retrodeck_home_path"] = new_home
+        plugin._state["retrodeck_home_path_previous"] = old_home
+
+        mock_loop = MagicMock()
+        emitted: list = []
+
+        def _capture_task(coro):
+            # Drive the coroutine to capture what was emitted, then close it.
+            try:
+                coro.send(None)
+            except StopIteration as e:
+                emitted.append(("returned", e.value))
+            except BaseException as e:
+                emitted.append(("raised", e))
+            coro.close()
+            return MagicMock()
+
+        mock_loop.create_task = _capture_task
+        plugin._migration_service._loop = mock_loop
+
+        # Replace _emit with a sync recorder so the coroutine resolves cleanly.
+        emit_calls: list = []
+
+        async def fake_emit(event, payload):
+            emit_calls.append((event, payload))
+
+        plugin._migration_service._emit = fake_emit  # type: ignore[method-assign]
+
+        plugin._migration_service._get_retrodeck_home = MagicMock(return_value=old_home)
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        assert len(emit_calls) == 1
+        event, payload = emit_calls[0]
+        assert event == "retrodeck_path_changed"
+        assert payload["cleared"] is True
+        assert payload["old_path"] == old_home
+        assert payload["new_path"] == old_home
+
+
+class TestIsRetroDeckMigrationPending:
+    def test_is_retrodeck_migration_pending_returns_false_when_unset(self, plugin):
+        plugin._state.pop("retrodeck_home_path_previous", None)
+        assert plugin._migration_service.is_retrodeck_migration_pending() is False
+
+    def test_is_retrodeck_migration_pending_returns_true_when_set(self, plugin):
+        plugin._state["retrodeck_home_path_previous"] = "/some/old/path"
+        assert plugin._migration_service.is_retrodeck_migration_pending() is True
+
+    def test_is_retrodeck_migration_pending_returns_false_for_empty_string(self, plugin):
+        plugin._state["retrodeck_home_path_previous"] = ""
+        assert plugin._migration_service.is_retrodeck_migration_pending() is False
+
+
+class TestDismissRetroDeckMigration:
+    def test_dismiss_retrodeck_migration_clears_marker(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        plugin._state["retrodeck_home_path_previous"] = "/old/path"
+
+        result = plugin._migration_service.dismiss_retrodeck_migration()
+
+        assert result == {"success": True}
+        assert "retrodeck_home_path_previous" not in plugin._state
+
+    def test_dismiss_retrodeck_migration_idempotent_when_no_marker(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        plugin._state.pop("retrodeck_home_path_previous", None)
+
+        result = plugin._migration_service.dismiss_retrodeck_migration()
+
+        assert result == {"success": True}
+        assert "retrodeck_home_path_previous" not in plugin._state
+
 
 class TestMigrateRetroDeckFiles:
     @pytest.mark.asyncio

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -837,6 +837,63 @@ class TestPreLaunchSync:
         assert order.index("detect") < order.index("gate")
 
 
+class TestRetroDeckMigrationBlocksSaveSync:
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
+        svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["success"] is False
+        assert result["blocked_by_migration"] is True
+        assert result["synced"] == 0
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
+        svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"data")
+
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is False
+        assert result["blocked_by_migration"] is True
+        assert result["synced"] == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_respects_migration_block_via_decorator_chain(self, tmp_path):
+        """End-to-end chain check: Plugin.sync_all_saves must be blocked by the
+        @migration_blocked decorator before SaveService.sync_all_saves runs, so
+        the internal _sync_rom_saves call path is never reached when migration
+        is pending. Protects against accidental decorator removal at the public
+        callable layer."""
+        from main import Plugin
+
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state["device_id"] = "test-device"
+        _install_rom(svc, tmp_path)
+
+        plugin = Plugin()
+        plugin._save_sync_service = svc
+        plugin._migration_service = MagicMock()
+        plugin._migration_service.is_retrodeck_migration_pending.return_value = True
+
+        spy = MagicMock(name="_sync_rom_saves_spy")
+        svc._sync_rom_saves = spy  # type: ignore[method-assign]
+
+        result = await plugin.sync_all_saves()
+
+        assert result["blocked_by_migration"] is True
+        assert result["success"] is False
+        spy.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # TestPostExitSync
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -252,6 +252,31 @@ class TestWireServices:
         assert save_sync_service._state is migration_service._state
         deps["loop"].close()
 
+    def test_save_service_receives_is_retrodeck_migration_pending(self, tmp_path):
+        """Regression test for #251: SaveService must receive the bound
+        ``migration_service.is_retrodeck_migration_pending`` callback so
+        pre_launch_sync / post_exit_sync can short-circuit while the user
+        still has files at the previous RetroDECK home."""
+        deps = self._make_deps(tmp_path)
+        result = wire_services(WiringConfig(**deps))
+        save_sync_service = result["save_sync_service"]
+        migration_service = result["migration_service"]
+        assert save_sync_service._is_retrodeck_migration_pending == migration_service.is_retrodeck_migration_pending
+        assert save_sync_service._is_retrodeck_migration_pending.__self__ is migration_service  # type: ignore[union-attr]
+        deps["loop"].close()
+
+    def test_download_service_receives_is_retrodeck_migration_pending(self, tmp_path):
+        """Regression test for #251: DownloadService must receive the bound
+        ``migration_service.is_retrodeck_migration_pending`` callback so
+        the download poll loop pauses while a migration is pending."""
+        deps = self._make_deps(tmp_path)
+        result = wire_services(WiringConfig(**deps))
+        download_service = result["download_service"]
+        migration_service = result["migration_service"]
+        assert download_service._is_retrodeck_migration_pending == migration_service.is_retrodeck_migration_pending
+        assert download_service._is_retrodeck_migration_pending.__self__ is migration_service  # type: ignore[union-attr]
+        deps["loop"].close()
+
     def test_save_sync_detect_sort_change_mutates_shared_state(self, tmp_path):
         """Functional check for #238: invoking the wired detect callback
         from SaveService updates state that SaveService subsequently

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,6 +27,10 @@ def plugin():
     # return a non-existent path or empty string.
     p._retrodeck_paths = MagicMock()
     p._retrodeck_paths.get_retrodeck_home.return_value = "/tmp"
+    # Default migration service mock — no migration pending. Tests that need
+    # to exercise the @migration_blocked gate override this.
+    p._migration_service = MagicMock()
+    p._migration_service.is_retrodeck_migration_pending.return_value = False
 
     import decky
 
@@ -549,6 +553,106 @@ class TestPruneStaleStateEdgeCases:
         plugin._prune_stale_installed_roms()
         assert "1" in plugin._state["installed_roms"]
 
+    def test_skip_preserves_entry_at_old_home_during_migration(self, plugin, tmp_path):
+        """Pending migration: entries living under old home are preserved (#251)."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
+        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
+        plugin._state["retrodeck_home_path_previous"] = "/run/media/old/retrodeck"
+
+        plugin._state["installed_roms"] = {
+            "1": {
+                "rom_id": 1,
+                "file_path": "/run/media/old/retrodeck/roms/n64/zelda.z64",
+                "system": "n64",
+            },
+            "2": {
+                "rom_id": 2,
+                "file_path": "/run/media/old/retrodeck/roms/psx/FF7/FF7.m3u",
+                "rom_dir": "/run/media/old/retrodeck/roms/psx/FF7",
+                "system": "psx",
+            },
+        }
+
+        plugin._prune_stale_installed_roms()
+        assert "1" in plugin._state["installed_roms"]
+        assert "2" in plugin._state["installed_roms"]
+
+    def test_skip_does_not_preserve_unrelated_path(self, plugin, tmp_path):
+        """Pending migration: ``old_home="/foo"`` does NOT preserve entry at ``/foobar/x``.
+
+        Path comparison must use the trailing separator to avoid prefix
+        false matches like /foo matching /foobar.
+        """
+        import decky
+
+        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
+        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
+        plugin._state["retrodeck_home_path_previous"] = "/foo"
+
+        plugin._state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/foobar/x.z64", "system": "n64"},
+        }
+
+        plugin._prune_stale_installed_roms()
+        # /foobar/x is NOT under /foo (with separator), file does not exist → pruned.
+        assert "1" not in plugin._state["installed_roms"]
+
+    def test_skip_does_not_fire_when_old_home_is_empty(self, plugin, tmp_path):
+        """No migration marker — prune behaves normally."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
+        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
+        plugin._state.pop("retrodeck_home_path_previous", None)
+
+        plugin._state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/gone/a.z64", "system": "n64"},
+        }
+
+        plugin._prune_stale_installed_roms()
+        assert "1" not in plugin._state["installed_roms"]
+
+    def test_skip_clears_after_migration_completes(self, plugin, tmp_path):
+        """After migration completes (marker dropped), normal prune behavior resumes."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
+        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
+
+        # First pass: marker set, entry preserved.
+        plugin._state["retrodeck_home_path_previous"] = "/old/retrodeck"
+        plugin._state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/a.z64", "system": "n64"},
+        }
+        plugin._prune_stale_installed_roms()
+        assert "1" in plugin._state["installed_roms"]
+
+        # Second pass: marker cleared (post-migration), file still missing → pruned.
+        plugin._state.pop("retrodeck_home_path_previous", None)
+        plugin._prune_stale_installed_roms()
+        assert "1" not in plugin._state["installed_roms"]
+
+    def test_skip_logs_info_when_preserving(self, plugin, tmp_path, caplog):
+        """Skip emits an info log naming the preserved rom_id and old home."""
+        import logging
+
+        import decky
+
+        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
+        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
+        plugin._state["retrodeck_home_path_previous"] = "/old/retrodeck"
+
+        plugin._state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/a.z64", "system": "n64"},
+        }
+
+        with caplog.at_level(logging.INFO):
+            plugin._prune_stale_installed_roms()
+
+        assert any("Skipping prune" in rec.message and "/old/retrodeck" in rec.message for rec in caplog.records)
+
 
 class TestAtomicSettingsWrite:
     def test_settings_written_atomically(self, plugin, tmp_path):
@@ -771,6 +875,273 @@ class TestRefreshMigrationState:
         await plugin.refresh_migration_state()
         ordered = [name for name, _args, _kwargs in manager.mock_calls]
         assert ordered == ["detect_retrodeck_path_change", "detect_save_sort_change"]
+
+
+_MIGRATION_BLOCKED_WHITELIST: set[str] = {
+    # Migration management itself (the unblock pathway must work while pending).
+    "migrate_retrodeck_files",
+    "get_migration_status",
+    "get_save_sort_migration_status",
+    "migrate_save_sort_files",
+    "dismiss_save_sort_migration",
+    "dismiss_retrodeck_migration",
+    "refresh_migration_state",
+    # Connection / settings (read-only or non-retrodeck).
+    "test_connection",
+    "get_romm_version",
+    "save_settings",
+    "get_settings",
+    "get_whitelist_settings",
+    "update_whitelist_settings",
+    "save_collection_platform_groups",
+    # Cancel operations — must remain callable mid-operation when migration
+    # marker fires so the user can stop in-flight work.
+    "cancel_sync",
+    "sync_cancel_preview",
+    "cancel_download",
+    # Frontend logging / diagnostic helpers.
+    "frontend_log",
+    "debug_log",
+    "save_log_level",
+    "save_steam_input_setting",
+    "apply_steam_input_setting",
+    "fix_retroarch_input_driver",
+    # Read-only library / sync state queries.
+    "get_cached_game_detail",
+    "get_available_cores",
+    "get_platforms",
+    "get_collections",
+    "get_sync_progress",
+    "sync_heartbeat",
+    "report_sync_results",
+    "get_registry_platforms",
+    "report_removal_results",
+    "get_artwork_base64",
+    "get_sync_stats",
+    "get_rom_by_steam_app_id",
+    "get_download_queue",
+    "get_installed_rom",
+    # Firmware / BIOS read-only checks.
+    "get_firmware_status",
+    "check_platform_bios",
+    "get_bios_status",
+    # Save sync read-only / device queries.
+    "ensure_device_registered",
+    "list_devices",
+    "get_save_status",
+    "check_core_change",
+    "get_save_slots",
+    "get_slot_saves",
+    "get_slot_delete_info",
+    "is_save_tracking_configured",
+    "get_save_setup_info",
+    "get_save_sync_settings",
+    "saves_list_file_versions",
+    # Playtime queries.
+    "record_session_start",
+    "record_session_end",
+    "get_server_playtime",
+    "get_all_playtime",
+    # SteamGridDB / Steam shortcut artwork (Steam-side, not retrodeck).
+    "get_sgdb_artwork_base64",
+    "verify_sgdb_api_key",
+    "save_sgdb_api_key",
+    "save_shortcut_icon",
+    # Metadata cache reads.
+    "get_rom_metadata",
+    "get_all_metadata_cache",
+    "get_app_id_rom_id_map",
+    # Achievements queries (server-side).
+    "get_achievements",
+    "get_achievement_progress",
+    "sync_achievements_after_session",
+}
+
+
+class TestMigrationBlockedDecoratorCoverage:
+    """Every Decky callable on Plugin must be classified: either explicitly
+    whitelisted (read-only / unblock pathway / non-retrodeck) or decorated
+    with @migration_blocked. Prevents new callables from being silently
+    unguarded against pending migration corruption (#251)."""
+
+    def test_all_callables_either_whitelisted_or_decorated(self):
+        import inspect
+
+        from main import Plugin
+
+        unclassified: list[str] = []
+        for name, value in inspect.getmembers(Plugin, predicate=inspect.iscoroutinefunction):
+            if name.startswith("_"):
+                continue  # lifecycle hooks (_main, _unload) are not callables
+            if name in _MIGRATION_BLOCKED_WHITELIST:
+                continue
+            if getattr(value, "_migration_blocked", False):
+                continue
+            unclassified.append(name)
+
+        assert not unclassified, (
+            "Unclassified async callables on Plugin — every one must be in "
+            "_MIGRATION_BLOCKED_WHITELIST or carry @migration_blocked: "
+            f"{sorted(unclassified)}"
+        )
+
+    def test_no_callable_is_both_decorated_and_whitelisted(self):
+        """A callable that is both decorated AND whitelisted is silently
+        passing the coverage check — likely a misclassification. Catch it."""
+        import inspect
+
+        from main import Plugin
+
+        double_classified: list[str] = []
+        for name, value in inspect.getmembers(Plugin, predicate=inspect.iscoroutinefunction):
+            if name.startswith("_"):
+                continue
+            if name in _MIGRATION_BLOCKED_WHITELIST and getattr(value, "_migration_blocked", False):
+                double_classified.append(name)
+
+        assert not double_classified, (
+            "Callables both whitelisted AND decorated with @migration_blocked — "
+            f"remove from one: {sorted(double_classified)}"
+        )
+
+    def test_whitelisted_callables_are_not_decorated(self):
+        """Every name in _MIGRATION_BLOCKED_WHITELIST must NOT carry the
+        @migration_blocked marker. Symmetric to the prior check, but reads
+        from the whitelist side."""
+        from main import Plugin
+
+        decorated: list[str] = []
+        for name in _MIGRATION_BLOCKED_WHITELIST:
+            method = getattr(Plugin, name, None)
+            if method is None:
+                continue
+            if getattr(method, "_migration_blocked", False) is True:
+                decorated.append(name)
+
+        assert not decorated, f"Whitelisted callables that also carry @migration_blocked: {sorted(decorated)}"
+
+
+class TestMainStartupOrdering:
+    """Lock-in test for the #251 startup-order invariant: detect_retrodeck_path_change
+    must run BEFORE _prune_stale_installed_roms so the prune skips entries living
+    under a pending migration's previous home. Brittle by design — the assertion
+    is intentionally narrow."""
+
+    @pytest.mark.asyncio
+    async def test_main_calls_detect_path_change_before_prune(self):
+        from unittest.mock import AsyncMock, patch
+
+        from main import Plugin
+
+        plugin = Plugin()
+        plugin._persistence = MagicMock()
+        plugin._persistence.load_settings.return_value = {}
+        plugin._persistence.load_state.side_effect = lambda x: x
+        plugin._persistence.load_metadata_cache.return_value = {}
+
+        call_order: list[str] = []
+
+        # Mocks for the call-order check.
+        migration_service = MagicMock()
+        migration_service.detect_retrodeck_path_change.side_effect = lambda: call_order.append(
+            "detect_retrodeck_path_change"
+        )
+        migration_service.detect_save_sort_change = MagicMock()
+
+        save_sync_service = MagicMock()
+        save_sync_service.init_state = MagicMock()
+        save_sync_service.load_state = MagicMock()
+        save_sync_service.prune_orphaned_state = MagicMock()
+
+        sgdb_service = MagicMock()
+        sgdb_service.prune_orphaned_artwork_cache = MagicMock()
+
+        artwork_service = MagicMock()
+        artwork_service.prune_orphaned_staging_artwork = MagicMock()
+
+        download_service = MagicMock()
+        download_service.cleanup_leftover_tmp_files = MagicMock()
+        download_service.poll_download_requests = AsyncMock()
+
+        firmware_service = MagicMock()
+        firmware_service.load_bios_registry = MagicMock()
+
+        wired_services = {
+            "save_sync_service": save_sync_service,
+            "playtime_service": MagicMock(),
+            "sync_service": MagicMock(),
+            "download_service": download_service,
+            "rom_removal_service": MagicMock(),
+            "firmware_service": firmware_service,
+            "sgdb_service": sgdb_service,
+            "metadata_service": MagicMock(),
+            "achievements_service": MagicMock(),
+            "migration_service": migration_service,
+            "game_detail_service": MagicMock(),
+            "artwork_service": artwork_service,
+            "shortcut_removal_service": MagicMock(),
+        }
+
+        bootstrapped_adapters = {
+            "persistence": plugin._persistence,
+            "http_adapter": MagicMock(),
+            "romm_api": MagicMock(),
+            "steam_config": MagicMock(),
+            "sgdb_adapter": MagicMock(),
+            "retrodeck_paths": MagicMock(),
+            "retroarch_config": MagicMock(),
+            "retroarch_core_info": MagicMock(),
+        }
+
+        with (
+            patch("main.bootstrap", return_value=bootstrapped_adapters),
+            patch("main.wire_services", return_value=wired_services),
+            patch.object(
+                Plugin,
+                "_prune_stale_installed_roms",
+                lambda self: call_order.append("_prune_stale_installed_roms"),
+            ),
+            patch.object(
+                Plugin,
+                "_prune_stale_registry",
+                lambda self: call_order.append("_prune_stale_registry"),
+            ),
+        ):
+            await plugin._main()
+
+        assert "detect_retrodeck_path_change" in call_order
+        assert "_prune_stale_installed_roms" in call_order
+        assert call_order.index("detect_retrodeck_path_change") < call_order.index("_prune_stale_installed_roms")
+
+
+class TestCancelCallablesNotBlockedByMigration:
+    """Cancel operations stop running work — they must remain callable when
+    a migration marker fires so the user can interrupt in-flight operations."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_sync_callable_when_migration_pending(self, plugin):
+        plugin._migration_service.is_retrodeck_migration_pending.return_value = True
+        plugin._sync_service.cancel_sync = MagicMock(return_value={"success": True, "stopped": True})
+        result = await plugin.cancel_sync()
+        assert result.get("blocked_by_migration") is not True
+        plugin._sync_service.cancel_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_cancel_preview_callable_when_migration_pending(self, plugin):
+        plugin._migration_service.is_retrodeck_migration_pending.return_value = True
+        plugin._sync_service.sync_cancel_preview = MagicMock(return_value={"success": True})
+        result = await plugin.sync_cancel_preview()
+        assert result.get("blocked_by_migration") is not True
+        plugin._sync_service.sync_cancel_preview.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_download_callable_when_migration_pending(self, plugin):
+        plugin._migration_service.is_retrodeck_migration_pending.return_value = True
+        plugin._download_service = MagicMock()
+        plugin._download_service.cancel_download = MagicMock(return_value={"success": True})
+        result = await plugin.cancel_download(42)
+        assert result.get("blocked_by_migration") is not True
+        plugin._download_service.cancel_download.assert_called_once_with(42)
 
 
 class TestMeetsMinVersion:

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -102,6 +102,11 @@ def plugin(tmp_path):
     # Store fake_api on plugin for test access
     p._fake_api = fake_api
 
+    # Default migration service mock — no migration pending. Tests that
+    # exercise the @migration_blocked gate override this.
+    p._migration_service = MagicMock()
+    p._migration_service.is_retrodeck_migration_pending.return_value = False
+
     # Enable save sync for tests — matches pre-feature-flag behavior
     p._save_sync_state["settings"]["save_sync_enabled"] = True
     return p


### PR DESCRIPTION
## Summary

Closes #251.

The original symptom — prune wiping `installed_roms` entries before migration detection ran — is fixed via reorder + skip-on-prefix. Beyond that, this PR implements a **hard block on all plugin operations** during pending RetroDECK path migration to prevent silent data divergence (mixed-state downloads, save-sync data loss when `last_sync_hash` references a different filesystem location than the current saves dir, etc.). User must migrate, dismiss, or revert RetroDECK before any sync/download/save activity resumes.

**Backend**
- `MigrationService.is_retrodeck_migration_pending()` — single state-bit check
- `@migration_blocked` decorator on mutating callables (whitelist enforced by introspection test)
- Inline guards in `pre_launch_sync` / `post_exit_sync` (defense in depth)
- `poll_download_requests` pauses (preserves pending requests)
- `dismiss_retrodeck_migration` callable (analog to existing `dismiss_save_sort_migration`)
- Auto-clear when user reverts to previous home — emits `retrodeck_path_changed` with `cleared: true` for live frontend update
- Reorder + skip + log in `_prune_stale_installed_roms` (the original data rescue, with `+ os.sep` boundary, empty-string guard, info-log)

**Frontend** (parallel to existing `VersionErrorCard` block pattern)
- `MigrationBlockedPage` (QAM) with Migrate + Dismiss buttons, revert hint
- `MigrationBlockedCard` (game detail page) with "Open QAM" hint
- `RomMPlaySection` returns null when blocked
- `launchInterceptor` cancels Steam launches with toast (belt-and-suspenders)
- `index.tsx` listener handles `cleared: true` for live block-removal
- Cleanup: removed startup toast + SettingsPage migration panel (block page owns it)

**Tests**: 1700 → 1725 (+25). New `tests/lib/test_migration_gate.py` for direct decorator coverage; bootstrap wiring tests; startup-ordering test; whitelist double-classification check; prune-skip edge cases; save-sync block; download-loop pause; cancel-callables-not-blocked.

## Test plan

- [x] All automated checks green: pytest (1725 passed), ruff, basedpyright (full scope incl. tests/), lint-imports, pnpm build, tsc
- [x] Smoke test on Steam Deck via state-file injection (`retrodeck_home_path_previous` set manually):
  - QAM shows MigrationBlockedPage with from/to paths and counts
  - Game detail shows MigrationBlockedCard
  - Settings no longer shows the migration panel
  - Steam launch of a RomM game cancelled with toast
  - Dismiss → confirmation → live UI returns to normal (no reload needed)
- [x] End-to-end real migration test:
  - Moved RetroDECK install from SD card to internal SSD
  - Plugin reload → block page shown with correct paths
  - Migrate Files succeeded; conflict modal correctly handled file present at both old + new paths
  - Post-migration state: `retrodeck_home_path_previous = None`, all tracked file paths updated to new home
  - `installed_roms` entries preserved (prune fix verified — pre-fix would have wiped them)

## Out of scope (future work)

- File detection on Download click for ROMs that exist on disk but are not in `installed_roms` — filed as #260
- Save-sync location-awareness rewrite (block prevents the loss path entirely; deferred)
- #248 boot-race issue (separate concern, handled by existing filesystem-readiness guard)