### PR TITLE
refactor(saves): route save_sync_state.json through PersistenceAdapter (#166)

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ sys.path.insert(0, plugin_dir)
 import decky
 from bootstrap import WiringConfig, bootstrap, wire_services
 
-from adapters.persistence import PersistenceAdapter
+from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -195,6 +195,7 @@ class Plugin:
                 save_metadata_cache=self._save_metadata_cache,
                 save_firmware_cache=self._persistence.save_firmware_cache,
                 load_firmware_cache=self._persistence.load_firmware_cache,
+                save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
                 log_debug=self._log_debug,
             )
         )

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -199,3 +199,54 @@ class PersistenceAdapter:
         data["version"] = _FIRMWARE_CACHE_VERSION
         cache_path = os.path.join(self._runtime_dir, "firmware_cache.json")
         self._locked_write(cache_path, data)
+
+    # ------------------------------------------------------------------
+    # Save-sync state
+    # ------------------------------------------------------------------
+
+    def save_save_sync_state(self, data: dict) -> None:
+        """Atomic write of *data* to ``save_sync_state.json`` with flock.
+
+        Does not stamp a version — ``save_sync_state.json`` carries its
+        own ``version`` key managed by the service-side migration layer
+        (``StateService._migrate_loaded_state``). Adapters do dumb I/O.
+        """
+        state_path = os.path.join(self._runtime_dir, "save_sync_state.json")
+        self._locked_write(state_path, data)
+
+    def load_save_sync_state(self) -> dict | None:
+        """Read ``save_sync_state.json`` and return the raw dict.
+
+        Returns ``None`` when the file is missing, corrupt, or not a
+        JSON object — callers (``StateService.load_state``) treat that
+        as "first run, keep defaults". Migrations on the returned payload
+        live in the service layer.
+        """
+        state_path = os.path.join(self._runtime_dir, "save_sync_state.json")
+        try:
+            with open(state_path) as f:
+                loaded = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        if not isinstance(loaded, dict):
+            return None
+        return loaded
+
+
+class SaveSyncStatePersisterAdapter:
+    """Adapter view exposing the ``SaveSyncStatePersister`` Protocol.
+
+    Wraps a :class:`PersistenceAdapter` and forwards ``save`` / ``load``
+    to its ``save_save_sync_state`` / ``load_save_sync_state`` methods.
+    Lives in the adapters layer so services depend only on the Protocol,
+    never on this class.
+    """
+
+    def __init__(self, persistence: PersistenceAdapter) -> None:
+        self._persistence = persistence
+
+    def save(self, data: dict) -> None:
+        self._persistence.save_save_sync_state(data)
+
+    def load(self) -> dict | None:
+        return self._persistence.load_save_sync_state()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -41,6 +41,7 @@ from services.protocols import (
     RommApiProtocol,
     RomsPathProvider,
     SavesPathProvider,
+    SaveSyncStatePersister,
     SettingsPersister,
     StatePersister,
 )
@@ -87,6 +88,7 @@ class WiringConfig:
     save_metadata_cache: StatePersister
     save_firmware_cache: Callable[[dict], None]
     load_firmware_cache: Callable[[], dict]
+    save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
 
 
@@ -196,6 +198,7 @@ def wire_services(cfg: WiringConfig) -> dict:
 
     save_service_config = SaveServiceConfig(
         runtime_dir=cfg.runtime_dir,
+        save_sync_state_persister=cfg.save_sync_state_persister,
         loop=cfg.loop,
         logger=cfg.logger,
         get_saves_path=cfg.get_saves_path,

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -297,6 +297,21 @@ class SettingsPersister(Protocol):
     def __call__(self) -> None: ...
 
 
+class SaveSyncStatePersister(Protocol):
+    """Read/write the on-disk save-sync state file.
+
+    Implementations are responsible for atomic writes, locking, and
+    handling missing/corrupt files. They perform dumb I/O only —
+    schema migrations on loaded data live in ``StateService``, so
+    ``load`` returns the raw dict (or ``None`` when the file does not
+    yet exist) without versioning the payload.
+    """
+
+    def save(self, data: dict) -> None: ...
+
+    def load(self) -> dict | None: ...
+
+
 class EventEmitter(Protocol):
     """Emit named events with a data payload to the frontend."""
 

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         EventEmitter,
         RomsPathProvider,
         SavesPathProvider,
+        SaveSyncStatePersister,
     )
 
 
@@ -36,8 +37,13 @@ class SaveServiceConfig:
     Parameters
     ----------
     runtime_dir:
-        Absolute path to the plugin runtime directory (for
-        ``save_sync_state.json`` persistence).
+        Absolute path to the plugin runtime directory. Consumed by
+        SaveService for ad-hoc runtime files; ``save_sync_state.json``
+        persistence routes through ``save_sync_state_persister``.
+    save_sync_state_persister:
+        Protocol-typed I/O wrapper for ``save_sync_state.json``. The
+        ``StateService`` uses ``.save(data)`` / ``.load() -> dict | None``
+        — file path, locking, and atomic-write are adapter-internal.
     loop:
         The plugin's ``asyncio`` event loop (for ``run_in_executor``).
     logger:
@@ -89,6 +95,7 @@ class SaveServiceConfig:
     """
 
     runtime_dir: str
+    save_sync_state_persister: SaveSyncStatePersister
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     get_saves_path: SavesPathProvider

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -79,7 +79,7 @@ class SaveService:
         self._state_svc = StateService(
             save_sync_state=save_sync_state,
             state=state,
-            runtime_dir=config.runtime_dir,
+            persister=config.save_sync_state_persister,
             logger=config.logger,
         )
         # Alias the dict so the dozens of self._save_sync_state[...] call

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -1,33 +1,36 @@
-"""Single source of truth for save_sync_state.json.
+"""In-memory save-sync state and on-disk migration logic.
 
-Anything that loads, persists, migrates, or owns the on-disk save-sync
-state lives here. Other modules read state via the ``data`` property and
-trigger persistence via ``save_state()`` — they never open the file
-directly.
+Anything that mutates ``save_sync_state`` in memory or migrates a
+freshly-loaded payload lives here. Raw I/O for ``save_sync_state.json``
+(atomic writes, locking, missing-file handling) belongs to the
+``SaveSyncStatePersister`` injected into ``StateService``; this service
+never opens the file directly.
 """
 
 from __future__ import annotations
 
-import fcntl
-import json
-import logging
-import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+    from services.protocols import SaveSyncStatePersister
 
 
 class StateService:
-    """Owns ``save_sync_state.json`` — single source of truth for on-disk save-sync state."""
+    """Owns the in-memory save-sync state dict and its on-load migrations."""
 
     def __init__(
         self,
         *,
         save_sync_state: dict,
         state: dict,
-        runtime_dir: str,
+        persister: SaveSyncStatePersister,
         logger: logging.Logger,
     ) -> None:
         self._save_sync_state = save_sync_state
         self._state = state
-        self._runtime_dir = runtime_dir
+        self._persister = persister
         self._logger = logger
 
     @property
@@ -115,36 +118,22 @@ class StateService:
 
     def load_state(self) -> None:
         """Load save sync state from disk, merging with defaults."""
-        path = os.path.join(self._runtime_dir, "save_sync_state.json")
-        try:
-            with open(path) as f:
-                saved = json.load(f)
-            for key in ("saves", "playtime"):
-                if key in saved:
-                    self._save_sync_state[key] = saved[key]
-            for key in ("version", "device_id", "device_name", "server_device_id"):
-                if key in saved:
-                    self._save_sync_state[key] = saved[key]
-            if "settings" in saved:
-                self._save_sync_state["settings"].update(saved["settings"])
-        except (FileNotFoundError, json.JSONDecodeError):
+        saved = self._persister.load()
+        if saved is None:
             return
+        for key in ("saves", "playtime"):
+            if key in saved:
+                self._save_sync_state[key] = saved[key]
+        for key in ("version", "device_id", "device_name", "server_device_id"):
+            if key in saved:
+                self._save_sync_state[key] = saved[key]
+        if "settings" in saved:
+            self._save_sync_state["settings"].update(saved["settings"])
         self._migrate_loaded_state()
 
     def save_state(self) -> None:
-        """Persist save sync state to disk (atomic write)."""
-        os.makedirs(self._runtime_dir, exist_ok=True)
-        path = os.path.join(self._runtime_dir, "save_sync_state.json")
-        tmp = path + ".tmp"
-        lock_fd = os.open(path + ".lock", os.O_WRONLY | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w") as f:
-                json.dump(self._save_sync_state, f, indent=2)
-            os.replace(tmp, path)
-        finally:
-            os.close(lock_fd)
+        """Persist save sync state to disk via the injected persister."""
+        self._persister.save(self._save_sync_state)
 
     def clear_files_state(self, rom_id_str: str) -> None:
         """Clear the per-file tracking dict for a ROM, preserving slot config.

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -14,6 +14,7 @@ from adapters.persistence import (
     _STATE_VERSION,
     DEFAULT_SETTINGS,
     PersistenceAdapter,
+    SaveSyncStatePersisterAdapter,
 )
 
 
@@ -317,3 +318,76 @@ class TestLoadingEdgeCases:
         settings_path = os.path.join(adapter._settings_dir, "settings.json")
         mode = os.stat(settings_path).st_mode & 0o777
         assert mode == 0o600
+
+
+# ── Save-sync state ────────────────────────────────────────────────────────────
+
+
+class TestSaveSyncState:
+    def test_save_creates_lock_file(self, adapter):
+        adapter.save_save_sync_state({"version": 1, "saves": {}})
+        lock_path = os.path.join(adapter._runtime_dir, "save_sync_state.json.lock")
+        assert os.path.exists(lock_path)
+
+    def test_save_round_trip(self, adapter):
+        payload = {
+            "version": 1,
+            "device_id": "dev-1",
+            "saves": {"42": {"files": {"game.srm": {"tracked_save_id": 7}}}},
+        }
+        adapter.save_save_sync_state(payload)
+        loaded = adapter.load_save_sync_state()
+        assert loaded == payload
+
+    def test_save_does_not_stamp_version_when_caller_omits_it(self, adapter):
+        """Adapter is dumb I/O — it must not inject a version when the caller
+        didn't supply one. Migrations and version stamping live in StateService."""
+        adapter.save_save_sync_state({"saves": {}, "playtime": {}})
+        loaded = adapter.load_save_sync_state()
+        assert loaded == {"saves": {}, "playtime": {}}
+        assert "version" not in loaded
+
+    def test_load_missing_file_returns_none(self, adapter):
+        result = adapter.load_save_sync_state()
+        assert result is None
+
+    def test_load_corrupt_json_returns_none(self, adapter):
+        path = os.path.join(adapter._runtime_dir, "save_sync_state.json")
+        with open(path, "w") as f:
+            f.write("CORRUPT{{{")
+        result = adapter.load_save_sync_state()
+        assert result is None
+
+    def test_load_non_dict_json_returns_none(self, adapter):
+        path = os.path.join(adapter._runtime_dir, "save_sync_state.json")
+        with open(path, "w") as f:
+            json.dump([1, 2, 3], f)
+        result = adapter.load_save_sync_state()
+        assert result is None
+
+    def test_save_atomic_write_no_tmp_file_after_success(self, adapter):
+        adapter.save_save_sync_state({"version": 1})
+        tmp_path = os.path.join(adapter._runtime_dir, "save_sync_state.json.tmp")
+        assert not os.path.exists(tmp_path)
+
+
+class TestSaveSyncStatePersisterAdapter:
+    def test_save_delegates_to_persistence_adapter(self, adapter):
+        wrapper = SaveSyncStatePersisterAdapter(adapter)
+        wrapper.save({"version": 1, "device_id": "dev-1"})
+
+        path = os.path.join(adapter._runtime_dir, "save_sync_state.json")
+        with open(path) as f:
+            on_disk = json.load(f)
+        assert on_disk == {"version": 1, "device_id": "dev-1"}
+
+    def test_load_delegates_to_persistence_adapter(self, adapter):
+        wrapper = SaveSyncStatePersisterAdapter(adapter)
+        wrapper.save({"version": 1, "saves": {"42": {"files": {}}}})
+
+        loaded = wrapper.load()
+        assert loaded == {"version": 1, "saves": {"42": {"files": {}}}}
+
+    def test_load_returns_none_when_missing(self, adapter):
+        wrapper = SaveSyncStatePersisterAdapter(adapter)
+        assert wrapper.load() is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,34 @@ def _make_testable_plugin():
     return instance
 
 
+class FakeSaveSyncStatePersister:
+    """In-memory ``SaveSyncStatePersister`` for tests.
+
+    Keeps the most recently saved dict in ``self.last_saved`` and the
+    canned payload returned by ``load`` in ``self.canned_load``. Tests
+    that don't care about persistence can use the default (no canned
+    payload, returns None) and rely on ``last_saved`` for assertions.
+    """
+
+    def __init__(self, *, canned_load: dict | None = None) -> None:
+        self.canned_load = canned_load
+        self.last_saved: dict | None = None
+        self.save_count = 0
+        self.load_count = 0
+
+    def save(self, data: dict) -> None:
+        self.save_count += 1
+        # Snapshot a deep-ish copy so later in-memory mutations don't
+        # silently change what the test inspects.
+        import copy
+
+        self.last_saved = copy.deepcopy(data)
+
+    def load(self) -> dict | None:
+        self.load_count += 1
+        return self.canned_load
+
+
 @pytest.fixture(autouse=True)
 def _reset_es_de_config_user_home():
     """Reset ``es_de_config`` module-level state between every test.

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 
+from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
 from services.firmware import FirmwareService
@@ -84,6 +85,13 @@ def plugin(tmp_path):
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             runtime_dir=str(tmp_path),
+            save_sync_state_persister=SaveSyncStatePersisterAdapter(
+                PersistenceAdapter(
+                    settings_dir=str(tmp_path),
+                    runtime_dir=str(tmp_path),
+                    logger=logging.getLogger("test"),
+                )
+            ),
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -12,8 +12,21 @@ from unittest.mock import MagicMock
 import pytest
 from fakes.fake_save_api import FakeSaveApi
 
+from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from lib.errors import RommApiError
 from services.saves import SaveService, SaveServiceConfig
+
+
+def _make_save_sync_state_persister(tmp_path) -> SaveSyncStatePersisterAdapter:
+    """Adapter rooted at tmp_path so disk-touching tests stay end-to-end."""
+    return SaveSyncStatePersisterAdapter(
+        PersistenceAdapter(
+            settings_dir=str(tmp_path),
+            runtime_dir=str(tmp_path),
+            logger=logging.getLogger("test"),
+        )
+    )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,6 +47,7 @@ def _make_retry():
 _CONFIG_FIELDS = frozenset(
     {
         "runtime_dir",
+        "save_sync_state_persister",
         "loop",
         "logger",
         "get_saves_path",
@@ -53,6 +67,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
     fake: FakeSaveApi = fake_api or FakeSaveApi()
     config_kwargs: dict[str, Any] = dict(
         runtime_dir=str(tmp_path),
+        save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
         get_saves_path=lambda: str(tmp_path / "saves"),

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -2,23 +2,31 @@
 
 import logging
 
+from conftest import FakeSaveSyncStatePersister
+
 from services.saves.state import StateService
 
 
-def _make_state_svc(tmp_path) -> StateService:
+def _make_state_svc(
+    persister: FakeSaveSyncStatePersister | None = None,
+) -> tuple[StateService, FakeSaveSyncStatePersister]:
     save_sync_state = StateService.make_default_state()
     state: dict = {"shortcut_registry": {}, "installed_roms": {}}
-    return StateService(
-        save_sync_state=save_sync_state,
-        state=state,
-        runtime_dir=str(tmp_path),
-        logger=logging.getLogger("test"),
+    p = persister or FakeSaveSyncStatePersister()
+    return (
+        StateService(
+            save_sync_state=save_sync_state,
+            state=state,
+            persister=p,
+            logger=logging.getLogger("test"),
+        ),
+        p,
     )
 
 
 class TestClearFilesState:
-    def test_clears_files_preserves_slot_config(self, tmp_path):
-        svc = _make_state_svc(tmp_path)
+    def test_clears_files_preserves_slot_config(self):
+        svc, _ = _make_state_svc()
         svc.data["saves"]["42"] = {
             "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
             "active_slot": "desktop",
@@ -42,26 +50,25 @@ class TestClearFilesState:
         assert entry["slots"] == {"default": {}, "desktop": {}}
         assert entry["system"] == "gba"
 
-    def test_creates_empty_entry_when_missing(self, tmp_path):
-        svc = _make_state_svc(tmp_path)
+    def test_creates_empty_entry_when_missing(self):
+        svc, _ = _make_state_svc()
         assert "999" not in svc.data["saves"]
 
         svc.clear_files_state("999")
 
         assert svc.data["saves"]["999"] == {"files": {}}
 
-    def test_does_not_persist_on_its_own(self, tmp_path):
+    def test_does_not_persist_on_its_own(self):
         """clear_files_state must not write to disk — caller orchestrates persistence."""
-        svc = _make_state_svc(tmp_path)
+        svc, persister = _make_state_svc()
         svc.data["saves"]["42"] = {"files": {"pokemon.srm": {}}}
 
         svc.clear_files_state("42")
 
-        # No file should have been written.
-        assert not (tmp_path / "save_sync_state.json").exists()
+        assert persister.save_count == 0
 
-    def test_idempotent(self, tmp_path):
-        svc = _make_state_svc(tmp_path)
+    def test_idempotent(self):
+        svc, _ = _make_state_svc()
         svc.data["saves"]["42"] = {
             "files": {"pokemon.srm": {}},
             "active_slot": "desktop",
@@ -76,11 +83,118 @@ class TestClearFilesState:
         assert entry["active_slot"] == "desktop"
         assert entry["slot_confirmed"] is True
 
-    def test_creates_saves_dict_if_missing(self, tmp_path):
+    def test_creates_saves_dict_if_missing(self):
         """Defensive: if the top-level 'saves' key were missing, recreate it."""
-        svc = _make_state_svc(tmp_path)
+        svc, _ = _make_state_svc()
         del svc.data["saves"]
 
         svc.clear_files_state("42")
 
         assert svc.data["saves"] == {"42": {"files": {}}}
+
+
+class TestSaveState:
+    def test_save_state_forwards_in_memory_dict_to_persister(self):
+        svc, persister = _make_state_svc()
+        svc.data["device_id"] = "abc123"
+        svc.data["saves"]["42"] = {"files": {"game.srm": {"tracked_save_id": 7}}}
+
+        svc.save_state()
+
+        assert persister.save_count == 1
+        assert persister.last_saved is not None
+        assert persister.last_saved["device_id"] == "abc123"
+        assert persister.last_saved["saves"]["42"]["files"]["game.srm"]["tracked_save_id"] == 7
+
+
+class TestLoadState:
+    def test_load_state_returns_early_when_persister_returns_none(self):
+        """First-run / missing-file: persister returns None → defaults stay intact."""
+        svc, persister = _make_state_svc(FakeSaveSyncStatePersister(canned_load=None))
+
+        # Mutate one default so we can detect it was preserved (load did NOT clobber it).
+        svc.data["device_id"] = "preserved"
+
+        svc.load_state()
+
+        assert persister.load_count == 1
+        assert svc.data["device_id"] == "preserved"
+        # Default settings still present (not wiped or overwritten with None).
+        assert svc.data["settings"]["save_sync_enabled"] is False
+
+    def test_load_state_merges_top_level_fields(self):
+        canned = {
+            "version": 1,
+            "device_id": "dev-1",
+            "device_name": "deck",
+            "server_device_id": "srv-1",
+            "saves": {"42": {"files": {}}},
+            "playtime": {"42": {"seconds": 3600}},
+            "settings": {"save_sync_enabled": True, "default_slot": "alt"},
+        }
+        svc, _ = _make_state_svc(FakeSaveSyncStatePersister(canned_load=canned))
+
+        svc.load_state()
+
+        assert svc.data["device_id"] == "dev-1"
+        assert svc.data["device_name"] == "deck"
+        assert svc.data["server_device_id"] == "srv-1"
+        assert svc.data["saves"] == {"42": {"files": {}}}
+        assert svc.data["playtime"] == {"42": {"seconds": 3600}}
+        # Settings merge with defaults — explicit keys win, others stay default.
+        assert svc.data["settings"]["save_sync_enabled"] is True
+        assert svc.data["settings"]["default_slot"] == "alt"
+        assert svc.data["settings"]["sync_before_launch"] is True  # default kept
+
+    def test_load_state_runs_migration_on_loaded_payload(self):
+        """active_core → last_synced_core, drops dismissed_newer_save_id, strips legacy settings."""
+        canned = {
+            "saves": {
+                "42": {
+                    "active_core": "mgba_libretro",
+                    "files": {
+                        "game.srm": {"tracked_save_id": 1, "dismissed_newer_save_id": 99},
+                    },
+                }
+            },
+            "settings": {
+                "save_sync_enabled": True,
+                "conflict_mode": "newest",  # legacy
+                "clock_skew_tolerance_sec": 5,  # legacy
+            },
+        }
+        svc, _ = _make_state_svc(FakeSaveSyncStatePersister(canned_load=canned))
+
+        svc.load_state()
+
+        entry = svc.data["saves"]["42"]
+        assert "active_core" not in entry
+        assert entry["last_synced_core"] == "mgba_libretro"
+        assert "dismissed_newer_save_id" not in entry["files"]["game.srm"]
+        assert "conflict_mode" not in svc.data["settings"]
+        assert "clock_skew_tolerance_sec" not in svc.data["settings"]
+
+
+class TestPruneOrphanedState:
+    def test_prune_persists_when_entries_removed(self):
+        svc, persister = _make_state_svc()
+        svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
+        svc.data["saves"]["42"] = {"files": {}}
+        svc.data["saves"]["999"] = {"files": {}}  # orphaned
+        svc.data["playtime"]["888"] = {"seconds": 0}  # orphaned
+
+        svc.prune_orphaned_state()
+
+        assert "999" not in svc.data["saves"]
+        assert "888" not in svc.data["playtime"]
+        assert "42" in svc.data["saves"]
+        assert persister.save_count == 1
+
+    def test_prune_does_not_persist_when_nothing_removed(self):
+        svc, persister = _make_state_svc()
+        svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
+        svc.data["saves"]["42"] = {"files": {}}
+
+        svc.prune_orphaned_state()
+
+        assert persister.save_count == 0

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -156,6 +156,7 @@ class TestWireServices:
             "save_metadata_cache": MagicMock(),
             "save_firmware_cache": MagicMock(),
             "load_firmware_cache": MagicMock(return_value={}),
+            "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
             "log_debug": MagicMock(),
         }
 

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -10,6 +10,7 @@ import pytest
 from conftest import _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 
+from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.library import LibraryService
@@ -85,6 +86,13 @@ def plugin(tmp_path):
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             runtime_dir=str(tmp_path),
+            save_sync_state_persister=SaveSyncStatePersisterAdapter(
+                PersistenceAdapter(
+                    settings_dir=str(tmp_path),
+                    runtime_dir=str(tmp_path),
+                    logger=logging.getLogger("test"),
+                )
+            ),
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),


### PR DESCRIPTION
## Summary

`StateService.save_state()` previously re-implemented the same `flock + tmp +
replace` pattern that `PersistenceAdapter._locked_write` already provides, and
was missing the `os.unlink(tmp_path)` cleanup-on-exception that the adapter
has — a latent correctness gap. This routes `save_sync_state.json` through
the existing adapter like all four other state files
(`settings.json`, `state.json`, `metadata_cache.json`, `firmware_cache.json`).

Closes #166.

## Implementation

Protocol-based dependency injection. Mirrors the existing
`StatePersister` / `SettingsPersister` precedent in `protocols.py:288-297`
(not the firmware-cache raw-callable shortcut at `bootstrap.py:88-89`).

- `services/protocols.py` — new `SaveSyncStatePersister(Protocol)` with
  `save(data) -> None` and `load() -> dict | None`.
- `adapters/persistence.py` — new `save_save_sync_state` /
  `load_save_sync_state` methods using the existing `_locked_write`. Plus
  a small `SaveSyncStatePersisterAdapter` wrapper exposing the Protocol
  shape for injection. No version-stamping at the adapter layer —
  migrations stay in the service.
- `services/saves/state.py` — `__init__` now takes
  `persister: SaveSyncStatePersister`; drops `runtime_dir`. `fcntl`, `os`,
  and `json` imports gone. `save_state` and `load_state` delegate to the
  persister. `_migrate_loaded_state` stays in the service (schema is
  service-side concern, I/O is adapter-side).
- Wired through `WiringConfig` → `SaveServiceConfig` → `StateService`.
  `main.py` constructs the wrapper once against the existing
  `PersistenceAdapter` instance — single I/O source.

## Cosmic Python notes

The `no-adapter-impl-in-services` import-linter contract stays intact —
`services/saves/state.py` no longer imports anything from `adapters.persistence`.
The Protocol describes what the service needs (a save/load pair); the
adapter provides the implementation. Tests pass a fake persister rather
than touching the filesystem.

## Behaviour preservation

JSON output format identical (`indent=2`, no `sort_keys`). Lock file
convention identical. Initial-load behaviour preserved (missing/corrupt
file → service keeps `init_state` defaults). The one expected
behavioural improvement: the adapter cleans up the `.tmp` file on
exception; the old `StateService.save_state` did not.

## Side benefit: I/O test gap from #279 plugged

After #279 split `tests/services/test_state.py` out of `test_saves.py`,
only `clear_files_state` had coverage there — `save_state`, `load_state`,
and migrations were untested. With the persister now injectable, those
methods are testable against a `FakeSaveSyncStatePersister` fixture
without touching the filesystem. New coverage in this PR:
save_state forwarding, load_state early-return on `None`, top-level
field merging, on-load migrations (`active_core` → `last_synced_core`,
legacy settings strip), and `prune_orphaned_state` only persisting when
entries change.

## Test plan

- [x] pytest: 1777 passed (1761 → 1777, +16 tests), 0 failures, 0 new skips
- [x] ruff check: clean
- [x] basedpyright: 0 errors, 0 warnings, 0 notes
- [x] lint-imports: 6/6 contracts kept (incl. `no-adapter-impl-in-services`)
- [x] pnpm build: clean
- [x] Smoke test on Steam Deck via `mise run dev`: plugin loaded cleanly,
      Mario Golf game detail rendered with prior `slot_confirmed=true`
      preserved, no first-setup wizard re-fire, no error toasts