### PR TITLE
refactor(saves): promote pure helpers from _helpers.py to domain (#272)

### DIFF
--- a/py_modules/domain/save_attribution.py
+++ b/py_modules/domain/save_attribution.py
@@ -1,0 +1,25 @@
+"""Uploader attribution for server saves.
+
+Three-way ``uploaded_by_us`` flag derived from RomM server-save records
+and the per-ROM ``own_upload_ids`` list. Pure: no I/O, no logging.
+"""
+
+from __future__ import annotations
+
+
+def compute_uploaded_by_us(
+    server_save: dict | None,
+    own_upload_ids: list[int] | None,
+) -> bool | None:
+    """Three-way attribution: True/False when ``own_upload_ids`` is known
+    for this ROM (we can tell whether this installation POSTed the save);
+    None for legacy ROM state without the ``own_upload_ids`` field
+    (attribution unknown). Returns None when *server_save* or its ``id``
+    is missing too — there is nothing to attribute.
+    """
+    if server_save is None or own_upload_ids is None:
+        return None
+    sid = server_save.get("id")
+    if sid is None:
+        return None
+    return sid in own_upload_ids

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -1,7 +1,9 @@
-"""Save file path resolution for RetroArch save directory layouts.
+"""Save file path and filename resolution for RetroArch save directory layouts.
 
 Handles the various save directory structures created by RetroArch's
-sort_savefiles_by_content_enable and sort_savefiles_enable settings.
+sort_savefiles_by_content_enable and sort_savefiles_enable settings,
+plus deriving the canonical local filename for a server-supplied save
+record.
 
 No I/O, no service/adapter/lib imports. Pure functions only.
 """
@@ -9,6 +11,7 @@ No I/O, no service/adapter/lib imports. Pure functions only.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 
 
 def resolve_save_dir(
@@ -110,6 +113,51 @@ def sanitize_save_filename(name: str) -> str:
     if base in ("", ".", ".."):
         raise ValueError(f"filename has no valid basename: {name!r}")
     return base
+
+
+@dataclass(frozen=True)
+class LocalSaveTarget:
+    """Resolved local filename for a server save with sanitization diagnostics.
+
+    ``filename`` is the canonical on-disk name.
+
+    ``fallback_extension`` is set to the offending value when the
+    server-supplied ``file_extension`` produced an unusable filename and
+    the function fell back to ``"srm"``. Service callers should log a
+    warning when this is non-None.
+
+    ``sanitized_from`` is set to the pre-sanitization filename when
+    path-traversal characters were stripped (e.g. ``../etc/passwd``).
+    Service callers should log a warning when this is non-None.
+
+    Both flags are mutually exclusive: an unusable extension triggers
+    fallback; a sanitizable one triggers strip-and-keep.
+    """
+
+    filename: str
+    fallback_extension: str | None = None
+    sanitized_from: str | None = None
+
+
+def compute_local_save_target(server_save: dict, rom_name: str) -> LocalSaveTarget:
+    """The canonical local filename for a server save: ``<rom_name>.<ext>``.
+
+    ``rom_name`` is the deterministic identity from RetroArch's
+    perspective — the ROM file's basename without extension, the same
+    string RetroArch uses to look up SRAM. Callers must have already
+    resolved the ROM via an "installed?" check; there is no fallback to
+    server-derived names because those can mismatch RetroArch's lookup
+    path and silently break the sync.
+    """
+    ext = server_save.get("file_extension", "srm")
+    target = f"{rom_name}.{ext}"
+    try:
+        sanitized = sanitize_save_filename(target)
+    except ValueError:
+        return LocalSaveTarget(f"{rom_name}.srm", fallback_extension=ext)
+    if sanitized != target:
+        return LocalSaveTarget(sanitized, sanitized_from=target)
+    return LocalSaveTarget(sanitized)
 
 
 def detect_path_change(stored_path: str | None, resolved_path: str) -> bool:

--- a/py_modules/services/saves/_helpers.py
+++ b/py_modules/services/saves/_helpers.py
@@ -1,62 +1,27 @@
-"""Cross-cutting helpers for the saves package — utilities shared across sub-services."""
+"""Logging wrappers around pure domain helpers consumed by the saves package."""
 
 from __future__ import annotations
 
 import logging
 
-from domain.save_path import sanitize_save_filename
+from domain.save_path import compute_local_save_target
 
 _logger = logging.getLogger(__name__)
 
 
-def _compute_uploaded_by_us(
-    server_save: dict | None,
-    own_upload_ids: list[int] | None,
-) -> bool | None:
-    """Three-way uploader attribution flag.
-
-    Returns True/False when own_upload_ids is known for this ROM (we can tell
-    whether this installation POSTed the save), or None for legacy ROM state
-    without the ``own_upload_ids`` field (attribution unknown).
-    """
-    if server_save is None or own_upload_ids is None:
-        return None
-    sid = server_save.get("id")
-    if sid is None:
-        return None
-    return sid in own_upload_ids
-
-
 def _local_save_target(server_save: dict, rom_name: str) -> str:
-    """The canonical local filename for a server save: ``<rom_name>.<ext>``.
-
-    ``rom_name`` is the deterministic identity from RetroArch's
-    perspective — it's the ROM file's basename without extension, the
-    same string RetroArch uses to look up SRAM. Callers must have
-    already resolved the ROM via ``_get_rom_save_info`` (which only
-    returns when the ROM is actually installed); there is no fallback
-    to server-derived names because those can mismatch RetroArch's
-    actual lookup path and silently break the sync.
-    """
-    ext = server_save.get("file_extension", "srm")
-    target = f"{rom_name}.{ext}"
-    try:
-        sanitized = sanitize_save_filename(target)
-    except ValueError:
-        # Server returned an extension that produces an unusable filename
-        # (NUL byte, ``"."``, ``".."``, …). Fall back to the safe default
-        # so the sync attempt doesn't crash the whole ROM loop.
+    """Resolve the local filename for *server_save*, logging any sanitization."""
+    result = compute_local_save_target(server_save, rom_name)
+    if result.fallback_extension is not None:
         _logger.warning(
             "Sanitized server-supplied save target — invalid file_extension=%r; falling back to 'srm'",
-            ext,
+            result.fallback_extension,
         )
-        return f"{rom_name}.srm"
-    if sanitized != target:
-        # Path-traversal characters were stripped (e.g. ``../etc/passwd``).
+    elif result.sanitized_from is not None:
         _logger.warning(
             "Sanitized server-supplied save target from %r to %r (file_extension=%r)",
-            target,
-            sanitized,
-            ext,
+            result.sanitized_from,
+            result.filename,
+            server_save.get("file_extension", "srm"),
         )
-    return sanitized
+    return result.filename

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 
 from models.saves import SaveConflict
 
+from domain.save_attribution import compute_uploaded_by_us
 from domain.sync_action import Conflict, Skip
 from lib.iso_time import parse_iso_to_epoch
-from services.saves._helpers import _compute_uploaded_by_us
 from services.saves.status.builders import (
     _build_file_status,
     _resolve_chosen_server,
@@ -66,7 +66,7 @@ class StatusService:
             last_sync_at=outcome.file_state.get("last_sync_at"),
             status=_status_from_action(action),
             server_device_id=server_device_id,
-            uploaded_by_us=_compute_uploaded_by_us(chosen_server, own_upload_ids),
+            uploaded_by_us=compute_uploaded_by_us(chosen_server, own_upload_ids),
         )
         conflict_entry: dict | None = None
         if isinstance(action, Conflict):

--- a/tests/domain/test_save_attribution.py
+++ b/tests/domain/test_save_attribution.py
@@ -1,0 +1,46 @@
+"""Tests for domain.save_attribution — pure uploader attribution flag."""
+
+from __future__ import annotations
+
+from domain.save_attribution import compute_uploaded_by_us
+
+
+class TestComputeUploadedByUs:
+    def test_server_save_none_returns_none(self) -> None:
+        """No server save record to attribute → None."""
+        assert compute_uploaded_by_us(None, [1, 2, 3]) is None
+
+    def test_own_upload_ids_none_returns_none(self) -> None:
+        """Legacy ROM state lacks own_upload_ids → attribution unknown → None."""
+        assert compute_uploaded_by_us({"id": 1}, None) is None
+
+    def test_both_none_returns_none(self) -> None:
+        assert compute_uploaded_by_us(None, None) is None
+
+    def test_server_save_missing_id_returns_none(self) -> None:
+        """A server-save record without an id can't be attributed."""
+        assert compute_uploaded_by_us({"file_name": "x.srm"}, [1, 2, 3]) is None
+
+    def test_server_save_id_explicitly_none_returns_none(self) -> None:
+        """Explicit None ``id`` is treated identically to missing key."""
+        assert compute_uploaded_by_us({"id": None}, [1, 2, 3]) is None
+
+    def test_id_in_own_uploads_returns_true(self) -> None:
+        """The server-save id matches one we POSTed → True."""
+        assert compute_uploaded_by_us({"id": 2}, [1, 2, 3]) is True
+
+    def test_id_not_in_own_uploads_returns_false(self) -> None:
+        """The server-save id does not match any we POSTed → False."""
+        assert compute_uploaded_by_us({"id": 99}, [1, 2, 3]) is False
+
+    def test_empty_own_upload_ids_returns_false(self) -> None:
+        """An empty list means we know we POSTed nothing → False, not None.
+
+        The presence of the ``own_upload_ids`` field (even empty) means
+        attribution is known; only ``None`` means "legacy ROM state".
+        """
+        assert compute_uploaded_by_us({"id": 1}, []) is False
+
+    def test_id_zero_in_own_uploads_returns_true(self) -> None:
+        """Edge: ``id`` 0 is a legitimate value and must match by membership."""
+        assert compute_uploaded_by_us({"id": 0}, [0, 1]) is True

--- a/tests/domain/test_save_path.py
+++ b/tests/domain/test_save_path.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from domain.save_path import (
+    LocalSaveTarget,
+    compute_local_save_target,
     detect_path_change,
     resolve_save_dir,
     resolve_save_filename,
@@ -243,3 +245,88 @@ class TestSanitizeSaveFilename:
         """``foo/`` has an empty basename, which is not a valid component."""
         with pytest.raises(ValueError):
             sanitize_save_filename("foo/")
+
+
+# ---------------------------------------------------------------------------
+# compute_local_save_target
+# ---------------------------------------------------------------------------
+
+
+class TestComputeLocalSaveTarget:
+    def test_happy_path_clean_extension(self) -> None:
+        """Clean ``file_extension`` produces ``<rom_name>.<ext>`` unchanged."""
+        result = compute_local_save_target({"file_extension": "srm"}, "pokemon")
+        assert result == LocalSaveTarget("pokemon.srm")
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension is None
+        assert result.sanitized_from is None
+
+    def test_default_extension_when_missing(self) -> None:
+        """A server save without ``file_extension`` defaults to ``srm``."""
+        result = compute_local_save_target({}, "pokemon")
+        assert result == LocalSaveTarget("pokemon.srm")
+
+    def test_traversal_in_extension_strips_and_flags(self) -> None:
+        """A traversal extension is sanitized to the safe basename."""
+        result = compute_local_save_target({"file_extension": "../etc/passwd"}, "pokemon")
+        # Sanitized filename is the basename of the joined target.
+        assert result.filename == "passwd"
+        assert result.sanitized_from == "pokemon.../etc/passwd"
+        assert result.fallback_extension is None
+
+    def test_trailing_separator_extension_falls_back(self) -> None:
+        """``evil/`` makes the joined target end with a separator → ValueError → fallback."""
+        result = compute_local_save_target({"file_extension": "evil/"}, "pokemon")
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension == "evil/"
+        assert result.sanitized_from is None
+
+    def test_nul_byte_extension_falls_back(self) -> None:
+        """A NUL byte in the extension is unusable → fallback to ``srm``."""
+        result = compute_local_save_target({"file_extension": "srm\x00evil"}, "pokemon")
+        assert result.filename == "pokemon.srm"
+        assert result.fallback_extension == "srm\x00evil"
+        assert result.sanitized_from is None
+
+    def test_empty_string_extension_keeps_trailing_dot(self) -> None:
+        """An empty ``file_extension`` produces ``<rom_name>.``.
+
+        ``sanitize_save_filename`` accepts ``pokemon.`` as a single safe
+        component (its basename is ``pokemon.``), so no diagnostic flag
+        is set.
+        """
+        result = compute_local_save_target({"file_extension": ""}, "pokemon")
+        assert result.filename == "pokemon."
+        assert result.fallback_extension is None
+        assert result.sanitized_from is None
+
+    def test_dotdot_extension_falls_back(self) -> None:
+        """``file_extension="."`` makes target ``pokemon..`` — sanitizable, no fallback.
+
+        ``..`` as an extension produces ``pokemon...`` whose basename is
+        the string itself; ``sanitize_save_filename`` accepts that. The
+        real fallback trigger is a value that drives the basename empty
+        or to ``.``/``..``.
+        """
+        # The explicit fallback test: an extension producing exactly ``"."``
+        # after join — there isn't one, since ``rom_name`` is always
+        # prepended. Use trailing-separator instead (covered above).
+        # Here just confirm a typical ``..`` extension survives untouched
+        # because the joined basename is non-trivial.
+        result = compute_local_save_target({"file_extension": ".."}, "pokemon")
+        # ``pokemon...`` is the basename — no path separators, no fallback.
+        assert result.filename == "pokemon..."
+        assert result.fallback_extension is None
+        assert result.sanitized_from is None
+
+    def test_result_is_frozen_dataclass(self) -> None:
+        """``LocalSaveTarget`` is immutable — assignment raises."""
+        result = compute_local_save_target({"file_extension": "srm"}, "pokemon")
+        with pytest.raises((AttributeError, Exception)):
+            result.filename = "other"  # type: ignore[misc]
+
+    def test_result_is_hashable(self) -> None:
+        """Frozen dataclasses are hashable — usable as dict keys / set members."""
+        result = compute_local_save_target({"file_extension": "srm"}, "pokemon")
+        assert hash(result) == hash(LocalSaveTarget("pokemon.srm"))
+        assert {result} == {LocalSaveTarget("pokemon.srm")}

--- a/tests/domain/test_save_path.py
+++ b/tests/domain/test_save_path.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from domain.save_path import (
@@ -300,29 +302,23 @@ class TestComputeLocalSaveTarget:
         assert result.fallback_extension is None
         assert result.sanitized_from is None
 
-    def test_dotdot_extension_falls_back(self) -> None:
-        """``file_extension="."`` makes target ``pokemon..`` — sanitizable, no fallback.
+    def test_dotdot_extension_survives_untouched(self) -> None:
+        """``..`` as an extension is accepted: ``pokemon...`` is a valid basename.
 
-        ``..`` as an extension produces ``pokemon...`` whose basename is
-        the string itself; ``sanitize_save_filename`` accepts that. The
-        real fallback trigger is a value that drives the basename empty
-        or to ``.``/``..``.
+        Fallback only kicks in when ``sanitize_save_filename`` raises,
+        which happens for empty basenames or basenames of exactly
+        ``"."`` / ``".."`` — none of which a ``rom_name + "." + ext``
+        join can produce when ``rom_name`` is non-empty.
         """
-        # The explicit fallback test: an extension producing exactly ``"."``
-        # after join — there isn't one, since ``rom_name`` is always
-        # prepended. Use trailing-separator instead (covered above).
-        # Here just confirm a typical ``..`` extension survives untouched
-        # because the joined basename is non-trivial.
         result = compute_local_save_target({"file_extension": ".."}, "pokemon")
-        # ``pokemon...`` is the basename — no path separators, no fallback.
         assert result.filename == "pokemon..."
         assert result.fallback_extension is None
         assert result.sanitized_from is None
 
     def test_result_is_frozen_dataclass(self) -> None:
-        """``LocalSaveTarget`` is immutable — assignment raises."""
+        """``LocalSaveTarget`` is immutable — assignment raises ``FrozenInstanceError``."""
         result = compute_local_save_target({"file_extension": "srm"}, "pokemon")
-        with pytest.raises((AttributeError, Exception)):
+        with pytest.raises(dataclasses.FrozenInstanceError):
             result.filename = "other"  # type: ignore[misc]
 
     def test_result_is_hashable(self) -> None:


### PR DESCRIPTION
First sub-issue of the saves vertical (#254). Promotes the two pure helpers in \`services/saves/_helpers.py\` into the domain layer.

## Changes

- **\`compute_uploaded_by_us\` → \`domain/save_attribution.py\`** — pure three-way attribution function. Single caller (\`status/service.py\`) now imports from domain directly. The \`_compute_uploaded_by_us\` indirection is gone.
- **\`compute_local_save_target\` → \`domain/save_path.py\`** — pure logic + diagnostic flags via a frozen \`LocalSaveTarget\` dataclass (\`filename\`, \`fallback_extension\`, \`sanitized_from\`). Domain stays free of logging.
- **\`services/saves/_helpers.py\`** — now a logging-only wrapper around \`compute_local_save_target\`. \`_local_save_target\` signature unchanged; all four call sites (engine, slots, versions, facade) work without modification. Logger messages preserved verbatim.

## Coverage

- \`domain/save_attribution.py\` — 100% line + branch
- New code in \`domain/save_path.py\` — 100% covered
- 18 new tests (9 attribution, 9 local-save-target). 2139 tests total (was 2121).

## Gates

- ruff: PASS
- basedpyright (full scope incl tests/): PASS (0/0/0)
- pytest: PASS (2139)
- \`scripts/check_cosmic_call_bans.sh\`: PASS
- \`lint-imports\` (7 contracts incl. domain independence): PASS
- \`pnpm build\`: PASS

## Cosmic Python

- Domain stays pure (no logging, no I/O, no service imports)
- The \`LocalSaveTarget\` dataclass is frozen and pure data
- Service-side logging concern lives in the thin \`_helpers.py\` wrapper

## Closes

#272. First step of #254 (saves epic). Four sub-issues to follow: #242 (file I/O adapter), #307 (peer-inject), #273 (typed state), #275 (test restructure).