### PR TITLE
refactor(services): promote artwork-remover + firmware-cache Callables to Protocols

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,11 @@ sys.path.insert(0, plugin_dir)
 import decky
 from bootstrap import WiringConfig, bootstrap, wire_services
 
-from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
+from adapters.persistence import (
+    FirmwareCachePersisterAdapter,
+    PersistenceAdapter,
+    SaveSyncStatePersisterAdapter,
+)
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -196,8 +200,7 @@ class Plugin:
                 save_state=self._save_state,
                 save_settings_to_disk=self._save_settings_to_disk,
                 save_metadata_cache=self._save_metadata_cache,
-                save_firmware_cache=self._persistence.save_firmware_cache,
-                load_firmware_cache=self._persistence.load_firmware_cache,
+                firmware_cache_persister=FirmwareCachePersisterAdapter(self._persistence),
                 save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
                 log_debug=self._log_debug,
             )

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -250,3 +250,22 @@ class SaveSyncStatePersisterAdapter:
 
     def load(self) -> dict | None:
         return self._persistence.load_save_sync_state()
+
+
+class FirmwareCachePersisterAdapter:
+    """Adapter view exposing the ``FirmwareCachePersister`` Protocol.
+
+    Wraps a :class:`PersistenceAdapter` and forwards ``save`` / ``load``
+    to its ``save_firmware_cache`` / ``load_firmware_cache`` methods.
+    Lives in the adapters layer so services depend only on the Protocol,
+    never on this class.
+    """
+
+    def __init__(self, persistence: PersistenceAdapter) -> None:
+        self._persistence = persistence
+
+    def save(self, data: dict) -> None:
+        self._persistence.save_firmware_cache(data)
+
+    def load(self) -> dict:
+        return self._persistence.load_firmware_cache()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -282,7 +282,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         logger=cfg.logger,
         emit=cfg.emit,
         save_state=cfg.save_state,
-        remove_artwork_files=artwork_service.remove_artwork_files,
+        artwork_remover=artwork_service,
     )
 
     sync_service = LibraryService(

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass
 
 from adapters.asyncio_sleeper import AsyncioSleeper
@@ -40,6 +39,7 @@ from services.protocols import (
     CoreNameProviderFn,
     DebugLogger,
     EventEmitter,
+    FirmwareCachePersister,
     RetroArchSaveSortingProvider,
     RetroDeckHomeProvider,
     RommApiProtocol,
@@ -95,8 +95,7 @@ class WiringConfig:
     save_state: StatePersister
     save_settings_to_disk: SettingsPersister
     save_metadata_cache: StatePersister
-    save_firmware_cache: Callable[[dict], None]
-    load_firmware_cache: Callable[[], dict]
+    firmware_cache_persister: FirmwareCachePersister
     save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
 
@@ -342,8 +341,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         plugin_dir=cfg.plugin_dir,
         clock=cfg.clock,
         save_state=cfg.save_state,
-        save_firmware_cache=cfg.save_firmware_cache,
-        load_firmware_cache=cfg.load_firmware_cache,
+        firmware_cache_persister=cfg.firmware_cache_persister,
         get_bios_path=cfg.get_bios_path,
     )
 

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -19,9 +19,14 @@ from lib.errors import error_response
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import BiosPathProvider, Clock, RommApiProtocol, StatePersister
+    from services.protocols import (
+        BiosPathProvider,
+        Clock,
+        FirmwareCachePersister,
+        RommApiProtocol,
+        StatePersister,
+    )
 
 _FIRMWARE_CACHE_TTL = 3600  # 1 hour
 
@@ -39,8 +44,7 @@ class FirmwareService:
         plugin_dir: str,
         clock: Clock,
         save_state: StatePersister,
-        save_firmware_cache: Callable[[dict], None] | None = None,
-        load_firmware_cache: Callable[[], dict] | None = None,
+        firmware_cache_persister: FirmwareCachePersister | None = None,
         get_bios_path: BiosPathProvider | None = None,
     ) -> None:
         self._romm_api = romm_api
@@ -50,8 +54,7 @@ class FirmwareService:
         self._plugin_dir = plugin_dir
         self._clock = clock
         self._save_state = save_state
-        self._save_firmware_cache = save_firmware_cache
-        self._load_firmware_cache = load_firmware_cache
+        self._firmware_cache_persister = firmware_cache_persister
         self._get_bios_path = get_bios_path
         self._bios_registry: dict = {}
         self._bios_files_index: dict = {}
@@ -152,10 +155,10 @@ class FirmwareService:
 
     def _restore_firmware_cache(self) -> None:
         """Load firmware cache from disk on init."""
-        if not self._load_firmware_cache:
+        if self._firmware_cache_persister is None:
             return
         try:
-            data = self._load_firmware_cache()
+            data = self._firmware_cache_persister.load()
             if data and "items" in data and "cached_at" in data:
                 self._firmware_cache = data["items"]
                 self._firmware_cache_epoch = data["cached_at"]
@@ -166,10 +169,12 @@ class FirmwareService:
 
     def _persist_firmware_cache(self) -> None:
         """Write current firmware cache to disk."""
-        if not self._save_firmware_cache or self._firmware_cache is None:
+        if self._firmware_cache_persister is None or self._firmware_cache is None:
             return
         try:
-            self._save_firmware_cache({"items": self._firmware_cache, "cached_at": self._firmware_cache_epoch})
+            self._firmware_cache_persister.save(
+                {"items": self._firmware_cache, "cached_at": self._firmware_cache_epoch}
+            )
         except Exception as e:
             self._logger.warning(f"Failed to persist firmware cache: {e}")
 
@@ -200,9 +205,9 @@ class FirmwareService:
         self._firmware_cache = None
         self._firmware_cache_at = 0
         self._firmware_cache_epoch = 0
-        if self._save_firmware_cache:
+        if self._firmware_cache_persister is not None:
             try:
-                self._save_firmware_cache({})
+                self._firmware_cache_persister.save({})
             except Exception as e:
                 self._logger.warning(f"Failed to clear persisted firmware cache: {e}")
 

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -44,7 +44,7 @@ class FirmwareService:
         plugin_dir: str,
         clock: Clock,
         save_state: StatePersister,
-        firmware_cache_persister: FirmwareCachePersister | None = None,
+        firmware_cache_persister: FirmwareCachePersister,
         get_bios_path: BiosPathProvider | None = None,
     ) -> None:
         self._romm_api = romm_api
@@ -155,8 +155,6 @@ class FirmwareService:
 
     def _restore_firmware_cache(self) -> None:
         """Load firmware cache from disk on init."""
-        if self._firmware_cache_persister is None:
-            return
         try:
             data = self._firmware_cache_persister.load()
             if data and "items" in data and "cached_at" in data:
@@ -169,7 +167,7 @@ class FirmwareService:
 
     def _persist_firmware_cache(self) -> None:
         """Write current firmware cache to disk."""
-        if self._firmware_cache_persister is None or self._firmware_cache is None:
+        if self._firmware_cache is None:
             return
         try:
             self._firmware_cache_persister.save(
@@ -205,11 +203,10 @@ class FirmwareService:
         self._firmware_cache = None
         self._firmware_cache_at = 0
         self._firmware_cache_epoch = 0
-        if self._firmware_cache_persister is not None:
-            try:
-                self._firmware_cache_persister.save({})
-            except Exception as e:
-                self._logger.warning(f"Failed to clear persisted firmware cache: {e}")
+        try:
+            self._firmware_cache_persister.save({})
+        except Exception as e:
+            self._logger.warning(f"Failed to clear persisted firmware cache: {e}")
 
     def check_platform_bios_cached(self, platform_slug, rom_filename=None):
         """Return BIOS status from in-memory cache only — no HTTP.

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -45,7 +45,7 @@ class FirmwareService:
         clock: Clock,
         save_state: StatePersister,
         firmware_cache_persister: FirmwareCachePersister,
-        get_bios_path: BiosPathProvider | None = None,
+        get_bios_path: BiosPathProvider,
     ) -> None:
         self._romm_api = romm_api
         self._state = state
@@ -144,7 +144,7 @@ class FirmwareService:
         placement (e.g. dc/dc_boot.bin). Falls back to flat in bios root
         for files not in the registry.
         """
-        bios_base = self._get_bios_path() if self._get_bios_path else ""
+        bios_base = self._get_bios_path()
         file_name = firmware.get("file_name", "")
         reg_entry = self._bios_files_index.get(file_name)
         if reg_entry and reg_entry.get("firmware_path"):
@@ -281,7 +281,7 @@ class FirmwareService:
 
     def _group_registry_firmware(self):
         """Build platform map from bios registry (offline fallback)."""
-        bios_base = self._get_bios_path() if self._get_bios_path else ""
+        bios_base = self._get_bios_path()
         platforms_map = {}
         for reg_slug, reg_files in self._bios_registry.get("platforms", {}).items():
             if reg_slug not in platforms_map:
@@ -520,7 +520,7 @@ class FirmwareService:
         except Exception:
             if not registry_platform:
                 return {"needs_bios": False}
-            bios_base = self._get_bios_path() if self._get_bios_path else ""
+            bios_base = self._get_bios_path()
             registry_items = [
                 {
                     "file_name": file_name,

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -440,6 +440,18 @@ class SyncStateRef(Protocol):
     def __call__(self) -> SyncState: ...
 
 
+class ArtworkRemover(Protocol):
+    """Delete the on-disk artwork files associated with a registry entry.
+
+    Consumed by ``ShortcutRemovalService`` to clean up grid/banner/cover
+    files when a shortcut is removed. The exact set of files and the
+    naming scheme are an artwork-layer concern — this Protocol exposes
+    only the single-entry deletion seam the removal flow needs.
+    """
+
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...
+
+
 # ---------------------------------------------------------------------------
 # Multi-method cross-service Protocols
 # ---------------------------------------------------------------------------

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -367,6 +367,22 @@ class SaveSyncStatePersister(Protocol):
     def load(self) -> dict | None: ...
 
 
+class FirmwareCachePersister(Protocol):
+    """Read/write the on-disk firmware list cache.
+
+    Owns the round-trip for the cached firmware listing consumed by
+    ``FirmwareService``. Path, file format, and version handling are
+    adapter concerns — services see only the dict payload they
+    previously wrote. ``load`` returns an empty dict (not ``None``)
+    when no cached payload is available so callers can probe with
+    ``"items" in data`` without a None-check.
+    """
+
+    def save(self, data: dict) -> None: ...
+
+    def load(self) -> dict: ...
+
+
 class EventEmitter(Protocol):
     """Emit named events with a data payload to the frontend."""
 

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import logging
-    from collections.abc import Callable
 
-    from services.protocols import EventEmitter, RommApiProtocol, StatePersister, SteamConfigAdapter
+    from services.protocols import (
+        ArtworkRemover,
+        EventEmitter,
+        RommApiProtocol,
+        StatePersister,
+        SteamConfigAdapter,
+    )
 
 
 class ShortcutRemovalService:
@@ -25,7 +30,7 @@ class ShortcutRemovalService:
         logger: logging.Logger,
         emit: EventEmitter,
         save_state: StatePersister,
-        remove_artwork_files: Callable[[str, str | int, dict], None],
+        artwork_remover: ArtworkRemover,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
@@ -34,7 +39,7 @@ class ShortcutRemovalService:
         self._logger = logger
         self._emit = emit
         self._save_state = save_state
-        self._remove_artwork_files = remove_artwork_files
+        self._artwork_remover = artwork_remover
 
     # ── Registry helpers ───────────────────────────────────────────────────
 
@@ -114,7 +119,7 @@ class ShortcutRemovalService:
         for rom_id in removed_rom_ids:
             entry = self._state["shortcut_registry"].pop(str(rom_id), None)
             if entry and grid:
-                self._remove_artwork_files(grid, rom_id, entry)
+                self._artwork_remover.remove_artwork_files(grid, rom_id, entry)
 
         # Update sync_stats to reflect current registry
         registry = self._state.get("shortcut_registry", {})

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -13,6 +13,7 @@ from adapters.persistence import (
     _SETTINGS_VERSION,
     _STATE_VERSION,
     DEFAULT_SETTINGS,
+    FirmwareCachePersisterAdapter,
     PersistenceAdapter,
     SaveSyncStatePersisterAdapter,
 )
@@ -391,3 +392,34 @@ class TestSaveSyncStatePersisterAdapter:
     def test_load_returns_none_when_missing(self, adapter):
         wrapper = SaveSyncStatePersisterAdapter(adapter)
         assert wrapper.load() is None
+
+
+class TestFirmwareCachePersisterAdapter:
+    def test_save_writes_through_persistence_adapter(self, adapter):
+        wrapper = FirmwareCachePersisterAdapter(adapter)
+        wrapper.save({"items": [{"id": 1, "file_name": "bios.bin"}], "cached_at": 1700.0})
+
+        path = os.path.join(adapter._runtime_dir, "firmware_cache.json")
+        with open(path) as f:
+            on_disk = json.load(f)
+        # PersistenceAdapter.save_firmware_cache stamps the version key
+        assert on_disk["items"] == [{"id": 1, "file_name": "bios.bin"}]
+        assert on_disk["cached_at"] == 1700.0
+        assert on_disk["version"] == _FIRMWARE_CACHE_VERSION
+
+    def test_save_then_load_round_trip(self, adapter):
+        wrapper = FirmwareCachePersisterAdapter(adapter)
+        payload = {"items": [{"id": 7, "file_name": "scph5501.bin"}], "cached_at": 42.0}
+        wrapper.save(payload)
+
+        loaded = wrapper.load()
+        assert loaded["items"] == payload["items"]
+        assert loaded["cached_at"] == payload["cached_at"]
+        assert loaded["version"] == _FIRMWARE_CACHE_VERSION
+
+    def test_load_returns_empty_dict_when_missing(self, adapter):
+        wrapper = FirmwareCachePersisterAdapter(adapter)
+        # No file written yet — should mirror PersistenceAdapter.load_firmware_cache
+        # behaviour and return the version-stamped empty dict, never None.
+        loaded = wrapper.load()
+        assert loaded == {"version": _FIRMWARE_CACHE_VERSION}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,39 @@ class FakeSaveSyncStatePersister:
         return self.canned_load
 
 
+class FakeFirmwareCachePersister:
+    """In-memory ``FirmwareCachePersister`` for tests.
+
+    Keeps the most recently saved dict in ``self.last_saved`` and the
+    canned payload returned by ``load`` in ``self.canned_load``. The
+    persister contract returns ``dict`` (never ``None``) so the default
+    canned load is an empty dict, mirroring the adapter's behaviour
+    when no on-disk cache is present.
+    """
+
+    def __init__(self, *, canned_load: dict | None = None, load_side_effect: BaseException | None = None) -> None:
+        self.canned_load: dict = canned_load if canned_load is not None else {}
+        self.load_side_effect = load_side_effect
+        self.last_saved: dict | None = None
+        self.save_count = 0
+        self.load_count = 0
+        self.save_side_effect: BaseException | None = None
+
+    def save(self, data: dict) -> None:
+        self.save_count += 1
+        if self.save_side_effect is not None:
+            raise self.save_side_effect
+        import copy
+
+        self.last_saved = copy.deepcopy(data)
+
+    def load(self) -> dict:
+        self.load_count += 1
+        if self.load_side_effect is not None:
+            raise self.load_side_effect
+        return self.canned_load
+
+
 @pytest.fixture(autouse=True)
 def _reset_es_de_config_user_home():
     """Reset ``es_de_config`` module-level state between every test.

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -1571,6 +1571,7 @@ class TestFirmwareListCache:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            get_bios_path=MagicMock(return_value=""),
         )
 
     def test_firmware_list_cached(self):
@@ -1668,6 +1669,7 @@ class TestCheckPlatformBiosCached:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            get_bios_path=MagicMock(return_value=""),
         )
         fw._firmware_cache = firmware_cache
         fw._firmware_cache_at = firmware_cache_at
@@ -1747,6 +1749,7 @@ class TestCheckPlatformBiosCached:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            get_bios_path=MagicMock(return_value=""),
         )
         fw._firmware_cache = []
         fw._firmware_cache_at = 1.0
@@ -1778,6 +1781,7 @@ class TestFirmwareCachePersistence:
             clock=clock,
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            get_bios_path=MagicMock(return_value=""),
         )
         assert fw._firmware_cache == cached_items
         assert fw._firmware_cache_epoch == 1000.0
@@ -1799,6 +1803,7 @@ class TestFirmwareCachePersistence:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            get_bios_path=MagicMock(return_value=""),
         )
         assert fw._firmware_cache is None
 
@@ -1816,6 +1821,7 @@ class TestFirmwareCachePersistence:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            get_bios_path=MagicMock(return_value=""),
         )
         assert fw._firmware_cache is None
 

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from conftest import FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.bios import BiosFileEntry
 
@@ -49,8 +50,7 @@ def plugin():
         plugin_dir=decky.DECKY_PLUGIN_DIR,
         clock=_make_clock(),
         save_state=MagicMock(),
-        save_firmware_cache=MagicMock(),
-        load_firmware_cache=MagicMock(return_value={}),
+        firmware_cache_persister=FakeFirmwareCachePersister(),
         get_bios_path=MagicMock(return_value=""),
     )
 
@@ -1764,7 +1764,7 @@ class TestFirmwareCachePersistence:
         import decky
 
         cached_items = [{"id": 1, "file_name": "bios.bin", "file_path": "bios/dc/bios.bin"}]
-        load_fn = MagicMock(return_value={"items": cached_items, "cached_at": 1000.0})
+        persister = FakeFirmwareCachePersister(canned_load={"items": cached_items, "cached_at": 1000.0})
         clock = _make_clock()
         fw = FirmwareService(
             romm_api=MagicMock(),
@@ -1774,20 +1774,19 @@ class TestFirmwareCachePersistence:
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             clock=clock,
             save_state=MagicMock(),
-            save_firmware_cache=MagicMock(),
-            load_firmware_cache=load_fn,
+            firmware_cache_persister=persister,
         )
         assert fw._firmware_cache == cached_items
         assert fw._firmware_cache_epoch == 1000.0
         # cache_at is set from the clock's monotonic reading (deterministic in tests)
         assert fw._firmware_cache_at == clock.monotonic()
-        load_fn.assert_called_once()
+        assert persister.load_count == 1
 
     def test_empty_disk_cache_leaves_memory_none(self):
         """Empty disk cache doesn't populate in-memory cache."""
         import decky
 
-        load_fn = MagicMock(return_value={})
+        persister = FakeFirmwareCachePersister(canned_load={})
         fw = FirmwareService(
             romm_api=MagicMock(),
             state={"shortcut_registry": {}, "downloaded_bios": {}},
@@ -1796,8 +1795,7 @@ class TestFirmwareCachePersistence:
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             clock=_make_clock(),
             save_state=MagicMock(),
-            save_firmware_cache=MagicMock(),
-            load_firmware_cache=load_fn,
+            firmware_cache_persister=persister,
         )
         assert fw._firmware_cache is None
 
@@ -1805,7 +1803,7 @@ class TestFirmwareCachePersistence:
         """FileNotFoundError from load doesn't crash init."""
         import decky
 
-        load_fn = MagicMock(side_effect=FileNotFoundError("no file"))
+        persister = FakeFirmwareCachePersister(load_side_effect=FileNotFoundError("no file"))
         fw = FirmwareService(
             romm_api=MagicMock(),
             state={"shortcut_registry": {}, "downloaded_bios": {}},
@@ -1814,13 +1812,12 @@ class TestFirmwareCachePersistence:
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             clock=_make_clock(),
             save_state=MagicMock(),
-            save_firmware_cache=MagicMock(),
-            load_firmware_cache=load_fn,
+            firmware_cache_persister=persister,
         )
         assert fw._firmware_cache is None
 
-    def test_no_load_callback_skips_restore(self):
-        """No load_firmware_cache callback skips disk restore gracefully."""
+    def test_no_persister_skips_restore(self):
+        """Omitting firmware_cache_persister skips disk restore gracefully."""
         import decky
 
         fw = FirmwareService(
@@ -1843,10 +1840,11 @@ class TestFirmwareCachePersistence:
         result = fw._get_firmware_list()
 
         assert result == firmware_list
-        fw._save_firmware_cache.assert_called_once()
-        call_data = fw._save_firmware_cache.call_args[0][0]
-        assert call_data["items"] == firmware_list
-        assert "cached_at" in call_data
+        persister = fw._firmware_cache_persister
+        assert persister.save_count == 1
+        assert persister.last_saved is not None
+        assert persister.last_saved["items"] == firmware_list
+        assert "cached_at" in persister.last_saved
 
     def test_invalidate_clears_persisted_cache(self, fw):
         """invalidate_firmware_cache writes empty dict to disk."""
@@ -1857,13 +1855,15 @@ class TestFirmwareCachePersistence:
         fw.invalidate_firmware_cache()
 
         assert fw._firmware_cache is None
-        fw._save_firmware_cache.assert_called_once_with({})
+        persister = fw._firmware_cache_persister
+        assert persister.save_count == 1
+        assert persister.last_saved == {}
 
     def test_persist_failure_does_not_crash_fetch(self, fw):
         """Disk write failure during fetch doesn't break the return value."""
         firmware_list = [{"id": 1, "file_name": "bios.bin", "file_path": "bios/dc/bios.bin"}]
         fw._romm_api.list_firmware.return_value = firmware_list
-        fw._save_firmware_cache.side_effect = OSError("disk full")
+        fw._firmware_cache_persister.save_side_effect = OSError("disk full")
         fw._firmware_cache = None
 
         result = fw._get_firmware_list()

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -1570,6 +1570,7 @@ class TestFirmwareListCache:
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             clock=_make_clock(),
             save_state=MagicMock(),
+            firmware_cache_persister=FakeFirmwareCachePersister(),
         )
 
     def test_firmware_list_cached(self):
@@ -1666,6 +1667,7 @@ class TestCheckPlatformBiosCached:
             plugin_dir="/fake",
             clock=_make_clock(),
             save_state=MagicMock(),
+            firmware_cache_persister=FakeFirmwareCachePersister(),
         )
         fw._firmware_cache = firmware_cache
         fw._firmware_cache_at = firmware_cache_at
@@ -1744,6 +1746,7 @@ class TestCheckPlatformBiosCached:
             plugin_dir="/fake",
             clock=_make_clock(),
             save_state=MagicMock(),
+            firmware_cache_persister=FakeFirmwareCachePersister(),
         )
         fw._firmware_cache = []
         fw._firmware_cache_at = 1.0
@@ -1813,21 +1816,6 @@ class TestFirmwareCachePersistence:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=persister,
-        )
-        assert fw._firmware_cache is None
-
-    def test_no_persister_skips_restore(self):
-        """Omitting firmware_cache_persister skips disk restore gracefully."""
-        import decky
-
-        fw = FirmwareService(
-            romm_api=MagicMock(),
-            state={"shortcut_registry": {}, "downloaded_bios": {}},
-            loop=asyncio.get_event_loop(),
-            logger=decky.logger,
-            plugin_dir=decky.DECKY_PLUGIN_DIR,
-            clock=_make_clock(),
-            save_state=MagicMock(),
         )
         assert fw._firmware_cache is None
 

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -132,6 +132,7 @@ def plugin(tmp_path):
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
+        get_bios_path=MagicMock(return_value=""),
     )
 
     # Store fake_api on plugin for test access

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import _make_testable_plugin
+from conftest import FakeFirmwareCachePersister, _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -131,6 +131,7 @@ def plugin(tmp_path):
         plugin_dir=decky.DECKY_PLUGIN_DIR,
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
+        firmware_cache_persister=FakeFirmwareCachePersister(),
     )
 
     # Store fake_api on plugin for test access

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -83,7 +83,7 @@ def plugin():
         logger=decky.logger,
         emit=decky.emit,
         save_state=p._save_state,
-        remove_artwork_files=artwork_service.remove_artwork_files,
+        artwork_remover=artwork_service,
     )
     # Default migration service mock — no migration pending. Tests that need
     # to exercise the @migration_blocked gate override this.

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -47,6 +47,7 @@ def plugin():
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
+        get_bios_path=MagicMock(return_value=""),
     )
 
     p._sync_service = LibraryService(

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -45,6 +46,7 @@ def plugin():
         plugin_dir=decky.DECKY_PLUGIN_DIR,
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
+        firmware_cache_persister=FakeFirmwareCachePersister(),
     )
 
     p._sync_service = LibraryService(

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -23,12 +23,12 @@ def steam_config():
 
 
 @pytest.fixture
-def remove_artwork_files_mock():
+def artwork_remover_mock():
     return MagicMock()
 
 
 @pytest.fixture
-def svc(state, steam_config, remove_artwork_files_mock):
+def svc(state, steam_config, artwork_remover_mock):
     service = ShortcutRemovalService(
         romm_api=MagicMock(),
         steam_config=steam_config,
@@ -37,7 +37,7 @@ def svc(state, steam_config, remove_artwork_files_mock):
         logger=decky.logger,
         emit=decky.emit,
         save_state=MagicMock(),
-        remove_artwork_files=remove_artwork_files_mock,
+        artwork_remover=artwork_remover_mock,
     )
     return service
 
@@ -173,7 +173,7 @@ class TestReportRemovalResults:
         assert state["shortcut_registry"] == {}
 
     @pytest.mark.asyncio
-    async def test_cleans_up_artwork_via_callback(self, svc, state, steam_config, remove_artwork_files_mock, tmp_path):
+    async def test_cleans_up_artwork_via_callback(self, svc, state, steam_config, artwork_remover_mock, tmp_path):
         grid_dir = tmp_path / "grid"
         grid_dir.mkdir()
         steam_config.grid_dir = lambda: str(grid_dir)
@@ -183,7 +183,7 @@ class TestReportRemovalResults:
         }
 
         await svc.report_removal_results([10])
-        assert remove_artwork_files_mock.called
+        assert artwork_remover_mock.remove_artwork_files.called
 
     @pytest.mark.asyncio
     async def test_partial_removal(self, svc, state, tmp_path):
@@ -245,7 +245,7 @@ class TestRemovalCleansUpArtwork:
             logger=decky.logger,
             emit=decky.emit,
             save_state=MagicMock(),
-            remove_artwork_files=artwork_svc.remove_artwork_files,
+            artwork_remover=artwork_svc,
         )
         svc._loop = asyncio.get_event_loop()
 
@@ -282,7 +282,7 @@ class TestRemovalCleansUpArtwork:
             logger=decky.logger,
             emit=decky.emit,
             save_state=MagicMock(),
-            remove_artwork_files=artwork_svc.remove_artwork_files,
+            artwork_remover=artwork_svc,
         )
         svc._loop = asyncio.get_event_loop()
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -158,8 +158,7 @@ class TestWireServices:
             "save_state": MagicMock(),
             "save_settings_to_disk": MagicMock(),
             "save_metadata_cache": MagicMock(),
-            "save_firmware_cache": MagicMock(),
-            "load_firmware_cache": MagicMock(return_value={}),
+            "firmware_cache_persister": MagicMock(load=MagicMock(return_value={}), save=MagicMock()),
             "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
             "log_debug": MagicMock(),
         }

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,6 +5,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 from bootstrap import WiringConfig, bootstrap, wire_services
+from conftest import FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -158,7 +159,7 @@ class TestWireServices:
             "save_state": MagicMock(),
             "save_settings_to_disk": MagicMock(),
             "save_metadata_cache": MagicMock(),
-            "firmware_cache_persister": MagicMock(load=MagicMock(return_value={}), save=MagicMock()),
+            "firmware_cache_persister": FakeFirmwareCachePersister(),
             "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
             "log_debug": MagicMock(),
         }


### PR DESCRIPTION
## Summary

Two Wave 1 cross-cutting items bundled because they share the same anti-pattern — replace a raw `Callable[..., …]` ctor param with a named Protocol on `services/protocols.py` matching the `StatePersister` precedent.

- **#292 — `ArtworkRemover` Protocol.** `ShortcutRemovalService.__init__` no longer takes `remove_artwork_files: Callable[[str, str | int, dict], None]`; takes `artwork_remover: ArtworkRemover` instead. Bootstrap passes `artwork_service` directly — `ArtworkService.remove_artwork_files` already matches structurally.
- **#289 — `FirmwareCachePersister` Protocol.** `FirmwareService` ctor swaps two Callable params (`save_firmware_cache`, `load_firmware_cache`) for one persister with `.save(dict)` / `.load() -> dict`. New concrete `FirmwareCachePersisterAdapter` lives in `adapters/persistence.py` next to the saves persister; new `FakeFirmwareCachePersister` mirrors `FakeSaveSyncStatePersister` in `conftest.py`.

## Dead optionality fix-pass (review feedback)

Two service params were typed `| None = None` even though `bootstrap.py` always wires concrete instances — leaving dead `if x is None` guards in the hot path. Both made required, guards collapsed, vestigial tests deleted:

- `FirmwareService.firmware_cache_persister` (3 guards dropped)
- `FirmwareService.get_bios_path` (3 guards dropped)

## Verified locally

- `ruff check .` — clean
- `basedpyright` — 0 errors / warnings / notes (full scope: `py_modules/` + `tests/`)
- `pytest tests/ -q` — 1785 passed
- `lint-imports --config .importlinter` — 7 contracts kept, 0 broken, **no `ignore_imports` carve-outs**
- Coverage on the new `FirmwareCachePersisterAdapter`: 100% line + branch
- Residue grep: no `Callable[` params left on `ShortcutRemovalService` or `FirmwareService`

## Out of scope (deferred)

- `get_bios_path: BiosPathProvider | None = None` on `MigrationService` and `DownloadService` is the same dead-optionality pattern but belongs to those services' Wave 3 verticals (#302 / #297) along with their other I/O extraction work.

Closes #292, closes #289, refs #256, refs #277.