### PR TITLE
refactor(downloads): lift resolve_local_file_name to domain/rom_files

### DIFF
--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -101,3 +101,30 @@ def detect_launch_file(files: list[tuple[str, int]]) -> str | None:
 
     # Largest file by pre-computed size
     return max(files, key=lambda t: t[1])[0]
+
+
+def resolve_local_file_name(rom_detail: dict) -> tuple[str, bool]:
+    """Resolve the on-disk filename for a ROM.
+
+    For nested-single-file ROMs RomM reports ``fs_name`` as the parent
+    folder, so the actual filename (with extension) lives in
+    ``files[0].file_name``. For all other layouts ``fs_name`` is already
+    the correct filename. When ``fs_name`` is missing the synthetic
+    ``rom_<id>`` (or ``rom_unknown`` if ``id`` is also missing) is used.
+
+    Returns
+    -------
+    tuple[str, bool]
+        ``(filename, has_inconsistency)`` where ``has_inconsistency`` is
+        ``True`` when ``has_nested_single_file=True`` but the ``files``
+        list is empty — the caller may want to log a warning. In that
+        inconsistent state the resolved name still falls back to
+        ``fs_name``.
+    """
+    fs_name = rom_detail.get("fs_name", f"rom_{rom_detail.get('id', 'unknown')}")
+    if not rom_detail.get("has_nested_single_file"):
+        return (fs_name, False)
+    files = rom_detail.get("files") or []
+    if not files:
+        return (fs_name, True)
+    return (files[0].get("file_name") or fs_name, False)

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -15,7 +15,7 @@ import urllib.parse
 import zipfile
 from typing import TYPE_CHECKING
 
-from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
+from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
 from lib.errors import error_response
 
 if TYPE_CHECKING:
@@ -36,23 +36,6 @@ if TYPE_CHECKING:
 _DOWNLOAD_QUEUE_MAX_TERMINAL = 50
 _ZIP_TMP_EXT = ".zip.tmp"
 _TMP_EXT = ".tmp"
-
-
-def _resolve_local_file_name(rom_detail: dict, logger: logging.Logger) -> str:
-    """Resolve the on-disk filename for a ROM.
-
-    For nested-single-file ROMs RomM reports ``fs_name`` as the parent folder,
-    so the actual filename (with extension) lives in ``files[0].file_name``.
-    For all other layouts ``fs_name`` is already the correct filename.
-    """
-    fs_name = rom_detail.get("fs_name", f"rom_{rom_detail.get('id', 'unknown')}")
-    if not rom_detail.get("has_nested_single_file"):
-        return fs_name
-    files = rom_detail.get("files") or []
-    if not files:
-        logger.warning(f"has_nested_single_file=true but files list is empty; falling back to fs_name='{fs_name}'")
-        return fs_name
-    return files[0].get("file_name") or fs_name
 
 
 class DownloadService:
@@ -241,7 +224,11 @@ class DownloadService:
         system = self._resolve_system(platform_slug, platform_fs_slug)
 
         roms_dir = os.path.join(self._get_roms_path() if self._get_roms_path else "", system)
-        file_name = _resolve_local_file_name(rom_detail, self._logger)
+        file_name, files_missing = resolve_local_file_name(rom_detail)
+        if files_missing:
+            self._logger.warning(
+                f"has_nested_single_file=true but files list is empty; falling back to fs_name='{file_name}'"
+            )
         # Fix 1: Sanitize fs_name to prevent path traversal
         safe_name = os.path.basename(file_name)
         if safe_name != file_name:

--- a/tests/domain/test_rom_files.py
+++ b/tests/domain/test_rom_files.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 
-from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u
+from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
 
 
 def _with_sizes(paths: list[str]) -> list[tuple[str, int]]:
@@ -194,3 +194,50 @@ class TestDetectLaunchFile:
         open(m3u, "w").close()
         result = detect_launch_file(_with_sizes([m3u]))
         assert result == m3u
+
+
+class TestResolveLocalFileName:
+    def test_non_nested_returns_fs_name(self):
+        assert resolve_local_file_name({"fs_name": "game.zip"}) == ("game.zip", False)
+
+    def test_nested_returns_file_name_from_files_list(self):
+        rom_detail = {
+            "fs_name": "parent_folder",
+            "has_nested_single_file": True,
+            "files": [{"file_name": "actual.rom"}],
+        }
+        assert resolve_local_file_name(rom_detail) == ("actual.rom", False)
+
+    def test_nested_but_empty_files_returns_fs_name_with_inconsistent_flag(self):
+        rom_detail = {
+            "fs_name": "parent",
+            "has_nested_single_file": True,
+            "files": [],
+        }
+        name, inconsistent = resolve_local_file_name(rom_detail)
+        assert name == "parent"
+        assert inconsistent is True
+
+    def test_nested_with_missing_file_name_falls_back_to_fs_name(self):
+        rom_detail = {
+            "fs_name": "parent",
+            "has_nested_single_file": True,
+            "files": [{}],
+        }
+        assert resolve_local_file_name(rom_detail) == ("parent", False)
+
+    def test_missing_fs_name_uses_id_fallback(self):
+        assert resolve_local_file_name({"id": 42}) == ("rom_42", False)
+
+    def test_missing_fs_name_and_id_uses_unknown_fallback(self):
+        assert resolve_local_file_name({}) == ("rom_unknown", False)
+
+    def test_files_explicitly_none(self):
+        rom_detail = {
+            "fs_name": "parent",
+            "has_nested_single_file": True,
+            "files": None,
+        }
+        name, inconsistent = resolve_local_file_name(rom_detail)
+        assert name == "parent"
+        assert inconsistent is True


### PR DESCRIPTION
## Summary

Fourth piece of Wave 2 (#295) — Cosmic Python domain promotions. Same shape as #315, #316, #317, but this one **extends the existing `domain/rom_files.py`** instead of creating a new module.

Lifts the module-level `_resolve_local_file_name` out of `services/downloads.py` into `domain/rom_files.py`:

- `resolve_local_file_name(rom_detail: dict) -> tuple[str, bool]` — returns the resolved on-disk filename plus an `inconsistency` flag (set when `has_nested_single_file=True` but `files` is empty/None).

The function previously took a `logger` parameter and emitted `logger.warning(...)` on the inconsistent path. Side effects don't belong in domain — the bool flag now surfaces the inconsistency so the caller (`DownloadService`) emits the warning. **Warning text preserved byte-identically** for log-grep compatibility.

## Changes

- `py_modules/domain/rom_files.py` — appends one pure function (`resolve_local_file_name`). Module docstring and existing 3 functions untouched.
- `py_modules/services/downloads.py` — adds `resolve_local_file_name` to the existing `domain.rom_files` import, deletes the old module-level `_resolve_local_file_name`, updates the single call site to unpack the tuple and conditionally emit the warning.
- `tests/domain/test_rom_files.py` — appends `TestResolveLocalFileName` (7 tests). 100% line + branch coverage on the new function.
- No test files removed — there were zero direct tests for this function on \`main\`; service integration tests in \`tests/services/test_downloads.py\` continue to cover the call path unchanged.

## Behavior branches (all verified)

| Input shape | Returns |
|---|---|
| Non-nested (`has_nested_single_file` falsy) | `(fs_name, False)` |
| Nested + `files[0].file_name` present | `(files[0]["file_name"], False)` |
| Nested + `files[0]` missing `file_name` | `(fs_name, False)` |
| Nested + `files=[]` OR `files=None` | `(fs_name, True)` — warning fires |
| Missing `fs_name` | falls back to `rom_<id>` (or `rom_unknown` if id missing) |

## Test plan

- [x] `python -m pytest tests/ -q` — 1811 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check py_modules tests` — clean
- [x] `basedpyright` — 0 errors
- [x] `mise run lint` — 7 contracts kept; cosmic call bans clean
- [x] Behavioral parity verified byte-for-byte (reviewer diffed against \`git show main:py_modules/services/downloads.py\`)
- [x] Warning text byte-identical to main for log-grep compatibility

Refs #295, part of #277.