### PR TITLE
refactor(downloads): extract raw file I/O into adapters

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,6 +192,8 @@ class Plugin:
                     sgdb_adapter=self._sgdb_adapter,
                     cover_art_file_store=adapters["cover_art_file_store"],
                     sgdb_artwork_cache=adapters["sgdb_artwork_cache"],
+                    download_files=adapters["download_files"],
+                    download_queue=adapters["download_queue"],
                 ),
                 stores=StateBundle(
                     state=self._state,

--- a/py_modules/adapters/download_file.py
+++ b/py_modules/adapters/download_file.py
@@ -1,0 +1,144 @@
+"""Filesystem adapter for ROM download target operations.
+
+Owns the raw POSIX calls used by DownloadService to manage downloaded
+ROM files under the RetroDECK roms/bios directories. Path construction,
+queue policy, and progress callbacks remain a service concern; this
+adapter exposes only the I/O seams declared by
+``services.protocols.DownloadFileAdapter``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import urllib.parse
+import zipfile
+
+
+class DownloadFileAdapter:
+    """Synchronous filesystem operations for ROM download files.
+
+    Implements the ``DownloadFileAdapter`` Protocol. Methods are
+    synchronous — services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def remove_tree(self, path: str) -> None:
+        """Recursively delete *path*. Idempotent: a missing directory is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(path)
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        os.makedirs(path, exist_ok=True)
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        os.replace(src, dst)
+
+    def disk_free(self, path: str) -> int:
+        """Return the free space in bytes for the filesystem hosting *path*."""
+        return shutil.disk_usage(path).free
+
+    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
+        """Recursively remove files under *base_dir* matching any of *suffixes*.
+
+        Returns the number of files removed. Idempotent on missing
+        *base_dir* (returns ``0``). Per-file ``OSError``s are swallowed
+        so one permission failure doesn't block the remaining sweep.
+        """
+        if not os.path.isdir(base_dir):
+            return 0
+        cleaned = 0
+        for root, _dirs, files in os.walk(base_dir):
+            for filename in files:
+                if not filename.endswith(suffixes):
+                    continue
+                full_path = os.path.join(root, filename)
+                try:
+                    os.remove(full_path)
+                    cleaned += 1
+                except OSError:
+                    continue
+        return cleaned
+
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+        """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
+
+        Resolves both *dest_dir* and *safe_root* via ``os.path.realpath``
+        and verifies that every ZIP member resolves within both before
+        extracting. Raises ``ValueError`` on any escape attempt.
+        Returns the list of extracted absolute file paths.
+        """
+        real_dest = os.path.realpath(dest_dir)
+        real_safe = os.path.realpath(safe_root)
+        if not (real_dest == real_safe or real_dest.startswith(real_safe + os.sep)):
+            raise ValueError(f"Extract directory would be outside safe root: {dest_dir}")
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            for member in zf.namelist():
+                member_path = os.path.realpath(os.path.join(real_dest, member))
+                if not (member_path == real_dest or member_path.startswith(real_dest + os.sep)):
+                    raise ValueError(f"ZIP member {member} would extract outside target directory")
+            zf.extractall(real_dest)
+            names = zf.namelist()
+        return [os.path.join(real_dest, name) for name in names]
+
+    def decode_url_encoded_names(self, directory: str) -> None:
+        """Rename URL-encoded files and directories under *directory* in place.
+
+        Walks bottom-up so nested encoded directories are handled
+        correctly. A no-op when the decoded name equals the original.
+        """
+        for root, dirs, files in os.walk(directory, topdown=False):
+            for fname in files:
+                decoded = urllib.parse.unquote(fname)
+                if decoded != fname:
+                    os.replace(os.path.join(root, fname), os.path.join(root, decoded))
+            for dname in dirs:
+                decoded = urllib.parse.unquote(dname)
+                if decoded != dname:
+                    os.replace(os.path.join(root, dname), os.path.join(root, decoded))
+
+    def scan_files_with_sizes(self, directory: str) -> list[tuple[str, int]]:
+        """Recursively return ``(absolute_path, size_bytes)`` tuples for every file under *directory*.
+
+        Files whose size cannot be read report size ``0`` rather than
+        raising so callers can still reason over the list.
+        """
+        out: list[tuple[str, int]] = []
+        for root, _dirs, files in os.walk(directory):
+            for f in files:
+                path = os.path.join(root, f)
+                try:
+                    size = os.path.getsize(path)
+                except OSError:
+                    size = 0
+                out.append((path, size))
+        return out
+
+    def write_text_atomic(self, path: str, content: str) -> None:
+        """Atomically write *content* to *path* as UTF-8 text.
+
+        Writes to ``path + ".tmp"`` first, then ``os.replace``s into
+        place. The temp file is removed on any failure so the caller is
+        free to retry without an orphan lingering.
+        """
+        tmp_path = path + ".tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(content)
+            os.replace(tmp_path, path)
+        except Exception:
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(tmp_path)
+            raise

--- a/py_modules/adapters/download_file.py
+++ b/py_modules/adapters/download_file.py
@@ -50,35 +50,27 @@ class DownloadFileAdapter:
         """Return the free space in bytes for the filesystem hosting *path*."""
         return shutil.disk_usage(path).free
 
-    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
-        """Recursively remove files under *base_dir* matching any of *suffixes*.
+    def walk_files_matching_suffixes(self, base_dir: str, suffixes: tuple[str, ...]) -> list[str]:
+        """Recursively list files under *base_dir* matching any of *suffixes*.
 
-        Returns the number of files removed. Idempotent on missing
-        *base_dir* (returns ``0``). Per-file ``OSError``s are swallowed
-        so one permission failure doesn't block the remaining sweep.
+        Returns absolute paths. Idempotent on missing *base_dir*
+        (returns ``[]``). Pure listing — does not mutate the filesystem.
         """
         if not os.path.isdir(base_dir):
-            return 0
-        cleaned = 0
+            return []
+        matches: list[str] = []
         for root, _dirs, files in os.walk(base_dir):
             for filename in files:
-                if not filename.endswith(suffixes):
-                    continue
-                full_path = os.path.join(root, filename)
-                try:
-                    os.remove(full_path)
-                    cleaned += 1
-                except OSError:
-                    continue
-        return cleaned
+                if filename.endswith(suffixes):
+                    matches.append(os.path.join(root, filename))
+        return matches
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
         """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
 
         Resolves both *dest_dir* and *safe_root* via ``os.path.realpath``
         and verifies that every ZIP member resolves within both before
         extracting. Raises ``ValueError`` on any escape attempt.
-        Returns the list of extracted absolute file paths.
         """
         real_dest = os.path.realpath(dest_dir)
         real_safe = os.path.realpath(safe_root)
@@ -90,8 +82,6 @@ class DownloadFileAdapter:
                 if not (member_path == real_dest or member_path.startswith(real_dest + os.sep)):
                     raise ValueError(f"ZIP member {member} would extract outside target directory")
             zf.extractall(real_dest)
-            names = zf.namelist()
-        return [os.path.join(real_dest, name) for name in names]
 
     def decode_url_encoded_names(self, directory: str) -> None:
         """Rename URL-encoded files and directories under *directory* in place.

--- a/py_modules/adapters/download_queue.py
+++ b/py_modules/adapters/download_queue.py
@@ -1,0 +1,47 @@
+"""Filesystem adapter for the launcher-script download request queue.
+
+Owns the lock-and-poll round-trip used by DownloadService to consume
+queued ROM-download requests written by the RetroDECK launcher script.
+Path construction and request dispatch remain a service concern; this
+adapter exposes only the read-and-clear seam declared by
+``services.protocols.DownloadQueueAdapter``.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+
+
+class DownloadQueueAdapter:
+    """Synchronous lock-and-poll over the download request file.
+
+    Implements the ``DownloadQueueAdapter`` Protocol. Methods are
+    synchronous — services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def poll_and_clear(self, path: str) -> list[dict]:
+        """Atomically read pending requests from *path* and clear the file.
+
+        Acquires an exclusive ``fcntl`` lock around the read-and-truncate
+        round-trip so concurrent writers cannot lose requests. Returns
+        the list of request dicts that were in the file. Idempotent on
+        a missing file (returns ``[]``); malformed JSON is treated as an
+        empty queue and the file is still cleared.
+        """
+        try:
+            with open(path, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    requests = json.load(f)
+                except json.JSONDecodeError:
+                    requests = []
+                if not requests:
+                    return []
+                f.seek(0)
+                f.truncate()
+                json.dump([], f)
+            return requests
+        except FileNotFoundError:
+            return []

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 
 from adapters.asyncio_sleeper import AsyncioSleeper
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
+from adapters.download_file import DownloadFileAdapter as DownloadFileAdapterImpl
+from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapterImpl
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
@@ -28,7 +30,7 @@ from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService
-from services.downloads import DownloadService
+from services.downloads import DownloadService, DownloadServiceConfig
 from services.firmware import FirmwareService
 from services.game_detail import GameDetailService
 from services.library import LibraryService
@@ -42,6 +44,8 @@ from services.protocols import (
     CoreNameProviderFn,
     CoverArtFileStore,
     DebugLogger,
+    DownloadFileAdapter,
+    DownloadQueueAdapter,
     EventEmitter,
     FirmwareCachePersister,
     RetroArchSaveSortingProvider,
@@ -73,6 +77,8 @@ class AdapterBundle:
     sgdb_adapter: SteamGridDbAdapter
     cover_art_file_store: CoverArtFileStore
     sgdb_artwork_cache: SgdbArtworkCache
+    download_files: DownloadFileAdapter
+    download_queue: DownloadQueueAdapter
 
 
 @dataclass(frozen=True)
@@ -174,6 +180,8 @@ def bootstrap(
     sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger)
     cover_art_file_store = CoverArtFileStoreAdapter()
     sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
+    download_files = DownloadFileAdapterImpl()
+    download_queue = DownloadQueueAdapterImpl()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -186,6 +194,8 @@ def bootstrap(
         "sgdb_adapter": sgdb_adapter,
         "cover_art_file_store": cover_art_file_store,
         "sgdb_artwork_cache": sgdb_artwork_cache,
+        "download_files": download_files,
+        "download_queue": download_queue,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -332,18 +342,22 @@ def wire_services(cfg: WiringConfig) -> dict:
 
     download_service = DownloadService(
         romm_api=cfg.adapters.romm_api,
-        resolve_system=cfg.adapters.http_adapter.resolve_system,
         state=cfg.stores.state,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        runtime_dir=cfg.runtime.runtime_dir,
-        emit=cfg.runtime.emit,
-        clock=cfg.runtime.clock,
-        sleeper=cfg.runtime.sleeper,
-        save_state=cfg.callbacks.save_state,
-        get_roms_path=cfg.callbacks.get_roms_path,
-        get_bios_path=cfg.callbacks.get_bios_path,
-        is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
+        download_files=cfg.adapters.download_files,
+        download_queue=cfg.adapters.download_queue,
+        config=DownloadServiceConfig(
+            resolve_system=cfg.adapters.http_adapter.resolve_system,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            runtime_dir=cfg.runtime.runtime_dir,
+            emit=cfg.runtime.emit,
+            clock=cfg.runtime.clock,
+            sleeper=cfg.runtime.sleeper,
+            save_state=cfg.callbacks.save_state,
+            get_roms_path=cfg.callbacks.get_roms_path,
+            get_bios_path=cfg.callbacks.get_bios_path,
+            is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
+        ),
     )
 
     rom_removal_service = RomRemovalService(

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -137,29 +137,45 @@ class DownloadService:
             del self._download_queue[rid]
         return {"success": True, "removed": len(terminal_ids)}
 
+    def _remove_tmp_files(self, paths: list[str]) -> int:
+        """Remove each path in *paths*, logging a warning on per-file failure.
+
+        Returns the count of successful removals. Mirrors the
+        SteamGridService cache-prune pattern: service owns the loop +
+        ``try``/``except`` + ``logger.warning`` so the operational
+        signal on each failure is preserved instead of being swallowed
+        inside the adapter.
+        """
+        removed = 0
+        for path in paths:
+            try:
+                self._download_files.remove(path)
+                removed += 1
+            except OSError as e:
+                self._logger.warning(f"Failed to remove tmp file {path}: {e}")
+        return removed
+
     def _clean_rom_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM directories."""
         roms_base = self._get_roms_path() if self._get_roms_path else ""
         if not roms_base:
             return 0
-        return self._download_files.clean_tmp_files(roms_base, (_TMP_EXT, _ZIP_TMP_EXT))
+        paths = self._download_files.walk_files_matching_suffixes(roms_base, (_TMP_EXT, _ZIP_TMP_EXT))
+        return self._remove_tmp_files(paths)
 
     def _clean_bios_tmp_files(self):
         """Remove leftover .tmp files from BIOS directory."""
         bios_base = self._get_bios_path() if self._get_bios_path else ""
         if not bios_base:
             return 0
-        return self._download_files.clean_tmp_files(bios_base, (_TMP_EXT,))
+        paths = self._download_files.walk_files_matching_suffixes(bios_base, (_TMP_EXT,))
+        return self._remove_tmp_files(paths)
 
     def cleanup_leftover_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM and BIOS directories on startup."""
         cleaned = self._clean_rom_tmp_files() + self._clean_bios_tmp_files()
         if cleaned:
             self._logger.info(f"Cleaned {cleaned} leftover tmp file(s)")
-
-    def _poll_download_requests_io(self, requests_path):
-        """Sync helper for poll_download_requests — file lock + read + write in executor."""
-        return self._download_queue_io.poll_and_clear(requests_path)
 
     async def poll_download_requests(self):
         """Poll for download requests from the launcher script."""
@@ -168,12 +184,12 @@ class DownloadService:
             try:
                 await self._sleeper.sleep(2)
                 # Pause polling while a RetroDECK migration is pending — must
-                # short-circuit BEFORE _poll_download_requests_io reads + clears
-                # the request file, otherwise queued requests would be silently
+                # short-circuit BEFORE poll_and_clear reads + clears the
+                # request file, otherwise queued requests would be silently
                 # dropped on the floor.
                 if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
                     continue
-                requests = await self._loop.run_in_executor(None, self._poll_download_requests_io, requests_path)
+                requests = await self._loop.run_in_executor(None, self._download_queue_io.poll_and_clear, requests_path)
                 if not requests:
                     continue
                 for req in requests:

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -1,18 +1,16 @@
-"""DownloadService — ROM download engine.
+"""DownloadService — ROM download orchestration.
 
 Handles ROM downloads (single and multi-file), disk space checks,
-download queue management, and partial download cleanup.
+download queue management, and partial download cleanup. All raw
+filesystem I/O is delegated to the ``DownloadFileAdapter`` and
+``DownloadQueueAdapter`` Protocols.
 """
 
 from __future__ import annotations
 
 import asyncio
-import fcntl
-import json
 import os
-import shutil
-import urllib.parse
-import zipfile
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
@@ -25,6 +23,8 @@ if TYPE_CHECKING:
     from services.protocols import (
         BiosPathProvider,
         Clock,
+        DownloadFileAdapter,
+        DownloadQueueAdapter,
         EventEmitter,
         RommApiProtocol,
         RomsPathProvider,
@@ -38,6 +38,30 @@ _ZIP_TMP_EXT = ".zip.tmp"
 _TMP_EXT = ".tmp"
 
 
+@dataclass(frozen=True)
+class DownloadServiceConfig:
+    """Frozen wiring bundle handed to ``DownloadService.__init__``.
+
+    Holds the runtime infrastructure, time/sleep seams, path providers,
+    and migration-aware callbacks DownloadService needs at construction
+    time. Protocol-typed adapters and the live state dict remain
+    explicit ctor parameters because they have different lifecycles
+    from this immutable wiring bundle.
+    """
+
+    resolve_system: SystemResolver
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    runtime_dir: str
+    emit: EventEmitter
+    clock: Clock
+    sleeper: Sleeper
+    save_state: StatePersister
+    get_roms_path: RomsPathProvider | None = None
+    get_bios_path: BiosPathProvider | None = None
+    is_retrodeck_migration_pending: Callable[[], bool] | None = None
+
+
 class DownloadService:
     """ROM download engine: downloads and queue management."""
 
@@ -45,32 +69,26 @@ class DownloadService:
         self,
         *,
         romm_api: RommApiProtocol,
-        resolve_system: SystemResolver,
         state: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        runtime_dir: str,
-        emit: EventEmitter,
-        clock: Clock,
-        sleeper: Sleeper,
-        save_state: StatePersister,
-        get_roms_path: RomsPathProvider | None = None,
-        get_bios_path: BiosPathProvider | None = None,
-        is_retrodeck_migration_pending: Callable[[], bool] | None = None,
+        download_files: DownloadFileAdapter,
+        download_queue: DownloadQueueAdapter,
+        config: DownloadServiceConfig,
     ):
         self._romm_api = romm_api
-        self._resolve_system = resolve_system
         self._state = state
-        self._loop = loop
-        self._logger = logger
-        self._runtime_dir = runtime_dir
-        self._emit = emit
-        self._clock = clock
-        self._sleeper = sleeper
-        self._save_state = save_state
-        self._get_roms_path = get_roms_path
-        self._get_bios_path = get_bios_path
-        self._is_retrodeck_migration_pending = is_retrodeck_migration_pending
+        self._download_files = download_files
+        self._download_queue_io = download_queue
+        self._resolve_system = config.resolve_system
+        self._loop = config.loop
+        self._logger = config.logger
+        self._runtime_dir = config.runtime_dir
+        self._emit = config.emit
+        self._clock = config.clock
+        self._sleeper = config.sleeper
+        self._save_state = config.save_state
+        self._get_roms_path = config.get_roms_path
+        self._get_bios_path = config.get_bios_path
+        self._is_retrodeck_migration_pending = config.is_retrodeck_migration_pending
 
         # Owned state
         self._download_in_progress: set = set()
@@ -119,44 +137,19 @@ class DownloadService:
             del self._download_queue[rid]
         return {"success": True, "removed": len(terminal_ids)}
 
-    def _remove_tmp_file(self, filepath):
-        """Try to remove a tmp file, return True on success."""
-        try:
-            if os.path.isfile(filepath):
-                os.remove(filepath)
-                self._logger.info(f"Removed leftover tmp file: {filepath}")
-                return True
-        except OSError as e:
-            self._logger.warning(f"Failed to remove tmp file {filepath}: {e}")
-        return False
-
     def _clean_rom_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM directories."""
-        cleaned = 0
         roms_base = self._get_roms_path() if self._get_roms_path else ""
-        if not os.path.isdir(roms_base):
-            return cleaned
-        for system_dir in os.listdir(roms_base):
-            system_path = os.path.join(roms_base, system_dir)
-            if not os.path.isdir(system_path):
-                continue
-            for filename in os.listdir(system_path):
-                full_path = os.path.join(system_path, filename)
-                if filename.endswith((_TMP_EXT, _ZIP_TMP_EXT)) and self._remove_tmp_file(full_path):
-                    cleaned += 1
-        return cleaned
+        if not roms_base:
+            return 0
+        return self._download_files.clean_tmp_files(roms_base, (_TMP_EXT, _ZIP_TMP_EXT))
 
     def _clean_bios_tmp_files(self):
         """Remove leftover .tmp files from BIOS directory."""
-        cleaned = 0
         bios_base = self._get_bios_path() if self._get_bios_path else ""
-        if not os.path.isdir(bios_base):
-            return cleaned
-        for root, _dirs, files in os.walk(bios_base):
-            for filename in files:
-                if filename.endswith(_TMP_EXT) and self._remove_tmp_file(os.path.join(root, filename)):
-                    cleaned += 1
-        return cleaned
+        if not bios_base:
+            return 0
+        return self._download_files.clean_tmp_files(bios_base, (_TMP_EXT,))
 
     def cleanup_leftover_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM and BIOS directories on startup."""
@@ -166,21 +159,7 @@ class DownloadService:
 
     def _poll_download_requests_io(self, requests_path):
         """Sync helper for poll_download_requests — file lock + read + write in executor."""
-        try:
-            with open(requests_path, "r+") as f:
-                fcntl.flock(f, fcntl.LOCK_EX)
-                try:
-                    requests = json.load(f)
-                except json.JSONDecodeError:
-                    requests = []
-                if not requests:
-                    return []
-                f.seek(0)
-                f.truncate()
-                json.dump([], f)
-            return requests
-        except FileNotFoundError:
-            return []
+        return self._download_queue_io.poll_and_clear(requests_path)
 
     async def poll_download_requests(self):
         """Poll for download requests from the launcher script."""
@@ -237,8 +216,8 @@ class DownloadService:
         file_size = rom_detail.get("fs_size_bytes", 0)
 
         # Check disk space: multi-file ROMs need space for ZIP + extracted contents
-        os.makedirs(roms_dir, exist_ok=True)
-        free_space = shutil.disk_usage(roms_dir).free
+        self._download_files.make_dirs(roms_dir)
+        free_space = self._download_files.disk_free(roms_dir)
         buffer = 100 * 1024 * 1024
         required = file_size * 2 + buffer if rom_detail.get("has_multiple_files") else file_size + buffer
         if file_size and free_space < required:
@@ -272,40 +251,18 @@ class DownloadService:
         self._download_tasks[rom_id] = task
         return {"success": True, "message": "Download started"}
 
-    def _decode_url_encoded_names(self, directory: str) -> None:
-        """Rename URL-encoded filenames and directories (e.g. %20 -> space)."""
-        for root, dirs, files in os.walk(directory, topdown=False):
-            for fname in files:
-                decoded = urllib.parse.unquote(fname)
-                if decoded != fname:
-                    os.replace(os.path.join(root, fname), os.path.join(root, decoded))
-                    self._logger.info(f"Renamed URL-encoded file: {fname} -> {decoded}")
-            for dname in dirs:
-                decoded = urllib.parse.unquote(dname)
-                if decoded != dname:
-                    os.replace(os.path.join(root, dname), os.path.join(root, decoded))
-                    self._logger.info(f"Renamed URL-encoded dir: {dname} -> {decoded}")
-
     def _post_download_multi_io(self, rom_id, rom_detail, target_path, file_name, system):
         """Sync helper for _do_download multi-file — extraction + renames in executor."""
         rom_dir_name = os.path.splitext(file_name)[0]
         extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
-        os.makedirs(extract_dir, exist_ok=True)
-        # Fix 4: Validate extract_dir is within roms_dir
+        self._download_files.make_dirs(extract_dir)
         roms_base = self._get_roms_path() if self._get_roms_path else ""
-        if not os.path.realpath(extract_dir).startswith(os.path.realpath(roms_base) + os.sep):
-            raise ValueError(f"Extract directory would be outside roms directory: {extract_dir}")
         tmp_zip = target_path + _ZIP_TMP_EXT
-        with zipfile.ZipFile(tmp_zip, "r") as zf:
-            # Fix 3: ZIP slip protection
-            real_extract = os.path.realpath(extract_dir)
-            for member in zf.namelist():
-                member_path = os.path.realpath(os.path.join(extract_dir, member))
-                if not member_path.startswith(real_extract + os.sep):
-                    raise ValueError(f"ZIP member {member} would extract outside target directory")
-            zf.extractall(extract_dir)
-        os.remove(tmp_zip)
-        self._decode_url_encoded_names(extract_dir)
+        # ZIP-slip protection: adapter validates members resolve within extract_dir
+        # AND that extract_dir itself resolves within roms_base.
+        self._download_files.extract_zip(tmp_zip, extract_dir, roms_base)
+        self._download_files.remove(tmp_zip)
+        self._download_files.decode_url_encoded_names(extract_dir)
         # Auto-generate M3U if missing and multiple disc files exist
         self._maybe_generate_m3u_io(extract_dir, rom_detail)
         # Detect launch file: prefer M3U > CUE > largest file
@@ -328,7 +285,7 @@ class DownloadService:
     def _post_download_single_io(self, rom_id, rom_detail, target_path, file_name, system):
         """Sync helper for _do_download single-file — rename + state update in executor."""
         tmp_path = target_path + _TMP_EXT
-        os.replace(tmp_path, target_path)
+        self._download_files.rename(tmp_path, target_path)
 
         installed_entry = {
             "rom_id": rom_id,
@@ -444,42 +401,29 @@ class DownloadService:
 
     def _maybe_generate_m3u_io(self, extract_dir: str, rom_detail: dict) -> None:
         """Auto-generate an M3U playlist if none exists and multiple disc files are found."""
+        all_files = self._download_files.scan_files_with_sizes(extract_dir)
         # Check if an M3U already exists (search recursively)
-        for _root, _dirs, files in os.walk(extract_dir):
-            for f in files:
-                if f.lower().endswith(".m3u"):
-                    return
+        if any(path.lower().endswith(".m3u") for path, _size in all_files):
+            return
 
         # Collect disc files: .cue, .chd, .iso (search recursively)
-        disc_files = []
-        for root, _dirs, files in os.walk(extract_dir):
-            for f in files:
-                if f.lower().endswith((".cue", ".chd", ".iso")):
-                    # Store path relative to extract_dir for M3U entries
-                    rel_path = os.path.relpath(os.path.join(root, f), extract_dir)
-                    disc_files.append(rel_path)
+        disc_files = [
+            os.path.relpath(path, extract_dir)
+            for path, _size in all_files
+            if path.lower().endswith((".cue", ".chd", ".iso"))
+        ]
 
         if not needs_m3u(disc_files):
             return
 
         rom_name = rom_detail.get("fs_name_no_ext", rom_detail.get("name", "playlist"))
         m3u_path = os.path.join(extract_dir, f"{rom_name}.m3u")
-        with open(m3u_path, "w") as f:
-            f.write(build_m3u_content(disc_files))
+        self._download_files.write_text_atomic(m3u_path, build_m3u_content(disc_files))
         self._logger.info(f"Auto-generated M3U playlist: {m3u_path}")
 
     def _collect_and_detect_launch_file(self, extract_dir: str) -> str:
         """Find the best launch file in an extracted multi-file ROM directory."""
-        all_files: list[tuple[str, int]] = []
-        for root, _dirs, files in os.walk(extract_dir):
-            for f in files:
-                path = os.path.join(root, f)
-                try:
-                    size = os.path.getsize(path)
-                except OSError:
-                    size = 0
-                all_files.append((path, size))
-
+        all_files = self._download_files.scan_files_with_sizes(extract_dir)
         result = detect_launch_file(all_files)
         return result if result is not None else extract_dir
 
@@ -492,16 +436,14 @@ class DownloadService:
         ]
         for path in paths_to_remove:
             try:
-                if os.path.exists(path):
-                    os.remove(path)
+                self._download_files.remove(path)
             except Exception as e:
                 self._logger.warning(f"Cleanup failed for {path}: {e}")
         if has_multiple:
             rom_dir_name = os.path.splitext(file_name)[0]
             extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
             try:
-                if os.path.isdir(extract_dir):
-                    shutil.rmtree(extract_dir)
+                self._download_files.remove_tree(extract_dir)
             except Exception as e:
                 self._logger.warning(f"Cleanup failed for directory {extract_dir}: {e}")
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -552,6 +552,114 @@ class CoverArtFileStore(Protocol):
         ...
 
 
+class DownloadFileAdapter(Protocol):
+    """Filesystem seam for ROM download target operations.
+
+    Owns the raw POSIX calls DownloadService uses to manage downloaded
+    ROM files: temp-file lifecycle, atomic renames, disk-space probes,
+    ZIP extraction with ZIP-slip protection, post-extract URL-decoding,
+    and file-size scans for launch-file detection. Path construction,
+    queue management, and progress callbacks remain a service concern;
+    this Protocol exposes only the I/O seams.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def remove_tree(self, path: str) -> None:
+        """Recursively delete *path*. Idempotent: a missing directory is not an error."""
+        ...
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        ...
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        ...
+
+    def disk_free(self, path: str) -> int:
+        """Return the free space in bytes for the filesystem hosting *path*."""
+        ...
+
+    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
+        """Recursively remove files under *base_dir* whose name ends with any of *suffixes*.
+
+        Returns the number of files removed. Idempotent on missing
+        *base_dir* (returns 0). Per-file errors are swallowed so a
+        single failure does not block the rest of the sweep.
+        """
+        ...
+
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+        """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
+
+        *safe_root* is the boundary outside of which extraction is
+        rejected. Implementations resolve both *dest_dir* and *safe_root*
+        via ``os.path.realpath`` and verify that every member resolves
+        within *safe_root* before extracting. Returns the list of
+        extracted absolute file paths.
+        """
+        ...
+
+    def decode_url_encoded_names(self, directory: str) -> None:
+        """Recursively rename URL-encoded entries under *directory*.
+
+        Files and subdirectories whose names contain ``%XX`` escapes are
+        renamed in place to their decoded form. Walks bottom-up so
+        nested encoded directories are handled correctly.
+        """
+        ...
+
+    def scan_files_with_sizes(self, directory: str) -> list[tuple[str, int]]:
+        """Recursively list files under *directory* with their sizes.
+
+        Returns a list of ``(absolute_path, size_bytes)`` tuples. Files
+        whose size cannot be read report size ``0`` so callers can still
+        reason over the list.
+        """
+        ...
+
+    def write_text_atomic(self, path: str, content: str) -> None:
+        """Atomically write *content* to *path* as UTF-8 text.
+
+        Writes to a temp file beside *path* and ``os.replace``s it to
+        the final destination. The temp file is removed on any failure.
+        """
+        ...
+
+
+class DownloadQueueAdapter(Protocol):
+    """Filesystem seam for the launcher-script download request queue.
+
+    Owns the lock-and-poll round-trip DownloadService uses to consume
+    queued ROM-download requests written by the RetroDECK launcher
+    script. Path construction and request dispatch remain a service
+    concern; this Protocol exposes only the read-and-clear seam.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def poll_and_clear(self, path: str) -> list[dict]:
+        """Atomically read all pending requests from *path* and clear the file.
+
+        Acquires an exclusive ``fcntl`` lock for the read-and-truncate
+        round-trip so concurrent writers cannot lose requests. Returns
+        the list of request dicts that were in the file. Idempotent on
+        missing or malformed files: returns ``[]``.
+        """
+        ...
+
+
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.
 

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -590,23 +590,22 @@ class DownloadFileAdapter(Protocol):
         """Return the free space in bytes for the filesystem hosting *path*."""
         ...
 
-    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
-        """Recursively remove files under *base_dir* whose name ends with any of *suffixes*.
+    def walk_files_matching_suffixes(self, base_dir: str, suffixes: tuple[str, ...]) -> list[str]:
+        """Recursively list files under *base_dir* whose name ends with any of *suffixes*.
 
-        Returns the number of files removed. Idempotent on missing
-        *base_dir* (returns 0). Per-file errors are swallowed so a
-        single failure does not block the rest of the sweep.
+        Returns absolute paths. Idempotent on missing *base_dir*
+        (returns ``[]``). Pure listing — does not mutate the filesystem;
+        callers own the removal loop and any per-file error handling.
         """
         ...
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
         """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
 
         *safe_root* is the boundary outside of which extraction is
         rejected. Implementations resolve both *dest_dir* and *safe_root*
         via ``os.path.realpath`` and verify that every member resolves
-        within *safe_root* before extracting. Returns the list of
-        extracted absolute file paths.
+        within *safe_root* before extracting.
         """
         ...
 

--- a/tests/adapters/test_download_file.py
+++ b/tests/adapters/test_download_file.py
@@ -1,0 +1,306 @@
+"""Tests for DownloadFileAdapter — raw filesystem ops for ROM downloads."""
+
+from __future__ import annotations
+
+import zipfile
+from unittest.mock import patch
+
+import pytest
+
+from adapters.download_file import DownloadFileAdapter
+
+
+@pytest.fixture
+def adapter() -> DownloadFileAdapter:
+    return DownloadFileAdapter()
+
+
+class TestExists:
+    def test_true_for_existing_file(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        assert adapter.exists(str(f)) is True
+
+    def test_true_for_directory(self, adapter, tmp_path):
+        assert adapter.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, adapter, tmp_path):
+        assert adapter.exists(str(tmp_path / "missing.rom")) is False
+
+
+class TestRemove:
+    def test_removes_existing(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        adapter.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, adapter, tmp_path):
+        # Idempotent — must not raise on a missing file
+        adapter.remove(str(tmp_path / "missing.rom"))
+
+    def test_propagates_non_filenotfound(self, adapter, tmp_path):
+        # Removing a directory with os.remove raises IsADirectoryError /
+        # OSError — anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            adapter.remove(str(tmp_path))
+
+
+class TestRemoveTree:
+    def test_removes_directory(self, adapter, tmp_path):
+        d = tmp_path / "rom_dir"
+        d.mkdir()
+        (d / "a").write_bytes(b"")
+        (d / "b").write_bytes(b"")
+        adapter.remove_tree(str(d))
+        assert not d.exists()
+
+    def test_missing_is_noop(self, adapter, tmp_path):
+        # Idempotent on missing directory
+        adapter.remove_tree(str(tmp_path / "missing"))
+
+    def test_removes_nested(self, adapter, tmp_path):
+        d = tmp_path / "rom"
+        nested = d / "sub" / "deeper"
+        nested.mkdir(parents=True)
+        (nested / "file").write_bytes(b"data")
+        adapter.remove_tree(str(d))
+        assert not d.exists()
+
+
+class TestMakeDirs:
+    def test_creates_directory(self, adapter, tmp_path):
+        target = tmp_path / "a" / "b" / "c"
+        adapter.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_idempotent_when_exists(self, adapter, tmp_path):
+        adapter.make_dirs(str(tmp_path))  # already exists — must not raise
+
+
+class TestRename:
+    def test_renames(self, adapter, tmp_path):
+        src = tmp_path / "src.rom"
+        dst = tmp_path / "dst.rom"
+        src.write_bytes(b"data")
+        adapter.rename(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"data"
+
+    def test_replaces_existing(self, adapter, tmp_path):
+        src = tmp_path / "src.rom"
+        dst = tmp_path / "dst.rom"
+        src.write_bytes(b"new")
+        dst.write_bytes(b"old")
+        adapter.rename(str(src), str(dst))
+        assert dst.read_bytes() == b"new"
+
+    def test_missing_source_raises(self, adapter, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            adapter.rename(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestDiskFree:
+    def test_returns_positive_int(self, adapter, tmp_path):
+        # Real filesystem returns some non-negative integer.
+        free = adapter.disk_free(str(tmp_path))
+        assert isinstance(free, int)
+        assert free >= 0
+
+
+class TestCleanTmpFiles:
+    def test_removes_matching_suffixes(self, adapter, tmp_path):
+        (tmp_path / "a.tmp").write_text("")
+        (tmp_path / "b.zip.tmp").write_text("")
+        (tmp_path / "real.rom").write_text("keep")
+        removed = adapter.clean_tmp_files(str(tmp_path), (".tmp", ".zip.tmp"))
+        assert removed == 2
+        assert not (tmp_path / "a.tmp").exists()
+        assert not (tmp_path / "b.zip.tmp").exists()
+        assert (tmp_path / "real.rom").exists()
+
+    def test_recursive(self, adapter, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "x.tmp").write_text("")
+        (tmp_path / "y.tmp").write_text("")
+        removed = adapter.clean_tmp_files(str(tmp_path), (".tmp",))
+        assert removed == 2
+
+    def test_missing_base_dir_returns_zero(self, adapter, tmp_path):
+        # Idempotent on missing base_dir
+        assert adapter.clean_tmp_files(str(tmp_path / "missing"), (".tmp",)) == 0
+
+    def test_no_matching_suffix(self, adapter, tmp_path):
+        (tmp_path / "rom.bin").write_text("")
+        assert adapter.clean_tmp_files(str(tmp_path), (".tmp",)) == 0
+
+    def test_empty_directory(self, adapter, tmp_path):
+        assert adapter.clean_tmp_files(str(tmp_path), (".tmp",)) == 0
+
+    def test_swallows_remove_failures(self, adapter, tmp_path):
+        (tmp_path / "a.tmp").write_text("")
+        with patch("adapters.download_file.os.remove", side_effect=OSError("perm denied")):
+            removed = adapter.clean_tmp_files(str(tmp_path), (".tmp",))
+        # Failure was swallowed; nothing counted as removed.
+        assert removed == 0
+        assert (tmp_path / "a.tmp").exists()
+
+
+class TestExtractZip:
+    def _make_zip(self, path, members: dict[str, bytes]) -> None:
+        with zipfile.ZipFile(str(path), "w") as zf:
+            for name, data in members.items():
+                zf.writestr(name, data)
+
+    def test_extracts_members(self, adapter, tmp_path):
+        archive = tmp_path / "src.zip"
+        self._make_zip(archive, {"a.bin": b"AAA", "b.bin": b"BBB"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        extracted = adapter.extract_zip(str(archive), str(dest), str(tmp_path))
+        assert sorted(p for p in extracted) == sorted([str(dest / "a.bin"), str(dest / "b.bin")])
+        assert (dest / "a.bin").read_bytes() == b"AAA"
+        assert (dest / "b.bin").read_bytes() == b"BBB"
+
+    def test_rejects_zip_slip(self, adapter, tmp_path):
+        archive = tmp_path / "evil.zip"
+        # ZIP member with .. traversal
+        self._make_zip(archive, {"../escape.txt": b"bad"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(ValueError, match="outside"):
+            adapter.extract_zip(str(archive), str(dest), str(tmp_path))
+        # Nothing should be extracted outside the safe root
+        assert not (tmp_path.parent / "escape.txt").exists()
+
+    def test_rejects_extract_dir_outside_safe_root(self, adapter, tmp_path):
+        archive = tmp_path / "src.zip"
+        self._make_zip(archive, {"a.bin": b"x"})
+        # dest is outside safe_root
+        outside = tmp_path.parent / "outside"
+        outside.mkdir(exist_ok=True)
+        with pytest.raises(ValueError, match="outside safe root"):
+            adapter.extract_zip(str(archive), str(outside), str(tmp_path))
+
+    def test_allows_dest_equal_to_safe_root(self, adapter, tmp_path):
+        archive = tmp_path / "src.zip"
+        self._make_zip(archive, {"a.bin": b"x"})
+        # dest == safe_root is allowed
+        extracted = adapter.extract_zip(str(archive), str(tmp_path), str(tmp_path))
+        assert (tmp_path / "a.bin").read_bytes() == b"x"
+        assert extracted == [str(tmp_path / "a.bin")]
+
+
+class TestDecodeUrlEncodedNames:
+    def test_renames_url_encoded_file(self, adapter, tmp_path):
+        (tmp_path / "Game%20Title.cue").write_text("")
+        adapter.decode_url_encoded_names(str(tmp_path))
+        assert (tmp_path / "Game Title.cue").exists()
+        assert not (tmp_path / "Game%20Title.cue").exists()
+
+    def test_renames_url_encoded_dir(self, adapter, tmp_path):
+        (tmp_path / "Disc%201").mkdir()
+        adapter.decode_url_encoded_names(str(tmp_path))
+        assert (tmp_path / "Disc 1").exists()
+
+    def test_handles_nested_encoded_dirs(self, adapter, tmp_path):
+        outer = tmp_path / "Disc%201"
+        outer.mkdir()
+        (outer / "track%20one.bin").write_text("")
+        adapter.decode_url_encoded_names(str(tmp_path))
+        decoded_dir = tmp_path / "Disc 1"
+        assert decoded_dir.exists()
+        assert (decoded_dir / "track one.bin").exists()
+
+    def test_noop_for_ascii_names(self, adapter, tmp_path):
+        (tmp_path / "plain.cue").write_text("")
+        (tmp_path / "subdir").mkdir()
+        adapter.decode_url_encoded_names(str(tmp_path))
+        assert (tmp_path / "plain.cue").exists()
+        assert (tmp_path / "subdir").exists()
+
+    def test_empty_directory(self, adapter, tmp_path):
+        # Must not raise
+        adapter.decode_url_encoded_names(str(tmp_path))
+
+
+class TestScanFilesWithSizes:
+    def test_returns_paths_and_sizes(self, adapter, tmp_path):
+        (tmp_path / "a.bin").write_bytes(b"\x00" * 10)
+        (tmp_path / "b.bin").write_bytes(b"\x00" * 20)
+        out = adapter.scan_files_with_sizes(str(tmp_path))
+        sizes = {p: s for p, s in out}
+        assert sizes[str(tmp_path / "a.bin")] == 10
+        assert sizes[str(tmp_path / "b.bin")] == 20
+
+    def test_recursive(self, adapter, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "deep.bin").write_bytes(b"\x00" * 5)
+        out = adapter.scan_files_with_sizes(str(tmp_path))
+        assert (str(sub / "deep.bin"), 5) in out
+
+    def test_empty_directory(self, adapter, tmp_path):
+        assert adapter.scan_files_with_sizes(str(tmp_path)) == []
+
+    def test_size_falls_back_to_zero_on_os_error(self, adapter, tmp_path):
+        (tmp_path / "a.bin").write_bytes(b"x")
+        with patch("adapters.download_file.os.path.getsize", side_effect=OSError):
+            out = adapter.scan_files_with_sizes(str(tmp_path))
+        assert out == [(str(tmp_path / "a.bin"), 0)]
+
+
+class TestWriteTextAtomic:
+    def test_writes_content(self, adapter, tmp_path):
+        dest = tmp_path / "playlist.m3u"
+        adapter.write_text_atomic(str(dest), "disc1.cue\ndisc2.cue\n")
+        assert dest.read_text() == "disc1.cue\ndisc2.cue\n"
+
+    def test_overwrites_existing(self, adapter, tmp_path):
+        dest = tmp_path / "playlist.m3u"
+        dest.write_text("old")
+        adapter.write_text_atomic(str(dest), "new")
+        assert dest.read_text() == "new"
+
+    def test_no_tmp_left_after_success(self, adapter, tmp_path):
+        dest = tmp_path / "playlist.m3u"
+        adapter.write_text_atomic(str(dest), "x")
+        assert not (tmp_path / "playlist.m3u.tmp").exists()
+
+    def test_cleans_tmp_on_failure(self, adapter, tmp_path):
+        dest = tmp_path / "playlist.m3u"
+        with (
+            patch("adapters.download_file.os.replace", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            adapter.write_text_atomic(str(dest), "data")
+        assert not (tmp_path / "playlist.m3u.tmp").exists()
+        assert not dest.exists()
+
+    def test_encodes_utf8(self, adapter, tmp_path):
+        dest = tmp_path / "playlist.m3u"
+        adapter.write_text_atomic(str(dest), "Final Fantasy VII — Disc 1.cue\n")
+        assert dest.read_text(encoding="utf-8") == "Final Fantasy VII — Disc 1.cue\n"
+
+
+class TestProtocolMethodCount:
+    """Sanity check that every Protocol method has at least one test class."""
+
+    def test_protocol_methods_covered(self):
+        method_names = {
+            "exists",
+            "remove",
+            "remove_tree",
+            "make_dirs",
+            "rename",
+            "disk_free",
+            "clean_tmp_files",
+            "extract_zip",
+            "decode_url_encoded_names",
+            "scan_files_with_sizes",
+            "write_text_atomic",
+        }
+        # All listed methods are implemented on the concrete adapter.
+        for name in method_names:
+            assert hasattr(DownloadFileAdapter(), name), f"missing {name}"

--- a/tests/adapters/test_download_file.py
+++ b/tests/adapters/test_download_file.py
@@ -108,15 +108,16 @@ class TestDiskFree:
         assert free >= 0
 
 
-class TestCleanTmpFiles:
-    def test_removes_matching_suffixes(self, adapter, tmp_path):
+class TestWalkFilesMatchingSuffixes:
+    def test_lists_matching_suffixes(self, adapter, tmp_path):
         (tmp_path / "a.tmp").write_text("")
         (tmp_path / "b.zip.tmp").write_text("")
         (tmp_path / "real.rom").write_text("keep")
-        removed = adapter.clean_tmp_files(str(tmp_path), (".tmp", ".zip.tmp"))
-        assert removed == 2
-        assert not (tmp_path / "a.tmp").exists()
-        assert not (tmp_path / "b.zip.tmp").exists()
+        matches = adapter.walk_files_matching_suffixes(str(tmp_path), (".tmp", ".zip.tmp"))
+        assert sorted(matches) == sorted([str(tmp_path / "a.tmp"), str(tmp_path / "b.zip.tmp")])
+        # Pure listing — nothing was removed
+        assert (tmp_path / "a.tmp").exists()
+        assert (tmp_path / "b.zip.tmp").exists()
         assert (tmp_path / "real.rom").exists()
 
     def test_recursive(self, adapter, tmp_path):
@@ -124,27 +125,28 @@ class TestCleanTmpFiles:
         sub.mkdir()
         (sub / "x.tmp").write_text("")
         (tmp_path / "y.tmp").write_text("")
-        removed = adapter.clean_tmp_files(str(tmp_path), (".tmp",))
-        assert removed == 2
+        matches = adapter.walk_files_matching_suffixes(str(tmp_path), (".tmp",))
+        assert sorted(matches) == sorted([str(sub / "x.tmp"), str(tmp_path / "y.tmp")])
 
-    def test_missing_base_dir_returns_zero(self, adapter, tmp_path):
+    def test_recurses_any_depth(self, adapter, tmp_path):
+        # The old clean_tmp_files scan capped at 2 levels — walk_files_matching_suffixes
+        # follows os.walk and recurses unbounded so deep mid-extraction crashes are caught.
+        deep = tmp_path / "a" / "b" / "c" / "d"
+        deep.mkdir(parents=True)
+        (deep / "stuck.tmp").write_text("")
+        matches = adapter.walk_files_matching_suffixes(str(tmp_path), (".tmp",))
+        assert matches == [str(deep / "stuck.tmp")]
+
+    def test_missing_base_dir_returns_empty(self, adapter, tmp_path):
         # Idempotent on missing base_dir
-        assert adapter.clean_tmp_files(str(tmp_path / "missing"), (".tmp",)) == 0
+        assert adapter.walk_files_matching_suffixes(str(tmp_path / "missing"), (".tmp",)) == []
 
     def test_no_matching_suffix(self, adapter, tmp_path):
         (tmp_path / "rom.bin").write_text("")
-        assert adapter.clean_tmp_files(str(tmp_path), (".tmp",)) == 0
+        assert adapter.walk_files_matching_suffixes(str(tmp_path), (".tmp",)) == []
 
     def test_empty_directory(self, adapter, tmp_path):
-        assert adapter.clean_tmp_files(str(tmp_path), (".tmp",)) == 0
-
-    def test_swallows_remove_failures(self, adapter, tmp_path):
-        (tmp_path / "a.tmp").write_text("")
-        with patch("adapters.download_file.os.remove", side_effect=OSError("perm denied")):
-            removed = adapter.clean_tmp_files(str(tmp_path), (".tmp",))
-        # Failure was swallowed; nothing counted as removed.
-        assert removed == 0
-        assert (tmp_path / "a.tmp").exists()
+        assert adapter.walk_files_matching_suffixes(str(tmp_path), (".tmp",)) == []
 
 
 class TestExtractZip:
@@ -158,8 +160,9 @@ class TestExtractZip:
         self._make_zip(archive, {"a.bin": b"AAA", "b.bin": b"BBB"})
         dest = tmp_path / "out"
         dest.mkdir()
-        extracted = adapter.extract_zip(str(archive), str(dest), str(tmp_path))
-        assert sorted(p for p in extracted) == sorted([str(dest / "a.bin"), str(dest / "b.bin")])
+        result = adapter.extract_zip(str(archive), str(dest), str(tmp_path))
+        # Adapter returns None — caller asserts on filesystem state.
+        assert result is None
         assert (dest / "a.bin").read_bytes() == b"AAA"
         assert (dest / "b.bin").read_bytes() == b"BBB"
 
@@ -187,9 +190,9 @@ class TestExtractZip:
         archive = tmp_path / "src.zip"
         self._make_zip(archive, {"a.bin": b"x"})
         # dest == safe_root is allowed
-        extracted = adapter.extract_zip(str(archive), str(tmp_path), str(tmp_path))
+        result = adapter.extract_zip(str(archive), str(tmp_path), str(tmp_path))
+        assert result is None
         assert (tmp_path / "a.bin").read_bytes() == b"x"
-        assert extracted == [str(tmp_path / "a.bin")]
 
 
 class TestDecodeUrlEncodedNames:
@@ -295,7 +298,7 @@ class TestProtocolMethodCount:
             "make_dirs",
             "rename",
             "disk_free",
-            "clean_tmp_files",
+            "walk_files_matching_suffixes",
             "extract_zip",
             "decode_url_encoded_names",
             "scan_files_with_sizes",

--- a/tests/adapters/test_download_queue.py
+++ b/tests/adapters/test_download_queue.py
@@ -1,0 +1,90 @@
+"""Tests for DownloadQueueAdapter — lock-and-poll on download_requests.json."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import threading
+import time
+
+import pytest
+
+from adapters.download_queue import DownloadQueueAdapter
+
+
+@pytest.fixture
+def adapter() -> DownloadQueueAdapter:
+    return DownloadQueueAdapter()
+
+
+class TestPollAndClear:
+    def test_returns_list_and_clears(self, adapter, tmp_path):
+        path = tmp_path / "requests.json"
+        path.write_text(json.dumps([{"rom_id": 1}, {"rom_id": 2}]))
+        result = adapter.poll_and_clear(str(path))
+        assert result == [{"rom_id": 1}, {"rom_id": 2}]
+        # File now holds an empty list
+        assert json.loads(path.read_text()) == []
+
+    def test_returns_empty_on_missing_file(self, adapter, tmp_path):
+        assert adapter.poll_and_clear(str(tmp_path / "missing.json")) == []
+
+    def test_returns_empty_on_empty_list_payload(self, adapter, tmp_path):
+        path = tmp_path / "requests.json"
+        path.write_text("[]")
+        assert adapter.poll_and_clear(str(path)) == []
+        # File is left as-is (already empty)
+        assert json.loads(path.read_text()) == []
+
+    def test_returns_empty_on_malformed_json(self, adapter, tmp_path):
+        path = tmp_path / "requests.json"
+        path.write_text("not json")
+        assert adapter.poll_and_clear(str(path)) == []
+
+    def test_acquires_exclusive_lock(self, adapter, tmp_path):
+        """Concurrent writers must wait for poll_and_clear to release the lock.
+
+        Reads the request file while another thread holds an LOCK_EX —
+        poll_and_clear should block until the lock is released, then
+        successfully consume the entry.
+        """
+        path = tmp_path / "requests.json"
+        path.write_text(json.dumps([{"rom_id": 42}]))
+
+        holder_acquired = threading.Event()
+        holder_release = threading.Event()
+        poll_done = threading.Event()
+        result_holder: list = []
+
+        def hold_lock() -> None:
+            with open(path, "r+") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                holder_acquired.set()
+                holder_release.wait(timeout=5)
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+        def do_poll() -> None:
+            result_holder.append(adapter.poll_and_clear(str(path)))
+            poll_done.set()
+
+        holder = threading.Thread(target=hold_lock)
+        poller = threading.Thread(target=do_poll)
+        holder.start()
+        assert holder_acquired.wait(timeout=5)
+        poller.start()
+        # Give poller a moment to attempt the lock and block.
+        time.sleep(0.1)
+        assert not poll_done.is_set(), "poll_and_clear should block while LOCK_EX is held"
+        holder_release.set()
+        assert poll_done.wait(timeout=5)
+        holder.join()
+        poller.join()
+        assert result_holder[0] == [{"rom_id": 42}]
+        # File is truncated
+        assert json.loads(path.read_text()) == []
+
+    def test_handles_unicode_payload(self, adapter, tmp_path):
+        path = tmp_path / "requests.json"
+        path.write_text(json.dumps([{"rom_id": 1, "note": "français"}]))
+        result = adapter.poll_and_clear(str(path))
+        assert result == [{"rom_id": 1, "note": "français"}]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,7 @@ class FakeDownloadFileAdapter:
     - ``fail_on_atomic_write`` — when True, ``write_text_atomic`` cleans
       up the tmp file and raises ``OSError`` to mirror the real adapter
       behaviour.
-    - ``decode_calls`` / ``extract_calls`` / ``clean_calls`` — captured
+    - ``decode_calls`` / ``extract_calls`` / ``walk_calls`` — captured
       argument lists for tests that need to assert on adapter calls.
     """
 
@@ -266,7 +266,8 @@ class FakeDownloadFileAdapter:
         self.tmp_files: set[str] = set()
         self.decode_calls: list[str] = []
         self.extract_calls: list[tuple[str, str, str]] = []
-        self.clean_calls: list[tuple[str, tuple[str, ...]]] = []
+        self.walk_calls: list[tuple[str, tuple[str, ...]]] = []
+        self.remove_failures: set[str] = set()
 
     def set_disk_free(self, bytes_free: int) -> None:
         self.disk_free_bytes = bytes_free
@@ -275,6 +276,8 @@ class FakeDownloadFileAdapter:
         return path in self.files or self.isdir(path)
 
     def remove(self, path: str) -> None:
+        if path in self.remove_failures:
+            raise OSError(f"simulated remove failure: {path}")
         self.files.pop(path, None)
 
     def remove_tree(self, path: str) -> None:
@@ -304,21 +307,20 @@ class FakeDownloadFileAdapter:
         prefix = path.rstrip("/") + "/"
         return any(stored.startswith(prefix) for stored in self.files)
 
-    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
-        self.clean_calls.append((base_dir, suffixes))
+    def walk_files_matching_suffixes(self, base_dir: str, suffixes: tuple[str, ...]) -> list[str]:
+        self.walk_calls.append((base_dir, suffixes))
         if not self.isdir(base_dir):
-            return 0
+            return []
         prefix = base_dir.rstrip("/") + "/"
-        removed = 0
-        for stored in list(self.files):
+        matches: list[str] = []
+        for stored in self.files:
             if not (stored == base_dir or stored.startswith(prefix)):
                 continue
             if stored.endswith(suffixes):
-                del self.files[stored]
-                removed += 1
-        return removed
+                matches.append(stored)
+        return matches
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
         self.extract_calls.append((archive_path, dest_dir, safe_root))
         if archive_path not in self.files:
             raise FileNotFoundError(archive_path)
@@ -327,13 +329,10 @@ class FakeDownloadFileAdapter:
             raise ValueError(f"Extract directory would be outside safe root: {dest_dir}")
         # Fake-mode: derive extracted entries from a paired dict the test set.
         members = getattr(self, "_zip_members", {}).get(archive_path, {})
-        extracted: list[str] = []
         self.make_dirs(dest_dir)
         for name, data in members.items():
             full = os.path.join(dest_dir, name)
             self.files[full] = data
-            extracted.append(full)
-        return extracted
 
     def set_zip_members(self, archive_path: str, members: dict[str, bytes]) -> None:
         if not hasattr(self, "_zip_members"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,171 @@ class FakeSgdbArtworkCache:
         self.tmp_files.discard(tmp_path)
 
 
+class FakeDownloadFileAdapter:
+    """In-memory ``DownloadFileAdapter`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` / ``remove_tree`` are
+    idempotent per the Protocol contract. ``isdir`` reports True for any
+    path that is the parent of an entry or matches a directory created
+    via ``make_dirs``.
+
+    The fake captures enough state to model the download flow:
+    - ``files`` — ``{path: bytes}`` snapshot of the virtual filesystem.
+    - ``dirs`` — explicit set of directory paths (populated by
+      ``make_dirs`` and ``extract_zip``).
+    - ``disk_free_bytes`` — value returned by ``disk_free`` (default
+      large, override via ``set_disk_free``).
+    - ``fail_on_atomic_write`` — when True, ``write_text_atomic`` cleans
+      up the tmp file and raises ``OSError`` to mirror the real adapter
+      behaviour.
+    - ``decode_calls`` / ``extract_calls`` / ``clean_calls`` — captured
+      argument lists for tests that need to assert on adapter calls.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        self.dirs: set[str] = set()
+        self.disk_free_bytes: int = 10 * 1024 * 1024 * 1024  # 10 GiB
+        self.fail_on_atomic_write: bool = False
+        self.tmp_files: set[str] = set()
+        self.decode_calls: list[str] = []
+        self.extract_calls: list[tuple[str, str, str]] = []
+        self.clean_calls: list[tuple[str, tuple[str, ...]]] = []
+
+    def set_disk_free(self, bytes_free: int) -> None:
+        self.disk_free_bytes = bytes_free
+
+    def exists(self, path: str) -> bool:
+        return path in self.files or self.isdir(path)
+
+    def remove(self, path: str) -> None:
+        self.files.pop(path, None)
+
+    def remove_tree(self, path: str) -> None:
+        prefix = path.rstrip("/") + "/"
+        for stored in list(self.files):
+            if stored == path or stored.startswith(prefix):
+                del self.files[stored]
+        self.dirs.discard(path)
+        for d in list(self.dirs):
+            if d.startswith(prefix):
+                self.dirs.discard(d)
+
+    def make_dirs(self, path: str) -> None:
+        self.dirs.add(path)
+
+    def rename(self, src: str, dst: str) -> None:
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+
+    def disk_free(self, path: str) -> int:
+        return self.disk_free_bytes
+
+    def isdir(self, path: str) -> bool:
+        if path in self.dirs:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def clean_tmp_files(self, base_dir: str, suffixes: tuple[str, ...]) -> int:
+        self.clean_calls.append((base_dir, suffixes))
+        if not self.isdir(base_dir):
+            return 0
+        prefix = base_dir.rstrip("/") + "/"
+        removed = 0
+        for stored in list(self.files):
+            if not (stored == base_dir or stored.startswith(prefix)):
+                continue
+            if stored.endswith(suffixes):
+                del self.files[stored]
+                removed += 1
+        return removed
+
+    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> list[str]:
+        self.extract_calls.append((archive_path, dest_dir, safe_root))
+        if archive_path not in self.files:
+            raise FileNotFoundError(archive_path)
+        # Model the slip-protection: dest_dir must live under safe_root
+        if not (dest_dir == safe_root or dest_dir.startswith(safe_root.rstrip("/") + "/")):
+            raise ValueError(f"Extract directory would be outside safe root: {dest_dir}")
+        # Fake-mode: derive extracted entries from a paired dict the test set.
+        members = getattr(self, "_zip_members", {}).get(archive_path, {})
+        extracted: list[str] = []
+        self.make_dirs(dest_dir)
+        for name, data in members.items():
+            full = os.path.join(dest_dir, name)
+            self.files[full] = data
+            extracted.append(full)
+        return extracted
+
+    def set_zip_members(self, archive_path: str, members: dict[str, bytes]) -> None:
+        if not hasattr(self, "_zip_members"):
+            self._zip_members: dict[str, dict[str, bytes]] = {}
+        self._zip_members[archive_path] = members
+
+    def decode_url_encoded_names(self, directory: str) -> None:
+        import urllib.parse
+
+        self.decode_calls.append(directory)
+        prefix = directory.rstrip("/") + "/"
+        for stored in list(self.files):
+            if not stored.startswith(prefix):
+                continue
+            rel = stored[len(prefix) :]
+            decoded = urllib.parse.unquote(rel)
+            if decoded != rel:
+                new_path = prefix + decoded
+                self.files[new_path] = self.files.pop(stored)
+
+    def scan_files_with_sizes(self, directory: str) -> list[tuple[str, int]]:
+        prefix = directory.rstrip("/") + "/"
+        out: list[tuple[str, int]] = []
+        for stored, data in self.files.items():
+            if stored == directory or stored.startswith(prefix):
+                out.append((stored, len(data)))
+        return out
+
+    def write_text_atomic(self, path: str, content: str) -> None:
+        tmp_path = path + ".tmp"
+        self.tmp_files.add(tmp_path)
+        if self.fail_on_atomic_write:
+            self.tmp_files.discard(tmp_path)
+            raise OSError("simulated atomic-write failure")
+        self.files[path] = content.encode("utf-8")
+        self.tmp_files.discard(tmp_path)
+
+
+class FakeDownloadQueueAdapter:
+    """In-memory ``DownloadQueueAdapter`` for tests.
+
+    Backed by a single ``entries`` list so ``poll_and_clear`` is
+    deterministic. Tests pre-populate ``entries`` to stage queued
+    requests and inspect ``poll_count`` / ``last_path`` for behaviour
+    assertions. ``set_missing(True)`` makes the next ``poll_and_clear``
+    behave as if the file were missing (returns ``[]`` without clearing).
+    """
+
+    def __init__(self, entries: list[dict] | None = None) -> None:
+        self.entries: list[dict] = list(entries) if entries else []
+        self.poll_count: int = 0
+        self.last_path: str | None = None
+        self.missing: bool = False
+
+    def set_missing(self, missing: bool) -> None:
+        self.missing = missing
+
+    def poll_and_clear(self, path: str) -> list[dict]:
+        self.poll_count += 1
+        self.last_path = path
+        if self.missing:
+            return []
+        out = list(self.entries)
+        self.entries.clear()
+        return out
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -509,38 +509,6 @@ class TestDiskSpaceMultiFile:
         assert result["success"] is True
 
 
-class TestPollDownloadRequestsIO:
-    """Tests for _poll_download_requests_io — file-based IPC."""
-
-    def test_reads_and_clears_requests(self, plugin, tmp_path):
-        requests_path = tmp_path / "download_requests.json"
-        requests_path.write_text(json.dumps([{"rom_id": 42}, {"rom_id": 99}]))
-        result = plugin._download_service._poll_download_requests_io(str(requests_path))
-        assert len(result) == 2
-        assert result[0]["rom_id"] == 42
-        assert result[1]["rom_id"] == 99
-        # File should be cleared
-        with open(str(requests_path)) as f:
-            remaining = json.load(f)
-        assert remaining == []
-
-    def test_empty_file_returns_empty(self, plugin, tmp_path):
-        requests_path = tmp_path / "download_requests.json"
-        requests_path.write_text(json.dumps([]))
-        result = plugin._download_service._poll_download_requests_io(str(requests_path))
-        assert result == []
-
-    def test_missing_file_returns_empty(self, plugin, tmp_path):
-        result = plugin._download_service._poll_download_requests_io(str(tmp_path / "nonexistent.json"))
-        assert result == []
-
-    def test_invalid_json_returns_empty(self, plugin, tmp_path):
-        requests_path = tmp_path / "download_requests.json"
-        requests_path.write_text("not valid json {{{{")
-        result = plugin._download_service._poll_download_requests_io(str(requests_path))
-        assert result == []
-
-
 class TestDownloadRequestPolling:
     @pytest.mark.asyncio
     async def test_processes_download_request(self, plugin, tmp_path):
@@ -612,21 +580,17 @@ class TestPollDownloadRequestsMigrationPause:
 
         plugin._download_service._sleeper = _CancellingSleeper()
 
-        # Track whether the request file IO was invoked.
-        io_called = [False]
-        original_io = plugin._download_service._poll_download_requests_io
+        # Track whether the request file IO was invoked via the queue adapter.
+        from conftest import FakeDownloadQueueAdapter
 
-        def tracking_io(path):
-            io_called[0] = True
-            return original_io(path)
-
-        plugin._download_service._poll_download_requests_io = tracking_io
+        tracking_queue = FakeDownloadQueueAdapter()
+        plugin._download_service._download_queue_io = tracking_queue
 
         with pytest.raises(asyncio.CancelledError):
             await plugin._download_service.poll_download_requests()
 
         # IO must NOT have been called while migration was pending.
-        assert io_called[0] is False
+        assert tracking_queue.poll_count == 0
         # Request file must still hold its original contents — not truncated.
         with open(requests_path) as f:
             assert json.load(f) == original_payload
@@ -1713,24 +1677,41 @@ class TestCleanupLeftoverTmpFiles:
         # No retrodeck/roms directory exists — should not crash
         plugin._download_service.cleanup_leftover_tmp_files()
 
-    def test_handles_permission_error(self, plugin, tmp_path):
+    def test_handles_permission_error(self, plugin, tmp_path, caplog):
+        import logging
+
         import decky
+        from conftest import FakeDownloadFileAdapter
 
         decky.DECKY_USER_HOME = str(tmp_path)
         plugin._download_service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
         plugin._download_service._get_bios_path = lambda: str(tmp_path / "retrodeck" / "bios")
         plugin._rom_removal_service._get_roms_path = lambda: str(tmp_path / "retrodeck" / "roms")
 
-        system_dir = tmp_path / "retrodeck" / "roms" / "n64"
-        system_dir.mkdir(parents=True)
-        tmp_file = system_dir / "zelda.z64.tmp"
-        tmp_file.write_text("partial")
+        # Stage a virtual tmp file via the fake adapter so the service can
+        # discover it via walk_files_matching_suffixes; the fake's
+        # ``remove_failures`` set makes the subsequent remove raise OSError.
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        bios_base = str(tmp_path / "retrodeck" / "bios")
+        tmp_file_path = os.path.join(roms_base, "n64", "zelda.z64.tmp")
 
-        # Adapter rejects deletion (e.g. permission denied) — the service
-        # must not raise; the file remains on disk.
-        plugin._download_service._download_files.clean_tmp_files = lambda _base, _suffixes: 0
-        plugin._download_service.cleanup_leftover_tmp_files()
-        assert tmp_file.exists()
+        fake = FakeDownloadFileAdapter()
+        fake.make_dirs(roms_base)
+        fake.make_dirs(bios_base)
+        fake.files[tmp_file_path] = b"partial"
+        fake.remove_failures.add(tmp_file_path)
+        plugin._download_service._download_files = fake
+
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
+            plugin._download_service.cleanup_leftover_tmp_files()
+
+        # Per-file warning must be emitted; sister-PR pattern in
+        # SteamGridService.prune_orphaned_artwork_cache.
+        assert any(
+            "Failed to remove tmp file" in rec.message and tmp_file_path in rec.message for rec in caplog.records
+        ), f"expected warning about {tmp_file_path}, got {[r.message for r in caplog.records]}"
+        # File still present in fake — service swallowed the OSError.
+        assert tmp_file_path in fake.files
 
 
 class TestRemoveRomCleansSaveSyncState:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,8 +10,10 @@ import pytest
 from conftest import _make_testable_plugin
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.download_file import DownloadFileAdapter
+from adapters.download_queue import DownloadQueueAdapter
 from adapters.steam_config import SteamConfigAdapter
-from services.downloads import DownloadService
+from services.downloads import DownloadService, DownloadServiceConfig
 from services.library import LibraryService
 from services.rom_removal import RomRemovalService
 
@@ -51,17 +53,21 @@ def plugin():
     p._save_sync_state = {"saves": {}, "playtime": {}, "settings": {}}
     p._download_service = DownloadService(
         romm_api=p._romm_api,
-        resolve_system=p._resolve_system,
         state=p._state,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
-        emit=decky.emit,
-        clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-        sleeper=FakeSleeper(),
-        save_state=MagicMock(),
-        get_roms_path=lambda: os.path.join(os.path.expanduser("~"), "retrodeck", "roms"),
-        get_bios_path=lambda: os.path.join(os.path.expanduser("~"), "retrodeck", "bios"),
+        download_files=DownloadFileAdapter(),
+        download_queue=DownloadQueueAdapter(),
+        config=DownloadServiceConfig(
+            resolve_system=p._resolve_system,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
+            emit=decky.emit,
+            clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
+            sleeper=FakeSleeper(),
+            save_state=MagicMock(),
+            get_roms_path=lambda: os.path.join(os.path.expanduser("~"), "retrodeck", "roms"),
+            get_bios_path=lambda: os.path.join(os.path.expanduser("~"), "retrodeck", "bios"),
+        ),
     )
     p._rom_removal_service = RomRemovalService(
         state=p._state,
@@ -86,7 +92,7 @@ async def _set_event_loop(plugin):
 class TestStartDownload:
     @pytest.mark.asyncio
     async def test_starts_download_task(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -114,9 +120,9 @@ class TestStartDownload:
             return MagicMock()
 
         plugin._download_service._loop.create_task = _close_coro_task
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(42)
+        result = await plugin.start_download(42)
 
         assert result["success"] is True
         assert 42 in plugin._download_service._download_queue
@@ -143,7 +149,7 @@ class TestStartDownload:
 
     @pytest.mark.asyncio
     async def test_checks_disk_space(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -164,8 +170,8 @@ class TestStartDownload:
         plugin._download_service._loop = MagicMock()
         plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=50 * 1024 * 1024)):
-            result = await plugin.start_download(42)
+        plugin._download_service._download_files.disk_free = lambda _path: 50 * 1024 * 1024
+        result = await plugin.start_download(42)
 
         assert result["success"] is False
         assert "disk space" in result["message"].lower()
@@ -440,7 +446,7 @@ class TestDetectLaunchFile:
 class TestDiskSpaceMultiFile:
     @pytest.mark.asyncio
     async def test_multi_file_rom_requires_double_space(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -464,15 +470,15 @@ class TestDiskSpaceMultiFile:
         plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
 
         # 700MB free: enough for single-file (600MB) but not multi-file (1100MB)
-        with patch("shutil.disk_usage", return_value=MagicMock(free=700 * 1024 * 1024)):
-            result = await plugin.start_download(42)
+        plugin._download_service._download_files.disk_free = lambda _path: 700 * 1024 * 1024
+        result = await plugin.start_download(42)
 
         assert result["success"] is False
         assert "disk space" in result["message"].lower()
 
     @pytest.mark.asyncio
     async def test_single_file_rom_uses_normal_space_check(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -497,8 +503,8 @@ class TestDiskSpaceMultiFile:
         plugin._download_service._loop.create_task = MagicMock()
 
         # 700MB free: enough for single-file (600MB)
-        with patch("shutil.disk_usage", return_value=MagicMock(free=700 * 1024 * 1024)):
-            result = await plugin.start_download(43)
+        plugin._download_service._download_files.disk_free = lambda _path: 700 * 1024 * 1024
+        result = await plugin.start_download(43)
 
         assert result["success"] is True
 
@@ -975,7 +981,7 @@ class TestDoDownloadNestedSingleFile:
     @pytest.mark.asyncio
     async def test_nested_single_file_start_download_uses_files_entry(self, plugin, tmp_path):
         """start_download: nested-single-file enters the queue with the resolved filename."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1005,8 +1011,8 @@ class TestDoDownloadNestedSingleFile:
 
         plugin._download_service._loop.create_task = _close_coro_task
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(7)
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
+        result = await plugin.start_download(7)
 
         assert result["success"] is True
         assert plugin._download_service._download_queue[7]["file_name"] == "Resident Evil.chd"
@@ -1015,7 +1021,7 @@ class TestDoDownloadNestedSingleFile:
     async def test_nested_single_file_empty_files_falls_back(self, plugin, tmp_path, caplog):
         """Defensive: empty files list falls back to fs_name and logs a warning."""
         import logging
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1044,11 +1050,9 @@ class TestDoDownloadNestedSingleFile:
             return MagicMock()
 
         plugin._download_service._loop.create_task = _close_coro_task
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
 
-        with (
-            caplog.at_level(logging.WARNING, logger="test_romm"),
-            patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)),
-        ):
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
             result = await plugin.start_download(8)
 
         assert result["success"] is True
@@ -1059,7 +1063,7 @@ class TestDoDownloadNestedSingleFile:
     async def test_nested_single_file_missing_files_key_falls_back(self, plugin, tmp_path, caplog):
         """Defensive: missing files key falls back to fs_name and logs a warning."""
         import logging
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1088,11 +1092,9 @@ class TestDoDownloadNestedSingleFile:
             return MagicMock()
 
         plugin._download_service._loop.create_task = _close_coro_task
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
 
-        with (
-            caplog.at_level(logging.WARNING, logger="test_romm"),
-            patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)),
-        ):
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
             result = await plugin.start_download(9)
 
         assert result["success"] is True
@@ -1102,7 +1104,7 @@ class TestDoDownloadNestedSingleFile:
     @pytest.mark.asyncio
     async def test_nested_single_file_traversal_sanitized(self, plugin, tmp_path):
         """Defensive: path traversal in files[0].file_name is sanitized via os.path.basename."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1132,8 +1134,8 @@ class TestDoDownloadNestedSingleFile:
 
         plugin._download_service._loop.create_task = _close_coro_task
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(13)
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
+        result = await plugin.start_download(13)
 
         assert result["success"] is True
         queue_entry = plugin._download_service._download_queue[13]
@@ -1204,7 +1206,7 @@ class TestPathTraversalFsName:
 
     @pytest.mark.asyncio
     async def test_fs_name_traversal_sanitized(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1231,8 +1233,8 @@ class TestPathTraversalFsName:
 
         plugin._download_service._loop.create_task = _close_coro_task
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(77)
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
+        result = await plugin.start_download(77)
 
         assert result["success"] is True
         # The target path should use sanitized basename only
@@ -1372,7 +1374,7 @@ class TestStartDownloadReDownload:
 
     @pytest.mark.asyncio
     async def test_re_download_after_completed(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1402,8 +1404,8 @@ class TestStartDownloadReDownload:
         # Set status to completed (previous download)
         plugin._download_service._download_queue[42] = {"status": "completed"}
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(42)
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
+        result = await plugin.start_download(42)
 
         assert result["success"] is True
         assert plugin._download_service._download_queue[42]["status"] == "downloading"
@@ -1724,10 +1726,10 @@ class TestCleanupLeftoverTmpFiles:
         tmp_file = system_dir / "zelda.z64.tmp"
         tmp_file.write_text("partial")
 
-        with patch("os.remove", side_effect=OSError("Permission denied")):
-            # Should not raise
-            plugin._download_service.cleanup_leftover_tmp_files()
-        # File still exists since os.remove was mocked to fail
+        # Adapter rejects deletion (e.g. permission denied) — the service
+        # must not raise; the file remains on disk.
+        plugin._download_service._download_files.clean_tmp_files = lambda _base, _suffixes: 0
+        plugin._download_service.cleanup_leftover_tmp_files()
         assert tmp_file.exists()
 
 
@@ -1886,7 +1888,7 @@ class TestStartDownloadCreateTaskFailure:
 
     @pytest.mark.asyncio
     async def test_create_task_failure_returns_error(self, plugin, tmp_path):
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
 
         import decky
 
@@ -1908,32 +1910,13 @@ class TestStartDownloadCreateTaskFailure:
         plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
         plugin._download_service._loop.create_task = MagicMock(side_effect=RuntimeError("loop closed"))
 
-        with patch("shutil.disk_usage", return_value=MagicMock(free=500 * 1024 * 1024)):
-            result = await plugin.start_download(42)
+        plugin._download_service._download_files.disk_free = lambda _path: 500 * 1024 * 1024
+        result = await plugin.start_download(42)
 
         assert result["success"] is False
         assert "Failed to start download" in result["message"]
         # Should not remain in download_in_progress
         assert 42 not in plugin._download_service._download_in_progress
-
-
-class TestRemoveTmpFile:
-    """Tests for _remove_tmp_file helper."""
-
-    def test_removes_existing_file(self, plugin, tmp_path):
-        f = tmp_path / "test.tmp"
-        f.write_text("data")
-        assert plugin._download_service._remove_tmp_file(str(f)) is True
-        assert not f.exists()
-
-    def test_nonexistent_file_returns_false(self, plugin, tmp_path):
-        assert plugin._download_service._remove_tmp_file(str(tmp_path / "nope.tmp")) is False
-
-    def test_os_error_returns_false(self, plugin, tmp_path):
-        f = tmp_path / "test.tmp"
-        f.write_text("data")
-        with patch("os.remove", side_effect=OSError("perm denied")):
-            assert plugin._download_service._remove_tmp_file(str(f)) is False
 
 
 class TestClearCompletedDownloads:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -16,6 +16,8 @@ from bootstrap import (
 from conftest import (
     FakeCoreInfoProvider,
     FakeCoverArtFileStore,
+    FakeDownloadFileAdapter,
+    FakeDownloadQueueAdapter,
     FakeFirmwareCachePersister,
     FakeSgdbArtworkCache,
 )
@@ -153,6 +155,8 @@ class TestWireServices:
             "sgdb_adapter": MagicMock(),
             "cover_art_file_store": FakeCoverArtFileStore(),
             "sgdb_artwork_cache": FakeSgdbArtworkCache(),
+            "download_files": FakeDownloadFileAdapter(),
+            "download_queue": FakeDownloadQueueAdapter(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -191,6 +195,8 @@ class TestWireServices:
                 sgdb_adapter=deps["sgdb_adapter"],
                 cover_art_file_store=deps["cover_art_file_store"],
                 sgdb_artwork_cache=deps["sgdb_artwork_cache"],
+                download_files=deps["download_files"],
+                download_queue=deps["download_queue"],
             ),
             stores=StateBundle(
                 state=deps["state"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1093,6 +1093,8 @@ class TestMainStartupOrdering:
             "sgdb_adapter": MagicMock(),
             "cover_art_file_store": MagicMock(),
             "sgdb_artwork_cache": MagicMock(),
+            "download_files": MagicMock(),
+            "download_queue": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),
             "retroarch_core_info": MagicMock(),


### PR DESCRIPTION
## Summary

Third Wave 3 vertical of the Cosmic Python refactor (umbrella #277, epic #297). Follows the pattern from sister PRs #321 (artwork) and #322 (steamgrid). Extracts all raw filesystem I/O from `DownloadService` behind two new Protocols + adapters, drops `fcntl` / `shutil` / `urllib.parse` / `zipfile` / raw `open()` from the service, and decomposes the ctor from 13 → 5 params via a `DownloadServiceConfig` frozen dataclass.

After this PR, `DownloadService` is free of direct `os.*` (non-algebra) / `shutil.*` / `fcntl.*` / `urllib.*` / `zipfile.*` / `open()` calls.

## Changes

- **New Protocol `DownloadFileAdapter`** in `services/protocols.py` — lifecycle (`exists`, `remove`, `remove_tree`, `make_dirs`, `rename`, `disk_free`), tmp listing (`walk_files_matching_suffixes`), archive pipeline (`extract_zip` with ZIP-slip protection, `decode_url_encoded_names`, `scan_files_with_sizes`), atomic text write (`write_text_atomic`).
- **New Protocol `DownloadQueueAdapter`** in `services/protocols.py` — single method `poll_and_clear(path) -> list[dict]` encapsulates the `fcntl.flock` + `json` round-trip on the download-requests queue file.
- **New concrete adapters** `adapters/download_file.py` + `adapters/download_queue.py`. Atomic write via `.tmp` + `os.replace` + cleanup-on-failure (mirrors `SgdbArtworkCacheAdapter.write_bytes_atomic`). ZIP-slip protection resolves `safe_root` via `os.path.realpath` and rejects any member that escapes.
- **`DownloadService`** drops the forbidden imports; injects `download_files` + `download_queue` Protocol params; routes all I/O via `run_in_executor` (existing pattern); per-file tmp cleanup loop with `logger.warning` on `OSError` mirrors `SteamGridService.prune_orphaned_artwork_cache`.
- **`DownloadServiceConfig`** frozen dataclass bundles 11 non-adapter wiring params; ctor goes from **13 → 5 params** (was past S107 threshold).
- **Tests** refactored to use `FakeDownloadFileAdapter` + `FakeDownloadQueueAdapter` (in-memory, atomic-write failure injection, OSError injection via `remove_failures: set[str]`). No more `patch("shutil.disk_usage", ...)` / `patch("os.*")` / `patch("fcntl.*")` / `patch("zipfile.*")` in `test_downloads.py`.
- **Bootstrap & main.py** wired through.

Note: tmp-file cleanup now recurses any depth under the ROM/BIOS base dir (was: 2 levels). Catches stuck `.tmp` files from mid-extraction crashes in deep ROM dirs (e.g. PSX multi-disc) that the old scan missed. Behavior change is intentional and covered by a dedicated test.

## Test plan

- [x] `python -m pytest tests/ -q` — **1949 passed** (+39 vs main baseline)
- [x] `ruff check py_modules/ tests/` — clean
- [x] `basedpyright py_modules/ tests/` — 0 errors, 0 warnings
- [x] `scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] Grep confirms no raw I/O / \`shutil\` / \`fcntl\` / \`urllib\` / \`zipfile\` / raw \`open(\` remain in \`services/downloads.py\`

Closes #243.