### PR TITLE
refactor(domain): extract is_safe_rom_path from RomRemovalService

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -20,8 +20,11 @@ description = "Run Python tests"
 run = "python -m pytest tests/ -q"
 
 [tasks.lint]
-description = "Check service/adapter layer boundaries"
-run = "PYTHONPATH=py_modules lint-imports"
+description = "Check Cosmic Python architecture rules (layer imports + forbidden service calls)"
+run = [
+    "PYTHONPATH=py_modules lint-imports",
+    "bash scripts/check_cosmic_call_bans.sh",
+]
 
 [tasks.deploy]
 description = "Deploy plugin files to Decky plugin directory"

--- a/py_modules/domain/path_safety.py
+++ b/py_modules/domain/path_safety.py
@@ -1,0 +1,33 @@
+"""Pure path containment predicates for guarding destructive filesystem ops.
+
+Stateless safety checks that answer "is path X safely inside configured
+root Y?" using only path algebra (``realpath``/``relpath``/``split``) —
+no filesystem reads, no clocks, no service collaborators. The source of
+the configured root (e.g. the ``RomsPathProvider`` Protocol) stays in
+``services/``; this module only consumes the resolved string.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def is_safe_rom_path(path: str, roms_base: str) -> bool:
+    """Return True when ``path`` is safely inside ``roms_base``.
+
+    Two properties must hold:
+
+    1. ``os.path.realpath(path)`` lies strictly inside
+       ``os.path.realpath(roms_base) + os.sep`` — equality with the base
+       is rejected and symlinks escaping the base are rejected.
+    2. The resolved path is at least two segments below the base, so a
+       bare platform directory (e.g. ``roms_base/gb/``) does not qualify
+       while a file beneath one (e.g. ``roms_base/gb/file.zip``) does.
+    """
+    resolved = os.path.realpath(path)
+    real_base = os.path.realpath(roms_base)
+    if not resolved.startswith(real_base + os.sep):
+        return False
+    rel = os.path.relpath(resolved, real_base)
+    parts = rel.split(os.sep)
+    return len(parts) >= 2

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -7,6 +7,8 @@ import os
 import shutil
 from typing import TYPE_CHECKING
 
+from domain.path_safety import is_safe_rom_path
+
 if TYPE_CHECKING:
     import logging
 
@@ -35,30 +37,18 @@ class RomRemovalService:
         self._save_save_sync_state = save_save_sync_state
         self._get_roms_path = get_roms_path
 
-    def _is_safe_rom_path(self, path: str) -> bool:
-        """Check that a path is safely contained within the roms base directory."""
-        roms_base = self._get_roms_path() if self._get_roms_path else ""
-        resolved = os.path.realpath(path)
-        real_base = os.path.realpath(roms_base)
-        if not resolved.startswith(real_base + os.sep):
-            return False
-        # Must be at least 2 levels deep (e.g. roms/gb/file.zip, not roms/gb/)
-        rel = os.path.relpath(resolved, real_base)
-        parts = rel.split(os.sep)
-        return len(parts) >= 2
-
     def _delete_rom_files(self, installed: dict) -> None:
         """Delete ROM files for an installed entry. Handles both single-file and multi-file ROMs."""
         rom_dir = installed.get("rom_dir", "")
         file_path = installed.get("file_path", "")
 
         if rom_dir and os.path.isdir(rom_dir):
-            if not self._is_safe_rom_path(rom_dir):
+            if not is_safe_rom_path(rom_dir, self._get_roms_path() if self._get_roms_path else ""):
                 self._logger.error(f"Refusing to delete path outside roms directory: {rom_dir}")
                 return
             shutil.rmtree(rom_dir)
         elif file_path:
-            if not self._is_safe_rom_path(file_path):
+            if not is_safe_rom_path(file_path, self._get_roms_path() if self._get_roms_path else ""):
                 self._logger.error(f"Refusing to delete path outside roms directory: {file_path}")
                 return
             if os.path.isdir(file_path):

--- a/tests/domain/test_path_safety.py
+++ b/tests/domain/test_path_safety.py
@@ -1,0 +1,48 @@
+"""Tests for domain.path_safety — pure path containment predicates."""
+
+import os
+
+from domain.path_safety import is_safe_rom_path
+
+
+class TestIsSafeRomPath:
+    def test_path_inside_roms_dir_is_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        safe = str(tmp_path / "retrodeck" / "roms" / "n64" / "game.z64")
+        assert is_safe_rom_path(safe, roms_base) is True
+
+    def test_path_outside_roms_dir_is_not_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        outside = str(tmp_path / "evil" / "game.z64")
+        assert is_safe_rom_path(outside, roms_base) is False
+
+    def test_roms_base_itself_is_not_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        # Only 1 level deep — must be at least 2
+        base = str(tmp_path / "retrodeck" / "roms" / "n64")
+        assert is_safe_rom_path(base, roms_base) is False
+
+    def test_etc_passwd_is_not_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        assert is_safe_rom_path("/etc/passwd", roms_base) is False
+
+    def test_deeper_than_two_levels_is_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        deep = str(tmp_path / "retrodeck" / "roms" / "gb" / "sub" / "file.zip")
+        assert is_safe_rom_path(deep, roms_base) is True
+
+    def test_exactly_two_levels_is_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        two_levels = str(tmp_path / "retrodeck" / "roms" / "gb" / "file.zip")
+        assert is_safe_rom_path(two_levels, roms_base) is True
+
+    def test_one_level_deep_is_not_safe(self, tmp_path):
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        one_level = str(tmp_path / "retrodeck" / "roms" / "file.zip")
+        assert is_safe_rom_path(one_level, roms_base) is False
+
+    def test_empty_roms_base_returns_quirky_cwd_match(self):
+        # Preserved quirk: empty roms_base resolves to cwd via os.path.realpath("").
+        cwd = os.path.realpath(os.getcwd())
+        path_two_levels_in_cwd = os.path.join(cwd, "a", "b")
+        assert is_safe_rom_path(path_two_levels_in_cwd, "") is True

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -49,29 +49,6 @@ async def _sync_loop(service):
     service._loop = asyncio.get_event_loop()
 
 
-class TestIsSafeRomPath:
-    def test_path_inside_roms_dir_is_safe(self, service, tmp_path):
-        service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
-        safe = str(tmp_path / "retrodeck" / "roms" / "n64" / "game.z64")
-        assert service._is_safe_rom_path(safe) is True
-
-    def test_path_outside_roms_dir_is_not_safe(self, service, tmp_path):
-        service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
-        outside = str(tmp_path / "evil" / "game.z64")
-        assert service._is_safe_rom_path(outside) is False
-
-    def test_roms_base_itself_is_not_safe(self, service, tmp_path):
-        service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
-        # Only 1 level deep — must be at least 2
-        base = str(tmp_path / "retrodeck" / "roms" / "n64")
-        assert service._is_safe_rom_path(base) is False
-
-    def test_etc_passwd_is_not_safe(self, service, tmp_path):
-
-        service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
-        assert service._is_safe_rom_path("/etc/passwd") is False
-
-
 class TestDeleteRomFiles:
     def test_deletes_single_file(self, service, tmp_path):
 


### PR DESCRIPTION
## Summary

Third piece of Wave 2 (#295) — Cosmic Python domain promotions. Same shape as #315 (firmware paths) and #316 (achievements).

Lifts the pure path-containment predicate out of `RomRemovalService` into a new domain module:

- `is_safe_rom_path(path: str, roms_base: str) -> bool` — verifies `path` resolves to inside `roms_base + os.sep` and is at least 2 segments deep below the base.

The Protocol-fetched `roms_base` (previously `self._get_roms_path()`) is now a parameter. The service supplies it inline at both call sites with the same `... if self._get_roms_path else ""` `None`-guard the original had.

## Preserved quirk

If `roms_base == ""`, `os.path.realpath("")` returns the cwd, so paths under cwd pass the containment check. This is the behavior on `main`; the PR preserves it byte-for-byte and pins it with `test_empty_roms_base_returns_quirky_cwd_match` so it can't silently regress. The one-line "Preserved quirk" comment in that test explains the why.

## Changes

- New `py_modules/domain/path_safety.py` — one pure predicate, stdlib-only (`os.path.realpath`/`relpath`/`split` is pure path algebra, allowed in services per CLAUDE.md and a perfect fit for domain).
- New `tests/domain/test_path_safety.py` — 8 tests, 100% line + branch coverage on the new module:
  - 4 relocated from `TestIsSafeRomPath` (preserved 1:1 with `tmp_path`-based real-filesystem setup; names retained for blame traceability).
  - 4 new: `test_deeper_than_two_levels_is_safe`, `test_exactly_two_levels_is_safe`, `test_one_level_deep_is_not_safe` (depth boundary, both sides), `test_empty_roms_base_returns_quirky_cwd_match` (quirk pin).
- `py_modules/services/rom_removal.py` — deleted `_is_safe_rom_path`, updated the 2 call sites with inline `is_safe_rom_path(path, self._get_roms_path() if self._get_roms_path else "")`.
- `tests/services/test_rom_removal.py` — removed `TestIsSafeRomPath`; integration tests in `TestDeleteRomFiles`/`TestRemoveRom`/`TestUninstallAllRoms` continue to cover the call path.

## Test plan

- [x] `python -m pytest tests/ -q` — 1804 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check py_modules tests` — clean
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] `scripts/check_cosmic_call_bans.sh` — no forbidden calls
- [x] Behavioral parity verified byte-for-byte (reviewer diffed against \`git show main:py_modules/services/rom_removal.py\`)

Refs #295, part of #277.