### PR TITLE
fix(qam): scroll and focus to top on QAM page navigation (#161)

### DIFF
--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -26,6 +26,7 @@ import {
   updateWhitelistSettings,
 } from "../api/backend";
 import { removeShortcut } from "../utils/steamShortcuts";
+import { scrollToTop } from "../utils/scrollHelpers";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import type { RegistryPlatform } from "../types";
 
@@ -234,7 +235,12 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
     <>
       <PanelSection>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={onBack}>
+          <ButtonItem
+            layout="below"
+            onClick={onBack}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
             Back
           </ButtonItem>
         </PanelSectionRow>

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -8,6 +8,7 @@ import {
 } from "@decky/ui";
 import { getDownloadQueue, cancelDownload } from "../api/backend";
 import { getDownloadState, setDownloads } from "../utils/downloadStore";
+import { scrollToTop } from "../utils/scrollHelpers";
 import type { DownloadItem } from "../types";
 
 interface DownloadQueueProps {
@@ -103,7 +104,12 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     <>
       <PanelSection>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={onBack}>
+          <ButtonItem
+            layout="below"
+            onClick={onBack}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
             Back
           </ButtonItem>
         </PanelSectionRow>

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -26,6 +26,7 @@ import {
   debugLog,
 } from "../api/backend";
 import type { PlatformSyncSetting, CollectionSyncSetting, FirmwarePlatformExt } from "../types";
+import { scrollToTop } from "../utils/scrollHelpers";
 
 const CATEGORY_TITLES: Record<string, string> = {
   favorites: "Favorites",
@@ -513,7 +514,12 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     <>
       <PanelSection>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={onBack}>
+          <ButtonItem
+            layout="below"
+            onClick={onBack}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
             Back
           </ButtonItem>
         </PanelSectionRow>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -26,6 +26,7 @@ import {
   logError,
 } from "../api/backend";
 import { getSyncProgress } from "../utils/syncProgress";
+import { scrollToTop } from "../utils/scrollHelpers";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
@@ -363,24 +364,28 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               label="RetroArch: input_driver issue"
               description={`Using "${retroarchWarning.current}"`}
             >
-              <DialogButton onClick={() => showModal(
-                <ConfirmModal
-                  strTitle="Fix RetroArch input_driver?"
-                  strDescription="This will change input_driver to sdl2 in your RetroArch config. Controllers should work better in RetroArch menus after this change."
-                  strOKButtonText="Apply Fix"
-                  strCancelButtonText="Cancel"
-                  onOK={async () => {
-                    try {
-                      const result = await fixRetroarchInputDriver();
-                      if (result.success) {
-                        setRetroarchWarning(null);
+              <DialogButton
+                onClick={() => showModal(
+                  <ConfirmModal
+                    strTitle="Fix RetroArch input_driver?"
+                    strDescription="This will change input_driver to sdl2 in your RetroArch config. Controllers should work better in RetroArch menus after this change."
+                    strOKButtonText="Apply Fix"
+                    strCancelButtonText="Cancel"
+                    onOK={async () => {
+                      try {
+                        const result = await fixRetroarchInputDriver();
+                        if (result.success) {
+                          setRetroarchWarning(null);
+                        }
+                      } catch {
+                        // ignore
                       }
-                    } catch {
-                      // ignore
-                    }
-                  }}
-                />
-              )}>
+                    }}
+                  />
+                )}
+                // @ts-expect-error onFocus works at runtime; not in Decky's DialogButton types
+                onFocus={scrollToTop}
+              >
                 Fix
               </DialogButton>
             </Field>
@@ -405,7 +410,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </div>
             </PanelSectionRow>
             <PanelSectionRow>
-              <ButtonItem layout="below" onClick={() => onNavigate("settings")}>
+              <ButtonItem
+                layout="below"
+                onClick={() => onNavigate("settings")}
+                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                onFocus={scrollToTop}
+              >
                 Go to Settings
               </ButtonItem>
             </PanelSectionRow>
@@ -425,7 +435,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             {preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0 || preview.summary.collection_diff?.has_changes || preview.summary.platform_collection_diff?.has_changes ? (
               <>
                 <PanelSectionRow>
-                  <ButtonItem layout="below" onClick={handleApply}>
+                  <ButtonItem
+                    layout="below"
+                    onClick={handleApply}
+                    // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                    onFocus={scrollToTop}
+                  >
                     Apply Sync
                   </ButtonItem>
                 </PanelSectionRow>
@@ -437,7 +452,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </>
             ) : (
               <PanelSectionRow>
-                <ButtonItem layout="below" onClick={handleDismiss}>
+                <ButtonItem
+                  layout="below"
+                  onClick={handleDismiss}
+                  // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                  onFocus={scrollToTop}
+                >
                   Dismiss
                 </ButtonItem>
               </PanelSectionRow>
@@ -450,6 +470,8 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                 layout="below"
                 onClick={handleSync}
                 disabled={loading || connected === false}
+                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                onFocus={scrollToTop}
               >
                 Sync Library
               </ButtonItem>
@@ -504,7 +526,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </PanelSectionRow>
             )}
             <PanelSectionRow>
-              <ButtonItem layout="below" onClick={handleCancel}>
+              <ButtonItem
+                layout="below"
+                onClick={handleCancel}
+                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                onFocus={scrollToTop}
+              >
                 Cancel Sync
               </ButtonItem>
             </PanelSectionRow>

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -19,6 +19,7 @@ import {
   clearMigration,
 } from "../utils/migrationStore";
 import { MigrationConflictModal } from "./MigrationConflictModal";
+import { scrollToTop } from "../utils/scrollHelpers";
 
 /**
  * Subscribe to migration state changes.
@@ -132,7 +133,13 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
         </div>
       </PanelSectionRow>
       <PanelSectionRow>
-        <ButtonItem layout="below" disabled={migrating} onClick={handleMigrate}>
+        <ButtonItem
+          layout="below"
+          disabled={migrating}
+          onClick={handleMigrate}
+          // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+          onFocus={scrollToTop}
+        >
           {migrating ? "Migrating..." : "Migrate Files"}
         </ButtonItem>
       </PanelSectionRow>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -34,6 +34,7 @@ import {
 } from "../api/backend";
 import type { SaveSortMigrationStatus, RegisteredDevice } from "../api/backend";
 import { getSaveSortMigrationState, setSaveSortMigrationStatus as setStoreSaveSortStatus, clearSaveSortMigration, onSaveSortMigrationChange } from "../utils/saveSortMigrationStore";
+import { scrollToTop } from "../utils/scrollHelpers";
 import type { SaveSyncSettings as SaveSyncSettingsType, RetroArchInputCheck } from "../types";
 
 // Module-level state survives component remounts (modal close can remount QAM)
@@ -324,7 +325,12 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     <>
       <PanelSection>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={onBack}>
+          <ButtonItem
+            layout="below"
+            onClick={onBack}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
             Back
           </ButtonItem>
         </PanelSectionRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,12 +41,25 @@ const QAMPanel: FC = () => {
     const el = rootRef.current;
     if (!el) return;
     const container = findOutermostScrollParent(el) ?? findScrollParent(el);
-    if (!container) return;
     // rAF lets the new page mount/measure before we set scrollTop.
-    const handle = requestAnimationFrame(() => {
-      container.scrollTop = 0;
+    const rafHandle = requestAnimationFrame(() => {
+      if (container) container.scrollTop = 0;
     });
-    return () => cancelAnimationFrame(handle);
+    // Steam's gamepad nav retains a focus pointer across page swaps and
+    // resolves it on the next input — landing on a button at the old page's
+    // position. Force focus to the first button so navigation starts at the
+    // top. Same querySelector + .focus() + gpfocus pattern as CustomPlayButton.
+    const focusTimer = setTimeout(() => {
+      const btn = el.querySelector("button");
+      if (btn) {
+        btn.focus();
+        btn.classList.add("gpfocus");
+      }
+    }, 50);
+    return () => {
+      cancelAnimationFrame(rafHandle);
+      clearTimeout(focusTimer);
+    };
   }, [page]);
 
   let content: ReactNode;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import {
   removeEventListener,
   toaster,
 } from "@decky/api";
-import { useState, FC } from "react";
+import { useState, useRef, useEffect, FC, type ReactNode } from "react";
 import { FaGamepad } from "react-icons/fa";
 import { MainPage } from "./components/MainPage";
 import { SettingsPage } from "./components/SettingsPage";
@@ -24,6 +24,7 @@ import { setMigrationStatus } from "./utils/migrationStore";
 import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
+import { findOutermostScrollParent, findScrollParent } from "./utils/scrollHelpers";
 import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, SaveStatus } from "./types";
 
 type Page = "main" | "settings" | "library" | "data" | "downloads";
@@ -33,20 +34,40 @@ let currentPage: Page = "main";
 
 const QAMPanel: FC = () => {
   const [page, setPageState] = useState<Page>(currentPage);
+  const rootRef = useRef<HTMLDivElement>(null);
   const setPage = (p: Page) => { currentPage = p; setPageState(p); };
 
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const container = findOutermostScrollParent(el) ?? findScrollParent(el);
+    if (!container) return;
+    // rAF lets the new page mount/measure before we set scrollTop.
+    const handle = requestAnimationFrame(() => {
+      container.scrollTop = 0;
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [page]);
+
+  let content: ReactNode;
   switch (page) {
     case "settings":
-      return <SettingsPage onBack={() => setPage("main")} />;
+      content = <SettingsPage onBack={() => setPage("main")} />;
+      break;
     case "library":
-      return <LibraryPage onBack={() => setPage("main")} />;
+      content = <LibraryPage onBack={() => setPage("main")} />;
+      break;
     case "data":
-      return <DangerZone onBack={() => setPage("main")} />;
+      content = <DangerZone onBack={() => setPage("main")} />;
+      break;
     case "downloads":
-      return <DownloadQueue onBack={() => setPage("main")} />;
+      content = <DownloadQueue onBack={() => setPage("main")} />;
+      break;
     default:
-      return <MainPage onNavigate={(p) => setPage(p)} />;
+      content = <MainPage onNavigate={(p) => setPage(p)} />;
   }
+
+  return <div ref={rootRef}>{content}</div>;
 };
 
 export default definePlugin(() => {

--- a/src/utils/scrollHelpers.ts
+++ b/src/utils/scrollHelpers.ts
@@ -12,7 +12,7 @@
  */
 
 /** Find the nearest ancestor with overflowY scroll/auto */
-function findScrollParent(el: HTMLElement): HTMLElement | null {
+export function findScrollParent(el: HTMLElement): HTMLElement | null {
   let parent: HTMLElement | null = el.parentElement;
   while (parent) {
     const ov = globalThis.getComputedStyle(parent).overflowY;
@@ -23,7 +23,7 @@ function findScrollParent(el: HTMLElement): HTMLElement | null {
 }
 
 /** Find the outermost ancestor with overflowY scroll/auto */
-function findOutermostScrollParent(el: HTMLElement): HTMLElement | null {
+export function findOutermostScrollParent(el: HTMLElement): HTMLElement | null {
   let parent: HTMLElement | null = el.parentElement;
   let outermost: HTMLElement | null = null;
   while (parent) {


### PR DESCRIPTION
## Summary
- Adds `onFocus={scrollToTop}` to the topmost focusable on every QAM page render branch — gamepad-up to Sync Library (or any state-conditional top button) snaps the viewport to top, exposing the Status section above it. Resolves the original issue.
- Auto-scrolls the QAM panel to top on every page change so opening a sub-page from a scrolled-down position lands at the top of the new screen, not mid-page.
- Programmatically focuses the first button in the new page's DOM after each page change so Steam's gamepad-nav engine starts from a known top position instead of resolving its retained focus pointer to a stale spot.

## Test plan
- [x] On Main, scroll down to Force Full Sync, gamepad-up to Sync Library → panel snaps to top exposing Status section.
- [x] Tap Settings/Library/Data Management/Downloads from a scrolled-down Main → sub-page opens at top with focus ring on Back.
- [x] Tap Back from a sub-page → Main opens at top with focus ring on first focusable.
- [x] First d-pad press after any page change moves focus naturally from the topmost button (no jump to a stale position).
- [x] Open QAM cold → focus ring lands deterministically on Main's first focusable.

Closes #161