### PR TITLE
refactor(es-de): introduce CoreInfoProvider protocol for FirmwareService

### DIFF
--- a/main.py
+++ b/main.py
@@ -201,6 +201,7 @@ class Plugin:
                 save_settings_to_disk=self._save_settings_to_disk,
                 save_metadata_cache=self._save_metadata_cache,
                 firmware_cache_persister=FirmwareCachePersisterAdapter(self._persistence),
+                core_info_provider=adapters["es_de_core_info"],
                 save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
                 log_debug=self._log_debug,
             )

--- a/py_modules/adapters/es_de_core_info.py
+++ b/py_modules/adapters/es_de_core_info.py
@@ -1,0 +1,30 @@
+"""ES-DE core info adapter — concrete CoreInfoProvider Protocol implementation.
+
+Wraps the module-level functions in domain.es_de_config behind an instance
+boundary so FirmwareService can be tested by injecting a fake rather than
+patching the module directly.
+
+Imports from domain.es_de_config are deferred to call time because the
+module requires domain.es_de_config.configure() to have been called first;
+bootstrap guarantees this before any service method runs.
+"""
+
+from __future__ import annotations
+
+
+class EsDeCoreInfoAdapter:
+    """Live CoreInfoProvider backed by domain.es_de_config."""
+
+    def get_active_core(
+        self,
+        system_name: str,
+        rom_filename: str | None = None,
+    ) -> tuple[str | None, str | None]:
+        from domain import es_de_config
+
+        return es_de_config.get_active_core(system_name, rom_filename=rom_filename)
+
+    def get_available_cores(self, system_name: str) -> list[dict]:
+        from domain import es_de_config
+
+        return es_de_config.get_available_cores(system_name)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -13,6 +13,7 @@ import logging
 from dataclasses import dataclass
 
 from adapters.asyncio_sleeper import AsyncioSleeper
+from adapters.es_de_core_info import EsDeCoreInfoAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
@@ -36,6 +37,7 @@ from services.playtime import PlaytimeService
 from services.protocols import (
     BiosPathProvider,
     Clock,
+    CoreInfoProvider,
     CoreNameProviderFn,
     DebugLogger,
     EventEmitter,
@@ -96,6 +98,7 @@ class WiringConfig:
     save_settings_to_disk: SettingsPersister
     save_metadata_cache: StatePersister
     firmware_cache_persister: FirmwareCachePersister
+    core_info_provider: CoreInfoProvider
     save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
 
@@ -147,6 +150,7 @@ def bootstrap(
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
+    es_de_core_info = EsDeCoreInfoAdapter()
 
     return {
         "persistence": persistence,
@@ -160,6 +164,7 @@ def bootstrap(
         "clock": clock,
         "uuid_gen": uuid_gen,
         "sleeper": sleeper,
+        "es_de_core_info": es_de_core_info,
     }
 
 
@@ -343,6 +348,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         save_state=cfg.save_state,
         firmware_cache_persister=cfg.firmware_cache_persister,
         get_bios_path=cfg.get_bios_path,
+        core_info=cfg.core_info_provider,
     )
 
     sgdb_service = SteamGridService(

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -12,7 +12,6 @@ import os
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
-from domain import es_de_config
 from domain.bios import collect_firmware_status
 from lib.errors import error_response
 
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
     from services.protocols import (
         BiosPathProvider,
         Clock,
+        CoreInfoProvider,
         FirmwareCachePersister,
         RommApiProtocol,
         StatePersister,
@@ -46,6 +46,7 @@ class FirmwareService:
         save_state: StatePersister,
         firmware_cache_persister: FirmwareCachePersister,
         get_bios_path: BiosPathProvider,
+        core_info: CoreInfoProvider,
     ) -> None:
         self._romm_api = romm_api
         self._state = state
@@ -56,6 +57,7 @@ class FirmwareService:
         self._save_state = save_state
         self._firmware_cache_persister = firmware_cache_persister
         self._get_bios_path = get_bios_path
+        self._core_info = core_info
         self._bios_registry: dict = {}
         self._bios_files_index: dict = {}
         self._firmware_cache: list | None = None
@@ -218,7 +220,7 @@ class FirmwareService:
             return None
 
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
-        active_core_so, active_core_label = es_de_config.get_active_core(platform_slug, rom_filename=rom_filename)
+        active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
 
         registry_platform = {}
         for slug in fw_slugs:
@@ -254,7 +256,7 @@ class FirmwareService:
             "files": [asdict(f) for f in files],
             "active_core": active_core_so,
             "active_core_label": active_core_label,
-            "available_cores": es_de_config.get_available_cores(platform_slug),
+            "available_cores": self._core_info.get_available_cores(platform_slug),
             "cached_at": self._firmware_cache_epoch,
         }
 
@@ -309,10 +311,10 @@ class FirmwareService:
         }
         for plat in platforms_map.values():
             slug = plat["platform_slug"]
-            core_so, core_label = es_de_config.get_active_core(slug)
+            core_so, core_label = self._core_info.get_active_core(slug)
             plat["active_core"] = core_so
             plat["active_core_label"] = core_label
-            plat["available_cores"] = es_de_config.get_available_cores(slug)
+            plat["available_cores"] = self._core_info.get_available_cores(slug)
             for f in plat["files"]:
                 self._enrich_firmware_file(f, core_so=core_so)
             plat["has_games"] = slug in installed_slugs
@@ -479,7 +481,7 @@ class FirmwareService:
             return resp
 
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
-        core_so, _ = es_de_config.get_active_core(platform_slug)
+        core_so, _ = self._core_info.get_active_core(platform_slug)
 
         platform_firmware = [
             fw
@@ -498,7 +500,7 @@ class FirmwareService:
     async def check_platform_bios(self, platform_slug, rom_filename=None):
         """Check if RomM has firmware for this platform and whether it's downloaded."""
         fw_slugs = self._platform_to_firmware_slugs(platform_slug)
-        active_core_so, active_core_label = es_de_config.get_active_core(platform_slug, rom_filename=rom_filename)
+        active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
 
         # Build combined registry entries for this platform from all mapped slugs
         registry_platform = {}
@@ -552,7 +554,7 @@ class FirmwareService:
             "files": [asdict(f) for f in files],
             "active_core": active_core_so,
             "active_core_label": active_core_label,
-            "available_cores": es_de_config.get_available_cores(platform_slug),
+            "available_cores": self._core_info.get_available_cores(platform_slug),
         }
 
     def _delete_platform_bios_io(self, files):

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -437,6 +437,22 @@ class CoreResolverFn(Protocol):
     def __call__(self, system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]: ...
 
 
+class CoreInfoProvider(Protocol):
+    """Core resolution for ES-DE configured systems, consumed by FirmwareService.
+
+    Wraps the module-level functions in domain.es_de_config behind a boundary
+    so services can be tested without patching module symbols.
+    """
+
+    def get_active_core(
+        self,
+        system_name: str,
+        rom_filename: str | None = None,
+    ) -> tuple[str | None, str | None]: ...
+
+    def get_available_cores(self, system_name: str) -> list[dict]: ...
+
+
 class CoreNameProviderFn(Protocol):
     """Return the RetroArch canonical ``corename`` for a core shared object.
 

--- a/tests/adapters/test_es_de_core_info.py
+++ b/tests/adapters/test_es_de_core_info.py
@@ -1,0 +1,56 @@
+"""Tests for the EsDeCoreInfoAdapter — wraps domain.es_de_config module functions."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from adapters.es_de_core_info import EsDeCoreInfoAdapter
+
+
+class TestGetActiveCore:
+    def test_delegates_to_es_de_config_with_rom_filename(self):
+        adapter = EsDeCoreInfoAdapter()
+        with patch(
+            "domain.es_de_config.get_active_core",
+            return_value=("mgba_libretro.so", "mGBA"),
+        ) as mock_fn:
+            result = adapter.get_active_core("gba", rom_filename="game.gba")
+        mock_fn.assert_called_once_with("gba", rom_filename="game.gba")
+        assert result == ("mgba_libretro.so", "mGBA")
+
+    def test_default_rom_filename_is_none(self):
+        adapter = EsDeCoreInfoAdapter()
+        with patch(
+            "domain.es_de_config.get_active_core",
+            return_value=("gpsp_libretro.so", "gpSP"),
+        ) as mock_fn:
+            adapter.get_active_core("gba")
+        mock_fn.assert_called_once_with("gba", rom_filename=None)
+
+    def test_returns_none_tuple_when_underlying_returns_none(self):
+        adapter = EsDeCoreInfoAdapter()
+        with patch("domain.es_de_config.get_active_core", return_value=(None, None)):
+            result = adapter.get_active_core("unknown_platform")
+        assert result == (None, None)
+
+
+class TestGetAvailableCores:
+    def test_delegates_to_es_de_config(self):
+        adapter = EsDeCoreInfoAdapter()
+        cores = [
+            {"core_so": "mgba_libretro.so", "label": "mGBA", "is_default": True},
+            {"core_so": "gpsp_libretro.so", "label": "gpSP", "is_default": False},
+        ]
+        with patch(
+            "domain.es_de_config.get_available_cores",
+            return_value=cores,
+        ) as mock_fn:
+            result = adapter.get_available_cores("gba")
+        mock_fn.assert_called_once_with("gba")
+        assert result == cores
+
+    def test_returns_empty_list_when_underlying_returns_empty(self):
+        adapter = EsDeCoreInfoAdapter()
+        with patch("domain.es_de_config.get_available_cores", return_value=[]):
+            result = adapter.get_available_cores("unknown_platform")
+        assert result == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,34 @@ class FakeFirmwareCachePersister:
         return self.canned_load
 
 
+class FakeCoreInfoProvider:
+    """In-memory CoreInfoProvider for tests.
+
+    Returns the configured active_core and available_cores for any system.
+    Both attributes are mutable so tests can set them directly on the
+    instance before exercising the code under test.
+    """
+
+    def __init__(
+        self,
+        *,
+        active_core: tuple[str | None, str | None] = (None, None),
+        available_cores: list[dict] | None = None,
+    ) -> None:
+        self.active_core = active_core
+        self.available_cores: list[dict] = available_cores if available_cores is not None else []
+
+    def get_active_core(
+        self,
+        system_name: str,
+        rom_filename: str | None = None,
+    ) -> tuple[str | None, str | None]:
+        return self.active_core
+
+    def get_available_cores(self, system_name: str) -> list[dict]:
+        return self.available_cores
+
+
 @pytest.fixture(autouse=True)
 def _reset_es_de_config_user_home():
     """Reset ``es_de_config`` module-level state between every test.

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.bios import BiosFileEntry
 
@@ -52,6 +52,7 @@ def plugin():
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
         get_bios_path=MagicMock(return_value=""),
+        core_info=FakeCoreInfoProvider(),
     )
 
     p._sync_service = LibraryService(
@@ -1199,11 +1200,9 @@ class TestPerCoreFiltering:
         fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
 
         # gpSP only uses gba_bios.bin — all files returned but gb/sgb marked as not used by active
-        with (
-            patch("services.firmware.es_de_config.get_active_core", return_value=("gpsp_libretro", "gpSP")),
-            patch("services.firmware.es_de_config.get_available_cores", return_value=[]),
-            patch.object(fw, "_get_bios_path", return_value=str(tmp_path / "bios")),
-        ):
+        fw._core_info.active_core = ("gpsp_libretro", "gpSP")
+        fw._core_info.available_cores = []
+        with patch.object(fw, "_get_bios_path", return_value=str(tmp_path / "bios")):
             result = await fw.check_platform_bios("gba")
 
         assert result["needs_bios"] is True
@@ -1293,11 +1292,9 @@ class TestPerCoreFiltering:
         fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
 
         # mGBA uses all 3 files, all optional
-        with (
-            patch("services.firmware.es_de_config.get_active_core", return_value=("mgba_libretro", "mGBA")),
-            patch("services.firmware.es_de_config.get_available_cores", return_value=[]),
-        ):
-            result = await fw.check_platform_bios("gba")
+        fw._core_info.active_core = ("mgba_libretro", "mGBA")
+        fw._core_info.available_cores = []
+        result = await fw.check_platform_bios("gba")
 
         assert result["needs_bios"] is True
         assert result["server_count"] == 3
@@ -1342,11 +1339,9 @@ class TestPerCoreFiltering:
         fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
 
         # Core resolution fails
-        with (
-            patch("services.firmware.es_de_config.get_active_core", return_value=(None, None)),
-            patch("services.firmware.es_de_config.get_available_cores", return_value=[]),
-        ):
-            result = await fw.check_platform_bios("gba")
+        fw._core_info.active_core = (None, None)
+        fw._core_info.available_cores = []
+        result = await fw.check_platform_bios("gba")
 
         assert result["needs_bios"] is True
         assert result["server_count"] == 1
@@ -1386,10 +1381,10 @@ class TestPerCoreFiltering:
 
         fw._loop = asyncio.get_event_loop()
 
+        fw._core_info.active_core = ("gpsp_libretro", "gpSP")
+        fw._core_info.available_cores = []
         with (
             patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")),
-            patch("services.firmware.es_de_config.get_active_core", return_value=("gpsp_libretro", "gpSP")),
-            patch("services.firmware.es_de_config.get_available_cores", return_value=[]),
             patch.object(fw, "_get_bios_path", return_value=str(bios_dir)),
         ):
             result = await fw.check_platform_bios("gba")
@@ -1539,11 +1534,11 @@ class TestGetFirmwareStatusOfflineFallback:
 
         fw._loop = asyncio.get_event_loop()
 
+        fw._core_info.active_core = (None, None)
+        fw._core_info.available_cores = []
         with (
             patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")),
             patch.object(fw, "_get_bios_path", return_value=str(bios_dir)),
-            patch("services.firmware.es_de_config.get_active_core", return_value=(None, None)),
-            patch("services.firmware.es_de_config.get_available_cores", return_value=[]),
         ):
             result = await fw.get_firmware_status()
 
@@ -1572,6 +1567,7 @@ class TestFirmwareListCache:
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
             get_bios_path=MagicMock(return_value=""),
+            core_info=FakeCoreInfoProvider(),
         )
 
     def test_firmware_list_cached(self):
@@ -1657,9 +1653,16 @@ class TestFirmwareListCache:
 class TestCheckPlatformBiosCached:
     """Tests for check_platform_bios_cached — cache-only BIOS status read."""
 
-    def _make_service(self, firmware_cache=None, firmware_cache_at: float = 0, bios_registry=None, state=None):
+    def _make_service(
+        self,
+        firmware_cache=None,
+        firmware_cache_at: float = 0,
+        bios_registry=None,
+        state=None,
+    ) -> tuple[FirmwareService, FakeCoreInfoProvider]:
         import logging
 
+        core_info = FakeCoreInfoProvider()
         fw = FirmwareService(
             romm_api=MagicMock(),
             state=state or {"shortcut_registry": {}, "installed_roms": {}, "downloaded_bios": {}},
@@ -1670,31 +1673,32 @@ class TestCheckPlatformBiosCached:
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
             get_bios_path=MagicMock(return_value=""),
+            core_info=core_info,
         )
         fw._firmware_cache = firmware_cache
         fw._firmware_cache_at = firmware_cache_at
         fw._firmware_cache_epoch = firmware_cache_at
         if bios_registry:
             fw._bios_registry = bios_registry
-        return fw
+        return fw, core_info
 
     def test_returns_none_when_cache_empty(self):
         """No firmware cache → returns None."""
-        fw = self._make_service(firmware_cache=None)
+        fw, _ = self._make_service(firmware_cache=None)
         result = fw.check_platform_bios_cached("gba")
         assert result is None
 
     def test_returns_needs_bios_false_no_matching_firmware(self):
         """Cache populated but no firmware for this platform → needs_bios=False."""
-        fw = self._make_service(
+        fw, core_info = self._make_service(
             firmware_cache=[
                 {"file_path": "bios/snes/some.bin", "file_name": "some.bin", "file_size_bytes": 100, "md5_hash": ""}
             ],
             firmware_cache_at=1000.0,
         )
 
-        with patch("domain.es_de_config.get_active_core", return_value=(None, None)):
-            result = fw.check_platform_bios_cached("gba")
+        core_info.active_core = (None, None)
+        result = fw.check_platform_bios_cached("gba")
 
         assert result is not None
         assert result["needs_bios"] is False
@@ -1702,7 +1706,7 @@ class TestCheckPlatformBiosCached:
 
     def test_returns_bios_status_from_cache(self, tmp_path):
         """Cache populated with matching firmware → full BIOS status with cached_at."""
-        fw = self._make_service(
+        fw, core_info = self._make_service(
             firmware_cache=[
                 {
                     "file_path": "bios/gba/gba_bios.bin",
@@ -1715,14 +1719,9 @@ class TestCheckPlatformBiosCached:
             firmware_cache_at=42.0,
         )
 
-        with (
-            patch("domain.es_de_config.get_active_core", return_value=("mgba_libretro.so", "mGBA")),
-            patch(
-                "domain.es_de_config.get_available_cores",
-                return_value=[{"label": "mGBA", "so": "mgba_libretro.so"}],
-            ),
-            patch.object(fw, "_get_bios_path", return_value=str(tmp_path)),
-        ):
+        core_info.active_core = ("mgba_libretro.so", "mGBA")
+        core_info.available_cores = [{"label": "mGBA", "so": "mgba_libretro.so"}]
+        with patch.object(fw, "_get_bios_path", return_value=str(tmp_path)):
             result = fw.check_platform_bios_cached("gba")
 
         assert result is not None
@@ -1740,6 +1739,7 @@ class TestCheckPlatformBiosCached:
         api = MagicMock()
         import logging
 
+        core_info = FakeCoreInfoProvider()
         fw = FirmwareService(
             romm_api=api,
             state={"shortcut_registry": {}, "installed_roms": {}, "downloaded_bios": {}},
@@ -1750,13 +1750,14 @@ class TestCheckPlatformBiosCached:
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
             get_bios_path=MagicMock(return_value=""),
+            core_info=core_info,
         )
         fw._firmware_cache = []
         fw._firmware_cache_at = 1.0
         fw._firmware_cache_epoch = 1.0
 
-        with patch("domain.es_de_config.get_active_core", return_value=(None, None)):
-            fw.check_platform_bios_cached("gba")
+        core_info.active_core = (None, None)
+        fw.check_platform_bios_cached("gba")
 
         api.list_firmware.assert_not_called()
         api.get_firmware.assert_not_called()
@@ -1782,6 +1783,7 @@ class TestFirmwareCachePersistence:
             save_state=MagicMock(),
             firmware_cache_persister=persister,
             get_bios_path=MagicMock(return_value=""),
+            core_info=FakeCoreInfoProvider(),
         )
         assert fw._firmware_cache == cached_items
         assert fw._firmware_cache_epoch == 1000.0
@@ -1804,6 +1806,7 @@ class TestFirmwareCachePersistence:
             save_state=MagicMock(),
             firmware_cache_persister=persister,
             get_bios_path=MagicMock(return_value=""),
+            core_info=FakeCoreInfoProvider(),
         )
         assert fw._firmware_cache is None
 
@@ -1822,6 +1825,7 @@ class TestFirmwareCachePersistence:
             save_state=MagicMock(),
             firmware_cache_persister=persister,
             get_bios_path=MagicMock(return_value=""),
+            core_info=FakeCoreInfoProvider(),
         )
         assert fw._firmware_cache is None
 

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import FakeFirmwareCachePersister, _make_testable_plugin
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -133,6 +133,7 @@ def plugin(tmp_path):
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
         get_bios_path=MagicMock(return_value=""),
+        core_info=FakeCoreInfoProvider(),
     )
 
     # Store fake_api on plugin for test access
@@ -472,11 +473,9 @@ class TestGetCachedGameDetailBiosFromCache:
         plugin._firmware_service._firmware_cache_at = 99.0
         plugin._firmware_service._firmware_cache_epoch = 99.0
 
-        with (
-            patch("domain.es_de_config.get_active_core", return_value=("mgba_libretro.so", "mGBA")),
-            patch("domain.es_de_config.get_available_cores", return_value=[]),
-            patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(tmp_path)),
-        ):
+        plugin._firmware_service._core_info.active_core = ("mgba_libretro.so", "mGBA")
+        plugin._firmware_service._core_info.available_cores = []
+        with patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(tmp_path)):
             result = game_detail_service.get_cached_game_detail(50000)
 
         assert result["found"] is True
@@ -500,8 +499,6 @@ class TestGetCachedGameDetailBiosFromCache:
     @pytest.mark.asyncio
     async def test_bios_status_none_when_needs_bios_false(self, plugin, game_detail_service):
         """Cache populated but no firmware for platform → bios_status is None."""
-        from unittest.mock import patch
-
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 50000,
             "name": "Tetris",
@@ -512,8 +509,8 @@ class TestGetCachedGameDetailBiosFromCache:
         plugin._firmware_service._firmware_cache_at = 50.0
         plugin._firmware_service._firmware_cache_epoch = 50.0
 
-        with patch("domain.es_de_config.get_active_core", return_value=(None, None)):
-            result = game_detail_service.get_cached_game_detail(50000)
+        plugin._firmware_service._core_info.active_core = (None, None)
+        result = game_detail_service.get_cached_game_detail(50000)
 
         assert result["bios_status"] is None
 
@@ -691,11 +688,9 @@ class TestComputedFields:
         ]
         plugin._firmware_service._firmware_cache_epoch = 100.0
 
-        with (
-            patch("domain.es_de_config.get_active_core", return_value=("mgba_libretro.so", "mGBA")),
-            patch("domain.es_de_config.get_available_cores", return_value=[]),
-            patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(tmp_path / "nonexistent")),
-        ):
+        plugin._firmware_service._core_info.active_core = ("mgba_libretro.so", "mGBA")
+        plugin._firmware_service._core_info.available_cores = []
+        with patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(tmp_path / "nonexistent")):
             result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["bios_level"] is not None
@@ -745,11 +740,9 @@ class TestComputedFields:
         ]
         plugin._firmware_service._firmware_cache_epoch = 100.0
 
-        with (
-            patch("domain.es_de_config.get_active_core", return_value=("mgba_libretro.so", "mGBA")),
-            patch("domain.es_de_config.get_available_cores", return_value=[]),
-            patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(bios_dir)),
-        ):
+        plugin._firmware_service._core_info.active_core = ("mgba_libretro.so", "mGBA")
+        plugin._firmware_service._core_info.available_cores = []
+        with patch.object(plugin._firmware_service, "_get_bios_path", return_value=str(bios_dir)):
             result = game_detail_service.get_cached_game_detail(99999)
 
         assert result["bios_level"] == "ok"

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
-from conftest import FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -48,6 +48,7 @@ def plugin():
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
         get_bios_path=MagicMock(return_value=""),
+        core_info=FakeCoreInfoProvider(),
     )
 
     p._sync_service = LibraryService(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,7 +5,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 from bootstrap import WiringConfig, bootstrap, wire_services
-from conftest import FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -160,6 +160,7 @@ class TestWireServices:
             "save_settings_to_disk": MagicMock(),
             "save_metadata_cache": MagicMock(),
             "firmware_cache_persister": FakeFirmwareCachePersister(),
+            "core_info_provider": FakeCoreInfoProvider(),
             "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
             "log_debug": MagicMock(),
         }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1098,6 +1098,7 @@ class TestMainStartupOrdering:
             "clock": MagicMock(),
             "uuid_gen": MagicMock(),
             "sleeper": MagicMock(),
+            "es_de_core_info": MagicMock(),
         }
 
         with (


### PR DESCRIPTION
## Summary
- Adds `CoreInfoProvider` Protocol (`services/protocols.py`) and `EsDeCoreInfoAdapter` (`adapters/es_de_core_info.py`) — thin pass-through that lazy-imports `domain.es_de_config` so the existing `configure()` ordering keeps working.
- Injects `core_info` into `FirmwareService`; drops the `from domain import es_de_config` module import. 7 call sites flipped to `self._core_info.*`.
- Replaces 12 `patch("...es_de_config.*")` test sites with `FakeCoreInfoProvider` fixture injection (7 in `test_firmware`, 5 in `test_game_detail`).
- 3 collateral one-line fixes (`test_migration`, `test_bootstrap`, `test_plugin`) for the new no-default `WiringConfig` field.
- `domain/es_de_config.py` untouched — that's #205's job.

## Test plan
- [x] `pytest tests/` — 1785 passed
- [x] `ruff check .` — clean
- [x] `basedpyright` — 0 errors / 0 warnings / 0 notes
- [x] `lint-imports` — 7 contracts kept, 0 broken

Closes #296
Part of #277 / #256