### PR TITLE
refactor(migration): extract raw file I/O into MigrationFileAdapter

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,6 +194,7 @@ class Plugin:
                     sgdb_artwork_cache=adapters["sgdb_artwork_cache"],
                     download_files=adapters["download_files"],
                     download_queue=adapters["download_queue"],
+                    migration_files=adapters["migration_files"],
                 ),
                 stores=StateBundle(
                     state=self._state,

--- a/py_modules/adapters/migration_file.py
+++ b/py_modules/adapters/migration_file.py
@@ -1,0 +1,74 @@
+"""Filesystem adapter for RetroDECK path and save-sort migration I/O.
+
+Owns the raw POSIX calls used by MigrationService to walk source
+locations, create destination directories, and relocate files when the
+RetroDECK home path changes or RetroArch save sorting flips. Path
+construction, conflict policy, and state updates remain a service
+concern; this adapter exposes only the I/O seams declared by
+``services.protocols.MigrationFileAdapter``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+
+
+class MigrationFileAdapter:
+    """Synchronous filesystem operations for RetroDECK migration flows.
+
+    Implements the ``MigrationFileAdapter`` Protocol. Methods are
+    synchronous — services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def is_dir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        return os.path.isdir(path)
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        os.makedirs(path, exist_ok=True)
+
+    def remove(self, path: str) -> None:
+        """Delete the file at *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def remove_tree(self, path: str) -> None:
+        """Recursively delete *path*. Idempotent: a missing directory is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(path)
+
+    def move(self, src: str, dst: str) -> None:
+        """Cross-filesystem-safe move from *src* to *dst*.
+
+        Uses ``shutil.move`` so the operation degrades to copy+delete
+        when *src* and *dst* live on different filesystems (``EXDEV``).
+        """
+        shutil.move(src, dst)
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*.
+
+        Uses ``os.replace`` — same-filesystem only.
+        """
+        os.replace(src, dst)
+
+    def getmtime(self, path: str) -> float:
+        """Return the mtime of *path* as a Unix timestamp."""
+        return os.path.getmtime(path)
+
+    def walk_files(self, base_dir: str) -> list[tuple[str, list[str], list[str]]]:
+        """Return ``os.walk``-style triples for *base_dir*.
+
+        Materialises the iterator to a list so callers receive a
+        snapshot that is safe to mutate in place (the caller may prune
+        ``dirnames`` to skip hidden directories).
+        """
+        return [(dirpath, list(dirnames), list(filenames)) for dirpath, dirnames, filenames in os.walk(base_dir)]

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -17,6 +17,7 @@ from adapters.cover_art_file_store import CoverArtFileStoreAdapter
 from adapters.download_file import DownloadFileAdapter as DownloadFileAdapterImpl
 from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapterImpl
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
+from adapters.migration_file import MigrationFileAdapter as MigrationFileAdapterImpl
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
@@ -35,7 +36,7 @@ from services.firmware import FirmwareService
 from services.game_detail import GameDetailService
 from services.library import LibraryService
 from services.metadata import MetadataService
-from services.migration import MigrationService
+from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService
 from services.protocols import (
     BiosPathProvider,
@@ -48,6 +49,7 @@ from services.protocols import (
     DownloadQueueAdapter,
     EventEmitter,
     FirmwareCachePersister,
+    MigrationFileAdapter,
     RetroArchSaveSortingProvider,
     RetroDeckHomeProvider,
     RommApiProtocol,
@@ -79,6 +81,7 @@ class AdapterBundle:
     sgdb_artwork_cache: SgdbArtworkCache
     download_files: DownloadFileAdapter
     download_queue: DownloadQueueAdapter
+    migration_files: MigrationFileAdapter
 
 
 @dataclass(frozen=True)
@@ -182,6 +185,7 @@ def bootstrap(
     sgdb_artwork_cache = SgdbArtworkCacheAdapter(runtime_dir=runtime_dir)
     download_files = DownloadFileAdapterImpl()
     download_queue = DownloadQueueAdapterImpl()
+    migration_files = MigrationFileAdapterImpl()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -196,6 +200,7 @@ def bootstrap(
         "sgdb_artwork_cache": sgdb_artwork_cache,
         "download_files": download_files,
         "download_queue": download_queue,
+        "migration_files": migration_files,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -239,19 +244,22 @@ def wire_services(cfg: WiringConfig) -> dict:
     # lookup to call time, so it is safe to reference here even though
     # ``firmware_service`` is constructed later in this function.
     migration_service = MigrationService(
-        state=cfg.stores.state,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        save_state=cfg.callbacks.save_state,
-        emit=cfg.runtime.emit,
-        get_bios_files_index=lambda: firmware_service.bios_files_index,
-        get_retrodeck_home=cfg.callbacks.get_retrodeck_home,
-        get_saves_path=cfg.callbacks.get_saves_path,
-        get_bios_path=cfg.callbacks.get_bios_path,
-        get_retroarch_save_sorting=cfg.callbacks.get_retroarch_save_sorting,
-        get_roms_path=cfg.callbacks.get_roms_path,
-        get_active_core=cfg.callbacks.core_info_provider.get_active_core,
-        get_core_name=cfg.callbacks.get_core_name,
+        migration_files=cfg.adapters.migration_files,
+        config=MigrationServiceConfig(
+            state=cfg.stores.state,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            save_state=cfg.callbacks.save_state,
+            emit=cfg.runtime.emit,
+            get_bios_files_index=lambda: firmware_service.bios_files_index,
+            get_retrodeck_home=cfg.callbacks.get_retrodeck_home,
+            get_saves_path=cfg.callbacks.get_saves_path,
+            get_bios_path=cfg.callbacks.get_bios_path,
+            get_retroarch_save_sorting=cfg.callbacks.get_retroarch_save_sorting,
+            get_roms_path=cfg.callbacks.get_roms_path,
+            get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+            get_core_name=cfg.callbacks.get_core_name,
+        ),
     )
 
     save_service_config = SaveServiceConfig(

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -1,15 +1,17 @@
-"""MigrationService — RetroDECK path migration.
+"""MigrationService — RetroDECK path and save-sort migration orchestration.
 
-Detects when RetroDECK home path changes (e.g., internal SSD to SD card)
-and migrates downloaded ROMs, BIOS files, and save files to the new location.
-Also detects RetroArch save sorting setting changes and migrates affected save files.
+Owns the runtime decisions for relocating ROMs, BIOS, and save files
+when the RetroDECK home path changes or RetroArch save sorting flips.
+All raw filesystem I/O is delegated to the ``MigrationFileAdapter``
+Protocol; conflict resolution, state mutations, and event emission
+remain the service's responsibility.
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
-import shutil
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.save_extensions import get_save_extensions
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
         CoreNameProviderFn,
         CoreResolverFn,
         EventEmitter,
+        MigrationFileAdapter,
         RetroArchSaveSortingProvider,
         RetroDeckHomeProvider,
         RomsPathProvider,
@@ -32,39 +35,55 @@ if TYPE_CHECKING:
     )
 
 
+@dataclass(frozen=True)
+class MigrationServiceConfig:
+    """Frozen wiring bundle handed to ``MigrationService.__init__``.
+
+    Holds the live state dict, runtime infrastructure, persistence
+    callback, event emitter, and the provider callables MigrationService
+    needs at construction time. Protocol-typed adapters remain explicit
+    ctor parameters because they have different lifecycles from this
+    immutable wiring bundle.
+    """
+
+    state: dict
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    save_state: StatePersister
+    emit: EventEmitter
+    get_bios_files_index: Callable[[], dict]
+    get_retrodeck_home: RetroDeckHomeProvider | None = None
+    get_saves_path: SavesPathProvider | None = None
+    get_bios_path: BiosPathProvider | None = None
+    get_retroarch_save_sorting: RetroArchSaveSortingProvider | None = None
+    get_roms_path: RomsPathProvider | None = None
+    get_active_core: CoreResolverFn | None = None
+    get_core_name: CoreNameProviderFn | None = None
+
+
 class MigrationService:
     """Handles RetroDECK path change detection and file migration."""
 
     def __init__(
         self,
         *,
-        state: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        save_state: StatePersister,
-        emit: EventEmitter,
-        get_bios_files_index: Callable[[], dict],
-        get_retrodeck_home: RetroDeckHomeProvider | None = None,
-        get_saves_path: SavesPathProvider | None = None,
-        get_bios_path: BiosPathProvider | None = None,
-        get_retroarch_save_sorting: RetroArchSaveSortingProvider | None = None,
-        get_roms_path: RomsPathProvider | None = None,
-        get_active_core: CoreResolverFn | None = None,
-        get_core_name: CoreNameProviderFn | None = None,
+        migration_files: MigrationFileAdapter,
+        config: MigrationServiceConfig,
     ) -> None:
-        self._state = state
-        self._loop = loop
-        self._logger = logger
-        self._save_state = save_state
-        self._emit = emit
-        self._get_bios_files_index = get_bios_files_index
-        self._get_retrodeck_home = get_retrodeck_home
-        self._get_saves_path = get_saves_path
-        self._get_bios_path = get_bios_path
-        self._get_retroarch_save_sorting = get_retroarch_save_sorting
-        self._get_roms_path = get_roms_path
-        self._get_active_core = get_active_core
-        self._get_core_name = get_core_name
+        self._migration_files = migration_files
+        self._state = config.state
+        self._loop = config.loop
+        self._logger = config.logger
+        self._save_state = config.save_state
+        self._emit = config.emit
+        self._get_bios_files_index = config.get_bios_files_index
+        self._get_retrodeck_home = config.get_retrodeck_home
+        self._get_saves_path = config.get_saves_path
+        self._get_bios_path = config.get_bios_path
+        self._get_retroarch_save_sorting = config.get_retroarch_save_sorting
+        self._get_roms_path = config.get_roms_path
+        self._get_active_core = config.get_active_core
+        self._get_core_name = config.get_core_name
 
     def detect_retrodeck_path_change(self) -> None:
         """Check if RetroDECK home path changed since last run."""
@@ -74,7 +93,7 @@ class MigrationService:
         if not current_home:
             return
 
-        if not os.path.isdir(current_home):
+        if not self._migration_files.is_dir(current_home):
             self._logger.warning(f"RetroDECK home path does not exist, skipping: {current_home}")
             return
 
@@ -194,7 +213,7 @@ class MigrationService:
         items = []
         old_bios = os.path.join(old_home, "bios")
         new_bios = self._get_bios_path() if self._get_bios_path else ""
-        if not os.path.isdir(old_bios):
+        if not self._migration_files.is_dir(old_bios):
             return items
         downloaded_bios = self._state.get("downloaded_bios", {})
         for file_name, reg_entry in self._get_bios_files_index().items():
@@ -203,20 +222,30 @@ class MigrationService:
             firmware_path = reg_entry.get("firmware_path", file_name)
             old_file = os.path.join(old_bios, firmware_path)
             new_file = os.path.join(new_bios, firmware_path)
-            if not os.path.exists(old_file):
+            if not self._migration_files.exists(old_file):
                 continue
             items.append((file_name, old_file, new_file, lambda: None, "bios"))
         return items
 
     def _collect_save_items(self, old_home):
-        """Collect save file migration items by scanning old saves directory."""
+        """Collect save file migration items by scanning old saves directory.
+
+        Hidden directories (those whose name begins with ``.``) and the
+        files they contain are skipped: the RomM plugin's ``.romm-backup``
+        sidecars and any ad-hoc user dotdirs must not be migrated.
+        """
         items = []
         old_saves = os.path.join(old_home, "saves")
         new_saves = self._get_saves_path() if self._get_saves_path else ""
-        if not os.path.isdir(old_saves):
+        if not self._migration_files.is_dir(old_saves):
             return items
-        for dirpath, _dirs, filenames in os.walk(old_saves):
-            _dirs[:] = [d for d in _dirs if not d.startswith(".")]
+        for dirpath, _dirs, filenames in self._migration_files.walk_files(old_saves):
+            rel_dir = os.path.relpath(dirpath, old_saves)
+            # Skip any descendant of a hidden directory by inspecting the
+            # relative-path segments. ``rel_dir == "."`` for the saves
+            # root itself, which is never hidden.
+            if rel_dir != "." and any(part.startswith(".") for part in rel_dir.split(os.sep)):
+                continue
             for fname in filenames:
                 if fname.startswith("."):
                     continue
@@ -239,12 +268,11 @@ class MigrationService:
         items.extend(self._collect_save_items(old_home))
         return items
 
-    @staticmethod
-    def _find_conflicts(items):
+    def _find_conflicts(self, items):
         """Return sorted list of labels where both source and destination exist."""
         conflict_set = set()
         for label, old_path, new_path, _updater, _kind in items:
-            if os.path.exists(new_path) and os.path.exists(old_path):
+            if self._migration_files.exists(new_path) and self._migration_files.exists(old_path):
                 conflict_set.add(label)
         return sorted(conflict_set)
 
@@ -252,14 +280,14 @@ class MigrationService:
         """Migrate a single file/directory item. Updates counts and errors in place."""
         count_key = kind if kind != "rom_dir" else None
 
-        if not os.path.exists(old_path):
-            if os.path.exists(new_path):
+        if not self._migration_files.exists(old_path):
+            if self._migration_files.exists(new_path):
                 state_updater()
                 if count_key:
                     counts[count_key] = counts.get(count_key, 0) + 1
             return
 
-        if os.path.exists(new_path):
+        if self._migration_files.exists(new_path):
             self._migrate_conflict_item(
                 label,
                 old_path,
@@ -273,8 +301,8 @@ class MigrationService:
             return
 
         try:
-            os.makedirs(os.path.dirname(new_path), exist_ok=True)
-            shutil.move(old_path, new_path)
+            self._migration_files.make_dirs(os.path.dirname(new_path))
+            self._migration_files.move(old_path, new_path)
             state_updater()
             if count_key:
                 counts[count_key] = counts.get(count_key, 0) + 1
@@ -297,12 +325,12 @@ class MigrationService:
         """Handle migration when destination already exists."""
         if conflict_strategy == "overwrite":
             try:
-                if os.path.isdir(new_path):
-                    shutil.rmtree(new_path)
+                if self._migration_files.is_dir(new_path):
+                    self._migration_files.remove_tree(new_path)
                 else:
-                    os.remove(new_path)
-                os.makedirs(os.path.dirname(new_path), exist_ok=True)
-                shutil.move(old_path, new_path)
+                    self._migration_files.remove(new_path)
+                self._migration_files.make_dirs(os.path.dirname(new_path))
+                self._migration_files.move(old_path, new_path)
                 state_updater()
                 if count_key:
                     counts[count_key] = counts.get(count_key, 0) + 1
@@ -561,7 +589,7 @@ class MigrationService:
             filename = rom_name + ext
             old_file = os.path.join(old_dir, filename)
             new_file = os.path.join(new_dir, filename)
-            if os.path.exists(old_file):
+            if self._migration_files.exists(old_file):
                 items.append((filename, old_file, new_file, lambda: None, "save"))
 
     def _get_save_sort_migration_status_io(self, old_settings: dict, new_settings: dict) -> dict:
@@ -608,8 +636,8 @@ class MigrationService:
         fails the server still holds the authoritative copy.
         """
         try:
-            old_mtime = os.path.getmtime(old_path)
-            new_mtime = os.path.getmtime(new_path)
+            old_mtime = self._migration_files.getmtime(old_path)
+            new_mtime = self._migration_files.getmtime(new_path)
         except OSError as e:
             errors.append(f"{label}: {e}")
             self._logger.error(f"Save-sort conflict mtime read failed: {old_path}: {e}")
@@ -618,7 +646,7 @@ class MigrationService:
         if new_mtime >= old_mtime:
             # Destination is newer — keep it, delete the stale orphan at old_path.
             try:
-                os.remove(old_path)
+                self._migration_files.remove(old_path)
                 state_updater()
                 counts[count_key] = counts.get(count_key, 0) + 1
                 self._logger.info(f"Save-sort conflict: kept newer {new_path}, removed stale {old_path}")
@@ -629,8 +657,8 @@ class MigrationService:
 
         # Source is newer — atomically overwrite destination.
         try:
-            os.makedirs(os.path.dirname(new_path), exist_ok=True)
-            os.replace(old_path, new_path)
+            self._migration_files.make_dirs(os.path.dirname(new_path))
+            self._migration_files.rename(old_path, new_path)
             state_updater()
             counts[count_key] = counts.get(count_key, 0) + 1
             self._logger.info(f"Save-sort conflict: moved newer {old_path} -> {new_path}")
@@ -653,7 +681,7 @@ class MigrationService:
         counts: dict[str, int] = {"rom": 0, "bios": 0, "save": 0}
         errors: list[str] = []
         for label, old_path, new_path, updater, _kind in items:
-            if os.path.exists(old_path) and os.path.exists(new_path):
+            if self._migration_files.exists(old_path) and self._migration_files.exists(new_path):
                 self._resolve_save_sort_conflict(label, old_path, new_path, updater, counts, "save", errors)
             else:
                 self._migrate_single_item(label, old_path, new_path, updater, "save", None, counts, errors)

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -659,6 +659,80 @@ class DownloadQueueAdapter(Protocol):
         ...
 
 
+class MigrationFileAdapter(Protocol):
+    """Filesystem seam for RetroDECK path and save-sort migration I/O.
+
+    Owns the raw POSIX calls MigrationService uses to walk source
+    locations, create destination directories, and relocate files when
+    the RetroDECK home path changes or RetroArch save sorting flips.
+    Path construction, conflict policy, and state updates remain a
+    service concern; this Protocol exposes only the I/O seams.
+
+    The Protocol distinguishes ``move`` from ``rename`` because the two
+    migration flows have different filesystem semantics. ``move`` is
+    the cross-device-safe shutil-style relocation used for RetroDECK
+    home changes (e.g., internal SSD to SD card); it falls back to
+    copy+delete on ``EXDEV``. ``rename`` is the same-filesystem atomic
+    ``os.replace`` used inside the saves tree where source and
+    destination are guaranteed to share a filesystem.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def is_dir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        ...
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete the file at *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def remove_tree(self, path: str) -> None:
+        """Recursively delete *path*. Idempotent: a missing directory is not an error."""
+        ...
+
+    def move(self, src: str, dst: str) -> None:
+        """Cross-filesystem-safe move from *src* to *dst*.
+
+        Uses ``shutil.move`` semantics: a same-filesystem rename when
+        possible, falling back to copy+delete on ``EXDEV``. Use this
+        for RetroDECK home migrations where source and destination may
+        live on different filesystems.
+        """
+        ...
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*.
+
+        Uses ``os.replace`` semantics — same-filesystem only. Use this
+        for save-sort migrations inside the saves tree where source
+        and destination are guaranteed to share a filesystem.
+        """
+        ...
+
+    def getmtime(self, path: str) -> float:
+        """Return the mtime of *path* as a Unix timestamp."""
+        ...
+
+    def walk_files(self, base_dir: str) -> list[tuple[str, list[str], list[str]]]:
+        """Return ``os.walk``-style ``(dirpath, dirnames, filenames)`` triples for *base_dir*.
+
+        Mirrors ``os.walk`` exactly: returns raw triples so callers
+        retain control over directory pruning (e.g., skipping hidden
+        directories).
+        """
+        ...
+
+
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.
 

--- a/tests/adapters/test_migration_file.py
+++ b/tests/adapters/test_migration_file.py
@@ -1,0 +1,218 @@
+"""Tests for MigrationFileAdapter — raw filesystem ops for RetroDECK migration."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from adapters.migration_file import MigrationFileAdapter
+
+
+@pytest.fixture
+def adapter() -> MigrationFileAdapter:
+    return MigrationFileAdapter()
+
+
+class TestExists:
+    def test_true_for_existing_file(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        assert adapter.exists(str(f)) is True
+
+    def test_true_for_directory(self, adapter, tmp_path):
+        assert adapter.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, adapter, tmp_path):
+        assert adapter.exists(str(tmp_path / "missing.rom")) is False
+
+
+class TestIsDir:
+    def test_true_for_directory(self, adapter, tmp_path):
+        assert adapter.is_dir(str(tmp_path)) is True
+
+    def test_false_for_file(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        assert adapter.is_dir(str(f)) is False
+
+    def test_false_for_missing(self, adapter, tmp_path):
+        assert adapter.is_dir(str(tmp_path / "missing")) is False
+
+
+class TestMakeDirs:
+    def test_creates_directory(self, adapter, tmp_path):
+        target = tmp_path / "a" / "b" / "c"
+        adapter.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_idempotent_when_exists(self, adapter, tmp_path):
+        adapter.make_dirs(str(tmp_path))  # already exists — must not raise
+
+
+class TestRemove:
+    def test_removes_existing(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        adapter.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, adapter, tmp_path):
+        # Idempotent — must not raise on a missing file
+        adapter.remove(str(tmp_path / "missing.rom"))
+
+    def test_propagates_non_filenotfound(self, adapter, tmp_path):
+        # Removing a directory with os.remove raises IsADirectoryError /
+        # OSError — anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            adapter.remove(str(tmp_path))
+
+
+class TestRemoveTree:
+    def test_removes_directory(self, adapter, tmp_path):
+        d = tmp_path / "tree"
+        d.mkdir()
+        (d / "a").write_bytes(b"")
+        (d / "b").write_bytes(b"")
+        adapter.remove_tree(str(d))
+        assert not d.exists()
+
+    def test_missing_is_noop(self, adapter, tmp_path):
+        # Idempotent on missing directory
+        adapter.remove_tree(str(tmp_path / "missing"))
+
+    def test_removes_nested(self, adapter, tmp_path):
+        d = tmp_path / "tree"
+        nested = d / "sub" / "deeper"
+        nested.mkdir(parents=True)
+        (nested / "file").write_bytes(b"data")
+        adapter.remove_tree(str(d))
+        assert not d.exists()
+
+
+class TestMove:
+    def test_moves_file_same_dir(self, adapter, tmp_path):
+        src = tmp_path / "src.rom"
+        dst = tmp_path / "dst.rom"
+        src.write_bytes(b"data")
+        adapter.move(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"data"
+
+    def test_moves_file_across_dirs(self, adapter, tmp_path):
+        src_dir = tmp_path / "old"
+        dst_dir = tmp_path / "new"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        src = src_dir / "a.rom"
+        dst = dst_dir / "a.rom"
+        src.write_bytes(b"payload")
+        adapter.move(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"payload"
+
+    def test_missing_source_raises(self, adapter, tmp_path):
+        with pytest.raises((FileNotFoundError, OSError)):
+            adapter.move(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestRename:
+    def test_renames(self, adapter, tmp_path):
+        src = tmp_path / "src.rom"
+        dst = tmp_path / "dst.rom"
+        src.write_bytes(b"data")
+        adapter.rename(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"data"
+
+    def test_replaces_existing(self, adapter, tmp_path):
+        src = tmp_path / "src.rom"
+        dst = tmp_path / "dst.rom"
+        src.write_bytes(b"new")
+        dst.write_bytes(b"old")
+        adapter.rename(str(src), str(dst))
+        assert dst.read_bytes() == b"new"
+
+    def test_missing_source_raises(self, adapter, tmp_path):
+        with pytest.raises(OSError):
+            adapter.rename(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestGetmtime:
+    def test_returns_mtime_float(self, adapter, tmp_path):
+        f = tmp_path / "a.rom"
+        f.write_bytes(b"x")
+        os.utime(str(f), (1_700_000_000.0, 1_700_000_000.0))
+        assert adapter.getmtime(str(f)) == pytest.approx(1_700_000_000.0)
+
+    def test_missing_raises_oserror(self, adapter, tmp_path):
+        with pytest.raises(OSError):
+            adapter.getmtime(str(tmp_path / "missing"))
+
+
+class TestWalkFiles:
+    def test_returns_os_walk_triples(self, adapter, tmp_path):
+        # Build a small tree:
+        # tmp_path/
+        #   a.txt
+        #   sub/
+        #     b.txt
+        (tmp_path / "a.txt").write_text("")
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "b.txt").write_text("")
+
+        triples = adapter.walk_files(str(tmp_path))
+        # Snapshot: expect 2 directories (root + sub).
+        dirs_visited = {dp for dp, _dn, _fn in triples}
+        assert str(tmp_path) in dirs_visited
+        assert str(tmp_path / "sub") in dirs_visited
+        # Locate the root triple by dirpath.
+        root_triple = next(t for t in triples if t[0] == str(tmp_path))
+        assert "sub" in root_triple[1]
+        assert "a.txt" in root_triple[2]
+
+    def test_returns_empty_for_empty_dir(self, adapter, tmp_path):
+        triples = adapter.walk_files(str(tmp_path))
+        # os.walk yields one entry for the root even when empty.
+        assert len(triples) == 1
+        assert triples[0][0] == str(tmp_path)
+        assert triples[0][1] == []
+        assert triples[0][2] == []
+
+    def test_returns_empty_for_missing_dir(self, adapter, tmp_path):
+        # os.walk silently returns nothing for a missing directory.
+        triples = adapter.walk_files(str(tmp_path / "missing"))
+        assert triples == []
+
+    def test_triples_are_mutable_snapshots(self, adapter, tmp_path):
+        """Caller can prune dirnames in place; we materialise to lists, not iterator state."""
+        (tmp_path / "keep.txt").write_text("")
+        (tmp_path / ".hidden").mkdir()
+        (tmp_path / ".hidden" / "x").write_text("")
+        triples = adapter.walk_files(str(tmp_path))
+        # Caller pruning the dirnames list is a no-op for our snapshot
+        # (we don't drive os.walk lazily) — but the lists must be
+        # mutable to mirror os.walk's API expectations.
+        root_triple = next(t for t in triples if t[0] == str(tmp_path))
+        root_triple[1][:] = [d for d in root_triple[1] if not d.startswith(".")]
+        # The mutation should stick on the returned list.
+        assert ".hidden" not in root_triple[1]
+
+
+class TestProtocolMethodCount:
+    """Sanity check that every Protocol method has at least one test class."""
+
+    def test_protocol_methods_covered(self):
+        method_names = {
+            "exists",
+            "is_dir",
+            "make_dirs",
+            "remove",
+            "remove_tree",
+            "move",
+            "rename",
+            "getmtime",
+            "walk_files",
+        }
+        for name in method_names:
+            assert hasattr(MigrationFileAdapter(), name), f"missing {name}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,125 @@ class FakeDownloadFileAdapter:
         self.tmp_files.discard(tmp_path)
 
 
+class FakeMigrationFileAdapter:
+    """In-memory ``MigrationFileAdapter`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` / ``remove_tree`` are
+    idempotent per the Protocol contract. ``is_dir`` reports True for
+    any path that is the parent of an entry or matches a directory
+    created via ``make_dirs``.
+
+    Failure-injection seams support partial-failure tests:
+    - ``move_failures``, ``rename_failures``, ``remove_failures`` —
+      sets of source paths that should raise ``OSError`` on the
+      respective operation.
+    - ``mtimes`` — explicit ``{path: mtime}`` overrides for
+      ``getmtime``; missing entries fall back to the order they were
+      added (monotonically increasing).
+    - ``walk_returns`` — explicit ``{base_dir: triples}`` override for
+      ``walk_files``; when absent, triples are synthesised from the
+      ``files`` and ``dirs`` snapshot.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        self.dirs: set[str] = set()
+        self.move_failures: set[str] = set()
+        self.rename_failures: set[str] = set()
+        self.remove_failures: set[str] = set()
+        self.mtimes: dict[str, float] = {}
+        self.walk_returns: dict[str, list[tuple[str, list[str], list[str]]]] | None = None
+        self.move_calls: list[tuple[str, str]] = []
+        self.rename_calls: list[tuple[str, str]] = []
+
+    def exists(self, path: str) -> bool:
+        return path in self.files or self.is_dir(path)
+
+    def is_dir(self, path: str) -> bool:
+        if path in self.dirs:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def make_dirs(self, path: str) -> None:
+        self.dirs.add(path)
+
+    def remove(self, path: str) -> None:
+        if path in self.remove_failures:
+            raise OSError(f"simulated remove failure: {path}")
+        self.files.pop(path, None)
+
+    def remove_tree(self, path: str) -> None:
+        prefix = path.rstrip("/") + "/"
+        for stored in list(self.files):
+            if stored == path or stored.startswith(prefix):
+                del self.files[stored]
+        self.dirs.discard(path)
+        for d in list(self.dirs):
+            if d.startswith(prefix):
+                self.dirs.discard(d)
+
+    def move(self, src: str, dst: str) -> None:
+        self.move_calls.append((src, dst))
+        if src in self.move_failures:
+            raise OSError(f"simulated move failure: {src}")
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+
+    def rename(self, src: str, dst: str) -> None:
+        self.rename_calls.append((src, dst))
+        if src in self.rename_failures:
+            raise OSError(f"simulated rename failure: {src}")
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+
+    def getmtime(self, path: str) -> float:
+        if path in self.mtimes:
+            return self.mtimes[path]
+        if path not in self.files:
+            raise OSError(f"no such file: {path}")
+        # Stable fallback derived from insertion order so callers can
+        # reason about relative ordering without setting mtimes
+        # explicitly.
+        return float(list(self.files).index(path))
+
+    def walk_files(self, base_dir: str) -> list[tuple[str, list[str], list[str]]]:
+        if self.walk_returns is not None and base_dir in self.walk_returns:
+            return [(dp, list(dn), list(fn)) for dp, dn, fn in self.walk_returns[base_dir]]
+        if not self.is_dir(base_dir):
+            return []
+        prefix = base_dir.rstrip("/") + "/"
+        # Build per-dir filename lists from the flat snapshot.
+        per_dir_files: dict[str, list[str]] = {}
+        per_dir_subdirs: dict[str, set[str]] = {}
+        for stored in self.files:
+            if not stored.startswith(prefix):
+                continue
+            rel = stored[len(prefix) :]
+            dirname, _, filename = rel.rpartition("/")
+            dir_abs = base_dir if not dirname else os.path.join(base_dir, dirname)
+            per_dir_files.setdefault(dir_abs, []).append(filename)
+            # Build the dir chain so subdir names propagate to parents.
+            current = base_dir
+            for part in dirname.split("/") if dirname else []:
+                per_dir_subdirs.setdefault(current, set()).add(part)
+                current = os.path.join(current, part)
+        triples: list[tuple[str, list[str], list[str]]] = []
+        all_dirs = sorted(set(per_dir_files) | set(per_dir_subdirs) | {base_dir})
+        for d in all_dirs:
+            triples.append(
+                (
+                    d,
+                    sorted(per_dir_subdirs.get(d, set())),
+                    sorted(per_dir_files.get(d, [])),
+                )
+            )
+        return triples
+
+
 class FakeDownloadQueueAdapter:
     """In-memory ``DownloadQueueAdapter`` for tests.
 

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -4,9 +4,10 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
-from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, FakeMigrationFileAdapter
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
 
@@ -14,7 +15,7 @@ from adapters.steam_config import SteamConfigAdapter
 from main import Plugin
 from services.firmware import FirmwareService
 from services.library import LibraryService
-from services.migration import MigrationService
+from services.migration import MigrationService, MigrationServiceConfig
 
 
 @pytest.fixture
@@ -70,19 +71,22 @@ def plugin():
     )
 
     p._migration_service = MigrationService(
-        state=p._state,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        save_state=p._save_state,
-        emit=decky.emit,
-        get_bios_files_index=lambda: p._firmware_service.bios_files_index,
-        get_retrodeck_home=MagicMock(return_value=""),
-        get_saves_path=MagicMock(return_value=""),
-        get_bios_path=MagicMock(return_value=""),
-        get_retroarch_save_sorting=MagicMock(return_value=(True, False)),
-        get_roms_path=MagicMock(return_value=""),
-        get_active_core=MagicMock(return_value=(None, None)),
-        get_core_name=MagicMock(return_value=None),
+        migration_files=MigrationFileAdapter(),
+        config=MigrationServiceConfig(
+            state=p._state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            save_state=p._save_state,
+            emit=decky.emit,
+            get_bios_files_index=lambda: p._firmware_service.bios_files_index,
+            get_retrodeck_home=MagicMock(return_value=""),
+            get_saves_path=MagicMock(return_value=""),
+            get_bios_path=MagicMock(return_value=""),
+            get_retroarch_save_sorting=MagicMock(return_value=(True, False)),
+            get_roms_path=MagicMock(return_value=""),
+            get_active_core=MagicMock(return_value=(None, None)),
+            get_core_name=MagicMock(return_value=None),
+        ),
     )
     return p
 
@@ -835,3 +839,133 @@ class TestDetectSaveSortChangeThreadSafety:
             "sort_by_content": True,
             "sort_by_core": True,
         }
+
+
+class TestMigrationFailureInjection:
+    """Adapter-level failure injection tests using FakeMigrationFileAdapter.
+
+    These tests exercise paths the tmp_path-based integration tests cannot
+    reach: simulated ``OSError`` during ``move`` / ``rename`` / ``remove``
+    must be caught by the service, appended to the ``errors`` list, and
+    must not abort the rest of the migration loop. The previous path
+    marker is also retained on partial failure so the user can retry.
+    """
+
+    def _make_service(self, fake_files, **overrides):
+        defaults = {
+            "state": {
+                "installed_roms": {},
+                "downloaded_bios": {},
+            },
+            "loop": asyncio.get_event_loop(),
+            "logger": MagicMock(),
+            "save_state": MagicMock(),
+            "emit": MagicMock(),
+            "get_bios_files_index": lambda: {},
+            "get_retrodeck_home": MagicMock(return_value=""),
+            "get_saves_path": MagicMock(return_value=""),
+            "get_bios_path": MagicMock(return_value=""),
+            "get_retroarch_save_sorting": MagicMock(return_value=(False, False)),
+            "get_roms_path": MagicMock(return_value=""),
+            "get_active_core": MagicMock(return_value=(None, None)),
+            "get_core_name": MagicMock(return_value=None),
+        }
+        defaults.update(overrides)
+        return MigrationService(
+            migration_files=fake_files,
+            config=MigrationServiceConfig(**defaults),
+        )
+
+    def test_move_failure_records_error_and_continues(self):
+        """Mid-batch ``move`` failure is captured in ``errors``; other items still move."""
+        fake = FakeMigrationFileAdapter()
+        old_home = "/old"
+        new_home = "/new"
+        bad_rom = "/old/roms/n64/bad.z64"
+        good_rom = "/old/roms/n64/good.z64"
+        fake.files[bad_rom] = b"bad"
+        fake.files[good_rom] = b"good"
+        fake.move_failures.add(bad_rom)
+
+        service = self._make_service(
+            fake,
+            state={
+                "installed_roms": {
+                    "1": {"rom_id": 1, "file_path": bad_rom, "system": "n64"},
+                    "2": {"rom_id": 2, "file_path": good_rom, "system": "n64"},
+                },
+                "downloaded_bios": {},
+                "retrodeck_home_path_previous": old_home,
+                "retrodeck_home_path": new_home,
+            },
+        )
+
+        result = service._migrate_retrodeck_files_io(old_home, new_home, None)
+
+        assert result["success"] is False
+        assert len(result["errors"]) == 1
+        assert "bad.z64" in result["errors"][0]
+        # Good ROM was moved successfully despite the bad one failing.
+        assert result["roms_moved"] == 1
+        # Marker is retained so the user can retry.
+        assert service._state.get("retrodeck_home_path_previous") == old_home
+
+    def test_rename_failure_records_save_sort_error(self):
+        """``OSError`` from ``rename`` during save-sort overwrite path is captured."""
+        fake = FakeMigrationFileAdapter()
+        old_path = "/saves/old/game.srm"
+        new_path = "/saves/new/game.srm"
+        fake.files[old_path] = b"new content"
+        fake.files[new_path] = b"old content"
+        # Source is newer => triggers rename path.
+        fake.mtimes[old_path] = 2000.0
+        fake.mtimes[new_path] = 1000.0
+        fake.rename_failures.add(old_path)
+
+        service = self._make_service(fake)
+
+        counts: dict[str, int] = {}
+        errors: list = []
+        service._resolve_save_sort_conflict(
+            label="gba/game.srm",
+            old_path=old_path,
+            new_path=new_path,
+            state_updater=MagicMock(),
+            counts=counts,
+            count_key="save",
+            errors=errors,
+        )
+
+        assert len(errors) == 1
+        assert "gba/game.srm" in errors[0]
+        assert counts.get("save", 0) == 0
+
+    def test_remove_failure_records_save_sort_orphan_cleanup_error(self):
+        """``OSError`` from ``remove`` during save-sort newest-wins cleanup is captured."""
+        fake = FakeMigrationFileAdapter()
+        old_path = "/saves/old/game.srm"
+        new_path = "/saves/new/game.srm"
+        fake.files[old_path] = b"stale"
+        fake.files[new_path] = b"fresh"
+        # Destination is newer => triggers orphan-removal path.
+        fake.mtimes[old_path] = 1000.0
+        fake.mtimes[new_path] = 2000.0
+        fake.remove_failures.add(old_path)
+
+        service = self._make_service(fake)
+
+        counts: dict[str, int] = {}
+        errors: list = []
+        service._resolve_save_sort_conflict(
+            label="gba/game.srm",
+            old_path=old_path,
+            new_path=new_path,
+            state_updater=MagicMock(),
+            counts=counts,
+            count_key="save",
+            errors=errors,
+        )
+
+        assert len(errors) == 1
+        assert "gba/game.srm" in errors[0]
+        assert counts.get("save", 0) == 0

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from services.migration import MigrationService
+from adapters.migration_file import MigrationFileAdapter
+from services.migration import MigrationService, MigrationServiceConfig
 
 
 def _active_core(system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]:
@@ -48,19 +49,22 @@ def _make_service(
     save_state_mock = MagicMock()
 
     svc = MigrationService(
-        state=state,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        save_state=save_state_mock,
-        emit=MagicMock(),
-        get_bios_files_index=lambda: {},
-        get_retrodeck_home=lambda: str(tmp_path),
-        get_saves_path=lambda: saves_path,
-        get_bios_path=lambda: str(tmp_path / "bios"),
-        get_retroarch_save_sorting=lambda: sort_settings,
-        get_roms_path=lambda: roms_path,
-        get_active_core=active_core,
-        get_core_name=get_core_name,
+        migration_files=MigrationFileAdapter(),
+        config=MigrationServiceConfig(
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=logging.getLogger("test"),
+            save_state=save_state_mock,
+            emit=MagicMock(),
+            get_bios_files_index=lambda: {},
+            get_retrodeck_home=lambda: str(tmp_path),
+            get_saves_path=lambda: saves_path,
+            get_bios_path=lambda: str(tmp_path / "bios"),
+            get_retroarch_save_sorting=lambda: sort_settings,
+            get_roms_path=lambda: roms_path,
+            get_active_core=active_core,
+            get_core_name=get_core_name,
+        ),
     )
     return svc, save_state_mock
 
@@ -137,12 +141,15 @@ class TestDetectSaveSortChange:
         """No get_retroarch_save_sorting callback — method is a no-op."""
         save_state_mock = MagicMock()
         svc = MigrationService(
-            state={"save_sort_settings": None, "installed_roms": {}},
-            loop=asyncio.get_event_loop(),
-            logger=logging.getLogger("test"),
-            save_state=save_state_mock,
-            emit=MagicMock(),
-            get_bios_files_index=lambda: {},
+            migration_files=MigrationFileAdapter(),
+            config=MigrationServiceConfig(
+                state={"save_sort_settings": None, "installed_roms": {}},
+                loop=asyncio.get_event_loop(),
+                logger=logging.getLogger("test"),
+                save_state=save_state_mock,
+                emit=MagicMock(),
+                get_bios_files_index=lambda: {},
+            ),
         )
         # Should not raise, no state changes
         svc.detect_save_sort_change()
@@ -758,27 +765,33 @@ class TestResolveRetroArchCorename:
             return ("snes9x_libretro", "Snes9x - Current")
 
         svc = MigrationService(
-            state={"installed_roms": {}, "save_sort_settings": None},
-            loop=asyncio.get_event_loop(),
-            logger=logging.getLogger("test"),
-            save_state=MagicMock(),
-            emit=MagicMock(),
-            get_bios_files_index=lambda: {},
-            get_active_core=active_core,
-            # get_core_name intentionally omitted
+            migration_files=MigrationFileAdapter(),
+            config=MigrationServiceConfig(
+                state={"installed_roms": {}, "save_sort_settings": None},
+                loop=asyncio.get_event_loop(),
+                logger=logging.getLogger("test"),
+                save_state=MagicMock(),
+                emit=MagicMock(),
+                get_bios_files_index=lambda: {},
+                get_active_core=active_core,
+                # get_core_name intentionally omitted
+            ),
         )
         assert svc._resolve_retroarch_corename("snes", "Zelda.sfc") == (None, None)
 
     def test_no_active_core_callback_returns_none(self, tmp_path):
         """Service constructed without ``get_active_core`` — method returns (None, None)."""
         svc = MigrationService(
-            state={"installed_roms": {}, "save_sort_settings": None},
-            loop=asyncio.get_event_loop(),
-            logger=logging.getLogger("test"),
-            save_state=MagicMock(),
-            emit=MagicMock(),
-            get_bios_files_index=lambda: {},
-            get_core_name=lambda core_so: "Snes9x",
+            migration_files=MigrationFileAdapter(),
+            config=MigrationServiceConfig(
+                state={"installed_roms": {}, "save_sort_settings": None},
+                loop=asyncio.get_event_loop(),
+                logger=logging.getLogger("test"),
+                save_state=MagicMock(),
+                emit=MagicMock(),
+                get_bios_files_index=lambda: {},
+                get_core_name=lambda core_so: "Snes9x",
+            ),
         )
         assert svc._resolve_retroarch_corename("snes", "Zelda.sfc") == (None, None)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -19,6 +19,7 @@ from conftest import (
     FakeDownloadFileAdapter,
     FakeDownloadQueueAdapter,
     FakeFirmwareCachePersister,
+    FakeMigrationFileAdapter,
     FakeSgdbArtworkCache,
 )
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
@@ -157,6 +158,7 @@ class TestWireServices:
             "sgdb_artwork_cache": FakeSgdbArtworkCache(),
             "download_files": FakeDownloadFileAdapter(),
             "download_queue": FakeDownloadQueueAdapter(),
+            "migration_files": FakeMigrationFileAdapter(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -197,6 +199,7 @@ class TestWireServices:
                 sgdb_artwork_cache=deps["sgdb_artwork_cache"],
                 download_files=deps["download_files"],
                 download_queue=deps["download_queue"],
+                migration_files=deps["migration_files"],
             ),
             stores=StateBundle(
                 state=deps["state"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1095,6 +1095,7 @@ class TestMainStartupOrdering:
             "sgdb_artwork_cache": MagicMock(),
             "download_files": MagicMock(),
             "download_queue": MagicMock(),
+            "migration_files": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),
             "retroarch_core_info": MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -11,11 +11,12 @@ from conftest import _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.library import LibraryService
-from services.migration import MigrationService
+from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService
 from services.saves import SaveService, SaveServiceConfig
 
@@ -434,13 +435,16 @@ class TestPostExitSync:
         # (NEW: sort_by_content=False, sort_by_core=False) — the mismatch
         # with state is what detect will discover.
         real_migration = MigrationService(
-            state=plugin._state,
-            loop=asyncio.get_event_loop(),
-            logger=logging.getLogger("test"),
-            save_state=plugin._save_state,
-            emit=MagicMock(),
-            get_bios_files_index=lambda: {},
-            get_retroarch_save_sorting=lambda: (False, False),
+            migration_files=MigrationFileAdapter(),
+            config=MigrationServiceConfig(
+                state=plugin._state,
+                loop=asyncio.get_event_loop(),
+                logger=logging.getLogger("test"),
+                save_state=plugin._save_state,
+                emit=MagicMock(),
+                get_bios_files_index=lambda: {},
+                get_retroarch_save_sorting=lambda: (False, False),
+            ),
         )
         # Sanity: same state object — mutations through migration will be
         # visible to SaveService on the next state read.


### PR DESCRIPTION
## Summary

Fifth Wave 3 vertical of the Cosmic Python refactor (umbrella #277, epic #302). Discussion #293 resolved as **extract**. Follows the pattern from sister PRs #321 (artwork), #322 (steamgrid), #323 (downloads), #324 (firmware). Largest Wave 3 adapter surface so far (9 methods), with the unique twist of preserving the `move` (cross-device, `shutil.move`) vs `rename` (same-fs atomic, `os.replace`) semantic distinction.

After this PR, `MigrationService` is free of `import shutil` and direct `os.*` (non-algebra) calls.

## Changes

- **New Protocol `MigrationFileAdapter`** in `services/protocols.py` — 9 sync methods: `exists`, `is_dir`, `make_dirs` (exist_ok=True, all parents), `remove` (idempotent), `remove_tree` (idempotent), `move` (cross-device safe), `rename` (same-fs atomic), `getmtime`, `walk_files` (returns raw `os.walk` triples).
- **New concrete adapter** `adapters/migration_file.py`. `remove` uses `contextlib.suppress(FileNotFoundError)`.
- **Semantic distinction preserved**: cross-device home migration (RetroDECK internal SSD → SD card) uses `move` (falls back to copy+delete on `EXDEV`); save-sort within the saves tree uses `rename` (atomic, same-fs).
- **`MigrationService`** drops `import shutil`; 22 forbidden I/O sites replaced; service-side per-file `try/except OSError` + error-collection patterns preserved.
- **`MigrationServiceConfig`** frozen dataclass bundles 13 cohesive wiring params (mirrors `DownloadServiceConfig` from #323). Ctor goes from **13 → 2 params** (`migration_files` + `config`).
- **`_collect_save_items` hidden-dir filter rewritten** to a per-iteration check (since `walk_files` materialises the walk output rather than yielding, in-place `_dirs` mutation no longer prunes). Behavior preserved; existing `test_hidden_dirs_skipped` passes.
- **`_find_conflicts`** converted from `@staticmethod` to instance method (now calls `self._migration_files.exists`).
- **Tests** use real `MigrationFileAdapter` for `tmp_path`-based integration tests + new `FakeMigrationFileAdapter` in `tests/conftest.py` with `move_failures` / `rename_failures` / `remove_failures` / `mtimes` injection seams for partial-failure paths. 30 new tests total (27 adapter + 3 service failure-injection).
- **Bootstrap + main.py** wired through.

## Test plan

- [x] \`python -m pytest tests/ -q\` — **1979 passed** (+7 vs main baseline)
- [x] \`ruff check py_modules/ tests/\` — clean
- [x] \`basedpyright py_modules/ tests/\` — 0 errors, 0 warnings
- [x] \`scripts/check_cosmic_call_bans.sh\` — clean
- [x] \`PYTHONPATH=py_modules lint-imports\` — 7 kept, 0 broken
- [x] Grep confirms no \`import shutil\` / raw \`os.*\` non-algebra in \`services/migration.py\`

Closes #302. Closes #293.