### PR TITLE
refactor(firmware): extract raw file I/O into adapter, return-new-dict for enrich

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,6 +194,7 @@ class Plugin:
                     sgdb_artwork_cache=adapters["sgdb_artwork_cache"],
                     download_files=adapters["download_files"],
                     download_queue=adapters["download_queue"],
+                    firmware_files=adapters["firmware_files"],
                 ),
                 stores=StateBundle(
                     state=self._state,

--- a/py_modules/adapters/firmware_file.py
+++ b/py_modules/adapters/firmware_file.py
@@ -1,0 +1,59 @@
+"""Filesystem adapter for firmware/BIOS file operations.
+
+Owns the raw POSIX calls used by FirmwareService to manage firmware
+downloads under the RetroDECK BIOS directory. Path construction,
+registry lookups, and download orchestration remain a service concern;
+this adapter exposes only the I/O seams declared by
+``services.protocols.FirmwareFileAdapter``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import pathlib
+
+_MD5_CHUNK_SIZE = 8192
+
+
+class FirmwareFileAdapter:
+    """Synchronous filesystem operations for firmware/BIOS files.
+
+    Implements the ``FirmwareFileAdapter`` Protocol. Methods are
+    synchronous — services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        os.replace(src, dst)
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        os.makedirs(path, exist_ok=True)
+
+    def checksum_md5(self, path: str) -> str:
+        """Return the hex-encoded MD5 digest of *path*'s contents.
+
+        Streams the file in fixed-size chunks so memory use stays
+        bounded for large firmware blobs.
+        """
+        h = hashlib.md5()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(_MD5_CHUNK_SIZE), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        return pathlib.Path(path).read_bytes()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -17,6 +17,7 @@ from adapters.cover_art_file_store import CoverArtFileStoreAdapter
 from adapters.download_file import DownloadFileAdapter as DownloadFileAdapterImpl
 from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapterImpl
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
+from adapters.firmware_file import FirmwareFileAdapter as FirmwareFileAdapterImpl
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
@@ -48,6 +49,7 @@ from services.protocols import (
     DownloadQueueAdapter,
     EventEmitter,
     FirmwareCachePersister,
+    FirmwareFileAdapter,
     RetroArchSaveSortingProvider,
     RetroDeckHomeProvider,
     RommApiProtocol,
@@ -79,6 +81,7 @@ class AdapterBundle:
     sgdb_artwork_cache: SgdbArtworkCache
     download_files: DownloadFileAdapter
     download_queue: DownloadQueueAdapter
+    firmware_files: FirmwareFileAdapter
 
 
 @dataclass(frozen=True)
@@ -182,6 +185,7 @@ def bootstrap(
     sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
     download_files = DownloadFileAdapterImpl()
     download_queue = DownloadQueueAdapterImpl()
+    firmware_files = FirmwareFileAdapterImpl()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -196,6 +200,7 @@ def bootstrap(
         "sgdb_artwork_cache": sgdb_artwork_cache,
         "download_files": download_files,
         "download_queue": download_queue,
+        "firmware_files": firmware_files,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -379,6 +384,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         clock=cfg.runtime.clock,
         save_state=cfg.callbacks.save_state,
         firmware_cache_persister=cfg.callbacks.firmware_cache_persister,
+        firmware_files=cfg.adapters.firmware_files,
         get_bios_path=cfg.callbacks.get_bios_path,
         core_info=cfg.callbacks.core_info_provider,
     )

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -6,7 +6,6 @@ deletion, and per-core filtering for RetroArch emulators.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from dataclasses import asdict
@@ -25,6 +24,7 @@ if TYPE_CHECKING:
         Clock,
         CoreInfoProvider,
         FirmwareCachePersister,
+        FirmwareFileAdapter,
         RommApiProtocol,
         StatePersister,
     )
@@ -46,6 +46,7 @@ class FirmwareService:
         clock: Clock,
         save_state: StatePersister,
         firmware_cache_persister: FirmwareCachePersister,
+        firmware_files: FirmwareFileAdapter,
         get_bios_path: BiosPathProvider,
         core_info: CoreInfoProvider,
     ) -> None:
@@ -57,6 +58,7 @@ class FirmwareService:
         self._clock = clock
         self._save_state = save_state
         self._firmware_cache_persister = firmware_cache_persister
+        self._firmware_files = firmware_files
         self._get_bios_path = get_bios_path
         self._core_info = core_info
         self._bios_registry: dict = {}
@@ -80,10 +82,10 @@ class FirmwareService:
         # then defaults/ subdirectory (dev deploys via mise run deploy)
         root_path = os.path.join(self._plugin_dir, "bios_registry.json")
         defaults_path = os.path.join(self._plugin_dir, "defaults", "bios_registry.json")
-        registry_path = root_path if os.path.exists(root_path) else defaults_path
+        registry_path = root_path if self._firmware_files.exists(root_path) else defaults_path
         try:
-            with open(registry_path) as f:
-                self._bios_registry = json.load(f)
+            data = self._firmware_files.read_bytes(registry_path)
+            self._bios_registry = json.loads(data)
             # Build flat reverse index: {filename: {entry_data + "platform": slug}}
             for platform, files in self._bios_registry.get("platforms", {}).items():
                 for filename, entry in files.items():
@@ -103,21 +105,24 @@ class FirmwareService:
                 is_required = entry["cores"][core_so]["required"]
             else:
                 is_required = entry.get("required", True)
-            file_dict["required"] = is_required
-            file_dict["description"] = entry.get("description", file_dict.get("file_name", ""))
-            file_dict["classification"] = "required" if is_required else "optional"
+            required = is_required
+            description = entry.get("description", file_dict.get("file_name", ""))
+            classification = "required" if is_required else "optional"
         else:
             # Unknown file: not in registry, don't count as required
-            file_dict["required"] = False
-            file_dict["description"] = file_dict.get("file_name", "")
-            file_dict["classification"] = "unknown"
+            required = False
+            description = file_dict.get("file_name", "")
+            classification = "unknown"
         file_md5 = file_dict.get("md5", "")
         registry_md5 = entry.get("md5", "") if entry else ""
-        if file_md5 and registry_md5:
-            file_dict["hash_valid"] = file_md5.lower() == registry_md5.lower()
-        else:
-            file_dict["hash_valid"] = None
-        return file_dict
+        hash_valid = file_md5.lower() == registry_md5.lower() if file_md5 and registry_md5 else None
+        return {
+            **file_dict,
+            "required": required,
+            "description": description,
+            "classification": classification,
+            "hash_valid": hash_valid,
+        }
 
     def _firmware_dest_path(self, firmware):
         """Determine local destination path for a firmware file.
@@ -209,7 +214,7 @@ class FirmwareService:
         items = [
             {
                 "file_name": fw.get("file_name", ""),
-                "downloaded": os.path.exists(self._firmware_dest_path(fw)),
+                "downloaded": self._firmware_files.exists(self._firmware_dest_path(fw)),
                 "dest": self._firmware_dest_path(fw),
             }
             for fw in self._firmware_cache
@@ -256,7 +261,7 @@ class FirmwareService:
                     "file_name": fw.get("file_name", ""),
                     "size": fw.get("file_size_bytes", 0),
                     "md5": fw.get("md5_hash", ""),
-                    "downloaded": os.path.exists(dest),
+                    "downloaded": self._firmware_files.exists(dest),
                 }
             )
         return platforms_map
@@ -277,7 +282,7 @@ class FirmwareService:
                         "file_name": file_name,
                         "size": 0,
                         "md5": reg_entry.get("md5", ""),
-                        "downloaded": os.path.exists(dest),
+                        "downloaded": self._firmware_files.exists(dest),
                     }
                 )
         return platforms_map
@@ -295,8 +300,7 @@ class FirmwareService:
             plat["active_core"] = core_so
             plat["active_core_label"] = core_label
             plat["available_cores"] = self._core_info.get_available_cores(slug)
-            for f in plat["files"]:
-                self._enrich_firmware_file(f, core_so=core_so)
+            plat["files"] = [self._enrich_firmware_file(f, core_so=core_so) for f in plat["files"]]
             plat["has_games"] = slug in installed_slugs
             plat["all_downloaded"] = all(f["downloaded"] for f in plat["files"])
 
@@ -322,33 +326,17 @@ class FirmwareService:
     def _download_firmware_post_io(self, fw, firmware_id, dest, tmp_path):
         """Sync helper for download_firmware — rename, hash verification, state save in executor."""
         file_name = fw.get("file_name", "")
-        os.replace(tmp_path, dest)
+        self._firmware_files.rename(tmp_path, dest)
 
-        # Verify MD5 if available
-        md5_match = None
+        # Compute local MD5 once (used for both server-hash and registry-hash checks)
         expected_md5 = fw.get("md5_hash", "")
-        local_md5 = None
-        if expected_md5:
-            h = hashlib.md5()
-            with open(dest, "rb") as f:
-                for chunk in iter(lambda: f.read(8192), b""):
-                    h.update(chunk)
-            local_md5 = h.hexdigest()
-            md5_match = local_md5 == expected_md5
-
-        # Check against registry hash
-        registry_hash_valid = None
         reg_entry = self._bios_files_index.get(file_name)
-        if reg_entry:
-            reg_md5 = reg_entry.get("md5", "")
-            if reg_md5:
-                if local_md5 is None:
-                    h = hashlib.md5()
-                    with open(dest, "rb") as f:
-                        for chunk in iter(lambda: f.read(8192), b""):
-                            h.update(chunk)
-                    local_md5 = h.hexdigest()
-                registry_hash_valid = local_md5.lower() == reg_md5.lower()
+        reg_md5 = reg_entry.get("md5", "") if reg_entry else ""
+
+        local_md5 = self._firmware_files.checksum_md5(dest) if (expected_md5 or reg_md5) else None
+
+        md5_match = local_md5 == expected_md5 if expected_md5 and local_md5 is not None else None
+        registry_hash_valid = local_md5.lower() == reg_md5.lower() if reg_md5 and local_md5 is not None else None
 
         # Track in state for migration support
         self._state["downloaded_bios"][file_name] = {
@@ -375,11 +363,10 @@ class FirmwareService:
         tmp_path = dest + ".tmp"
 
         try:
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            await self._loop.run_in_executor(None, self._firmware_files.make_dirs, os.path.dirname(dest))
             await self._loop.run_in_executor(None, self._romm_api.download_firmware, firmware_id, file_name, tmp_path)
         except Exception as e:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
+            await self._loop.run_in_executor(None, self._firmware_files.remove, tmp_path)
             self._logger.error(f"Failed to download firmware {file_name}: {e}")
             return error_response(e)
 
@@ -413,7 +400,7 @@ class FirmwareService:
         errors = []
         for fw in platform_firmware:
             dest = self._firmware_dest_path(fw)
-            if os.path.exists(dest):
+            if self._firmware_files.exists(dest):
                 continue
             result = await self.download_firmware(fw["id"])
             if result.get("success"):
@@ -441,7 +428,7 @@ class FirmwareService:
         errors = []
         for fw in platform_firmware:
             dest = self._firmware_dest_path(fw)
-            if os.path.exists(dest):
+            if self._firmware_files.exists(dest):
                 continue
             result = await self.download_firmware(fw["id"])
             if result.get("success"):
@@ -492,7 +479,7 @@ class FirmwareService:
             items = [
                 {
                     "file_name": fw.get("file_name", ""),
-                    "downloaded": os.path.exists(self._firmware_dest_path(fw)),
+                    "downloaded": self._firmware_files.exists(self._firmware_dest_path(fw)),
                     "dest": self._firmware_dest_path(fw),
                 }
                 for fw in firmware_list
@@ -506,7 +493,9 @@ class FirmwareService:
             registry_items = [
                 {
                     "file_name": file_name,
-                    "downloaded": os.path.exists(os.path.join(bios_base, reg_entry.get("firmware_path", file_name))),
+                    "downloaded": self._firmware_files.exists(
+                        os.path.join(bios_base, reg_entry.get("firmware_path", file_name))
+                    ),
                     "dest": os.path.join(bios_base, reg_entry.get("firmware_path", file_name)),
                 }
                 for file_name, reg_entry in registry_platform.items()
@@ -545,12 +534,14 @@ class FirmwareService:
             if not f.downloaded:
                 continue
             try:
-                os.remove(f.local_path)
-                deleted += 1
-                # Remove from state tracking
-                self._state["downloaded_bios"].pop(f.file_name, None)
-            except Exception as e:
+                self._firmware_files.remove(f.local_path)
+            except OSError as e:
+                self._logger.warning(f"Failed to remove BIOS file {f.file_name}: {e}")
                 errors.append(f"{f.file_name}: {e}")
+                continue
+            deleted += 1
+            # Remove from state tracking
+            self._state["downloaded_bios"].pop(f.file_name, None)
 
         if deleted:
             self._save_state()

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -659,6 +659,45 @@ class DownloadQueueAdapter(Protocol):
         ...
 
 
+class FirmwareFileAdapter(Protocol):
+    """Filesystem seam for firmware/BIOS file operations.
+
+    Owns the raw POSIX calls FirmwareService uses to manage firmware
+    downloads under the RetroDECK BIOS directory: existence probes,
+    atomic temp-file lifecycle, parent-directory creation, MD5 hashing
+    of downloaded payloads, and BIOS registry JSON reads. Path
+    construction, registry lookups, and download orchestration remain a
+    service concern; this Protocol exposes only the I/O seams.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        ...
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        ...
+
+    def checksum_md5(self, path: str) -> str:
+        """Return the hex-encoded MD5 digest of *path*'s contents."""
+        ...
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        ...
+
+
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.
 

--- a/tests/adapters/test_firmware_file.py
+++ b/tests/adapters/test_firmware_file.py
@@ -1,0 +1,137 @@
+"""Tests for FirmwareFileAdapter — raw filesystem ops for firmware/BIOS files."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import pytest
+
+from adapters.firmware_file import FirmwareFileAdapter
+
+
+@pytest.fixture
+def fw_files() -> FirmwareFileAdapter:
+    return FirmwareFileAdapter()
+
+
+class TestExists:
+    def test_true_for_existing_file(self, fw_files, tmp_path):
+        f = tmp_path / "bios.bin"
+        f.write_bytes(b"x")
+        assert fw_files.exists(str(f)) is True
+
+    def test_true_for_directory(self, fw_files, tmp_path):
+        assert fw_files.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, fw_files, tmp_path):
+        assert fw_files.exists(str(tmp_path / "missing.bin")) is False
+
+
+class TestRemove:
+    def test_removes_existing(self, fw_files, tmp_path):
+        f = tmp_path / "bios.bin"
+        f.write_bytes(b"x")
+        fw_files.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, fw_files, tmp_path):
+        # idempotent: must not raise
+        fw_files.remove(str(tmp_path / "missing.bin"))
+
+    def test_propagates_non_filenotfound_errors(self, fw_files, tmp_path):
+        # Removing a non-empty directory raises IsADirectoryError or OSError —
+        # anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            fw_files.remove(str(tmp_path))
+
+
+class TestRename:
+    def test_renames_file(self, fw_files, tmp_path):
+        src = tmp_path / "a.bin.tmp"
+        dst = tmp_path / "a.bin"
+        src.write_bytes(b"payload")
+        fw_files.rename(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"payload"
+
+    def test_overwrites_existing_destination(self, fw_files, tmp_path):
+        src = tmp_path / "new.tmp"
+        dst = tmp_path / "old.bin"
+        src.write_bytes(b"new")
+        dst.write_bytes(b"old")
+        fw_files.rename(str(src), str(dst))
+        assert dst.read_bytes() == b"new"
+        assert not src.exists()
+
+    def test_missing_source_raises(self, fw_files, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            fw_files.rename(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestMakeDirs:
+    def test_creates_dir(self, fw_files, tmp_path):
+        target = tmp_path / "bios"
+        fw_files.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_creates_parents(self, fw_files, tmp_path):
+        target = tmp_path / "retrodeck" / "bios" / "dc"
+        fw_files.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_idempotent_when_dir_exists(self, fw_files, tmp_path):
+        target = tmp_path / "bios"
+        target.mkdir()
+        # Must not raise
+        fw_files.make_dirs(str(target))
+        assert target.is_dir()
+
+
+class TestChecksumMd5:
+    def test_matches_hashlib(self, fw_files, tmp_path):
+        f = tmp_path / "bios.bin"
+        payload = b"firmware payload bytes"
+        f.write_bytes(payload)
+        expected = hashlib.md5(payload).hexdigest()
+        assert fw_files.checksum_md5(str(f)) == expected
+
+    def test_returns_hex_digest_format(self, fw_files, tmp_path):
+        f = tmp_path / "bios.bin"
+        f.write_bytes(b"x")
+        digest = fw_files.checksum_md5(str(f))
+        # 32-char lowercase hex string
+        assert re.fullmatch(r"[0-9a-f]{32}", digest)
+
+    def test_empty_file(self, fw_files, tmp_path):
+        f = tmp_path / "empty.bin"
+        f.write_bytes(b"")
+        assert fw_files.checksum_md5(str(f)) == hashlib.md5(b"").hexdigest()
+
+    def test_streams_large_file(self, fw_files, tmp_path):
+        """Files larger than one chunk are hashed correctly."""
+        f = tmp_path / "large.bin"
+        # 25 KiB — well above the 8 KiB chunk size
+        payload = b"A" * (25 * 1024)
+        f.write_bytes(payload)
+        assert fw_files.checksum_md5(str(f)) == hashlib.md5(payload).hexdigest()
+
+    def test_missing_file_raises(self, fw_files, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            fw_files.checksum_md5(str(tmp_path / "missing.bin"))
+
+
+class TestReadBytes:
+    def test_roundtrip(self, fw_files, tmp_path):
+        f = tmp_path / "bios.bin"
+        f.write_bytes(b"\x00\x01\x02\x03")
+        assert fw_files.read_bytes(str(f)) == b"\x00\x01\x02\x03"
+
+    def test_empty_file(self, fw_files, tmp_path):
+        f = tmp_path / "empty.bin"
+        f.write_bytes(b"")
+        assert fw_files.read_bytes(str(f)) == b""
+
+    def test_missing_raises(self, fw_files, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            fw_files.read_bytes(str(tmp_path / "missing.bin"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,6 +400,62 @@ class FakeDownloadQueueAdapter:
         return out
 
 
+class FakeFirmwareFileAdapter:
+    """In-memory ``FirmwareFileAdapter`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` is idempotent per the
+    Protocol contract. ``exists`` reports True for any stored file or
+    any path explicitly registered as a directory (via ``make_dirs``).
+
+    Failure injection:
+    - ``remove_failures`` — paths that raise ``OSError`` when removed,
+      letting tests assert error handling without a real filesystem.
+    - ``checksum_overrides`` — pinned hex digests returned by
+      ``checksum_md5`` for specific paths, sidestepping the in-memory
+      ``hashlib`` call when tests want a deterministic mismatch.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        self.dirs: set[str] = set()
+        self.remove_failures: set[str] = set()
+        self.checksum_overrides: dict[str, str] = {}
+
+    def exists(self, path: str) -> bool:
+        if path in self.files or path in self.dirs:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def remove(self, path: str) -> None:
+        if path in self.remove_failures:
+            raise OSError(f"simulated remove failure: {path}")
+        self.files.pop(path, None)
+
+    def rename(self, src: str, dst: str) -> None:
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+
+    def make_dirs(self, path: str) -> None:
+        self.dirs.add(path)
+
+    def checksum_md5(self, path: str) -> str:
+        if path in self.checksum_overrides:
+            return self.checksum_overrides[path]
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        import hashlib
+
+        return hashlib.md5(self.files[path]).hexdigest()
+
+    def read_bytes(self, path: str) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -4,10 +4,11 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, FakeFirmwareFileAdapter
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.bios import BiosFileEntry
 
+from adapters.firmware_file import FirmwareFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -51,6 +52,7 @@ def plugin():
         clock=_make_clock(),
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
+        firmware_files=FirmwareFileAdapter(),
         get_bios_path=MagicMock(return_value=""),
         core_info=FakeCoreInfoProvider(),
     )
@@ -1553,6 +1555,7 @@ class TestFirmwareListCache:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=FakeCoreInfoProvider(),
         )
@@ -1659,6 +1662,7 @@ class TestCheckPlatformBiosCached:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=core_info,
         )
@@ -1736,6 +1740,7 @@ class TestCheckPlatformBiosCached:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=FakeFirmwareCachePersister(),
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=core_info,
         )
@@ -1769,6 +1774,7 @@ class TestFirmwareCachePersistence:
             clock=clock,
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=FakeCoreInfoProvider(),
         )
@@ -1792,6 +1798,7 @@ class TestFirmwareCachePersistence:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=FakeCoreInfoProvider(),
         )
@@ -1811,6 +1818,7 @@ class TestFirmwareCachePersistence:
             clock=_make_clock(),
             save_state=MagicMock(),
             firmware_cache_persister=persister,
+            firmware_files=FirmwareFileAdapter(),
             get_bios_path=MagicMock(return_value=""),
             core_info=FakeCoreInfoProvider(),
         )
@@ -1855,3 +1863,100 @@ class TestFirmwareCachePersistence:
 
         assert result == firmware_list
         assert fw._firmware_cache == firmware_list
+
+
+class TestEnrichFirmwareFileReturnsNewDict:
+    """Regression coverage for #170 — _enrich_firmware_file must not mutate its input."""
+
+    def test_input_dict_is_not_mutated(self, fw):
+        """Calling _enrich_firmware_file leaves the caller's dict untouched."""
+        fw._bios_files_index = {
+            "scph5501.bin": {
+                "description": "PS1 BIOS",
+                "required": True,
+                "md5": "abc",
+                "platform": "psx",
+            },
+        }
+        original = {"file_name": "scph5501.bin", "md5": "abc"}
+        snapshot = dict(original)
+
+        result = fw._enrich_firmware_file(original)
+
+        # Caller's dict still has only the original keys.
+        assert original == snapshot
+        # Returned dict carries the enrichment.
+        assert result is not original
+        assert result["required"] is True
+        assert result["description"] == "PS1 BIOS"
+        assert result["classification"] == "required"
+        assert result["hash_valid"] is True
+
+    def test_unknown_file_does_not_mutate_input(self, fw):
+        """The unknown-file branch must also return a new dict."""
+        fw._bios_files_index = {}
+        original = {"file_name": "mystery.bin", "md5": ""}
+        snapshot = dict(original)
+
+        result = fw._enrich_firmware_file(original)
+
+        assert original == snapshot
+        assert result is not original
+        assert result["classification"] == "unknown"
+        assert result["required"] is False
+
+
+class TestDeletePlatformBiosIOLogsWarnings:
+    """Coverage for the OSError-warning path in _delete_platform_bios_io."""
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_and_collects_error_when_remove_fails(self, plugin, fw, caplog):
+        """A per-file OSError surfaces as a logger.warning and an error entry."""
+        import logging
+
+        fake_files = FakeFirmwareFileAdapter()
+        fake_files.remove_failures.add("/fake/bios/scph5501.bin")
+        fw._firmware_files = fake_files
+
+        async def mock_check(slug, rom_filename=None):
+            return {
+                "needs_bios": True,
+                "files": (
+                    BiosFileEntry(
+                        file_name="scph5501.bin",
+                        downloaded=True,
+                        local_path="/fake/bios/scph5501.bin",
+                        required=True,
+                        description="PS1 BIOS",
+                        classification="required",
+                        cores={},
+                        used_by_active=True,
+                    ),
+                    BiosFileEntry(
+                        file_name="scph5502.bin",
+                        downloaded=True,
+                        local_path="/fake/bios/scph5502.bin",
+                        required=True,
+                        description="PS1 BIOS (EU)",
+                        classification="required",
+                        cores={},
+                        used_by_active=True,
+                    ),
+                ),
+            }
+
+        fw.check_platform_bios = mock_check
+        plugin._state["downloaded_bios"]["scph5501.bin"] = {"file_path": "/fake/bios/scph5501.bin"}
+        plugin._state["downloaded_bios"]["scph5502.bin"] = {"file_path": "/fake/bios/scph5502.bin"}
+
+        with caplog.at_level(logging.WARNING):
+            result = await fw.delete_platform_bios("psx")
+
+        # One file deleted (the second), one failed with a logged warning.
+        assert result["success"] is False
+        assert result["deleted_count"] == 1
+        assert any("scph5501.bin" in record.getMessage() for record in caplog.records)
+        # The failing file's state entry must remain (it wasn't actually removed).
+        assert "scph5501.bin" in plugin._state["downloaded_bios"]
+        # The successful file's state entry is cleared.
+        assert "scph5502.bin" not in plugin._state["downloaded_bios"]

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -10,6 +10,7 @@ from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, _make_tes
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
@@ -132,6 +133,7 @@ def plugin(tmp_path):
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
+        firmware_files=FirmwareFileAdapter(),
         get_bios_path=MagicMock(return_value=""),
         core_info=FakeCoreInfoProvider(),
     )

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
 
@@ -47,6 +48,7 @@ def plugin():
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=MagicMock(),
         firmware_cache_persister=FakeFirmwareCachePersister(),
+        firmware_files=FirmwareFileAdapter(),
         get_bios_path=MagicMock(return_value=""),
         core_info=FakeCoreInfoProvider(),
     )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -19,6 +19,7 @@ from conftest import (
     FakeDownloadFileAdapter,
     FakeDownloadQueueAdapter,
     FakeFirmwareCachePersister,
+    FakeFirmwareFileAdapter,
     FakeSgdbArtworkCache,
 )
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
@@ -157,6 +158,7 @@ class TestWireServices:
             "sgdb_artwork_cache": FakeSgdbArtworkCache(),
             "download_files": FakeDownloadFileAdapter(),
             "download_queue": FakeDownloadQueueAdapter(),
+            "firmware_files": FakeFirmwareFileAdapter(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -197,6 +199,7 @@ class TestWireServices:
                 sgdb_artwork_cache=deps["sgdb_artwork_cache"],
                 download_files=deps["download_files"],
                 download_queue=deps["download_queue"],
+                firmware_files=deps["firmware_files"],
             ),
             stores=StateBundle(
                 state=deps["state"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1094,6 +1094,7 @@ class TestMainStartupOrdering:
             "cover_art_file_store": MagicMock(),
             "sgdb_artwork_cache": MagicMock(),
             "download_files": MagicMock(),
+            "firmware_files": MagicMock(),
             "download_queue": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),


### PR DESCRIPTION
## Summary

Fourth Wave 3 vertical of the Cosmic Python refactor (umbrella #277, epic #298). Follows the pattern from sister PRs #321 (artwork), #322 (steamgrid), #323 (downloads). Extracts all raw filesystem and crypto I/O from `FirmwareService` behind a new `FirmwareFileAdapter` Protocol + adapter. Also fixes the `_enrich_firmware_file` mutation (#170) by returning a new dict instead of mutating the input.

After this PR, `FirmwareService` is free of `import hashlib`, `hashlib.md5(open(...))`, raw `os.*` (non-algebra), and `open()` calls.

## Changes

- **New Protocol `FirmwareFileAdapter`** in `services/protocols.py` — 6 sync methods: `exists`, `remove` (idempotent), `rename` (atomic os.replace), `make_dirs` (exist_ok=True, all parents), `checksum_md5` (hex str), `read_bytes`.
- **New concrete adapter** `adapters/firmware_file.py`. `remove` uses `contextlib.suppress(FileNotFoundError)`. `checksum_md5` reads in 8192-byte chunks, returns `.hexdigest()`.
- **`FirmwareService`** drops `import hashlib`; injects `firmware_files: FirmwareFileAdapter` (ctor: 10 → 11 params, under S107); all 13 raw-I/O sites replaced with adapter calls.
- **Dual MD5 collapsed** in `_download_firmware_post_io`: was two separate `hashlib.md5() + open()` invocations against the same file, now one `self._firmware_files.checksum_md5(dest)` call reused for server-hash + registry-hash comparisons. Pure optimization, no behavior change.
- **`_delete_platform_bios_io`**: service-side loop with per-file `logger.warning` on `OSError`, mirroring `SteamGridService.prune_orphaned_artwork_cache` from #322.
- **Fix #170**: `_enrich_firmware_file` now returns a new dict via `{**file_dict, ...}` spread; caller `_enrich_platform_map` reassigns the list with the returned values. No more in-place mutation.
- **Tests** use real `FirmwareFileAdapter` for `tmp_path`-based integration tests + new `FakeFirmwareFileAdapter` in `tests/conftest.py` (`remove_failures: set[str]` for `OSError` injection, `checksum_overrides: dict[str, str]` for deterministic MD5s) for failure-path tests.
- **Bootstrap + main.py** wired through.

## Test plan

- [x] \`python -m pytest tests/ -q\` — **1972 passed** (+23 vs main baseline)
- [x] \`ruff check py_modules/ tests/\` — clean
- [x] \`basedpyright py_modules/ tests/\` — 0 errors, 0 warnings
- [x] \`scripts/check_cosmic_call_bans.sh\` — clean
- [x] \`PYTHONPATH=py_modules lint-imports\` — 7 kept, 0 broken
- [x] Grep confirms no \`import hashlib\` / \`hashlib.md5(\` / raw \`open(\` / \`os.*\` non-algebra in \`services/firmware.py\`

Closes #288. Closes #170.