### PR TITLE
refactor(bootstrap): split WiringConfig into 4 frozen bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
 
 - **Wave 1 — Cross-cutting infrastructure** ([#256](https://github.com/danielcopper/decky-romm-sync/issues/256))
   Protocols, persisters, bootstrap cleanup. Do first — every later vertical consumes the Protocols defined here.
-  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311).
-  Open: #168 (`_sync_state_box` — next), #169 (WiringConfig split), #259 (SonarCloud arch rules — deferred until Python supported).
+  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311), ~~#168~~ (sync_state_box dead-code removal, shipped as #312).
+  Open: #169 (WiringConfig split — next), #259 (SonarCloud arch rules — deferred until Python supported).
 - **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295))
   Extract pure logic from non-saves services into `domain/`. Library sync_classification cluster first (highest value), then firmware paths, achievements, path safety, filename resolution.
 - **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2)

--- a/main.py
+++ b/main.py
@@ -9,7 +9,15 @@ sys.path.insert(0, os.path.join(plugin_dir, "py_modules"))
 sys.path.insert(0, plugin_dir)
 
 import decky
-from bootstrap import WiringConfig, bootstrap, wire_services
+from bootstrap import (
+    AdapterBundle,
+    CallbackBundle,
+    RuntimeBundle,
+    StateBundle,
+    WiringConfig,
+    bootstrap,
+    wire_services,
+)
 
 from adapters.persistence import (
     FirmwareCachePersisterAdapter,
@@ -177,35 +185,43 @@ class Plugin:
         self._save_sync_state = SaveService.make_default_state()
         services = wire_services(
             WiringConfig(
-                http_adapter=self._http_adapter,
-                romm_api=self._romm_api,
-                steam_config=self._steam_config,
-                sgdb_adapter=self._sgdb_adapter,
-                state=self._state,
-                settings=self.settings,
-                metadata_cache=self._metadata_cache,
-                save_sync_state=self._save_sync_state,
-                loop=self.loop,
-                logger=decky.logger,
-                plugin_dir=decky.DECKY_PLUGIN_DIR,
-                runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
-                emit=decky.emit,
-                clock=adapters["clock"],
-                uuid_gen=adapters["uuid_gen"],
-                sleeper=adapters["sleeper"],
-                get_saves_path=self._retrodeck_paths.get_saves_path,
-                get_roms_path=self._retrodeck_paths.get_roms_path,
-                get_bios_path=self._retrodeck_paths.get_bios_path,
-                get_retrodeck_home=self._retrodeck_paths.get_retrodeck_home,
-                get_retroarch_save_sorting=self._retroarch_config.get_retroarch_save_sorting,
-                get_core_name=self._retroarch_core_info.get_corename,
-                save_state=self._save_state,
-                save_settings_to_disk=self._save_settings_to_disk,
-                save_metadata_cache=self._save_metadata_cache,
-                firmware_cache_persister=FirmwareCachePersisterAdapter(self._persistence),
-                core_info_provider=adapters["core_resolver"],
-                save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
-                log_debug=self._log_debug,
+                adapters=AdapterBundle(
+                    http_adapter=self._http_adapter,
+                    romm_api=self._romm_api,
+                    steam_config=self._steam_config,
+                    sgdb_adapter=self._sgdb_adapter,
+                ),
+                stores=StateBundle(
+                    state=self._state,
+                    settings=self.settings,
+                    metadata_cache=self._metadata_cache,
+                    save_sync_state=self._save_sync_state,
+                ),
+                runtime=RuntimeBundle(
+                    loop=self.loop,
+                    logger=decky.logger,
+                    plugin_dir=decky.DECKY_PLUGIN_DIR,
+                    runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
+                    emit=decky.emit,
+                    clock=adapters["clock"],
+                    uuid_gen=adapters["uuid_gen"],
+                    sleeper=adapters["sleeper"],
+                ),
+                callbacks=CallbackBundle(
+                    get_saves_path=self._retrodeck_paths.get_saves_path,
+                    get_roms_path=self._retrodeck_paths.get_roms_path,
+                    get_bios_path=self._retrodeck_paths.get_bios_path,
+                    get_retrodeck_home=self._retrodeck_paths.get_retrodeck_home,
+                    get_retroarch_save_sorting=self._retroarch_config.get_retroarch_save_sorting,
+                    get_core_name=self._retroarch_core_info.get_corename,
+                    save_state=self._save_state,
+                    save_settings_to_disk=self._save_settings_to_disk,
+                    save_metadata_cache=self._save_metadata_cache,
+                    firmware_cache_persister=FirmwareCachePersisterAdapter(self._persistence),
+                    core_info_provider=adapters["core_resolver"],
+                    save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
+                    log_debug=self._log_debug,
+                ),
             )
         )
         self._save_sync_service = services["save_sync_service"]

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -59,24 +59,30 @@ from services.shortcut_removal import ShortcutRemovalService
 from services.steamgrid import SteamGridService
 
 
-@dataclass
-class WiringConfig:
-    """Configuration bundle for wire_services — groups the parameters
-    into a single object to keep the composition root readable."""
+@dataclass(frozen=True)
+class AdapterBundle:
+    """Concrete I/O adapters wired into services."""
 
-    # Adapters
     http_adapter: RommHttpAdapter
     romm_api: RommApiProtocol
     steam_config: SteamConfigProtocol
     sgdb_adapter: SteamGridDbAdapter
 
-    # State (live dict refs)
+
+@dataclass(frozen=True)
+class StateBundle:
+    """Live mutable state dicts shared across services."""
+
     state: dict
     settings: dict
     metadata_cache: dict
     save_sync_state: dict
 
-    # Runtime
+
+@dataclass(frozen=True)
+class RuntimeBundle:
+    """Process-level runtime infrastructure (event loop, logger, paths, time/UUID/sleep seams)."""
+
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -86,7 +92,11 @@ class WiringConfig:
     uuid_gen: UuidGen
     sleeper: Sleeper
 
-    # Callbacks
+
+@dataclass(frozen=True)
+class CallbackBundle:
+    """Provider callables and persister Protocols injected into services."""
+
     get_saves_path: SavesPathProvider
     get_roms_path: RomsPathProvider
     get_bios_path: BiosPathProvider
@@ -100,6 +110,16 @@ class WiringConfig:
     core_info_provider: CoreInfoProvider
     save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
+
+
+@dataclass(frozen=True)
+class WiringConfig:
+    """Composition-root inputs for ``wire_services`` grouped into four bundles."""
+
+    adapters: AdapterBundle
+    stores: StateBundle
+    runtime: RuntimeBundle
+    callbacks: CallbackBundle
 
 
 def bootstrap(
@@ -199,175 +219,175 @@ def wire_services(cfg: WiringConfig) -> dict:
     # lookup to call time, so it is safe to reference here even though
     # ``firmware_service`` is constructed later in this function.
     migration_service = MigrationService(
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        save_state=cfg.save_state,
-        emit=cfg.emit,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        save_state=cfg.callbacks.save_state,
+        emit=cfg.runtime.emit,
         get_bios_files_index=lambda: firmware_service.bios_files_index,
-        get_retrodeck_home=cfg.get_retrodeck_home,
-        get_saves_path=cfg.get_saves_path,
-        get_bios_path=cfg.get_bios_path,
-        get_retroarch_save_sorting=cfg.get_retroarch_save_sorting,
-        get_roms_path=cfg.get_roms_path,
-        get_active_core=cfg.core_info_provider.get_active_core,
-        get_core_name=cfg.get_core_name,
+        get_retrodeck_home=cfg.callbacks.get_retrodeck_home,
+        get_saves_path=cfg.callbacks.get_saves_path,
+        get_bios_path=cfg.callbacks.get_bios_path,
+        get_retroarch_save_sorting=cfg.callbacks.get_retroarch_save_sorting,
+        get_roms_path=cfg.callbacks.get_roms_path,
+        get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+        get_core_name=cfg.callbacks.get_core_name,
     )
 
     save_service_config = SaveServiceConfig(
-        runtime_dir=cfg.runtime_dir,
-        save_sync_state_persister=cfg.save_sync_state_persister,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        clock=cfg.clock,
-        get_saves_path=cfg.get_saves_path,
-        get_roms_path=cfg.get_roms_path,
-        get_active_core=cfg.core_info_provider.get_active_core,
-        get_core_name=cfg.get_core_name,
-        plugin_version=_read_plugin_version(cfg.plugin_dir),
-        emit=cfg.emit,
+        runtime_dir=cfg.runtime.runtime_dir,
+        save_sync_state_persister=cfg.callbacks.save_sync_state_persister,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        clock=cfg.runtime.clock,
+        get_saves_path=cfg.callbacks.get_saves_path,
+        get_roms_path=cfg.callbacks.get_roms_path,
+        get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+        get_core_name=cfg.callbacks.get_core_name,
+        plugin_version=_read_plugin_version(cfg.runtime.plugin_dir),
+        emit=cfg.runtime.emit,
         # SaveService must observe fresh sort state before computing saves_dir (#238).
         detect_sort_change=migration_service.detect_save_sort_change,
         is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
     )
     save_sync_service = SaveService(
-        romm_api=cfg.romm_api,
-        retry=cfg.http_adapter,
-        settings=cfg.settings,
-        state=cfg.state,
-        save_sync_state=cfg.save_sync_state,
+        romm_api=cfg.adapters.romm_api,
+        retry=cfg.adapters.http_adapter,
+        settings=cfg.stores.settings,
+        state=cfg.stores.state,
+        save_sync_state=cfg.stores.save_sync_state,
         config=save_service_config,
     )
 
     playtime_service = PlaytimeService(
-        romm_api=cfg.romm_api,
-        retry=cfg.http_adapter,
-        save_sync_state=cfg.save_sync_state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        clock=cfg.clock,
+        romm_api=cfg.adapters.romm_api,
+        retry=cfg.adapters.http_adapter,
+        save_sync_state=cfg.stores.save_sync_state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        clock=cfg.runtime.clock,
         save_state=save_sync_service.save_state,
     )
 
     metadata_service = MetadataService(
-        romm_api=cfg.romm_api,
-        state=cfg.state,
-        metadata_cache=cfg.metadata_cache,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        clock=cfg.clock,
-        save_metadata_cache=cfg.save_metadata_cache,
-        log_debug=cfg.log_debug,
+        romm_api=cfg.adapters.romm_api,
+        state=cfg.stores.state,
+        metadata_cache=cfg.stores.metadata_cache,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        clock=cfg.runtime.clock,
+        save_metadata_cache=cfg.callbacks.save_metadata_cache,
+        log_debug=cfg.callbacks.log_debug,
     )
 
     artwork_service = ArtworkService(
-        romm_api=cfg.romm_api,
-        steam_config=cfg.steam_config,
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        emit=cfg.emit,
+        romm_api=cfg.adapters.romm_api,
+        steam_config=cfg.adapters.steam_config,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        emit=cfg.runtime.emit,
     )
 
     shortcut_removal_service = ShortcutRemovalService(
-        romm_api=cfg.romm_api,
-        steam_config=cfg.steam_config,
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        emit=cfg.emit,
-        save_state=cfg.save_state,
+        romm_api=cfg.adapters.romm_api,
+        steam_config=cfg.adapters.steam_config,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        emit=cfg.runtime.emit,
+        save_state=cfg.callbacks.save_state,
         artwork_remover=artwork_service,
     )
 
     sync_service = LibraryService(
-        romm_api=cfg.romm_api,
-        steam_config=cfg.steam_config,
-        state=cfg.state,
-        settings=cfg.settings,
-        metadata_cache=cfg.metadata_cache,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        plugin_dir=cfg.plugin_dir,
-        emit=cfg.emit,
-        clock=cfg.clock,
-        uuid_gen=cfg.uuid_gen,
-        sleeper=cfg.sleeper,
-        save_state=cfg.save_state,
-        save_settings_to_disk=cfg.save_settings_to_disk,
-        log_debug=cfg.log_debug,
+        romm_api=cfg.adapters.romm_api,
+        steam_config=cfg.adapters.steam_config,
+        state=cfg.stores.state,
+        settings=cfg.stores.settings,
+        metadata_cache=cfg.stores.metadata_cache,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        plugin_dir=cfg.runtime.plugin_dir,
+        emit=cfg.runtime.emit,
+        clock=cfg.runtime.clock,
+        uuid_gen=cfg.runtime.uuid_gen,
+        sleeper=cfg.runtime.sleeper,
+        save_state=cfg.callbacks.save_state,
+        save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
+        log_debug=cfg.callbacks.log_debug,
         metadata_service=metadata_service,
         artwork=artwork_service,
     )
 
     download_service = DownloadService(
-        romm_api=cfg.romm_api,
-        resolve_system=cfg.http_adapter.resolve_system,
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        runtime_dir=cfg.runtime_dir,
-        emit=cfg.emit,
-        clock=cfg.clock,
-        sleeper=cfg.sleeper,
-        save_state=cfg.save_state,
-        get_roms_path=cfg.get_roms_path,
-        get_bios_path=cfg.get_bios_path,
+        romm_api=cfg.adapters.romm_api,
+        resolve_system=cfg.adapters.http_adapter.resolve_system,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        runtime_dir=cfg.runtime.runtime_dir,
+        emit=cfg.runtime.emit,
+        clock=cfg.runtime.clock,
+        sleeper=cfg.runtime.sleeper,
+        save_state=cfg.callbacks.save_state,
+        get_roms_path=cfg.callbacks.get_roms_path,
+        get_bios_path=cfg.callbacks.get_bios_path,
         is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
     )
 
     rom_removal_service = RomRemovalService(
-        state=cfg.state,
-        save_sync_state=cfg.save_sync_state,
-        logger=cfg.logger,
-        loop=cfg.loop,
-        save_state=cfg.save_state,
+        state=cfg.stores.state,
+        save_sync_state=cfg.stores.save_sync_state,
+        logger=cfg.runtime.logger,
+        loop=cfg.runtime.loop,
+        save_state=cfg.callbacks.save_state,
         save_save_sync_state=save_sync_service.save_state,
-        get_roms_path=cfg.get_roms_path,
+        get_roms_path=cfg.callbacks.get_roms_path,
     )
 
     firmware_service = FirmwareService(
-        romm_api=cfg.romm_api,
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        plugin_dir=cfg.plugin_dir,
-        clock=cfg.clock,
-        save_state=cfg.save_state,
-        firmware_cache_persister=cfg.firmware_cache_persister,
-        get_bios_path=cfg.get_bios_path,
-        core_info=cfg.core_info_provider,
+        romm_api=cfg.adapters.romm_api,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        plugin_dir=cfg.runtime.plugin_dir,
+        clock=cfg.runtime.clock,
+        save_state=cfg.callbacks.save_state,
+        firmware_cache_persister=cfg.callbacks.firmware_cache_persister,
+        get_bios_path=cfg.callbacks.get_bios_path,
+        core_info=cfg.callbacks.core_info_provider,
     )
 
     sgdb_service = SteamGridService(
-        sgdb_api=cfg.sgdb_adapter,
-        romm_api=cfg.romm_api,
-        steam_config=cfg.steam_config,
-        state=cfg.state,
-        settings=cfg.settings,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        runtime_dir=cfg.runtime_dir,
-        save_state=cfg.save_state,
-        save_settings_to_disk=cfg.save_settings_to_disk,
+        sgdb_api=cfg.adapters.sgdb_adapter,
+        romm_api=cfg.adapters.romm_api,
+        steam_config=cfg.adapters.steam_config,
+        state=cfg.stores.state,
+        settings=cfg.stores.settings,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        runtime_dir=cfg.runtime.runtime_dir,
+        save_state=cfg.callbacks.save_state,
+        save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
         get_pending_sync=lambda: sync_service.pending_sync,
     )
 
     achievements_service = AchievementsService(
-        romm_api=cfg.romm_api,
-        state=cfg.state,
-        loop=cfg.loop,
-        logger=cfg.logger,
-        clock=cfg.clock,
-        log_debug=cfg.log_debug,
+        romm_api=cfg.adapters.romm_api,
+        state=cfg.stores.state,
+        loop=cfg.runtime.loop,
+        logger=cfg.runtime.logger,
+        clock=cfg.runtime.clock,
+        log_debug=cfg.callbacks.log_debug,
     )
 
     game_detail_service = GameDetailService(
-        state=cfg.state,
-        metadata_cache=cfg.metadata_cache,
-        save_sync_state=cfg.save_sync_state,
-        logger=cfg.logger,
-        clock=cfg.clock,
+        state=cfg.stores.state,
+        metadata_cache=cfg.stores.metadata_cache,
+        save_sync_state=cfg.stores.save_sync_state,
+        logger=cfg.runtime.logger,
+        clock=cfg.runtime.clock,
         bios_checker=firmware_service,
         achievements=achievements_service,
     )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,7 +4,15 @@ import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
-from bootstrap import WiringConfig, bootstrap, wire_services
+from bootstrap import (
+    AdapterBundle,
+    CallbackBundle,
+    RuntimeBundle,
+    StateBundle,
+    WiringConfig,
+    bootstrap,
+    wire_services,
+)
 from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -165,9 +173,52 @@ class TestWireServices:
             "log_debug": MagicMock(),
         }
 
+    @staticmethod
+    def _make_config(deps: dict) -> WiringConfig:
+        """Build a WiringConfig from the flat deps dict produced by ``_make_deps``."""
+        return WiringConfig(
+            adapters=AdapterBundle(
+                http_adapter=deps["http_adapter"],
+                romm_api=deps["romm_api"],
+                steam_config=deps["steam_config"],
+                sgdb_adapter=deps["sgdb_adapter"],
+            ),
+            stores=StateBundle(
+                state=deps["state"],
+                settings=deps["settings"],
+                metadata_cache=deps["metadata_cache"],
+                save_sync_state=deps["save_sync_state"],
+            ),
+            runtime=RuntimeBundle(
+                loop=deps["loop"],
+                logger=deps["logger"],
+                plugin_dir=deps["plugin_dir"],
+                runtime_dir=deps["runtime_dir"],
+                emit=deps["emit"],
+                clock=deps["clock"],
+                uuid_gen=deps["uuid_gen"],
+                sleeper=deps["sleeper"],
+            ),
+            callbacks=CallbackBundle(
+                get_saves_path=deps["get_saves_path"],
+                get_roms_path=deps["get_roms_path"],
+                get_bios_path=deps["get_bios_path"],
+                get_retrodeck_home=deps["get_retrodeck_home"],
+                get_retroarch_save_sorting=deps["get_retroarch_save_sorting"],
+                get_core_name=deps["get_core_name"],
+                save_state=deps["save_state"],
+                save_settings_to_disk=deps["save_settings_to_disk"],
+                save_metadata_cache=deps["save_metadata_cache"],
+                firmware_cache_persister=deps["firmware_cache_persister"],
+                core_info_provider=deps["core_info_provider"],
+                save_sync_state_persister=deps["save_sync_state_persister"],
+                log_debug=deps["log_debug"],
+            ),
+        )
+
     def test_returns_all_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         assert isinstance(result["save_sync_service"], SaveService)
         assert isinstance(result["playtime_service"], PlaytimeService)
         assert isinstance(result["sync_service"], LibraryService)
@@ -180,7 +231,7 @@ class TestWireServices:
 
     def test_services_share_state_reference(self, tmp_path):
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         # download_service and sync_service should share the same state dict
         assert result["download_service"]._state is deps["state"]
         assert result["sync_service"]._state is deps["state"]
@@ -188,7 +239,7 @@ class TestWireServices:
 
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         assert len(result) == 13
         assert "migration_service" in result
         assert "game_detail_service" in result
@@ -199,7 +250,7 @@ class TestWireServices:
         """MigrationService must receive the get_core_name callback from wire_services."""
         deps = self._make_deps(tmp_path)
         get_core_name_mock = deps["get_core_name"]
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         migration_service = result["migration_service"]
         # Callback is stored as _get_core_name on the service
         assert migration_service._get_core_name is get_core_name_mock
@@ -214,7 +265,7 @@ class TestWireServices:
         """
         deps = self._make_deps(tmp_path)
         get_core_name_mock = deps["get_core_name"]
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
         assert save_sync_service._get_core_name is get_core_name_mock
         deps["loop"].close()
@@ -230,7 +281,7 @@ class TestWireServices:
         migration step.
         """
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
         migration_service = result["migration_service"]
         # Bound method equality: same function + same bound instance.
@@ -250,7 +301,7 @@ class TestWireServices:
         stale copy — defeating the detect-first invariant.
         """
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
         migration_service = result["migration_service"]
         assert save_sync_service._state is deps["state"]
@@ -264,7 +315,7 @@ class TestWireServices:
         pre_launch_sync / post_exit_sync can short-circuit while the user
         still has files at the previous RetroDECK home."""
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
         migration_service = result["migration_service"]
         assert save_sync_service._is_retrodeck_migration_pending == migration_service.is_retrodeck_migration_pending
@@ -276,7 +327,7 @@ class TestWireServices:
         ``migration_service.is_retrodeck_migration_pending`` callback so
         the download poll loop pauses while a migration is pending."""
         deps = self._make_deps(tmp_path)
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         download_service = result["download_service"]
         migration_service = result["migration_service"]
         assert download_service._is_retrodeck_migration_pending == migration_service.is_retrodeck_migration_pending
@@ -295,7 +346,7 @@ class TestWireServices:
         deps = self._make_deps(tmp_path)
         # The default mock returns (True, False); no prior state seeded.
         assert "save_sort_settings" not in deps["state"]
-        result = wire_services(WiringConfig(**deps))
+        result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
 
         # Invoke the bound detect callback SaveService received.


### PR DESCRIPTION
## Summary
- Splits `WiringConfig` (29 fields, single flat dataclass) into 4 frozen sub-dataclasses matching its existing inline comment sections: `AdapterBundle` / `StateBundle` / `RuntimeBundle` / `CallbackBundle`. `WiringConfig` itself becomes a frozen wrapper with 4 fields: `adapters`, `stores`, `runtime`, `callbacks`.
- Outer field renamed from `state` to `stores` to avoid `cfg.state.state` collision (inner `state: dict` inside `StateBundle` stays put — no ripple through services).
- All 5 dataclasses are `frozen=True` — config immutability is now statically enforced.
- `main.py` construction site rewrites to 4 named bundle constructors instead of a 29-line flat kwarg list.
- Service signatures unchanged — the split is 100% invisible below `wire_services()`.

Wave 1 cross-cutting infrastructure, umbrella #277. Last actionable Wave 1 ticket (after this, only #259 remains, blocked on SonarCloud Python arch support).

## Test plan
- [x] `python -m pytest tests/ -q` — 1785 passed
- [x] `ruff check` — clean
- [x] `basedpyright py_modules/ tests/ main.py` — 0/0/0
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] Coverage: 88% total, no regression
- [x] Field accounting: each of the 29 original fields appears in exactly one bundle (grep-verified)
- [x] Bundle access correctness: spot-checked `cfg.<bundle>.<field>` chains across `wire_services()` resolve to the correct bundle
- [x] Identity tests still pass — `cfg.stores.state` lands `is`-identical on `download_service._state`, `sync_service._state`, `rom_removal_service._state`

Closes #169.