### PR TITLE
refactor(domain): extract firmware path helpers from FirmwareService

### DIFF
--- a/py_modules/domain/firmware_paths.py
+++ b/py_modules/domain/firmware_paths.py
@@ -1,0 +1,39 @@
+"""Firmware path parsing and platform-to-firmware slug remapping.
+
+Pure string logic for translating between RomM's firmware ``file_path``
+layout and platform slugs. BIOS file I/O, registry loading, and HTTP
+calls live in FirmwareService; anything that reaches the filesystem or
+network does not belong here.
+"""
+
+from __future__ import annotations
+
+_PLATFORM_TO_FIRMWARE_SLUGS: dict[str, list[str]] = {
+    "psx": ["psx", "ps"],
+    "ps2": ["ps2"],
+}
+
+
+def parse_firmware_slug(file_path: str) -> str:
+    """Extract the firmware slug from a RomM firmware ``file_path``.
+
+    Returns the slug directly under ``bios/`` (e.g. ``"bios/ps/scph.bin"``
+    -> ``"ps"``), or the first segment for non-``bios`` layouts. Returns
+    an empty string when ``file_path`` has fewer than two segments.
+    """
+    parts = file_path.strip("/").split("/")
+    if len(parts) >= 2 and parts[0] == "bios":
+        return parts[1]
+    elif len(parts) >= 2:
+        return parts[0]
+    return ""
+
+
+def resolve_firmware_slugs(platform_slug: str) -> list[str]:
+    """Map a platform slug to the firmware directory slugs RomM may use.
+
+    RomM uses different slugs for platforms vs firmware directories
+    (e.g. platform ``"psx"`` is stored under firmware dir ``"ps"``).
+    Unknown platforms fall through as ``[platform_slug]``.
+    """
+    return _PLATFORM_TO_FIRMWARE_SLUGS.get(platform_slug, [platform_slug])

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -12,6 +12,7 @@ import os
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
+from domain import firmware_paths
 from domain.bios import collect_firmware_status
 from lib.errors import error_response
 
@@ -118,27 +119,6 @@ class FirmwareService:
             file_dict["hash_valid"] = None
         return file_dict
 
-    def _firmware_slug(self, file_path):
-        """Extract firmware slug from file_path (e.g. 'bios/ps' -> 'ps')."""
-        parts = file_path.strip("/").split("/")
-        if len(parts) >= 2 and parts[0] == "bios":
-            return parts[1]
-        elif len(parts) >= 2:
-            return parts[0]
-        return ""
-
-    def _platform_to_firmware_slugs(self, platform_slug):
-        """Map platform slug to possible firmware directory slugs.
-
-        RomM uses different slugs for platforms vs firmware directories
-        (e.g. platform 'psx' -> firmware dir 'ps').
-        """
-        mapping = {
-            "psx": ["psx", "ps"],
-            "ps2": ["ps2"],
-        }
-        return mapping.get(platform_slug, [platform_slug])
-
     def _firmware_dest_path(self, firmware):
         """Determine local destination path for a firmware file.
 
@@ -219,7 +199,7 @@ class FirmwareService:
         if self._firmware_cache is None:
             return None
 
-        fw_slugs = self._platform_to_firmware_slugs(platform_slug)
+        fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
         active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
 
         registry_platform = {}
@@ -233,7 +213,7 @@ class FirmwareService:
                 "dest": self._firmware_dest_path(fw),
             }
             for fw in self._firmware_cache
-            if self._firmware_slug(fw.get("file_path", "")) in fw_slugs
+            if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
         ]
         files = collect_firmware_status(items, registry_platform, active_core_so)
 
@@ -266,7 +246,7 @@ class FirmwareService:
         """Group server firmware list by platform slug."""
         platforms_map = {}
         for fw in firmware_list:
-            platform_slug = self._firmware_slug(fw.get("file_path", "")) or "unknown"
+            platform_slug = firmware_paths.parse_firmware_slug(fw.get("file_path", "")) or "unknown"
             if platform_slug not in platforms_map:
                 platforms_map[platform_slug] = {"platform_slug": platform_slug, "files": []}
             dest = self._firmware_dest_path(fw)
@@ -374,7 +354,7 @@ class FirmwareService:
         self._state["downloaded_bios"][file_name] = {
             "file_path": dest,
             "firmware_id": firmware_id,
-            "platform_slug": self._firmware_slug(fw.get("file_path", "")),
+            "platform_slug": firmware_paths.parse_firmware_slug(fw.get("file_path", "")),
             "downloaded_at": self._clock.now().isoformat(),
         }
         self._save_state()
@@ -422,10 +402,10 @@ class FirmwareService:
             return resp
 
         # Filter by platform slug (use mapped slugs, e.g. "psx" -> ["psx", "ps"])
-        fw_slugs = self._platform_to_firmware_slugs(platform_slug)
+        fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
         platform_firmware = []
         for fw in firmware_list:
-            slug = self._firmware_slug(fw.get("file_path", ""))
+            slug = firmware_paths.parse_firmware_slug(fw.get("file_path", ""))
             if slug in fw_slugs:
                 platform_firmware.append(fw)
 
@@ -480,13 +460,13 @@ class FirmwareService:
             resp["downloaded"] = 0
             return resp
 
-        fw_slugs = self._platform_to_firmware_slugs(platform_slug)
+        fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
         core_so, _ = self._core_info.get_active_core(platform_slug)
 
         platform_firmware = [
             fw
             for fw in firmware_list
-            if self._firmware_slug(fw.get("file_path", "")) in fw_slugs
+            if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
             and self._is_firmware_required(fw.get("file_name", ""), core_so) is True
         ]
 
@@ -499,7 +479,7 @@ class FirmwareService:
 
     async def check_platform_bios(self, platform_slug, rom_filename=None):
         """Check if RomM has firmware for this platform and whether it's downloaded."""
-        fw_slugs = self._platform_to_firmware_slugs(platform_slug)
+        fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
         active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
 
         # Build combined registry entries for this platform from all mapped slugs
@@ -516,7 +496,7 @@ class FirmwareService:
                     "dest": self._firmware_dest_path(fw),
                 }
                 for fw in firmware_list
-                if self._firmware_slug(fw.get("file_path", "")) in fw_slugs
+                if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
             ]
             files = collect_firmware_status(items, registry_platform, active_core_so)
         except Exception:

--- a/tests/domain/test_firmware_paths.py
+++ b/tests/domain/test_firmware_paths.py
@@ -1,0 +1,34 @@
+"""Tests for domain.firmware_paths — pure firmware slug parsing and platform mapping."""
+
+from domain.firmware_paths import parse_firmware_slug, resolve_firmware_slugs
+
+
+class TestParseFirmwareSlug:
+    def test_bios_prefix_returns_second_segment(self):
+        assert parse_firmware_slug("bios/ps/scph.bin") == "ps"
+
+    def test_single_part_returns_empty(self):
+        assert parse_firmware_slug("bios") == ""
+
+    def test_non_bios_prefix(self):
+        assert parse_firmware_slug("firmware/dc/boot.bin") == "firmware"
+
+    def test_empty_path(self):
+        assert parse_firmware_slug("") == ""
+
+    def test_leading_and_trailing_slashes_stripped(self):
+        assert parse_firmware_slug("/bios/ps/") == "ps"
+
+
+class TestResolveFirmwareSlugs:
+    def test_psx_maps_to_psx_and_ps(self):
+        assert resolve_firmware_slugs("psx") == ["psx", "ps"]
+
+    def test_ps2_maps_to_ps2(self):
+        assert resolve_firmware_slugs("ps2") == ["ps2"]
+
+    def test_unknown_platform_returns_identity(self):
+        assert resolve_firmware_slugs("snes") == ["snes"]
+
+    def test_empty_string_returns_identity(self):
+        assert resolve_firmware_slugs("") == [""]

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -1418,19 +1418,6 @@ class TestLoadBiosRegistryErrors:
         assert fw._bios_registry == {}
 
 
-class TestFirmwareSlugEdgeCases:
-    """Tests for _firmware_slug edge cases."""
-
-    def test_single_part_returns_empty(self, fw):
-        assert fw._firmware_slug("bios") == ""
-
-    def test_non_bios_prefix(self, fw):
-        assert fw._firmware_slug("firmware/dc/boot.bin") == "firmware"
-
-    def test_empty_path(self, fw):
-        assert fw._firmware_slug("") == ""
-
-
 class TestDownloadFirmwarePostIORegistryHash:
     """Tests for _download_firmware_post_io registry hash verification."""
 


### PR DESCRIPTION
## Summary

First piece of Wave 2 (#295) — Cosmic Python domain promotions.

Lift two pure helpers out of the 595-LOC `FirmwareService` into a new domain module:

- `parse_firmware_slug(file_path)` — extract firmware slug from a registry path (`bios/ps/...` → `ps`)
- `resolve_firmware_slugs(platform_slug)` — map platform → firmware-dir slug (`psx` → `[psx, ps]`, `ps2` → `[ps2]`, unknown → identity)

Both are pure string logic with no state or I/O — they belong in `domain/`, not on a stateful service.

## Changes

- New `py_modules/domain/firmware_paths.py` — two module-level pure functions, contract-style docstring, stdlib only.
- New `tests/domain/test_firmware_paths.py` — 9 tests covering happy / bad / edge for both functions (100% line + branch coverage on the new module).
- `py_modules/services/firmware.py` — deleted the two wrapper methods, migrated all 10 call sites to call the module functions directly. Net `-20` LOC on the service.
- `tests/services/test_firmware.py` — removed `TestFirmwareSlugEdgeCases` (its 3 tests now live in the domain test file, expanded).

## Test plan

- [x] `python -m pytest tests/ -q` — 1791 passed
- [x] `ruff check .` — clean
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken (domain layer boundary holds)
- [x] `scripts/check_cosmic_call_bans.sh` — no forbidden calls
- [x] Behavioral parity verified byte-for-byte against the originals

Refs #295, part of #277.