### PR TITLE
refactor(bootstrap): remove dead _sync_state_box indirection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
 
 - **Wave 1 — Cross-cutting infrastructure** ([#256](https://github.com/danielcopper/decky-romm-sync/issues/256))
   Protocols, persisters, bootstrap cleanup. Do first — every later vertical consumes the Protocols defined here.
-  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310).
-  Open: #205 (domain/es_de_config I/O split — next), #168 (`_sync_state_box`), #169 (WiringConfig split), #259 (SonarCloud arch rules — deferred until Python supported).
+  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311).
+  Open: #168 (`_sync_state_box` — next), #169 (WiringConfig split), #259 (SonarCloud arch rules — deferred until Python supported).
 - **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295))
   Extract pure logic from non-saves services into `domain/`. Library sync_classification cluster first (highest value), then firmware paths, achievements, path safety, filename resolution.
 - **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -260,13 +260,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         log_debug=cfg.log_debug,
     )
 
-    # Mutable container to break the circular dependency:
-    # ArtworkService needs sync_state_ref but LibraryService isn't created yet.
-    # We put a mutable list with one element; after LibraryService is created we
-    # replace that element.  ArtworkService reads _sync_state_box[0]() so it always
-    # gets the live value without any post-construction attribute mutation.
-    _sync_state_box: list = [lambda: None]
-
     artwork_service = ArtworkService(
         romm_api=cfg.romm_api,
         steam_config=cfg.steam_config,
@@ -274,7 +267,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         loop=cfg.loop,
         logger=cfg.logger,
         emit=cfg.emit,
-        sync_state_ref=lambda: _sync_state_box[0](),
     )
 
     shortcut_removal_service = ShortcutRemovalService(
@@ -307,9 +299,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         metadata_service=metadata_service,
         artwork=artwork_service,
     )
-
-    # Resolve the circular dependency: point the box at the real sync_state getter.
-    _sync_state_box[0] = lambda: sync_service.sync_state
 
     download_service = DownloadService(
         romm_api=cfg.romm_api,

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import EventEmitter, RommApiProtocol, SteamConfigAdapter, SyncStateRef
+    from services.protocols import EventEmitter, RommApiProtocol, SteamConfigAdapter
 
 
 class ArtworkService:
@@ -27,7 +27,6 @@ class ArtworkService:
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         emit: EventEmitter,
-        sync_state_ref: SyncStateRef,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
@@ -35,9 +34,6 @@ class ArtworkService:
         self._loop = loop
         self._logger = logger
         self._emit = emit
-        # A callable that returns the current SyncState value so artwork
-        # download can react to cancellation without importing library.py.
-        self._sync_state_ref = sync_state_ref
 
     # ── Existing cover path check ──────────────────────────────────────────
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Protocol
 
-from domain.sync_state import SyncState
-
 
 class SteamConfigAdapter(Protocol):
     """Protocol for Steam configuration operations."""
@@ -489,12 +487,6 @@ class CoreNameProviderFn(Protocol):
     """
 
     def __call__(self, core_so: str) -> str | None: ...
-
-
-class SyncStateRef(Protocol):
-    """Return the current sync state value (used by ArtworkService)."""
-
-    def __call__(self) -> SyncState: ...
 
 
 class ArtworkRemover(Protocol):

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -11,7 +11,6 @@ import decky
 import pytest
 
 from adapters.steam_config import SteamConfigAdapter
-from domain.sync_state import SyncState
 from services.artwork import ArtworkService
 
 
@@ -34,7 +33,6 @@ def artwork_service(state, steam_config):
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
         emit=decky.emit,
-        sync_state_ref=lambda: SyncState.IDLE,
     )
     return svc
 

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -49,7 +49,6 @@ def plugin():
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
         emit=decky.emit,
-        sync_state_ref=lambda: SyncState.IDLE,
     )
     p._artwork_service = artwork_service
 
@@ -72,8 +71,6 @@ def plugin():
         metadata_service=metadata_service,
         artwork=artwork_service,
     )
-
-    artwork_service._sync_state_ref = lambda: p._sync_service.sync_state
 
     p._shortcut_removal_service = ShortcutRemovalService(
         romm_api=p._romm_api,

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -8,7 +8,6 @@ import decky
 import pytest
 
 from adapters.steam_config import SteamConfigAdapter
-from domain.sync_state import SyncState
 from services.shortcut_removal import ShortcutRemovalService
 
 
@@ -234,7 +233,6 @@ class TestRemovalCleansUpArtwork:
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             emit=decky.emit,
-            sync_state_ref=lambda: SyncState.IDLE,
         )
 
         svc = ShortcutRemovalService(
@@ -271,7 +269,6 @@ class TestRemovalCleansUpArtwork:
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             emit=decky.emit,
-            sync_state_ref=lambda: SyncState.IDLE,
         )
 
         svc = ShortcutRemovalService(


### PR DESCRIPTION
## Summary
- Removes the `_sync_state_box` mutable-list hack from `bootstrap.py` — it was solving a fake circular dependency.
- Drops the dead `sync_state_ref` parameter from `ArtworkService.__init__` (assigned but never read in the entire 229-line service).
- Removes the `SyncStateRef` Protocol from `services/protocols.py` (only importer was `ArtworkService`, only to type the unused param).
- Cleans the `sync_state_ref=lambda: SyncState.IDLE` kwargs out of three test files.
- Net: 3 insertions, 34 deletions across 7 files.

If artwork-download cancellation ever becomes a real feature, the right shape is a per-call callback on the specific method that needs it — not a persistent reference on the service.

Wave 1 cross-cutting infrastructure, umbrella #277.

## Test plan
- [x] `python -m pytest tests/ -q` — 1785 passed
- [x] `ruff check` — clean
- [x] `basedpyright py_modules/ tests/ main.py` — 0/0/0
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] Coverage: 88% total, no regression
- [x] Callsite check: zero static refs to any removed name, zero dynamic access (`getattr`/`hasattr`/`setattr`/`__dict__`/`vars`), all 5 `ArtworkService(...)` constructors accounted for

Closes #168.