### PR TITLE
refactor(steamgrid): extract raw file I/O into SgdbArtworkCache adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,21 +77,24 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
 - **Wave 2 — Domain promotions** ([#295](https://github.com/danielcopper/decky-romm-sync/issues/295)) — **complete**
   Pure logic extracted from non-saves services into `domain/`.
   Done: ~~#315~~ (firmware paths), ~~#316~~ (achievements), ~~#317~~ (path safety + mise lint bundle), ~~#318~~ (filename resolution), ~~#319~~ (sync_diff cluster).
-- **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2)
-  - [#299](https://github.com/danielcopper/decky-romm-sync/issues/299) ArtworkService + SteamGridService — small, do as one chunk
-  - [#297](https://github.com/danielcopper/decky-romm-sync/issues/297) DownloadService
-  - [#298](https://github.com/danielcopper/decky-romm-sync/issues/298) FirmwareService — fold [#301](https://github.com/danielcopper/decky-romm-sync/issues/301) GameDetailService in alongside (shares `CoreInfoProvider`)
-  - [#302](https://github.com/danielcopper/decky-romm-sync/issues/302) MigrationService — decision first (#293), then act
-  - [#300](https://github.com/danielcopper/decky-romm-sync/issues/300) LibraryService **last** — by then most of its un-injected deps and pure logic have moved out
+- **Wave 3 — Per-service verticals** (smallest-to-largest, after Waves 1+2). Each epic body lists exact remaining work; native Sub-Issues panel is source of truth for open sub-issues.
+  - [#299](https://github.com/danielcopper/decky-romm-sync/issues/299) ArtworkService + SteamGridService — two sub-issues: #290 (artwork file I/O), #291 (steamgrid file I/O). Do as one chunk.
+  - [#297](https://github.com/danielcopper/decky-romm-sync/issues/297) DownloadService — one sub-issue: #243 (file I/O). Clock+Sleeper already wired; `_resolve_local_file_name` already in `domain/rom_files`.
+  - [#298](https://github.com/danielcopper/decky-romm-sync/issues/298) FirmwareService — two sub-issues: #288 (file I/O), #170 (mutation fix). Cache persister, Clock, CoreInfoProvider, firmware path helpers all wired in Wave 1/2.
+  - ~~#301~~ GameDetailService — **closed as superseded**. All scope (Clock, CoreInfoProvider) wired via Wave 1.
+  - [#302](https://github.com/danielcopper/decky-romm-sync/issues/302) MigrationService — decision first (#293), then act.
+  - [#300](https://github.com/danielcopper/decky-romm-sync/issues/300) LibraryService **last** — one sub-issue: #172 (ctor params). Service has zero remaining direct-I/O / time / random violations after Waves 1+2; what's left is structural.
 - **Wave 4 — Close-out**
   - #274 main.py callable thinness audit (last, after services have settled)
   - #277 final verification — tick all checklist items, close
 
 **Saves vertical** ([#254](https://github.com/danielcopper/decky-romm-sync/issues/254)) runs in parallel — independent of the waves above.
 
-**Why this order**: doing #294 (Clock/UuidGen/Sleeper) before any per-service vertical means every later PR is "drop the import, inject the Protocol" — mechanical. Doing #295 (domain extraction) before LibraryService shrinks the scariest service before lifting it. LibraryService last because it has the largest blast radius.
+**Why this order**: doing #294 (Clock/UuidGen/Sleeper) before any per-service vertical means every later PR is "drop the import, inject the Protocol" — mechanical. Doing #295 (domain extraction) before LibraryService shrunk the scariest service before lifting it. LibraryService last because it has the largest blast radius.
 
-When picking work: Waves 1 and 2 are finished (modulo deferred #259), so every per-service vertical's Protocol and domain dependencies are in place. Wave 3 (#297–#302) is the next active wave.
+When picking work: Waves 1 and 2 are finished (modulo deferred #259), so every per-service vertical's Protocol and domain dependencies are in place. Wave 3 (#297, #298, #299, #300, #302) is the next active wave.
+
+**Sub-issue policy**: Epic bodies do **not** carry markdown sub-issue lists — open work is tracked via GitHub's native Sub-Issues panel on each epic. If a new sub-issue is needed, link it natively (don't add a body bullet).
 
 ## Sub-package layout — `__init__.py` is re-export only
 

--- a/main.py
+++ b/main.py
@@ -191,6 +191,7 @@ class Plugin:
                     steam_config=self._steam_config,
                     sgdb_adapter=self._sgdb_adapter,
                     cover_art_file_store=adapters["cover_art_file_store"],
+                    sgdb_artwork_cache=adapters["sgdb_artwork_cache"],
                 ),
                 stores=StateBundle(
                     state=self._state,

--- a/py_modules/adapters/sgdb_artwork_cache.py
+++ b/py_modules/adapters/sgdb_artwork_cache.py
@@ -1,0 +1,69 @@
+"""Filesystem adapter for the SteamGridDB artwork cache.
+
+Owns the raw POSIX calls used by SteamGridService to manage cached SGDB
+artwork (heroes, logos, grids, icons) under the plugin runtime directory.
+Path construction and pruning policy remain a service concern; this
+adapter exposes only the I/O seams declared by
+``services.protocols.SgdbArtworkCache``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import pathlib
+
+
+class SgdbArtworkCacheAdapter:
+    """Synchronous filesystem operations for the SGDB artwork cache.
+
+    Implements the ``SgdbArtworkCache`` Protocol. Methods are synchronous —
+    services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def __init__(self, *, runtime_dir: str) -> None:
+        self._runtime_dir = runtime_dir
+
+    def cache_dir(self) -> str:
+        """Return the SGDB artwork cache directory, creating it if missing."""
+        art_dir = os.path.join(self._runtime_dir, "artwork")
+        os.makedirs(art_dir, exist_ok=True)
+        return art_dir
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entries in *directory*."""
+        return os.listdir(directory)
+
+    def isdir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        return os.path.isdir(path)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        return pathlib.Path(path).read_bytes()
+
+    def write_bytes_atomic(self, path: str, data: bytes) -> None:
+        """Write *data* to *path* via a temp file + ``os.replace`` swap.
+
+        On failure the temp file is removed and the exception re-raised so
+        callers can decide how to react.
+        """
+        tmp_path = path + ".tmp"
+        try:
+            with open(tmp_path, "wb") as f:
+                f.write(data)
+            os.replace(tmp_path, path)
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(tmp_path)
+            raise

--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -7,6 +7,7 @@ Steam ``userdata`` directory (resolved from ``DECKY_USER_HOME``).
 from __future__ import annotations
 
 import binascii
+import contextlib
 import logging
 import os
 import struct
@@ -90,6 +91,30 @@ class SteamConfigAdapter:
         with open(tmp_path, "wb") as f:
             f.write(vdf.binary_dumps(data))
         os.replace(tmp_path, path)
+
+    def write_shortcut_icon(self, app_id: int, icon_bytes: bytes) -> str:
+        """Write an icon PNG into Steam's grid dir and return its path.
+
+        Uses a temp file + ``os.replace`` for atomicity; the temp file is
+        cleaned up on any failure before the exception propagates.
+
+        Raises ``RuntimeError`` when the Steam grid directory cannot be
+        located.
+        """
+        grid_dir = self.grid_dir()
+        if not grid_dir:
+            raise RuntimeError("Cannot find Steam grid directory")
+        icon_path = os.path.join(grid_dir, f"{app_id}_icon.png")
+        tmp_path = icon_path + ".tmp"
+        try:
+            with open(tmp_path, "wb") as f:
+                f.write(icon_bytes)
+            os.replace(tmp_path, icon_path)
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(tmp_path)
+            raise
+        return icon_path
 
     # -- Steam Input config ---------------------------------------------------
 

--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -14,6 +14,8 @@ import struct
 
 import vdf
 
+from lib.errors import SteamGridDirMissingError
+
 
 class SteamConfigAdapter:
     """Thin wrapper around Steam's on-disk config files."""
@@ -98,12 +100,12 @@ class SteamConfigAdapter:
         Uses a temp file + ``os.replace`` for atomicity; the temp file is
         cleaned up on any failure before the exception propagates.
 
-        Raises ``RuntimeError`` when the Steam grid directory cannot be
-        located.
+        Raises ``lib.errors.SteamGridDirMissingError`` when the Steam grid
+        directory cannot be located.
         """
         grid_dir = self.grid_dir()
         if not grid_dir:
-            raise RuntimeError("Cannot find Steam grid directory")
+            raise SteamGridDirMissingError("Cannot find Steam grid directory")
         icon_path = os.path.join(grid_dir, f"{app_id}_icon.png")
         tmp_path = icon_path + ".tmp"
         try:

--- a/py_modules/adapters/steamgriddb.py
+++ b/py_modules/adapters/steamgriddb.py
@@ -6,10 +6,12 @@ import contextlib
 import json
 import os
 import ssl
+import urllib.error
 import urllib.request
 from typing import TYPE_CHECKING
 
 from lib.certifi_bundle import ca_bundle as _ca_bundle
+from lib.errors import SgdbApiError
 
 if TYPE_CHECKING:
     import logging
@@ -37,8 +39,11 @@ class SteamGridDbAdapter:
         req = urllib.request.Request(url, method="GET")
         req.add_header("Authorization", f"Bearer {api_key}")
         req.add_header("User-Agent", _USER_AGENT)
-        with urllib.request.urlopen(req, context=self._ssl_context(), timeout=30) as resp:
-            return json.loads(resp.read().decode())
+        try:
+            with urllib.request.urlopen(req, context=self._ssl_context(), timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            raise SgdbApiError(status_code=e.code, message=str(e)) from e
 
     def download_image(self, url: str, dest_path: str) -> bool:
         """Download image from URL to dest_path with atomic write."""
@@ -63,10 +68,17 @@ class SteamGridDbAdapter:
             return False
 
     def verify_api_key(self, api_key: str) -> dict:
-        """Verify an API key against SGDB."""
+        """Verify an API key against SGDB.
+
+        Raises ``SgdbApiError`` on non-2xx HTTP responses so callers can
+        react to auth failures without importing ``urllib``.
+        """
         url = f"{_SGDB_BASE_URL}/search/autocomplete/test"
         req = urllib.request.Request(url, method="GET")
         req.add_header("Authorization", f"Bearer {api_key}")
         req.add_header("User-Agent", _USER_AGENT)
-        with urllib.request.urlopen(req, context=self._ssl_context(), timeout=30) as resp:
-            return json.loads(resp.read().decode())
+        try:
+            with urllib.request.urlopen(req, context=self._ssl_context(), timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            raise SgdbApiError(status_code=e.code, message=str(e)) from e

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -21,6 +21,7 @@ from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApi
+from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
 from adapters.steam_config import SteamConfigAdapter
 from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
@@ -50,6 +51,7 @@ from services.protocols import (
     SavesPathProvider,
     SaveSyncStatePersister,
     SettingsPersister,
+    SgdbArtworkCache,
     Sleeper,
     StatePersister,
     UuidGen,
@@ -70,6 +72,7 @@ class AdapterBundle:
     steam_config: SteamConfigProtocol
     sgdb_adapter: SteamGridDbAdapter
     cover_art_file_store: CoverArtFileStore
+    sgdb_artwork_cache: SgdbArtworkCache
 
 
 @dataclass(frozen=True)
@@ -170,6 +173,7 @@ def bootstrap(
     steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
     sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger)
     cover_art_file_store = CoverArtFileStoreAdapter()
+    sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -181,6 +185,7 @@ def bootstrap(
         "steam_config": steam_config,
         "sgdb_adapter": sgdb_adapter,
         "cover_art_file_store": cover_art_file_store,
+        "sgdb_artwork_cache": sgdb_artwork_cache,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -368,11 +373,11 @@ def wire_services(cfg: WiringConfig) -> dict:
         sgdb_api=cfg.adapters.sgdb_adapter,
         romm_api=cfg.adapters.romm_api,
         steam_config=cfg.adapters.steam_config,
+        sgdb_artwork_cache=cfg.adapters.sgdb_artwork_cache,
         state=cfg.stores.state,
         settings=cfg.stores.settings,
         loop=cfg.runtime.loop,
         logger=cfg.runtime.logger,
-        runtime_dir=cfg.runtime.runtime_dir,
         save_state=cfg.callbacks.save_state,
         save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
         get_pending_sync=lambda: sync_service.pending_sync,

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -60,7 +60,7 @@ from services.protocols import SteamConfigAdapter as SteamConfigProtocol
 from services.rom_removal import RomRemovalService
 from services.saves import SaveService, SaveServiceConfig
 from services.shortcut_removal import ShortcutRemovalService
-from services.steamgrid import SteamGridService
+from services.steamgrid import SteamGridConfig, SteamGridService
 
 
 @dataclass(frozen=True)
@@ -376,11 +376,13 @@ def wire_services(cfg: WiringConfig) -> dict:
         sgdb_artwork_cache=cfg.adapters.sgdb_artwork_cache,
         state=cfg.stores.state,
         settings=cfg.stores.settings,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        save_state=cfg.callbacks.save_state,
-        save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
-        get_pending_sync=lambda: sync_service.pending_sync,
+        config=SteamGridConfig(
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            save_state=cfg.callbacks.save_state,
+            save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
+            get_pending_sync=lambda: sync_service.pending_sync,
+        ),
     )
 
     achievements_service = AchievementsService(

--- a/py_modules/domain/sgdb_artwork.py
+++ b/py_modules/domain/sgdb_artwork.py
@@ -1,0 +1,62 @@
+"""Pure helpers for SteamGridDB asset-type maps, endpoint paths, and app-id math.
+
+Owns the stateless compute SteamGridService needs to translate the
+plugin's internal asset-type vocabulary into SteamGridDB API endpoints
+and to convert unsigned Steam app IDs into the signed int32 form
+``shortcuts.vdf`` records use.
+"""
+
+from __future__ import annotations
+
+import struct
+
+# Plugin-internal singular asset-type names mapped to the SGDB endpoint segment.
+# The asset-type strings on the right are what the SGDB HTTP API exposes
+# (``/heroes/game/{id}``, ``/logos/game/{id}``, ``/grids/game/{id}``,
+# ``/icons/game/{id}``).
+_ASSET_TYPE_TO_ENDPOINT: dict[str, str] = {
+    "hero": "heroes",
+    "logo": "logos",
+    "grid": "grids",
+    "icon": "icons",
+}
+
+# Numeric asset-type codes used by the frontend's `get_sgdb_artwork_base64`
+# callable. Keep in sync with the frontend's encoding.
+_ASSET_TYPE_NUM_TO_NAME: dict[int, str] = {
+    1: "hero",
+    2: "logo",
+    3: "grid",
+    4: "icon",
+}
+
+
+def asset_type_name(type_num: int) -> str | None:
+    """Return the singular asset-type name for a numeric code, or ``None``."""
+    return _ASSET_TYPE_NUM_TO_NAME.get(type_num)
+
+
+def asset_type_endpoint(asset_type: str) -> str | None:
+    """Return the SGDB endpoint segment for a singular asset-type name, or ``None``."""
+    return _ASSET_TYPE_TO_ENDPOINT.get(asset_type)
+
+
+def sgdb_endpoint_path(asset_type: str, sgdb_game_id: int) -> str | None:
+    """Build the SGDB API path for fetching artwork of a given type.
+
+    Returns ``None`` when *asset_type* is not a recognised name. The path
+    is suffixed with the dimensions query string for the ``grid`` type so
+    callers do not need to special-case it.
+    """
+    endpoint = asset_type_endpoint(asset_type)
+    if endpoint is None:
+        return None
+    path = f"/{endpoint}/game/{sgdb_game_id}"
+    if asset_type == "grid":
+        path += "?dimensions=460x215,920x430"
+    return path
+
+
+def to_signed_app_id(app_id: int) -> int:
+    """Convert an unsigned Steam shortcut app ID to its signed int32 form."""
+    return struct.unpack("i", struct.pack("I", app_id & 0xFFFFFFFF))[0]

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -1,6 +1,17 @@
 """RomM API error types for structured error handling."""
 
 
+class SgdbApiError(Exception):
+    """Raised by SteamGridDb adapter for non-2xx HTTP responses.
+
+    Wraps urllib.error.HTTPError so callers never import urllib.
+    """
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
 class RommApiError(Exception):
     """Base exception for all RomM HTTP API errors."""
 

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -12,6 +12,15 @@ class SgdbApiError(Exception):
         self.status_code = status_code
 
 
+class SteamGridDirMissingError(Exception):
+    """Raised when the Steam grid directory cannot be located.
+
+    Distinguishes the "expected, user-recoverable" missing-grid-dir
+    condition from generic write failures so callers can route the
+    two cases through different log levels.
+    """
+
+
 class RommApiError(Exception):
     """Base exception for all RomM HTTP API errors."""
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -18,6 +18,7 @@ class SteamConfigAdapter(Protocol):
     def read_shortcuts(self) -> dict: ...
     def write_shortcuts(self, data: dict) -> None: ...
     def set_steam_input_config(self, app_ids: list, mode: str = "default") -> None: ...
+    def write_shortcut_icon(self, app_id: int, icon_bytes: bytes) -> str: ...
 
 
 class RommApiProtocol(Protocol):
@@ -539,6 +540,54 @@ class CoverArtFileStore(Protocol):
         ...
 
 
+class SgdbArtworkCache(Protocol):
+    """Filesystem seam for the SteamGridDB artwork cache directory.
+
+    Owns the raw POSIX calls SteamGridService uses to manage cached
+    SGDB artwork (heroes, logos, grids, icons) under the plugin runtime
+    directory. Path construction and pruning policy remain a service
+    concern; this Protocol exposes only the I/O seams.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def cache_dir(self) -> str:
+        """Return the absolute path to the SGDB artwork cache directory.
+
+        Idempotently ensures the directory exists before returning.
+        """
+        ...
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entries in *directory*."""
+        ...
+
+    def isdir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        ...
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        ...
+
+    def write_bytes_atomic(self, path: str, data: bytes) -> None:
+        """Atomically write *data* to *path*.
+
+        Writes to a temp file beside *path* and ``os.replace``s it to the
+        final destination. The temp file is removed on any failure.
+        """
+        ...
+
+
 # ---------------------------------------------------------------------------
 # Multi-method cross-service Protocols
 # ---------------------------------------------------------------------------
@@ -609,6 +658,7 @@ class SteamGridDbApi(Protocol):
     def verify_api_key(self, api_key: str) -> dict:
         """Verify an API key against SGDB. Returns parsed JSON response.
 
-        Raises urllib.error.HTTPError on auth failures (401/403).
+        Raises ``lib.errors.SgdbApiError`` on non-2xx HTTP responses
+        (e.g. 401/403 for an invalid key).
         """
         ...

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -351,6 +351,18 @@ class SettingsPersister(Protocol):
     def __call__(self) -> None: ...
 
 
+class PendingSyncReader(Protocol):
+    """Read seam for the LibraryService pending-sync map.
+
+    SteamGridService consults the pending-sync map when resolving SGDB
+    IDs for ROMs that are mid-sync (not yet in the registry). Exposing
+    this as a Protocol avoids a service-to-service concrete import and
+    keeps the typed seam narrow to "give me the current mapping".
+    """
+
+    def __call__(self) -> dict: ...
+
+
 class SaveSyncStatePersister(Protocol):
     """Read/write the on-disk save-sync state file.
 

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -1,17 +1,26 @@
-"""SteamGridService — SteamGridDB artwork management.
+"""SteamGridDB orchestration — API key flow, artwork fetch/cache, icon save.
 
-Handles SGDB API key verification, artwork fetching/caching, icon saving
-to Steam grid directory, and orphaned artwork cache pruning.
+Owns the runtime decisions for SteamGridDB integration: resolving SGDB
+game IDs from registry/RomM hints, fanning out cached vs. remote
+artwork requests, and routing icon writes into Steam's grid directory.
+All raw I/O is delegated to adapters (``SgdbArtworkCache``,
+``SteamConfigAdapter``); pure asset-type / endpoint compute lives in
+``domain.sgdb_artwork``.
 """
 
 from __future__ import annotations
 
 import base64
-import contextlib
 import os
-import pathlib
-import struct
 from typing import TYPE_CHECKING, ClassVar
+
+from domain.sgdb_artwork import (
+    asset_type_endpoint,
+    asset_type_name,
+    sgdb_endpoint_path,
+    to_signed_app_id,
+)
+from lib.errors import SgdbApiError
 
 if TYPE_CHECKING:
     import asyncio
@@ -21,6 +30,7 @@ if TYPE_CHECKING:
     from services.protocols import (
         RommApiProtocol,
         SettingsPersister,
+        SgdbArtworkCache,
         StatePersister,
         SteamConfigAdapter,
         SteamGridDbApi,
@@ -28,7 +38,7 @@ if TYPE_CHECKING:
 
 
 class SteamGridService:
-    """SteamGridDB artwork: API key management, artwork fetch/cache, icon save."""
+    """SteamGridDB orchestration: API key flow, artwork fetch/cache, icon save."""
 
     def __init__(
         self,
@@ -36,11 +46,11 @@ class SteamGridService:
         sgdb_api: SteamGridDbApi,
         romm_api: RommApiProtocol,
         steam_config: SteamConfigAdapter,
+        sgdb_artwork_cache: SgdbArtworkCache,
         state: dict,
         settings: dict,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
-        runtime_dir: str,
         save_state: StatePersister,
         save_settings_to_disk: SettingsPersister,
         get_pending_sync: Callable[[], dict],
@@ -48,11 +58,11 @@ class SteamGridService:
         self._sgdb_api = sgdb_api
         self._romm_api = romm_api
         self._steam_config = steam_config
+        self._sgdb_artwork_cache = sgdb_artwork_cache
         self._state = state
         self._settings = settings
         self._loop = loop
         self._logger = logger
-        self._runtime_dir = runtime_dir
         self._save_state = save_state
         self._save_settings_to_disk = save_settings_to_disk
         self._get_pending_sync = get_pending_sync
@@ -65,13 +75,6 @@ class SteamGridService:
         configured = self._settings.get("log_level", "warn")
         if self._LOG_LEVELS.get("debug", 0) >= self._LOG_LEVELS.get(configured, 2):
             self._logger.info(msg)
-
-    # -- artwork dir -------------------------------------------------------
-
-    def _sgdb_artwork_dir(self):
-        art_dir = os.path.join(self._runtime_dir, "artwork")
-        os.makedirs(art_dir, exist_ok=True)
-        return art_dir
 
     # -- SGDB lookup -------------------------------------------------------
 
@@ -87,24 +90,17 @@ class SteamGridService:
     # -- artwork download --------------------------------------------------
 
     def _download_sgdb_artwork(self, sgdb_game_id, rom_id, asset_type):
-        type_map = {
-            "hero": "heroes",
-            "logo": "logos",
-            "grid": "grids",
-            "icon": "icons",
-        }
-        endpoint = type_map.get(asset_type)
-        if not endpoint:
+        if asset_type_endpoint(asset_type) is None:
             return None
 
-        art_dir = self._sgdb_artwork_dir()
+        art_dir = self._sgdb_artwork_cache.cache_dir()
         cached = os.path.join(art_dir, f"{rom_id}_{asset_type}.png")
-        if os.path.exists(cached):
+        if self._sgdb_artwork_cache.exists(cached):
             return cached
 
-        path = f"/{endpoint}/game/{sgdb_game_id}"
-        if asset_type == "grid":
-            path += "?dimensions=460x215,920x430"
+        path = sgdb_endpoint_path(asset_type, sgdb_game_id)
+        if path is None:
+            return None
 
         try:
             result = self._sgdb_api.request(path)
@@ -122,7 +118,7 @@ class SteamGridService:
     async def _read_file_as_base64(self, path):
         """Read a file and return base64-encoded string, or None on failure."""
         try:
-            data = await self._loop.run_in_executor(None, lambda: pathlib.Path(path).read_bytes())
+            data = await self._loop.run_in_executor(None, self._sgdb_artwork_cache.read_bytes, path)
             return base64.b64encode(data).decode("ascii")
         except Exception as e:
             self._logger.warning(f"Failed to read file {path}: {e}")
@@ -176,17 +172,16 @@ class SteamGridService:
     async def get_sgdb_artwork_base64(self, rom_id, asset_type_num):
         rom_id = int(rom_id)
         asset_type_num = int(asset_type_num)
-        type_names = {1: "hero", 2: "logo", 3: "grid", 4: "icon"}
-        asset_type = type_names.get(asset_type_num)
+        asset_type = asset_type_name(asset_type_num)
         self._log_debug(f"SGDB artwork request: rom_id={rom_id}, asset_type={asset_type_num}")
         if not asset_type:
             return {"base64": None, "no_api_key": False}
 
-        art_dir = self._sgdb_artwork_dir()
+        art_dir = self._sgdb_artwork_cache.cache_dir()
         cached = os.path.join(art_dir, f"{rom_id}_{asset_type}.png")
 
         # Return from cache if available
-        if os.path.exists(cached):
+        if self._sgdb_artwork_cache.exists(cached):
             self._log_debug(f"SGDB artwork cache hit: {cached}")
             b64 = await self._read_file_as_base64(cached)
             if b64:
@@ -202,7 +197,7 @@ class SteamGridService:
             return {"base64": None, "no_api_key": False}
 
         path = await self._loop.run_in_executor(None, self._download_sgdb_artwork, sgdb_id, rom_id, asset_type)
-        if path and os.path.exists(path):
+        if path and self._sgdb_artwork_cache.exists(path):
             self._log_debug(f"SGDB artwork download success: rom_id={rom_id}, asset_type={asset_type}")
             b64 = await self._read_file_as_base64(path)
             if b64:
@@ -215,8 +210,6 @@ class SteamGridService:
     # -- API key management ------------------------------------------------
 
     async def verify_sgdb_api_key(self, api_key=None):
-        import urllib.error
-
         # Use saved key if no valid key provided (modal pattern doesn't hold the real key)
         if not api_key or api_key == "••••":
             api_key = self._settings.get("steamgriddb_api_key", "")
@@ -227,11 +220,11 @@ class SteamGridService:
             if data.get("success"):
                 return {"success": True, "message": "API key is valid"}
             return {"success": False, "message": "API key rejected by SteamGridDB"}
-        except urllib.error.HTTPError as e:
-            self._logger.warning(f"SGDB API key verification HTTP error: {e.code}")
-            if e.code in (401, 403):
+        except SgdbApiError as e:
+            self._logger.warning(f"SGDB API key verification HTTP error: {e.status_code}")
+            if e.status_code in (401, 403):
                 return {"success": False, "message": "Invalid API key"}
-            return {"success": False, "message": f"SteamGridDB error: HTTP {e.code}"}
+            return {"success": False, "message": f"SteamGridDB error: HTTP {e.status_code}"}
         except Exception as e:
             self._logger.error(f"SGDB API key verification failed: {e}")
             return {"success": False, "message": f"Connection failed: {e}"}
@@ -246,16 +239,16 @@ class SteamGridService:
 
     def prune_orphaned_artwork_cache(self):
         """Remove SGDB artwork cache files for rom_ids not in the shortcut registry."""
-        art_dir = os.path.join(self._runtime_dir, "artwork")
-        if not os.path.isdir(art_dir):
+        art_dir = self._sgdb_artwork_cache.cache_dir()
+        if not self._sgdb_artwork_cache.isdir(art_dir):
             return
         registry = self._state.get("shortcut_registry", {})
         pruned = 0
-        for filename in os.listdir(art_dir):
+        for filename in self._sgdb_artwork_cache.listdir(art_dir):
             # Always remove leftover .tmp files
             if filename.endswith(".tmp"):
                 try:
-                    os.remove(os.path.join(art_dir, filename))
+                    self._sgdb_artwork_cache.remove(os.path.join(art_dir, filename))
                     pruned += 1
                     self._logger.info(f"Removed leftover artwork tmp: {filename}")
                 except OSError as e:
@@ -268,7 +261,7 @@ class SteamGridService:
             rom_id = parts[0]
             if rom_id not in registry:
                 try:
-                    os.remove(os.path.join(art_dir, filename))
+                    self._sgdb_artwork_cache.remove(os.path.join(art_dir, filename))
                     pruned += 1
                 except OSError as e:
                     self._logger.warning(f"Failed to remove orphaned artwork {filename}: {e}")
@@ -279,30 +272,19 @@ class SteamGridService:
 
     def _save_icon_to_grid(self, app_id, icon_bytes):
         """Write icon PNG to Steam's grid dir and update shortcuts.vdf icon field."""
-        grid_dir = self._steam_config.grid_dir()
-        if not grid_dir:
-            self._logger.warning("Cannot find Steam grid directory for icon save")
-            return False
-
-        # Write icon file to grid dir
-        icon_path = os.path.join(grid_dir, f"{app_id}_icon.png")
-        tmp_path = icon_path + ".tmp"
         try:
-            with open(tmp_path, "wb") as f:
-                f.write(icon_bytes)
-            os.replace(tmp_path, icon_path)
+            icon_path = self._steam_config.write_shortcut_icon(app_id, icon_bytes)
+        except RuntimeError as e:
+            self._logger.warning(f"Cannot save icon: {e}")
+            return False
         except Exception as e:
-            self._logger.error(f"Failed to write icon file {icon_path}: {e}")
-            if os.path.exists(tmp_path):
-                with contextlib.suppress(OSError):
-                    os.remove(tmp_path)
+            self._logger.error(f"Failed to write icon file for app_id {app_id}: {e}")
             return False
 
         # Update shortcuts.vdf icon field
         try:
             vdf_data = self._steam_config.read_shortcuts()
-            # Convert unsigned app_id to signed int32 for VDF comparison
-            signed_id = struct.unpack("i", struct.pack("I", app_id & 0xFFFFFFFF))[0]
+            signed_id = to_signed_app_id(app_id)
             shortcuts = vdf_data.get("shortcuts", {})
             for entry in shortcuts.values():
                 if entry.get("appid") == signed_id:

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import base64
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from domain.sgdb_artwork import (
@@ -20,14 +21,14 @@ from domain.sgdb_artwork import (
     sgdb_endpoint_path,
     to_signed_app_id,
 )
-from lib.errors import SgdbApiError
+from lib.errors import SgdbApiError, SteamGridDirMissingError
 
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
 
     from services.protocols import (
+        PendingSyncReader,
         RommApiProtocol,
         SettingsPersister,
         SgdbArtworkCache,
@@ -35,6 +36,39 @@ if TYPE_CHECKING:
         SteamConfigAdapter,
         SteamGridDbApi,
     )
+
+
+@dataclass(frozen=True)
+class SteamGridConfig:
+    """Frozen wiring bundle handed to ``SteamGridService.__init__``.
+
+    Holds the runtime infrastructure and external callbacks SteamGridService
+    needs at construction time. Live mutable state references (``state``,
+    ``settings``) and abstract Protocol-typed adapters remain explicit ctor
+    parameters because they have different lifecycles from this immutable
+    wiring bundle.
+
+    Parameters
+    ----------
+    loop:
+        The plugin's ``asyncio`` event loop (for ``run_in_executor``).
+    logger:
+        Standard-library logger (replaces ``decky.logger``).
+    save_state:
+        Persists the main plugin state dict to disk.
+    save_settings_to_disk:
+        Persists the live settings dict to disk after API-key updates.
+    get_pending_sync:
+        Read seam returning the current LibraryService pending-sync map.
+        Used to resolve SGDB IDs for ROMs mid-sync that are not yet in
+        the registry.
+    """
+
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    save_state: StatePersister
+    save_settings_to_disk: SettingsPersister
+    get_pending_sync: PendingSyncReader
 
 
 class SteamGridService:
@@ -49,11 +83,7 @@ class SteamGridService:
         sgdb_artwork_cache: SgdbArtworkCache,
         state: dict,
         settings: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        save_state: StatePersister,
-        save_settings_to_disk: SettingsPersister,
-        get_pending_sync: Callable[[], dict],
+        config: SteamGridConfig,
     ) -> None:
         self._sgdb_api = sgdb_api
         self._romm_api = romm_api
@@ -61,11 +91,11 @@ class SteamGridService:
         self._sgdb_artwork_cache = sgdb_artwork_cache
         self._state = state
         self._settings = settings
-        self._loop = loop
-        self._logger = logger
-        self._save_state = save_state
-        self._save_settings_to_disk = save_settings_to_disk
-        self._get_pending_sync = get_pending_sync
+        self._loop = config.loop
+        self._logger = config.logger
+        self._save_state = config.save_state
+        self._save_settings_to_disk = config.save_settings_to_disk
+        self._get_pending_sync = config.get_pending_sync
 
     # -- logging -----------------------------------------------------------
 
@@ -274,7 +304,7 @@ class SteamGridService:
         """Write icon PNG to Steam's grid dir and update shortcuts.vdf icon field."""
         try:
             icon_path = self._steam_config.write_shortcut_icon(app_id, icon_bytes)
-        except RuntimeError as e:
+        except SteamGridDirMissingError as e:
             self._logger.warning(f"Cannot save icon: {e}")
             return False
         except Exception as e:

--- a/tests/adapters/test_sgdb_artwork_cache.py
+++ b/tests/adapters/test_sgdb_artwork_cache.py
@@ -1,0 +1,152 @@
+"""Tests for SgdbArtworkCacheAdapter — raw filesystem ops for the SGDB artwork cache."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
+
+
+@pytest.fixture
+def cache(tmp_path) -> SgdbArtworkCacheAdapter:
+    return SgdbArtworkCacheAdapter(runtime_dir=str(tmp_path))
+
+
+class TestCacheDir:
+    def test_returns_artwork_subdir(self, cache, tmp_path):
+        result = cache.cache_dir()
+        assert result == os.path.join(str(tmp_path), "artwork")
+
+    def test_creates_dir_if_missing(self, cache, tmp_path):
+        art_dir = tmp_path / "artwork"
+        assert not art_dir.exists()
+        cache.cache_dir()
+        assert art_dir.is_dir()
+
+    def test_idempotent_when_dir_exists(self, cache, tmp_path):
+        (tmp_path / "artwork").mkdir()
+        # Must not raise
+        result = cache.cache_dir()
+        assert result == str(tmp_path / "artwork")
+
+
+class TestExists:
+    def test_true_for_existing_file(self, cache, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"x")
+        assert cache.exists(str(f)) is True
+
+    def test_true_for_directory(self, cache, tmp_path):
+        assert cache.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, cache, tmp_path):
+        assert cache.exists(str(tmp_path / "missing.png")) is False
+
+
+class TestRemove:
+    def test_removes_existing(self, cache, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"x")
+        cache.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, cache, tmp_path):
+        # idempotent: must not raise
+        cache.remove(str(tmp_path / "missing.png"))
+
+    def test_propagates_non_filenotfound_errors(self, cache, tmp_path):
+        # Removing a non-empty directory raises IsADirectoryError or OSError —
+        # anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            cache.remove(str(tmp_path))
+
+
+class TestListdir:
+    def test_returns_entries(self, cache, tmp_path):
+        (tmp_path / "a.png").write_bytes(b"")
+        (tmp_path / "b.png").write_bytes(b"")
+        entries = cache.listdir(str(tmp_path))
+        assert sorted(entries) == ["a.png", "b.png"]
+
+    def test_empty_dir(self, cache, tmp_path):
+        assert cache.listdir(str(tmp_path)) == []
+
+    def test_missing_dir_raises(self, cache, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            cache.listdir(str(tmp_path / "missing"))
+
+
+class TestIsdir:
+    def test_true_for_directory(self, cache, tmp_path):
+        assert cache.isdir(str(tmp_path)) is True
+
+    def test_false_for_file(self, cache, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"")
+        assert cache.isdir(str(f)) is False
+
+    def test_false_for_missing(self, cache, tmp_path):
+        assert cache.isdir(str(tmp_path / "missing")) is False
+
+
+class TestReadBytes:
+    def test_roundtrip(self, cache, tmp_path):
+        f = tmp_path / "a.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n")
+        assert cache.read_bytes(str(f)) == b"\x89PNG\r\n\x1a\n"
+
+    def test_empty_file(self, cache, tmp_path):
+        f = tmp_path / "empty.png"
+        f.write_bytes(b"")
+        assert cache.read_bytes(str(f)) == b""
+
+    def test_missing_raises(self, cache, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            cache.read_bytes(str(tmp_path / "missing.png"))
+
+
+class TestWriteBytesAtomic:
+    def test_writes_data(self, cache, tmp_path):
+        dest = tmp_path / "icon.png"
+        cache.write_bytes_atomic(str(dest), b"icon-payload")
+        assert dest.read_bytes() == b"icon-payload"
+
+    def test_no_tmp_left_after_success(self, cache, tmp_path):
+        dest = tmp_path / "icon.png"
+        cache.write_bytes_atomic(str(dest), b"data")
+        assert not (tmp_path / "icon.png.tmp").exists()
+
+    def test_overwrites_existing(self, cache, tmp_path):
+        dest = tmp_path / "icon.png"
+        dest.write_bytes(b"old")
+        cache.write_bytes_atomic(str(dest), b"new")
+        assert dest.read_bytes() == b"new"
+
+    def test_cleans_tmp_on_failure(self, cache, tmp_path):
+        dest = tmp_path / "icon.png"
+        # Make os.replace fail; the tmp file should be removed and the
+        # exception propagated to the caller.
+        with (
+            patch("adapters.sgdb_artwork_cache.os.replace", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            cache.write_bytes_atomic(str(dest), b"data")
+        assert not (tmp_path / "icon.png.tmp").exists()
+        assert not dest.exists()
+
+    def test_cleans_tmp_when_open_fails(self, cache, tmp_path):
+        dest = tmp_path / "icon.png"
+        # Simulate write-side failure after tmp was opened — ensure that
+        # if a tmp file lingers, the cleanup still suppresses
+        # FileNotFoundError gracefully.
+        with (
+            patch("builtins.open", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            cache.write_bytes_atomic(str(dest), b"data")
+        # tmp may or may not exist depending on how open() failed; what
+        # matters is cleanup didn't itself raise.
+        assert not dest.exists()

--- a/tests/adapters/test_steam_config.py
+++ b/tests/adapters/test_steam_config.py
@@ -193,6 +193,56 @@ class TestWriteShortcuts:
         assert (config_dir / "shortcuts.vdf").exists()
 
 
+# ── write_shortcut_icon ─────────────────────────────────────
+
+
+class TestWriteShortcutIcon:
+    def test_writes_png_to_grid_dir(self, tmp_path):
+        userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
+        userdata.mkdir(parents=True)
+        adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        result = adapter.write_shortcut_icon(12345, b"png-data")
+        grid_dir = userdata / "config" / "grid"
+        expected = grid_dir / "12345_icon.png"
+        assert result == str(expected)
+        assert expected.read_bytes() == b"png-data"
+
+    def test_atomic_write_leaves_no_tmp(self, tmp_path):
+        userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
+        userdata.mkdir(parents=True)
+        adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        adapter.write_shortcut_icon(12345, b"data")
+        grid_dir = userdata / "config" / "grid"
+        assert not (grid_dir / "12345_icon.png.tmp").exists()
+
+    def test_overwrites_existing(self, tmp_path):
+        userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
+        userdata.mkdir(parents=True)
+        adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        adapter.write_shortcut_icon(12345, b"first")
+        adapter.write_shortcut_icon(12345, b"second")
+        grid_dir = userdata / "config" / "grid"
+        assert (grid_dir / "12345_icon.png").read_bytes() == b"second"
+
+    def test_raises_when_no_grid_dir(self, tmp_path):
+        adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        with pytest.raises(RuntimeError, match="grid directory"):
+            adapter.write_shortcut_icon(12345, b"data")
+
+    def test_cleans_tmp_on_failure(self, tmp_path):
+        userdata = tmp_path / ".local" / "share" / "Steam" / "userdata" / "123"
+        userdata.mkdir(parents=True)
+        adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        with (
+            patch("adapters.steam_config.os.replace", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            adapter.write_shortcut_icon(12345, b"data")
+        grid_dir = userdata / "config" / "grid"
+        assert not (grid_dir / "12345_icon.png.tmp").exists()
+        assert not (grid_dir / "12345_icon.png").exists()
+
+
 # ── set_steam_input_config ──────────────────────────────────
 
 

--- a/tests/adapters/test_steam_config.py
+++ b/tests/adapters/test_steam_config.py
@@ -6,6 +6,7 @@ import pytest
 import vdf
 
 from adapters.steam_config import SteamConfigAdapter
+from lib.errors import SteamGridDirMissingError
 
 
 @pytest.fixture
@@ -226,7 +227,7 @@ class TestWriteShortcutIcon:
 
     def test_raises_when_no_grid_dir(self, tmp_path):
         adapter = SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
-        with pytest.raises(RuntimeError, match="grid directory"):
+        with pytest.raises(SteamGridDirMissingError, match="grid directory"):
             adapter.write_shortcut_icon(12345, b"data")
 
     def test_cleans_tmp_on_failure(self, tmp_path):

--- a/tests/adapters/test_steamgriddb.py
+++ b/tests/adapters/test_steamgriddb.py
@@ -1,12 +1,15 @@
 """Tests for adapters.steamgriddb — SteamGridDB HTTP adapter."""
 
+import http.client
 import json
 import logging
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from adapters.steamgriddb import SteamGridDbAdapter
+from lib.errors import SgdbApiError
 
 
 @pytest.fixture
@@ -111,3 +114,32 @@ class TestVerifyApiKey:
             adapter.verify_api_key("different-key")
             req = mock_open.call_args[0][0]
             assert req.get_header("Authorization") == "Bearer different-key"
+
+    def test_http_error_raises_sgdb_api_error(self, adapter):
+        http_error = urllib.error.HTTPError(
+            "https://steamgriddb.com", 401, "Unauthorized", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=http_error):
+            with pytest.raises(SgdbApiError) as exc_info:
+                adapter.verify_api_key("bad-key")
+            assert exc_info.value.status_code == 401
+
+    def test_http_500_raises_sgdb_api_error(self, adapter):
+        http_error = urllib.error.HTTPError(
+            "https://steamgriddb.com", 500, "Server Error", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=http_error):
+            with pytest.raises(SgdbApiError) as exc_info:
+                adapter.verify_api_key("any-key")
+            assert exc_info.value.status_code == 500
+
+
+class TestRequestHttpErrorWrapping:
+    def test_request_wraps_http_error(self, adapter):
+        http_error = urllib.error.HTTPError(
+            "https://steamgriddb.com", 403, "Forbidden", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=http_error):
+            with pytest.raises(SgdbApiError) as exc_info:
+                adapter.request("/games/igdb/123")
+            assert exc_info.value.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,14 @@ class FakeSgdbArtworkCache:
     the loose "directory exists when it contains files" semantics tests
     need.
 
+    ``write_bytes_atomic`` models the real adapter's tmp-file +
+    ``os.replace`` round-trip: the data lands at ``path + ".tmp"``
+    first, then renames to ``path`` on success. Set
+    ``fail_on_atomic_write`` to make the rename step raise — the
+    tmp file is cleaned up before the exception propagates, mirroring
+    the adapter's behaviour. ``tmp_files`` exposes the set of
+    in-flight tmp paths for tests that need to assert on them.
+
     Tests can pre-populate ``files`` directly to stage cached artwork.
     ``isdir_paths`` can be set explicitly when a test needs to model an
     empty cache directory.
@@ -184,6 +192,8 @@ class FakeSgdbArtworkCache:
         self.files: dict[str, bytes] = dict(files) if files else {}
         self.isdir_paths: set[str] | None = None
         self.cache_dir_call_count = 0
+        self.fail_on_atomic_write: bool = False
+        self.tmp_files: set[str] = set()
 
     def cache_dir(self) -> str:
         self.cache_dir_call_count += 1
@@ -215,7 +225,15 @@ class FakeSgdbArtworkCache:
         return self.files[path]
 
     def write_bytes_atomic(self, path: str, data: bytes) -> None:
-        self.files[path] = data
+        tmp_path = path + ".tmp"
+        self.tmp_files.add(tmp_path)
+        self.files[tmp_path] = data
+        if self.fail_on_atomic_write:
+            self.files.pop(tmp_path, None)
+            self.tmp_files.discard(tmp_path)
+            raise OSError("simulated atomic-write failure")
+        self.files[path] = self.files.pop(tmp_path)
+        self.tmp_files.discard(tmp_path)
 
 
 class FakeCoreInfoProvider:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,61 @@ class FakeCoverArtFileStore:
         return self.files[path]
 
 
+class FakeSgdbArtworkCache:
+    """In-memory ``SgdbArtworkCache`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` is idempotent per the
+    Protocol contract. ``cache_dir`` returns the canonical
+    ``{cache_root}/artwork`` path; ``isdir`` reports True for any path
+    that is the parent of an entry or matches ``cache_dir``, mirroring
+    the loose "directory exists when it contains files" semantics tests
+    need.
+
+    Tests can pre-populate ``files`` directly to stage cached artwork.
+    ``isdir_paths`` can be set explicitly when a test needs to model an
+    empty cache directory.
+    """
+
+    def __init__(self, cache_root: str = "/runtime", files: dict[str, bytes] | None = None) -> None:
+        self._cache_dir = os.path.join(cache_root, "artwork")
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        self.isdir_paths: set[str] | None = None
+        self.cache_dir_call_count = 0
+
+    def cache_dir(self) -> str:
+        self.cache_dir_call_count += 1
+        return self._cache_dir
+
+    def exists(self, path: str) -> bool:
+        return path in self.files or self.isdir(path)
+
+    def remove(self, path: str) -> None:
+        self.files.pop(path, None)
+
+    def listdir(self, directory: str) -> list[str]:
+        prefix = directory.rstrip("/") + "/"
+        return [
+            path[len(prefix) :] for path in self.files if path.startswith(prefix) and "/" not in path[len(prefix) :]
+        ]
+
+    def isdir(self, path: str) -> bool:
+        if self.isdir_paths is not None:
+            return path in self.isdir_paths
+        if path == self._cache_dir:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def read_bytes(self, path: str) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    def write_bytes_atomic(self, path: str, data: bytes) -> None:
+        self.files[path] = data
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/domain/test_sgdb_artwork.py
+++ b/tests/domain/test_sgdb_artwork.py
@@ -1,0 +1,88 @@
+"""Tests for domain.sgdb_artwork — SGDB asset-type and endpoint helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.sgdb_artwork import (
+    asset_type_endpoint,
+    asset_type_name,
+    sgdb_endpoint_path,
+    to_signed_app_id,
+)
+
+
+class TestAssetTypeName:
+    @pytest.mark.parametrize(
+        ("type_num", "expected"),
+        [
+            (1, "hero"),
+            (2, "logo"),
+            (3, "grid"),
+            (4, "icon"),
+        ],
+    )
+    def test_known_codes(self, type_num, expected):
+        assert asset_type_name(type_num) == expected
+
+    def test_unknown_returns_none(self):
+        assert asset_type_name(99) is None
+
+    def test_zero_returns_none(self):
+        assert asset_type_name(0) is None
+
+
+class TestAssetTypeEndpoint:
+    @pytest.mark.parametrize(
+        ("name", "endpoint"),
+        [
+            ("hero", "heroes"),
+            ("logo", "logos"),
+            ("grid", "grids"),
+            ("icon", "icons"),
+        ],
+    )
+    def test_known_names(self, name, endpoint):
+        assert asset_type_endpoint(name) == endpoint
+
+    def test_unknown_returns_none(self):
+        assert asset_type_endpoint("banner") is None
+
+    def test_empty_returns_none(self):
+        assert asset_type_endpoint("") is None
+
+
+class TestSgdbEndpointPath:
+    def test_hero_path(self):
+        assert sgdb_endpoint_path("hero", 9999) == "/heroes/game/9999"
+
+    def test_logo_path(self):
+        assert sgdb_endpoint_path("logo", 42) == "/logos/game/42"
+
+    def test_icon_path(self):
+        assert sgdb_endpoint_path("icon", 1) == "/icons/game/1"
+
+    def test_grid_path_appends_dimensions_query(self):
+        assert sgdb_endpoint_path("grid", 7) == "/grids/game/7?dimensions=460x215,920x430"
+
+    def test_unknown_asset_returns_none(self):
+        assert sgdb_endpoint_path("banner", 1) is None
+
+
+class TestToSignedAppId:
+    def test_low_positive_unchanged(self):
+        # Values below 2^31 round-trip as themselves.
+        assert to_signed_app_id(100001) == 100001
+        assert to_signed_app_id(0) == 0
+        assert to_signed_app_id(1) == 1
+
+    def test_high_bit_becomes_negative(self):
+        # 3_000_000_000 has its high bit set in 32-bit space → negative as int32.
+        # Confirmed in steamgrid tests: app_id 3000000000 → signed = -1294967296.
+        assert to_signed_app_id(3000000000) == -1294967296
+
+    def test_max_uint32_is_negative_one(self):
+        assert to_signed_app_id(0xFFFFFFFF) == -1
+
+    def test_2_pow_31_is_int32_min(self):
+        assert to_signed_app_id(0x80000000) == -2147483648

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -8,12 +8,12 @@ from conftest import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.steam_config import SteamConfigAdapter
-from lib.errors import SgdbApiError
+from lib.errors import SgdbApiError, SteamGridDirMissingError
 
 # conftest.py patches decky before this import
 from main import Plugin
 from services.library import LibraryService
-from services.steamgrid import SteamGridService
+from services.steamgrid import SteamGridConfig, SteamGridService
 
 
 @pytest.fixture
@@ -63,11 +63,13 @@ def plugin(sgdb_artwork_cache):
         sgdb_artwork_cache=sgdb_artwork_cache,
         state=p._state,
         settings=p.settings,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        save_state=MagicMock(),
-        save_settings_to_disk=MagicMock(),
-        get_pending_sync=lambda: p._sync_service._pending_sync,
+        config=SteamGridConfig(
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            save_state=MagicMock(),
+            save_settings_to_disk=MagicMock(),
+            get_pending_sync=lambda: p._sync_service._pending_sync,
+        ),
     )
     return p
 
@@ -608,10 +610,10 @@ class TestSaveShortcutIcon:
     def test_save_icon_to_grid_no_grid_dir(self, plugin):
         """Should return False if the grid directory cannot be found."""
 
-        def raise_runtime(_app_id, _bytes):
-            raise RuntimeError("Cannot find Steam grid directory")
+        def raise_missing(_app_id, _bytes):
+            raise SteamGridDirMissingError("Cannot find Steam grid directory")
 
-        plugin._steam_config.write_shortcut_icon = raise_runtime  # type: ignore[method-assign]
+        plugin._steam_config.write_shortcut_icon = raise_missing  # type: ignore[method-assign]
 
         result = plugin._sgdb_service._save_icon_to_grid(12345, b"data")
         assert result is False
@@ -689,3 +691,34 @@ class TestSaveShortcutIcon:
         result = await plugin.save_shortcut_icon(12345, "not-valid-base64!!!")
 
         assert result["success"] is False
+
+
+class TestFakeSgdbArtworkCacheAtomicWrite:
+    """Unit tests for the in-memory fake's ``write_bytes_atomic`` round-trip.
+
+    Verifies the fake models the real adapter's ``path.tmp`` -> ``os.replace``
+    sequence so service-layer tests can exercise atomic-write failure paths
+    through the same Protocol seam.
+    """
+
+    def test_happy_path_writes_final_and_clears_tmp(self):
+        cache = FakeSgdbArtworkCache()
+        dest = os.path.join(cache.cache_dir(), "42_hero.png")
+
+        cache.write_bytes_atomic(dest, b"payload")
+
+        assert cache.files[dest] == b"payload"
+        assert (dest + ".tmp") not in cache.files
+        assert cache.tmp_files == set()
+
+    def test_failure_cleans_tmp_and_raises(self):
+        cache = FakeSgdbArtworkCache()
+        cache.fail_on_atomic_write = True
+        dest = os.path.join(cache.cache_dir(), "42_hero.png")
+
+        with pytest.raises(OSError, match="simulated atomic-write failure"):
+            cache.write_bytes_atomic(dest, b"payload")
+
+        assert dest not in cache.files
+        assert (dest + ".tmp") not in cache.files
+        assert cache.tmp_files == set()

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -1,11 +1,14 @@
 import asyncio
 import http.client
+import os
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.steam_config import SteamConfigAdapter
+from lib.errors import SgdbApiError
 
 # conftest.py patches decky before this import
 from main import Plugin
@@ -14,7 +17,13 @@ from services.steamgrid import SteamGridService
 
 
 @pytest.fixture
-def plugin():
+def sgdb_artwork_cache():
+    """Fresh in-memory SGDB artwork cache per test."""
+    return FakeSgdbArtworkCache(cache_root="/runtime")
+
+
+@pytest.fixture
+def plugin(sgdb_artwork_cache):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
@@ -51,11 +60,11 @@ def plugin():
         sgdb_api=sgdb_api,
         romm_api=p._romm_api,
         steam_config=steam_config,
+        sgdb_artwork_cache=sgdb_artwork_cache,
         state=p._state,
         settings=p.settings,
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
-        runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
         save_state=MagicMock(),
         save_settings_to_disk=MagicMock(),
         get_pending_sync=lambda: p._sync_service._pending_sync,
@@ -67,6 +76,10 @@ def plugin():
 async def _set_event_loop(plugin):
     """Ensure plugin.loop matches the running event loop for async tests."""
     plugin.loop = asyncio.get_event_loop()
+
+
+def _cached_path(cache: FakeSgdbArtworkCache, rom_id: int, asset_type: str) -> str:
+    return os.path.join(cache.cache_dir(), f"{rom_id}_{asset_type}.png")
 
 
 class TestVerifySgdbApiKey:
@@ -83,12 +96,8 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_invalid_api_key_401(self, plugin):
-        import urllib.error
-
         plugin._sgdb_service._loop = asyncio.get_event_loop()
-        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = urllib.error.HTTPError(
-            "https://steamgriddb.com", 401, "Unauthorized", http.client.HTTPMessage(), None
-        )
+        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = SgdbApiError(401, "Unauthorized")
 
         result = await plugin.verify_sgdb_api_key("bad-key")
 
@@ -97,12 +106,8 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_invalid_api_key_403(self, plugin):
-        import urllib.error
-
         plugin._sgdb_service._loop = asyncio.get_event_loop()
-        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = urllib.error.HTTPError(
-            "https://steamgriddb.com", 403, "Forbidden", http.client.HTTPMessage(), None
-        )
+        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = SgdbApiError(403, "Forbidden")
 
         result = await plugin.verify_sgdb_api_key("bad-key")
 
@@ -169,33 +174,41 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_http_500_error(self, plugin):
-        import urllib.error
-
         plugin._sgdb_service._loop = asyncio.get_event_loop()
-        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = urllib.error.HTTPError(
-            "https://steamgriddb.com", 500, "Internal Server Error", http.client.HTTPMessage(), None
-        )
+        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = SgdbApiError(500, "Internal Server Error")
 
         result = await plugin.verify_sgdb_api_key("some-key")
 
         assert result["success"] is False
         assert "HTTP 500" in result["message"]
 
+    @pytest.mark.asyncio
+    async def test_legacy_urllib_http_error_still_handled(self, plugin):
+        """Defence-in-depth: a stray urllib.error.HTTPError should still be handled."""
+        import urllib.error
+
+        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._sgdb_api.verify_api_key.side_effect = urllib.error.HTTPError(
+            "https://steamgriddb.com", 502, "Bad Gateway", http.client.HTTPMessage(), None
+        )
+
+        result = await plugin.verify_sgdb_api_key("some-key")
+
+        assert result["success"] is False
+        # Falls into the generic Exception branch since it's not an SgdbApiError.
+        assert "Connection failed" in result["message"]
+
 
 class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
-    async def test_cached_artwork_returns_base64(self, plugin, tmp_path):
+    async def test_cached_artwork_returns_base64(self, plugin, sgdb_artwork_cache):
         import base64
 
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 
-        # Create cached artwork file
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_hero.png"
-        art_file.write_bytes(b"fake png data")
+        # Pre-populate the in-memory cache
+        sgdb_artwork_cache.files[_cached_path(sgdb_artwork_cache, 42, "hero")] = b"fake png data"
 
         result = await plugin.get_sgdb_artwork_base64(42, 1)  # 1 = hero
         assert result["no_api_key"] is False
@@ -203,9 +216,7 @@ class TestGetSgdbArtworkBase64:
         assert base64.b64decode(result["base64"]) == b"fake png data"
 
     @pytest.mark.asyncio
-    async def test_no_api_key_returns_no_api_key_true(self, plugin, tmp_path):
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
+    async def test_no_api_key_returns_no_api_key_true(self, plugin):
         # No API key in settings
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 
@@ -214,9 +225,7 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is True
 
     @pytest.mark.asyncio
-    async def test_invalid_asset_type(self, plugin, tmp_path):
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
+    async def test_invalid_asset_type(self, plugin):
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 
@@ -225,11 +234,9 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is False
 
     @pytest.mark.asyncio
-    async def test_no_igdb_id_fetched_from_romm(self, plugin, tmp_path):
+    async def test_no_igdb_id_fetched_from_romm(self, plugin, sgdb_artwork_cache):
         import base64
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -244,14 +251,11 @@ class TestGetSgdbArtworkBase64:
         # RomM API returns igdb_id
         romm_response = {"igdb_id": 1234}
 
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_hero.png"
+        art_path = _cached_path(sgdb_artwork_cache, 42, "hero")
 
         def fake_download_sgdb(sgdb_game_id, rom_id, asset_type):
-            # Simulate writing the file
-            art_file.write_bytes(b"hero artwork")
-            return str(art_file)
+            sgdb_artwork_cache.files[art_path] = b"hero artwork"
+            return art_path
 
         svc = plugin._sgdb_service
         with (
@@ -268,10 +272,8 @@ class TestGetSgdbArtworkBase64:
         assert plugin._state["shortcut_registry"]["42"]["igdb_id"] == 1234
 
     @pytest.mark.asyncio
-    async def test_no_igdb_id_anywhere(self, plugin, tmp_path):
+    async def test_no_igdb_id_anywhere(self, plugin):
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -291,10 +293,8 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is False
 
     @pytest.mark.asyncio
-    async def test_sgdb_game_lookup_no_match(self, plugin, tmp_path):
+    async def test_sgdb_game_lookup_no_match(self, plugin):
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -315,10 +315,8 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is False
 
     @pytest.mark.asyncio
-    async def test_download_fails_returns_null(self, plugin, tmp_path):
+    async def test_download_fails_returns_null(self, plugin):
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -339,11 +337,9 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is False
 
     @pytest.mark.asyncio
-    async def test_igdb_id_from_pending_sync(self, plugin, tmp_path):
+    async def test_igdb_id_from_pending_sync(self, plugin, sgdb_artwork_cache):
         import base64
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -355,13 +351,11 @@ class TestGetSgdbArtworkBase64:
             "igdb_id": 5678,
         }
 
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_logo.png"
+        art_path = _cached_path(sgdb_artwork_cache, 42, "logo")
 
         def fake_download_sgdb(sgdb_game_id, rom_id, asset_type):
-            art_file.write_bytes(b"logo data")
-            return str(art_file)
+            sgdb_artwork_cache.files[art_path] = b"logo data"
+            return art_path
 
         svc = plugin._sgdb_service
         with (
@@ -374,10 +368,8 @@ class TestGetSgdbArtworkBase64:
         assert base64.b64decode(result["base64"]) == b"logo data"
 
     @pytest.mark.asyncio
-    async def test_romm_api_fetch_fails_gracefully(self, plugin, tmp_path):
+    async def test_romm_api_fetch_fails_gracefully(self, plugin):
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -390,10 +382,8 @@ class TestGetSgdbArtworkBase64:
         assert result["no_api_key"] is False
 
     @pytest.mark.asyncio
-    async def test_sgdb_id_cached_in_registry(self, plugin, tmp_path):
+    async def test_sgdb_id_cached_in_registry(self, plugin, sgdb_artwork_cache):
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -407,14 +397,12 @@ class TestGetSgdbArtworkBase64:
             "sgdb_id": 9999,
         }
 
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_grid.png"
+        art_path = _cached_path(sgdb_artwork_cache, 42, "grid")
 
         def fake_download_sgdb(sgdb_game_id, rom_id, asset_type):
             assert sgdb_game_id == 9999  # Should use cached sgdb_id
-            art_file.write_bytes(b"grid data")
-            return str(art_file)
+            sgdb_artwork_cache.files[art_path] = b"grid data"
+            return art_path
 
         svc = plugin._sgdb_service
         # _get_sgdb_game_id should NOT be called since sgdb_id is cached
@@ -437,20 +425,15 @@ class TestIconSupport:
         assert plugin._sgdb_service._download_sgdb_artwork  # method exists
 
     @pytest.mark.asyncio
-    async def test_icon_asset_type_num_is_4(self, plugin, tmp_path):
+    async def test_icon_asset_type_num_is_4(self, plugin, sgdb_artwork_cache):
         """Asset type number 4 should map to 'icon'."""
         import base64
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 
-        # Create cached icon file
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_icon.png"
-        art_file.write_bytes(b"icon png data")
+        # Pre-populate cache
+        sgdb_artwork_cache.files[_cached_path(sgdb_artwork_cache, 42, "icon")] = b"icon png data"
 
         result = await plugin.get_sgdb_artwork_base64(42, 4)  # 4 = icon
         assert result["no_api_key"] is False
@@ -458,12 +441,10 @@ class TestIconSupport:
         assert base64.b64decode(result["base64"]) == b"icon png data"
 
     @pytest.mark.asyncio
-    async def test_icon_download_from_sgdb(self, plugin, tmp_path):
+    async def test_icon_download_from_sgdb(self, plugin, sgdb_artwork_cache):
         """Icon should be downloadable from SGDB icons endpoint."""
         import base64
         from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
         plugin._sgdb_service._loop = asyncio.get_event_loop()
@@ -476,15 +457,13 @@ class TestIconSupport:
             "sgdb_id": 9999,
         }
 
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        art_file = art_dir / "42_icon.png"
+        art_path = _cached_path(sgdb_artwork_cache, 42, "icon")
 
         def fake_download_sgdb(sgdb_game_id, rom_id, asset_type):
             assert asset_type == "icon"
             assert sgdb_game_id == 9999
-            art_file.write_bytes(b"icon data")
-            return str(art_file)
+            sgdb_artwork_cache.files[art_path] = b"icon data"
+            return art_path
 
         with patch.object(plugin._sgdb_service, "_download_sgdb_artwork", side_effect=fake_download_sgdb):
             result = await plugin.get_sgdb_artwork_base64(42, 4)
@@ -492,13 +471,8 @@ class TestIconSupport:
         assert result["base64"] is not None
         assert base64.b64decode(result["base64"]) == b"icon data"
 
-    def test_download_sgdb_artwork_icon_endpoint(self, plugin, tmp_path):
+    def test_download_sgdb_artwork_icon_endpoint(self, plugin):
         """_download_sgdb_artwork should use /icons/ endpoint for icon type."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-
         # Track which SGDB path was requested
         requested_paths = []
 
@@ -517,122 +491,101 @@ class TestIconSupport:
 
 
 class TestPruneOrphanedArtworkCache:
-    def test_removes_orphan_artwork(self, plugin, tmp_path):
+    def test_removes_orphan_artwork(self, plugin, sgdb_artwork_cache):
         """Artwork for rom_id not in registry should be deleted."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        orphan = art_dir / "42_hero.png"
-        orphan.write_bytes(b"orphaned data")
+        orphan = _cached_path(sgdb_artwork_cache, 42, "hero")
+        sgdb_artwork_cache.files[orphan] = b"orphaned data"
 
         # Registry has no rom_id "42"
         plugin._state["shortcut_registry"] = {"99": {"app_id": 1}}
 
         plugin._sgdb_service.prune_orphaned_artwork_cache()
 
-        assert not orphan.exists()
+        assert orphan not in sgdb_artwork_cache.files
 
-    def test_keeps_artwork_in_registry(self, plugin, tmp_path):
+    def test_keeps_artwork_in_registry(self, plugin, sgdb_artwork_cache):
         """Artwork for rom_id in registry should survive."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        kept = art_dir / "42_hero.png"
-        kept.write_bytes(b"keep me")
+        kept = _cached_path(sgdb_artwork_cache, 42, "hero")
+        sgdb_artwork_cache.files[kept] = b"keep me"
 
         plugin._state["shortcut_registry"] = {"42": {"app_id": 1}}
 
         plugin._sgdb_service.prune_orphaned_artwork_cache()
 
-        assert kept.exists()
-        assert kept.read_bytes() == b"keep me"
+        assert sgdb_artwork_cache.files[kept] == b"keep me"
 
-    def test_removes_leftover_tmp(self, plugin, tmp_path):
+    def test_removes_leftover_tmp(self, plugin, sgdb_artwork_cache):
         """Leftover .tmp files should always be removed regardless of rom_id."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        tmp_file = art_dir / "42_hero.png.tmp"
-        tmp_file.write_bytes(b"tmp data")
+        tmp_path = _cached_path(sgdb_artwork_cache, 42, "hero") + ".tmp"
+        sgdb_artwork_cache.files[tmp_path] = b"tmp data"
 
         # rom_id "42" IS in registry, but .tmp should still be removed
         plugin._state["shortcut_registry"] = {"42": {"app_id": 1}}
 
         plugin._sgdb_service.prune_orphaned_artwork_cache()
 
-        assert not tmp_file.exists()
+        assert tmp_path not in sgdb_artwork_cache.files
 
-    def test_empty_artwork_dir(self, plugin, tmp_path):
+    def test_empty_artwork_dir(self, plugin):
         """No crash on empty artwork directory."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-
         plugin._sgdb_service.prune_orphaned_artwork_cache()
         # Should complete without error
 
-    def test_no_artwork_dir(self, plugin, tmp_path):
+    def test_no_artwork_dir(self, plugin, sgdb_artwork_cache):
         """No crash when artwork directory doesn't exist."""
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        # Don't create artwork dir
+        # Mark the cache directory as absent.
+        sgdb_artwork_cache.isdir_paths = set()
         plugin._sgdb_service.prune_orphaned_artwork_cache()
         # Should complete without error
 
-    def test_handles_os_error(self, plugin, tmp_path):
-        """OSError on os.remove should log warning, not crash."""
-        from unittest.mock import patch
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
-        art_dir = tmp_path / "artwork"
-        art_dir.mkdir()
-        orphan = art_dir / "42_hero.png"
-        orphan.write_bytes(b"orphaned data")
+    def test_handles_os_error(self, plugin, sgdb_artwork_cache):
+        """OSError on cache.remove should log warning, not crash."""
+        orphan = _cached_path(sgdb_artwork_cache, 42, "hero")
+        sgdb_artwork_cache.files[orphan] = b"orphaned data"
 
         plugin._state["shortcut_registry"] = {}
 
-        with patch("os.remove", side_effect=OSError("Permission denied")):
-            plugin._sgdb_service.prune_orphaned_artwork_cache()
+        def raising_remove(_path: str) -> None:
+            raise OSError("Permission denied")
 
-        # File still exists because os.remove was mocked to fail
-        assert orphan.exists()
-        # Warning should have been logged (no crash)
+        sgdb_artwork_cache.remove = raising_remove  # type: ignore[method-assign]
+        plugin._sgdb_service.prune_orphaned_artwork_cache()
+        # File still exists because remove was patched to fail
+        assert orphan in sgdb_artwork_cache.files
 
 
 class TestSaveShortcutIcon:
     """Tests for VDF-based icon saving (save_shortcut_icon callable)."""
 
     def test_save_icon_to_grid_writes_file(self, plugin, tmp_path):
-        """Icon PNG should be written to Steam's grid directory."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._steam_config.read_shortcuts = lambda: {"shortcuts": {}}
-        plugin._steam_config.write_shortcuts = lambda data: None
+        """Icon PNG should be written via the SteamConfigAdapter seam."""
+        written: dict = {}
+
+        def fake_write_icon(app_id, icon_bytes):
+            path = os.path.join(str(tmp_path), f"{app_id}_icon.png")
+            written[path] = icon_bytes
+            return path
+
+        plugin._steam_config.write_shortcut_icon = fake_write_icon  # type: ignore[method-assign]
+        plugin._steam_config.read_shortcuts = lambda: {"shortcuts": {}}  # type: ignore[method-assign]
+        plugin._steam_config.write_shortcuts = lambda data: None  # type: ignore[method-assign]
 
         result = plugin._sgdb_service._save_icon_to_grid(12345, b"fake png data")
 
         assert result is True
-        icon_path = grid_dir / "12345_icon.png"
-        assert icon_path.exists()
-        assert icon_path.read_bytes() == b"fake png data"
+        icon_path = os.path.join(str(tmp_path), "12345_icon.png")
+        assert written[icon_path] == b"fake png data"
 
     def test_save_icon_to_grid_updates_vdf(self, plugin, tmp_path):
         """VDF icon field should be updated for the matching shortcut."""
-        import struct
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
+        from domain.sgdb_artwork import to_signed_app_id
 
         # app_id 3000000000 -> signed = -1294967296
         app_id = 3000000000
-        signed_id = struct.unpack("i", struct.pack("I", app_id & 0xFFFFFFFF))[0]
+        signed_id = to_signed_app_id(app_id)
+
+        def fake_write_icon(a, _b):
+            return os.path.join(str(tmp_path), f"{a}_icon.png")
 
         written_data = {}
 
@@ -642,8 +595,9 @@ class TestSaveShortcutIcon:
         def mock_write(data):
             written_data.update(data)
 
-        plugin._steam_config.read_shortcuts = mock_read
-        plugin._steam_config.write_shortcuts = mock_write
+        plugin._steam_config.write_shortcut_icon = fake_write_icon  # type: ignore[method-assign]
+        plugin._steam_config.read_shortcuts = mock_read  # type: ignore[method-assign]
+        plugin._steam_config.write_shortcuts = mock_write  # type: ignore[method-assign]
 
         result = plugin._sgdb_service._save_icon_to_grid(app_id, b"icon data")
 
@@ -652,17 +606,37 @@ class TestSaveShortcutIcon:
         assert shortcut["icon"].endswith(f"{app_id}_icon.png")
 
     def test_save_icon_to_grid_no_grid_dir(self, plugin):
-        """Should return False if grid directory cannot be found."""
-        plugin._steam_config.grid_dir = lambda: None
+        """Should return False if the grid directory cannot be found."""
+
+        def raise_runtime(_app_id, _bytes):
+            raise RuntimeError("Cannot find Steam grid directory")
+
+        plugin._steam_config.write_shortcut_icon = raise_runtime  # type: ignore[method-assign]
+
+        result = plugin._sgdb_service._save_icon_to_grid(12345, b"data")
+        assert result is False
+
+    def test_save_icon_to_grid_write_failure(self, plugin):
+        """Unexpected write failures should return False without crashing."""
+
+        def raise_oserror(_app_id, _bytes):
+            raise OSError("disk full")
+
+        plugin._steam_config.write_shortcut_icon = raise_oserror  # type: ignore[method-assign]
 
         result = plugin._sgdb_service._save_icon_to_grid(12345, b"data")
         assert result is False
 
     def test_save_icon_to_grid_vdf_mismatch_still_writes_file(self, plugin, tmp_path):
         """If VDF has no matching shortcut, icon file should still be saved."""
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
+        written: dict = {}
+
+        def fake_write_icon(app_id, icon_bytes):
+            path = os.path.join(str(tmp_path), f"{app_id}_icon.png")
+            written[path] = icon_bytes
+            return path
+
+        plugin._steam_config.write_shortcut_icon = fake_write_icon  # type: ignore[method-assign]
 
         written_data = {}
 
@@ -672,13 +646,14 @@ class TestSaveShortcutIcon:
         def mock_write(data):
             written_data.update(data)
 
-        plugin._steam_config.read_shortcuts = mock_read
-        plugin._steam_config.write_shortcuts = mock_write
+        plugin._steam_config.read_shortcuts = mock_read  # type: ignore[method-assign]
+        plugin._steam_config.write_shortcuts = mock_write  # type: ignore[method-assign]
 
         result = plugin._sgdb_service._save_icon_to_grid(12345, b"icon data")
 
         assert result is True
-        assert (grid_dir / "12345_icon.png").exists()
+        icon_path = os.path.join(str(tmp_path), "12345_icon.png")
+        assert written[icon_path] == b"icon data"
         # VDF was written but icon field not set on any shortcut
         assert written_data["shortcuts"]["0"].get("icon") is None
 
@@ -687,21 +662,27 @@ class TestSaveShortcutIcon:
         """save_shortcut_icon callable should decode base64 and save."""
         import base64
 
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-        plugin._steam_config.read_shortcuts = lambda: {"shortcuts": {}}
-        plugin._steam_config.write_shortcuts = lambda data: None
+        written: dict = {}
+
+        def fake_write_icon(app_id, icon_bytes):
+            path = os.path.join(str(tmp_path), f"{app_id}_icon.png")
+            written[path] = icon_bytes
+            return path
+
+        plugin._steam_config.write_shortcut_icon = fake_write_icon  # type: ignore[method-assign]
+        plugin._steam_config.read_shortcuts = lambda: {"shortcuts": {}}  # type: ignore[method-assign]
+        plugin._steam_config.write_shortcuts = lambda data: None  # type: ignore[method-assign]
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 
         icon_b64 = base64.b64encode(b"real icon png").decode("ascii")
         result = await plugin.save_shortcut_icon(12345, icon_b64)
 
         assert result["success"] is True
-        assert (grid_dir / "12345_icon.png").read_bytes() == b"real icon png"
+        icon_path = os.path.join(str(tmp_path), "12345_icon.png")
+        assert written[icon_path] == b"real icon png"
 
     @pytest.mark.asyncio
-    async def test_save_shortcut_icon_invalid_base64(self, plugin, tmp_path):
+    async def test_save_shortcut_icon_invalid_base64(self, plugin):
         """Invalid base64 should return success=False."""
         plugin._sgdb_service._loop = asyncio.get_event_loop()
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -13,7 +13,12 @@ from bootstrap import (
     bootstrap,
     wire_services,
 )
-from conftest import FakeCoreInfoProvider, FakeCoverArtFileStore, FakeFirmwareCachePersister
+from conftest import (
+    FakeCoreInfoProvider,
+    FakeCoverArtFileStore,
+    FakeFirmwareCachePersister,
+    FakeSgdbArtworkCache,
+)
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -147,6 +152,7 @@ class TestWireServices:
             "steam_config": steam_config,
             "sgdb_adapter": MagicMock(),
             "cover_art_file_store": FakeCoverArtFileStore(),
+            "sgdb_artwork_cache": FakeSgdbArtworkCache(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -184,6 +190,7 @@ class TestWireServices:
                 steam_config=deps["steam_config"],
                 sgdb_adapter=deps["sgdb_adapter"],
                 cover_art_file_store=deps["cover_art_file_store"],
+                sgdb_artwork_cache=deps["sgdb_artwork_cache"],
             ),
             stores=StateBundle(
                 state=deps["state"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,7 +13,7 @@ from adapters.steam_config import SteamConfigAdapter
 # conftest.py patches decky before this import
 from main import Plugin
 from services.library import LibraryService
-from services.steamgrid import SteamGridService
+from services.steamgrid import SteamGridConfig, SteamGridService
 
 
 @pytest.fixture
@@ -64,11 +64,13 @@ def plugin():
         sgdb_artwork_cache=FakeSgdbArtworkCache(cache_root=decky.DECKY_PLUGIN_RUNTIME_DIR),
         state=p._state,
         settings=p.settings,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        save_state=MagicMock(),
-        save_settings_to_disk=MagicMock(),
-        get_pending_sync=lambda: p._sync_service._pending_sync,
+        config=SteamGridConfig(
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            save_state=MagicMock(),
+            save_settings_to_disk=MagicMock(),
+            get_pending_sync=lambda: p._sync_service._pending_sync,
+        ),
     )
     return p
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -60,11 +61,11 @@ def plugin():
         sgdb_api=MagicMock(),
         romm_api=p._romm_api,
         steam_config=steam_config,
+        sgdb_artwork_cache=FakeSgdbArtworkCache(cache_root=decky.DECKY_PLUGIN_RUNTIME_DIR),
         state=p._state,
         settings=p.settings,
         loop=asyncio.get_event_loop(),
         logger=decky.logger,
-        runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
         save_state=MagicMock(),
         save_settings_to_disk=MagicMock(),
         get_pending_sync=lambda: p._sync_service._pending_sync,
@@ -298,8 +299,6 @@ class TestLogLevel:
 
         import decky
 
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
-
         plugin.settings["log_level"] = "warn"
         with patch.object(decky.logger, "info") as mock_info:
             result = await plugin.get_sgdb_artwork_base64(1, 99)
@@ -313,8 +312,6 @@ class TestLogLevel:
         from unittest.mock import patch
 
         import decky
-
-        plugin._sgdb_service._runtime_dir = str(tmp_path)
 
         plugin.settings["log_level"] = "debug"
         plugin.settings["steamgriddb_api_key"] = ""
@@ -1093,6 +1090,7 @@ class TestMainStartupOrdering:
             "steam_config": MagicMock(),
             "sgdb_adapter": MagicMock(),
             "cover_art_file_store": MagicMock(),
+            "sgdb_artwork_cache": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),
             "retroarch_core_info": MagicMock(),


### PR DESCRIPTION
## Summary

Second Wave 3 vertical of the Cosmic Python refactor (umbrella #277, epic #299). Follows the pattern from sister PR #321. Extracts all raw filesystem I/O from `SteamGridService` behind a new `SgdbArtworkCache` Protocol + adapter, moves icon writes to `SteamConfigAdapter`, wraps SGDB HTTP errors as a domain exception so the service never imports `urllib`, and promotes inline helpers (asset-type maps, endpoint builder, signed-app-id conversion) to `domain/sgdb_artwork.py`.

After this PR, `SteamGridService` is free of direct `os.*` / `pathlib` / `urllib` / `struct` / `open()` calls.

Also includes a `CLAUDE.md` refresh of the refactor wave plan: epic body sub-issue lists removed (native panel is source of truth), Wave 3 verticals tightened to reflect Wave 1/2 already-shipped slices, `#301` closed as superseded.

## Changes

- **New Protocol** `SgdbArtworkCache` in `services/protocols.py` (cache_dir, exists, remove, listdir, isdir, read_bytes, write_bytes_atomic).
- **New adapter** `SgdbArtworkCacheAdapter` in `adapters/sgdb_artwork_cache.py`. `write_bytes_atomic` writes to `.tmp` + `os.replace`, cleans up tmp on failure. `remove` is idempotent.
- **New domain exception** `SgdbApiError` in `lib/errors.py`. `SteamGridDbAdapter` catches `urllib.error.HTTPError` internally and re-raises `SgdbApiError(status_code, message)`. Service never sees urllib.
- **New domain exception** `SteamGridDirMissingError` in `lib/errors.py` — typed sentinel for the grid-dir-missing case (replaces a bare `RuntimeError` flagged in review).
- **New `write_shortcut_icon` method** on `SteamConfigAdapter` Protocol + concrete. Atomic write with tmp cleanup. Service's `_save_icon_to_grid` becomes a thin orchestrator.
- **New domain module** `domain/sgdb_artwork.py`: `asset_type_name`, `asset_type_endpoint`, `sgdb_endpoint_path`, `to_signed_app_id`. Consolidates two inline asset-type inversions.
- **`SteamGridService`**: drops `runtime_dir`, `urllib.error`, `struct` imports; injects `sgdb_artwork_cache`; ctor decomposed from **11 → 7 params** via a frozen `SteamGridConfig` dataclass + new `PendingSyncReader` Protocol (`Callable[[], dict]` → typed Protocol).
- **Bootstrap wiring** updated for both new adapter and config bundle.
- **Tests** refactored to use `FakeSgdbArtworkCache` (in-memory, models `.tmp` round-trip with failure injection). New adapter tests, new domain tests, new icon-write tests on `SteamConfigAdapter`. No more `patch("os.*")` or `patch.object(..., "_loop", ...)` in `test_steamgrid.py`.
- **`CLAUDE.md`** refactor wave plan refreshed (separate commit `docs(claude.md): refresh refactor wave plan post-cleanup`).

## Test plan

- [x] `python -m pytest tests/ -q` — **1910 passed** (+56 vs main baseline)
- [x] `ruff check py_modules/ tests/` — clean
- [x] `basedpyright py_modules/ tests/` — 0 errors, 0 warnings
- [x] `scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] Grep confirms no raw I/O / urllib / struct remain in `services/steamgrid.py`

Closes #291.