### PR TITLE
refactor(artwork): extract raw file I/O into CoverArtFileStore adapter

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ class Plugin:
                     romm_api=self._romm_api,
                     steam_config=self._steam_config,
                     sgdb_adapter=self._sgdb_adapter,
+                    cover_art_file_store=adapters["cover_art_file_store"],
                 ),
                 stores=StateBundle(
                     state=self._state,

--- a/py_modules/adapters/cover_art_file_store.py
+++ b/py_modules/adapters/cover_art_file_store.py
@@ -1,0 +1,47 @@
+"""Filesystem adapter for cover-art file operations.
+
+Owns the raw POSIX calls used by ArtworkService to manage cover art under
+the Steam grid directory. Path construction, registry lookups, and orphan
+detection remain a service concern; this adapter exposes only the I/O
+seams declared by ``services.protocols.CoverArtFileStore``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import pathlib
+
+
+class CoverArtFileStoreAdapter:
+    """Synchronous filesystem operations for cover-art files.
+
+    Implements the ``CoverArtFileStore`` Protocol. Methods are synchronous —
+    services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        os.replace(src, dst)
+
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entries in *directory*."""
+        return os.listdir(directory)
+
+    def isdir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        return os.path.isdir(path)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        return pathlib.Path(path).read_bytes()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -13,6 +13,7 @@ import logging
 from dataclasses import dataclass
 
 from adapters.asyncio_sleeper import AsyncioSleeper
+from adapters.cover_art_file_store import CoverArtFileStoreAdapter
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
@@ -38,6 +39,7 @@ from services.protocols import (
     Clock,
     CoreInfoProvider,
     CoreNameProviderFn,
+    CoverArtFileStore,
     DebugLogger,
     EventEmitter,
     FirmwareCachePersister,
@@ -67,6 +69,7 @@ class AdapterBundle:
     romm_api: RommApiProtocol
     steam_config: SteamConfigProtocol
     sgdb_adapter: SteamGridDbAdapter
+    cover_art_file_store: CoverArtFileStore
 
 
 @dataclass(frozen=True)
@@ -166,6 +169,7 @@ def bootstrap(
     romm_api = RommApi(http_adapter)
     steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
     sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger)
+    cover_art_file_store = CoverArtFileStoreAdapter()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -176,6 +180,7 @@ def bootstrap(
         "romm_api": romm_api,
         "steam_config": steam_config,
         "sgdb_adapter": sgdb_adapter,
+        "cover_art_file_store": cover_art_file_store,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -283,10 +288,10 @@ def wire_services(cfg: WiringConfig) -> dict:
     artwork_service = ArtworkService(
         romm_api=cfg.adapters.romm_api,
         steam_config=cfg.adapters.steam_config,
+        cover_art_file_store=cfg.adapters.cover_art_file_store,
         state=cfg.stores.state,
         loop=cfg.runtime.loop,
         logger=cfg.runtime.logger,
-        emit=cfg.runtime.emit,
     )
 
     shortcut_removal_service = ShortcutRemovalService(

--- a/py_modules/domain/artwork_paths.py
+++ b/py_modules/domain/artwork_paths.py
@@ -1,0 +1,30 @@
+"""Cover-art filename builders for the Steam grid directory.
+
+Pure naming logic for the two filename conventions ArtworkService writes
+into the grid dir: the per-ROM staging name used before a Steam app_id is
+known, and the final ``{app_id}p.png`` name Steam reads as the portrait
+cover. Filesystem I/O lives in adapters; this module is import- and
+state-free.
+"""
+
+from __future__ import annotations
+
+
+def staging_filename(rom_id: int | str) -> str:
+    """Return the staging filename for a downloaded cover keyed by RomM ID.
+
+    Used before the shortcut's Steam ``app_id`` is known. Renamed to
+    :func:`final_filename` once the shortcut has been created. Accepts
+    either an ``int`` ID (the canonical RomM payload type) or its string
+    form (used in registry keys and removal callers).
+    """
+    return f"romm_{rom_id}_cover.png"
+
+
+def final_filename(app_id: int | str) -> str:
+    """Return the Steam grid filename for a finalised portrait cover.
+
+    Accepts either ``int`` (Steam shortcut app_id) or ``str`` (legacy
+    ``artwork_id`` payloads observed in some registry entries).
+    """
+    return f"{app_id}p.png"

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
-import pathlib
 from typing import TYPE_CHECKING
+
+from domain.artwork_paths import final_filename, staging_filename
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import EventEmitter, RommApiProtocol, SteamConfigAdapter
+    from services.protocols import CoverArtFileStore, RommApiProtocol, SteamConfigAdapter
 
 
 class ArtworkService:
@@ -23,33 +24,33 @@ class ArtworkService:
         *,
         romm_api: RommApiProtocol,
         steam_config: SteamConfigAdapter,
+        cover_art_file_store: CoverArtFileStore,
         state: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        emit: EventEmitter,
     ) -> None:
         self._romm_api = romm_api
         self._steam_config = steam_config
+        self._cover_art_file_store = cover_art_file_store
         self._state = state
         self._loop = loop
         self._logger = logger
-        self._emit = emit
 
     # ── Existing cover path check ──────────────────────────────────────────
 
     def existing_cover_path(self, rom_id: int, grid: str) -> str | None:
         """Return an existing cover path for *rom_id*, or ``None`` if a download is needed."""
-        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+        staging = os.path.join(grid, staging_filename(rom_id))
 
         # If already synced and final artwork exists, reuse it
         reg = self._state["shortcut_registry"].get(str(rom_id))
         if reg and reg.get("app_id"):
-            final = os.path.join(grid, f"{reg['app_id']}p.png")
-            if os.path.exists(final):
+            final = os.path.join(grid, final_filename(reg["app_id"]))
+            if self._cover_art_file_store.exists(final):
                 return final
 
         # If staging file already exists (e.g. retry), reuse it
-        if os.path.exists(staging):
+        if self._cover_art_file_store.exists(staging):
             return staging
 
         return None
@@ -101,7 +102,7 @@ class ArtworkService:
                 cover_paths[rom_id] = existing
                 continue
 
-            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
+            staging = os.path.join(grid, staging_filename(rom_id))
             try:
                 await self._loop.run_in_executor(None, self._romm_api.download_cover, cover_url, staging)
                 cover_paths[rom_id] = staging
@@ -116,14 +117,14 @@ class ArtworkService:
         """Rename staged artwork to final Steam app_id filename, return final path."""
         if not grid or not cover_path:
             return cover_path
-        final_path = os.path.join(grid, f"{app_id}p.png")
-        if cover_path != final_path and os.path.exists(cover_path):
+        final_path = os.path.join(grid, final_filename(app_id))
+        if cover_path != final_path and self._cover_art_file_store.exists(cover_path):
             try:
-                os.replace(cover_path, final_path)
+                self._cover_art_file_store.rename(cover_path, final_path)
                 return final_path
             except OSError as e:
                 self._logger.warning(f"Failed to rename artwork for rom {rom_id_str}: {e}")
-        elif os.path.exists(final_path):
+        elif self._cover_art_file_store.exists(final_path):
             return final_path
         return cover_path
 
@@ -134,26 +135,26 @@ class ArtworkService:
         removed = False
         # Try cover_path first (stores the final renamed path)
         cover_path = entry.get("cover_path", "")
-        if cover_path and os.path.exists(cover_path):
-            os.remove(cover_path)
+        if cover_path and self._cover_art_file_store.exists(cover_path):
+            self._cover_art_file_store.remove(cover_path)
             removed = True
         # Try {app_id}p.png (the standard Steam grid filename)
         if not removed and entry.get("app_id"):
-            app_path = os.path.join(grid, f"{entry['app_id']}p.png")
-            if os.path.exists(app_path):
-                os.remove(app_path)
+            app_path = os.path.join(grid, final_filename(entry["app_id"]))
+            if self._cover_art_file_store.exists(app_path):
+                self._cover_art_file_store.remove(app_path)
                 removed = True
         # Fallback: legacy artwork_id format
         if not removed:
             artwork_id = entry.get("artwork_id")
             if artwork_id:
-                art_path = os.path.join(grid, f"{artwork_id}p.png")
-                if os.path.exists(art_path):
-                    os.remove(art_path)
+                art_path = os.path.join(grid, final_filename(artwork_id))
+                if self._cover_art_file_store.exists(art_path):
+                    self._cover_art_file_store.remove(art_path)
         # Clean up any leftover staging file
-        staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-        if os.path.exists(staging):
-            os.remove(staging)
+        staging = os.path.join(grid, staging_filename(rom_id))
+        if self._cover_art_file_store.exists(staging):
+            self._cover_art_file_store.remove(staging)
 
     # ── Artwork base64 query ───────────────────────────────────────────────
 
@@ -174,13 +175,13 @@ class ArtworkService:
 
         # Try staging filename as last resort
         if not cover_path:
-            staging = os.path.join(grid, f"romm_{rom_id}_cover.png")
-            if os.path.exists(staging):
+            staging = os.path.join(grid, staging_filename(rom_id))
+            if self._cover_art_file_store.exists(staging):
                 cover_path = staging
 
-        if cover_path and os.path.exists(cover_path):
+        if cover_path and self._cover_art_file_store.exists(cover_path):
             try:
-                data = await self._loop.run_in_executor(None, lambda: pathlib.Path(cover_path).read_bytes())
+                data = await self._loop.run_in_executor(None, self._cover_art_file_store.read_bytes, cover_path)
                 return {"base64": base64.b64encode(data).decode("ascii")}
             except Exception as e:
                 self._logger.warning(f"Failed to read artwork for rom {rom_id}: {e}")
@@ -195,18 +196,18 @@ class ArtworkService:
             return True
         app_id = registry[rom_id].get("app_id")
         if app_id:
-            final = os.path.join(grid, f"{app_id}p.png")
-            return os.path.exists(final)
+            final = os.path.join(grid, final_filename(app_id))
+            return self._cover_art_file_store.exists(final)
         return False
 
     def prune_orphaned_staging_artwork(self) -> None:
         """Remove orphaned romm_{rom_id}_cover.png staging files from Steam grid dir."""
         grid = self._steam_config.grid_dir()
-        if not grid or not os.path.isdir(grid):
+        if not grid or not self._cover_art_file_store.isdir(grid):
             return
         registry = self._state.get("shortcut_registry", {})
         pruned = []
-        for filename in os.listdir(grid):
+        for filename in self._cover_art_file_store.listdir(grid):
             if not filename.startswith("romm_") or not filename.endswith("_cover.png"):
                 continue
             try:
@@ -217,7 +218,7 @@ class ArtworkService:
             if not self.is_staging_file_orphaned(grid, registry, rom_id):
                 continue
             try:
-                os.remove(os.path.join(grid, filename))
+                self._cover_art_file_store.remove(os.path.join(grid, filename))
                 pruned.append(filename)
             except OSError as e:
                 self._logger.warning(f"Failed to remove orphaned staging artwork {filename}: {e}")

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -501,6 +501,44 @@ class ArtworkRemover(Protocol):
     def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...
 
 
+class CoverArtFileStore(Protocol):
+    """Filesystem seam for cover-art file operations.
+
+    Owns the raw POSIX calls (``exists``, ``remove``, atomic ``rename``,
+    ``listdir``, ``isdir``, ``read_bytes``) ArtworkService uses to manage
+    cover art under the Steam grid directory. Path construction, registry
+    lookups, and orphan detection remain a service concern; this Protocol
+    exposes only the I/O seams.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        ...
+
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entries in *directory*."""
+        ...
+
+    def isdir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        ...
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        ...
+
+
 # ---------------------------------------------------------------------------
 # Multi-method cross-service Protocols
 # ---------------------------------------------------------------------------

--- a/tests/adapters/test_cover_art_file_store.py
+++ b/tests/adapters/test_cover_art_file_store.py
@@ -1,0 +1,115 @@
+"""Tests for CoverArtFileStoreAdapter — raw filesystem ops for cover art."""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.cover_art_file_store import CoverArtFileStoreAdapter
+
+
+@pytest.fixture
+def store() -> CoverArtFileStoreAdapter:
+    return CoverArtFileStoreAdapter()
+
+
+class TestExists:
+    def test_true_for_existing_file(self, store, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"x")
+        assert store.exists(str(f)) is True
+
+    def test_true_for_directory(self, store, tmp_path):
+        assert store.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, store, tmp_path):
+        assert store.exists(str(tmp_path / "missing.png")) is False
+
+
+class TestRemove:
+    def test_removes_existing(self, store, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"x")
+        store.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, store, tmp_path):
+        # idempotent: must not raise
+        store.remove(str(tmp_path / "missing.png"))
+
+    def test_propagates_non_filenotfound_errors(self, store, tmp_path):
+        # Removing a non-empty directory raises IsADirectoryError or
+        # OSError — anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            store.remove(str(tmp_path))
+
+
+class TestRename:
+    def test_renames_to_new_path(self, store, tmp_path):
+        src = tmp_path / "src.png"
+        src.write_bytes(b"data")
+        dst = tmp_path / "dst.png"
+
+        store.rename(str(src), str(dst))
+
+        assert not src.exists()
+        assert dst.exists()
+        assert dst.read_bytes() == b"data"
+
+    def test_replaces_existing_dst(self, store, tmp_path):
+        src = tmp_path / "src.png"
+        src.write_bytes(b"new")
+        dst = tmp_path / "dst.png"
+        dst.write_bytes(b"old")
+
+        store.rename(str(src), str(dst))
+
+        assert not src.exists()
+        assert dst.read_bytes() == b"new"
+
+    def test_missing_src_raises(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            store.rename(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestListdir:
+    def test_returns_entries(self, store, tmp_path):
+        (tmp_path / "a.png").write_bytes(b"")
+        (tmp_path / "b.png").write_bytes(b"")
+        entries = store.listdir(str(tmp_path))
+        assert sorted(entries) == ["a.png", "b.png"]
+
+    def test_empty_dir(self, store, tmp_path):
+        assert store.listdir(str(tmp_path)) == []
+
+    def test_missing_dir_raises(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            store.listdir(str(tmp_path / "missing"))
+
+
+class TestIsdir:
+    def test_true_for_directory(self, store, tmp_path):
+        assert store.isdir(str(tmp_path)) is True
+
+    def test_false_for_file(self, store, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"")
+        assert store.isdir(str(f)) is False
+
+    def test_false_for_missing(self, store, tmp_path):
+        assert store.isdir(str(tmp_path / "missing")) is False
+
+
+class TestReadBytes:
+    def test_roundtrip(self, store, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n")
+        assert store.read_bytes(str(f)) == b"\x89PNG\r\n\x1a\n"
+
+    def test_empty_file(self, store, tmp_path):
+        f = tmp_path / "empty.png"
+        f.write_bytes(b"")
+        assert store.read_bytes(str(f)) == b""
+
+    def test_missing_raises(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            store.read_bytes(str(tmp_path / "missing.png"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,57 @@ class FakeFirmwareCachePersister:
         return self.canned_load
 
 
+class FakeCoverArtFileStore:
+    """In-memory ``CoverArtFileStore`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` is idempotent per the
+    Protocol contract. ``listdir`` returns entries whose path's parent
+    directory matches *directory* (no recursion). ``isdir`` reports True
+    for any path that is the parent of an entry, mirroring the loose
+    "directory exists when it contains files" semantics tests need.
+
+    Tests can pre-populate ``files`` directly to stage fixtures, and
+    inspect it after the act to assert removals/renames. ``isdir_paths``
+    can be set explicitly when a test needs to model an empty directory
+    or override the path-based default.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        # Explicit directory whitelist; when None, isdir is inferred from
+        # parent-of-files membership.
+        self.isdir_paths: set[str] | None = None
+
+    def exists(self, path: str) -> bool:
+        return path in self.files or self.isdir(path)
+
+    def remove(self, path: str) -> None:
+        self.files.pop(path, None)
+
+    def rename(self, src: str, dst: str) -> None:
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+
+    def listdir(self, directory: str) -> list[str]:
+        prefix = directory.rstrip("/") + "/"
+        return [
+            path[len(prefix) :] for path in self.files if path.startswith(prefix) and "/" not in path[len(prefix) :]
+        ]
+
+    def isdir(self, path: str) -> bool:
+        if self.isdir_paths is not None:
+            return path in self.isdir_paths
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def read_bytes(self, path: str) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/domain/test_artwork_paths.py
+++ b/tests/domain/test_artwork_paths.py
@@ -1,0 +1,30 @@
+"""Tests for domain.artwork_paths — pure cover-art filename builders."""
+
+from __future__ import annotations
+
+from domain.artwork_paths import final_filename, staging_filename
+
+
+class TestStagingFilename:
+    def test_int_rom_id(self):
+        assert staging_filename(42) == "romm_42_cover.png"
+
+    def test_str_rom_id(self):
+        assert staging_filename("42") == "romm_42_cover.png"
+
+    def test_zero(self):
+        assert staging_filename(0) == "romm_0_cover.png"
+
+    def test_large_id(self):
+        assert staging_filename(999_999_999) == "romm_999999999_cover.png"
+
+
+class TestFinalFilename:
+    def test_app_id(self):
+        assert final_filename(100001) == "100001p.png"
+
+    def test_str_id(self):
+        assert final_filename("12345") == "12345p.png"
+
+    def test_zero(self):
+        assert final_filename(0) == "0p.png"

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -4,13 +4,13 @@ import asyncio
 import base64
 import logging
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 # conftest.py patches decky before this import
 import decky
 import pytest
+from conftest import FakeCoverArtFileStore
 
-from adapters.steam_config import SteamConfigAdapter
 from services.artwork import ArtworkService
 
 
@@ -20,21 +20,36 @@ def state():
 
 
 @pytest.fixture
-def steam_config():
-    return SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
+def file_store() -> FakeCoverArtFileStore:
+    return FakeCoverArtFileStore()
 
 
 @pytest.fixture
-def artwork_service(state, steam_config):
-    svc = ArtworkService(
-        romm_api=MagicMock(),
+def steam_config():
+    """Minimal steam-config stub. grid_dir is overridden per test."""
+
+    cfg = MagicMock()
+    cfg.grid_dir = MagicMock(return_value=None)
+    return cfg
+
+
+@pytest.fixture
+def romm_api():
+    return MagicMock()
+
+
+@pytest.fixture
+def artwork_service(state, steam_config, file_store, romm_api):
+    # _loop is replaced by the autouse fixture below for async tests; for
+    # sync tests it is never touched, so a MagicMock is fine here.
+    return ArtworkService(
+        romm_api=romm_api,
         steam_config=steam_config,
+        cover_art_file_store=file_store,
         state=state,
-        loop=asyncio.get_event_loop(),
+        loop=MagicMock(),
         logger=decky.logger,
-        emit=decky.emit,
     )
-    return svc
 
 
 @pytest.fixture(autouse=True)
@@ -59,20 +74,20 @@ def _not_cancelling():
 class TestExistingCoverPath:
     """Tests for existing_cover_path()."""
 
-    def test_returns_final_when_exists(self, artwork_service, state, tmp_path):
-        final = tmp_path / "99999p.png"
-        final.write_text("final")
+    def test_returns_final_when_exists(self, artwork_service, state, file_store, tmp_path):
+        final = os.path.join(str(tmp_path), "99999p.png")
+        file_store.files[final] = b"final"
         state["shortcut_registry"]["42"] = {"app_id": 99999}
 
         result = artwork_service.existing_cover_path(42, str(tmp_path))
-        assert result == str(final)
+        assert result == final
 
-    def test_returns_staging_when_exists(self, artwork_service, tmp_path):
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
+    def test_returns_staging_when_exists(self, artwork_service, file_store, tmp_path):
+        staging = os.path.join(str(tmp_path), "romm_42_cover.png")
+        file_store.files[staging] = b"staging"
 
         result = artwork_service.existing_cover_path(42, str(tmp_path))
-        assert result == str(staging)
+        assert result == staging
 
     def test_returns_none_when_nothing_exists(self, artwork_service, tmp_path):
         result = artwork_service.existing_cover_path(42, str(tmp_path))
@@ -91,14 +106,9 @@ class TestDownloadArtwork:
     """Tests for download_artwork()."""
 
     @pytest.mark.asyncio
-    async def test_download_uses_staging_filename(self, artwork_service, steam_config, tmp_path):
+    async def test_download_uses_staging_filename(self, artwork_service, steam_config, romm_api, tmp_path):
         grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        artwork_service._loop = mock_loop
+        steam_config.grid_dir.return_value = str(grid_dir)
 
         roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
         result = await artwork_service.download_artwork(
@@ -107,22 +117,22 @@ class TestDownloadArtwork:
 
         assert 42 in result
         assert result[42].endswith("romm_42_cover.png")
-        call_args = mock_loop.run_in_executor.call_args[0]
-        assert "romm_42_cover.png" in call_args[3]
+        # download_cover called with the cover URL and a staging dest
+        romm_api.download_cover.assert_called_once()
+        call_args = romm_api.download_cover.call_args[0]
+        assert call_args[0] == "/cover.png"
+        assert call_args[1].endswith("romm_42_cover.png")
 
     @pytest.mark.asyncio
-    async def test_skips_download_if_final_exists(self, artwork_service, state, steam_config, tmp_path):
+    async def test_skips_download_if_final_exists(
+        self, artwork_service, state, steam_config, file_store, romm_api, tmp_path
+    ):
         """If {app_id}p.png exists from a prior sync, skip re-download."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
+        grid_dir = str(tmp_path / "grid")
+        steam_config.grid_dir.return_value = grid_dir
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        artwork_service._loop = mock_loop
-
-        final_art = grid_dir / "99999p.png"
-        final_art.write_text("fake")
+        final = os.path.join(grid_dir, "99999p.png")
+        file_store.files[final] = b"fake"
         state["shortcut_registry"]["42"] = {"app_id": 99999, "name": "Test"}
 
         roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
@@ -130,34 +140,31 @@ class TestDownloadArtwork:
             roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
         )
 
-        assert result[42] == str(final_art)
-        mock_loop.run_in_executor.assert_not_called()
+        assert result[42] == final
+        romm_api.download_cover.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_download_if_staging_exists(self, artwork_service, steam_config, tmp_path):
+    async def test_skips_download_if_staging_exists(
+        self, artwork_service, steam_config, file_store, romm_api, tmp_path
+    ):
         """If staging file exists (e.g. retry), skip re-download."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
+        grid_dir = str(tmp_path / "grid")
+        steam_config.grid_dir.return_value = grid_dir
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock()
-        artwork_service._loop = mock_loop
-
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
+        staging = os.path.join(grid_dir, "romm_42_cover.png")
+        file_store.files[staging] = b"fake"
 
         roms = [{"id": 42, "name": "Test Game", "path_cover_large": "/cover.png"}]
         result = await artwork_service.download_artwork(
             roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
         )
 
-        assert result[42] == str(staging)
-        mock_loop.run_in_executor.assert_not_called()
+        assert result[42] == staging
+        romm_api.download_cover.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_grid_returns_empty(self, artwork_service, steam_config):
-        steam_config.grid_dir = lambda: None
+        steam_config.grid_dir.return_value = None
         roms = [{"id": 1, "name": "G", "path_cover_large": "/c.png"}]
         result = await artwork_service.download_artwork(
             roms, emit_progress=_noop_emit_progress, is_cancelling=_not_cancelling
@@ -166,9 +173,7 @@ class TestDownloadArtwork:
 
     @pytest.mark.asyncio
     async def test_skips_rom_without_cover_url(self, artwork_service, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
 
         roms = [{"id": 1, "name": "No Cover"}]
         result = await artwork_service.download_artwork(
@@ -177,14 +182,9 @@ class TestDownloadArtwork:
         assert 1 not in result
 
     @pytest.mark.asyncio
-    async def test_download_failure_logged(self, artwork_service, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Network error"))
-        artwork_service._loop = mock_loop
+    async def test_download_failure_logged(self, artwork_service, steam_config, romm_api, tmp_path):
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
+        romm_api.download_cover.side_effect = Exception("Network error")
 
         roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
         result = await artwork_service.download_artwork(
@@ -194,9 +194,7 @@ class TestDownloadArtwork:
 
     @pytest.mark.asyncio
     async def test_cancelling_during_artwork(self, artwork_service, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = str(tmp_path / "grid")
 
         roms = [{"id": 1, "name": "Game", "path_cover_large": "/cover.png"}]
         result = await artwork_service.download_artwork(
@@ -211,24 +209,24 @@ class TestDownloadArtwork:
 class TestFinalizeCoverPath:
     """Tests for finalize_cover_path()."""
 
-    def test_renames_staging_to_final(self, artwork_service, tmp_path):
+    def test_renames_staging_to_final(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        staging = tmp_path / "romm_1_cover.png"
-        staging.write_text("cover data")
+        staging = os.path.join(grid, "romm_1_cover.png")
+        file_store.files[staging] = b"cover data"
 
-        result = artwork_service.finalize_cover_path(grid, str(staging), 100001, "1")
+        result = artwork_service.finalize_cover_path(grid, staging, 100001, "1")
         expected = os.path.join(grid, "100001p.png")
         assert result == expected
-        assert not staging.exists()
-        assert os.path.exists(expected)
+        assert staging not in file_store.files
+        assert file_store.files[expected] == b"cover data"
 
-    def test_returns_existing_final(self, artwork_service, tmp_path):
+    def test_returns_existing_final(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        final = tmp_path / "100001p.png"
-        final.write_text("final data")
+        final = os.path.join(grid, "100001p.png")
+        file_store.files[final] = b"final data"
 
         result = artwork_service.finalize_cover_path(grid, "/nonexistent/path.png", 100001, "1")
-        assert result == str(final)
+        assert result == final
 
     def test_returns_cover_path_when_no_grid(self, artwork_service):
         result = artwork_service.finalize_cover_path(None, "/some/path.png", 100001, "1")
@@ -238,14 +236,22 @@ class TestFinalizeCoverPath:
         result = artwork_service.finalize_cover_path(str(tmp_path), "", 100001, "1")
         assert result == ""
 
-    def test_handles_rename_os_error(self, artwork_service, tmp_path):
+    def test_handles_rename_os_error(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        staging = tmp_path / "romm_1_cover.png"
-        staging.write_text("data")
+        staging = os.path.join(grid, "romm_1_cover.png")
+        file_store.files[staging] = b"data"
 
-        with patch("os.replace", side_effect=OSError("perm denied")):
-            result = artwork_service.finalize_cover_path(grid, str(staging), 100001, "1")
-        assert result == str(staging)
+        original_rename = file_store.rename
+
+        def boom(src, dst):
+            raise OSError("perm denied")
+
+        file_store.rename = boom  # type: ignore[method-assign]
+        try:
+            result = artwork_service.finalize_cover_path(grid, staging, 100001, "1")
+        finally:
+            file_store.rename = original_rename  # type: ignore[method-assign]
+        assert result == staging
 
 
 # ── TestRemoveArtworkFiles ────────────────────────────────────────────────────
@@ -254,48 +260,48 @@ class TestFinalizeCoverPath:
 class TestRemoveArtworkFiles:
     """Tests for remove_artwork_files()."""
 
-    def test_removes_cover_path(self, artwork_service, tmp_path):
+    def test_removes_cover_path(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        cover = tmp_path / "100001p.png"
-        cover.write_text("cover data")
-        entry = {"cover_path": str(cover), "app_id": 100001}
+        cover = os.path.join(grid, "100001p.png")
+        file_store.files[cover] = b"cover data"
+        entry = {"cover_path": cover, "app_id": 100001}
         artwork_service.remove_artwork_files(grid, "42", entry)
-        assert not cover.exists()
+        assert cover not in file_store.files
 
-    def test_removes_app_id_fallback(self, artwork_service, tmp_path):
+    def test_removes_app_id_fallback(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        art = tmp_path / "100001p.png"
-        art.write_text("data")
+        art = os.path.join(grid, "100001p.png")
+        file_store.files[art] = b"data"
         entry = {"cover_path": "", "app_id": 100001}
         artwork_service.remove_artwork_files(grid, "42", entry)
-        assert not art.exists()
+        assert art not in file_store.files
 
-    def test_removes_legacy_artwork_id(self, artwork_service, tmp_path):
+    def test_removes_legacy_artwork_id(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        art = tmp_path / "12345p.png"
-        art.write_text("data")
+        art = os.path.join(grid, "12345p.png")
+        file_store.files[art] = b"data"
         entry = {"cover_path": "", "artwork_id": 12345}
         artwork_service.remove_artwork_files(grid, "42", entry)
-        assert not art.exists()
+        assert art not in file_store.files
 
-    def test_removes_staging_leftover(self, artwork_service, tmp_path):
+    def test_removes_staging_leftover(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
+        staging = os.path.join(grid, "romm_42_cover.png")
+        file_store.files[staging] = b"staging"
         entry = {"cover_path": ""}
         artwork_service.remove_artwork_files(grid, "42", entry)
-        assert not staging.exists()
+        assert staging not in file_store.files
 
-    def test_removes_all_types(self, artwork_service, tmp_path):
+    def test_removes_all_types(self, artwork_service, file_store, tmp_path):
         grid = str(tmp_path)
-        cover = tmp_path / "mycover.png"
-        cover.write_text("cover")
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_text("staging")
-        entry = {"cover_path": str(cover), "app_id": 100001}
+        cover = os.path.join(grid, "mycover.png")
+        file_store.files[cover] = b"cover"
+        staging = os.path.join(grid, "romm_42_cover.png")
+        file_store.files[staging] = b"staging"
+        entry = {"cover_path": cover, "app_id": 100001}
         artwork_service.remove_artwork_files(grid, "42", entry)
-        assert not cover.exists()
-        assert not staging.exists()
+        assert cover not in file_store.files
+        assert staging not in file_store.files
 
 
 # ── TestGetArtworkBase64 ──────────────────────────────────────────────────────
@@ -305,49 +311,66 @@ class TestGetArtworkBase64:
     """Tests for get_artwork_base64()."""
 
     @pytest.mark.asyncio
-    async def test_returns_base64_from_pending(self, artwork_service, steam_config, tmp_path):
-        steam_config.grid_dir = lambda: str(tmp_path)
+    async def test_returns_base64_from_pending(self, artwork_service, steam_config, file_store, tmp_path):
+        steam_config.grid_dir.return_value = str(tmp_path)
 
-        cover = tmp_path / "romm_42_cover.png"
-        cover.write_bytes(b"fake png data")
+        cover = os.path.join(str(tmp_path), "romm_42_cover.png")
+        file_store.files[cover] = b"fake png data"
 
-        pending_sync = {42: {"cover_path": str(cover)}}
+        pending_sync = {42: {"cover_path": cover}}
         result = await artwork_service.get_artwork_base64(42, pending_sync)
         assert result["base64"] is not None
         assert base64.b64decode(result["base64"]) == b"fake png data"
 
     @pytest.mark.asyncio
-    async def test_returns_base64_from_registry(self, artwork_service, state, steam_config, tmp_path):
-        steam_config.grid_dir = lambda: str(tmp_path)
+    async def test_returns_base64_from_registry(self, artwork_service, state, steam_config, file_store, tmp_path):
+        steam_config.grid_dir.return_value = str(tmp_path)
 
-        cover = tmp_path / "100001p.png"
-        cover.write_bytes(b"registry png")
-        state["shortcut_registry"]["42"] = {"cover_path": str(cover)}
+        cover = os.path.join(str(tmp_path), "100001p.png")
+        file_store.files[cover] = b"registry png"
+        state["shortcut_registry"]["42"] = {"cover_path": cover}
 
         result = await artwork_service.get_artwork_base64(42, {})
         assert result["base64"] is not None
 
     @pytest.mark.asyncio
-    async def test_returns_base64_from_staging_fallback(self, artwork_service, steam_config, tmp_path):
-        steam_config.grid_dir = lambda: str(tmp_path)
+    async def test_returns_base64_from_staging_fallback(self, artwork_service, steam_config, file_store, tmp_path):
+        steam_config.grid_dir.return_value = str(tmp_path)
 
-        staging = tmp_path / "romm_42_cover.png"
-        staging.write_bytes(b"staging png")
+        staging = os.path.join(str(tmp_path), "romm_42_cover.png")
+        file_store.files[staging] = b"staging png"
 
         result = await artwork_service.get_artwork_base64(42, {})
         assert result["base64"] is not None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_grid(self, artwork_service, steam_config):
-        steam_config.grid_dir = lambda: None
+        steam_config.grid_dir.return_value = None
         result = await artwork_service.get_artwork_base64(42, {})
         assert result["base64"] is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_file_missing(self, artwork_service, steam_config, tmp_path):
-        steam_config.grid_dir = lambda: str(tmp_path)
+        steam_config.grid_dir.return_value = str(tmp_path)
         result = await artwork_service.get_artwork_base64(42, {})
         assert result["base64"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_read_raises(self, artwork_service, steam_config, file_store, tmp_path, caplog):
+        steam_config.grid_dir.return_value = str(tmp_path)
+
+        staging = os.path.join(str(tmp_path), "romm_42_cover.png")
+        file_store.files[staging] = b"data"
+
+        def boom(_path: str) -> bytes:
+            raise OSError("read failed")
+
+        file_store.read_bytes = boom  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.WARNING):
+            result = await artwork_service.get_artwork_base64(42, {})
+        assert result["base64"] is None
+        assert any("Failed to read artwork" in r.message for r in caplog.records)
 
 
 # ── TestIsStagingFileOrphaned ─────────────────────────────────────────────────
@@ -360,9 +383,9 @@ class TestIsStagingFileOrphaned:
         result = artwork_service.is_staging_file_orphaned(str(tmp_path), {}, "42")
         assert result is True
 
-    def test_orphaned_when_final_exists(self, artwork_service, tmp_path):
-        final = tmp_path / "1001p.png"
-        final.write_text("final")
+    def test_orphaned_when_final_exists(self, artwork_service, file_store, tmp_path):
+        final = os.path.join(str(tmp_path), "1001p.png")
+        file_store.files[final] = b"final"
         registry = {"42": {"app_id": 1001}}
         result = artwork_service.is_staging_file_orphaned(str(tmp_path), registry, "42")
         assert result is True
@@ -384,77 +407,84 @@ class TestIsStagingFileOrphaned:
 class TestPruneOrphanedStagingArtwork:
     """Tests for prune_orphaned_staging_artwork()."""
 
-    def test_removes_staging_not_in_registry(self, artwork_service, state, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
+    def test_removes_staging_not_in_registry(self, artwork_service, state, steam_config, file_store, tmp_path):
+        grid_dir = str(tmp_path / "grid")
+        staging = os.path.join(grid_dir, "romm_42_cover.png")
+        file_store.files[staging] = b"fake"
 
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = grid_dir
         state["shortcut_registry"] = {}
 
         artwork_service.prune_orphaned_staging_artwork()
-        assert not staging.exists()
+        assert staging not in file_store.files
 
-    def test_removes_redundant_staging_with_final(self, artwork_service, state, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake staging")
-        final = grid_dir / "1001p.png"
-        final.write_text("fake final")
+    def test_removes_redundant_staging_with_final(self, artwork_service, state, steam_config, file_store, tmp_path):
+        grid_dir = str(tmp_path / "grid")
+        staging = os.path.join(grid_dir, "romm_42_cover.png")
+        final = os.path.join(grid_dir, "1001p.png")
+        file_store.files[staging] = b"fake staging"
+        file_store.files[final] = b"fake final"
 
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = grid_dir
         state["shortcut_registry"] = {"42": {"app_id": 1001, "name": "Game A"}}
 
         artwork_service.prune_orphaned_staging_artwork()
-        assert not staging.exists()
-        assert final.exists()
+        assert staging not in file_store.files
+        assert final in file_store.files
 
-    def test_keeps_staging_when_no_final(self, artwork_service, state, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake staging")
+    def test_keeps_staging_when_no_final(self, artwork_service, state, steam_config, file_store, tmp_path):
+        grid_dir = str(tmp_path / "grid")
+        staging = os.path.join(grid_dir, "romm_42_cover.png")
+        file_store.files[staging] = b"fake staging"
 
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = grid_dir
         state["shortcut_registry"] = {"42": {"app_id": 1001, "name": "Game A"}}
 
         artwork_service.prune_orphaned_staging_artwork()
-        assert staging.exists()
+        assert staging in file_store.files
 
-    def test_ignores_non_staging_files(self, artwork_service, state, steam_config, tmp_path):
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        final = grid_dir / "1001p.png"
-        final.write_text("final art")
-        other = grid_dir / "something_else.png"
-        other.write_text("other")
+    def test_ignores_non_staging_files(self, artwork_service, state, steam_config, file_store, tmp_path):
+        grid_dir = str(tmp_path / "grid")
+        final = os.path.join(grid_dir, "1001p.png")
+        other = os.path.join(grid_dir, "something_else.png")
+        file_store.files[final] = b"final art"
+        file_store.files[other] = b"other"
 
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = grid_dir
         state["shortcut_registry"] = {}
 
         artwork_service.prune_orphaned_staging_artwork()
-        assert final.exists()
-        assert other.exists()
+        assert final in file_store.files
+        assert other in file_store.files
 
     def test_no_grid_dir_no_crash(self, artwork_service, state, steam_config):
-        steam_config.grid_dir = lambda: None
+        steam_config.grid_dir.return_value = None
         state["shortcut_registry"] = {}
         artwork_service.prune_orphaned_staging_artwork()  # should not raise
 
-    def test_handles_os_error(self, artwork_service, state, steam_config, tmp_path, caplog):
+    def test_grid_not_a_directory_no_crash(self, artwork_service, state, steam_config, file_store, tmp_path):
+        grid_dir = str(tmp_path / "grid")
+        steam_config.grid_dir.return_value = grid_dir
+        # No files under grid_dir => isdir returns False
+        file_store.isdir_paths = set()
+        state["shortcut_registry"] = {}
+        artwork_service.prune_orphaned_staging_artwork()  # should not raise
 
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        staging = grid_dir / "romm_42_cover.png"
-        staging.write_text("fake")
+    def test_handles_os_error(self, artwork_service, state, steam_config, file_store, tmp_path, caplog):
+        grid_dir = str(tmp_path / "grid")
+        staging = os.path.join(grid_dir, "romm_42_cover.png")
+        file_store.files[staging] = b"fake"
 
-        steam_config.grid_dir = lambda: str(grid_dir)
+        steam_config.grid_dir.return_value = grid_dir
         state["shortcut_registry"] = {}
 
-        with caplog.at_level(logging.WARNING), patch("os.remove", side_effect=OSError("permission denied")):
+        def boom(_path: str) -> None:
+            raise OSError("permission denied")
+
+        file_store.remove = boom  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.WARNING):
             artwork_service.prune_orphaned_staging_artwork()
 
-        assert staging.exists()
+        assert staging in file_store.files
         assert any("Failed to remove orphaned staging artwork" in r.message for r in caplog.records)

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.cover_art_file_store import CoverArtFileStoreAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.sync_diff import classify_roms
@@ -46,10 +47,10 @@ def plugin():
     artwork_service = ArtworkService(
         romm_api=p._romm_api,
         steam_config=steam_config,
+        cover_art_file_store=CoverArtFileStoreAdapter(),
         state=p._state,
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
-        emit=decky.emit,
     )
     p._artwork_service = artwork_service
 

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -224,15 +224,16 @@ class TestRemovalCleansUpArtwork:
         state["shortcut_registry"] = {"10": {"app_id": 100001, "name": "Game A", "cover_path": ""}}
         steam_config.grid_dir = lambda: str(grid_dir)
 
+        from adapters.cover_art_file_store import CoverArtFileStoreAdapter
         from services.artwork import ArtworkService
 
         artwork_svc = ArtworkService(
             romm_api=MagicMock(),
             steam_config=steam_config,
+            cover_art_file_store=CoverArtFileStoreAdapter(),
             state=state,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
-            emit=decky.emit,
         )
 
         svc = ShortcutRemovalService(
@@ -260,15 +261,16 @@ class TestRemovalCleansUpArtwork:
         state["shortcut_registry"] = {"10": {"app_id": 100001, "name": "Game A", "cover_path": ""}}
         steam_config.grid_dir = lambda: str(grid_dir)
 
+        from adapters.cover_art_file_store import CoverArtFileStoreAdapter
         from services.artwork import ArtworkService
 
         artwork_svc = ArtworkService(
             romm_api=MagicMock(),
             steam_config=steam_config,
+            cover_art_file_store=CoverArtFileStoreAdapter(),
             state=state,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
-            emit=decky.emit,
         )
 
         svc = ShortcutRemovalService(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -13,7 +13,7 @@ from bootstrap import (
     bootstrap,
     wire_services,
 )
-from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeCoverArtFileStore, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -146,6 +146,7 @@ class TestWireServices:
             "romm_api": romm_api,
             "steam_config": steam_config,
             "sgdb_adapter": MagicMock(),
+            "cover_art_file_store": FakeCoverArtFileStore(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -182,6 +183,7 @@ class TestWireServices:
                 romm_api=deps["romm_api"],
                 steam_config=deps["steam_config"],
                 sgdb_adapter=deps["sgdb_adapter"],
+                cover_art_file_store=deps["cover_art_file_store"],
             ),
             stores=StateBundle(
                 state=deps["state"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1092,6 +1092,7 @@ class TestMainStartupOrdering:
             "romm_api": MagicMock(),
             "steam_config": MagicMock(),
             "sgdb_adapter": MagicMock(),
+            "cover_art_file_store": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),
             "retroarch_core_info": MagicMock(),


### PR DESCRIPTION
## Summary

First Wave 3 vertical of the Cosmic Python refactor (umbrella #277, epic #299). Extracts all raw filesystem I/O from `ArtworkService` behind a new `CoverArtFileStore` Protocol + adapter, promotes inline filename f-strings to `domain/artwork_paths.py`, and drops the dead `emit` ctor param.

After this PR, `ArtworkService` is free of direct `os.*` / `pathlib.read_bytes` / `os.replace` calls — only `os.path.join` (pure path algebra) remains.

## Changes

- New Protocol `CoverArtFileStore` in `services/protocols.py` (`exists`, `remove`, `rename`, `listdir`, `isdir`, `read_bytes`).
- New adapter `CoverArtFileStoreAdapter` in `adapters/cover_art_file_store.py` (sync methods; service offloads via `run_in_executor`). `remove` is idempotent via `contextlib.suppress(FileNotFoundError)`.
- New domain module `domain/artwork_paths.py` with `staging_filename` / `final_filename` builders.
- `ArtworkService`: injected `cover_art_file_store`, dropped dead `emit` param, all I/O routed through adapter, filename f-strings replaced with domain helpers.
- Bootstrap wiring updated (new adapter added to `AdapterBundle`).
- Tests rewritten to use a `FakeCoverArtFileStore` (in-memory dict-backed) — no more `patch("os.*")` or `patch.object(..., "_loop", ...)`.

## Test plan

- [x] `python -m pytest tests/ -q` — 1854 passed
- [x] `ruff check py_modules/ tests/` — clean
- [x] `basedpyright py_modules/ tests/` — 0 errors, 0 warnings (matches main baseline)
- [x] `scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] Grep confirms no raw I/O remains in `services/artwork.py`

Closes #290.