### PR TITLE
chore(saves): remove conflict_mode and clock_skew_tolerance_sec

### DIFF
--- a/py_modules/models/saves.py
+++ b/py_modules/models/saves.py
@@ -42,7 +42,6 @@ class SaveSyncSettings:
     """User-facing save sync configuration."""
 
     save_sync_enabled: bool
-    conflict_mode: str
     sync_before_launch: bool
     sync_after_exit: bool
     clock_skew_tolerance_sec: int

--- a/py_modules/models/saves.py
+++ b/py_modules/models/saves.py
@@ -44,7 +44,6 @@ class SaveSyncSettings:
     save_sync_enabled: bool
     sync_before_launch: bool
     sync_after_exit: bool
-    clock_skew_tolerance_sec: int
 
 
 @dataclass(frozen=True)

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -256,7 +256,7 @@ class SaveService:
         # Strip removed legacy settings keys. Old state files keep these
         # forever otherwise (load_state does dict.update on settings, so
         # orphan keys survive). Idempotent: pop returns None when absent.
-        settings = self._save_sync_state.get("settings", {})
+        settings = self._save_sync_state.get("settings")
         if isinstance(settings, dict):
             settings.pop("conflict_mode", None)
             settings.pop("clock_skew_tolerance_sec", None)

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -237,20 +237,29 @@ class SaveService:
         - Rename per-game ``active_core`` → ``last_synced_core``.
         - Drop legacy per-file ``dismissed_newer_save_id`` (was used by
           the removed newer-in-slot detection).
+        - Strip removed legacy settings keys (``conflict_mode``,
+          ``clock_skew_tolerance_sec``).
         """
         saves = self._save_sync_state.get("saves", {})
-        if not isinstance(saves, dict):
-            return
-        for entry in saves.values():
-            if not isinstance(entry, dict):
-                continue
-            if "active_core" in entry:
-                entry["last_synced_core"] = entry.pop("active_core")
-            files = entry.get("files", {})
-            if isinstance(files, dict):
-                for file_state in files.values():
-                    if isinstance(file_state, dict):
-                        file_state.pop("dismissed_newer_save_id", None)
+        if isinstance(saves, dict):
+            for entry in saves.values():
+                if not isinstance(entry, dict):
+                    continue
+                if "active_core" in entry:
+                    entry["last_synced_core"] = entry.pop("active_core")
+                files = entry.get("files", {})
+                if isinstance(files, dict):
+                    for file_state in files.values():
+                        if isinstance(file_state, dict):
+                            file_state.pop("dismissed_newer_save_id", None)
+
+        # Strip removed legacy settings keys. Old state files keep these
+        # forever otherwise (load_state does dict.update on settings, so
+        # orphan keys survive). Idempotent: pop returns None when absent.
+        settings = self._save_sync_state.get("settings", {})
+        if isinstance(settings, dict):
+            settings.pop("conflict_mode", None)
+            settings.pop("clock_skew_tolerance_sec", None)
 
     def load_state(self) -> None:
         """Load save sync state from disk, merging with defaults."""

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -205,7 +205,6 @@ class SaveService:
             "playtime": {},
             "settings": {
                 "save_sync_enabled": False,
-                "conflict_mode": "ask_me",
                 "sync_before_launch": True,
                 "sync_after_exit": True,
                 "clock_skew_tolerance_sec": 60,
@@ -2590,21 +2589,18 @@ class SaveService:
         settings.setdefault("autocleanup_limit", 10)
         if not self._save_sync_state.get("settings"):
             settings.setdefault("save_sync_enabled", False)
-            settings.setdefault("conflict_mode", "ask_me")
             settings.setdefault("sync_before_launch", True)
             settings.setdefault("sync_after_exit", True)
             settings.setdefault("clock_skew_tolerance_sec", 60)
         return settings
 
     @staticmethod
-    def _sanitize_setting(key: str, value: object, valid_modes: set[str]) -> tuple[object, bool]:
+    def _sanitize_setting(key: str, value: object) -> tuple[object, bool]:
         """Validate and coerce a single settings key/value pair.
 
         Returns (coerced_value, skip) where skip=True means the value should
-        be discarded (e.g. invalid conflict_mode or empty slot name).
+        be discarded (e.g. empty slot name).
         """
-        if key == "conflict_mode":
-            return value, value not in valid_modes
         if key == "clock_skew_tolerance_sec":
             return max(0, int(value)), False  # type: ignore[arg-type]
         if key == "default_slot":
@@ -2619,24 +2615,22 @@ class SaveService:
         return value, False
 
     def update_save_sync_settings(self, settings: dict) -> dict:
-        """Update save sync settings (conflict_mode, sync toggles, etc.)."""
+        """Update save sync settings (sync toggles, slot, etc.)."""
         allowed_keys = {
             "save_sync_enabled",
-            "conflict_mode",
             "sync_before_launch",
             "sync_after_exit",
             "clock_skew_tolerance_sec",
             "default_slot",
             "autocleanup_limit",
         }
-        valid_modes = {"newest_wins", "always_upload", "always_download", "ask_me"}
 
         current = self._save_sync_state.setdefault("settings", {})
 
         for key, value in settings.items():
             if key not in allowed_keys:
                 continue
-            value, skip = self._sanitize_setting(key, value, valid_modes)
+            value, skip = self._sanitize_setting(key, value)
             if skip:
                 continue
             current[key] = value

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -207,7 +207,6 @@ class SaveService:
                 "save_sync_enabled": False,
                 "sync_before_launch": True,
                 "sync_after_exit": True,
-                "clock_skew_tolerance_sec": 60,
                 "default_slot": "default",
                 "autocleanup_limit": 10,
             },
@@ -2591,7 +2590,6 @@ class SaveService:
             settings.setdefault("save_sync_enabled", False)
             settings.setdefault("sync_before_launch", True)
             settings.setdefault("sync_after_exit", True)
-            settings.setdefault("clock_skew_tolerance_sec", 60)
         return settings
 
     @staticmethod
@@ -2601,8 +2599,6 @@ class SaveService:
         Returns (coerced_value, skip) where skip=True means the value should
         be discarded (e.g. empty slot name).
         """
-        if key == "clock_skew_tolerance_sec":
-            return max(0, int(value)), False  # type: ignore[arg-type]
         if key == "default_slot":
             if value is None:
                 return None, False  # None = legacy mode
@@ -2620,7 +2616,6 @@ class SaveService:
             "save_sync_enabled",
             "sync_before_launch",
             "sync_after_exit",
-            "clock_skew_tolerance_sec",
             "default_slot",
             "autocleanup_limit",
         }

--- a/py_modules/services/saves.py
+++ b/py_modules/services/saves.py
@@ -240,22 +240,32 @@ class SaveService:
         - Strip removed legacy settings keys (``conflict_mode``,
           ``clock_skew_tolerance_sec``).
         """
-        saves = self._save_sync_state.get("saves", {})
-        if isinstance(saves, dict):
-            for entry in saves.values():
-                if not isinstance(entry, dict):
-                    continue
-                if "active_core" in entry:
-                    entry["last_synced_core"] = entry.pop("active_core")
-                files = entry.get("files", {})
-                if isinstance(files, dict):
-                    for file_state in files.values():
-                        if isinstance(file_state, dict):
-                            file_state.pop("dismissed_newer_save_id", None)
+        self._migrate_saves_entries()
+        self._strip_legacy_settings()
 
-        # Strip removed legacy settings keys. Old state files keep these
-        # forever otherwise (load_state does dict.update on settings, so
-        # orphan keys survive). Idempotent: pop returns None when absent.
+    def _migrate_saves_entries(self) -> None:
+        """Rename ``active_core`` → ``last_synced_core`` and drop dead per-file flags."""
+        saves = self._save_sync_state.get("saves")
+        if not isinstance(saves, dict):
+            return
+        for entry in saves.values():
+            if not isinstance(entry, dict):
+                continue
+            if "active_core" in entry:
+                entry["last_synced_core"] = entry.pop("active_core")
+            files = entry.get("files")
+            if not isinstance(files, dict):
+                continue
+            for file_state in files.values():
+                if isinstance(file_state, dict):
+                    file_state.pop("dismissed_newer_save_id", None)
+
+    def _strip_legacy_settings(self) -> None:
+        """Strip removed settings keys from loaded state.
+
+        Old state files keep these forever otherwise (``load_state`` does
+        ``dict.update`` on settings, so orphan keys survive). Idempotent.
+        """
         settings = self._save_sync_state.get("settings")
         if isinstance(settings, dict):
             settings.pop("conflict_mode", None)

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -34,7 +34,7 @@ import {
 } from "../api/backend";
 import type { SaveSortMigrationStatus, RegisteredDevice } from "../api/backend";
 import { getSaveSortMigrationState, setSaveSortMigrationStatus as setStoreSaveSortStatus, clearSaveSortMigration, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
-import type { SaveSyncSettings as SaveSyncSettingsType, ConflictMode, RetroArchInputCheck } from "../types";
+import type { SaveSyncSettings as SaveSyncSettingsType, RetroArchInputCheck } from "../types";
 
 // Module-level state survives component remounts (modal close can remount QAM)
 const pendingEdits: { url?: string; username?: string; password?: string } = {};
@@ -90,13 +90,6 @@ const TextInputModal: FC<{
     </ConfirmModal>
   );
 };
-
-const conflictModeOptions = [
-  { data: "ask_me" as ConflictMode, label: "Ask Me (Default)" },
-  { data: "newest_wins" as ConflictMode, label: "Newest Wins" },
-  { data: "always_upload" as ConflictMode, label: "Always Upload" },
-  { data: "always_download" as ConflictMode, label: "Always Download" },
-];
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -583,15 +576,6 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
                     description="Upload changed saves to server after closing a game"
                     checked={saveSyncSettings.sync_after_exit}
                     onChange={(value) => handleSaveSyncSettingChange({ sync_after_exit: value })}
-                  />
-                </PanelSectionRow>
-                <PanelSectionRow>
-                  <DropdownItem
-                    label="When saves conflict"
-                    description="How to handle conflicting save files between devices"
-                    rgOptions={conflictModeOptions}
-                    selectedOption={saveSyncSettings.conflict_mode}
-                    onChange={(option) => handleSaveSyncSettingChange({ conflict_mode: option.data as ConflictMode })}
                   />
                 </PanelSectionRow>
                 <PanelSectionRow>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -251,11 +251,8 @@ export interface RomMetadata {
   steam_categories?: number[];
 }
 
-export type ConflictMode = "newest_wins" | "always_upload" | "always_download" | "ask_me";
-
 export interface SaveSyncSettings {
   save_sync_enabled: boolean;
-  conflict_mode: ConflictMode;
   sync_before_launch: boolean;
   sync_after_exit: boolean;
   clock_skew_tolerance_sec: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -255,7 +255,6 @@ export interface SaveSyncSettings {
   save_sync_enabled: boolean;
   sync_before_launch: boolean;
   sync_after_exit: boolean;
-  clock_skew_tolerance_sec: number;
   default_slot: string | null;
   autocleanup_limit: number;
 }

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -7,7 +7,7 @@
 
 import { toaster } from "@decky/api";
 import { isRomMAppId } from "../patches/gameDetailPatch";
-import { getInstalledRom, getSaveStatus, getSaveSyncSettings, refreshMigrationState, logInfo, logError } from "../api/backend";
+import { getInstalledRom, getSaveStatus, refreshMigrationState, logInfo, logError } from "../api/backend";
 import { getMigrationState, setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { hasAnySaveConflict } from "./saveStatus";
@@ -64,20 +64,17 @@ export function registerLaunchInterceptor(): void {
           return;
         }
 
-        // Check for save conflicts in ask_me mode
+        // Block launch when a save conflict is pending — the user must
+        // resolve it from the game page before playing.
         try {
-          const settings = await getSaveSyncSettings();
-          if (settings.conflict_mode === "ask_me") {
-            const saveStatus = await getSaveStatus(rom.rom_id);
-            const hasConflict = hasAnySaveConflict(saveStatus);
-            if (hasConflict) {
-              SteamClient.Apps.CancelGameAction(gameActionId);
-              toaster.toast({
-                title: "RomM Save Sync",
-                body: "Save conflict detected \u2014 open game page to resolve before playing",
-              });
-              return;
-            }
+          const saveStatus = await getSaveStatus(rom.rom_id);
+          if (hasAnySaveConflict(saveStatus)) {
+            SteamClient.Apps.CancelGameAction(gameActionId);
+            toaster.toast({
+              title: "RomM Save Sync",
+              body: "Save conflict detected — open game page to resolve before playing",
+            });
+            return;
           }
         } catch {
           // Non-critical — let the game launch if we can't check conflicts

--- a/tests/models/test_saves.py
+++ b/tests/models/test_saves.py
@@ -84,7 +84,6 @@ class TestSaveSyncSettings:
             save_sync_enabled=True,
             sync_before_launch=True,
             sync_after_exit=True,
-            clock_skew_tolerance_sec=60,
         )
         assert s.save_sync_enabled is True
 
@@ -93,10 +92,11 @@ class TestSaveSyncSettings:
             save_sync_enabled=False,
             sync_before_launch=False,
             sync_after_exit=False,
-            clock_skew_tolerance_sec=120,
         )
         d = asdict(s)
-        assert d["clock_skew_tolerance_sec"] == 120
+        assert d["save_sync_enabled"] is False
+        assert d["sync_before_launch"] is False
+        assert d["sync_after_exit"] is False
 
 
 class TestSyncResult:

--- a/tests/models/test_saves.py
+++ b/tests/models/test_saves.py
@@ -82,7 +82,6 @@ class TestSaveSyncSettings:
     def test_construction(self):
         s = SaveSyncSettings(
             save_sync_enabled=True,
-            conflict_mode="newest_wins",
             sync_before_launch=True,
             sync_after_exit=True,
             clock_skew_tolerance_sec=60,
@@ -92,7 +91,6 @@ class TestSaveSyncSettings:
     def test_asdict(self):
         s = SaveSyncSettings(
             save_sync_enabled=False,
-            conflict_mode="ask_me",
             sync_before_launch=False,
             sync_after_exit=False,
             clock_skew_tolerance_sec=120,

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -128,7 +128,7 @@ class TestStateManagement:
 
     def test_init_state_populates_defaults(self, tmp_path):
         svc, _ = make_service(tmp_path, save_sync_state={})
-        assert svc._save_sync_state["settings"]["conflict_mode"] == "ask_me"
+        assert svc._save_sync_state["settings"]["save_sync_enabled"] is False
         assert svc._save_sync_state["saves"] == {}
 
     def test_init_state_preserves_existing(self, tmp_path):
@@ -1239,8 +1239,9 @@ class TestSettings:
     async def test_get_defaults(self, tmp_path):
         svc, _ = make_service(tmp_path)
         settings = svc.get_save_sync_settings()
-        assert settings["conflict_mode"] == "ask_me"
         assert settings["save_sync_enabled"] is False
+        assert settings["sync_before_launch"] is True
+        assert settings["sync_after_exit"] is True
 
     @pytest.mark.asyncio
     async def test_update_settings(self, tmp_path):
@@ -1248,19 +1249,12 @@ class TestSettings:
         result = svc.update_save_sync_settings(
             {
                 "save_sync_enabled": True,
-                "conflict_mode": "newest_wins",
+                "sync_before_launch": False,
             }
         )
         assert result["success"] is True
         assert result["settings"]["save_sync_enabled"] is True
-        assert result["settings"]["conflict_mode"] == "newest_wins"
-
-    @pytest.mark.asyncio
-    async def test_invalid_mode_ignored(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        svc.update_save_sync_settings({"conflict_mode": "invalid_mode"})
-        settings = svc.get_save_sync_settings()
-        assert settings["conflict_mode"] == "ask_me"
+        assert result["settings"]["sync_before_launch"] is False
 
     @pytest.mark.asyncio
     async def test_unknown_key_ignored(self, tmp_path):
@@ -2294,25 +2288,25 @@ class TestSaveSyncSettingsSlotAndCleanup:
 
     def test_empty_string_becomes_none(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        val, skip = svc._sanitize_setting("default_slot", "", set())
+        val, skip = svc._sanitize_setting("default_slot", "")
         assert val is None
         assert skip is False
 
     def test_none_value_passes_through(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        val, skip = svc._sanitize_setting("default_slot", None, set())
+        val, skip = svc._sanitize_setting("default_slot", None)
         assert val is None
         assert skip is False
 
     def test_whitespace_only_becomes_none(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        val, skip = svc._sanitize_setting("default_slot", "   ", set())
+        val, skip = svc._sanitize_setting("default_slot", "   ")
         assert val is None
         assert skip is False
 
     def test_nonempty_string_trimmed(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        val, skip = svc._sanitize_setting("default_slot", "  desktop  ", set())
+        val, skip = svc._sanitize_setting("default_slot", "  desktop  ")
         assert val == "desktop"
         assert skip is False
 

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -237,6 +237,32 @@ class TestStateManagement:
         files = svc._save_sync_state["saves"]["42"]["files"]
         assert "dismissed_newer_save_id" not in files["good.srm"]
 
+    def test_migrate_loaded_state_strips_legacy_settings_keys(self, tmp_path):
+        """Legacy ``conflict_mode`` and ``clock_skew_tolerance_sec`` settings
+        are dropped on state load. Other settings keys survive."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"] = {
+            "conflict_mode": "ask_me",
+            "clock_skew_tolerance_sec": 60,
+            "save_sync_enabled": True,
+        }
+
+        svc._migrate_loaded_state()
+
+        settings = svc._save_sync_state["settings"]
+        assert "conflict_mode" not in settings
+        assert "clock_skew_tolerance_sec" not in settings
+        assert settings["save_sync_enabled"] is True
+
+    def test_migrate_loaded_state_strip_legacy_settings_idempotent(self, tmp_path):
+        """Stripping legacy settings is a no-op when they aren't present."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"] = {"save_sync_enabled": True}
+
+        svc._migrate_loaded_state()  # should not raise
+
+        assert svc._save_sync_state["settings"] == {"save_sync_enabled": True}
+
     def test_save_and_load_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["device_id"] = "test-device"

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -263,6 +263,24 @@ class TestStateManagement:
 
         assert svc._save_sync_state["settings"] == {"save_sync_enabled": True}
 
+    def test_migrate_loaded_state_handles_missing_settings(self, tmp_path):
+        """Migration is defensive: missing ``settings`` key doesn't crash."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.pop("settings", None)
+
+        svc._migrate_loaded_state()  # should not raise
+
+        assert "settings" not in svc._save_sync_state
+
+    def test_migrate_loaded_state_handles_non_dict_settings(self, tmp_path):
+        """Migration is defensive: non-dict ``settings`` is left untouched."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state["settings"] = "broken"
+
+        svc._migrate_loaded_state()  # should not raise
+
+        assert svc._save_sync_state["settings"] == "broken"
+
     def test_save_and_load_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._save_sync_state["device_id"] = "test-device"

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -1263,13 +1263,6 @@ class TestSettings:
         assert result["success"] is True
         assert "unknown_key" not in result["settings"]
 
-    @pytest.mark.asyncio
-    async def test_clock_skew_clamped(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        svc.update_save_sync_settings({"clock_skew_tolerance_sec": -10})
-        settings = svc.get_save_sync_settings()
-        assert settings["clock_skew_tolerance_sec"] == 0
-
 
 # ---------------------------------------------------------------------------
 # TestDeleteSaves

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -631,7 +631,6 @@ class TestSaveSyncSettings:
         assert result["save_sync_enabled"] is True
         assert result["sync_before_launch"] is True
         assert result["sync_after_exit"] is True
-        assert result["clock_skew_tolerance_sec"] == 60
 
     @pytest.mark.asyncio
     async def test_update_changes_settings(self, plugin, tmp_path):
@@ -667,17 +666,6 @@ class TestSaveSyncSettings:
         assert result["success"] is True
         assert result["settings"]["sync_before_launch"] is True
         assert "unknown_key" not in result["settings"]
-
-    @pytest.mark.asyncio
-    async def test_clock_skew_clamped_to_zero(self, plugin):
-        """Negative clock_skew_tolerance_sec clamped to 0."""
-        result = await plugin.update_save_sync_settings(
-            {
-                "clock_skew_tolerance_sec": -10,
-            }
-        )
-
-        assert result["settings"]["clock_skew_tolerance_sec"] == 0
 
     @pytest.mark.asyncio
     async def test_boolean_coercion(self, plugin):

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -628,7 +628,7 @@ class TestSaveSyncSettings:
         """Returns current settings."""
         result = await plugin.get_save_sync_settings()
 
-        assert result["conflict_mode"] == "ask_me"
+        assert result["save_sync_enabled"] is True
         assert result["sync_before_launch"] is True
         assert result["sync_after_exit"] is True
         assert result["clock_skew_tolerance_sec"] == 60
@@ -638,13 +638,13 @@ class TestSaveSyncSettings:
         """Updates and persists settings."""
         result = await plugin.update_save_sync_settings(
             {
-                "conflict_mode": "always_download",
+                "save_sync_enabled": True,
                 "sync_before_launch": False,
             }
         )
 
         assert result["success"] is True
-        assert result["settings"]["conflict_mode"] == "always_download"
+        assert result["settings"]["save_sync_enabled"] is True
         assert result["settings"]["sync_before_launch"] is False
         # sync_after_exit unchanged
         assert result["settings"]["sync_after_exit"] is True
@@ -652,20 +652,7 @@ class TestSaveSyncSettings:
         # Persisted
         path = tmp_path / "save_sync_state.json"
         data = json.loads(path.read_text())
-        assert data["settings"]["conflict_mode"] == "always_download"
-
-    @pytest.mark.asyncio
-    async def test_invalid_conflict_mode_ignored(self, plugin):
-        """Unknown conflict mode is silently ignored."""
-        result = await plugin.update_save_sync_settings(
-            {
-                "conflict_mode": "invalid_mode",
-            }
-        )
-
-        assert result["success"] is True
-        # Original value preserved
-        assert result["settings"]["conflict_mode"] == "ask_me"
+        assert data["settings"]["save_sync_enabled"] is True
 
     @pytest.mark.asyncio
     async def test_unknown_keys_ignored(self, plugin):
@@ -673,12 +660,12 @@ class TestSaveSyncSettings:
         result = await plugin.update_save_sync_settings(
             {
                 "unknown_key": "value",
-                "conflict_mode": "ask_me",
+                "sync_before_launch": True,
             }
         )
 
         assert result["success"] is True
-        assert result["settings"]["conflict_mode"] == "ask_me"
+        assert result["settings"]["sync_before_launch"] is True
         assert "unknown_key" not in result["settings"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR 2 of 2 for #258 (post-0.16 save sync polish). Removes the two legacy settings end-to-end: `conflict_mode` and `clock_skew_tolerance_sec`. Both were leftovers from before the 0.16 newest-wins matrix sync rewrite; the wiki had already pre-announced their removal in `Save-Sync.md`, and the actual `domain/save_conflicts.resolve_conflict_by_mode` consumer was deleted in PR1 (#264).

- **`conflict_mode`** — removed from model, persistence, sanitize/allowlist, TS type, Settings UI dropdown, and `launchInterceptor.ts`. **Behaviour change**: the launch interceptor now always checks for conflicts and blocks launch when one is detected (previously only in `"ask_me"` mode). Users who had it set to `newest_wins` / `always_upload` / `always_download` will now see the conflict modal — but those modes never actually did anything in the matrix sync model post-0.16, so this catches the implementation up to the documented behaviour.
- **`clock_skew_tolerance_sec`** — removed from model, persistence, TS type. Pure cleanup: zero consumers after PR1.
- **Migration strip** — `_migrate_loaded_state` now silently strips both legacy keys from loaded state. `load_state` does `dict.update` on the settings block, so orphan keys would otherwise survive forever. After the first load+save post-merge, on-disk state files are clean. Tests pin the strip behaviour and the defensive `isinstance(settings, dict)` guard (covers missing-key and non-dict edge cases).
- **Wiki** — `Save-Sync.md` "When saves conflict" section + screenshot caption updated; `Save-File-Sync-Architecture.md` "Legacy field migration" extended to document the new strips, "Settings fields not driving behaviour" paragraph removed.

Closes #258.

## Test plan

- [x] CI green: pytest, ruff, ruff format, basedpyright, lint-imports, pnpm build
- [ ] Manual: Settings page renders without the conflict-mode dropdown; no console errors
- [ ] Manual: trigger a real two-sided conflict, confirm modal blocks Play regardless of any prior `conflict_mode` setting
- [ ] Manual: load a state file containing `conflict_mode` / `clock_skew_tolerance_sec`, trigger a save, confirm both keys are gone from the on-disk JSON