### PR TITLE
fix(saves): preserve slot config on delete + confirm before platform delete

### DIFF
--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -1046,12 +1046,14 @@ class SaveService:
         return {"success": True, "settings": current}
 
     def _delete_saves_for_roms(self, rom_ids: list[int]) -> tuple[int, list[str]]:
-        """Delete local save files for the given ROM IDs and clean their sync state.
+        """Delete local save files for the given ROM IDs and clear file tracking state.
 
         For each ROM ID, enumerates files via ``_find_save_files``, removes them
         on disk (counting successes and collecting per-file error strings), and
-        pops the ROM's entry from ``_save_sync_state['saves']``. Persists state
-        once at the end via ``save_state()``.
+        clears the ROM's per-file tracking dict via ``StateService.clear_files_state``.
+        Slot config (``active_slot``, ``slot_confirmed``, ``emulator``,
+        ``last_synced_core``, ``own_upload_ids``, ``slots``, ``system``) is
+        preserved. Persists state once at the end via ``save_state()``.
 
         Returns a ``(total_deleted, errors)`` tuple.
         """
@@ -1066,7 +1068,7 @@ class SaveService:
                     total_deleted += 1
                 except Exception as e:
                     errors.append(f"{f['filename']}: {e}")
-            self._save_sync_state.get("saves", {}).pop(rom_id_str, None)
+            self._state_svc.clear_files_state(rom_id_str)
 
         self.save_state()
         return total_deleted, errors

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -362,8 +362,7 @@ class SlotsService:
                 self._save_service._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
 
         # Clear file tracking state (but keep slot config)
-        save_entry = self._state_svc.data.get("saves", {}).get(rom_id_str, {})
-        save_entry["files"] = {}
+        self._state_svc.clear_files_state(rom_id_str)
 
     # ------------------------------------------------------------------
     # Save Setup Wizard

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -146,6 +146,20 @@ class StateService:
         finally:
             os.close(lock_fd)
 
+    def clear_files_state(self, rom_id_str: str) -> None:
+        """Clear the per-file tracking dict for a ROM, preserving slot config.
+
+        Resets ``data["saves"][rom_id_str]["files"]`` to an empty dict while
+        leaving ``active_slot``, ``slot_confirmed``, ``emulator``,
+        ``last_synced_core``, ``own_upload_ids``, ``slots``, ``system``, and any
+        other slot/attribution metadata untouched. Creates the ROM entry as an
+        empty dict (with only ``files``) when none exists. Caller is
+        responsible for persisting via ``save_state()``.
+        """
+        saves = self._save_sync_state.setdefault("saves", {})
+        entry = saves.setdefault(rom_id_str, {})
+        entry["files"] = {}
+
     def prune_orphaned_state(self) -> None:
         """Remove save sync state entries for rom_ids no longer in shortcut registry."""
         registry = self._state.get("shortcut_registry", {})

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useMemo, FC } from "react";
+import { useState, useEffect, useMemo, FC, createElement } from "react";
 import {
   PanelSection,
   PanelSectionRow,
   ButtonItem,
+  ConfirmModal,
   Field,
   TextField,
   ToggleField,
@@ -210,15 +211,27 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
     }
   };
 
-  const handleDeleteSaves = async (p: RegistryPlatform) => {
-    setActionStatus(`Deleting ${p.name} saves...`);
-    try {
-      const result = await deletePlatformSaves(p.slug);
-      setActionStatus(result.message);
-      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
-    } catch {
-      setActionStatus("Failed to delete saves");
-    }
+  const handleDeleteSaves = (p: RegistryPlatform) => {
+    const platformName = p.name || p.slug;
+    showModal(
+      createElement(ConfirmModal, {
+        strTitle: `Delete all save files for ${platformName}?`,
+        strDescription:
+          "This will delete every local save file for ROMs on this platform. Any local changes that haven't been uploaded to RomM yet will be lost permanently. Make sure saves are synced first.",
+        strOKButtonText: "Delete Save Files",
+        strCancelButtonText: "Cancel",
+        onOK: async () => {
+          setActionStatus(`Deleting ${p.name} saves...`);
+          try {
+            const result = await deletePlatformSaves(p.slug);
+            setActionStatus(result.message);
+            window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
+          } catch {
+            setActionStatus("Failed to delete saves");
+          }
+        },
+      } as any),
+    );
   };
 
   const handleDeleteBios = async (p: RegistryPlatform) => {

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -1350,7 +1350,60 @@ class TestDeleteSaves:
         assert result["success"] is True
         assert result["deleted_count"] == 1
         assert not save_path.exists()
+        # Entry survives — only files are cleared.
+        assert "42" in svc._save_sync_state["saves"]
+        assert svc._save_sync_state["saves"]["42"]["files"] == {}
+
+    @pytest.mark.asyncio
+    async def test_delete_local_saves_preserves_slot_config(self, tmp_path):
+        """Slot config and attribution metadata survive a delete (#279)."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+        assert save_path.exists()
+
+        svc._save_sync_state["saves"]["42"] = {
+            "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
+            "active_slot": "desktop",
+            "slot_confirmed": True,
+            "emulator": "retroarch-mgba",
+            "last_synced_core": "mgba_libretro",
+            "own_upload_ids": ["save-1", "save-2"],
+            "slots": {"default": {}, "desktop": {}},
+            "system": "gba",
+        }
+
+        result = svc.delete_local_saves(42)
+        assert result["success"] is True
+        assert result["deleted_count"] == 1
+        assert not save_path.exists()
+
+        entry = svc._save_sync_state["saves"]["42"]
+        assert entry["files"] == {}
+        assert entry["active_slot"] == "desktop"
+        assert entry["slot_confirmed"] is True
+        assert entry["emulator"] == "retroarch-mgba"
+        assert entry["last_synced_core"] == "mgba_libretro"
+        assert entry["own_upload_ids"] == ["save-1", "save-2"]
+        assert entry["slots"] == {"default": {}, "desktop": {}}
+        assert entry["system"] == "gba"
+
+    @pytest.mark.asyncio
+    async def test_delete_local_saves_no_prior_state_entry(self, tmp_path):
+        """Delete on a ROM with no prior saves entry creates a stable empty entry."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+
+        # No svc._save_sync_state["saves"]["42"] set up.
         assert "42" not in svc._save_sync_state["saves"]
+
+        result = svc.delete_local_saves(42)
+        assert result["success"] is True
+        assert result["deleted_count"] == 1
+        assert not save_path.exists()
+        # clear_files_state creates an empty entry with files={}.
+        assert svc._save_sync_state["saves"]["42"] == {"files": {}}
 
     @pytest.mark.asyncio
     async def test_delete_no_saves(self, tmp_path):
@@ -1412,6 +1465,46 @@ class TestEmulatorTag:
         assert result["deleted_count"] == 2
 
     @pytest.mark.asyncio
+    async def test_delete_platform_saves_preserves_slot_config(self, tmp_path):
+        """Per-platform delete preserves slot config for every affected ROM (#279)."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _install_rom(svc, tmp_path, rom_id=2, system="gba", file_name="game2.gba")
+        _create_save(tmp_path, system="gba", rom_name="game1")
+        _create_save(tmp_path, system="gba", rom_name="game2")
+
+        svc._save_sync_state["saves"]["1"] = {
+            "files": {"game1.srm": {}},
+            "active_slot": "desktop",
+            "slot_confirmed": True,
+            "emulator": "retroarch-mgba",
+            "system": "gba",
+        }
+        svc._save_sync_state["saves"]["2"] = {
+            "files": {"game2.srm": {}},
+            "active_slot": "default",
+            "slot_confirmed": True,
+            "own_upload_ids": ["save-x"],
+            "system": "gba",
+        }
+
+        result = svc.delete_platform_saves("gba")
+        assert result["success"] is True
+        assert result["deleted_count"] == 2
+
+        entry1 = svc._save_sync_state["saves"]["1"]
+        assert entry1["files"] == {}
+        assert entry1["active_slot"] == "desktop"
+        assert entry1["slot_confirmed"] is True
+        assert entry1["emulator"] == "retroarch-mgba"
+
+        entry2 = svc._save_sync_state["saves"]["2"]
+        assert entry2["files"] == {}
+        assert entry2["active_slot"] == "default"
+        assert entry2["slot_confirmed"] is True
+        assert entry2["own_upload_ids"] == ["save-x"]
+
+    @pytest.mark.asyncio
     async def test_delete_platform_saves_other_platform_untouched(self, tmp_path):
         svc, _ = make_service(tmp_path)
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
@@ -1419,8 +1512,20 @@ class TestEmulatorTag:
         _create_save(tmp_path, system="gba", rom_name="game1")
         snes_save = _create_save(tmp_path, system="snes", rom_name="game2")
 
+        svc._save_sync_state["saves"]["2"] = {
+            "files": {"game2.srm": {}},
+            "active_slot": "default",
+            "slot_confirmed": True,
+            "system": "snes",
+        }
+
         svc.delete_platform_saves("gba")
         assert snes_save.exists()
+        # Other-platform entry must be entirely untouched.
+        snes_entry = svc._save_sync_state["saves"]["2"]
+        assert snes_entry["files"] == {"game2.srm": {}}
+        assert snes_entry["active_slot"] == "default"
+        assert snes_entry["slot_confirmed"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -1,0 +1,86 @@
+"""Tests for services.saves.state.StateService."""
+
+import logging
+
+from services.saves.state import StateService
+
+
+def _make_state_svc(tmp_path) -> StateService:
+    save_sync_state = StateService.make_default_state()
+    state: dict = {"shortcut_registry": {}, "installed_roms": {}}
+    return StateService(
+        save_sync_state=save_sync_state,
+        state=state,
+        runtime_dir=str(tmp_path),
+        logger=logging.getLogger("test"),
+    )
+
+
+class TestClearFilesState:
+    def test_clears_files_preserves_slot_config(self, tmp_path):
+        svc = _make_state_svc(tmp_path)
+        svc.data["saves"]["42"] = {
+            "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
+            "active_slot": "desktop",
+            "slot_confirmed": True,
+            "emulator": "retroarch-mgba",
+            "last_synced_core": "mgba_libretro",
+            "own_upload_ids": ["save-1"],
+            "slots": {"default": {}, "desktop": {}},
+            "system": "gba",
+        }
+
+        svc.clear_files_state("42")
+
+        entry = svc.data["saves"]["42"]
+        assert entry["files"] == {}
+        assert entry["active_slot"] == "desktop"
+        assert entry["slot_confirmed"] is True
+        assert entry["emulator"] == "retroarch-mgba"
+        assert entry["last_synced_core"] == "mgba_libretro"
+        assert entry["own_upload_ids"] == ["save-1"]
+        assert entry["slots"] == {"default": {}, "desktop": {}}
+        assert entry["system"] == "gba"
+
+    def test_creates_empty_entry_when_missing(self, tmp_path):
+        svc = _make_state_svc(tmp_path)
+        assert "999" not in svc.data["saves"]
+
+        svc.clear_files_state("999")
+
+        assert svc.data["saves"]["999"] == {"files": {}}
+
+    def test_does_not_persist_on_its_own(self, tmp_path):
+        """clear_files_state must not write to disk — caller orchestrates persistence."""
+        svc = _make_state_svc(tmp_path)
+        svc.data["saves"]["42"] = {"files": {"pokemon.srm": {}}}
+
+        svc.clear_files_state("42")
+
+        # No file should have been written.
+        assert not (tmp_path / "save_sync_state.json").exists()
+
+    def test_idempotent(self, tmp_path):
+        svc = _make_state_svc(tmp_path)
+        svc.data["saves"]["42"] = {
+            "files": {"pokemon.srm": {}},
+            "active_slot": "desktop",
+            "slot_confirmed": True,
+        }
+
+        svc.clear_files_state("42")
+        svc.clear_files_state("42")
+
+        entry = svc.data["saves"]["42"]
+        assert entry["files"] == {}
+        assert entry["active_slot"] == "desktop"
+        assert entry["slot_confirmed"] is True
+
+    def test_creates_saves_dict_if_missing(self, tmp_path):
+        """Defensive: if the top-level 'saves' key were missing, recreate it."""
+        svc = _make_state_svc(tmp_path)
+        del svc.data["saves"]
+
+        svc.clear_files_state("42")
+
+        assert svc.data["saves"] == {"42": {"files": {}}}

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -869,7 +869,57 @@ async def test_delete_local_saves_happy_path(plugin, tmp_path):
     assert result["deleted_count"] == 2
     assert not srm.exists()
     assert not rtc.exists()
-    assert "100" not in plugin._save_sync_state["saves"]
+    # Entry survives — only files are cleared (#279).
+    assert "100" in plugin._save_sync_state["saves"]
+    assert plugin._save_sync_state["saves"]["100"]["files"] == {}
+    assert plugin._save_sync_state["saves"]["100"]["system"] == system
+
+
+@pytest.mark.asyncio
+async def test_delete_local_saves_preserves_slot_config(plugin, tmp_path):
+    """Slot config / attribution metadata survive a delete (#279)."""
+    rom_id = 101
+    system = "snes"
+    rom_name = "SlotGame"
+
+    plugin._state["installed_roms"]["101"] = {
+        "rom_id": 101,
+        "file_name": f"{rom_name}.sfc",
+        "file_path": str(tmp_path / "retrodeck" / "roms" / system / f"{rom_name}.sfc"),
+        "system": system,
+        "platform_slug": "snes",
+    }
+
+    saves_dir = tmp_path / "retrodeck" / "saves" / system
+    saves_dir.mkdir(parents=True)
+    srm = saves_dir / f"{rom_name}.srm"
+    srm.write_bytes(b"\x00" * 32)
+
+    plugin._save_sync_state["saves"]["101"] = {
+        "files": {f"{rom_name}.srm": {"last_sync_hash": "hash"}},
+        "active_slot": "desktop",
+        "slot_confirmed": True,
+        "emulator": "retroarch-snes9x",
+        "last_synced_core": "snes9x_libretro",
+        "own_upload_ids": ["save-9"],
+        "slots": {"default": {}, "desktop": {}},
+        "system": system,
+    }
+
+    result = await plugin.delete_local_saves(rom_id)
+    assert result["success"] is True
+    assert result["deleted_count"] == 1
+    assert not srm.exists()
+
+    entry = plugin._save_sync_state["saves"]["101"]
+    assert entry["files"] == {}
+    assert entry["active_slot"] == "desktop"
+    assert entry["slot_confirmed"] is True
+    assert entry["emulator"] == "retroarch-snes9x"
+    assert entry["last_synced_core"] == "snes9x_libretro"
+    assert entry["own_upload_ids"] == ["save-9"]
+    assert entry["slots"] == {"default": {}, "desktop": {}}
+    assert entry["system"] == system
 
 
 @pytest.mark.asyncio
@@ -942,8 +992,13 @@ async def test_delete_platform_saves(plugin, tmp_path):
     assert result["deleted_count"] == 2
     assert not srm1.exists()
     assert not srm2.exists()
-    assert "10" not in plugin._save_sync_state["saves"]
-    assert "20" not in plugin._save_sync_state["saves"]
+    # Entries survive — only files are cleared (#279).
+    assert "10" in plugin._save_sync_state["saves"]
+    assert plugin._save_sync_state["saves"]["10"]["files"] == {}
+    assert plugin._save_sync_state["saves"]["10"]["system"] == "snes"
+    assert "20" in plugin._save_sync_state["saves"]
+    assert plugin._save_sync_state["saves"]["20"]["files"] == {}
+    assert plugin._save_sync_state["saves"]["20"]["system"] == "snes"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Two related fixes to the save-delete flows surfaced during smoke testing of #278.

Closes #279, closes #280.

## #279 — preserve slot config on delete

`_delete_saves_for_roms` previously called `pop(rom_id_str, None)` on the
state dict, which wiped the entire ROM entry — `active_slot`, `slot_confirmed`,
`emulator`, `last_synced_core`, `own_upload_ids`, `slots`, `system`. The
first-setup wizard then re-fired on the next game-detail mount, even though
slot tracking had already been configured. On the per-platform path this
re-triggered the wizard once per installed ROM on the platform.

- New `StateService.clear_files_state(rom_id_str)` — clears only the per-file
  tracking dict, leaves slot/attribution metadata untouched.
- `_delete_saves_for_roms` (facade) routes through it.
- `SlotsService._delete_local_saves_for_switch` (slot-switch cleanup) routed
  through the same method to keep the file-clear pattern in one place.

Side note: `clear_files_state` creates a `{"files": {}}` stub entry when a
ROM had no prior state. Benign — all callers `.get(rom_id_str, {})` and
`prune_orphaned_state` cleans it up. Tested as a deliberate behavior.

## #280 — confirm before platform-wide delete

`DangerZone.handleDeleteSaves` fired `deletePlatformSaves(slug)` with no
confirmation modal — a single tap could wipe every local save for every
installed ROM on a platform. The per-ROM path in `RomMPlaySection` already
had a `ConfirmModal`.

Wrapped the platform path in a `ConfirmModal` matching the existing pattern.
Copy warns about losing unsynced local changes.

## Test plan

- [x] pytest: 1747 passed (1738 → 1747, +9 new tests)
- [x] ruff check: clean
- [x] basedpyright: 0 errors, 0 warnings, 0 notes
- [x] lint-imports: 6/6 contracts kept
- [x] pnpm build: clean
- [x] Smoke test on Steam Deck — per-ROM delete (Mario Golf Advance): slot_confirmed survived, files dict cleared, no wizard re-fire
- [x] Smoke test on Steam Deck — per-platform delete via QAM: ConfirmModal appears, OK proceeds, slot config preserved across processed ROMs, stale orphan entries correctly untouched