### PR TITLE
fix(saves): sanitize server-supplied and frontend filenames (#224)

### DIFF
--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -86,6 +86,32 @@ def resolve_save_filename(rom_path: str, ext: str = ".srm") -> str:
     return name + ext
 
 
+def sanitize_save_filename(name: str) -> str:
+    """Reduce *name* to a safe filename component for joining onto ``saves_dir``.
+
+    Defends path joins against compromised-server data (e.g. a malicious
+    ``file_extension``) and frontend-supplied filenames (e.g. the
+    ``resolve_sync_conflict`` callable parameter). Pure: no I/O, stdlib only.
+
+    Returns the basename of *name* unchanged when it is already a single
+    safe component. Raises :class:`ValueError` for inputs that cannot be
+    coerced into a usable filename:
+
+    - empty string
+    - ``"."`` or ``".."``
+    - any string containing a NUL byte
+    - inputs whose basename is empty (e.g. trailing path separator)
+    """
+    if "\x00" in name:
+        raise ValueError("filename contains a NUL byte")
+    if name in ("", ".", ".."):
+        raise ValueError(f"filename is not a valid path component: {name!r}")
+    base = os.path.basename(name)
+    if base in ("", ".", ".."):
+        raise ValueError(f"filename has no valid basename: {name!r}")
+    return base
+
+
 def detect_path_change(stored_path: str | None, resolved_path: str) -> bool:
     """Detect if the save path has changed since last sync.
 

--- a/py_modules/services/saves/_helpers.py
+++ b/py_modules/services/saves/_helpers.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
+from domain.save_path import sanitize_save_filename
+
+_logger = logging.getLogger(__name__)
+
 
 def _compute_uploaded_by_us(
     server_save: dict | None,
@@ -33,4 +39,24 @@ def _local_save_target(server_save: dict, rom_name: str) -> str:
     actual lookup path and silently break the sync.
     """
     ext = server_save.get("file_extension", "srm")
-    return f"{rom_name}.{ext}"
+    target = f"{rom_name}.{ext}"
+    try:
+        sanitized = sanitize_save_filename(target)
+    except ValueError:
+        # Server returned an extension that produces an unusable filename
+        # (NUL byte, ``"."``, ``".."``, …). Fall back to the safe default
+        # so the sync attempt doesn't crash the whole ROM loop.
+        _logger.warning(
+            "Sanitized server-supplied save target — invalid file_extension=%r; falling back to 'srm'",
+            ext,
+        )
+        return f"{rom_name}.srm"
+    if sanitized != target:
+        # Path-traversal characters were stripped (e.g. ``../etc/passwd``).
+        _logger.warning(
+            "Sanitized server-supplied save target from %r to %r (file_extension=%r)",
+            target,
+            sanitized,
+            ext,
+        )
+    return sanitized

--- a/py_modules/services/saves/_helpers.py
+++ b/py_modules/services/saves/_helpers.py
@@ -1,4 +1,4 @@
-"""Pure helpers for the saves package — no state, no I/O."""
+"""Cross-cutting helpers for the saves package — utilities shared across sub-services."""
 
 from __future__ import annotations
 

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -13,7 +13,7 @@ from models.saves import SaveConflict
 
 from domain.emulator_tag import detect_core_change
 from domain.save_extensions import get_save_extensions
-from domain.save_path import resolve_save_dir
+from domain.save_path import resolve_save_dir, sanitize_save_filename
 from lib.errors import classify_error
 from lib.iso_time import parse_iso_to_epoch
 from services.protocols import (
@@ -849,6 +849,27 @@ class SaveService:
 
         if action not in ("keep_local", "use_server"):
             return {"success": False, "message": f"Invalid action: {action}"}
+
+        # Frontend-supplied filename flows into ``os.path.join(saves_dir, …)``
+        # via ``_resolve_conflict_keep_local``. Reject anything that isn't
+        # already a clean basename — legitimate callers always pass one.
+        try:
+            sanitized = sanitize_save_filename(filename)
+        except ValueError as e:
+            self._logger.warning(
+                "resolve_sync_conflict(rom_id=%d, action=%s) rejected invalid filename: %s",
+                rom_id,
+                action,
+                e,
+            )
+            return {"success": False, "message": "Invalid filename"}
+        if sanitized != filename:
+            self._logger.warning(
+                "resolve_sync_conflict(rom_id=%d, action=%s) rejected non-basename filename",
+                rom_id,
+                action,
+            )
+            return {"success": False, "message": "Invalid filename"}
 
         async with self._rom_lock(rom_id):
             info = self._get_rom_save_info(rom_id)

--- a/tests/domain/test_save_path.py
+++ b/tests/domain/test_save_path.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from domain.save_path import (
     detect_path_change,
     resolve_save_dir,
     resolve_save_filename,
+    sanitize_save_filename,
 )
 
 # ---------------------------------------------------------------------------
@@ -197,3 +200,46 @@ class TestDetectPathChange:
     def test_trailing_slash_difference(self) -> None:
         """Paths with vs without trailing slash are different strings."""
         assert detect_path_change("/saves/gba/", "/saves/gba") is True
+
+
+# ---------------------------------------------------------------------------
+# sanitize_save_filename
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeSaveFilename:
+    def test_clean_basename_returned_unchanged(self) -> None:
+        assert sanitize_save_filename("mario.srm") == "mario.srm"
+
+    def test_clean_name_with_spaces_and_parens_unchanged(self) -> None:
+        """RetroArch-friendly filenames with USA/Europe tags are valid."""
+        name = "Mario Golf - Advance Tour (USA).srm"
+        assert sanitize_save_filename(name) == name
+
+    def test_traversal_components_stripped_to_basename(self) -> None:
+        """``../../etc/passwd`` → ``passwd`` (basename of last component)."""
+        assert sanitize_save_filename("../../etc/passwd") == "passwd"
+
+    def test_absolute_path_stripped_to_basename(self) -> None:
+        assert sanitize_save_filename("/etc/passwd") == "passwd"
+
+    def test_null_byte_rejected(self) -> None:
+        with pytest.raises(ValueError, match="NUL byte"):
+            sanitize_save_filename("foo\x00bar.srm")
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            sanitize_save_filename("")
+
+    def test_dot_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            sanitize_save_filename(".")
+
+    def test_dotdot_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            sanitize_save_filename("..")
+
+    def test_trailing_separator_rejected(self) -> None:
+        """``foo/`` has an empty basename, which is not a valid component."""
+        with pytest.raises(ValueError):
+            sanitize_save_filename("foo/")

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -5384,6 +5384,91 @@ class TestResolveSyncConflict:
 
 
 # ---------------------------------------------------------------------------
+# Path-traversal defense (#224)
+# ---------------------------------------------------------------------------
+
+
+class TestPathTraversalDefense:
+    """Defense in depth against malicious filenames at the two choke points.
+
+    1. Server-supplied ``file_extension`` flowing through ``_local_save_target``.
+    2. Frontend-supplied ``filename`` arriving at ``resolve_sync_conflict``.
+    """
+
+    def test_local_save_target_strips_traversal_in_extension(self):
+        """A malicious ``file_extension`` cannot produce a path-escape filename."""
+        from services.saves._helpers import _local_save_target
+
+        target = _local_save_target({"file_extension": "../etc/passwd"}, "pokemon")
+        # Sanitization reduces to a simple basename — no separators, no parent refs.
+        assert "/" not in target
+        assert ".." not in target.split(".")
+        assert os.path.basename(target) == target
+
+    def test_local_save_target_happy_path_unchanged(self):
+        """Clean ``file_extension`` produces ``<rom_name>.<ext>`` unchanged."""
+        from services.saves._helpers import _local_save_target
+
+        assert _local_save_target({"file_extension": "srm"}, "pokemon") == "pokemon.srm"
+
+    def test_local_save_target_falls_back_to_srm_on_unusable_ext(self, caplog):
+        """When the server's extension produces an empty/dot-only name, fall back to ``srm``."""
+        from services.saves._helpers import _local_save_target
+
+        with caplog.at_level(logging.WARNING):
+            # An ``ext`` that drives the basename to ``""`` after sanitization
+            # (e.g. trailing separator) — the helper degrades to ``"srm"``.
+            target = _local_save_target({"file_extension": "evil/"}, "pokemon")
+        # Either the sanitized basename or the safe default — never traversal.
+        assert "/" not in target
+        assert target.endswith(".srm") or target == "pokemon.srm"
+
+    @pytest.mark.asyncio
+    async def test_resolve_sync_conflict_rejects_traversal_filename(self, tmp_path, caplog):
+        """Frontend-supplied traversal filename is rejected before any I/O."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"local data")
+
+        # Snapshot files outside saves_dir to assert nothing got written there.
+        outside = tmp_path / "outside.txt"
+
+        with caplog.at_level(logging.WARNING):
+            result = await svc.resolve_sync_conflict(
+                rom_id=42,
+                filename="../../etc/passwd",
+                action="keep_local",
+            )
+
+        assert result["success"] is False
+        assert "invalid" in result["message"].lower()
+        # No I/O against the server (no list_saves, no upload_save).
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        # Nothing written outside saves_dir.
+        assert not outside.exists()
+        assert not (tmp_path / "etc").exists()
+        # A warning was logged identifying the rejection.
+        assert any("rejected" in rec.message.lower() and "filename" in rec.message.lower() for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_resolve_sync_conflict_rejects_null_byte_filename(self, tmp_path):
+        """NUL byte in filename is rejected with the same shape."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon\x00.srm",
+            action="keep_local",
+        )
+
+        assert result["success"] is False
+        assert "invalid" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
 # Per-rom lock serialization
 # ---------------------------------------------------------------------------
 

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -5395,15 +5395,18 @@ class TestPathTraversalDefense:
     2. Frontend-supplied ``filename`` arriving at ``resolve_sync_conflict``.
     """
 
-    def test_local_save_target_strips_traversal_in_extension(self):
+    def test_local_save_target_strips_traversal_in_extension(self, caplog):
         """A malicious ``file_extension`` cannot produce a path-escape filename."""
         from services.saves._helpers import _local_save_target
 
-        target = _local_save_target({"file_extension": "../etc/passwd"}, "pokemon")
+        with caplog.at_level(logging.WARNING):
+            target = _local_save_target({"file_extension": "../etc/passwd"}, "pokemon")
         # Sanitization reduces to a simple basename — no separators, no parent refs.
         assert "/" not in target
         assert ".." not in target.split(".")
         assert os.path.basename(target) == target
+        # The strip-and-warn path must log a warning identifying the sanitized field.
+        assert any("Sanitized" in rec.message and "file_extension" in rec.message for rec in caplog.records)
 
     def test_local_save_target_happy_path_unchanged(self):
         """Clean ``file_extension`` produces ``<rom_name>.<ext>`` unchanged."""
@@ -5422,6 +5425,9 @@ class TestPathTraversalDefense:
         # Either the sanitized basename or the safe default — never traversal.
         assert "/" not in target
         assert target.endswith(".srm") or target == "pokemon.srm"
+        # The fallback path is the only signal of a glitched server extension —
+        # assert it actually fires so a future refactor can't drop it silently.
+        assert any("invalid" in rec.message.lower() and "file_extension" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
     async def test_resolve_sync_conflict_rejects_traversal_filename(self, tmp_path, caplog):
@@ -5444,6 +5450,7 @@ class TestPathTraversalDefense:
         assert result["success"] is False
         assert "invalid" in result["message"].lower()
         # No I/O against the server (no list_saves, no upload_save).
+        assert not any(c[0] == "list_saves" for c in fake.call_log)
         assert not any(c[0] == "upload_save" for c in fake.call_log)
         # Nothing written outside saves_dir.
         assert not outside.exists()


### PR DESCRIPTION
## Summary

Defense in depth against path-traversal via filenames in the saves subsystem.

Closes #224.

## Threat model

Two ways a tainted filename could reach an `os.path.join(saves_dir, …)` site:

1. **Compromised RomM server** — the `file_extension` field on save objects flows
   through `_local_save_target` and ends up joined to `saves_dir` at four
   sites in `sync_engine`, `versions`, `slots`, and `facade`. A server
   returning `file_extension: "../etc/passwd"` (or `"/etc/passwd"`) could
   write outside `saves_dir`.
2. **Frontend callable** — `resolve_sync_conflict(filename, …)` is a
   `@decky.callable` that takes a `filename` from the JS layer and passes
   it to `_resolve_conflict_keep_local` for a join. Wider attack surface
   than (1) — any JS caller can craft input.

Note on issue body: the original report cited `file_name` as the vector,
but post-#278 only `file_extension` reaches a join through server data.
`file_name` is used for display and dict keys only. Audit scope was
narrower than the issue suggested.

## Implementation

Pure helper `sanitize_save_filename(name: str) -> str` in
`domain/save_path.py` — `os.path.basename(name)` with explicit rejection of
`""`, `"."`, `".."`, and null bytes (raises `ValueError`).

Applied at two boundaries — not at every join site:

- **Server-data choke point** — `_helpers._local_save_target` sanitizes
  the constructed `<rom_name>.<ext>`. **Lenient pattern** matching
  `services/downloads.py:242-245`: log a warning and proceed with the
  basename if traversal characters were stripped; fall back to
  `<rom_name>.srm` if sanitization itself raises (truly broken input).
  Single fix covers all four downstream consumers.

- **Frontend boundary** — `facade.resolve_sync_conflict` rejects the
  call with `{"success": False, "message": "Invalid filename"}` when
  the sanitized result differs from the input. **Strict pattern** here
  because legitimate JS callers always pass a clean basename — any
  deviation is either a bug or an attack and shouldn't silently rewrite.

## Behaviour preservation

Pre-existing `_local_save_target` defaults are preserved: empty
`file_extension` still produces `<rom_name>.srm`. Clean filenames
(`Mario Golf - Advance Tour (USA).srm`) round-trip unchanged. No
existing tests required updates beyond adding new defensive coverage.

## Test plan

- [x] pytest: 1761 passed (1747 → 1761, +14 tests)
- [x] ruff check: clean
- [x] basedpyright: 0 errors, 0 warnings, 0 notes
- [x] lint-imports: 6/6 contracts kept
- [x] pnpm build: clean
- [x] New `TestPathTraversalDefense` covers: traversal in `file_extension`
      (strip + warn), unusable `file_extension` (fall back to `srm` + warn),
      frontend traversal `filename` (reject + no I/O), frontend null-byte
      `filename` (reject)
- [x] Helper tests in `tests/domain/test_save_path.py`: happy / traversal /
      absolute / null / empty / `.` / `..` / trailing-separator
- [x] Warning-log assertions present so the only observability of a
      glitched server can't be silently dropped by a future refactor