### PR TITLE
fix(game-detail): scroll to top on focus of action buttons (#162)

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -700,6 +700,8 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           background: dropdownBg,
         }}
         onClick={showDropdownMenu}
+        // @ts-expect-error onFocus works at runtime; not in Decky's DialogButton types
+        onFocus={scrollToTop}
       >
         <svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M1 1.5L6 6.5L11 1.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -26,6 +26,7 @@ import {
 import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icons/fa";
 import { CustomPlayButton } from "./CustomPlayButton";
 import { hasAnySaveConflict } from "../utils/saveStatus";
+import { scrollToTop } from "../utils/scrollHelpers";
 import {
   getCachedGameDetail,
   _cachedGameDetailCache,
@@ -932,6 +933,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       createElement(DialogButton, {
         className: "romm-gear-btn",
         onClick: showRomMMenu,
+        onFocus: scrollToTop,
         title: "RomM Actions",
       } as any,
         createElement(FaGamepad, { size: 18, color: "#553e98" }),
@@ -942,6 +944,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
           key: "core-btn",
           className: "romm-gear-btn",
           onClick: showCoreMenu,
+          onFocus: scrollToTop,
           title: "Emulator Core",
         } as any,
           createElement(FaMicrochip, { size: 18, color: info.activeCoreIsDefault ? "#8f98a0" : "#d4a72c" }),
@@ -951,6 +954,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       createElement(DialogButton, {
         className: "romm-gear-btn",
         onClick: showSteamMenu,
+        onFocus: scrollToTop,
         title: "Steam Properties",
       } as any,
         createElement(FaCog, { size: 18, color: "#8f98a0" }),


### PR DESCRIPTION
## Summary
- Extends the existing `onFocus={scrollToTop}` pattern (shipped under #161) to four `DialogButton` action-area buttons that were missing it: Play-button dropdown, RomM Actions, Emulator Core, Steam Properties.
- Resolves the inconsistent scroll behaviour reported in #162 Problem 1 — gamepad-up onto any of these buttons now snaps the page to top, exposing the banner/hero like the Play button already does.
- Problem 2 (download-cancel dropdown) extracted to #269.

## Test plan
- [x] On a game detail page scrolled down, gamepad-up to the Play dropdown (▼) → page snaps to top.
- [x] Same for RomM Actions (gamepad icon).
- [x] Same for Emulator Core (microchip icon — multi-core platform).
- [x] Same for Steam Properties (gear icon).
- [x] Play button itself still scrolls to top on focus (no #161 regression).

Closes #162