### PR TITLE
refactor(services): extract CoreService (#274 part 3/4)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -102,6 +102,7 @@ type = independence
 modules =
     services.achievements
     services.artwork
+    services.cores
     services.downloads
     services.firmware
     services.game_detail

--- a/main.py
+++ b/main.py
@@ -161,8 +161,6 @@ class Plugin:
         self._retrodeck_paths: RetroDeckPathsAdapter = adapters["retrodeck_paths"]
         self._retroarch_config: RetroArchConfigAdapter = adapters["retroarch_config"]
         self._retroarch_core_info: RetroArchCoreInfoAdapter = adapters["retroarch_core_info"]
-        self._core_resolver = adapters["core_resolver"]
-        self._gamelist_editor = adapters["gamelist_editor"]
 
         # ── 3. Load state ───────────────────────────────────────────────────
         self._state = {
@@ -196,6 +194,7 @@ class Plugin:
                     download_queue=adapters["download_queue"],
                     firmware_files=adapters["firmware_files"],
                     migration_files=adapters["migration_files"],
+                    gamelist_editor=adapters["gamelist_editor"],
                 ),
                 stores=StateBundle(
                     state=self._state,
@@ -244,6 +243,7 @@ class Plugin:
         self._artwork_service = services["artwork_service"]
         self._shortcut_removal_service = services["shortcut_removal_service"]
         self._settings_service = services["settings_service"]
+        self._core_service = services["core_service"]
         self._firmware_service.load_bios_registry()
 
         # ── 5. Startup healing ──────────────────────────────────────────────
@@ -388,56 +388,15 @@ class Plugin:
         return self._game_detail_service.get_cached_game_detail(app_id)
 
     async def get_available_cores(self, platform_slug):
-        """Return available RetroArch cores for a platform."""
-        cores = self._core_resolver.get_available_cores(platform_slug)
-        active_core_so, active_core_label = self._core_resolver.get_active_core(platform_slug)
-        return {
-            "cores": cores,
-            "active_core": active_core_so,
-            "active_core_label": active_core_label,
-        }
-
-    def _set_system_core_io(self, retrodeck_home, platform_slug, core_label):
-        """Sync helper for set_system_core — XML read/parse/write in executor."""
-        self._gamelist_editor.set_system_override(retrodeck_home, platform_slug, core_label or None)
-        self._core_resolver.reset_cache()
+        return await self._core_service.get_available_cores(platform_slug)
 
     @migration_blocked
     async def set_system_core(self, platform_slug, core_label):
-        """Set system-wide core override. Pass empty string to reset to default."""
-        retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
-        if not retrodeck_home:
-            return {"success": False, "message": "RetroDECK home not found"}
-        try:
-            await self.loop.run_in_executor(None, self._set_system_core_io, retrodeck_home, platform_slug, core_label)
-            bios = await self._firmware_service.check_platform_bios(platform_slug)
-            return {"success": True, "bios_status": bios}
-        except Exception as e:
-            decky.logger.error(f"Failed to set system core: {e}")
-            return {"success": False, "message": str(e)}
-
-    def _set_game_core_io(self, retrodeck_home, platform_slug, rom_path, core_label):
-        """Sync helper for set_game_core — XML read/parse/write in executor."""
-        self._gamelist_editor.set_game_override(retrodeck_home, platform_slug, rom_path, core_label or None)
-        self._core_resolver.reset_cache()
+        return await self._core_service.set_system_core(platform_slug, core_label)
 
     @migration_blocked
     async def set_game_core(self, platform_slug, rom_path, core_label):
-        """Set per-game core override. Pass empty string to reset to platform default."""
-        retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
-        if not retrodeck_home:
-            return {"success": False, "message": "RetroDECK home not found"}
-        try:
-            await self.loop.run_in_executor(
-                None, self._set_game_core_io, retrodeck_home, platform_slug, rom_path, core_label
-            )
-            # Extract rom filename from path for per-game core detection
-            rom_filename = rom_path.lstrip("./") if rom_path else None
-            bios = await self._firmware_service.check_platform_bios(platform_slug, rom_filename=rom_filename)
-            return {"success": True, "bios_status": bios}
-        except Exception as e:
-            decky.logger.error(f"Failed to set game core: {e}")
-            return {"success": False, "message": str(e)}
+        return await self._core_service.set_game_core(platform_slug, rom_path, core_label)
 
     # ── Firmware delegation to FirmwareService ──────────────
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -32,6 +32,7 @@ from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService, ArtworkServiceConfig
+from services.cores import CoreService, CoreServiceConfig
 from services.downloads import DownloadService, DownloadServiceConfig
 from services.firmware import FirmwareService
 from services.game_detail import GameDetailService
@@ -51,6 +52,7 @@ from services.protocols import (
     EventEmitter,
     FirmwareCachePersister,
     FirmwareFileAdapter,
+    GamelistXmlEditorProtocol,
     MigrationFileAdapter,
     RetroArchSaveSortingProvider,
     RetroDeckHomeProvider,
@@ -86,6 +88,7 @@ class AdapterBundle:
     download_queue: DownloadQueueAdapter
     firmware_files: FirmwareFileAdapter
     migration_files: MigrationFileAdapter
+    gamelist_editor: GamelistXmlEditorProtocol
 
 
 @dataclass(frozen=True)
@@ -455,6 +458,17 @@ def wire_services(cfg: WiringConfig) -> dict:
         ),
     )
 
+    core_service = CoreService(
+        config=CoreServiceConfig(
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            core_info=cfg.callbacks.core_info_provider,
+            gamelist_editor=cfg.adapters.gamelist_editor,
+            retrodeck_home=cfg.callbacks.get_retrodeck_home,
+            bios_checker=firmware_service,
+        ),
+    )
+
     return {
         "save_sync_service": save_sync_service,
         "playtime_service": playtime_service,
@@ -470,4 +484,5 @@ def wire_services(cfg: WiringConfig) -> dict:
         "artwork_service": artwork_service,
         "shortcut_removal_service": shortcut_removal_service,
         "settings_service": settings_service,
+        "core_service": core_service,
     }

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -1,0 +1,141 @@
+"""CoreService — RetroArch core selection and overrides per system/ROM.
+
+Owns reads and writes of ES-DE's per-system and per-game RetroArch
+core overrides. Enumerating the cores available for a platform,
+toggling the system-wide default, and pinning a per-game core all
+live here; the cross-service BIOS recheck that follows a write is
+also scheduled from this service.
+
+XML reads/writes happen via the injected ``GamelistXmlEditorProtocol``
+and ``CoreInfoProvider`` adapters; the on-executor scheduling and the
+cross-service BIOS recheck are this service's concern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.protocols import (
+        CoreInfoProvider,
+        GamelistXmlEditorProtocol,
+        PlatformBiosChecker,
+        RetroDeckHomeProvider,
+    )
+
+
+@dataclass(frozen=True)
+class CoreServiceConfig:
+    """Frozen wiring bundle handed to ``CoreService.__init__``.
+
+    Carries the runtime infrastructure (event loop, logger), the
+    ES-DE read/write seams, the RetroDECK home provider, and the
+    cross-service BIOS checker. Bundled here so the ctor stays
+    within the S107 parameter budget.
+    """
+
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    core_info: CoreInfoProvider
+    gamelist_editor: GamelistXmlEditorProtocol
+    retrodeck_home: RetroDeckHomeProvider
+    bios_checker: PlatformBiosChecker
+
+
+class CoreService:
+    """RetroArch core override reads and writes via ES-DE / gamelist.xml."""
+
+    def __init__(self, *, config: CoreServiceConfig) -> None:
+        self._loop = config.loop
+        self._logger = config.logger
+        self._core_info = config.core_info
+        self._gamelist_editor = config.gamelist_editor
+        self._retrodeck_home = config.retrodeck_home
+        self._bios_checker = config.bios_checker
+
+    async def get_available_cores(self, platform_slug: str) -> dict:
+        """Return available cores for a platform along with the active selection."""
+        cores = self._core_info.get_available_cores(platform_slug)
+        active_so, active_label = self._core_info.get_active_core(platform_slug)
+        return {
+            "cores": cores,
+            "active_core": active_so,
+            "active_core_label": active_label,
+        }
+
+    def _set_system_core_io(
+        self,
+        retrodeck_home: str,
+        platform_slug: str,
+        core_label: str,
+    ) -> None:
+        self._gamelist_editor.set_system_override(retrodeck_home, platform_slug, core_label or None)
+        self._core_info.reset_cache()
+
+    async def set_system_core(self, platform_slug: str, core_label: str) -> dict:
+        """Set or clear the system-wide core override for a platform.
+
+        Empty ``core_label`` clears the override (reverts to the ES-DE
+        default). Returns ``{"success": True, "bios_status": ...}`` on
+        success, where ``bios_status`` is the BIOS payload re-checked
+        against the newly chosen core. On any failure (missing
+        RetroDECK home, XML write error, BIOS recheck error) returns
+        ``{"success": False, "message": ...}``.
+        """
+        retrodeck_home = self._retrodeck_home()
+        if not retrodeck_home:
+            return {"success": False, "message": "RetroDECK home not found"}
+        try:
+            await self._loop.run_in_executor(
+                None,
+                self._set_system_core_io,
+                retrodeck_home,
+                platform_slug,
+                core_label,
+            )
+            bios = await self._bios_checker.check_platform_bios(platform_slug)
+            return {"success": True, "bios_status": bios}
+        except Exception as e:
+            self._logger.error(f"Failed to set system core: {e}")
+            return {"success": False, "message": str(e)}
+
+    def _set_game_core_io(
+        self,
+        retrodeck_home: str,
+        platform_slug: str,
+        rom_path: str,
+        core_label: str,
+    ) -> None:
+        self._gamelist_editor.set_game_override(retrodeck_home, platform_slug, rom_path, core_label or None)
+        self._core_info.reset_cache()
+
+    async def set_game_core(self, platform_slug: str, rom_path: str, core_label: str) -> dict:
+        """Set or clear the per-game core override.
+
+        Empty ``core_label`` clears the per-game override (reverts to
+        the platform default). The BIOS recheck is narrowed by the ROM
+        filename derived from ``rom_path`` (stripping leading ``./``)
+        so the response reflects the per-game core selection. Returns
+        the same success/error shape as ``set_system_core``.
+        """
+        retrodeck_home = self._retrodeck_home()
+        if not retrodeck_home:
+            return {"success": False, "message": "RetroDECK home not found"}
+        try:
+            await self._loop.run_in_executor(
+                None,
+                self._set_game_core_io,
+                retrodeck_home,
+                platform_slug,
+                rom_path,
+                core_label,
+            )
+            rom_filename = rom_path.lstrip("./") if rom_path else None
+            bios = await self._bios_checker.check_platform_bios(platform_slug, rom_filename=rom_filename)
+            return {"success": True, "bios_status": bios}
+        except Exception as e:
+            self._logger.error(f"Failed to set game core: {e}")
+            return {"success": False, "message": str(e)}

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -474,11 +474,13 @@ class CoreResolverFn(Protocol):
 
 
 class CoreInfoProvider(Protocol):
-    """Core resolution for ES-DE configured systems, consumed by FirmwareService.
+    """Core resolution for ES-DE configured systems, consumed by services.
 
     Exposes the read seam services need to ask "which RetroArch core is
     active for this system/ROM?" without depending on the concrete
-    adapter. Implementations own the underlying file reads.
+    adapter. Implementations own the underlying file reads and may
+    cache parse results; ``reset_cache`` lets writers invalidate the
+    cache after editing the underlying configuration.
     """
 
     def get_active_core(
@@ -488,6 +490,8 @@ class CoreInfoProvider(Protocol):
     ) -> tuple[str | None, str | None]: ...
 
     def get_available_cores(self, system_name: str) -> list[dict]: ...
+
+    def reset_cache(self) -> None: ...
 
 
 class GamelistXmlEditorProtocol(Protocol):
@@ -864,6 +868,23 @@ class BiosChecker(Protocol):
     def check_platform_bios_cached(self, platform_slug: str, rom_filename: str | None = None) -> dict | None: ...
 
     async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict: ...
+
+
+class PlatformBiosChecker(Protocol):
+    """Cross-service read seam: ask the firmware service whether a
+    platform's required BIOS files are present, optionally narrowed
+    by a per-game core override.
+
+    Exposes only the single async ``check_platform_bios`` entry point
+    CoreService needs after writing a core override, without dragging
+    in the rest of FirmwareService's surface.
+    """
+
+    async def check_platform_bios(
+        self,
+        platform_slug: str,
+        rom_filename: str | None = None,
+    ) -> dict: ...
 
 
 class AchievementsReader(Protocol):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -600,7 +600,9 @@ class FakeCoreInfoProvider:
 
     Returns the configured active_core and available_cores for any system.
     Both attributes are mutable so tests can set them directly on the
-    instance before exercising the code under test.
+    instance before exercising the code under test. ``reset_cache``
+    increments ``reset_cache_count`` so writers can assert the cache
+    was invalidated after a write.
     """
 
     def __init__(
@@ -611,6 +613,7 @@ class FakeCoreInfoProvider:
     ) -> None:
         self.active_core = active_core
         self.available_cores: list[dict] = available_cores if available_cores is not None else []
+        self.reset_cache_count = 0
 
     def get_active_core(
         self,
@@ -621,6 +624,9 @@ class FakeCoreInfoProvider:
 
     def get_available_cores(self, system_name: str) -> list[dict]:
         return self.available_cores
+
+    def reset_cache(self) -> None:
+        self.reset_cache_count += 1
 
 
 @pytest.fixture(autouse=True)

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -1,0 +1,253 @@
+"""Tests for CoreService."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from conftest import FakeCoreInfoProvider
+
+from services.cores import CoreService, CoreServiceConfig
+
+
+class FakeGamelistEditor:
+    """In-memory ``GamelistXmlEditorProtocol`` for tests."""
+
+    def __init__(self) -> None:
+        self.system_calls: list[tuple[str, str, str | None]] = []
+        self.game_calls: list[tuple[str, str, str, str | None]] = []
+        self.system_side_effect: BaseException | None = None
+        self.game_side_effect: BaseException | None = None
+
+    def set_system_override(self, retrodeck_home: str, system_name: str, core_label: str | None) -> bool:
+        if self.system_side_effect is not None:
+            raise self.system_side_effect
+        self.system_calls.append((retrodeck_home, system_name, core_label))
+        return True
+
+    def set_game_override(
+        self,
+        retrodeck_home: str,
+        system_name: str,
+        rom_path: str,
+        core_label: str | None,
+    ) -> bool:
+        if self.game_side_effect is not None:
+            raise self.game_side_effect
+        self.game_calls.append((retrodeck_home, system_name, rom_path, core_label))
+        return True
+
+
+class FakeBiosChecker:
+    """In-memory ``PlatformBiosChecker`` for tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+        self.payload: dict = {"needs_bios": False}
+        self.side_effect: BaseException | None = None
+
+    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict:
+        if self.side_effect is not None:
+            raise self.side_effect
+        self.calls.append((platform_slug, rom_filename))
+        return self.payload
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test_cores")
+
+
+@pytest.fixture
+def core_info() -> FakeCoreInfoProvider:
+    return FakeCoreInfoProvider(
+        active_core=("snes9x_libretro", "Snes9x"),
+        available_cores=[{"core_so": "snes9x_libretro", "label": "Snes9x"}],
+    )
+
+
+@pytest.fixture
+def gamelist_editor() -> FakeGamelistEditor:
+    return FakeGamelistEditor()
+
+
+@pytest.fixture
+def bios_checker() -> FakeBiosChecker:
+    return FakeBiosChecker()
+
+
+@pytest.fixture
+def retrodeck_home() -> MagicMock:
+    return MagicMock(return_value="/home/deck/retrodeck")
+
+
+@pytest.fixture
+def service(event_loop, logger, core_info, gamelist_editor, bios_checker, retrodeck_home) -> CoreService:
+    return CoreService(
+        config=CoreServiceConfig(
+            loop=event_loop,
+            logger=logger,
+            core_info=core_info,
+            gamelist_editor=gamelist_editor,
+            retrodeck_home=retrodeck_home,
+            bios_checker=bios_checker,
+        ),
+    )
+
+
+# ── get_available_cores ────────────────────────────────────────────────
+
+
+class TestGetAvailableCores:
+    def test_happy_path(self, event_loop, service, core_info):
+        result = event_loop.run_until_complete(service.get_available_cores("snes"))
+        assert result == {
+            "cores": core_info.available_cores,
+            "active_core": "snes9x_libretro",
+            "active_core_label": "Snes9x",
+        }
+
+    def test_no_active_core(self, event_loop, service, core_info):
+        core_info.active_core = (None, None)
+        result = event_loop.run_until_complete(service.get_available_cores("snes"))
+        assert result["active_core"] is None
+        assert result["active_core_label"] is None
+
+    def test_empty_cores_list(self, event_loop, service, core_info):
+        core_info.available_cores = []
+        result = event_loop.run_until_complete(service.get_available_cores("snes"))
+        assert result["cores"] == []
+
+
+# ── set_system_core ────────────────────────────────────────────────────
+
+
+class TestSetSystemCore:
+    def test_happy_path(self, event_loop, service, core_info, gamelist_editor, bios_checker):
+        bios_checker.payload = {"needs_bios": True, "files": []}
+        result = event_loop.run_until_complete(service.set_system_core("snes", "Snes9x"))
+        assert result == {"success": True, "bios_status": {"needs_bios": True, "files": []}}
+        assert gamelist_editor.system_calls == [("/home/deck/retrodeck", "snes", "Snes9x")]
+        assert core_info.reset_cache_count == 1
+        assert bios_checker.calls == [("snes", None)]
+
+    def test_empty_core_label_clears_override(self, event_loop, service, gamelist_editor):
+        result = event_loop.run_until_complete(service.set_system_core("snes", ""))
+        assert result["success"] is True
+        # Editor sees None when core_label is the empty string.
+        assert gamelist_editor.system_calls == [("/home/deck/retrodeck", "snes", None)]
+
+    def test_no_retrodeck_home(
+        self,
+        event_loop,
+        service,
+        retrodeck_home,
+        gamelist_editor,
+        bios_checker,
+        core_info,
+    ):
+        retrodeck_home.return_value = ""
+        result = event_loop.run_until_complete(service.set_system_core("snes", "Snes9x"))
+        assert result == {"success": False, "message": "RetroDECK home not found"}
+        assert gamelist_editor.system_calls == []
+        assert bios_checker.calls == []
+        assert core_info.reset_cache_count == 0
+
+    def test_editor_raises_returns_error(self, event_loop, service, gamelist_editor, bios_checker):
+        gamelist_editor.system_side_effect = RuntimeError("xml write failed")
+        result = event_loop.run_until_complete(service.set_system_core("snes", "Snes9x"))
+        assert result["success"] is False
+        assert "xml write failed" in result["message"]
+        # BIOS checker must not be invoked after a failed write.
+        assert bios_checker.calls == []
+
+    def test_bios_checker_raises_returns_error(self, event_loop, service, gamelist_editor, bios_checker):
+        bios_checker.side_effect = RuntimeError("bios probe failed")
+        result = event_loop.run_until_complete(service.set_system_core("snes", "Snes9x"))
+        assert result["success"] is False
+        assert "bios probe failed" in result["message"]
+        # The write itself still happened.
+        assert gamelist_editor.system_calls == [("/home/deck/retrodeck", "snes", "Snes9x")]
+
+
+# ── set_game_core ──────────────────────────────────────────────────────
+
+
+class TestSetGameCore:
+    def test_happy_path(self, event_loop, service, core_info, gamelist_editor, bios_checker):
+        result = event_loop.run_until_complete(service.set_game_core("n64", "n64/zelda.z64", "Mupen64Plus"))
+        assert result == {"success": True, "bios_status": {"needs_bios": False}}
+        assert gamelist_editor.game_calls == [
+            ("/home/deck/retrodeck", "n64", "n64/zelda.z64", "Mupen64Plus"),
+        ]
+        assert core_info.reset_cache_count == 1
+        assert bios_checker.calls == [("n64", "n64/zelda.z64")]
+
+    def test_rom_path_with_leading_dotslash(self, event_loop, service, bios_checker):
+        result = event_loop.run_until_complete(
+            service.set_game_core("n64", "./n64/zelda.z64", "Mupen64Plus"),
+        )
+        assert result["success"] is True
+        assert bios_checker.calls == [("n64", "n64/zelda.z64")]
+
+    def test_empty_rom_path_yields_none_filename(self, event_loop, service, gamelist_editor, bios_checker):
+        result = event_loop.run_until_complete(service.set_game_core("n64", "", "Mupen64Plus"))
+        assert result["success"] is True
+        assert bios_checker.calls == [("n64", None)]
+        # The editor still receives the empty rom_path verbatim — the
+        # write-side fallback is "set None core_label", not "skip write".
+        assert gamelist_editor.game_calls == [("/home/deck/retrodeck", "n64", "", "Mupen64Plus")]
+
+    def test_empty_core_label_clears_override(self, event_loop, service, gamelist_editor):
+        result = event_loop.run_until_complete(service.set_game_core("n64", "n64/zelda.z64", ""))
+        assert result["success"] is True
+        assert gamelist_editor.game_calls == [
+            ("/home/deck/retrodeck", "n64", "n64/zelda.z64", None),
+        ]
+
+    def test_no_retrodeck_home(
+        self,
+        event_loop,
+        service,
+        retrodeck_home,
+        gamelist_editor,
+        bios_checker,
+        core_info,
+    ):
+        retrodeck_home.return_value = ""
+        result = event_loop.run_until_complete(
+            service.set_game_core("n64", "n64/zelda.z64", "Mupen64Plus"),
+        )
+        assert result == {"success": False, "message": "RetroDECK home not found"}
+        assert gamelist_editor.game_calls == []
+        assert bios_checker.calls == []
+        assert core_info.reset_cache_count == 0
+
+    def test_editor_raises_returns_error(self, event_loop, service, gamelist_editor, bios_checker):
+        gamelist_editor.game_side_effect = RuntimeError("xml write failed")
+        result = event_loop.run_until_complete(
+            service.set_game_core("n64", "n64/zelda.z64", "Mupen64Plus"),
+        )
+        assert result["success"] is False
+        assert "xml write failed" in result["message"]
+        assert bios_checker.calls == []
+
+    def test_bios_checker_raises_returns_error(self, event_loop, service, gamelist_editor, bios_checker):
+        bios_checker.side_effect = RuntimeError("bios probe failed")
+        result = event_loop.run_until_complete(
+            service.set_game_core("n64", "n64/zelda.z64", "Mupen64Plus"),
+        )
+        assert result["success"] is False
+        assert "bios probe failed" in result["message"]
+        assert gamelist_editor.game_calls == [
+            ("/home/deck/retrodeck", "n64", "n64/zelda.z64", "Mupen64Plus"),
+        ]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -33,6 +33,7 @@ from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApi
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
+from services.cores import CoreService
 from services.downloads import DownloadService
 from services.firmware import FirmwareService
 from services.library import LibraryService
@@ -161,6 +162,7 @@ class TestWireServices:
             "download_queue": FakeDownloadQueueAdapter(),
             "firmware_files": FakeFirmwareFileAdapter(),
             "migration_files": FakeMigrationFileAdapter(),
+            "gamelist_editor": MagicMock(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -203,6 +205,7 @@ class TestWireServices:
                 download_queue=deps["download_queue"],
                 firmware_files=deps["firmware_files"],
                 migration_files=deps["migration_files"],
+                gamelist_editor=deps["gamelist_editor"],
             ),
             stores=StateBundle(
                 state=deps["state"],
@@ -261,11 +264,13 @@ class TestWireServices:
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(self._make_config(deps))
-        assert len(result) == 14
+        assert len(result) == 15
         assert "migration_service" in result
         assert "game_detail_service" in result
         assert "rom_removal_service" in result
         assert "settings_service" in result
+        assert "core_service" in result
+        assert isinstance(result["core_service"], CoreService)
         deps["loop"].close()
 
     def test_migration_service_receives_get_core_name(self, tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1076,6 +1076,7 @@ class TestMainStartupOrdering:
             "artwork_service": artwork_service,
             "shortcut_removal_service": MagicMock(),
             "settings_service": MagicMock(),
+            "core_service": MagicMock(),
         }
 
         bootstrapped_adapters = {


### PR DESCRIPTION
Third PR for #274 (callable thinness audit). Extracts core-selection callable logic into a new `CoreService`.

## Changes

- New `py_modules/services/cores.py` — `CoreService` + frozen `CoreServiceConfig` (6 fields)
- `CoreInfoProvider` Protocol gains `reset_cache()` (concrete already implements it)
- New `PlatformBiosChecker` Protocol — narrow async seam structurally satisfied by `FirmwareService` (avoids service-to-service concrete coupling)
- `gamelist_editor` lifted into `AdapterBundle` (was reached via the raw adapter dict before)
- `bootstrap.py` wires the new service; service count 14 → 15
- `.importlinter` adds `services.cores` to the independence list
- 3 callables in `main.py` thinned to one-line delegates:
  - `get_available_cores`
  - `set_system_core` (was 13 lines + executor helper)
  - `set_game_core` (was 13 lines + executor helper)
- Two private `_set_*_core_io` helpers move into the service
- `Plugin._core_resolver` / `Plugin._gamelist_editor` attributes removed (no remaining reads)

## main.py delta

About 30 lines net removed; logic landed in the correct architectural layer.

## Coverage

- New `CoreService` at 100% line + 100% branch
- 15 new tests cover happy / bad / edge for all three methods (empty core_label clears override, empty rom_path → None filename, retrodeck-home short-circuit, editor/BIOS-checker exceptions)
- 2087 total tests, all passing

## Gates

- ruff: PASS
- basedpyright (full scope incl tests/): PASS (0/0/0)
- pytest: PASS (2087)
- `scripts/check_cosmic_call_bans.sh`: PASS
- `lint-imports` (7 contracts): PASS
- `pnpm build`: PASS

## Cosmic Python

- `CoreService` depends only on Protocols
- No new raw I/O, no clock/uuid/sleep direct calls
- New `PlatformBiosChecker` Protocol keeps the cross-service dep (CoreService → FirmwareService) Protocol-typed
- Frozen `CoreServiceConfig` decomposes the 6-param ctor

## Closes

Partial of #274. One PR remains: ConnectionService + StartupHealingService extraction, which will close #274.