### PR TITLE
refactor(library): extract sync_diff cluster to domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,9 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
   Protocols, persisters, bootstrap cleanup. Done first so every later vertical consumes the Protocols defined here.
   Done: ~~#294~~ (Clock/UuidGen/Sleeper), ~~#289~~ (FirmwareCachePersister), ~~#292~~ (ArtworkRemover), ~~#296~~ (CoreInfoProvider, shipped as #310), ~~#205~~ (es_de_config I/O split, shipped as #311), ~~#168~~ (sync_state_box dead-code removal, shipped as #312), ~~#169~~ (WiringConfig split, shipped as #313), ~~#303~~ (call-site clock/sleep ban, shipped as #314).
   Deferred: #259 (SonarCloud arch rules — waiting on SonarCloud Python support).
-- **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295))
-  Extract pure logic from non-saves services into `domain/`. Library sync_classification cluster first (highest value), then firmware paths, achievements, path safety, filename resolution.
+- **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295)) — **complete**
+  Pure logic extracted from non-saves services into `domain/`.
+  Done: ~~#315~~ (firmware paths), ~~#316~~ (achievements), ~~#317~~ (path safety + mise lint bundle), ~~#318~~ (filename resolution), ~~#319~~ (sync_diff cluster).
 - **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2)
   - [#299](https://github.com/danielcopper/decky-romm-sync/issues/299) ArtworkService + SteamGridService — small, do as one chunk
   - [#297](https://github.com/danielcopper/decky-romm-sync/issues/297) DownloadService
@@ -90,7 +91,7 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
 
 **Why this order**: doing #294 (Clock/UuidGen/Sleeper) before any per-service vertical means every later PR is "drop the import, inject the Protocol" — mechanical. Doing #295 (domain extraction) before LibraryService shrinks the scariest service before lifting it. LibraryService last because it has the largest blast radius.
 
-When picking work: Wave 1 is finished (modulo deferred #259), so every later vertical's Protocol dependencies are in place. Wave 2 (#295) is the next active wave.
+When picking work: Waves 1 and 2 are finished (modulo deferred #259), so every per-service vertical's Protocol and domain dependencies are in place. Wave 3 (#297–#302) is the next active wave.
 
 ## Sub-package layout — `__init__.py` is re-export only
 

--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -1,0 +1,135 @@
+"""Sync diffs — pure delta computations between current state and last-synced state.
+
+Anything that compares "what the next sync should produce" against "what we
+recorded last sync" lives here: per-ROM bucketing (new / changed / unchanged /
+stale), enabled-collection add/remove diffs, and the platform-collection
+membership predicate that drives the platform-collection diff.
+
+State reads (registry, last_synced_*), setting reads, network fetches, and
+Steam interaction stay in LibraryService; this module receives the relevant
+slices as primitive parameters and returns primitives or NamedTuple results.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class ClassificationResult(NamedTuple):
+    new: list[dict]
+    changed: list[dict]
+    unchanged_ids: list[int]
+    stale: list[int]
+    disabled_count: int
+
+
+def classify_roms(
+    shortcuts_data: list[dict],
+    registry: dict,
+    fetched_platform_names: set[str],
+) -> ClassificationResult:
+    """Bucket fetched ROMs against the saved shortcut registry.
+
+    Returns the ROMs split into new (not in registry), changed (registry
+    entry exists but name/platform_name/platform_slug/fs_name differs),
+    unchanged_ids (registry matches exactly), stale (in registry but not in
+    the current fetch), and the count of stale ROMs whose stored platform
+    no longer appears in fetched_platform_names.
+
+    Changed ROMs are returned as fresh dicts with an added ``existing_app_id``
+    key — the caller's shortcuts_data is not mutated.
+    """
+    new: list[dict] = []
+    changed: list[dict] = []
+    unchanged_ids: list[int] = []
+
+    for sd in shortcuts_data:
+        reg = registry.get(str(sd["rom_id"]))
+        if not reg or not reg.get("app_id"):
+            new.append(sd)
+        elif (
+            reg.get("name") != sd["name"]
+            or reg.get("platform_name") != sd.get("platform_name")
+            or reg.get("platform_slug") != sd.get("platform_slug")
+            or reg.get("fs_name") != sd.get("fs_name", "")
+        ):
+            changed.append({**sd, "existing_app_id": reg["app_id"]})
+        else:
+            unchanged_ids.append(sd["rom_id"])
+
+    current_ids = {sd["rom_id"] for sd in shortcuts_data}
+    stale = [int(rid) for rid in registry if int(rid) not in current_ids]
+    disabled_count = sum(
+        1 for rid in stale if registry.get(str(rid), {}).get("platform_name") not in fetched_platform_names
+    )
+    return ClassificationResult(new, changed, unchanged_ids, stale, disabled_count)
+
+
+def compute_collection_diff(
+    collection_memberships: dict[str, list[int]],
+    last_synced_collections: list[str],
+) -> dict:
+    """Diff enabled collections (by name) against the last-synced set.
+
+    Returns ``{"has_changes": bool, "added": [...], "removed": [...]}``.
+    ``has_changes`` is True if there are any added/removed collections, or
+    if there are any current collections at all (covers first-sync case).
+    """
+    current = set(collection_memberships.keys())
+    previous = set(last_synced_collections)
+    added = sorted(current - previous)
+    removed = sorted(previous - current)
+    return {
+        "has_changes": bool(added or removed or current),
+        "added": added,
+        "removed": removed,
+    }
+
+
+def should_include_in_platform_collection(
+    rom_id: int,
+    platform_rom_ids: set[int] | None,
+    create_platform_groups: bool,
+) -> bool:
+    """Predicate: should this ROM appear in platform-grouped collections?
+
+    If ``create_platform_groups`` is True, every ROM qualifies. Otherwise:
+    platform_rom_ids=None means no tracking (legacy sync) so include all;
+    platform_rom_ids=set() means no platforms enabled so exclude all;
+    otherwise membership in platform_rom_ids decides.
+    """
+    if create_platform_groups:
+        return True
+    if platform_rom_ids is None:
+        return True
+    return rom_id in platform_rom_ids
+
+
+def compute_platform_collection_diff(
+    shortcuts_data: list[dict],
+    platform_rom_ids: set[int] | None,
+    last_synced_platforms: list[str],
+    create_platform_groups: bool,
+) -> dict:
+    """Diff future platform-group collections against last-synced platforms.
+
+    Returns ``{"has_changes": bool, "added_count": int, "removed_count": int}``.
+    Uses ``should_include_in_platform_collection`` to decide which ROMs
+    qualify under the current ``create_platform_groups`` setting.
+    """
+    future_platforms: set[str] = set()
+    for sd in shortcuts_data:
+        rid = sd["rom_id"]
+        if should_include_in_platform_collection(rid, platform_rom_ids, create_platform_groups):
+            pname = sd.get("platform_name", "")
+            if pname:
+                future_platforms.add(pname)
+
+    current_platforms = set(last_synced_platforms)
+    added = sorted(future_platforms - current_platforms)
+    removed = sorted(current_platforms - future_platforms)
+    return {
+        "has_changes": bool(added or removed),
+        "added_count": len(added),
+        "removed_count": len(removed),
+    }

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -13,6 +13,12 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from domain.shortcut_data import build_registry_entry, build_shortcuts_data
+from domain.sync_diff import (
+    classify_roms,
+    compute_collection_diff,
+    compute_platform_collection_diff,
+    should_include_in_platform_collection,
+)
 from domain.sync_state import SyncState
 from lib.errors import classify_error
 
@@ -276,8 +282,12 @@ class LibraryService:
         try:
             fetch_result = await self._fetch_and_prepare()
             all_roms, shortcuts_data, platforms, collection_memberships, platform_rom_ids = fetch_result
-            platform_names = {p.get("name") for p in platforms}
-            new, changed, unchanged_ids, stale, disabled_count = self._classify_roms(shortcuts_data, platform_names)
+            platform_names = {p["name"] for p in platforms if p.get("name")}
+            new, changed, unchanged_ids, stale, disabled_count = classify_roms(
+                shortcuts_data,
+                self._state["shortcut_registry"],
+                platform_names,
+            )
 
             # Build rom lookup for artwork download during apply
             roms_by_id = {r["id"]: r for r in all_roms}
@@ -309,9 +319,15 @@ class LibraryService:
                     "unchanged_count": len(unchanged_ids),
                     "remove_count": len(stale),
                     "disabled_platform_remove_count": disabled_count,
-                    "collection_diff": self._compute_collection_diff(collection_memberships),
-                    "platform_collection_diff": self._compute_platform_collection_diff(
-                        shortcuts_data, platform_rom_ids
+                    "collection_diff": compute_collection_diff(
+                        collection_memberships,
+                        self._state.get("last_synced_collections", []),
+                    ),
+                    "platform_collection_diff": compute_platform_collection_diff(
+                        shortcuts_data,
+                        platform_rom_ids,
+                        self._state.get("last_synced_platforms", []),
+                        self._settings.get("collection_create_platform_groups", False),
                     ),
                 },
                 "new_names": [s["name"] for s in new[:10]],
@@ -460,93 +476,6 @@ class LibraryService:
                     return
 
         self._loop.create_task(_safety_timeout())
-
-    # ── Classification ───────────────────────────────────────
-
-    def _classify_roms(self, shortcuts_data, fetched_platform_names):
-        """Classify each ROM as new/changed/unchanged/stale."""
-        registry = self._state["shortcut_registry"]
-        new, changed, unchanged_ids = [], [], []
-
-        for sd in shortcuts_data:
-            reg = registry.get(str(sd["rom_id"]))
-            if not reg or not reg.get("app_id"):
-                new.append(sd)
-            elif (
-                reg.get("name") != sd["name"]
-                or reg.get("platform_name") != sd.get("platform_name")
-                or reg.get("platform_slug") != sd.get("platform_slug")
-                or reg.get("fs_name") != sd.get("fs_name", "")
-            ):
-                sd["existing_app_id"] = reg["app_id"]
-                changed.append(sd)
-            else:
-                unchanged_ids.append(sd["rom_id"])
-
-        # Stale: in registry but not in fetched set
-        current_ids = {sd["rom_id"] for sd in shortcuts_data}
-        stale = [int(rid) for rid in registry if int(rid) not in current_ids]
-
-        # Classify stale by disabled platform
-        disabled_count = sum(
-            1 for rid in stale if registry.get(str(rid), {}).get("platform_name") not in fetched_platform_names
-        )
-
-        return new, changed, unchanged_ids, stale, disabled_count
-
-    def _compute_collection_diff(self, collection_memberships: dict[str, list[int]]) -> dict:
-        """Compare current enabled collections against last synced state."""
-        current = set(collection_memberships.keys())
-        previous = set(self._state.get("last_synced_collections", []))
-        added = sorted(current - previous)
-        removed = sorted(previous - current)
-        return {
-            "has_changes": bool(added or removed or current),
-            "added": added,
-            "removed": removed,
-        }
-
-    def _compute_platform_collection_diff(self, shortcuts_data: list[dict], platform_rom_ids: set[int]) -> dict:
-        """Compare future platform collections against current registry.
-
-        Respects the collection_create_platform_groups toggle — if OFF,
-        only platforms from platform-fetched ROMs get collections.
-        """
-        # Future: platforms that will have collections after sync
-        future_platforms: set[str] = set()
-        for sd in shortcuts_data:
-            rid = sd["rom_id"]
-            if self._should_include_in_platform_collection(rid, platform_rom_ids):
-                pname = sd.get("platform_name", "")
-                if pname:
-                    future_platforms.add(pname)
-
-        # Current: platforms that had collections at last sync
-        current_platforms = set(self._state.get("last_synced_platforms", []))
-
-        added = sorted(future_platforms - current_platforms)
-        removed = sorted(current_platforms - future_platforms)
-        return {
-            "has_changes": bool(added or removed),
-            "added_count": len(added),
-            "removed_count": len(removed),
-        }
-
-    def _should_include_in_platform_collection(self, rom_id: int, platform_rom_ids: set[int] | None) -> bool:
-        """Check if a ROM should appear in platform collections.
-
-        If collection_create_platform_groups is False (default), only ROMs
-        fetched via enabled platforms are included. Collection-only ROMs
-        are excluded from platform collections but still synced.
-
-        platform_rom_ids=None means no tracking data (legacy sync) → include all.
-        platform_rom_ids=set() means no platforms enabled → exclude all (unless toggle ON).
-        """
-        if self._settings.get("collection_create_platform_groups", False):
-            return True
-        if platform_rom_ids is None:
-            return True  # Legacy sync without platform tracking
-        return rom_id in platform_rom_ids
 
     # ── Fetch & prepare ──────────────────────────────────────
 
@@ -968,7 +897,11 @@ class LibraryService:
         """Build platform_app_ids and romm_collection_app_ids from the shortcut registry."""
         platform_app_ids: dict = {}
         for rid_str, entry in registry.items():
-            if not self._should_include_in_platform_collection(int(rid_str), pending_platform_rom_ids):
+            if not should_include_in_platform_collection(
+                int(rid_str),
+                pending_platform_rom_ids,
+                self._settings.get("collection_create_platform_groups", False),
+            ):
                 continue
             pname = entry.get("platform_name", "Unknown")
             platform_app_ids.setdefault(pname, []).append(entry.get("app_id"))

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -1,0 +1,360 @@
+"""Tests for domain.sync_diff — pure delta computations for the sync engine."""
+
+from domain.sync_diff import (
+    ClassificationResult,
+    classify_roms,
+    compute_collection_diff,
+    compute_platform_collection_diff,
+    should_include_in_platform_collection,
+)
+
+
+def _make_sd(
+    rom_id,
+    name="Game",
+    platform_name="N64",
+    platform_slug="n64",
+    fs_name="game.z64",
+    igdb_id=None,
+    sgdb_id=None,
+):
+    """Build a shortcut_data dict matching _fetch_and_prepare output."""
+    return {
+        "rom_id": rom_id,
+        "name": name,
+        "platform_name": platform_name,
+        "platform_slug": platform_slug,
+        "fs_name": fs_name,
+        "igdb_id": igdb_id,
+        "sgdb_id": sgdb_id,
+    }
+
+
+def _reg(name="Game", platform_name="N64", platform_slug="n64", fs_name="game.z64", app_id=1001):
+    """Build a registry entry dict matching build_registry_entry output."""
+    return {
+        "app_id": app_id,
+        "name": name,
+        "platform_name": platform_name,
+        "platform_slug": platform_slug,
+        "fs_name": fs_name,
+    }
+
+
+class TestClassifyRoms:
+    """classify_roms() — bucketing fetched ROMs against the saved registry."""
+
+    def test_all_new_empty_registry(self):
+        sd = [_make_sd(1, "Game A"), _make_sd(2, "Game B")]
+        new, changed, unchanged_ids, stale, disabled = classify_roms(sd, {}, {"N64"})
+        assert len(new) == 2
+        assert changed == []
+        assert unchanged_ids == []
+        assert stale == []
+        assert disabled == 0
+
+    def test_all_unchanged(self):
+        registry = {
+            "1": _reg(name="Game A", fs_name="gamea.z64", app_id=1001),
+            "2": _reg(name="Game B", fs_name="gameb.z64", app_id=1002),
+        }
+        sd = [
+            _make_sd(1, "Game A", fs_name="gamea.z64"),
+            _make_sd(2, "Game B", fs_name="gameb.z64"),
+        ]
+        new, changed, unchanged_ids, stale, _ = classify_roms(sd, registry, {"N64"})
+        assert new == []
+        assert changed == []
+        assert set(unchanged_ids) == {1, 2}
+        assert stale == []
+
+    def test_mixed_new_changed_unchanged(self):
+        registry = {
+            "1": _reg(name="Game A", fs_name="gamea.z64", app_id=1001),
+            "2": _reg(name="Old Name", fs_name="gameb.z64", app_id=1002),
+        }
+        sd = [
+            _make_sd(1, "Game A", fs_name="gamea.z64"),  # unchanged
+            _make_sd(2, "New Name", fs_name="gameb.z64"),  # changed (name)
+            _make_sd(3, "Game C", fs_name="gamec.z64"),  # new
+        ]
+        new, changed, unchanged_ids, _, _ = classify_roms(sd, registry, {"N64"})
+        assert len(new) == 1
+        assert new[0]["rom_id"] == 3
+        assert len(changed) == 1
+        assert changed[0]["rom_id"] == 2
+        assert changed[0]["existing_app_id"] == 1002
+        assert unchanged_ids == [1]
+
+    def test_stale_detection(self):
+        registry = {
+            "1": _reg(name="Game A", fs_name="", platform_slug="n64", app_id=1001),
+            "99": {"app_id": 1099, "name": "Deleted Game", "platform_name": "N64"},
+        }
+        sd = [_make_sd(1, "Game A", fs_name="")]
+        _, _, _, stale, disabled = classify_roms(sd, registry, {"N64"})
+        assert 99 in stale
+        assert disabled == 0  # N64 is in fetched_platform_names
+
+    def test_disabled_platform_stale_count(self):
+        registry = {
+            "1": {"app_id": 1001, "name": "Game A", "platform_name": "SNES"},
+        }
+        sd: list = []  # nothing fetched
+        _, _, _, stale, disabled = classify_roms(sd, registry, {"N64"})
+        assert 1 in stale
+        assert disabled == 1  # SNES not in {"N64"}
+
+    def test_name_change_detected(self):
+        registry = {
+            "1": _reg(name="Old Title", app_id=1001),
+        }
+        sd = [_make_sd(1, "New Title")]
+        new, changed, unchanged_ids, _, _ = classify_roms(sd, registry, {"N64"})
+        assert len(changed) == 1
+        assert changed[0]["existing_app_id"] == 1001
+        assert new == []
+        assert unchanged_ids == []
+
+    def test_platform_name_change_detected(self):
+        registry = {
+            "1": _reg(name="Game A", platform_name="Nintendo 64", app_id=1001),
+        }
+        sd = [_make_sd(1, "Game A", platform_name="N64")]
+        _, changed, _, _, _ = classify_roms(sd, registry, {"N64"})
+        assert len(changed) == 1
+        assert changed[0]["rom_id"] == 1
+
+    def test_fs_name_change_detected(self):
+        registry = {
+            "1": _reg(name="Game A", fs_name="old.z64", app_id=1001),
+        }
+        sd = [_make_sd(1, "Game A", fs_name="new.z64")]
+        _, changed, _, _, _ = classify_roms(sd, registry, {"N64"})
+        assert len(changed) == 1
+        assert changed[0]["rom_id"] == 1
+
+    def test_igdb_id_change_no_false_positive(self):
+        registry = {
+            "1": _reg(name="Game A", app_id=1001),
+        }
+        sd = [_make_sd(1, "Game A", igdb_id=999, sgdb_id=888)]
+        new, changed, unchanged_ids, _, _ = classify_roms(sd, registry, {"N64"})
+        assert unchanged_ids == [1]
+        assert changed == []
+        assert new == []
+
+    def test_registry_without_app_id_is_new(self):
+        registry = {
+            "1": {"name": "Game A", "platform_name": "N64"},
+        }
+        sd = [_make_sd(1, "Game A")]
+        new, changed, _, _, _ = classify_roms(sd, registry, {"N64"})
+        assert len(new) == 1
+        assert new[0]["rom_id"] == 1
+        assert changed == []
+
+    def test_first_sync_empty_registry_all_new(self):
+        sd = [_make_sd(i, f"Game {i}") for i in range(1, 6)]
+        new, changed, unchanged_ids, stale, disabled = classify_roms(sd, {}, {"N64"})
+        assert len(new) == 5
+        assert changed == []
+        assert unchanged_ids == []
+        assert stale == []
+        assert disabled == 0
+
+    def test_no_changes(self):
+        registry = {
+            "1": _reg(name="Game A", app_id=1001),
+        }
+        sd = [_make_sd(1, "Game A")]
+        new, changed, unchanged_ids, stale, _ = classify_roms(sd, registry, {"N64"})
+        assert len(new) == 0
+        assert len(changed) == 0
+        assert len(stale) == 0
+        assert len(unchanged_ids) == 1
+
+    def test_all_stale_disabled_platforms(self):
+        registry = {
+            "1": {"app_id": 1001, "name": "Game A", "platform_name": "GBA"},
+            "2": {"app_id": 1002, "name": "Game B", "platform_name": "SNES"},
+        }
+        sd: list = []
+        _, _, _, stale, disabled = classify_roms(sd, registry, {"N64"})
+        assert len(stale) == 2
+        assert disabled == 2
+
+    def test_returns_classification_result_namedtuple(self):
+        """Result supports both positional unpacking and attribute access."""
+        result = classify_roms([_make_sd(1)], {}, {"N64"})
+        assert isinstance(result, ClassificationResult)
+        # Attribute access
+        assert result.new[0]["rom_id"] == 1
+        assert result.changed == []
+        assert result.unchanged_ids == []
+        assert result.stale == []
+        assert result.disabled_count == 0
+        # Positional unpacking still works
+        new, changed, unchanged_ids, stale, disabled = result
+        assert new == result.new
+        assert changed == result.changed
+        assert unchanged_ids == result.unchanged_ids
+        assert stale == result.stale
+        assert disabled == result.disabled_count
+
+    def test_does_not_mutate_input_shortcuts_data(self):
+        """Changed ROMs are returned as fresh dicts; caller's input is untouched."""
+        registry = {
+            "1": _reg(name="Old Title", app_id=1001),
+        }
+        sd_item = _make_sd(1, "New Title")
+        sd_snapshot = dict(sd_item)
+        sd = [sd_item]
+        _, changed, _, _, _ = classify_roms(sd, registry, {"N64"})
+        # Caller's dict is unchanged — no existing_app_id leaked in
+        assert sd_item == sd_snapshot
+        assert "existing_app_id" not in sd_item
+        # The returned changed entry does carry existing_app_id
+        assert changed[0]["existing_app_id"] == 1001
+
+
+class TestComputeCollectionDiff:
+    """compute_collection_diff() — diff enabled collections vs last-synced set."""
+
+    def test_first_sync_with_collections_has_changes(self):
+        result = compute_collection_diff({"Favorites": [1, 2]}, [])
+        assert result["has_changes"] is True
+        assert result["added"] == ["Favorites"]
+        assert result["removed"] == []
+
+    def test_empty_current_and_previous_no_changes(self):
+        result = compute_collection_diff({}, [])
+        assert result["has_changes"] is False
+        assert result["added"] == []
+        assert result["removed"] == []
+
+    def test_added_collection_detected(self):
+        result = compute_collection_diff({"Favorites": [1], "RPG": [2]}, ["Favorites"])
+        assert result["has_changes"] is True
+        assert result["added"] == ["RPG"]
+        assert result["removed"] == []
+
+    def test_removed_collection_detected(self):
+        result = compute_collection_diff({"Favorites": [1]}, ["Favorites", "RPG"])
+        assert result["has_changes"] is True
+        assert result["added"] == []
+        assert result["removed"] == ["RPG"]
+
+    def test_unchanged_collections_still_has_changes_when_current_nonempty(self):
+        """has_changes is True even with no add/remove if current is non-empty."""
+        result = compute_collection_diff({"Favorites": [1]}, ["Favorites"])
+        assert result["has_changes"] is True
+        assert result["added"] == []
+        assert result["removed"] == []
+
+    def test_added_and_removed_sorted(self):
+        result = compute_collection_diff(
+            {"Zelda": [1], "Mario": [2], "Pokemon": [3]},
+            ["Sonic", "Kirby"],
+        )
+        assert result["added"] == ["Mario", "Pokemon", "Zelda"]
+        assert result["removed"] == ["Kirby", "Sonic"]
+
+
+class TestShouldIncludeInPlatformCollection:
+    """should_include_in_platform_collection() — toggle-aware membership predicate."""
+
+    def test_sc5b_should_include_helper_excludes_collection_only_rom(self):
+        """Returns False for collection-only ROM when toggle is OFF."""
+        platform_rom_ids = {1, 2}  # ROM 3 is collection-only
+        assert should_include_in_platform_collection(1, platform_rom_ids, False) is True
+        assert should_include_in_platform_collection(3, platform_rom_ids, False) is False
+
+    def test_sc5b_should_include_helper_includes_all_when_toggle_on(self):
+        """Returns True for all ROMs when toggle is ON."""
+        platform_rom_ids = {1, 2}
+        assert should_include_in_platform_collection(1, platform_rom_ids, True) is True
+        assert should_include_in_platform_collection(3, platform_rom_ids, True) is True
+
+    def test_sc5b_should_include_helper_excludes_all_when_no_platforms_enabled(self):
+        """Empty set = no platforms enabled -> exclude all (toggle OFF)."""
+        assert should_include_in_platform_collection(1, set(), False) is False
+
+    def test_sc5b_should_include_helper_includes_all_when_no_tracking_data(self):
+        """None = legacy sync without platform tracking -> include all."""
+        assert should_include_in_platform_collection(1, None, False) is True
+
+    def test_sc5b_should_include_helper_includes_all_empty_set_when_toggle_on(self):
+        """Empty set + toggle ON -> include all."""
+        assert should_include_in_platform_collection(1, set(), True) is True
+
+    def test_should_include_helper_includes_all_when_none_and_toggle_on(self):
+        """None + toggle ON -> include all."""
+        assert should_include_in_platform_collection(1, None, True) is True
+
+
+class TestComputePlatformCollectionDiff:
+    """compute_platform_collection_diff() — diff future platform groups vs last-synced."""
+
+    def test_first_sync_adds_all_platforms(self):
+        sd = [
+            _make_sd(1, platform_name="Game Boy Advance"),
+            _make_sd(2, platform_name="Nintendo 64"),
+        ]
+        result = compute_platform_collection_diff(sd, {1, 2}, [], False)
+        assert result["has_changes"] is True
+        assert result["added_count"] == 2
+        assert result["removed_count"] == 0
+
+    def test_no_changes_when_platforms_match_last_sync(self):
+        sd = [_make_sd(1, platform_name="Game Boy Advance")]
+        result = compute_platform_collection_diff(sd, {1}, ["Game Boy Advance"], False)
+        assert result["has_changes"] is False
+        assert result["added_count"] == 0
+        assert result["removed_count"] == 0
+
+    def test_removed_platform_detected(self):
+        sd = [_make_sd(1, platform_name="Game Boy Advance")]
+        result = compute_platform_collection_diff(
+            sd,
+            {1},
+            ["Game Boy Advance", "Nintendo 64"],
+            False,
+        )
+        assert result["has_changes"] is True
+        assert result["added_count"] == 0
+        assert result["removed_count"] == 1
+
+    def test_collection_only_rom_excluded_when_toggle_off(self):
+        """ROM not in platform_rom_ids doesn't contribute its platform when toggle is OFF."""
+        sd = [
+            _make_sd(1, platform_name="Game Boy Advance"),
+            _make_sd(2, platform_name="PlayStation"),  # collection-only
+        ]
+        result = compute_platform_collection_diff(sd, {1}, [], False)
+        # Only GBA gets added; PSX is filtered out
+        assert result["added_count"] == 1
+
+    def test_collection_only_rom_included_when_toggle_on(self):
+        """create_platform_groups=True forces every ROM's platform into the diff."""
+        sd = [
+            _make_sd(1, platform_name="Game Boy Advance"),
+            _make_sd(2, platform_name="PlayStation"),  # collection-only
+        ]
+        result = compute_platform_collection_diff(sd, {1}, [], True)
+        # Both platforms qualify
+        assert result["added_count"] == 2
+
+    def test_none_platform_rom_ids_treats_all_as_qualifying(self):
+        """platform_rom_ids=None (legacy sync) includes every ROM regardless of toggle."""
+        sd = [_make_sd(1, platform_name="Game Boy Advance")]
+        result = compute_platform_collection_diff(sd, None, [], False)
+        assert result["added_count"] == 1
+
+    def test_empty_platform_name_is_skipped(self):
+        sd = [
+            _make_sd(1, platform_name=""),
+            _make_sd(2, platform_name="Nintendo 64"),
+        ]
+        result = compute_platform_collection_diff(sd, {1, 2}, [], False)
+        assert result["added_count"] == 1

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -7,6 +7,7 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.sync_diff import classify_roms
 from domain.sync_state import SyncState
 
 # conftest.py patches decky before this import
@@ -721,242 +722,6 @@ class TestShortcutDataFormat:
         id_b = SteamConfigAdapter.generate_artwork_id(exe, "Game B")
 
         assert id_a != id_b, "Different games should have different artwork IDs"
-
-
-class TestClassifyRoms:
-    """Tests for _classify_roms() delta classification."""
-
-    def _make_sd(
-        self,
-        rom_id,
-        name="Game",
-        platform_name="N64",
-        platform_slug="n64",
-        fs_name="game.z64",
-        igdb_id=None,
-        sgdb_id=None,
-    ):
-        """Helper to build a shortcut_data dict matching _fetch_and_prepare output."""
-        return {
-            "rom_id": rom_id,
-            "name": name,
-            "platform_name": platform_name,
-            "platform_slug": platform_slug,
-            "fs_name": fs_name,
-            "igdb_id": igdb_id,
-            "sgdb_id": sgdb_id,
-        }
-
-    def test_all_new_empty_registry(self, plugin):
-        """Empty registry -> all in new, none in changed/unchanged."""
-        sd = [self._make_sd(1, "Game A"), self._make_sd(2, "Game B")]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(new) == 2
-        assert changed == []
-        assert unchanged_ids == []
-        assert stale == []
-        assert disabled == 0
-
-    def test_all_unchanged(self, plugin):
-        """Registry matches all items -> all in unchanged_ids."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "gamea.z64",
-            },
-            "2": {
-                "app_id": 1002,
-                "name": "Game B",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "gameb.z64",
-            },
-        }
-        sd = [
-            self._make_sd(1, "Game A", fs_name="gamea.z64"),
-            self._make_sd(2, "Game B", fs_name="gameb.z64"),
-        ]
-        new, changed, unchanged_ids, stale, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert new == []
-        assert changed == []
-        assert set(unchanged_ids) == {1, 2}
-        assert stale == []
-
-    def test_mixed_new_changed_unchanged(self, plugin):
-        """Mix of new, changed, unchanged ROMs."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "gamea.z64",
-            },
-            "2": {
-                "app_id": 1002,
-                "name": "Old Name",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "gameb.z64",
-            },
-        }
-        sd = [
-            self._make_sd(1, "Game A", fs_name="gamea.z64"),  # unchanged
-            self._make_sd(2, "New Name", fs_name="gameb.z64"),  # changed (name)
-            self._make_sd(3, "Game C", fs_name="gamec.z64"),  # new
-        ]
-        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(new) == 1
-        assert new[0]["rom_id"] == 3
-        assert len(changed) == 1
-        assert changed[0]["rom_id"] == 2
-        assert changed[0]["existing_app_id"] == 1002
-        assert unchanged_ids == [1]
-
-    def test_stale_detection(self, plugin):
-        """Registry has ROM not in fetched set -> appears in stale."""
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 1001, "name": "Game A", "platform_name": "N64"},
-            "99": {"app_id": 1099, "name": "Deleted Game", "platform_name": "N64"},
-        }
-        sd = [self._make_sd(1, "Game A", fs_name="")]
-        # Must also set fs_name in registry to match
-        plugin._state["shortcut_registry"]["1"]["fs_name"] = ""
-        plugin._state["shortcut_registry"]["1"]["platform_slug"] = "n64"
-        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert 99 in stale
-        assert disabled == 0  # N64 is in fetched_platform_names
-
-    def test_disabled_platform_stale_count(self, plugin):
-        """Stale ROMs from platforms not in fetched_platform_names -> counted as disabled."""
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 1001, "name": "Game A", "platform_name": "SNES"},
-        }
-        sd = []  # nothing fetched
-        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert 1 in stale
-        assert disabled == 1  # SNES is not in {"N64"}
-
-    def test_name_change_detected(self, plugin):
-        """ROM name changed -> classified as changed with existing_app_id."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Old Title",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "game.z64",
-            },
-        }
-        sd = [self._make_sd(1, "New Title")]
-        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(changed) == 1
-        assert changed[0]["existing_app_id"] == 1001
-        assert new == []
-        assert unchanged_ids == []
-
-    def test_platform_name_change_detected(self, plugin):
-        """Platform name changed -> classified as changed."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "Nintendo 64",
-                "platform_slug": "n64",
-                "fs_name": "game.z64",
-            },
-        }
-        sd = [self._make_sd(1, "Game A", platform_name="N64")]
-        _, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(changed) == 1
-        assert changed[0]["rom_id"] == 1
-
-    def test_fs_name_change_detected(self, plugin):
-        """fs_name changed -> classified as changed."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "old.z64",
-            },
-        }
-        sd = [self._make_sd(1, "Game A", fs_name="new.z64")]
-        _, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(changed) == 1
-        assert changed[0]["rom_id"] == 1
-
-    def test_igdb_id_change_no_false_positive(self, plugin):
-        """Only igdb_id/sgdb_id changed -> still unchanged."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "game.z64",
-            },
-        }
-        sd = [self._make_sd(1, "Game A", igdb_id=999, sgdb_id=888)]
-        new, changed, unchanged_ids, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert unchanged_ids == [1]
-        assert changed == []
-        assert new == []
-
-    def test_registry_without_app_id_is_new(self, plugin):
-        """Registry entry without app_id -> classified as new."""
-        plugin._state["shortcut_registry"] = {
-            "1": {"name": "Game A", "platform_name": "N64"},
-        }
-        sd = [self._make_sd(1, "Game A")]
-        new, changed, _, _, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(new) == 1
-        assert new[0]["rom_id"] == 1
-        assert changed == []
-
-    def test_first_sync_empty_registry_all_new(self, plugin):
-        """First sync (empty registry) -> all new."""
-        sd = [self._make_sd(i, f"Game {i}") for i in range(1, 6)]
-        new, changed, unchanged_ids, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(new) == 5
-        assert changed == []
-        assert unchanged_ids == []
-        assert stale == []
-        assert disabled == 0
-
-    def test_no_changes(self, plugin):
-        """Exact match -> 0 new, 0 changed, 0 removed."""
-        plugin._state["shortcut_registry"] = {
-            "1": {
-                "app_id": 1001,
-                "name": "Game A",
-                "platform_name": "N64",
-                "platform_slug": "n64",
-                "fs_name": "game.z64",
-            },
-        }
-        sd = [self._make_sd(1, "Game A")]
-        new, changed, unchanged_ids, stale, _ = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(new) == 0
-        assert len(changed) == 0
-        assert len(stale) == 0
-        assert len(unchanged_ids) == 1
-
-    def test_all_stale_disabled_platforms(self, plugin):
-        """Everything stale from disabled platforms."""
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 1001, "name": "Game A", "platform_name": "GBA"},
-            "2": {"app_id": 1002, "name": "Game B", "platform_name": "SNES"},
-        }
-        sd = []  # nothing fetched
-        # Neither GBA nor SNES in fetched set
-        _, _, _, stale, disabled = plugin._sync_service._classify_roms(sd, {"N64"})
-        assert len(stale) == 2
-        assert disabled == 2
 
 
 class TestSyncPreview:
@@ -2707,7 +2472,7 @@ def _page(items):
 class TestCollectionSyncEdgeCases:
     """Edge-case tests for the merged platform + collection sync engine.
 
-    Tests exercise _classify_roms() and _report_sync_results_io() directly,
+    Tests exercise classify_roms() and _report_sync_results_io() directly,
     and use _fetch_collection_roms() for collection-fetch scenarios.
     """
 
@@ -2745,8 +2510,8 @@ class TestCollectionSyncEdgeCases:
         # GBA is not in fetched platform names (platform disabled)
         fetched_platform_names = set()
 
-        new, _changed, unchanged_ids, stale, _disabled_count = svc._classify_roms(
-            shortcuts_data, fetched_platform_names
+        new, _changed, unchanged_ids, stale, _disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], fetched_platform_names
         )
 
         assert 1 in unchanged_ids, "ROM A should be unchanged (collection keeps it alive)"
@@ -2785,7 +2550,9 @@ class TestCollectionSyncEdgeCases:
         ]
         fetched_platform_names = {"Game Boy Advance"}
 
-        new, _changed, unchanged_ids, stale, disabled_count = svc._classify_roms(shortcuts_data, fetched_platform_names)
+        new, _changed, unchanged_ids, stale, disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], fetched_platform_names
+        )
 
         assert 1 in unchanged_ids, "ROM A should be unchanged (platform still enabled)"
         assert 3 in stale, "ROM C should be stale (collection disabled, PSX not enabled)"
@@ -2817,8 +2584,8 @@ class TestCollectionSyncEdgeCases:
         ]
         fetched_platform_names = set()
 
-        _new, _changed, unchanged_ids, stale, _disabled_count = svc._classify_roms(
-            shortcuts_data, fetched_platform_names
+        _new, _changed, unchanged_ids, stale, _disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], fetched_platform_names
         )
 
         assert 1 in unchanged_ids, "ROM A should stay alive via RPG collection"
@@ -2959,47 +2726,6 @@ class TestCollectionSyncEdgeCases:
         assert "PlayStation" in platform_app_ids
         assert 1002 in platform_app_ids["PlayStation"]
 
-    # ------------------------------------------------------------------
-    # Scenario 5b/6b: Platform groups toggle in _should_include_in_platform_collection
-    # These test the shared helper that both sync_apply_delta and
-    # _report_sync_results_io use — the bug was that sync_apply_delta
-    # didn't apply the toggle at all.
-    # ------------------------------------------------------------------
-
-    def test_sc5b_should_include_helper_excludes_collection_only_rom(self, plugin):
-        """Helper returns False for collection-only ROM when toggle is OFF."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = False
-        platform_rom_ids = {1, 2}  # ROM 3 is collection-only
-        assert svc._should_include_in_platform_collection(1, platform_rom_ids) is True
-        assert svc._should_include_in_platform_collection(3, platform_rom_ids) is False
-
-    def test_sc5b_should_include_helper_includes_all_when_toggle_on(self, plugin):
-        """Helper returns True for all ROMs when toggle is ON."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = True
-        platform_rom_ids = {1, 2}
-        assert svc._should_include_in_platform_collection(1, platform_rom_ids) is True
-        assert svc._should_include_in_platform_collection(3, platform_rom_ids) is True
-
-    def test_sc5b_should_include_helper_excludes_all_when_no_platforms_enabled(self, plugin):
-        """Empty set = no platforms enabled → exclude all (toggle OFF)."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = False
-        assert svc._should_include_in_platform_collection(1, set()) is False
-
-    def test_sc5b_should_include_helper_includes_all_when_no_tracking_data(self, plugin):
-        """None = legacy sync without platform tracking → include all."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = False
-        assert svc._should_include_in_platform_collection(1, None) is True
-
-    def test_sc5b_should_include_helper_includes_all_empty_set_when_toggle_on(self, plugin):
-        """Empty set + toggle ON → include all."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = True
-        assert svc._should_include_in_platform_collection(1, set()) is True
-
     def test_sc5c_build_collection_app_ids_excludes_collection_only_roms(self, plugin):
         """_build_collection_app_ids respects the toggle.
 
@@ -3138,7 +2864,9 @@ class TestCollectionSyncEdgeCases:
         shortcuts_data: list = []
         fetched_platform_names: set = set()
 
-        new, changed, unchanged_ids, stale, _disabled_count = svc._classify_roms(shortcuts_data, fetched_platform_names)
+        new, changed, unchanged_ids, stale, _disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], fetched_platform_names
+        )
 
         assert 1 in stale
         assert len(new) == 0
@@ -3325,7 +3053,9 @@ class TestCollectionSyncEdgeCases:
             }
         ]
 
-        new, changed, unchanged_ids, stale, _disabled_count = svc._classify_roms(shortcuts_data, {"GBA"})
+        new, changed, unchanged_ids, stale, _disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], {"GBA"}
+        )
 
         assert len(new) == 1
         assert new[0]["rom_id"] == 1
@@ -3350,7 +3080,9 @@ class TestCollectionSyncEdgeCases:
             }
         ]
 
-        new, changed, unchanged_ids, _stale, _disabled_count = svc._classify_roms(shortcuts_data, {"GBA"})
+        new, changed, unchanged_ids, _stale, _disabled_count = classify_roms(
+            shortcuts_data, svc._state["shortcut_registry"], {"GBA"}
+        )
 
         assert len(changed) == 1
         assert changed[0]["rom_id"] == 1


### PR DESCRIPTION
## Summary

Fifth and final piece of Wave 2 (#295) — closes the wave. Sub-issue #319.

Lifts four pure-compute methods out of the 1,138-LOC `LibraryService` into a new `domain/sync_diff.py` module:

- `classify_roms(shortcuts_data, registry, fetched_platform_names) -> ClassificationResult` — buckets ROMs into new/changed/unchanged/stale + disabled count
- `compute_collection_diff(collection_memberships, last_synced_collections) -> dict` — diffs enabled collections
- `should_include_in_platform_collection(rom_id, platform_rom_ids, create_platform_groups) -> bool` — predicate
- `compute_platform_collection_diff(shortcuts_data, platform_rom_ids, last_synced_platforms, create_platform_groups) -> dict` — diffs platform-group collections

State (`shortcut_registry`, `last_synced_*`) and settings (`collection_create_platform_groups`) thread in as explicit parameters; the helpers no longer touch `self`. `LibraryService` inlines the four call sites with the state/settings reads.

## Design decisions (locked before implementation)

| | Choice |
|---|---|
| Input mutation in `classify_roms` | New dict per changed ROM (`{**sd, "existing_app_id": reg["app_id"]}`) — no mutation of caller's input |
| Cross-method calls inside the module | Direct call (intra-module coupling is fine) |
| Return shape for `classify_roms` | `ClassificationResult` NamedTuple — preserves positional unpacking, adds attribute access |
| Settings flag | `create_platform_groups: bool` parameter threaded through both functions that need it |
| Module name | `sync_diff.py` (not `sync_classification.py` as #295 suggested — "diff" describes all four functions, "classification" only fits the first) |
| Service shape | Wrappers deleted, call sites inlined (consistent with #315–#318) |

## Subtle behavior-adjacent change

`library.py:285` — the `platform_names` set comprehension narrowed from `{p.get("name") for p in platforms}` to `{p["name"] for p in platforms if p.get("name")}` to satisfy basedpyright once `classify_roms`' parameter got an explicit `set[str]` annotation.

Strict semantics: the old code could include `None` in the set when a platform had no name; the new code filters those out. Practical impact is inert — `_fetch_enabled_platforms` already does `[p['name'] for p in platforms]` unconditionally at line 494, so any nameless platform would have crashed there first. RomM's schema requires `name` on platforms. Documenting for the record.

## Changes

- New `py_modules/domain/sync_diff.py` — 136 LOC, stdlib-only (`from typing import NamedTuple`), contract-style module docstring. 100% line + branch coverage on the new module.
- `py_modules/services/library.py` — deleted four private methods (89 LOC), deleted the `# ── Classification ──` section header, inlined the four call sites (lines 280, 312-313, 971 on \`main\`), added the domain import, tightened `platform_names` set comp.
- New `tests/domain/test_sync_diff.py` — 34 tests across 4 classes (`TestClassifyRoms`, `TestComputeCollectionDiff`, `TestShouldIncludeInPlatformCollection`, `TestComputePlatformCollectionDiff`). Relocates the dedicated `TestClassifyRoms` class + the `sc5b_*`-prefixed `should_include` cases from `test_library.py`. Adds explicit pins for mutation-contract and NamedTuple dual-access.
- `tests/services/test_library.py` — removes relocated classes, rewrites integration tests in `TestCollectionSyncEdgeCases` to call `classify_roms` directly (no `svc._...` private-method access).
- `CLAUDE.md` — Wave 2 block marked **complete** with all five sub-issues listed; "next active wave" pointer updated to Wave 3.

## Test plan

- [x] `python -m pytest tests/ -q` — 1827 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check py_modules tests` — clean
- [x] `basedpyright` — 0 errors
- [x] `mise run lint` — 7 contracts kept; cosmic call bans clean
- [x] Behavioral parity verified byte-for-byte for all four functions (reviewer diffed against \`git show main:py_modules/services/library.py\`)
- [x] Coverage on \`domain.sync_diff\`: 100% lines, 100% branches
- [x] Mutation contract pinned by \`test_does_not_mutate_input_shortcuts_data\`
- [x] No leftover references to old private names anywhere in the repo

Closes #319, refs #295, part of #277.