### PR TITLE
ci(services): add cosmic-python call-ban check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Check import boundaries
         run: PYTHONPATH=py_modules lint-imports
 
+      - name: Check Cosmic Python call bans
+        run: bash scripts/check_cosmic_call_bans.sh
+
   sonarcloud:
     runs-on: ubuntu-latest
     needs: [test]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Roadmap and open work: [GitHub Projects board](https://github.com/users/danielco
 - **Ruff**: Python linting in CI.
 - **basedpyright**: Type checking in CI.
 - **import-linter**: Layer boundary enforcement in CI (services ↛ adapters, adapters ↛ services, services independent).
+- **Cosmic Python call bans**: `scripts/check_cosmic_call_bans.sh` — services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` / `random.*` directly (use the corresponding Protocol).
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
 ## Architecture — Cosmic Python rules
@@ -69,10 +70,10 @@ If a refactor breaks one of these rules, that's a Cosmic Python regression — c
 
 The full Cosmic Python migration is tracked under [#277](https://github.com/danielcopper/decky-romm-sync/issues/277) (umbrella). Order is chosen to minimize rework: cross-cutting Protocols first, then domain promotions, then per-service vertical refactors smallest-to-largest.
 
-- **Wave 1 — Cross-cutting infrastructure** ([#256](https://github.com/danielcopper/decky-romm-sync/issues/256))
-  Protocols, persisters, bootstrap cleanup. Do first — every later vertical consumes the Protocols defined here.
-  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311), ~~#168~~ (sync_state_box dead-code removal, shipped as #312).
-  Open: #169 (WiringConfig split — next), #259 (SonarCloud arch rules — deferred until Python supported).
+- **Wave 1 — Cross-cutting infrastructure** ([#256](https://github.com/danielcopper/decky-romm-sync/issues/256)) — **complete except for deferred CI gate**
+  Protocols, persisters, bootstrap cleanup. Done first so every later vertical consumes the Protocols defined here.
+  Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311), ~~#168~~ (sync_state_box dead-code removal, shipped as #312), ~~#169~~ (WiringConfig split, shipped as #313), ~~#303~~ (call-site clock/sleep ban, shipped as #314).
+  Deferred: #259 (SonarCloud arch rules — waiting on SonarCloud Python support).
 - **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295))
   Extract pure logic from non-saves services into `domain/`. Library sync_classification cluster first (highest value), then firmware paths, achievements, path safety, filename resolution.
 - **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2)
@@ -89,7 +90,7 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
 
 **Why this order**: doing #294 (Clock/UuidGen/Sleeper) before any per-service vertical means every later PR is "drop the import, inject the Protocol" — mechanical. Doing #295 (domain extraction) before LibraryService shrinks the scariest service before lifting it. LibraryService last because it has the largest blast radius.
 
-When picking work: any unblocked Wave 1 issue is a safe pick. Wave 2 PRs can start once their Wave 1 dependencies (Clock for the affected service) ship.
+When picking work: Wave 1 is finished (modulo deferred #259), so every later vertical's Protocol dependencies are in place. Wave 2 (#295) is the next active wave.
 
 ## Sub-package layout — `__init__.py` is re-export only
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -312,7 +312,7 @@ class Clock(Protocol):
 class UuidGen(Protocol):
     """Sole source of UUID values for services.
 
-    Services consume this Protocol instead of ``uuid.uuid4()`` directly so
+    Services consume this Protocol instead of ``uuid.uuid4`` directly so
     tests can supply deterministic IDs.
     """
 

--- a/scripts/check_cosmic_call_bans.sh
+++ b/scripts/check_cosmic_call_bans.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Cosmic Python call-ban check.
+# Services must inject Clock / UuidGen / Sleeper Protocols instead of
+# calling datetime.now() / time.time() / time.monotonic() / asyncio.sleep() /
+# uuid.uuid4() / random.* directly.
+#
+# Limitation: grep-based. Aliased module imports (``import asyncio as aio; aio.sleep()``)
+# and direct function imports (``from asyncio import sleep; sleep()``) bypass the regex.
+# Reviewers catch those workarounds.
+
+set -euo pipefail
+
+readonly SERVICES_DIR="py_modules/services"
+
+readonly PATTERNS=(
+    'datetime\.now\('
+    'asyncio\.sleep\('
+    'time\.time\('
+    'time\.monotonic\('
+    'uuid\.uuid4\('
+    '(^|[^a-zA-Z_.])random\.[a-zA-Z_]'
+)
+
+found_any=0
+for pattern in "${PATTERNS[@]}"; do
+    if matches=$(grep -rnE "$pattern" "$SERVICES_DIR" 2>/dev/null); then
+        echo "Forbidden Cosmic Python call '$pattern' in $SERVICES_DIR:"
+        echo "$matches"
+        echo
+        found_any=1
+    fi
+done
+
+if [[ $found_any -ne 0 ]]; then
+    echo "ERROR: services must inject Clock / UuidGen / Sleeper Protocols (CLAUDE.md)."
+    exit 1
+fi
+
+echo "OK: no forbidden calls in $SERVICES_DIR."


### PR DESCRIPTION
## Summary
- Adds `scripts/check_cosmic_call_bans.sh` — a grep-based shell script that fails CI if `py_modules/services/` contains direct calls to: `datetime.now(`, `asyncio.sleep(`, `time.time(`, `time.monotonic(`, `uuid.uuid4(`, or `random.<ident>`. Services must inject the corresponding Protocols (`Clock` / `UuidGen` / `Sleeper`).
- Wired into the CI `lint` job alongside ruff / basedpyright / lint-imports — a 4th gate.
- Reworded `services/protocols.py:315` docstring (`uuid.uuid4()` → `uuid.uuid4`) to dodge a regex false positive in a docstring.
- Zero current violations across all 6 patterns — this is pure regression prevention.

Documents known grep limitations (aliased + bare-function imports bypass the regex; reviewers catch those workarounds).

Closes the last actionable Wave 1 ticket. Wave 1 is now wrapped except for deferred #259 (SonarCloud arch rules, blocked on SonarCloud Python support).

## Test plan
- [x] `bash scripts/check_cosmic_call_bans.sh` — exits 0 cleanly on current `services/`
- [x] Synthetic-violation smoke test — all 6 patterns flagged when planted in a fixture; negative controls (`_random_state`, `self.myrandom`, `seed_random`, `my_random.x`) not flagged
- [x] `python -m pytest tests/ -q` — 1785 passed
- [x] `ruff check` — clean
- [x] `basedpyright py_modules/ tests/ main.py` — 0/0/0
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken

Closes #303.