### PR TITLE
refactor(services): extract ConnectionService + StartupHealingService (#274 part 4/4)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -102,6 +102,7 @@ type = independence
 modules =
     services.achievements
     services.artwork
+    services.connection
     services.cores
     services.downloads
     services.firmware
@@ -114,4 +115,5 @@ modules =
     services.saves
     services.settings
     services.shortcut_removal
+    services.startup_healing
     services.steamgrid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ The full Cosmic Python migration is tracked under [#277](https://github.com/dani
   - ~~#302~~ MigrationService — shipped as #325 (`MigrationFileAdapter` with cross-device `move` (`shutil.move`) vs same-fs `rename` (`os.replace`) distinction; ctor 13 → 2 via `MigrationServiceConfig`; closed discussion #293 with "extract" verdict).
   - ~~#300~~ LibraryService — shipped as #326 (ctor 17 → 8 via `LibraryServiceConfig`; no I/O extraction — Waves 1+2 had already removed all violations).
 - **Wave 4 — Close-out** — **active**
-  - #274 main.py callable thinness audit. Each `@decky.callable` should be a one-line delegate to a service method; any logic in `main.py` is a smell.
+  - ~~#274~~ shipped as #328 + #329 + #330 + this PR (callable thinness audit)
   - #277 final verification — tick all 11 compliance-checklist items in the umbrella body, then close.
 
 **Saves vertical** ([#254](https://github.com/danielcopper/decky-romm-sync/issues/254)) runs in parallel — independent of the waves above.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import os
 import sys
 from typing import ClassVar
@@ -27,13 +26,14 @@ from adapters.persistence import (
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
-from domain.version import meets_min_version
 from lib.migration_gate import migration_blocked
 
 
 class Plugin:
     settings: dict
     loop: asyncio.AbstractEventLoop
+
+    _MIN_REQUIRED_VERSION = (4, 8, 1)
 
     # -- logging ---------------------------------------------------------------
 
@@ -73,66 +73,6 @@ class Plugin:
 
     def _load_metadata_cache(self):
         self._metadata_cache = self._persistence.load_metadata_cache()
-
-    # -- pruning ---------------------------------------------------------------
-
-    def _is_pending_migration_path(self, file_path: str, rom_dir: str) -> bool:
-        """True when an installed_roms entry lives under the pre-migration home."""
-        pending = self._state.get("retrodeck_home_path_previous", "")
-        if not pending:
-            return False
-        prefix = pending + os.sep
-        return file_path.startswith(prefix) or rom_dir.startswith(prefix)
-
-    def _prune_stale_installed_roms(self):
-        """Remove installed_roms entries whose files no longer exist on disk.
-
-        Skipped entirely when the RetroDECK home path is not yet available on
-        disk — that almost always means the SD card hasn't finished mounting
-        (boot-time race), and a naive os.path.exists() check would wipe every
-        entry that lives on the card. The next plugin reload, with the
-        filesystem ready, will run the prune normally.
-
-        Entries living under a pending migration's previous home are also
-        preserved — RetroDECK has moved away from that path so the files
-        won't exist there, but the user hasn't migrated yet and the entries
-        must survive until they do.
-        """
-        retrodeck_home = self._retrodeck_paths.get_retrodeck_home()
-        if not retrodeck_home or not os.path.exists(retrodeck_home):
-            decky.logger.info(
-                f"Skipping installed_roms prune: retrodeck home unavailable ({retrodeck_home or 'unset'})"
-            )
-            return
-
-        pruned = []
-        for rom_id, entry in list(self._state["installed_roms"].items()):  # list(): dict mutated below
-            file_path = entry.get("file_path", "")
-            rom_dir = entry.get("rom_dir", "")
-            if self._is_pending_migration_path(file_path, rom_dir):
-                decky.logger.info(f"Skipping prune of {rom_id} ({file_path}): pending migration")
-                continue
-            if (file_path and os.path.exists(file_path)) or (rom_dir and os.path.exists(rom_dir)):
-                continue
-            decky.logger.info(f"Pruned stale installed_roms entry: {rom_id} ({file_path})")
-            pruned.append(rom_id)
-        for rom_id in pruned:
-            del self._state["installed_roms"][rom_id]
-        if pruned:
-            self._save_state()
-
-    def _prune_stale_registry(self):
-        """Remove shortcut_registry entries with missing or invalid app_id."""
-        pruned = []
-        for rom_id, entry in list(self._state["shortcut_registry"].items()):  # list(): dict mutated below
-            app_id = entry.get("app_id")
-            if not app_id or not isinstance(app_id, int):
-                decky.logger.info(f"Pruned stale registry entry: rom_id={rom_id} (invalid app_id={app_id})")
-                pruned.append(rom_id)
-        for rom_id in pruned:
-            del self._state["shortcut_registry"][rom_id]
-        if pruned:
-            self._save_state()
 
     async def _main(self):  # Decky lifecycle — must be async
         self.loop = asyncio.get_event_loop()
@@ -195,6 +135,7 @@ class Plugin:
                     firmware_files=adapters["firmware_files"],
                     migration_files=adapters["migration_files"],
                     gamelist_editor=adapters["gamelist_editor"],
+                    path_probe=adapters["path_probe"],
                 ),
                 stores=StateBundle(
                     state=self._state,
@@ -211,6 +152,7 @@ class Plugin:
                     clock=adapters["clock"],
                     uuid_gen=adapters["uuid_gen"],
                     sleeper=adapters["sleeper"],
+                    min_required_version=self._MIN_REQUIRED_VERSION,
                 ),
                 callbacks=CallbackBundle(
                     get_saves_path=self._retrodeck_paths.get_saves_path,
@@ -244,6 +186,8 @@ class Plugin:
         self._shortcut_removal_service = services["shortcut_removal_service"]
         self._settings_service = services["settings_service"]
         self._core_service = services["core_service"]
+        self._connection_service = services["connection_service"]
+        self._startup_healing_service = services["startup_healing_service"]
         self._firmware_service.load_bios_registry()
 
         # ── 5. Startup healing ──────────────────────────────────────────────
@@ -252,8 +196,8 @@ class Plugin:
         # Detect retrodeck path changes BEFORE pruning so the prune can skip
         # entries living under a pending migration's previous home.
         self._migration_service.detect_retrodeck_path_change()
-        self._prune_stale_installed_roms()
-        self._prune_stale_registry()
+        self._startup_healing_service.prune_stale_installed_roms()
+        self._startup_healing_service.prune_stale_registry()
         self._save_sync_service.prune_orphaned_state()
         self._sgdb_service.prune_orphaned_artwork_cache()
         self._artwork_service.prune_orphaned_staging_artwork()
@@ -292,63 +236,13 @@ class Plugin:
         self._download_service.shutdown()
         decky.logger.info("RomM Sync plugin unloaded")
 
-    _MIN_REQUIRED_VERSION = (4, 8, 1)
-
     # ── Callables ──────────────────────────────────────────────────────
     # All methods below are exposed to the frontend via Decky's callable()
     # framework, which requires `async def` even when no `await` is used.
     # S7503 warnings are suppressed in sonar-project.properties (fp1).
 
     async def test_connection(self):
-        from lib.errors import error_response
-
-        if not self.settings.get("romm_url"):
-            return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
-        # Test basic connectivity (heartbeat may not require auth)
-        try:
-            heartbeat = await self.loop.run_in_executor(None, self._romm_api.heartbeat)
-        except Exception as e:
-            self._romm_api.set_version(None)
-            return error_response(e)
-
-        # Extract server version from heartbeat
-        version: str | None = None
-        with contextlib.suppress(AttributeError, TypeError):
-            version = heartbeat.get("SYSTEM", {}).get("VERSION")
-        self._romm_api.set_version(version)
-        if version:
-            decky.logger.info(f"RomM server version: {version}")
-
-        # Test authenticated access
-        try:
-            await self.loop.run_in_executor(None, self._romm_api.list_platforms)
-        except Exception as e:
-            resp = error_response(e)
-            if resp["error_code"] not in ("auth_error", "forbidden_error"):
-                resp["message"] = f"Server reachable but API request failed: {resp['message']}"
-            return resp
-
-        # Enforce minimum version
-        if version and version != "development" and not meets_min_version(version, self._MIN_REQUIRED_VERSION):
-            min_str = ".".join(str(v) for v in self._MIN_REQUIRED_VERSION)
-            return {
-                "success": False,
-                "message": (
-                    f"This plugin requires RomM {min_str} or newer. "
-                    f"Your server is running {version}. "
-                    "Please update your RomM server to continue using this plugin."
-                ),
-                "error_code": "version_error",
-                "romm_version": version,
-            }
-
-        result = {"success": True, "message": "Connected to RomM"}
-        if version and version != "development":
-            result["message"] = f"Connected to RomM {version}"
-            result["romm_version"] = version
-        elif version == "development":
-            result["romm_version"] = version
-        return result
+        return await self._connection_service.test_connection()
 
     async def get_romm_version(self):
         """Return cached RomM version (detected on last test_connection or device probe)."""

--- a/py_modules/adapters/path_probe.py
+++ b/py_modules/adapters/path_probe.py
@@ -1,0 +1,12 @@
+"""Concrete ``PathExistsProbe`` adapter — generic filesystem existence probe."""
+
+from __future__ import annotations
+
+import os
+
+
+class PathProbeAdapter:
+    """Thin wrapper over ``os.path.exists`` for the ``PathExistsProbe`` Protocol."""
+
+    def exists(self, path: str) -> bool:
+        return os.path.exists(path)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -19,6 +19,7 @@ from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapter
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
 from adapters.firmware_file import FirmwareFileAdapter as FirmwareFileAdapterImpl
 from adapters.migration_file import MigrationFileAdapter as MigrationFileAdapterImpl
+from adapters.path_probe import PathProbeAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
@@ -32,6 +33,7 @@ from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService, ArtworkServiceConfig
+from services.connection import ConnectionService, ConnectionServiceConfig
 from services.cores import CoreService, CoreServiceConfig
 from services.downloads import DownloadService, DownloadServiceConfig
 from services.firmware import FirmwareService
@@ -54,6 +56,7 @@ from services.protocols import (
     FirmwareFileAdapter,
     GamelistXmlEditorProtocol,
     MigrationFileAdapter,
+    PathExistsProbe,
     RetroArchSaveSortingProvider,
     RetroDeckHomeProvider,
     RommApiProtocol,
@@ -71,6 +74,7 @@ from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 from services.saves import SaveService, SaveServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
 from services.shortcut_removal import ShortcutRemovalService
+from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridConfig, SteamGridService
 
 
@@ -89,6 +93,7 @@ class AdapterBundle:
     firmware_files: FirmwareFileAdapter
     migration_files: MigrationFileAdapter
     gamelist_editor: GamelistXmlEditorProtocol
+    path_probe: PathExistsProbe
 
 
 @dataclass(frozen=True)
@@ -113,6 +118,7 @@ class RuntimeBundle:
     clock: Clock
     uuid_gen: UuidGen
     sleeper: Sleeper
+    min_required_version: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -194,6 +200,7 @@ def bootstrap(
     download_queue = DownloadQueueAdapterImpl()
     firmware_files = FirmwareFileAdapterImpl()
     migration_files = MigrationFileAdapterImpl()
+    path_probe = PathProbeAdapter()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
@@ -210,6 +217,7 @@ def bootstrap(
         "download_queue": download_queue,
         "firmware_files": firmware_files,
         "migration_files": migration_files,
+        "path_probe": path_probe,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
         "retroarch_core_info": retroarch_core_info,
@@ -469,6 +477,26 @@ def wire_services(cfg: WiringConfig) -> dict:
         ),
     )
 
+    connection_service = ConnectionService(
+        config=ConnectionServiceConfig(
+            settings=cfg.stores.settings,
+            romm_api=cfg.adapters.romm_api,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            min_required_version=cfg.runtime.min_required_version,
+        ),
+    )
+
+    startup_healing_service = StartupHealingService(
+        config=StartupHealingServiceConfig(
+            state=cfg.stores.state,
+            logger=cfg.runtime.logger,
+            save_state=cfg.callbacks.save_state,
+            retrodeck_home=cfg.callbacks.get_retrodeck_home,
+            path_probe=cfg.adapters.path_probe,
+        ),
+    )
+
     return {
         "save_sync_service": save_sync_service,
         "playtime_service": playtime_service,
@@ -485,4 +513,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         "shortcut_removal_service": shortcut_removal_service,
         "settings_service": settings_service,
         "core_service": core_service,
+        "connection_service": connection_service,
+        "startup_healing_service": startup_healing_service,
     }

--- a/py_modules/domain/installed_roms.py
+++ b/py_modules/domain/installed_roms.py
@@ -1,0 +1,26 @@
+"""Pure logic for installed_roms state — pre-migration path detection.
+
+Functions that classify or transform ``installed_roms`` entries without
+touching the filesystem belong here. Anything that probes disk or
+mutates state lives in the corresponding service or adapter.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def is_pending_migration_path(file_path: str, rom_dir: str, pending_home: str) -> bool:
+    """Return True when an installed_roms entry lives under a pre-migration home.
+
+    *pending_home* is the previous ``retrodeck_home_path`` value held in
+    state while a RetroDECK migration is pending; pass an empty string
+    when no migration is pending and the function will return ``False``.
+
+    The check uses the platform path separator so prefix false-matches
+    like ``"/foo"`` matching ``"/foobar/x"`` are rejected.
+    """
+    if not pending_home:
+        return False
+    prefix = pending_home + os.sep
+    return file_path.startswith(prefix) or rom_dir.startswith(prefix)

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.version import meets_min_version
+from lib.errors import error_response
 
 if TYPE_CHECKING:
     from services.protocols import RommApiProtocol
@@ -59,8 +60,6 @@ class ConnectionService:
         On success or version failure, ``romm_version`` carries the
         detected server version when the heartbeat exposed one.
         """
-        from lib.errors import error_response
-
         if not self._settings.get("romm_url"):
             return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
 

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -1,0 +1,107 @@
+"""ConnectionService — RomM server reachability and minimum-version probe.
+
+Owns the ``test_connection`` flow: heartbeat + version sniff +
+authenticated endpoint probe + minimum-version gate. Pure I/O happens
+through the ``RommApiProtocol``; this service composes that I/O with the
+response-shape contract the frontend depends on. The minimum version is
+injected so the policy stays anchored at the plugin entrypoint while
+this service remains a pure orchestration layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from domain.version import meets_min_version
+
+if TYPE_CHECKING:
+    from services.protocols import RommApiProtocol
+
+
+@dataclass(frozen=True)
+class ConnectionServiceConfig:
+    """Frozen wiring bundle handed to ``ConnectionService.__init__``.
+
+    Carries the live settings dict, the RomM API Protocol, the runtime
+    infrastructure (event loop, logger), and the minimum-version policy
+    tuple. Bundled here so the ctor stays within the S107 parameter
+    budget and so the version constant stays declared once at the
+    plugin entrypoint.
+    """
+
+    settings: dict
+    romm_api: RommApiProtocol
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    min_required_version: tuple[int, ...]
+
+
+class ConnectionService:
+    """Heartbeat, version sniff, auth probe, and minimum-version gate."""
+
+    def __init__(self, *, config: ConnectionServiceConfig) -> None:
+        self._settings = config.settings
+        self._romm_api = config.romm_api
+        self._loop = config.loop
+        self._logger = config.logger
+        self._min_required_version = config.min_required_version
+
+    async def test_connection(self) -> dict:
+        """Probe the configured server and return a frontend-shaped result dict.
+
+        The result dict always carries ``success`` and ``message``. On
+        failure, ``error_code`` classifies the cause (``config_error``,
+        ``version_error``, or an :func:`lib.errors.error_response` code).
+        On success or version failure, ``romm_version`` carries the
+        detected server version when the heartbeat exposed one.
+        """
+        from lib.errors import error_response
+
+        if not self._settings.get("romm_url"):
+            return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+
+        try:
+            heartbeat = await self._loop.run_in_executor(None, self._romm_api.heartbeat)
+        except Exception as e:
+            self._romm_api.set_version(None)
+            return error_response(e)
+
+        version: str | None = None
+        with contextlib.suppress(AttributeError, TypeError):
+            version = heartbeat.get("SYSTEM", {}).get("VERSION")
+        self._romm_api.set_version(version)
+        if version:
+            self._logger.info(f"RomM server version: {version}")
+
+        try:
+            await self._loop.run_in_executor(None, self._romm_api.list_platforms)
+        except Exception as e:
+            resp = error_response(e)
+            if resp["error_code"] not in ("auth_error", "forbidden_error"):
+                resp["message"] = f"Server reachable but API request failed: {resp['message']}"
+            return resp
+
+        if version and version != "development" and not meets_min_version(version, self._min_required_version):
+            min_str = ".".join(str(v) for v in self._min_required_version)
+            return {
+                "success": False,
+                "message": (
+                    f"This plugin requires RomM {min_str} or newer. "
+                    f"Your server is running {version}. "
+                    "Please update your RomM server to continue using this plugin."
+                ),
+                "error_code": "version_error",
+                "romm_version": version,
+            }
+
+        result: dict = {"success": True, "message": "Connected to RomM"}
+        if version and version != "development":
+            result["message"] = f"Connected to RomM {version}"
+            result["romm_version"] = version
+        elif version == "development":
+            result["romm_version"] = version
+        return result

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -543,6 +543,22 @@ class ArtworkRemover(Protocol):
     def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...
 
 
+class PathExistsProbe(Protocol):
+    """Generic filesystem existence probe.
+
+    Used by services that need to check whether a path is currently
+    present on disk without touching ``os.path`` directly. Distinct from
+    the domain-shaped ``CoverArtFileStore`` / ``DownloadFileAdapter`` /
+    ``MigrationFileAdapter`` Protocols: this one exposes only the
+    semantic question "does this path exist?" and carries no implication
+    about which subtree of the filesystem the caller is reasoning about.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+
 class CoverArtFileStore(Protocol):
     """Filesystem seam for cover-art file operations.
 

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -1,0 +1,102 @@
+"""StartupHealingService — startup-time state reconciliation.
+
+Owns the reconciliation step that runs after state is loaded and
+adapters are wired: drops persisted ``installed_roms`` and
+``shortcut_registry`` entries that no longer reflect what's on disk.
+Skipped when the RetroDECK home is missing on disk (boot-time SD-card
+mount race) so legitimate entries on a card that hasn't finished
+mounting don't get wiped on the next reload.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from domain.installed_roms import is_pending_migration_path
+
+if TYPE_CHECKING:
+    from services.protocols import PathExistsProbe, RetroDeckHomeProvider, StatePersister
+
+
+@dataclass(frozen=True)
+class StartupHealingServiceConfig:
+    """Frozen wiring bundle handed to ``StartupHealingService.__init__``.
+
+    Carries the live state dict, the runtime logger, the state
+    persister, the RetroDECK home provider, and the generic path-exists
+    probe. Bundled here so the ctor stays within the S107 parameter
+    budget and the service stays free of raw filesystem I/O.
+    """
+
+    state: dict
+    logger: logging.Logger
+    save_state: StatePersister
+    retrodeck_home: RetroDeckHomeProvider
+    path_probe: PathExistsProbe
+
+
+class StartupHealingService:
+    """Reconciles persisted ``installed_roms`` / ``shortcut_registry`` against disk."""
+
+    def __init__(self, *, config: StartupHealingServiceConfig) -> None:
+        self._state = config.state
+        self._logger = config.logger
+        self._save_state = config.save_state
+        self._retrodeck_home = config.retrodeck_home
+        self._path_probe = config.path_probe
+
+    def prune_stale_installed_roms(self) -> None:
+        """Remove installed_roms entries whose files no longer exist on disk.
+
+        Skipped when the RetroDECK home is not yet available on disk —
+        almost always a boot-time SD-card-mount race; the next plugin
+        reload, with the filesystem ready, will run the prune normally.
+        Entries living under a pending migration's previous home are
+        also preserved because RetroDECK has moved away from that path
+        but the user hasn't migrated yet, so the entries must survive
+        until they do.
+        """
+        retrodeck_home = self._retrodeck_home()
+        if not retrodeck_home or not self._path_probe.exists(retrodeck_home):
+            self._logger.info(
+                f"Skipping installed_roms prune: retrodeck home unavailable ({retrodeck_home or 'unset'})"
+            )
+            return
+
+        pending_home = self._state.get("retrodeck_home_path_previous", "")
+        pruned: list[str] = []
+        for rom_id, entry in list(self._state["installed_roms"].items()):  # list(): dict mutated below
+            file_path = entry.get("file_path", "")
+            rom_dir = entry.get("rom_dir", "")
+            if is_pending_migration_path(file_path, rom_dir, pending_home):
+                self._logger.info(f"Skipping prune of {rom_id} ({file_path}): pending migration")
+                continue
+            if (file_path and self._path_probe.exists(file_path)) or (rom_dir and self._path_probe.exists(rom_dir)):
+                continue
+            self._logger.info(f"Pruned stale installed_roms entry: {rom_id} ({file_path})")
+            pruned.append(rom_id)
+        for rom_id in pruned:
+            del self._state["installed_roms"][rom_id]
+        if pruned:
+            self._save_state()
+
+    def prune_stale_registry(self) -> None:
+        """Remove shortcut_registry entries with missing or invalid ``app_id``.
+
+        A registry entry is considered stale when ``app_id`` is falsy or
+        not an ``int``; both shapes indicate a half-written shortcut
+        that Steam will not honour, so the entry is dropped from the
+        registry to keep state honest.
+        """
+        pruned: list[str] = []
+        for rom_id, entry in list(self._state["shortcut_registry"].items()):  # list(): dict mutated below
+            app_id = entry.get("app_id")
+            if not app_id or not isinstance(app_id, int):
+                self._logger.info(f"Pruned stale registry entry: rom_id={rom_id} (invalid app_id={app_id})")
+                pruned.append(rom_id)
+        for rom_id in pruned:
+            del self._state["shortcut_registry"][rom_id]
+        if pruned:
+            self._save_state()

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -67,7 +67,7 @@ class StartupHealingService:
 
         pending_home = self._state.get("retrodeck_home_path_previous", "")
         pruned: list[str] = []
-        for rom_id, entry in list(self._state["installed_roms"].items()):  # list(): dict mutated below
+        for rom_id, entry in self._state["installed_roms"].items():
             file_path = entry.get("file_path", "")
             rom_dir = entry.get("rom_dir", "")
             if is_pending_migration_path(file_path, rom_dir, pending_home):
@@ -91,7 +91,7 @@ class StartupHealingService:
         registry to keep state honest.
         """
         pruned: list[str] = []
-        for rom_id, entry in list(self._state["shortcut_registry"].items()):  # list(): dict mutated below
+        for rom_id, entry in self._state["shortcut_registry"].items():
             app_id = entry.get("app_id")
             if not app_id or not isinstance(app_id, int):
                 self._logger.info(f"Pruned stale registry entry: rom_id={rom_id} (invalid app_id={app_id})")

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -23,6 +23,7 @@ from lib.errors import (
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.connection import ConnectionService, ConnectionServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 
 
@@ -59,6 +60,16 @@ def plugin():
             save_state=p._save_state,
             save_settings_to_disk=p._save_settings_to_disk,
             log_debug=p._log_debug,
+        ),
+    )
+
+    p._connection_service = ConnectionService(
+        config=ConnectionServiceConfig(
+            settings=p.settings,
+            romm_api=p._romm_api,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            min_required_version=Plugin._MIN_REQUIRED_VERSION,
         ),
     )
     return p
@@ -300,11 +311,29 @@ class TestPlatformMap:
 
 
 def _setup_plugin(plugin):
-    """Configure plugin with valid settings for HTTP tests."""
+    """Configure plugin with valid settings for HTTP tests.
+
+    Also rebuilds the connection service on the live event loop so
+    executor calls dispatch on the loop the test awaits — pytest-asyncio
+    creates a fresh loop per test in auto mode, so the loop the fixture
+    captured at setup time is not the loop the test runs on.
+    """
+    import decky
+
     plugin.settings["romm_url"] = "http://romm.local"
     plugin.settings["romm_user"] = "user"
     plugin.settings["romm_pass"] = "pass"
     plugin.settings["romm_allow_insecure_ssl"] = False
+    plugin.loop = asyncio.get_event_loop()
+    plugin._connection_service = ConnectionService(
+        config=ConnectionServiceConfig(
+            settings=plugin.settings,
+            romm_api=plugin._romm_api,
+            loop=plugin.loop,
+            logger=decky.logger,
+            min_required_version=Plugin._MIN_REQUIRED_VERSION,
+        ),
+    )
 
 
 class TestTranslateHttpError:

--- a/tests/adapters/test_path_probe.py
+++ b/tests/adapters/test_path_probe.py
@@ -1,0 +1,23 @@
+"""Tests for the concrete ``PathProbeAdapter``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adapters.path_probe import PathProbeAdapter
+
+
+class TestExists:
+    def test_returns_true_for_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "present"
+        f.write_text("x")
+        assert PathProbeAdapter().exists(str(f)) is True
+
+    def test_returns_true_for_existing_directory(self, tmp_path: Path) -> None:
+        assert PathProbeAdapter().exists(str(tmp_path)) is True
+
+    def test_returns_false_for_missing_path(self, tmp_path: Path) -> None:
+        assert PathProbeAdapter().exists(str(tmp_path / "nope")) is False
+
+    def test_returns_false_for_empty_path(self) -> None:
+        assert PathProbeAdapter().exists("") is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -595,6 +595,22 @@ class FakeFirmwareFileAdapter:
         return self.files[path]
 
 
+class FakePathProbe:
+    """In-memory ``PathExistsProbe`` for tests.
+
+    Backed by a ``set[str]`` of paths that report as existing. Tests
+    pre-populate ``paths`` directly to stage what the probe should
+    treat as present on disk. Lookup is exact: ``exists("/a/b")`` is
+    True iff ``"/a/b"`` is in the set.
+    """
+
+    def __init__(self, paths: set[str] | None = None) -> None:
+        self.paths: set[str] = set(paths) if paths else set()
+
+    def exists(self, path: str) -> bool:
+        return path in self.paths
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/domain/test_installed_roms.py
+++ b/tests/domain/test_installed_roms.py
@@ -1,0 +1,57 @@
+"""Tests for ``domain.installed_roms.is_pending_migration_path``."""
+
+from __future__ import annotations
+
+from domain.installed_roms import is_pending_migration_path
+
+
+class TestIsPendingMigrationPath:
+    def test_empty_pending_home_returns_false(self):
+        """No pending migration marker → no entry is preserved."""
+        assert is_pending_migration_path("/old/retrodeck/roms/n64/a.z64", "", "") is False
+
+    def test_file_path_under_pending_home(self):
+        """file_path under pending_home → True."""
+        assert (
+            is_pending_migration_path(
+                "/old/retrodeck/roms/n64/zelda.z64",
+                "",
+                "/old/retrodeck",
+            )
+            is True
+        )
+
+    def test_rom_dir_under_pending_home(self):
+        """rom_dir under pending_home → True (fallback for multi-file ROMs)."""
+        assert (
+            is_pending_migration_path(
+                "",
+                "/old/retrodeck/roms/psx/FF7",
+                "/old/retrodeck",
+            )
+            is True
+        )
+
+    def test_both_unrelated_returns_false(self):
+        """Neither file_path nor rom_dir under pending_home → False."""
+        assert (
+            is_pending_migration_path(
+                "/new/retrodeck/roms/n64/a.z64",
+                "/new/retrodeck/roms/psx/FF7",
+                "/old/retrodeck",
+            )
+            is False
+        )
+
+    def test_both_empty_returns_false(self):
+        """Empty file_path and rom_dir → False even when pending_home set."""
+        assert is_pending_migration_path("", "", "/old/retrodeck") is False
+
+    def test_prefix_false_match_rejected(self):
+        """``/foo`` does NOT preserve ``/foobar/x`` — the separator must follow."""
+        assert is_pending_migration_path("/foobar/x.z64", "", "/foo") is False
+
+    def test_exact_match_without_separator_rejected(self):
+        """``/old/retrodeck`` exactly matching the pending_home root (no trailing
+        separator) is not "under" the pending home and is rejected."""
+        assert is_pending_migration_path("/old/retrodeck", "", "/old/retrodeck") is False

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -1,0 +1,202 @@
+"""Tests for ConnectionService."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.errors import RommAuthError, RommConnectionError, RommServerError
+from services.connection import ConnectionService, ConnectionServiceConfig
+
+_MIN_VERSION = (4, 8, 1)
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test_connection")
+
+
+@pytest.fixture
+def romm_api() -> MagicMock:
+    api = MagicMock()
+    api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+    api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
+    return api
+
+
+def _make_service(
+    *,
+    settings: dict,
+    romm_api: MagicMock,
+    loop: asyncio.AbstractEventLoop,
+    logger: logging.Logger,
+    min_required_version: tuple[int, ...] = _MIN_VERSION,
+) -> ConnectionService:
+    return ConnectionService(
+        config=ConnectionServiceConfig(
+            settings=settings,
+            romm_api=romm_api,
+            loop=loop,
+            logger=logger,
+            min_required_version=min_required_version,
+        ),
+    )
+
+
+class TestTestConnectionHappyPath:
+    def test_returns_success_with_version(self, event_loop, romm_api, logger):
+        settings = {"romm_url": "http://romm.local"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert result["message"] == "Connected to RomM 4.8.1"
+        assert result["romm_version"] == "4.8.1"
+        romm_api.set_version.assert_called_once_with("4.8.1")
+
+    def test_version_exact_minimum_succeeds(self, event_loop, romm_api, logger):
+        """Version equal to minimum tuple is accepted (>= comparison)."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert result["romm_version"] == "4.8.1"
+
+
+class TestTestConnectionBadPath:
+    def test_missing_url_returns_config_error(self, event_loop, romm_api, logger):
+        settings = {"romm_url": ""}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result == {
+            "success": False,
+            "message": "No server URL configured",
+            "error_code": "config_error",
+        }
+        romm_api.heartbeat.assert_not_called()
+
+    def test_unset_url_key_returns_config_error(self, event_loop, romm_api, logger):
+        """``romm_url`` absent from settings dict → config_error."""
+        settings: dict = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["error_code"] == "config_error"
+
+    def test_heartbeat_connection_error_clears_version(self, event_loop, romm_api, logger):
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.side_effect = RommConnectionError("connection refused")
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is False
+        assert result["error_code"] == "connection_error"
+        romm_api.set_version.assert_called_once_with(None)
+        romm_api.list_platforms.assert_not_called()
+
+    def test_list_platforms_server_error_prefixed(self, event_loop, romm_api, logger):
+        """Non-auth/forbidden errors from list_platforms get prefixed."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.list_platforms.side_effect = RommServerError("boom", status_code=503)
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is False
+        assert result["error_code"] == "server_error"
+        assert result["message"].startswith("Server reachable but API request failed: ")
+
+    def test_list_platforms_auth_error_not_prefixed(self, event_loop, romm_api, logger):
+        """auth_error / forbidden_error keep their original message — no prefix."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.list_platforms.side_effect = RommAuthError("bad credentials")
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is False
+        assert result["error_code"] == "auth_error"
+        assert not result["message"].startswith("Server reachable")
+
+
+class TestTestConnectionVersionGate:
+    def test_version_below_minimum_rejected(self, event_loop, romm_api, logger):
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is False
+        assert result["error_code"] == "version_error"
+        assert result["romm_version"] == "4.5.0"
+        assert "4.8.1" in result["message"]
+        assert "4.5.0" in result["message"]
+
+    def test_version_one_patch_below_minimum_rejected(self, event_loop, romm_api, logger):
+        """4.8.0 is below 4.8.1 — must be rejected."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.0"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["error_code"] == "version_error"
+
+    def test_development_version_bypasses_gate(self, event_loop, romm_api, logger):
+        """``development`` version string skips the minimum-version check."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "development"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert result["message"] == "Connected to RomM"
+        assert result["romm_version"] == "development"
+
+
+class TestTestConnectionEdgeCases:
+    def test_heartbeat_without_system_field(self, event_loop, romm_api, logger):
+        """Heartbeat dict without SYSTEM.VERSION → list_platforms still probed, success without romm_version."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert result["message"] == "Connected to RomM"
+        assert "romm_version" not in result
+        romm_api.set_version.assert_called_once_with(None)
+
+    def test_heartbeat_returns_none_safely_handled(self, event_loop, romm_api, logger):
+        """A ``None`` heartbeat payload is tolerated via ``contextlib.suppress``."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = None
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        # No version detected from heartbeat → set_version called with None.
+        romm_api.set_version.assert_called_once_with(None)
+
+    def test_heartbeat_with_malformed_system_field(self, event_loop, romm_api, logger):
+        """SYSTEM field that is not a dict raises AttributeError, suppressed → version=None."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": "not-a-dict"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        romm_api.set_version.assert_called_once_with(None)
+
+    def test_min_required_version_injected(self, event_loop, romm_api, logger):
+        """Service uses the injected minimum, not a hard-coded tuple."""
+        settings = {"romm_url": "http://romm.local"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "5.0.0"}}
+        # Inject a higher minimum so 5.0.0 is rejected.
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            min_required_version=(5, 1, 0),
+        )
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["error_code"] == "version_error"
+        assert "5.1.0" in result["message"]

--- a/tests/services/test_startup_healing.py
+++ b/tests/services/test_startup_healing.py
@@ -1,0 +1,232 @@
+"""Tests for StartupHealingService."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from conftest import FakePathProbe
+
+from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
+
+_RETRODECK_HOME = "/run/media/deck/Emulation/retrodeck"
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test_startup_healing")
+
+
+@pytest.fixture
+def save_state() -> MagicMock:
+    return MagicMock()
+
+
+def _make_state() -> dict:
+    return {
+        "installed_roms": {},
+        "shortcut_registry": {},
+    }
+
+
+def _make_service(
+    *,
+    state: dict,
+    logger: logging.Logger,
+    save_state: MagicMock,
+    retrodeck_home: str = _RETRODECK_HOME,
+    path_probe: FakePathProbe | None = None,
+) -> StartupHealingService:
+    probe = path_probe if path_probe is not None else FakePathProbe(paths={retrodeck_home})
+    return StartupHealingService(
+        config=StartupHealingServiceConfig(
+            state=state,
+            logger=logger,
+            save_state=save_state,
+            retrodeck_home=lambda: retrodeck_home,
+            path_probe=probe,
+        ),
+    )
+
+
+class TestPruneStaleInstalledRoms:
+    def test_skip_when_retrodeck_home_missing_on_disk(self, logger, save_state, caplog):
+        """Guard: retrodeck home not present on disk → skip prune, log info."""
+        state = _make_state()
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/run/media/deck/Emulation/retrodeck/roms/n64/a.z64"},
+        }
+        # path_probe knows nothing — retrodeck home not on disk.
+        service = _make_service(
+            state=state,
+            logger=logger,
+            save_state=save_state,
+            path_probe=FakePathProbe(),
+        )
+        with caplog.at_level(logging.INFO):
+            service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        save_state.assert_not_called()
+        assert any("retrodeck home unavailable" in rec.message for rec in caplog.records)
+
+    def test_skip_when_retrodeck_home_unset(self, logger, save_state):
+        """Empty retrodeck_home (first-run) → skip prune."""
+        state = _make_state()
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/somewhere/a.z64"},
+        }
+        service = _make_service(
+            state=state,
+            logger=logger,
+            save_state=save_state,
+            retrodeck_home="",
+            path_probe=FakePathProbe(),
+        )
+        service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        save_state.assert_not_called()
+
+    def test_prune_missing_file_path(self, logger, save_state):
+        state = _make_state()
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/nonexistent/game.z64"},
+        }
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_installed_roms()
+        assert "1" not in state["installed_roms"]
+        save_state.assert_called_once()
+
+    def test_preserve_existing_file_path(self, logger, save_state):
+        state = _make_state()
+        rom_file = "/run/media/deck/Emulation/retrodeck/roms/n64/game.z64"
+        state["installed_roms"] = {"1": {"rom_id": 1, "file_path": rom_file}}
+        probe = FakePathProbe(paths={_RETRODECK_HOME, rom_file})
+        service = _make_service(state=state, logger=logger, save_state=save_state, path_probe=probe)
+        service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        save_state.assert_not_called()
+
+    def test_preserve_via_rom_dir_fallback(self, logger, save_state):
+        """file_path missing but rom_dir exists → entry preserved (PSX multi-file fallback)."""
+        state = _make_state()
+        rom_dir = "/run/media/deck/Emulation/retrodeck/roms/psx/FF7"
+        state["installed_roms"] = {
+            "1": {
+                "rom_id": 1,
+                "file_path": f"{rom_dir}/FF7.m3u",  # file gone
+                "rom_dir": rom_dir,
+            },
+        }
+        probe = FakePathProbe(paths={_RETRODECK_HOME, rom_dir})
+        service = _make_service(state=state, logger=logger, save_state=save_state, path_probe=probe)
+        service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        save_state.assert_not_called()
+
+    def test_preserve_pending_migration_entry(self, logger, save_state, caplog):
+        """Entry under pending migration's previous home → preserved with info log."""
+        state = _make_state()
+        state["retrodeck_home_path_previous"] = "/old/retrodeck"
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/zelda.z64"},
+        }
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        with caplog.at_level(logging.INFO):
+            service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        save_state.assert_not_called()
+        assert any("Skipping prune" in rec.message and "/old/retrodeck" in rec.message for rec in caplog.records)
+
+    def test_no_prune_does_not_save(self, logger, save_state):
+        """When no entry is pruned, save_state is not invoked."""
+        state = _make_state()
+        # Empty installed_roms — nothing to prune.
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_installed_roms()
+        save_state.assert_not_called()
+
+    def test_mixed_prune_some_preserve_others(self, logger, save_state):
+        state = _make_state()
+        existing = "/run/media/deck/Emulation/retrodeck/roms/n64/keep.z64"
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": existing},
+            "2": {"rom_id": 2, "file_path": "/gone/dead.z64"},
+        }
+        probe = FakePathProbe(paths={_RETRODECK_HOME, existing})
+        service = _make_service(state=state, logger=logger, save_state=save_state, path_probe=probe)
+        service.prune_stale_installed_roms()
+        assert "1" in state["installed_roms"]
+        assert "2" not in state["installed_roms"]
+        save_state.assert_called_once()
+
+    def test_prefix_false_match_not_preserved(self, logger, save_state):
+        """``pending_home="/foo"`` does NOT preserve ``/foobar/x``."""
+        state = _make_state()
+        state["retrodeck_home_path_previous"] = "/foo"
+        state["installed_roms"] = {
+            "1": {"rom_id": 1, "file_path": "/foobar/x.z64"},
+        }
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_installed_roms()
+        assert "1" not in state["installed_roms"]
+        save_state.assert_called_once()
+
+
+class TestPruneStaleRegistry:
+    def test_prune_missing_app_id(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {"1": {"name": "Game"}}
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" not in state["shortcut_registry"]
+        save_state.assert_called_once()
+
+    def test_prune_zero_app_id(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {"1": {"app_id": 0, "name": "Game"}}
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" not in state["shortcut_registry"]
+
+    def test_prune_string_app_id(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {"1": {"app_id": "42", "name": "Game"}}
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" not in state["shortcut_registry"]
+
+    def test_prune_none_app_id(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {"1": {"app_id": None, "name": "Game"}}
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" not in state["shortcut_registry"]
+
+    def test_preserve_valid_app_id(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {"1": {"app_id": 1234567890, "name": "Game"}}
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" in state["shortcut_registry"]
+        save_state.assert_not_called()
+
+    def test_no_prune_does_not_save(self, logger, save_state):
+        state = _make_state()
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        save_state.assert_not_called()
+
+    def test_mixed_prune_some_preserve_others(self, logger, save_state):
+        state = _make_state()
+        state["shortcut_registry"] = {
+            "1": {"app_id": 100, "name": "Keep"},
+            "2": {"name": "Drop"},
+            "3": {"app_id": "stringy", "name": "Drop2"},
+        }
+        service = _make_service(state=state, logger=logger, save_state=save_state)
+        service.prune_stale_registry()
+        assert "1" in state["shortcut_registry"]
+        assert "2" not in state["shortcut_registry"]
+        assert "3" not in state["shortcut_registry"]
+        save_state.assert_called_once()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -21,6 +21,7 @@ from conftest import (
     FakeFirmwareCachePersister,
     FakeFirmwareFileAdapter,
     FakeMigrationFileAdapter,
+    FakePathProbe,
     FakeSgdbArtworkCache,
 )
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
@@ -163,6 +164,7 @@ class TestWireServices:
             "firmware_files": FakeFirmwareFileAdapter(),
             "migration_files": FakeMigrationFileAdapter(),
             "gamelist_editor": MagicMock(),
+            "path_probe": FakePathProbe(),
             "state": state,
             "settings": settings,
             "metadata_cache": {},
@@ -175,6 +177,7 @@ class TestWireServices:
             "clock": FakeClock(),
             "uuid_gen": FakeUuidGen(),
             "sleeper": FakeSleeper(),
+            "min_required_version": (4, 8, 1),
             "get_saves_path": MagicMock(return_value=str(tmp_path / "saves")),
             "get_roms_path": MagicMock(return_value=str(tmp_path / "retrodeck" / "roms")),
             "get_bios_path": MagicMock(return_value=str(tmp_path / "retrodeck" / "bios")),
@@ -206,6 +209,7 @@ class TestWireServices:
                 firmware_files=deps["firmware_files"],
                 migration_files=deps["migration_files"],
                 gamelist_editor=deps["gamelist_editor"],
+                path_probe=deps["path_probe"],
             ),
             stores=StateBundle(
                 state=deps["state"],
@@ -222,6 +226,7 @@ class TestWireServices:
                 clock=deps["clock"],
                 uuid_gen=deps["uuid_gen"],
                 sleeper=deps["sleeper"],
+                min_required_version=deps["min_required_version"],
             ),
             callbacks=CallbackBundle(
                 get_saves_path=deps["get_saves_path"],
@@ -264,13 +269,15 @@ class TestWireServices:
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(self._make_config(deps))
-        assert len(result) == 15
+        assert len(result) == 17
         assert "migration_service" in result
         assert "game_detail_service" in result
         assert "rom_removal_service" in result
         assert "settings_service" in result
         assert "core_service" in result
         assert isinstance(result["core_service"], CoreService)
+        assert "connection_service" in result
+        assert "startup_healing_service" in result
         deps["loop"].close()
 
     def test_migration_service_receives_get_core_name(self, tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-from conftest import FakeSgdbArtworkCache
+from conftest import FakePathProbe, FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.persistence import PersistenceAdapter
@@ -12,8 +12,10 @@ from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
 from main import Plugin
+from services.connection import ConnectionService, ConnectionServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
+from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridConfig, SteamGridService
 
 
@@ -85,6 +87,26 @@ def plugin():
             steam_config=steam_config,
         ),
     )
+
+    p._connection_service = ConnectionService(
+        config=ConnectionServiceConfig(
+            settings=p.settings,
+            romm_api=p._romm_api,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            min_required_version=Plugin._MIN_REQUIRED_VERSION,
+        ),
+    )
+
+    p._startup_healing_service = StartupHealingService(
+        config=StartupHealingServiceConfig(
+            state=p._state,
+            logger=decky.logger,
+            save_state=p._save_state,
+            retrodeck_home=p._retrodeck_paths.get_retrodeck_home,
+            path_probe=FakePathProbe(),
+        ),
+    )
     return p
 
 
@@ -124,10 +146,23 @@ class TestSettings:
 class TestConnection:
     @pytest.mark.asyncio
     async def test_test_connection_sets_version_on_romm_api(self, plugin):
+        import decky
+
         plugin.loop = asyncio.get_event_loop()
         plugin.settings["romm_url"] = "http://romm.local"
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         plugin._romm_api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
+        # Rebuild connection service with the live event loop so executor
+        # callbacks dispatch on the same loop the test awaits.
+        plugin._connection_service = ConnectionService(
+            config=ConnectionServiceConfig(
+                settings=plugin.settings,
+                romm_api=plugin._romm_api,
+                loop=plugin.loop,
+                logger=decky.logger,
+                min_required_version=Plugin._MIN_REQUIRED_VERSION,
+            ),
+        )
         result = await plugin.test_connection()
         assert result["success"] is True
         plugin._romm_api.set_version.assert_called_once_with("4.8.1")
@@ -419,257 +454,6 @@ class TestSettingsFilePermissions:
         assert os.stat(settings_path).st_mode & 0o777 == 0o600
 
 
-class TestPruneStaleState:
-    def test_prunes_missing_files(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/nonexistent/game.z64", "system": "n64"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" not in plugin._state["installed_roms"]
-
-    def test_keeps_existing_files(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        rom_file = tmp_path / "game.z64"
-        rom_file.write_text("data")
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": str(rom_file), "system": "n64"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-
-    def test_keeps_existing_rom_dir(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        rom_dir = tmp_path / "FF7"
-        rom_dir.mkdir()
-
-        plugin._state["installed_roms"] = {
-            "1": {
-                "rom_id": 1,
-                "file_path": str(rom_dir / "FF7.m3u"),  # file missing but dir exists
-                "rom_dir": str(rom_dir),
-                "system": "psx",
-            },
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-
-    def test_saves_state_only_when_pruned(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        rom_file = tmp_path / "game.z64"
-        rom_file.write_text("data")
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": str(rom_file), "system": "n64"},
-        }
-
-        # No pruning needed — state file should NOT be written
-        state_path = tmp_path / "state.json"
-        plugin._prune_stale_installed_roms()
-        assert not state_path.exists()
-
-    def test_prunes_mixed(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        rom_file = tmp_path / "game.z64"
-        rom_file.write_text("data")
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": str(rom_file), "system": "n64"},
-            "2": {"rom_id": 2, "file_path": "/gone/game.z64", "system": "snes"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-        assert "2" not in plugin._state["installed_roms"]
-
-
-class TestPruneStaleStateEdgeCases:
-    """Edge case tests for _prune_stale_installed_roms."""
-
-    def test_empty_installed_roms_no_crash(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["installed_roms"] = {}
-        plugin._prune_stale_installed_roms()
-        # Should not crash, _save_state should NOT be called
-        state_path = tmp_path / "state.json"
-        assert not state_path.exists()
-
-    def test_all_entries_stale(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/gone/a.z64", "system": "n64"},
-            "2": {"rom_id": 2, "file_path": "/gone/b.z64", "system": "snes"},
-            "3": {"rom_id": 3, "file_path": "/gone/c.z64", "system": "gb"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert plugin._state["installed_roms"] == {}
-        # _save_state should have been called (state.json written)
-        state_path = tmp_path / "state.json"
-        assert state_path.exists()
-
-    def test_skips_when_retrodeck_home_unavailable(self, plugin, tmp_path):
-        """Guard: if retrodeck home doesn't exist on disk (SD card not mounted yet
-        at boot), prune skips entirely rather than wiping every entry whose
-        file_path lives on the unmounted volume."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = "/run/media/deck/Emulation/retrodeck-not-mounted"
-
-        plugin._state["installed_roms"] = {
-            "1": {
-                "rom_id": 1,
-                "file_path": "/run/media/deck/Emulation/retrodeck-not-mounted/roms/n64/a.z64",
-                "system": "n64",
-            },
-        }
-
-        plugin._prune_stale_installed_roms()
-        # Entry preserved despite stale file_path — guard short-circuited.
-        assert "1" in plugin._state["installed_roms"]
-
-    def test_skips_when_retrodeck_home_unset(self, plugin, tmp_path):
-        """Guard: empty retrodeck_home (first-run before path is detected) also
-        skips the prune."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = ""
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/somewhere/a.z64", "system": "n64"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-
-    def test_skip_preserves_entry_at_old_home_during_migration(self, plugin, tmp_path):
-        """Pending migration: entries living under old home are preserved (#251)."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
-        plugin._state["retrodeck_home_path_previous"] = "/run/media/old/retrodeck"
-
-        plugin._state["installed_roms"] = {
-            "1": {
-                "rom_id": 1,
-                "file_path": "/run/media/old/retrodeck/roms/n64/zelda.z64",
-                "system": "n64",
-            },
-            "2": {
-                "rom_id": 2,
-                "file_path": "/run/media/old/retrodeck/roms/psx/FF7/FF7.m3u",
-                "rom_dir": "/run/media/old/retrodeck/roms/psx/FF7",
-                "system": "psx",
-            },
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-        assert "2" in plugin._state["installed_roms"]
-
-    def test_skip_does_not_preserve_unrelated_path(self, plugin, tmp_path):
-        """Pending migration: ``old_home="/foo"`` does NOT preserve entry at ``/foobar/x``.
-
-        Path comparison must use the trailing separator to avoid prefix
-        false matches like /foo matching /foobar.
-        """
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
-        plugin._state["retrodeck_home_path_previous"] = "/foo"
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/foobar/x.z64", "system": "n64"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        # /foobar/x is NOT under /foo (with separator), file does not exist → pruned.
-        assert "1" not in plugin._state["installed_roms"]
-
-    def test_skip_does_not_fire_when_old_home_is_empty(self, plugin, tmp_path):
-        """No migration marker — prune behaves normally."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
-        plugin._state.pop("retrodeck_home_path_previous", None)
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/gone/a.z64", "system": "n64"},
-        }
-
-        plugin._prune_stale_installed_roms()
-        assert "1" not in plugin._state["installed_roms"]
-
-    def test_skip_clears_after_migration_completes(self, plugin, tmp_path):
-        """After migration completes (marker dropped), normal prune behavior resumes."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
-
-        # First pass: marker set, entry preserved.
-        plugin._state["retrodeck_home_path_previous"] = "/old/retrodeck"
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/a.z64", "system": "n64"},
-        }
-        plugin._prune_stale_installed_roms()
-        assert "1" in plugin._state["installed_roms"]
-
-        # Second pass: marker cleared (post-migration), file still missing → pruned.
-        plugin._state.pop("retrodeck_home_path_previous", None)
-        plugin._prune_stale_installed_roms()
-        assert "1" not in plugin._state["installed_roms"]
-
-    def test_skip_logs_info_when_preserving(self, plugin, tmp_path, caplog):
-        """Skip emits an info log naming the preserved rom_id and old home."""
-        import logging
-
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-        plugin._retrodeck_paths.get_retrodeck_home.return_value = str(tmp_path)
-        plugin._state["retrodeck_home_path_previous"] = "/old/retrodeck"
-
-        plugin._state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/a.z64", "system": "n64"},
-        }
-
-        with caplog.at_level(logging.INFO):
-            plugin._prune_stale_installed_roms()
-
-        assert any("Skipping prune" in rec.message and "/old/retrodeck" in rec.message for rec in caplog.records)
-
-
 class TestAtomicSettingsWrite:
     def test_settings_written_atomically(self, plugin, tmp_path):
         import decky
@@ -774,76 +558,6 @@ class TestWhitelistSettings:
         assert result["success"] is True
         assert plugin.settings["whitelist_disabled_defaults"] == ["moonlight"]
         assert plugin.settings["whitelist_custom_names"] == ["Custom Game"]
-
-
-class TestPruneStaleRegistry:
-    def test_prunes_missing_app_id(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"name": "Game A"},
-        }
-        plugin._prune_stale_registry()
-        assert "1" not in plugin._state["shortcut_registry"]
-
-    def test_prunes_zero_app_id(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 0, "name": "Game A"},
-        }
-        plugin._prune_stale_registry()
-        assert "1" not in plugin._state["shortcut_registry"]
-
-    def test_prunes_non_int_app_id(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": "abc", "name": "Game A"},
-        }
-        plugin._prune_stale_registry()
-        assert "1" not in plugin._state["shortcut_registry"]
-
-    def test_keeps_valid_entry(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 12345678, "name": "Game A"},
-        }
-        plugin._prune_stale_registry()
-        assert "1" in plugin._state["shortcut_registry"]
-
-    def test_saves_only_when_pruned(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 12345678, "name": "Game A"},
-        }
-        plugin._prune_stale_registry()
-        # No pruning needed — state file should NOT be written
-        state_path = tmp_path / "state.json"
-        assert not state_path.exists()
-
-    def test_empty_registry_no_crash(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(decky.DECKY_PLUGIN_SETTINGS_DIR, str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {}
-        plugin._prune_stale_registry()
-        # Should not crash, state file should NOT be written
-        state_path = tmp_path / "state.json"
-        assert not state_path.exists()
 
 
 class TestRefreshMigrationState:
@@ -1017,8 +731,8 @@ class TestMigrationBlockedDecoratorCoverage:
 
 
 class TestMainStartupOrdering:
-    """Lock-in test for the #251 startup-order invariant: detect_retrodeck_path_change
-    must run BEFORE _prune_stale_installed_roms so the prune skips entries living
+    """Lock-in test for the #251 startup-order invariant: ``detect_retrodeck_path_change``
+    must run BEFORE ``prune_stale_installed_roms`` so the prune skips entries living
     under a pending migration's previous home. Brittle by design — the assertion
     is intentionally narrow."""
 
@@ -1061,6 +775,12 @@ class TestMainStartupOrdering:
         firmware_service = MagicMock()
         firmware_service.load_bios_registry = MagicMock()
 
+        startup_healing_service = MagicMock()
+        startup_healing_service.prune_stale_installed_roms.side_effect = lambda: call_order.append(
+            "prune_stale_installed_roms"
+        )
+        startup_healing_service.prune_stale_registry.side_effect = lambda: call_order.append("prune_stale_registry")
+
         wired_services = {
             "save_sync_service": save_sync_service,
             "playtime_service": MagicMock(),
@@ -1077,6 +797,8 @@ class TestMainStartupOrdering:
             "shortcut_removal_service": MagicMock(),
             "settings_service": MagicMock(),
             "core_service": MagicMock(),
+            "connection_service": MagicMock(),
+            "startup_healing_service": startup_healing_service,
         }
 
         bootstrapped_adapters = {
@@ -1091,6 +813,7 @@ class TestMainStartupOrdering:
             "firmware_files": MagicMock(),
             "download_queue": MagicMock(),
             "migration_files": MagicMock(),
+            "path_probe": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),
             "retroarch_core_info": MagicMock(),
@@ -1104,22 +827,12 @@ class TestMainStartupOrdering:
         with (
             patch("main.bootstrap", return_value=bootstrapped_adapters),
             patch("main.wire_services", return_value=wired_services),
-            patch.object(
-                Plugin,
-                "_prune_stale_installed_roms",
-                lambda self: call_order.append("_prune_stale_installed_roms"),
-            ),
-            patch.object(
-                Plugin,
-                "_prune_stale_registry",
-                lambda self: call_order.append("_prune_stale_registry"),
-            ),
         ):
             await plugin._main()
 
         assert "detect_retrodeck_path_change" in call_order
-        assert "_prune_stale_installed_roms" in call_order
-        assert call_order.index("detect_retrodeck_path_change") < call_order.index("_prune_stale_installed_roms")
+        assert "prune_stale_installed_roms" in call_order
+        assert call_order.index("detect_retrodeck_path_change") < call_order.index("prune_stale_installed_roms")
 
 
 class TestCancelCallablesNotBlockedByMigration:


### PR DESCRIPTION
Final PR for #274 (callable thinness audit). Closes the issue.

## Changes

- New `py_modules/services/connection.py` — `ConnectionService` owns the full `test_connection` flow (heartbeat + version sniff + auth probe + min-version gate). Frozen `ConnectionServiceConfig`.
- New `py_modules/services/startup_healing.py` — `StartupHealingService` owns `prune_stale_installed_roms` + `prune_stale_registry`. Frozen `StartupHealingServiceConfig`.
- New `py_modules/domain/installed_roms.py` — pure `is_pending_migration_path` helper (uses only `os.sep`, no I/O).
- New `PathExistsProbe` Protocol + `PathProbeAdapter` (thin `os.path.exists` wrapper) — keeps the prune service free of raw I/O.
- `Plugin._MIN_REQUIRED_VERSION` retained as class constant on the entrypoint; threaded into the service via `RuntimeBundle.min_required_version`.
- `bootstrap.py` wires both new services; service count 15 → 17.
- `main.py` callable `test_connection` becomes one-liner; three private prune helpers removed.
- `CLAUDE.md` updated — Wave 4 #274 marked shipped as #328 + #329 + #330 + this PR.
- `.importlinter` adds `services.connection` + `services.startup_healing` to independence list.

## main.py delta

-118 lines / +5 lines (callable + 2 wiring lines + 1 prune-call replacement). All remaining `main.py` logic is now lifecycle (`_main`, `_unload`) or thin delegates.

## Coverage

- `services/connection.py` — 100% line + branch
- `services/startup_healing.py` — 100% line + branch
- `domain/installed_roms.py` — 100% line + branch
- `adapters/path_probe.py` — 100% (covered via new `tests/adapters/test_path_probe.py`)
- 47 new tests (16 connection + 16 startup healing + 7 domain + 4 adapter + ~4 plugin wiring updates); 25 old plugin-level prune tests removed (equivalent coverage now in the service test files)
- 2108 total tests, all passing

## Gates

- ruff: PASS
- basedpyright (full scope incl tests/): PASS (0/0/0)
- pytest: PASS (2108)
- `scripts/check_cosmic_call_bans.sh`: PASS
- `lint-imports` (7 contracts): PASS
- `pnpm build`: PASS

## Cosmic Python

- Both new services depend only on Protocols
- No raw I/O in services (path existence via Protocol)
- New frozen `*ServiceConfig` dataclasses keep ctor budgets clean

## Closes

#274 ✅