### PR TITLE
refactor(saves): extract local file I/O into SaveFileAdapter (#242)

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ class Plugin:
                     firmware_files=adapters["firmware_files"],
                     migration_files=adapters["migration_files"],
                     rom_files=adapters["rom_files"],
+                    save_file=adapters["save_file"],
                     gamelist_editor=adapters["gamelist_editor"],
                     path_probe=adapters["path_probe"],
                 ),

--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -1,0 +1,88 @@
+"""Filesystem adapter for local save file operations.
+
+Owns the raw POSIX, ``open()``, ``tempfile``, and ``hashlib``-on-file
+calls used by SaveService and its sub-services when reading, writing,
+backing up, hashing, and removing local save files under the RetroDECK
+saves directory. Path construction, platform-specific extension lookup,
+and slot/sync policy remain a service or domain concern; this adapter
+exposes only the I/O seams declared by
+``services.protocols.SaveFileAdapter``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import tempfile
+
+_MD5_CHUNK_SIZE = 8192
+
+
+class SaveFileAdapter:
+    """Synchronous filesystem operations for local save files.
+
+    Implements the ``SaveFileAdapter`` Protocol. Methods are
+    synchronous — services that call from an async context offload via
+    ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        return os.path.exists(path)
+
+    def is_file(self, path: str) -> bool:
+        """Return True when *path* exists and is a regular file."""
+        return os.path.isfile(path)
+
+    def is_dir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        return os.path.isdir(path)
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        os.makedirs(path, exist_ok=True)
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
+        os.replace(src, dst)
+
+    def get_mtime(self, path: str) -> float:
+        """Return the mtime of *path* as a Unix timestamp."""
+        return os.path.getmtime(path)
+
+    def get_size(self, path: str) -> int:
+        """Return the size of *path* in bytes."""
+        return os.path.getsize(path)
+
+    def checksum_md5(self, path: str) -> str:
+        """Return the hex-encoded MD5 digest of *path*'s contents.
+
+        Streams the file in fixed-size chunks so memory use stays
+        bounded for large save files. Non-security use: MD5 here is the
+        drift baseline that ``compute_sync_action`` compares against
+        ``last_sync_hash`` to decide whether a local save changed since
+        the last sync. ``usedforsecurity=False`` documents this and
+        silences Sonar S4790.
+        """
+        h = hashlib.md5(usedforsecurity=False)
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(_MD5_CHUNK_SIZE), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def make_temp_path(self, suffix: str = "") -> str:
+        """Return a fresh, unique path safe to write to.
+
+        Backed by ``tempfile.mkstemp`` so the file is created atomically
+        (``O_EXCL``) before the fd is closed. The caller owns the file
+        and is responsible for removing it.
+        """
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        os.close(fd)
+        return path

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -27,6 +27,7 @@ from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.rom_files import RomFileAdapter as RomFileAdapterImpl
 from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApi
+from adapters.save_file import SaveFileAdapter as SaveFileAdapterImpl
 from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
 from adapters.steam_config import SteamConfigAdapter
 from adapters.steamgriddb import SteamGridDbAdapter
@@ -63,6 +64,7 @@ from services.protocols import (
     RomFileAdapter,
     RommApiProtocol,
     RomsPathProvider,
+    SaveFileAdapter,
     SavesPathProvider,
     SaveSyncStatePersister,
     SettingsPersister,
@@ -95,6 +97,7 @@ class AdapterBundle:
     firmware_files: FirmwareFileAdapter
     migration_files: MigrationFileAdapter
     rom_files: RomFileAdapter
+    save_file: SaveFileAdapter
     gamelist_editor: GamelistXmlEditorProtocol
     path_probe: PathExistsProbe
 
@@ -204,6 +207,7 @@ def bootstrap(
     firmware_files = FirmwareFileAdapterImpl()
     migration_files = MigrationFileAdapterImpl()
     rom_files = RomFileAdapterImpl()
+    save_file = SaveFileAdapterImpl()
     path_probe = PathProbeAdapter()
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
@@ -222,6 +226,7 @@ def bootstrap(
         "firmware_files": firmware_files,
         "migration_files": migration_files,
         "rom_files": rom_files,
+        "save_file": save_file,
         "path_probe": path_probe,
         "retrodeck_paths": retrodeck_paths,
         "retroarch_config": retroarch_config,
@@ -287,6 +292,7 @@ def wire_services(cfg: WiringConfig) -> dict:
     save_service_config = SaveServiceConfig(
         runtime_dir=cfg.runtime.runtime_dir,
         save_sync_state_persister=cfg.callbacks.save_sync_state_persister,
+        save_file=cfg.adapters.save_file,
         loop=cfg.runtime.loop,
         logger=cfg.runtime.logger,
         clock=cfg.runtime.clock,

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -846,6 +846,75 @@ class RomFileAdapter(Protocol):
         ...
 
 
+class SaveFileAdapter(Protocol):
+    """Filesystem seam for local save file operations.
+
+    Owns the raw POSIX, ``open()``, ``tempfile``, and ``hashlib``-on-file
+    calls SaveService and its sub-services use when reading, writing,
+    backing up, hashing, and removing local save files under the
+    RetroDECK saves directory. Path construction and platform-specific
+    extension lookup remain a domain concern; this Protocol exposes only
+    the I/O seams.
+
+    Implementations are synchronous — services that call from an async
+    context offload via ``loop.run_in_executor``.
+    """
+
+    def exists(self, path: str) -> bool:
+        """Return True when *path* refers to an existing file or directory."""
+        ...
+
+    def is_file(self, path: str) -> bool:
+        """Return True when *path* exists and is a regular file."""
+        ...
+
+    def is_dir(self, path: str) -> bool:
+        """Return True when *path* exists and is a directory."""
+        ...
+
+    def make_dirs(self, path: str) -> None:
+        """Create *path* and any missing parents. Idempotent."""
+        ...
+
+    def remove(self, path: str) -> None:
+        """Delete *path*. Idempotent: a missing file is not an error."""
+        ...
+
+    def rename(self, src: str, dst: str) -> None:
+        """Atomically rename *src* to *dst*, replacing any existing file at *dst*.
+
+        Uses ``os.replace`` semantics — same-filesystem only.
+        """
+        ...
+
+    def get_mtime(self, path: str) -> float:
+        """Return the mtime of *path* as a Unix timestamp."""
+        ...
+
+    def get_size(self, path: str) -> int:
+        """Return the size of *path* in bytes."""
+        ...
+
+    def checksum_md5(self, path: str) -> str:
+        """Return the hex-encoded MD5 digest of *path*'s contents.
+
+        Non-security use: drift detection between the local file and the
+        recorded ``last_sync_hash`` baseline. A collision here would mean
+        two different save files treated as identical — "sync misses an
+        update", not a security breach.
+        """
+        ...
+
+    def make_temp_path(self, suffix: str = "") -> str:
+        """Return a fresh, unique path safe to write to.
+
+        Backed by ``tempfile.mkstemp`` so the file is created atomically
+        (``O_EXCL``) before the fd is closed. The caller owns the file
+        and is responsible for removing it.
+        """
+        ...
+
+
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.
 

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         CoreResolverFn,
         EventEmitter,
         RomsPathProvider,
+        SaveFileAdapter,
         SavesPathProvider,
         SaveSyncStatePersister,
     )
@@ -45,6 +46,11 @@ class SaveServiceConfig:
         Protocol-typed I/O wrapper for ``save_sync_state.json``. The
         ``StateService`` uses ``.save(data)`` / ``.load() -> dict | None``
         — file path, locking, and atomic-write are adapter-internal.
+    save_file:
+        Protocol-typed filesystem adapter for local save files. Owns the
+        raw POSIX, ``open()``, ``tempfile``, and ``hashlib``-on-file
+        calls SaveService and its sub-services use when reading,
+        writing, backing up, hashing, and removing local save files.
     loop:
         The plugin's ``asyncio`` event loop (for ``run_in_executor``).
     logger:
@@ -97,6 +103,7 @@ class SaveServiceConfig:
 
     runtime_dir: str
     save_sync_state_persister: SaveSyncStatePersister
+    save_file: SaveFileAdapter
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     clock: Clock

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import os
 import socket
 from dataclasses import asdict
@@ -90,6 +89,7 @@ class SaveService:
         self._loop = config.loop
         self._logger = config.logger
         self._clock = config.clock
+        self._save_file = config.save_file
         self._get_saves_path = config.get_saves_path
         self._get_roms_path = config.get_roms_path
         self._get_active_core = config.get_active_core
@@ -114,6 +114,7 @@ class SaveService:
             retry=self._retry,
             logger=self._logger,
             clock=self._clock,
+            save_file=self._save_file,
         )
         self._status = StatusService(
             save_service=self,
@@ -130,6 +131,7 @@ class SaveService:
             retry=self._retry,
             logger=self._logger,
             clock=self._clock,
+            save_file=self._save_file,
         )
 
     def _rom_lock(self, rom_id: int) -> asyncio.Lock:
@@ -313,23 +315,16 @@ class SaveService:
     # File Helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _file_md5(path: str) -> str:
+    def _file_md5(self, path: str) -> str:
         """Compute MD5 hash of a file for sync drift detection.
 
-        ``usedforsecurity=False`` documents (and silences Sonar S4790) that
-        this hash is for content-comparison only — drift detection between
-        local file and the recorded ``last_sync_hash`` baseline. Not used
-        for passwords, signing, certificates, or any security-critical
-        purpose. A hash collision here would mean two different save files
-        treated as identical → "sync misses an update", not a security
-        breach.
+        Delegates to the injected ``SaveFileAdapter``. The hash is used
+        for content-comparison only — drift detection between local
+        file and the recorded ``last_sync_hash`` baseline. A collision
+        here would mean two different save files treated as identical
+        → "sync misses an update", not a security breach.
         """
-        h = hashlib.md5(usedforsecurity=False)
-        with open(path, "rb") as f:
-            for chunk in iter(lambda: f.read(8192), b""):
-                h.update(chunk)
-        return h.hexdigest()
+        return self._save_file.checksum_md5(path)
 
     def _find_save_files(self, rom_id: int) -> list[dict]:
         """Find local save files for a ROM.
@@ -342,12 +337,12 @@ class SaveService:
         rom_name = info["rom_name"]
         saves_dir = info["saves_dir"]
         platform_slug = info["platform_slug"]
-        if not os.path.isdir(saves_dir):
+        if not self._save_file.is_dir(saves_dir):
             return []
         results = []
         for ext in get_save_extensions(platform_slug):
             save_path = os.path.join(saves_dir, rom_name + ext)
-            if os.path.isfile(save_path):
+            if self._save_file.is_file(save_path):
                 results.append({"path": save_path, "filename": rom_name + ext})
         return results
 
@@ -996,7 +991,7 @@ class SaveService:
         local content already matches the server's content hash.
         """
         local_path = os.path.join(saves_dir, filename)
-        if not os.path.isfile(local_path):
+        if not self._save_file.is_file(local_path):
             raise FileNotFoundError(f"Local save not found: {local_path}")
         local_hash = self._file_md5(local_path)
         try:
@@ -1018,8 +1013,8 @@ class SaveService:
             file_state["last_sync_at"] = self._clock.now().isoformat()
             file_state["last_sync_server_updated_at"] = server.get("updated_at", "")
             file_state["last_sync_server_size"] = server.get("file_size_bytes")
-            file_state["last_sync_local_mtime"] = os.path.getmtime(local_path)
-            file_state["last_sync_local_size"] = os.path.getsize(local_path)
+            file_state["last_sync_local_mtime"] = self._save_file.get_mtime(local_path)
+            file_state["last_sync_local_size"] = self._save_file.get_size(local_path)
             self.save_state()
             return
 
@@ -1111,7 +1106,7 @@ class SaveService:
             files = self._find_save_files(rom_id)
             for f in files:
                 try:
-                    os.remove(f["path"])
+                    self._save_file.remove(f["path"])
                     total_deleted += 1
                 except Exception as e:
                     errors.append(f"{f['filename']}: {e}")

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -10,7 +10,7 @@ from services.saves._messages import SAVE_SYNC_DISABLED
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import Clock, RetryStrategy, RommApiProtocol
+    from services.protocols import Clock, RetryStrategy, RommApiProtocol, SaveFileAdapter
     from services.saves import SaveService
     from services.saves.state import StateService
     from services.saves.sync_engine import SyncEngine
@@ -32,6 +32,7 @@ class SlotsService:
         retry: RetryStrategy,
         logger: logging.Logger,
         clock: Clock,
+        save_file: SaveFileAdapter,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
@@ -40,6 +41,7 @@ class SlotsService:
         self._retry = retry
         self._logger = logger
         self._clock = clock
+        self._save_file = save_file
 
     # ------------------------------------------------------------------
     # Slot listing
@@ -357,7 +359,7 @@ class SlotsService:
         local_files = self._save_service._find_save_files(rom_id)
         for lf in local_files:
             try:
-                os.remove(lf["path"])
+                self._save_file.remove(lf["path"])
                 self._save_service._log_debug(f"Deleted local save for switch: {lf['filename']}")
             except Exception as e:
                 self._save_service._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
@@ -397,7 +399,7 @@ class SlotsService:
             local_file_info.append(
                 {
                     "filename": lf["filename"],
-                    "size": os.path.getsize(lf["path"]) if os.path.isfile(lf["path"]) else 0,
+                    "size": self._save_file.get_size(lf["path"]) if self._save_file.is_file(lf["path"]) else 0,
                 }
             )
 
@@ -543,7 +545,7 @@ class SlotsService:
         for old_save in old_slot_saves:
             fname = old_save.get("file_name", "")
             local_file = local_by_name.get(fname)
-            if local_file and os.path.isfile(local_file["path"]):
+            if local_file and self._save_file.is_file(local_file["path"]):
                 # Upload to new slot
                 await self._save_service._loop.run_in_executor(
                     None,

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -25,7 +24,7 @@ from services.saves._helpers import _local_save_target
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import Clock, RetryStrategy, RommApiProtocol
+    from services.protocols import Clock, RetryStrategy, RommApiProtocol, SaveFileAdapter
     from services.saves import SaveService
     from services.saves.state import StateService
 
@@ -62,6 +61,7 @@ class SyncEngine:
         retry: RetryStrategy,
         logger: logging.Logger,
         clock: Clock,
+        save_file: SaveFileAdapter,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
@@ -69,6 +69,7 @@ class SyncEngine:
         self._retry = retry
         self._logger = logger
         self._clock = clock
+        self._save_file = save_file
 
     # ------------------------------------------------------------------
     # Server Save Hash Helper
@@ -84,10 +85,9 @@ class SyncEngine:
         save_id = server_save.get("id")
         if not save_id:
             return None
-        tmp_path = None
+        tmp_path: str | None = None
         try:
-            fd, tmp_path = tempfile.mkstemp(suffix=".tmp")
-            os.close(fd)
+            tmp_path = self._save_file.make_temp_path(suffix=".tmp")
             self._romm_api.download_save(save_id, tmp_path)
             return self._save_service._file_md5(tmp_path)
         except Exception as e:
@@ -98,7 +98,7 @@ class SyncEngine:
         finally:
             if tmp_path:
                 with contextlib.suppress(OSError):
-                    os.remove(tmp_path)
+                    self._save_file.remove(tmp_path)
 
     def _update_file_sync_state(
         self,
@@ -129,7 +129,8 @@ class SyncEngine:
             save_entry["last_synced_core"] = core_so
 
         now = self._clock.now().isoformat()
-        local_hash = self._save_service._file_md5(local_path) if os.path.isfile(local_path) else ""
+        local_exists = self._save_file.is_file(local_path)
+        local_hash = self._save_service._file_md5(local_path) if local_exists else ""
 
         save_entry["files"][filename] = {
             "last_sync_hash": local_hash,
@@ -137,8 +138,8 @@ class SyncEngine:
             "last_sync_server_updated_at": server_response.get("updated_at", now),
             "last_sync_server_save_id": server_response.get("id"),
             "last_sync_server_size": server_response.get("file_size_bytes"),
-            "last_sync_local_mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
-            "last_sync_local_size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
+            "last_sync_local_mtime": self._save_file.get_mtime(local_path) if local_exists else None,
+            "last_sync_local_size": self._save_file.get_size(local_path) if local_exists else None,
             "tracked_save_id": server_response.get("id"),
         }
 
@@ -149,7 +150,7 @@ class SyncEngine:
     def _do_download_save(self, server_save: dict, saves_dir: str, filename: str, rom_id_str: str, system: str) -> None:
         """Download a save file from server. Backs up existing local file first."""
         local_path = os.path.join(saves_dir, filename)
-        os.makedirs(saves_dir, exist_ok=True)
+        self._save_file.make_dirs(saves_dir)
         tmp_path = local_path + ".tmp"
 
         device_id = self._save_service._get_server_device_id()
@@ -163,14 +164,14 @@ class SyncEngine:
         )
 
         # Backup existing local save before overwriting
-        if os.path.isfile(local_path):
+        if self._save_file.is_file(local_path):
             backup_dir = os.path.join(saves_dir, ".romm-backup")
-            os.makedirs(backup_dir, exist_ok=True)
+            self._save_file.make_dirs(backup_dir)
             ts = self._clock.now().strftime("%Y%m%d_%H%M%S")
             name, ext = os.path.splitext(filename)
-            os.replace(local_path, os.path.join(backup_dir, f"{name}_{ts}{ext}"))
+            self._save_file.rename(local_path, os.path.join(backup_dir, f"{name}_{ts}{ext}"))
 
-        os.replace(tmp_path, local_path)
+        self._save_file.rename(tmp_path, local_path)
         self._update_file_sync_state(rom_id_str, filename, server_save, local_path, system)
         self._save_service._log_debug(f"Downloaded save: {filename} for rom {rom_id_str}")
 
@@ -260,7 +261,7 @@ class SyncEngine:
         errors.append(f"{filename}: {_msg}")
         tmp = os.path.join(saves_dir, filename + ".tmp")
         with contextlib.suppress(OSError):
-            os.remove(tmp)
+            self._save_file.remove(tmp)
 
     @staticmethod
     def _filter_server_saves_to_slot(server_saves: list[dict], active_slot: str | None) -> list[dict]:
@@ -273,14 +274,14 @@ class SyncEngine:
             return [ss for ss in server_saves if ss.get("slot") == active_slot or ss.get("slot") is None]
         return [ss for ss in server_saves if not ss.get("slot")]
 
-    @staticmethod
-    def _build_local_input(local_path: str, filename: str) -> dict:
+    def _build_local_input(self, local_path: str, filename: str) -> dict:
         """Build the dict shape consumed by ``compute_sync_action``."""
+        exists = self._save_file.is_file(local_path)
         return {
             "filename": filename,
             "path": local_path,
-            "size": os.path.getsize(local_path) if os.path.isfile(local_path) else None,
-            "mtime": os.path.getmtime(local_path) if os.path.isfile(local_path) else None,
+            "size": self._save_file.get_size(local_path) if exists else None,
+            "mtime": self._save_file.get_mtime(local_path) if exists else None,
         }
 
     def _build_sync_conflict_entry(
@@ -294,9 +295,9 @@ class SyncEngine:
         """Build a Phase-2 ``sync_conflict`` descriptor for the frontend."""
         local_mtime = None
         local_size = None
-        if local_path and os.path.isfile(local_path):
-            local_mtime = datetime.fromtimestamp(os.path.getmtime(local_path), tz=UTC).isoformat()
-            local_size = os.path.getsize(local_path)
+        if local_path and self._save_file.is_file(local_path):
+            local_mtime = datetime.fromtimestamp(self._save_file.get_mtime(local_path), tz=UTC).isoformat()
+            local_size = self._save_file.get_size(local_path)
         return {
             "type": "sync_conflict",
             "rom_id": rom_id,
@@ -462,14 +463,15 @@ class SyncEngine:
             filename = lf["filename"]
             local_path = lf["path"]
             handled_filenames.add(filename)
-            local_hash = self._save_service._file_md5(local_path) if os.path.isfile(local_path) else None
+            local_exists = self._save_file.is_file(local_path)
+            local_hash = self._save_service._file_md5(local_path) if local_exists else None
             file_state = files_state.get(filename, {})
             local_mtime_iso = (
-                datetime.fromtimestamp(os.path.getmtime(local_path), tz=UTC).isoformat()
-                if os.path.isfile(local_path)
+                datetime.fromtimestamp(self._save_file.get_mtime(local_path), tz=UTC).isoformat()
+                if local_exists
                 else None
             )
-            local_size = os.path.getsize(local_path) if os.path.isfile(local_path) else None
+            local_size = self._save_file.get_size(local_path) if local_exists else None
             action = compute_sync_action(
                 local_file=self._build_local_input(local_path, filename),
                 server_saves_in_slot=server_in_slot,

--- a/tests/adapters/test_save_file.py
+++ b/tests/adapters/test_save_file.py
@@ -1,0 +1,206 @@
+"""Tests for SaveFileAdapter — raw filesystem ops for local save files."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+
+import pytest
+
+from adapters.save_file import SaveFileAdapter
+
+
+@pytest.fixture
+def save_files() -> SaveFileAdapter:
+    return SaveFileAdapter()
+
+
+class TestExists:
+    def test_true_for_existing_file(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        assert save_files.exists(str(f)) is True
+
+    def test_true_for_directory(self, save_files, tmp_path):
+        assert save_files.exists(str(tmp_path)) is True
+
+    def test_false_for_missing(self, save_files, tmp_path):
+        assert save_files.exists(str(tmp_path / "missing.srm")) is False
+
+
+class TestIsFile:
+    def test_true_for_existing_file(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        assert save_files.is_file(str(f)) is True
+
+    def test_false_for_directory(self, save_files, tmp_path):
+        assert save_files.is_file(str(tmp_path)) is False
+
+    def test_false_for_missing(self, save_files, tmp_path):
+        assert save_files.is_file(str(tmp_path / "missing.srm")) is False
+
+
+class TestIsDir:
+    def test_true_for_directory(self, save_files, tmp_path):
+        assert save_files.is_dir(str(tmp_path)) is True
+
+    def test_false_for_file(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        assert save_files.is_dir(str(f)) is False
+
+    def test_false_for_missing(self, save_files, tmp_path):
+        assert save_files.is_dir(str(tmp_path / "missing")) is False
+
+
+class TestMakeDirs:
+    def test_creates_dir(self, save_files, tmp_path):
+        target = tmp_path / "saves"
+        save_files.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_creates_parents(self, save_files, tmp_path):
+        target = tmp_path / "retrodeck" / "saves" / "gba"
+        save_files.make_dirs(str(target))
+        assert target.is_dir()
+
+    def test_idempotent_when_dir_exists(self, save_files, tmp_path):
+        target = tmp_path / "saves"
+        target.mkdir()
+        save_files.make_dirs(str(target))
+        assert target.is_dir()
+
+
+class TestRemove:
+    def test_removes_existing(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        save_files.remove(str(f))
+        assert not f.exists()
+
+    def test_missing_is_noop(self, save_files, tmp_path):
+        # Idempotent: must not raise.
+        save_files.remove(str(tmp_path / "missing.srm"))
+
+    def test_propagates_non_filenotfound_errors(self, save_files, tmp_path):
+        # Removing a non-empty directory raises IsADirectoryError or OSError —
+        # anything other than FileNotFoundError must surface.
+        with pytest.raises(OSError):
+            save_files.remove(str(tmp_path))
+
+
+class TestRename:
+    def test_renames_file(self, save_files, tmp_path):
+        src = tmp_path / "a.tmp"
+        dst = tmp_path / "a.srm"
+        src.write_bytes(b"payload")
+        save_files.rename(str(src), str(dst))
+        assert not src.exists()
+        assert dst.read_bytes() == b"payload"
+
+    def test_overwrites_existing_destination(self, save_files, tmp_path):
+        src = tmp_path / "new.tmp"
+        dst = tmp_path / "old.srm"
+        src.write_bytes(b"new")
+        dst.write_bytes(b"old")
+        save_files.rename(str(src), str(dst))
+        assert dst.read_bytes() == b"new"
+        assert not src.exists()
+
+    def test_missing_source_raises(self, save_files, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            save_files.rename(str(tmp_path / "missing"), str(tmp_path / "dst"))
+
+
+class TestGetMtime:
+    def test_returns_unix_timestamp(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        mtime = save_files.get_mtime(str(f))
+        assert mtime == pytest.approx(f.stat().st_mtime)
+
+    def test_missing_raises(self, save_files, tmp_path):
+        with pytest.raises(OSError):
+            save_files.get_mtime(str(tmp_path / "missing.srm"))
+
+
+class TestGetSize:
+    def test_returns_byte_count(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"abcdef")
+        assert save_files.get_size(str(f)) == 6
+
+    def test_zero_for_empty_file(self, save_files, tmp_path):
+        f = tmp_path / "empty.srm"
+        f.write_bytes(b"")
+        assert save_files.get_size(str(f)) == 0
+
+    def test_missing_raises(self, save_files, tmp_path):
+        with pytest.raises(OSError):
+            save_files.get_size(str(tmp_path / "missing.srm"))
+
+
+class TestChecksumMd5:
+    def test_matches_hashlib(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        payload = b"save payload bytes"
+        f.write_bytes(payload)
+        expected = hashlib.md5(payload).hexdigest()
+        assert save_files.checksum_md5(str(f)) == expected
+
+    def test_returns_hex_digest_format(self, save_files, tmp_path):
+        f = tmp_path / "game.srm"
+        f.write_bytes(b"x")
+        digest = save_files.checksum_md5(str(f))
+        assert re.fullmatch(r"[0-9a-f]{32}", digest)
+
+    def test_empty_file(self, save_files, tmp_path):
+        f = tmp_path / "empty.srm"
+        f.write_bytes(b"")
+        assert save_files.checksum_md5(str(f)) == hashlib.md5(b"").hexdigest()
+
+    def test_streams_large_file(self, save_files, tmp_path):
+        """Files larger than one chunk are hashed correctly."""
+        f = tmp_path / "large.srm"
+        # 25 KiB — well above the 8 KiB chunk size.
+        payload = b"A" * (25 * 1024)
+        f.write_bytes(payload)
+        assert save_files.checksum_md5(str(f)) == hashlib.md5(payload).hexdigest()
+
+    def test_missing_file_raises(self, save_files, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            save_files.checksum_md5(str(tmp_path / "missing.srm"))
+
+
+class TestMakeTempPath:
+    def test_returns_existing_empty_file(self, save_files):
+        path = save_files.make_temp_path()
+        try:
+            assert os.path.isfile(path)
+            assert os.path.getsize(path) == 0
+        finally:
+            os.remove(path)
+
+    def test_unique_paths_each_call(self, save_files):
+        paths = [save_files.make_temp_path() for _ in range(3)]
+        try:
+            assert len(set(paths)) == 3
+        finally:
+            for p in paths:
+                os.remove(p)
+
+    def test_respects_suffix(self, save_files):
+        path = save_files.make_temp_path(suffix=".srm.tmp")
+        try:
+            assert path.endswith(".srm.tmp")
+        finally:
+            os.remove(path)
+
+    def test_no_suffix_default(self, save_files):
+        path = save_files.make_temp_path()
+        try:
+            assert os.path.isfile(path)
+        finally:
+            os.remove(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -659,6 +659,108 @@ class FakeRomFileAdapter:
                 self.dirs.discard(d)
 
 
+class FakeSaveFileAdapter:
+    """In-memory ``SaveFileAdapter`` for tests.
+
+    Backed by a ``dict[str, bytes]`` so file ops are deterministic and
+    free of filesystem side effects. ``remove`` is idempotent per the
+    Protocol contract. ``is_dir`` reports True for any path explicitly
+    registered as a directory (via ``make_dirs``) or any path that is
+    the parent of a stored file. ``make_temp_path`` returns a
+    monotonically incrementing path under ``/tmp`` and registers it as
+    an empty file so subsequent ``remove`` calls behave like the real
+    adapter.
+
+    Mtime/size behaviour: ``get_mtime`` returns the value set via
+    ``set_mtime`` (or the monotonically-incrementing default assigned
+    on first write), and ``get_size`` returns ``len(files[path])``.
+
+    Failure injection:
+    - ``remove_failures`` — paths that raise ``OSError`` when removed.
+    - ``checksum_overrides`` — pinned hex digests returned by
+      ``checksum_md5`` for specific paths, sidestepping the in-memory
+      ``hashlib`` call when tests want a deterministic mismatch.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files) if files else {}
+        self.dirs: set[str] = set()
+        self.mtimes: dict[str, float] = {}
+        self.remove_failures: set[str] = set()
+        self.checksum_overrides: dict[str, str] = {}
+        self.remove_calls: list[str] = []
+        self.rename_calls: list[tuple[str, str]] = []
+        self.temp_counter: int = 0
+        self._next_mtime: float = 1_000_000.0
+
+    def _ensure_mtime(self, path: str) -> None:
+        if path not in self.mtimes:
+            self.mtimes[path] = self._next_mtime
+            self._next_mtime += 1.0
+
+    def set_mtime(self, path: str, mtime: float) -> None:
+        self.mtimes[path] = mtime
+
+    def exists(self, path: str) -> bool:
+        return path in self.files or self.is_dir(path)
+
+    def is_file(self, path: str) -> bool:
+        return path in self.files
+
+    def is_dir(self, path: str) -> bool:
+        if path in self.dirs:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self.files)
+
+    def make_dirs(self, path: str) -> None:
+        self.dirs.add(path)
+
+    def remove(self, path: str) -> None:
+        self.remove_calls.append(path)
+        if path in self.remove_failures:
+            raise OSError(f"simulated remove failure: {path}")
+        self.files.pop(path, None)
+        self.mtimes.pop(path, None)
+
+    def rename(self, src: str, dst: str) -> None:
+        self.rename_calls.append((src, dst))
+        if src not in self.files:
+            raise FileNotFoundError(src)
+        self.files[dst] = self.files.pop(src)
+        if src in self.mtimes:
+            self.mtimes[dst] = self.mtimes.pop(src)
+        else:
+            self._ensure_mtime(dst)
+
+    def get_mtime(self, path: str) -> float:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        self._ensure_mtime(path)
+        return self.mtimes[path]
+
+    def get_size(self, path: str) -> int:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return len(self.files[path])
+
+    def checksum_md5(self, path: str) -> str:
+        if path in self.checksum_overrides:
+            return self.checksum_overrides[path]
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        import hashlib
+
+        return hashlib.md5(self.files[path]).hexdigest()
+
+    def make_temp_path(self, suffix: str = "") -> str:
+        self.temp_counter += 1
+        path = f"/tmp/fake-save-{self.temp_counter}{suffix}"
+        self.files[path] = b""
+        self._ensure_mtime(path)
+        return path
+
+
 class FakePathProbe:
     """In-memory ``PathExistsProbe`` for tests.
 

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -12,6 +12,7 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
+from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
 from services.firmware import FirmwareService, FirmwareServiceConfig
@@ -100,6 +101,7 @@ def plugin(tmp_path):
                     logger=logging.getLogger("test"),
                 )
             ),
+            save_file=SaveFileAdapter(),
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -15,6 +15,7 @@ from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
+from adapters.save_file import SaveFileAdapter
 from lib.errors import RommApiError
 from services.saves import SaveService, SaveServiceConfig
 
@@ -50,6 +51,7 @@ _CONFIG_FIELDS = frozenset(
     {
         "runtime_dir",
         "save_sync_state_persister",
+        "save_file",
         "loop",
         "logger",
         "clock",
@@ -71,6 +73,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
     config_kwargs: dict[str, Any] = dict(
         runtime_dir=str(tmp_path),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
+        save_file=SaveFileAdapter(),
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -1712,33 +1715,37 @@ class TestFileMd5:
     """Tests for _file_md5."""
 
     def test_known_content(self, tmp_path):
+        svc, _ = make_service(tmp_path)
         f = tmp_path / "test.srm"
         content = b"Hello, save file!"
         f.write_bytes(content)
 
-        assert SaveService._file_md5(str(f)) == hashlib.md5(content).hexdigest()
+        assert svc._file_md5(str(f)) == hashlib.md5(content).hexdigest()
 
     def test_empty_file(self, tmp_path):
+        svc, _ = make_service(tmp_path)
         f = tmp_path / "empty.srm"
         f.write_bytes(b"")
 
-        assert SaveService._file_md5(str(f)) == hashlib.md5(b"").hexdigest()
+        assert svc._file_md5(str(f)) == hashlib.md5(b"").hexdigest()
 
     def test_large_file_chunked(self, tmp_path):
+        svc, _ = make_service(tmp_path)
         f = tmp_path / "large.srm"
         content = os.urandom(2 * 1024 * 1024)
         f.write_bytes(content)
 
-        assert SaveService._file_md5(str(f)) == hashlib.md5(content).hexdigest()
+        assert svc._file_md5(str(f)) == hashlib.md5(content).hexdigest()
 
     def test_permission_error(self, tmp_path):
+        svc, _ = make_service(tmp_path)
         f = tmp_path / "locked.srm"
         f.write_bytes(b"data")
         f.chmod(0o000)
 
         try:
             with pytest.raises(PermissionError):
-                SaveService._file_md5(str(f))
+                svc._file_md5(str(f))
         finally:
             f.chmod(0o644)
 
@@ -2055,7 +2062,7 @@ class TestUpdateFileSyncState:
         svc._update_file_sync_state("42", "pokemon.srm", server_resp, str(save_file), "gba")
 
         entry = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert entry["last_sync_hash"] == SaveService._file_md5(str(save_file))
+        assert entry["last_sync_hash"] == svc._file_md5(str(save_file))
         assert entry["last_sync_at"] is not None
         assert entry["last_sync_server_save_id"] == 200
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -23,6 +23,7 @@ from conftest import (
     FakeMigrationFileAdapter,
     FakePathProbe,
     FakeRomFileAdapter,
+    FakeSaveFileAdapter,
     FakeSgdbArtworkCache,
 )
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
@@ -165,6 +166,7 @@ class TestWireServices:
             "firmware_files": FakeFirmwareFileAdapter(),
             "migration_files": FakeMigrationFileAdapter(),
             "rom_files": FakeRomFileAdapter(),
+            "save_file": FakeSaveFileAdapter(),
             "gamelist_editor": MagicMock(),
             "path_probe": FakePathProbe(),
             "state": state,
@@ -211,6 +213,7 @@ class TestWireServices:
                 firmware_files=deps["firmware_files"],
                 migration_files=deps["migration_files"],
                 rom_files=deps["rom_files"],
+                save_file=deps["save_file"],
                 gamelist_editor=deps["gamelist_editor"],
                 path_probe=deps["path_probe"],
             ),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -814,6 +814,7 @@ class TestMainStartupOrdering:
             "download_queue": MagicMock(),
             "migration_files": MagicMock(),
             "rom_files": MagicMock(),
+            "save_file": MagicMock(),
             "path_probe": MagicMock(),
             "retrodeck_paths": MagicMock(),
             "retroarch_config": MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -14,6 +14,7 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.romm.http import RommHttpAdapter
+from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.library import LibraryService, LibraryServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
@@ -101,6 +102,7 @@ def plugin(tmp_path):
                     logger=logging.getLogger("test"),
                 )
             ),
+            save_file=SaveFileAdapter(),
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),


### PR DESCRIPTION
Biggest sub-issue of the saves vertical (#254). Extracts all local-save-file I/O from \`services/saves/\` into a new \`SaveFileAdapter\` Protocol + concrete adapter — the saves package no longer has any raw \`os.*\` (except path algebra), \`open()\`, \`tempfile\`, or \`hashlib\` calls.

## Changes

- New \`SaveFileAdapter\` Protocol in \`services/protocols.py\` — 10 methods covering existence checks, mtime/size, makedirs, remove, rename (atomic replace), MD5 checksum, and temp-path creation
- New concrete \`adapters/save_file.py\` — uses \`hashlib.md5(usedforsecurity=False)\` to preserve the existing S4790 suppression; \`make_temp_path\` wraps the \`tempfile.mkstemp + os.close(fd)\` idiom
- \`SaveServiceConfig\` extended with \`save_file: SaveFileAdapter\`
- \`SyncEngine\` and \`SlotsService\` ctors get a \`save_file\` param wired from the facade
- 43 I/O call sites rewritten across \`facade.py\` (14), \`sync_engine/engine.py\` (24), \`slots/service.py\` (4); \`versions.py\` was already pure path algebra
- \`_file_md5\` on the facade becomes an instance method delegating to \`self._save_file.checksum_md5\`
- \`FakeSaveFileAdapter\` added to \`tests/conftest.py\`
- New \`tests/adapters/test_save_file.py\` (32 tests, 100% line + branch coverage)
- Bootstrap wires the adapter through \`AdapterBundle\`

## Behavior preservation

- Atomic-rename + backup-on-overwrite flow byte-for-byte equivalent (download → tmp → backup existing → replace)
- MD5 digest identical (same 8192-byte chunk size, same usedforsecurity flag)
- Backup naming (\`<name>_<ts><ext>\`) and backup directory (\`.romm-backup\`) unchanged
- Logger messages unchanged
- \`make_temp_path\` closes the fd before returning, matching the old \`mkstemp\` + \`os.close(fd)\` pattern

One subtle nuance noted by the reviewer (approved): \`SaveFileAdapter.remove\` suppresses \`FileNotFoundError\` for idempotency. The only path this could behave differently is a TOCTOU race in \`_delete_saves_for_roms\` between \`_find_save_files\` and the remove call. \`_find_save_files\` pre-filters by \`is_file == True\`, so in practice this is equivalent — and arguably more correct ("file is gone, deletion succeeded").

## Test results

- 2139 → 2171 tests (+32 adapter tests; service tests preserved with real adapter + \`tmp_path\`)
- \`adapters/save_file.py\` — 100% line + branch
- Saves package overall: 93%

## Gates

- ruff: PASS
- basedpyright (full scope incl tests/): PASS (0/0/0)
- pytest: PASS (2171)
- \`scripts/check_cosmic_call_bans.sh\`: PASS
- \`lint-imports\` (7 contracts): PASS
- \`pnpm build\`: PASS

## Cosmic Python

Final leak check on \`py_modules/services/saves/\` — only hit is the docstring reference in \`_config.py\` enumerating the I/O classes the adapter wraps. Zero real call leaks.

## Closes

#242. Saves vertical (#254): 2 of 5 sub-issues complete (#272, #242). Remaining: #307 (peer-inject), #273 (typed state), #275 (test restructure).