### PR TITLE
refactor(saves): introduce typed SaveSyncState aggregate (#273)

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -33,6 +33,7 @@ from adapters.steam_config import SteamConfigAdapter
 from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
+from domain.save_state import SaveSyncState
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService, ArtworkServiceConfig
 from services.connection import ConnectionService, ConnectionServiceConfig
@@ -104,12 +105,12 @@ class AdapterBundle:
 
 @dataclass(frozen=True)
 class StateBundle:
-    """Live mutable state dicts shared across services."""
+    """Live mutable state stores shared across services."""
 
     state: dict
     settings: dict
     metadata_cache: dict
-    save_sync_state: dict
+    save_sync_state: SaveSyncState
 
 
 @dataclass(frozen=True)

--- a/py_modules/domain/save_state.py
+++ b/py_modules/domain/save_state.py
@@ -1,0 +1,400 @@
+"""Typed in-memory model for ``save_sync_state.json``.
+
+Pure data shapes — no I/O, no logging, no service/adapter imports.
+``StateService`` owns the aggregate at runtime; on-disk format stays
+JSON via ``SaveSyncState.from_dict`` / ``SaveSyncState.to_dict``.
+Legacy schema migrations apply inside ``from_dict``.
+
+Aggregate root is :class:`SaveSyncState`. Per-ROM, per-file, playtime,
+and settings shapes are reflected in dedicated dataclasses. Mutation
+is supported (dataclasses are *not* frozen) so existing code paths
+that update nested fields in place continue to work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Schema version. Bump only when ``from_dict`` migrations change shape.
+_SCHEMA_VERSION = 1
+
+
+@dataclass
+class FileSyncState:
+    """Per-file sync tracking under a ROM's ``saves`` entry.
+
+    Tracks the last-observed local hash + sizes + timestamps so the
+    newest-wins matrix can detect drift on the next sync. New entries
+    use the defaults; persistence preserves whatever fields were set
+    at the time of the last update.
+    """
+
+    tracked_save_id: int | None = None
+    last_sync_hash: str | None = None
+    last_sync_at: str = ""
+    last_sync_server_updated_at: str = ""
+    last_sync_server_save_id: int | None = None
+    last_sync_server_size: int | None = None
+    last_sync_local_mtime: float | None = None
+    last_sync_local_size: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FileSyncState:
+        """Build from a raw dict, dropping legacy keys (``dismissed_newer_save_id``)."""
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            tracked_save_id=data.get("tracked_save_id"),
+            last_sync_hash=data.get("last_sync_hash"),
+            last_sync_at=data.get("last_sync_at", "") or "",
+            last_sync_server_updated_at=data.get("last_sync_server_updated_at", "") or "",
+            last_sync_server_save_id=data.get("last_sync_server_save_id"),
+            last_sync_server_size=data.get("last_sync_server_size"),
+            last_sync_local_mtime=data.get("last_sync_local_mtime"),
+            last_sync_local_size=data.get("last_sync_local_size"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the on-disk JSON dict."""
+        return {
+            "tracked_save_id": self.tracked_save_id,
+            "last_sync_hash": self.last_sync_hash,
+            "last_sync_at": self.last_sync_at,
+            "last_sync_server_updated_at": self.last_sync_server_updated_at,
+            "last_sync_server_save_id": self.last_sync_server_save_id,
+            "last_sync_server_size": self.last_sync_server_size,
+            "last_sync_local_mtime": self.last_sync_local_mtime,
+            "last_sync_local_size": self.last_sync_local_size,
+        }
+
+
+@dataclass
+class RomSaveState:
+    """Per-ROM save-sync state — slot config, attribution, per-file tracking.
+
+    ``last_sync_check_at`` records when the sync engine last evaluated
+    the matrix for this ROM regardless of whether any file transferred.
+    ``slots`` keeps the merged server/local slot listing so the UI can
+    survive a server outage. ``extra`` holds any unknown keys preserved
+    from disk so the aggregate can round-trip forward-compatible state
+    without losing fields the current code does not understand.
+    """
+
+    active_slot: str | None = None
+    slot_confirmed: bool = False
+    emulator: str = "retroarch"
+    system: str = ""
+    last_synced_core: str | None = None
+    # ``None`` distinguishes "uploader attribution unknown" (legacy state
+    # entry created before #186) from "we definitely uploaded nothing"
+    # (empty list). Consumers downstream (status DTOs, version listings)
+    # surface ``uploaded_by_us=None`` in the former case so the UI can hide
+    # the attribution badge instead of asserting "not yours".
+    own_upload_ids: list[int] | None = None
+    slots: dict[str, dict[str, Any]] = field(default_factory=dict)
+    files: dict[str, FileSyncState] = field(default_factory=dict)
+    last_sync_check_at: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    _KNOWN_KEYS = frozenset(
+        {
+            "active_slot",
+            "slot_confirmed",
+            "emulator",
+            "system",
+            "last_synced_core",
+            "own_upload_ids",
+            "slots",
+            "files",
+            "last_sync_check_at",
+        }
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RomSaveState:
+        """Build from a raw dict.
+
+        Applies legacy migrations:
+
+        - ``active_core`` → ``last_synced_core`` (if both are present,
+          ``last_synced_core`` wins).
+
+        Unknown keys are kept in ``extra`` so persistence preserves them.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        raw_files = data.get("files")
+        files: dict[str, FileSyncState] = {}
+        if isinstance(raw_files, dict):
+            files = {fn: FileSyncState.from_dict(fs) for fn, fs in raw_files.items()}
+
+        slots_raw = data.get("slots")
+        slots: dict[str, dict[str, Any]] = slots_raw if isinstance(slots_raw, dict) else {}
+
+        # Preserve the "missing key" vs "explicitly empty" distinction.
+        own_upload_ids: list[int] | None
+        if "own_upload_ids" not in data:
+            own_upload_ids = None
+        elif isinstance(data.get("own_upload_ids"), list):
+            own_upload_ids = data["own_upload_ids"]
+        else:
+            own_upload_ids = None
+
+        last_synced_core = data.get("last_synced_core")
+        if last_synced_core is None and "active_core" in data:
+            last_synced_core = data.get("active_core")
+
+        extra = {k: v for k, v in data.items() if k not in cls._KNOWN_KEYS and k != "active_core"}
+
+        return cls(
+            active_slot=data.get("active_slot"),
+            slot_confirmed=bool(data.get("slot_confirmed", False)),
+            emulator=str(data.get("emulator", "retroarch")),
+            system=str(data.get("system", "") or ""),
+            last_synced_core=last_synced_core,
+            own_upload_ids=own_upload_ids,
+            slots=slots,
+            files=files,
+            last_sync_check_at=data.get("last_sync_check_at"),
+            extra=extra,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the on-disk JSON dict.
+
+        Preserves any unknown keys captured in ``extra`` and keeps a
+        stable ordering compatible with the previous untyped layout.
+        """
+        out: dict[str, Any] = {
+            "active_slot": self.active_slot,
+            "slot_confirmed": self.slot_confirmed,
+            "emulator": self.emulator,
+            "system": self.system,
+            "last_synced_core": self.last_synced_core,
+            "slots": dict(self.slots),
+            "files": {fn: fs.to_dict() for fn, fs in self.files.items()},
+        }
+        # Persist ``own_upload_ids`` only when known; "missing key" round-trips
+        # so legacy entries don't gain a misleading empty list on first reload.
+        if self.own_upload_ids is not None:
+            out["own_upload_ids"] = list(self.own_upload_ids)
+        if self.last_sync_check_at is not None:
+            out["last_sync_check_at"] = self.last_sync_check_at
+        for k, v in self.extra.items():
+            out[k] = v
+        return out
+
+
+@dataclass
+class PlaytimeEntry:
+    """Per-ROM playtime tracking entry.
+
+    Owned by :class:`PlaytimeService`. Field shape mirrors what the
+    service writes today: a running ``total_seconds`` counter, the
+    open ``last_session_start`` timestamp, a ``session_count`` for
+    UI display, and the optional ``note_id`` returned by the RomM
+    notes API. ``offline_deltas`` is kept for forward compatibility
+    with the (currently unused) offline-buffer code path; ``extra``
+    preserves any unknown keys round-tripped from disk.
+    """
+
+    total_seconds: int = 0
+    session_count: int = 0
+    last_session_start: str | None = None
+    last_session_duration_sec: int | None = None
+    offline_deltas: list[Any] = field(default_factory=list)
+    note_id: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    _KNOWN_KEYS = frozenset(
+        {
+            "total_seconds",
+            "session_count",
+            "last_session_start",
+            "last_session_duration_sec",
+            "offline_deltas",
+            "note_id",
+        }
+    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PlaytimeEntry:
+        """Build from a raw dict, capturing unknown keys in ``extra``."""
+        if not isinstance(data, dict):
+            return cls()
+        offline_raw = data.get("offline_deltas")
+        offline_deltas = offline_raw if isinstance(offline_raw, list) else []
+        extra = {k: v for k, v in data.items() if k not in cls._KNOWN_KEYS}
+        return cls(
+            total_seconds=int(data.get("total_seconds", 0) or 0),
+            session_count=int(data.get("session_count", 0) or 0),
+            last_session_start=data.get("last_session_start"),
+            last_session_duration_sec=data.get("last_session_duration_sec"),
+            offline_deltas=offline_deltas,
+            note_id=data.get("note_id"),
+            extra=extra,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the on-disk JSON dict."""
+        out: dict[str, Any] = {
+            "total_seconds": self.total_seconds,
+            "session_count": self.session_count,
+            "last_session_start": self.last_session_start,
+            "last_session_duration_sec": self.last_session_duration_sec,
+            "offline_deltas": list(self.offline_deltas),
+        }
+        if self.note_id is not None:
+            out["note_id"] = self.note_id
+        for k, v in self.extra.items():
+            out[k] = v
+        return out
+
+
+@dataclass
+class SaveSyncSettings:
+    """Save-sync feature settings (user-toggleable).
+
+    Legacy keys (``conflict_mode``, ``clock_skew_tolerance_sec``)
+    are dropped at :meth:`from_dict`. Any forward-compatible unknown
+    keys are preserved in ``extra``.
+    """
+
+    save_sync_enabled: bool = False
+    sync_before_launch: bool = True
+    sync_after_exit: bool = True
+    default_slot: str | None = "default"
+    autocleanup_limit: int = 10
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    _KNOWN_KEYS = frozenset(
+        {
+            "save_sync_enabled",
+            "sync_before_launch",
+            "sync_after_exit",
+            "default_slot",
+            "autocleanup_limit",
+        }
+    )
+    _LEGACY_DROPPED_KEYS = frozenset({"conflict_mode", "clock_skew_tolerance_sec"})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SaveSyncSettings:
+        """Build from a raw dict, dropping legacy keys."""
+        if not isinstance(data, dict):
+            return cls()
+        extra = {k: v for k, v in data.items() if k not in cls._KNOWN_KEYS and k not in cls._LEGACY_DROPPED_KEYS}
+        # ``default_slot=None`` is the legacy ("no slots") mode; preserve it
+        # rather than collapsing it to the "default" string default.
+        raw_slot = data.get("default_slot", "default") if "default_slot" in data else "default"
+        if raw_slot is None:
+            default_slot: str | None = None
+        else:
+            slot_str = str(raw_slot)
+            default_slot = slot_str if slot_str else None
+        return cls(
+            save_sync_enabled=bool(data.get("save_sync_enabled", False)),
+            sync_before_launch=bool(data.get("sync_before_launch", True)),
+            sync_after_exit=bool(data.get("sync_after_exit", True)),
+            default_slot=default_slot,
+            autocleanup_limit=int(data.get("autocleanup_limit", 10) or 10),
+            extra=extra,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the on-disk JSON dict."""
+        out: dict[str, Any] = {
+            "save_sync_enabled": self.save_sync_enabled,
+            "sync_before_launch": self.sync_before_launch,
+            "sync_after_exit": self.sync_after_exit,
+            "default_slot": self.default_slot,
+            "autocleanup_limit": self.autocleanup_limit,
+        }
+        for k, v in self.extra.items():
+            out[k] = v
+        return out
+
+
+@dataclass
+class SaveSyncState:
+    """Aggregate root for the on-disk ``save_sync_state.json``.
+
+    Carries device identity, per-ROM save state, playtime tracking,
+    and feature settings. Persistence flows through :meth:`to_dict` /
+    :meth:`from_dict`; schema migrations apply on load. Mutation is
+    in-place — held by reference across services.
+    """
+
+    version: int = _SCHEMA_VERSION
+    device_id: str | None = None
+    device_name: str | None = None
+    server_device_id: int | str | None = None
+    saves: dict[str, RomSaveState] = field(default_factory=dict)
+    playtime: dict[str, PlaytimeEntry] = field(default_factory=dict)
+    settings: SaveSyncSettings = field(default_factory=SaveSyncSettings)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SaveSyncState:
+        """Build from a freshly-loaded JSON dict, applying legacy migrations."""
+        if not isinstance(data, dict):
+            return cls()
+        raw_saves = data.get("saves")
+        saves: dict[str, RomSaveState] = {}
+        if isinstance(raw_saves, dict):
+            saves = {rid: RomSaveState.from_dict(entry) for rid, entry in raw_saves.items()}
+
+        raw_playtime = data.get("playtime")
+        playtime: dict[str, PlaytimeEntry] = {}
+        if isinstance(raw_playtime, dict):
+            playtime = {rid: PlaytimeEntry.from_dict(entry) for rid, entry in raw_playtime.items()}
+
+        return cls(
+            version=int(data.get("version", _SCHEMA_VERSION) or _SCHEMA_VERSION),
+            device_id=data.get("device_id"),
+            device_name=data.get("device_name"),
+            server_device_id=data.get("server_device_id"),
+            saves=saves,
+            playtime=playtime,
+            settings=SaveSyncSettings.from_dict(data.get("settings", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the on-disk JSON dict.
+
+        Output key order matches the historical untyped layout so the
+        on-disk file diff is empty when nothing has changed semantically.
+        """
+        return {
+            "version": self.version,
+            "device_id": self.device_id,
+            "device_name": self.device_name,
+            "server_device_id": self.server_device_id,
+            "saves": {rid: rs.to_dict() for rid, rs in self.saves.items()},
+            "playtime": {rid: pe.to_dict() for rid, pe in self.playtime.items()},
+            "settings": self.settings.to_dict(),
+        }
+
+    def replace_with(self, other: SaveSyncState) -> None:
+        """Mutate this aggregate in-place to mirror *other*.
+
+        Used by :class:`StateService` so callers that hold a long-lived
+        reference (other services, sub-services, ``main.py``) keep
+        seeing the latest loaded state without rewiring.
+        """
+        self.version = other.version
+        self.device_id = other.device_id
+        self.device_name = other.device_name
+        self.server_device_id = other.server_device_id
+        self.saves = other.saves
+        self.playtime = other.playtime
+        self.settings = other.settings
+
+
+__all__ = [
+    "FileSyncState",
+    "PlaytimeEntry",
+    "RomSaveState",
+    "SaveSyncSettings",
+    "SaveSyncState",
+]

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from models.metadata import AchievementSummary
 
 from domain.bios import compute_bios_label, compute_bios_level, format_bios_status
+from domain.save_state import SaveSyncState
 from domain.save_status import compute_save_sync_display
 
 if TYPE_CHECKING:
@@ -34,7 +35,7 @@ class GameDetailService:
         *,
         state: dict,
         metadata_cache: dict,
-        save_sync_state: dict,
+        save_sync_state: SaveSyncState,
         logger: logging.Logger,
         clock: Clock,
         bios_checker: BiosChecker,
@@ -67,24 +68,20 @@ class GameDetailService:
 
     def _build_save_status(self, rom_id_str: str) -> dict | None:
         """Build cached save-sync status for a ROM, or None if no saves."""
-        raw_save = self._save_sync_state.get("saves", {}).get(rom_id_str)
-        if not raw_save:
+        rom_state = self._save_sync_state.saves.get(rom_id_str)
+        if rom_state is None:
             return None
-        raw_files = raw_save.get("files", {})
-        if isinstance(raw_files, dict):
-            files_list = [
-                {
-                    "filename": fn,
-                    "status": "synced" if fdata.get("last_sync_hash") else "unknown",
-                    "last_sync_at": fdata.get("last_sync_at"),
-                }
-                for fn, fdata in raw_files.items()
-            ]
-        else:
-            files_list = raw_files
+        files_list = [
+            {
+                "filename": fn,
+                "status": "synced" if fdata.last_sync_hash else "unknown",
+                "last_sync_at": fdata.last_sync_at or None,
+            }
+            for fn, fdata in rom_state.files.items()
+        ]
         return {
             "files": files_list,
-            "last_sync_check_at": raw_save.get("last_sync_check_at"),
+            "last_sync_check_at": rom_state.last_sync_check_at,
             "conflicts": [],  # cached only — full conflicts via get_save_status()
         }
 
@@ -152,7 +149,7 @@ class GameDetailService:
         installed = rom_id_str in self._state["installed_roms"]
 
         # Save sync
-        save_sync_enabled = self._save_sync_state.get("settings", {}).get("save_sync_enabled", False)
+        save_sync_enabled = self._save_sync_state.settings.save_sync_enabled
         save_status = self._build_save_status(rom_id_str)
         save_sync_display = None
         if save_status is not None:

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -10,6 +10,7 @@ import contextlib
 import json
 from typing import TYPE_CHECKING
 
+from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.iso_time import parse_iso
 from services.protocols import Clock, RetryStrategy, RommApiProtocol, StatePersister
 
@@ -28,8 +29,8 @@ class PlaytimeService:
     retry:
         Retry strategy — provides ``with_retry`` and ``is_retryable``.
     save_sync_state:
-        Live reference to the save-sync state dict.  Playtime data lives
-        in ``save_sync_state["playtime"]``.
+        Live reference to the typed :class:`SaveSyncState` aggregate.
+        Playtime data lives in ``save_sync_state.playtime``.
     loop:
         The plugin's ``asyncio`` event loop (for ``run_in_executor``).
     logger:
@@ -45,7 +46,7 @@ class PlaytimeService:
         *,
         romm_api: RommApiProtocol,
         retry: RetryStrategy,
-        save_sync_state: dict,
+        save_sync_state: SaveSyncState,
         loop: asyncio.AbstractEventLoop,
         logger: logging.Logger,
         clock: Clock,
@@ -99,9 +100,9 @@ class PlaytimeService:
         # Store note_id in state for future updates
         if isinstance(result, dict) and result.get("id"):
             rom_id_str = str(int(rom_id))
-            entry = self._save_sync_state.get("playtime", {}).get(rom_id_str)
+            entry = self._save_sync_state.playtime.get(rom_id_str)
             if entry is not None:
-                entry["note_id"] = result["id"]
+                entry.note_id = result["id"]
                 self._save_state()
         return result
 
@@ -134,12 +135,12 @@ class PlaytimeService:
         """
         rom_id = int(rom_id)
         rom_id_str = str(rom_id)
-        entry = self._save_sync_state.get("playtime", {}).get(rom_id_str)
+        entry = self._save_sync_state.playtime.get(rom_id_str)
         if not entry:
             return
 
-        local_total = entry.get("total_seconds", 0)
-        device_name = self._save_sync_state.get("device_name", "")
+        local_total = entry.total_seconds
+        device_name = self._save_sync_state.device_name or ""
 
         try:
             note = self._retry.with_retry(self._get_playtime_note, rom_id)
@@ -167,7 +168,7 @@ class PlaytimeService:
                 self._retry.with_retry(self._create_playtime_note, rom_id, playtime_data)
 
             # Sync local state to the merged total
-            entry["total_seconds"] = new_total
+            entry.total_seconds = new_total
             self._save_state()
 
         except Exception as e:
@@ -180,18 +181,9 @@ class PlaytimeService:
     def record_session_start(self, rom_id: int) -> dict:
         """Record the start of a play session for playtime tracking."""
         rom_id_str = str(int(rom_id))
-        playtime = self._save_sync_state.setdefault("playtime", {})
-        entry = playtime.setdefault(
-            rom_id_str,
-            {
-                "total_seconds": 0,
-                "session_count": 0,
-                "last_session_start": None,
-                "last_session_duration_sec": None,
-                "offline_deltas": [],
-            },
-        )
-        entry["last_session_start"] = self._clock.now().isoformat()
+        playtime = self._save_sync_state.playtime
+        entry = playtime.setdefault(rom_id_str, PlaytimeEntry())
+        entry.last_session_start = self._clock.now().isoformat()
         self._save_state()
         return {"success": True}
 
@@ -201,14 +193,13 @@ class PlaytimeService:
         Only handles playtime — save sync is handled separately.
         """
         rom_id_str = str(int(rom_id))
-        playtime = self._save_sync_state.get("playtime", {})
-        entry = playtime.get(rom_id_str)
+        entry = self._save_sync_state.playtime.get(rom_id_str)
 
-        if not entry or not entry.get("last_session_start"):
+        if not entry or not entry.last_session_start:
             return {"success": False, "message": "No active session"}
 
         try:
-            start = parse_iso(entry["last_session_start"])
+            start = parse_iso(entry.last_session_start)
             if start is None:
                 return {"success": False, "message": "Failed to calculate session duration"}
             now = self._clock.now()
@@ -217,10 +208,10 @@ class PlaytimeService:
             # Sanity check: clamp to 0-24h
             duration = max(0, min(duration, 86400))
 
-            entry["total_seconds"] = entry.get("total_seconds", 0) + int(duration)
-            entry["session_count"] = entry.get("session_count", 0) + 1
-            entry["last_session_duration_sec"] = int(duration)
-            entry["last_session_start"] = None
+            entry.total_seconds += int(duration)
+            entry.session_count += 1
+            entry.last_session_duration_sec = int(duration)
+            entry.last_session_start = None
 
             self._save_state()
 
@@ -231,8 +222,8 @@ class PlaytimeService:
             return {
                 "success": True,
                 "duration_sec": int(duration),
-                "total_seconds": entry["total_seconds"],
-                "session_count": entry["session_count"],
+                "total_seconds": entry.total_seconds,
+                "session_count": entry.session_count,
             }
         except (ValueError, TypeError):
             return {"success": False, "message": "Failed to calculate session duration"}
@@ -242,8 +233,8 @@ class PlaytimeService:
         rom_id = int(rom_id)
         rom_id_str = str(rom_id)
 
-        local_entry = self._save_sync_state.get("playtime", {}).get(rom_id_str, {})
-        local_seconds = local_entry.get("total_seconds", 0)
+        local_entry = self._save_sync_state.playtime.get(rom_id_str)
+        local_seconds = local_entry.total_seconds if local_entry else 0
 
         server_seconds = 0
         try:
@@ -263,9 +254,9 @@ class PlaytimeService:
             "local_seconds": local_seconds,
             "server_seconds": server_seconds,
             "total_seconds": max(local_seconds, server_seconds),
-            "session_count": local_entry.get("session_count", 0),
+            "session_count": local_entry.session_count if local_entry else 0,
         }
 
     def get_all_playtime(self) -> dict:
         """Return all local playtime entries keyed by rom_id string."""
-        return {"playtime": self._save_sync_state.get("playtime", {})}
+        return {"playtime": {rid: pe.to_dict() for rid, pe in self._save_sync_state.playtime.items()}}

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.path_safety import is_safe_rom_path
+from domain.save_state import SaveSyncState
 
 if TYPE_CHECKING:
     import logging
@@ -26,7 +27,7 @@ class RomRemovalServiceConfig:
     """
 
     state: dict
-    save_sync_state: dict
+    save_sync_state: SaveSyncState
     logger: logging.Logger
     loop: asyncio.AbstractEventLoop
     save_state: StatePersister
@@ -80,9 +81,9 @@ class RomRemovalService:
         del self._state["installed_roms"][rom_id_str]
         # Clean save sync state for removed ROM
         save_changed = False
-        if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
+        if self._save_sync_state.saves.pop(rom_id_str, None) is not None:
             save_changed = True
-        if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
+        if self._save_sync_state.playtime.pop(rom_id_str, None) is not None:
             save_changed = True
         if save_changed:
             self._save_save_sync_state()
@@ -125,9 +126,9 @@ class RomRemovalService:
         # Clean save sync state for all removed ROMs
         save_changed = False
         for rom_id_str in successfully_deleted:
-            if self._save_sync_state.get("saves", {}).pop(rom_id_str, None) is not None:
+            if self._save_sync_state.saves.pop(rom_id_str, None) is not None:
                 save_changed = True
-            if self._save_sync_state.get("playtime", {}).pop(rom_id_str, None) is not None:
+            if self._save_sync_state.playtime.pop(rom_id_str, None) is not None:
                 save_changed = True
         if save_changed:
             self._save_save_sync_state()

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -12,6 +12,7 @@ from models.saves import SaveConflict
 from domain.emulator_tag import detect_core_change
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir, sanitize_save_filename
+from domain.save_state import FileSyncState, SaveSyncState
 from lib.errors import classify_error
 from lib.iso_time import parse_iso_to_epoch
 from services.protocols import (
@@ -49,8 +50,9 @@ class SaveService:
         Live reference to the main plugin state dict (``installed_roms``,
         ``shortcut_registry``).
     save_sync_state:
-        Live reference to the save-sync state dict. Caller should
-        pre-populate via :meth:`init_state` / :meth:`load_state`.
+        Live reference to the typed :class:`SaveSyncState` aggregate.
+        Caller should pre-populate via :meth:`load_state` after
+        construction; the aggregate ships with defaults out of the box.
     config:
         Construction-time wiring bundle (paths, callbacks, asyncio loop,
         logger, plugin metadata). See :class:`SaveServiceConfig` for the
@@ -66,7 +68,7 @@ class SaveService:
         retry: RetryStrategy,
         settings: dict,
         state: dict,
-        save_sync_state: dict,
+        save_sync_state: SaveSyncState,
         config: SaveServiceConfig,
     ) -> None:
         self._romm_api = romm_api
@@ -80,10 +82,8 @@ class SaveService:
             persister=config.save_sync_state_persister,
             logger=config.logger,
         )
-        # Alias the dict so the dozens of self._save_sync_state[...] call
-        # sites elsewhere in SaveService keep working unchanged. Both names
-        # reference the same underlying dict object.
-        self._save_sync_state = self._state_svc.data
+        # Convenience alias — both names reference the same aggregate.
+        self._save_sync_state = self._state_svc.state
         # Convenience aliases — the rest of the class body (and sub-services
         # via the ``_save_service`` back-ref) read these attributes directly.
         self._loop = config.loop
@@ -152,24 +152,21 @@ class SaveService:
 
     def _get_server_device_id(self) -> str | None:
         """Return the server device ID if registered, else None."""
-        return self._save_sync_state.get("server_device_id")
+        sid = self._save_sync_state.server_device_id
+        return str(sid) if sid is not None else None
 
     # ------------------------------------------------------------------
     # State Management
     # ------------------------------------------------------------------
 
     @staticmethod
-    def make_default_state() -> dict:
-        """Return a fresh default save-sync state dict."""
+    def make_default_state() -> SaveSyncState:
+        """Return a fresh default save-sync state aggregate."""
         return StateService.make_default_state()
 
     def init_state(self) -> None:
-        """Populate ``_save_sync_state`` with defaults (idempotent)."""
+        """No-op for the typed aggregate (defaults ship at construction)."""
         self._state_svc.init_state()
-
-    def _migrate_loaded_state(self) -> None:
-        """Apply schema migrations to data just read from disk."""
-        self._state_svc._migrate_loaded_state()
 
     def load_state(self) -> None:
         """Load save sync state from disk, merging with defaults."""
@@ -349,7 +346,7 @@ class SaveService:
 
     def _is_save_sync_enabled(self) -> bool:
         """Check if save sync feature is enabled."""
-        return self._save_sync_state.get("settings", {}).get("save_sync_enabled", False)
+        return self._save_sync_state.settings.save_sync_enabled
 
     # ------------------------------------------------------------------
     # Public async API (callable endpoints)
@@ -378,18 +375,19 @@ class SaveService:
                 self._logger.debug(f"ensure_device_registered: version probe failed (non-fatal): {e}")
 
         # Already registered
-        has_device_id = self._save_sync_state.get("device_id")
-        has_server_id = self._save_sync_state.get("server_device_id")
+        has_device_id = self._save_sync_state.device_id
+        has_server_id = self._save_sync_state.server_device_id
         if has_device_id and has_server_id:
+            server_id_str = str(has_server_id)
             with contextlib.suppress(Exception):
                 await self._loop.run_in_executor(
                     None,
-                    lambda: self._romm_api.update_device(has_server_id, client_version=self._plugin_version),
+                    lambda: self._romm_api.update_device(server_id_str, client_version=self._plugin_version),
                 )
             return {
                 "success": True,
-                "device_id": self._save_sync_state["device_id"],
-                "device_name": self._save_sync_state.get("device_name", ""),
+                "device_id": self._save_sync_state.device_id,
+                "device_name": self._save_sync_state.device_name or "",
                 "server_device_id": has_server_id,
             }
 
@@ -407,9 +405,9 @@ class SaveService:
             )
             server_device_id = result.get("id") or result.get("device_id")
             if server_device_id:
-                self._save_sync_state["device_id"] = str(server_device_id)
-                self._save_sync_state["device_name"] = hostname
-                self._save_sync_state["server_device_id"] = str(server_device_id)
+                self._save_sync_state.device_id = str(server_device_id)
+                self._save_sync_state.device_name = hostname
+                self._save_sync_state.server_device_id = str(server_device_id)
                 self.save_state()
                 self._logger.info(f"Device registered with server: {server_device_id} ({hostname})")
                 return {
@@ -473,12 +471,12 @@ class SaveService:
             return {"changed": False}
 
         rom_id_str = str(rom_id)
-        save_entry = self._save_sync_state.get("saves", {}).get(rom_id_str)
+        save_entry = self._save_sync_state.saves.get(rom_id_str)
         if not save_entry:
             return {"changed": False}  # Never synced
 
-        stored_core = save_entry.get("last_synced_core")
-        system = save_entry.get("system")
+        stored_core = save_entry.last_synced_core
+        system = save_entry.system
         if not stored_core or not system:
             return {"changed": False}
 
@@ -574,11 +572,10 @@ class SaveService:
                     "save_sort_changed": True,
                 }
 
-            settings = self._save_sync_state.get("settings", {})
-            if not settings.get("sync_before_launch", True):
+            if not self._save_sync_state.settings.sync_before_launch:
                 return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
 
-            if not self._save_sync_state.get("device_id"):
+            if not self._save_sync_state.device_id:
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
                     return {"success": False, "message": DEVICE_NOT_REGISTERED}
@@ -621,8 +618,7 @@ class SaveService:
                     "blocked_by_migration": True,
                 }
 
-            settings = self._save_sync_state.get("settings", {})
-            if not settings.get("sync_after_exit", True):
+            if not self._save_sync_state.settings.sync_after_exit:
                 self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
                 return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
 
@@ -635,7 +631,7 @@ class SaveService:
                 self._logger.info("post_exit_sync skipped: server offline")
                 return {"success": False, "message": "Server offline", "synced": 0, "offline": True}
 
-            if not self._save_sync_state.get("device_id"):
+            if not self._save_sync_state.device_id:
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
                     return {"success": False, "message": DEVICE_NOT_REGISTERED}
@@ -679,7 +675,7 @@ class SaveService:
             # sync before any detect has fired.
             await self._refresh_save_sort_state("sync_rom_saves")
 
-            if not self._save_sync_state.get("device_id"):
+            if not self._save_sync_state.device_id:
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
                     return {"success": False, "message": DEVICE_NOT_REGISTERED}
@@ -753,7 +749,7 @@ class SaveService:
         # sync before any detect has fired.
         await self._refresh_save_sort_state("sync_all_saves")
 
-        if not self._save_sync_state.get("device_id"):
+        if not self._save_sync_state.device_id:
             reg = await self.ensure_device_registered()
             if not reg.get("success"):
                 return {"success": False, "message": DEVICE_NOT_REGISTERED}
@@ -861,8 +857,8 @@ class SaveService:
                 _code, _msg = classify_error(e)
                 return {"success": False, "message": f"Failed to fetch saves: {_msg}"}
 
-            save_state = self._save_sync_state["saves"].get(rom_id_str, {})
-            active_slot = save_state.get("active_slot")
+            rom_state = self._save_sync_state.saves.get(rom_id_str)
+            active_slot = rom_state.active_slot if rom_state else None
             server_in_slot = SyncEngine._filter_server_saves_to_slot(server_saves, active_slot)
             if not server_in_slot:
                 return {"success": False, "message": "No server save in active slot"}
@@ -954,17 +950,15 @@ class SaveService:
             self._log_debug(
                 f"keep_local: hash matches server, adopting without upload (rom={rom_id} filename={filename})"
             )
-            saves = self._save_sync_state.setdefault("saves", {})
-            rom_entry = saves.setdefault(rom_id_str, {"files": {}})
-            files = rom_entry.setdefault("files", {})
-            file_state = files.setdefault(filename, {})
-            file_state["tracked_save_id"] = server.get("id")
-            file_state["last_sync_hash"] = local_hash
-            file_state["last_sync_at"] = self._clock.now().isoformat()
-            file_state["last_sync_server_updated_at"] = server.get("updated_at", "")
-            file_state["last_sync_server_size"] = server.get("file_size_bytes")
-            file_state["last_sync_local_mtime"] = self._save_file.get_mtime(local_path)
-            file_state["last_sync_local_size"] = self._save_file.get_size(local_path)
+            rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+            file_state = rom_state.files.setdefault(filename, FileSyncState())
+            file_state.tracked_save_id = server.get("id")
+            file_state.last_sync_hash = local_hash
+            file_state.last_sync_at = self._clock.now().isoformat()
+            file_state.last_sync_server_updated_at = server.get("updated_at", "") or ""
+            file_state.last_sync_server_size = server.get("file_size_bytes")
+            file_state.last_sync_local_mtime = self._save_file.get_mtime(local_path)
+            file_state.last_sync_local_size = self._save_file.get_size(local_path)
             self.save_state()
             return
 
@@ -985,16 +979,8 @@ class SaveService:
         return await self._versions.rollback_to_version(rom_id, slot, save_id)
 
     def get_save_sync_settings(self) -> dict:
-        """Return current save sync settings."""
-        settings = self._save_sync_state.get("settings", {})
-        # Defensive defaults for keys added after initial release
-        settings.setdefault("default_slot", "default")
-        settings.setdefault("autocleanup_limit", 10)
-        if not self._save_sync_state.get("settings"):
-            settings.setdefault("save_sync_enabled", False)
-            settings.setdefault("sync_before_launch", True)
-            settings.setdefault("sync_after_exit", True)
-        return settings
+        """Return current save sync settings as the on-disk dict shape."""
+        return self._save_sync_state.settings.to_dict()
 
     @staticmethod
     def _sanitize_setting(key: str, value: object) -> tuple[object, bool]:
@@ -1024,7 +1010,7 @@ class SaveService:
             "autocleanup_limit",
         }
 
-        current = self._save_sync_state.setdefault("settings", {})
+        current = self._save_sync_state.settings
 
         for key, value in settings.items():
             if key not in allowed_keys:
@@ -1032,10 +1018,10 @@ class SaveService:
             value, skip = self._sanitize_setting(key, value)
             if skip:
                 continue
-            current[key] = value
+            setattr(current, key, value)
 
         self.save_state()
-        return {"success": True, "settings": current}
+        return {"success": True, "settings": current.to_dict()}
 
     def _delete_saves_for_roms(self, rom_ids: list[int]) -> tuple[int, list[str]]:
         """Delete local save files for the given ROM IDs and clear file tracking state.

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING
 
 from domain.emulator_tag import build_emulator_tag
+from domain.save_state import RomSaveState
 from services.saves._helpers import _local_save_target
 from services.saves._messages import SAVE_SYNC_DISABLED
 
@@ -61,12 +62,17 @@ class SlotsService:
 
         rom_id_str = str(rom_id)
         device_id = self._save_service._get_server_device_id()
-        rom_state = self._state_svc.data.get("saves", {}).get(rom_id_str, {})
-        active_slot = rom_state.get(
-            "active_slot",
-            self._state_svc.data.get("settings", {}).get("default_slot", "default"),
-        )
-        persisted_slots: dict[str, dict] = rom_state.get("slots", {})
+        rom_state = self._state_svc.state.saves.get(rom_id_str)
+        default_slot = self._state_svc.state.settings.default_slot or "default"
+        # ROM not tracked → fall back to the global default slot. ROM
+        # tracked with ``active_slot=None`` → preserve legacy mode (None
+        # means "no slots"; the persisted slots dict will contain ``""``).
+        if rom_state is None:
+            active_slot: str | None = default_slot
+            persisted_slots: dict[str, dict] = {}
+        else:
+            active_slot = rom_state.active_slot
+            persisted_slots = rom_state.slots
 
         # Fetch server slots
         server_slots_list: list[dict] = []
@@ -95,8 +101,8 @@ class SlotsService:
         self._merge_persisted_slots(persisted_slots, merged, active_slot)
 
         # Persist merged slots in state
-        game_entry = self._state_svc.data.setdefault("saves", {}).setdefault(rom_id_str, {})
-        game_entry["slots"] = merged
+        game_entry = self._state_svc.ensure_rom_state(rom_id_str)
+        game_entry.slots = merged
         self._state_svc.save_state()
 
         # Build response list
@@ -185,17 +191,13 @@ class SlotsService:
         resolved_slot: str | None = slot_str if slot_str else None
 
         rom_id_str = str(rom_id)
-        saves = self._state_svc.data.setdefault("saves", {})
-        if rom_id_str not in saves:
-            saves[rom_id_str] = {"files": {}, "active_slot": resolved_slot}
-        else:
-            saves[rom_id_str]["active_slot"] = resolved_slot
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        rom_state.active_slot = resolved_slot
 
         # Ensure slot is in the persisted slots dict (use "" as key for legacy/None)
         slot_key = resolved_slot if resolved_slot is not None else ""
-        slots_dict: dict[str, dict] = saves[rom_id_str].setdefault("slots", {})
-        if slot_key not in slots_dict:
-            slots_dict[slot_key] = {"source": "local", "count": 0, "latest_updated_at": None}
+        if slot_key not in rom_state.slots:
+            rom_state.slots[slot_key] = {"source": "local", "count": 0, "latest_updated_at": None}
 
         self._state_svc.save_state()
         self._save_service._loop.create_task(self._save_service.check_save_status_background(rom_id))
@@ -216,15 +218,15 @@ class SlotsService:
         ``{"ready": False, "reason": str, "files": list[str]}``.
         """
         rom_id_str = str(rom_id)
-        save_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        files_state = save_state.get("files", {})
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        files_state = save_state.files if save_state else {}
 
         pending: list[str] = []
         local_files = self._save_service._find_save_files(rom_id)
         for lf in local_files:
             filename = lf["filename"]
-            file_state = files_state.get(filename, {})
-            last_sync_hash = file_state.get("last_sync_hash")
+            file_state = files_state.get(filename)
+            last_sync_hash = file_state.last_sync_hash if file_state else None
             if last_sync_hash:
                 current_hash = self._save_service._file_md5(lf["path"])
                 if current_hash != last_sync_hash:
@@ -323,8 +325,8 @@ class SlotsService:
             )
 
         # 8. Update last_sync_check_at
-        save_entry = self._state_svc.data["saves"].setdefault(rom_id_str, {})
-        save_entry["last_sync_check_at"] = self._clock.now().isoformat()
+        save_entry = self._state_svc.ensure_rom_state(rom_id_str)
+        save_entry.last_sync_check_at = self._clock.now().isoformat()
         self._state_svc.save_state()
 
         # 9. Return fresh status
@@ -378,9 +380,9 @@ class SlotsService:
         Returns {"configured": bool, "active_slot": str|None}
         """
         rom_id_str = str(int(rom_id))
-        game_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        configured = game_state.get("slot_confirmed", False)
-        active_slot = game_state.get("active_slot") if configured else None
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        configured = bool(game_state.slot_confirmed) if game_state else False
+        active_slot = game_state.active_slot if (game_state and configured) else None
         return {"configured": configured, "active_slot": active_slot}
 
     async def get_save_setup_info(self, rom_id: int) -> dict:
@@ -444,10 +446,10 @@ class SlotsService:
             )
 
         # State info
-        game_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        default_slot = self._state_svc.data.get("settings", {}).get("default_slot", "default")
-        slot_confirmed = game_state.get("slot_confirmed", False)
-        active_slot = game_state.get("active_slot") if slot_confirmed else None
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        default_slot = self._state_svc.state.settings.default_slot or "default"
+        slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
+        active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
 
         return {
             "has_local_saves": len(local_files) > 0,
@@ -479,11 +481,9 @@ class SlotsService:
             return {"success": False, "needs_conflict_resolution": False, "message": "Slot name cannot be empty"}
 
         # Update state
-        saves = self._state_svc.data.setdefault("saves", {})
-        if rom_id_str not in saves:
-            saves[rom_id_str] = {"files": {}}
-        saves[rom_id_str]["active_slot"] = chosen_slot
-        saves[rom_id_str]["slot_confirmed"] = True
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        rom_state.active_slot = chosen_slot
+        rom_state.slot_confirmed = True
 
         # Migration: re-upload local files to new slot, delete old server saves
         if migrate_from_slot is not _NO_MIGRATION:
@@ -576,10 +576,10 @@ class SlotsService:
     # Slot deletion
     # ------------------------------------------------------------------
 
-    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[str, dict, dict[str, dict]]:
+    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[str, RomSaveState, dict[str, dict]]:
         """Shared validation for slot delete operations.
 
-        Returns an error dict on failure, or a (rom_id_str, save_state, slots_dict)
+        Returns an error dict on failure, or a (rom_id_str, rom_state, slots_dict)
         tuple on success.
         """
         if not self._save_service._is_save_sync_enabled():
@@ -587,8 +587,10 @@ class SlotsService:
         if not self._save_service._get_rom_save_info(rom_id):
             return {"success": False, "reason": "not_installed"}
         rom_id_str = str(rom_id)
-        save_state = self._state_svc.data.get("saves", {}).get(rom_id_str, {})
-        slots_dict: dict[str, dict] = save_state.get("slots", {})
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        if save_state is None:
+            return {"success": False, "reason": "not_found"}
+        slots_dict: dict[str, dict] = save_state.slots
         if slot not in slots_dict:
             return {"success": False, "reason": "not_found"}
         return rom_id_str, save_state, slots_dict
@@ -605,7 +607,7 @@ class SlotsService:
 
         slot_info = slots_dict[slot]
         source = slot_info.get("source", "server")
-        active_slot = save_state.get("active_slot")
+        active_slot = save_state.active_slot
         is_active = slot == (active_slot or "")
 
         # Server save count
@@ -624,12 +626,12 @@ class SlotsService:
                 self._save_service._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
 
         # Local tracked files pointing to server saves in this slot
-        files_state = save_state.get("files", {})
+        files_state = save_state.files
         local_filenames: list[str] = []
         if server_save_ids:
             id_set = set(server_save_ids)
             for filename, fstate in files_state.items():
-                if fstate.get("tracked_save_id") in id_set:
+                if fstate.tracked_save_id in id_set:
                     local_filenames.append(filename)
 
         return {
@@ -680,7 +682,7 @@ class SlotsService:
             return result
         _rom_id_str, save_state, slots_dict = result
 
-        effective_active = save_state.get("active_slot") or ""
+        effective_active = save_state.active_slot or ""
         if slot == effective_active:
             return {
                 "success": False,
@@ -703,9 +705,9 @@ class SlotsService:
             deleted_ids = result["ids"]
 
         # Clean up tracked file entries pointing to deleted saves
-        files_state = save_state.get("files", {})
+        files_state = save_state.files
         if deleted_ids:
-            to_remove = [fn for fn, fs in files_state.items() if fs.get("tracked_save_id") in deleted_ids]
+            to_remove = [fn for fn, fs in files_state.items() if fs.tracked_save_id in deleted_ids]
             for fn in to_remove:
                 del files_state[fn]
                 cleaned_files += 1

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -1,15 +1,24 @@
-"""In-memory save-sync state and on-disk migration logic.
+"""In-memory save-sync state and on-disk persistence orchestration.
 
-Anything that mutates ``save_sync_state`` in memory or migrates a
-freshly-loaded payload lives here. Raw I/O for ``save_sync_state.json``
-(atomic writes, locking, missing-file handling) belongs to the
-``SaveSyncStatePersister`` injected into ``StateService``; this service
-never opens the file directly.
+Owns the live :class:`SaveSyncState` aggregate. Anything that mutates
+the aggregate at service level (defaults seeding, file-tracking reset,
+orphan pruning) or coordinates persistence with the
+``SaveSyncStatePersister`` lives here. Schema migrations for newly
+loaded payloads live in :class:`SaveSyncState.from_dict` — this service
+never opens the JSON file directly.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
+from domain.save_state import (
+    FileSyncState,
+    PlaytimeEntry,
+    RomSaveState,
+    SaveSyncSettings,
+    SaveSyncState,
+)
 
 if TYPE_CHECKING:
     import logging
@@ -18,12 +27,12 @@ if TYPE_CHECKING:
 
 
 class StateService:
-    """Owns the in-memory save-sync state dict and its on-load migrations."""
+    """Owns the live ``SaveSyncState`` aggregate and its persistence."""
 
     def __init__(
         self,
         *,
-        save_sync_state: dict,
+        save_sync_state: SaveSyncState,
         state: dict,
         persister: SaveSyncStatePersister,
         logger: logging.Logger,
@@ -34,134 +43,100 @@ class StateService:
         self._logger = logger
 
     @property
-    def data(self) -> dict:
-        """Live reference to the in-memory state dict."""
+    def state(self) -> SaveSyncState:
+        """Live reference to the typed save-sync aggregate."""
         return self._save_sync_state
 
     @staticmethod
-    def make_default_state() -> dict:
-        """Return a fresh default save-sync state dict."""
-        return {
-            "version": 1,
-            "device_id": None,
-            "device_name": None,
-            "server_device_id": None,
-            "saves": {},
-            "playtime": {},
-            "settings": {
-                "save_sync_enabled": False,
-                "sync_before_launch": True,
-                "sync_after_exit": True,
-                "default_slot": "default",
-                "autocleanup_limit": 10,
-            },
-        }
+    def make_default_state() -> SaveSyncState:
+        """Return a fresh default save-sync state aggregate."""
+        return SaveSyncState()
 
     def init_state(self) -> None:
-        """Populate ``_save_sync_state`` with defaults (idempotent).
+        """No-op: the aggregate ships with defaults at construction.
 
-        Defaults only — schema migrations on loaded data live in
-        ``load_state``. Running them here would be a no-op because
-        ``init_state`` is called before any disk data is loaded.
+        Kept for backward compatibility with callers that historically
+        seeded a dict with default keys after construction. Schema
+        migrations on loaded data live in :meth:`load_state`.
         """
-        defaults = self.make_default_state()
-        for key, value in defaults.items():
-            self._save_sync_state.setdefault(key, value)
-        self._save_sync_state.setdefault("settings", {})
-        for key, value in defaults["settings"].items():
-            self._save_sync_state["settings"].setdefault(key, value)
-
-    def _migrate_loaded_state(self) -> None:
-        """Apply schema migrations to data just read from disk.
-
-        Migrations are idempotent. Called from ``load_state`` after the
-        disk content has been merged into ``_save_sync_state``; the next
-        ``save_state`` then persists the cleaned form.
-
-        Currently:
-        - Rename per-game ``active_core`` → ``last_synced_core``.
-        - Drop legacy per-file ``dismissed_newer_save_id`` (was used by
-          the removed newer-in-slot detection).
-        - Strip removed legacy settings keys (``conflict_mode``,
-          ``clock_skew_tolerance_sec``).
-        """
-        self._migrate_saves_entries()
-        self._strip_legacy_settings()
-
-    def _migrate_saves_entries(self) -> None:
-        """Rename ``active_core`` → ``last_synced_core`` and drop dead per-file flags."""
-        saves = self._save_sync_state.get("saves")
-        if not isinstance(saves, dict):
-            return
-        for entry in saves.values():
-            if not isinstance(entry, dict):
-                continue
-            if "active_core" in entry:
-                entry["last_synced_core"] = entry.pop("active_core")
-            files = entry.get("files")
-            if not isinstance(files, dict):
-                continue
-            for file_state in files.values():
-                if isinstance(file_state, dict):
-                    file_state.pop("dismissed_newer_save_id", None)
-
-    def _strip_legacy_settings(self) -> None:
-        """Strip removed settings keys from loaded state.
-
-        Old state files keep these forever otherwise (``load_state`` does
-        ``dict.update`` on settings, so orphan keys survive). Idempotent.
-        """
-        settings = self._save_sync_state.get("settings")
-        if isinstance(settings, dict):
-            settings.pop("conflict_mode", None)
-            settings.pop("clock_skew_tolerance_sec", None)
 
     def load_state(self) -> None:
-        """Load save sync state from disk, merging with defaults."""
+        """Load save-sync state from disk via the persister.
+
+        Mutates the live aggregate in place so callers holding a
+        reference (other services, sub-services, ``main.py``) keep
+        observing the latest state without rewiring.
+        """
         saved = self._persister.load()
         if saved is None:
             return
-        for key in ("saves", "playtime"):
-            if key in saved:
-                self._save_sync_state[key] = saved[key]
-        for key in ("version", "device_id", "device_name", "server_device_id"):
-            if key in saved:
-                self._save_sync_state[key] = saved[key]
-        if "settings" in saved:
-            self._save_sync_state["settings"].update(saved["settings"])
-        self._migrate_loaded_state()
+        loaded = SaveSyncState.from_dict(saved)
+        self._save_sync_state.replace_with(loaded)
 
     def save_state(self) -> None:
-        """Persist save sync state to disk via the injected persister."""
-        self._persister.save(self._save_sync_state)
+        """Persist the live aggregate to disk via the injected persister."""
+        self._persister.save(self._save_sync_state.to_dict())
+
+    # ------------------------------------------------------------------
+    # Typed accessors for the per-ROM substructure
+    # ------------------------------------------------------------------
+
+    def get_rom_state(self, rom_id_str: str) -> RomSaveState | None:
+        """Return the typed per-ROM state, or ``None`` if not tracked."""
+        return self._save_sync_state.saves.get(rom_id_str)
+
+    def ensure_rom_state(self, rom_id_str: str) -> RomSaveState:
+        """Return the per-ROM state, creating an empty one if missing."""
+        return self._save_sync_state.saves.setdefault(rom_id_str, RomSaveState())
+
+    def get_file_state(self, rom_id_str: str, filename: str) -> FileSyncState | None:
+        """Return the typed per-file tracking entry, or ``None`` if not tracked."""
+        rom = self._save_sync_state.saves.get(rom_id_str)
+        if rom is None:
+            return None
+        return rom.files.get(filename)
+
+    def get_settings(self) -> SaveSyncSettings:
+        """Return the live settings dataclass."""
+        return self._save_sync_state.settings
+
+    def get_playtime(self, rom_id_str: str) -> PlaytimeEntry | None:
+        """Return the typed playtime entry, or ``None`` if not tracked."""
+        return self._save_sync_state.playtime.get(rom_id_str)
+
+    # ------------------------------------------------------------------
+    # File tracking mutations
+    # ------------------------------------------------------------------
 
     def clear_files_state(self, rom_id_str: str) -> None:
         """Clear the per-file tracking dict for a ROM, preserving slot config.
 
-        Resets ``data["saves"][rom_id_str]["files"]`` to an empty dict while
-        leaving ``active_slot``, ``slot_confirmed``, ``emulator``,
-        ``last_synced_core``, ``own_upload_ids``, ``slots``, ``system``, and any
-        other slot/attribution metadata untouched. Creates the ROM entry as an
-        empty dict (with only ``files``) when none exists. Caller is
-        responsible for persisting via ``save_state()``.
+        Resets the ROM's ``files`` dict to empty while leaving slot
+        attribution and the rest of the entry untouched. Creates the
+        ROM entry when none exists. Caller is responsible for persisting
+        via :meth:`save_state`.
         """
-        saves = self._save_sync_state.setdefault("saves", {})
-        entry = saves.setdefault(rom_id_str, {})
-        entry["files"] = {}
+        rom = self.ensure_rom_state(rom_id_str)
+        rom.files = {}
 
     def prune_orphaned_state(self) -> None:
-        """Remove save sync state entries for rom_ids no longer in shortcut registry."""
+        """Remove save-sync state entries for rom_ids no longer in the shortcut registry."""
         registry = self._state.get("shortcut_registry", {})
         changed = False
 
-        for section in ("saves", "playtime"):
-            data = self._save_sync_state.get(section, {})
-            stale = [rid for rid in data if rid not in registry]
-            for rid in stale:
-                del data[rid]
-                self._logger.info(f"Pruned orphaned save sync state: {section}[{rid}]")
-            if stale:
-                changed = True
+        saves_stale = [rid for rid in self._save_sync_state.saves if rid not in registry]
+        for rid in saves_stale:
+            del self._save_sync_state.saves[rid]
+            self._logger.info(f"Pruned orphaned save sync state: saves[{rid}]")
+        if saves_stale:
+            changed = True
+
+        playtime_stale = [rid for rid in self._save_sync_state.playtime if rid not in registry]
+        for rid in playtime_stale:
+            del self._save_sync_state.playtime[rid]
+            self._logger.info(f"Pruned orphaned save sync state: playtime[{rid}]")
+        if playtime_stale:
+            changed = True
 
         if changed:
             self.save_state()

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -63,7 +63,7 @@ class StatusService:
             local_mtime=outcome.local_mtime_iso,
             local_size=outcome.local_size,
             server=chosen_server,
-            last_sync_at=outcome.file_state.get("last_sync_at"),
+            last_sync_at=outcome.file_state.last_sync_at or None,
             status=_status_from_action(action),
             server_device_id=server_device_id,
             uploaded_by_us=compute_uploaded_by_us(chosen_server, own_upload_ids),
@@ -135,13 +135,11 @@ class StatusService:
         info = self._save_service._get_rom_save_info(rom_id)
         server_device_id = self._save_service._get_server_device_id()
 
-        save_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        active_slot = save_state.get("active_slot")
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        active_slot = save_state.active_slot if save_state else None
         server_in_slot = self._sync_engine._filter_server_saves_to_slot(server_saves, active_slot)
 
-        # own_upload_ids: None means missing key (legacy entry — unknown attribution).
-        raw_own_ids = save_state.get("own_upload_ids")
-        own_upload_ids: list[int] | None = raw_own_ids if isinstance(raw_own_ids, list) else None
+        own_upload_ids: list[int] | None = save_state.own_upload_ids if save_state else None
 
         file_statuses: list[dict] = []
         conflicts: list[SaveConflict | dict] = []
@@ -164,15 +162,16 @@ class StatusService:
                 if conflict_entry is not None:
                     conflicts.append(conflict_entry)
 
-        playtime = self._state_svc.data.get("playtime", {}).get(rom_id_str, {})
-        save_entry = self._state_svc.data.get("saves", {}).get(rom_id_str, {})
+        playtime_entry = self._state_svc.state.playtime.get(rom_id_str)
+        playtime = playtime_entry.to_dict() if playtime_entry is not None else {}
+        save_entry = self._state_svc.state.saves.get(rom_id_str)
 
         return {
             "rom_id": rom_id,
             "files": file_statuses,
             "playtime": playtime,
-            "device_id": self._state_svc.data.get("device_id", ""),
-            "last_sync_check_at": save_entry.get("last_sync_check_at"),
+            "device_id": self._state_svc.state.device_id or "",
+            "last_sync_check_at": save_entry.last_sync_check_at if save_entry else None,
             "conflicts": conflicts,
             "save_sort_changed": self._save_service._is_save_sort_changed(),
         }

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from models.saves import SaveConflict
 
 from domain.emulator_tag import build_emulator_tag
+from domain.save_state import FileSyncState, RomSaveState
 from domain.sync_action import (
     Conflict,
     Download,
@@ -45,7 +46,7 @@ class MatrixOutcome:
     local_hash: str | None
     local_mtime_iso: str | None
     local_size: int | None
-    file_state: dict
+    file_state: FileSyncState
     server_candidates: list[dict]
 
 
@@ -112,36 +113,35 @@ class SyncEngine:
         core_so: str | None = None,
     ) -> None:
         """Update per-file sync tracking after a successful sync operation."""
-        if rom_id_str not in self._state_svc.data["saves"]:
-            self._state_svc.data["saves"][rom_id_str] = {
-                "files": {},
-                "emulator": emulator_tag or "retroarch",
-                "system": system,
-                "last_synced_core": core_so,
-                "active_slot": self._state_svc.data.get("settings", {}).get("default_slot", "default"),
-                "own_upload_ids": [],
-            }
-        save_entry = self._state_svc.data["saves"][rom_id_str]
-        save_entry.setdefault("files", {})
+        saves = self._state_svc.state.saves
+        if rom_id_str not in saves:
+            settings_default_slot = self._state_svc.state.settings.default_slot or "default"
+            saves[rom_id_str] = RomSaveState(
+                emulator=emulator_tag or "retroarch",
+                system=system,
+                last_synced_core=core_so,
+                active_slot=settings_default_slot,
+            )
+        save_entry = saves[rom_id_str]
         if emulator_tag is not None:
-            save_entry["emulator"] = emulator_tag
+            save_entry.emulator = emulator_tag
         if core_so is not None:
-            save_entry["last_synced_core"] = core_so
+            save_entry.last_synced_core = core_so
 
         now = self._clock.now().isoformat()
         local_exists = self._save_file.is_file(local_path)
         local_hash = self._save_service._file_md5(local_path) if local_exists else ""
 
-        save_entry["files"][filename] = {
-            "last_sync_hash": local_hash,
-            "last_sync_at": now,
-            "last_sync_server_updated_at": server_response.get("updated_at", now),
-            "last_sync_server_save_id": server_response.get("id"),
-            "last_sync_server_size": server_response.get("file_size_bytes"),
-            "last_sync_local_mtime": self._save_file.get_mtime(local_path) if local_exists else None,
-            "last_sync_local_size": self._save_file.get_size(local_path) if local_exists else None,
-            "tracked_save_id": server_response.get("id"),
-        }
+        save_entry.files[filename] = FileSyncState(
+            last_sync_hash=local_hash,
+            last_sync_at=now,
+            last_sync_server_updated_at=server_response.get("updated_at", now) or now,
+            last_sync_server_save_id=server_response.get("id"),
+            last_sync_server_size=server_response.get("file_size_bytes"),
+            last_sync_local_mtime=self._save_file.get_mtime(local_path) if local_exists else None,
+            last_sync_local_size=self._save_file.get_size(local_path) if local_exists else None,
+            tracked_save_id=server_response.get("id"),
+        )
 
     # ------------------------------------------------------------------
     # Sync Helpers
@@ -195,8 +195,11 @@ class SyncEngine:
 
         # v4.7: pass device_id and slot
         device_id = self._save_service._get_server_device_id()
-        game_state = self._state_svc.data.get("saves", {}).get(rom_id_str, {})
-        slot = game_state.get("active_slot", "default") if device_id else None
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        if device_id:
+            slot = game_state.active_slot if game_state and game_state.active_slot is not None else "default"
+        else:
+            slot = None
 
         is_post = save_id is None
         result = self._retry.with_retry(
@@ -214,7 +217,8 @@ class SyncEngine:
 
         # Promote local slot to server after successful upload
         if slot:
-            slots_dict = self._state_svc.data.get("saves", {}).get(rom_id_str, {}).get("slots", {})
+            rom_state = self._state_svc.state.saves.get(rom_id_str)
+            slots_dict = rom_state.slots if rom_state else {}
             if slot in slots_dict and slots_dict[slot].get("source") == "local":
                 slots_dict[slot]["source"] = "server"
                 slots_dict[slot]["count"] = 1
@@ -241,12 +245,12 @@ class SyncEngine:
         """
         if new_id is None:
             return
-        rom_state = self._state_svc.data["saves"].setdefault(rom_id_str, {"own_upload_ids": []})
-        own_ids: list[int] = rom_state.get("own_upload_ids", [])
-        if new_id in own_ids:
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        if rom_state.own_upload_ids is None:
+            rom_state.own_upload_ids = []
+        if new_id in rom_state.own_upload_ids:
             return
-        own_ids.append(new_id)
-        rom_state["own_upload_ids"] = own_ids
+        rom_state.own_upload_ids.append(new_id)
         self._state_svc.save_state()
 
     def _handle_unexpected_error(
@@ -428,11 +432,9 @@ class SyncEngine:
         baseline yet. Recording the baseline lets subsequent runs detect
         offline-edit drift. State mutation only, no I/O.
         """
-        saves = self._state_svc.data.setdefault("saves", {})
-        rom_entry = saves.setdefault(rom_id_str, {"files": {}})
-        files = rom_entry.setdefault("files", {})
-        file_state = files.setdefault(filename, {})
-        file_state["last_sync_hash"] = local_hash
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        file_state = rom_state.files.setdefault(filename, FileSyncState())
+        file_state.last_sync_hash = local_hash
 
     def iter_matrix_outcomes(
         self,
@@ -452,8 +454,8 @@ class SyncEngine:
         rom_id_str = str(int(rom_id))
         rom_name = info["rom_name"]
 
-        save_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        files_state = save_state.get("files", {})
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        files_state: dict[str, FileSyncState] = save_state.files if save_state else {}
         device_id = self._save_service._get_server_device_id() or ""
 
         local_files = self._save_service._find_save_files(rom_id)
@@ -465,7 +467,7 @@ class SyncEngine:
             handled_filenames.add(filename)
             local_exists = self._save_file.is_file(local_path)
             local_hash = self._save_service._file_md5(local_path) if local_exists else None
-            file_state = files_state.get(filename, {})
+            file_state = files_state.get(filename, FileSyncState())
             local_mtime_iso = (
                 datetime.fromtimestamp(self._save_file.get_mtime(local_path), tz=UTC).isoformat()
                 if local_exists
@@ -475,7 +477,7 @@ class SyncEngine:
             action = compute_sync_action(
                 local_file=self._build_local_input(local_path, filename),
                 server_saves_in_slot=server_in_slot,
-                files_state=file_state,
+                files_state=file_state.to_dict(),
                 device_id=device_id,
                 local_hash=local_hash,
             )
@@ -501,11 +503,11 @@ class SyncEngine:
             server_only_groups.setdefault(target, []).append(ss)
 
         for target_filename, group in server_only_groups.items():
-            file_state = files_state.get(target_filename, {})
+            file_state = files_state.get(target_filename, FileSyncState())
             action = compute_sync_action(
                 local_file=None,
                 server_saves_in_slot=group,
-                files_state=file_state,
+                files_state=file_state.to_dict(),
                 device_id=device_id,
                 local_hash=None,
             )
@@ -548,8 +550,8 @@ class SyncEngine:
             return 0, [f"Failed to fetch saves: {_msg}"], []
         self._save_service._log_debug(f"[TIMING] _sync_rom_saves({rom_id}): list_saves {self._clock.time() - t0:.3f}s")
 
-        save_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        active_slot = save_state.get("active_slot")
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        active_slot = save_state.active_slot if save_state else None
         server_in_slot = self._filter_server_saves_to_slot(server_saves, active_slot)
 
         self._save_service._log_debug(
@@ -588,8 +590,8 @@ class SyncEngine:
                 synced += 1
 
         # Record when this sync check ran (regardless of whether files transferred)
-        save_entry = self._state_svc.data["saves"].setdefault(rom_id_str, {})
-        save_entry["last_sync_check_at"] = self._clock.now().isoformat()
+        save_entry = self._state_svc.ensure_rom_state(rom_id_str)
+        save_entry.last_sync_check_at = self._clock.now().isoformat()
 
         self._save_service._log_debug(
             f"[TIMING] _sync_rom_saves({rom_id}): TOTAL {self._clock.time() - t_total:.3f}s"

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -175,6 +175,36 @@ class SyncEngine:
         self._update_file_sync_state(rom_id_str, filename, server_save, local_path, system)
         self._save_service._log_debug(f"Downloaded save: {filename} for rom {rom_id_str}")
 
+    def _resolve_upload_slot(self, rom_id_str: str, device_id: str | None) -> str | None:
+        """The slot field to send with an upload; ``None`` when device sync is off."""
+        if not device_id:
+            return None
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        if game_state and game_state.active_slot is not None:
+            return game_state.active_slot
+        return "default"
+
+    def _promote_local_slot_to_server(self, rom_id_str: str, slot: str) -> None:
+        """Mark *slot* as having a server copy after a successful upload of a local-only slot."""
+        rom_state = self._state_svc.state.saves.get(rom_id_str)
+        if not rom_state:
+            return
+        slot_entry = rom_state.slots.get(slot)
+        if slot_entry and slot_entry.get("source") == "local":
+            slot_entry["source"] = "server"
+            slot_entry["count"] = 1
+
+    def _confirm_upload_sync(self, upload_id: int | None, device_id: str | None) -> None:
+        """Ack the uploaded save on the server's DeviceSaveSync row (non-fatal)."""
+        # RomM's upload endpoint updates updated_at but NOT last_synced_at,
+        # so is_current would be False on the next list_saves without this.
+        if not device_id or not upload_id:
+            return
+        try:
+            self._romm_api.confirm_download(upload_id, device_id)
+        except Exception:
+            self._save_service._log_debug(f"confirm_download after upload failed for save {upload_id} (non-fatal)")
+
     def _do_upload_save(
         self,
         rom_id: int,
@@ -195,11 +225,7 @@ class SyncEngine:
 
         # v4.7: pass device_id and slot
         device_id = self._save_service._get_server_device_id()
-        game_state = self._state_svc.state.saves.get(rom_id_str)
-        if device_id:
-            slot = game_state.active_slot if game_state and game_state.active_slot is not None else "default"
-        else:
-            slot = None
+        slot = self._resolve_upload_slot(rom_id_str, device_id)
 
         is_post = save_id is None
         result = self._retry.with_retry(
@@ -215,23 +241,10 @@ class SyncEngine:
         if is_post:
             self._record_own_upload(rom_id_str, result.get("id"))
 
-        # Promote local slot to server after successful upload
         if slot:
-            rom_state = self._state_svc.state.saves.get(rom_id_str)
-            slots_dict = rom_state.slots if rom_state else {}
-            if slot in slots_dict and slots_dict[slot].get("source") == "local":
-                slots_dict[slot]["source"] = "server"
-                slots_dict[slot]["count"] = 1
+            self._promote_local_slot_to_server(rom_id_str, slot)
 
-        # Mark device as synced with the uploaded save version.
-        # RomM's upload endpoint updates updated_at but NOT last_synced_at in
-        # DeviceSaveSync, so is_current would be False on the next list_saves.
-        upload_id = result.get("id")
-        if device_id and upload_id:
-            try:
-                self._romm_api.confirm_download(upload_id, device_id)
-            except Exception:
-                self._save_service._log_debug(f"confirm_download after upload failed for save {upload_id} (non-fatal)")
+        self._confirm_upload_sync(result.get("id"), device_id)
 
         self._save_service._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
         return result

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -19,6 +19,7 @@ from services.saves._helpers import _local_save_target
 if TYPE_CHECKING:
     import logging
 
+    from domain.save_state import FileSyncState
     from services.protocols import RommApiProtocol
     from services.saves import SaveService
     from services.saves.state import StateService
@@ -51,7 +52,7 @@ class VersionsService:
     # Version History API
     # ------------------------------------------------------------------
 
-    def _find_file_state(self, rom_id_str: str, filename: str, server_saves: list[dict]) -> dict:  # noqa: ARG002 — server_saves kept for callable signature stability
+    def _find_file_state(self, rom_id_str: str, filename: str, server_saves: list[dict]) -> FileSyncState | None:  # noqa: ARG002 — server_saves kept for callable signature stability
         """Look up the per-file sync state for *filename* (canonical local name).
 
         State keys are always ``<rom_name>.<ext>`` — the same canonical
@@ -59,8 +60,7 @@ class VersionsService:
         RetroArch — so a single dict lookup is enough. The previous
         ``file_name_no_tags``-anchored slow path is gone.
         """
-        files_state = self._state_svc.data.get("saves", {}).get(rom_id_str, {}).get("files", {})
-        return files_state.get(filename, {})
+        return self._state_svc.get_file_state(rom_id_str, filename)
 
     async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> list[dict]:
         """List server-side saves in the active slot, excluding the currently-tracked one.
@@ -93,11 +93,10 @@ class VersionsService:
             return []
 
         file_state = self._find_file_state(rom_id_str, filename, server_saves)
-        tracked_id = file_state.get("tracked_save_id")
+        tracked_id = file_state.tracked_save_id if file_state else None
 
-        rom_state = self._state_svc.data["saves"].get(rom_id_str, {})
-        raw = rom_state.get("own_upload_ids")
-        own_upload_ids: list[int] | None = raw if isinstance(raw, list) else None
+        rom_state = self._state_svc.state.saves.get(rom_id_str)
+        own_upload_ids: list[int] | None = rom_state.own_upload_ids if rom_state else None
 
         versions = [
             {

--- a/tests/domain/test_save_state.py
+++ b/tests/domain/test_save_state.py
@@ -1,0 +1,409 @@
+"""Tests for the typed save-sync state aggregate (``domain.save_state``)."""
+
+from __future__ import annotations
+
+from domain.save_state import (
+    FileSyncState,
+    PlaytimeEntry,
+    RomSaveState,
+    SaveSyncSettings,
+    SaveSyncState,
+)
+
+# ---------------------------------------------------------------------------
+# FileSyncState
+# ---------------------------------------------------------------------------
+
+
+class TestFileSyncState:
+    def test_defaults(self) -> None:
+        fs = FileSyncState()
+        assert fs.tracked_save_id is None
+        assert fs.last_sync_hash is None
+        assert fs.last_sync_at == ""
+        assert fs.last_sync_server_updated_at == ""
+        assert fs.last_sync_server_save_id is None
+        assert fs.last_sync_server_size is None
+        assert fs.last_sync_local_mtime is None
+        assert fs.last_sync_local_size is None
+
+    def test_from_dict_round_trip(self) -> None:
+        payload = {
+            "tracked_save_id": 7,
+            "last_sync_hash": "abc",
+            "last_sync_at": "2026-05-01T00:00:00",
+            "last_sync_server_updated_at": "2026-05-01T00:00:01",
+            "last_sync_server_save_id": 7,
+            "last_sync_server_size": 1024,
+            "last_sync_local_mtime": 12345.6,
+            "last_sync_local_size": 1024,
+        }
+        fs = FileSyncState.from_dict(payload)
+        assert fs.to_dict() == payload
+
+    def test_from_dict_drops_legacy_dismissed_newer_save_id(self) -> None:
+        payload = {
+            "tracked_save_id": 1,
+            "dismissed_newer_save_id": 99,
+        }
+        fs = FileSyncState.from_dict(payload)
+        out = fs.to_dict()
+        assert "dismissed_newer_save_id" not in out
+        assert out["tracked_save_id"] == 1
+
+    def test_from_dict_handles_non_dict_input(self) -> None:
+        fs = FileSyncState.from_dict("garbage")  # type: ignore[arg-type]
+        assert fs == FileSyncState()
+
+    def test_mutation(self) -> None:
+        fs = FileSyncState()
+        fs.tracked_save_id = 42
+        fs.last_sync_hash = "deadbeef"
+        assert fs.tracked_save_id == 42
+        assert fs.last_sync_hash == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# RomSaveState
+# ---------------------------------------------------------------------------
+
+
+class TestRomSaveState:
+    def test_defaults(self) -> None:
+        rs = RomSaveState()
+        assert rs.active_slot is None
+        assert rs.slot_confirmed is False
+        assert rs.emulator == "retroarch"
+        assert rs.system == ""
+        assert rs.last_synced_core is None
+        # None distinguishes "uploader attribution unknown" (legacy / fresh)
+        # from "we uploaded nothing" (explicitly empty list).
+        assert rs.own_upload_ids is None
+        assert rs.slots == {}
+        assert rs.files == {}
+        assert rs.last_sync_check_at is None
+        assert rs.extra == {}
+
+    def test_from_dict_round_trip(self) -> None:
+        payload = {
+            "active_slot": "default",
+            "slot_confirmed": True,
+            "emulator": "retroarch",
+            "system": "gba",
+            "last_synced_core": "mgba_libretro",
+            "own_upload_ids": [1, 2, 3],
+            "slots": {"default": {"source": "server", "count": 2}},
+            "files": {
+                "pokemon.srm": {
+                    "tracked_save_id": 5,
+                    "last_sync_hash": "h",
+                    "last_sync_at": "t",
+                    "last_sync_server_updated_at": "u",
+                    "last_sync_server_save_id": 5,
+                    "last_sync_server_size": 1024,
+                    "last_sync_local_mtime": 100.0,
+                    "last_sync_local_size": 1024,
+                },
+            },
+        }
+        rs = RomSaveState.from_dict(payload)
+        out = rs.to_dict()
+        assert out["files"]["pokemon.srm"]["tracked_save_id"] == 5
+        for key in (
+            "active_slot",
+            "slot_confirmed",
+            "emulator",
+            "system",
+            "last_synced_core",
+            "own_upload_ids",
+            "slots",
+        ):
+            assert out[key] == payload[key]
+
+    def test_from_dict_migrates_active_core_to_last_synced_core(self) -> None:
+        rs = RomSaveState.from_dict({"active_core": "snes9x_libretro"})
+        assert rs.last_synced_core == "snes9x_libretro"
+        out = rs.to_dict()
+        assert "active_core" not in out
+        assert out["last_synced_core"] == "snes9x_libretro"
+
+    def test_last_synced_core_wins_over_active_core(self) -> None:
+        rs = RomSaveState.from_dict(
+            {"last_synced_core": "winner", "active_core": "loser"},
+        )
+        assert rs.last_synced_core == "winner"
+
+    def test_unknown_keys_preserved_in_extra(self) -> None:
+        rs = RomSaveState.from_dict({"future_field": "keep-me"})
+        assert rs.extra == {"future_field": "keep-me"}
+        out = rs.to_dict()
+        assert out["future_field"] == "keep-me"
+
+    def test_last_sync_check_at_round_trip(self) -> None:
+        rs = RomSaveState.from_dict({"last_sync_check_at": "2026-05-14T00:00:00"})
+        assert rs.last_sync_check_at == "2026-05-14T00:00:00"
+        assert rs.to_dict()["last_sync_check_at"] == "2026-05-14T00:00:00"
+
+    def test_last_sync_check_at_omitted_when_none(self) -> None:
+        rs = RomSaveState()
+        assert "last_sync_check_at" not in rs.to_dict()
+
+    def test_malformed_files_defaults_to_empty(self) -> None:
+        rs = RomSaveState.from_dict({"files": "not-a-dict"})
+        assert rs.files == {}
+
+    def test_malformed_slots_defaults_to_empty(self) -> None:
+        rs = RomSaveState.from_dict({"slots": ["not", "a", "dict"]})
+        assert rs.slots == {}
+
+    def test_malformed_own_upload_ids_defaults_to_none(self) -> None:
+        rs = RomSaveState.from_dict({"own_upload_ids": "not-a-list"})
+        assert rs.own_upload_ids is None
+
+    def test_from_dict_drops_legacy_dismissed_newer_save_id_in_files(self) -> None:
+        rs = RomSaveState.from_dict(
+            {"files": {"f.srm": {"tracked_save_id": 1, "dismissed_newer_save_id": 99}}},
+        )
+        assert "dismissed_newer_save_id" not in rs.to_dict()["files"]["f.srm"]
+
+
+# ---------------------------------------------------------------------------
+# PlaytimeEntry
+# ---------------------------------------------------------------------------
+
+
+class TestPlaytimeEntry:
+    def test_defaults(self) -> None:
+        pe = PlaytimeEntry()
+        assert pe.total_seconds == 0
+        assert pe.session_count == 0
+        assert pe.last_session_start is None
+        assert pe.last_session_duration_sec is None
+        assert pe.offline_deltas == []
+        assert pe.note_id is None
+        assert pe.extra == {}
+
+    def test_from_dict_round_trip(self) -> None:
+        payload = {
+            "total_seconds": 3600,
+            "session_count": 3,
+            "last_session_start": "2026-05-14T00:00:00",
+            "last_session_duration_sec": 1200,
+            "offline_deltas": [{"delta": 100}],
+            "note_id": 42,
+        }
+        pe = PlaytimeEntry.from_dict(payload)
+        out = pe.to_dict()
+        assert out == payload
+
+    def test_note_id_omitted_when_none(self) -> None:
+        pe = PlaytimeEntry(total_seconds=10)
+        assert "note_id" not in pe.to_dict()
+
+    def test_unknown_keys_preserved_in_extra(self) -> None:
+        pe = PlaytimeEntry.from_dict({"future": "value"})
+        assert pe.extra == {"future": "value"}
+        assert pe.to_dict()["future"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# SaveSyncSettings
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSyncSettings:
+    def test_defaults(self) -> None:
+        s = SaveSyncSettings()
+        assert s.save_sync_enabled is False
+        assert s.sync_before_launch is True
+        assert s.sync_after_exit is True
+        assert s.default_slot == "default"
+        assert s.autocleanup_limit == 10
+
+    def test_from_dict_round_trip(self) -> None:
+        payload = {
+            "save_sync_enabled": True,
+            "sync_before_launch": False,
+            "sync_after_exit": False,
+            "default_slot": "main",
+            "autocleanup_limit": 5,
+        }
+        s = SaveSyncSettings.from_dict(payload)
+        assert s.to_dict() == payload
+
+    def test_drops_legacy_conflict_mode(self) -> None:
+        s = SaveSyncSettings.from_dict({"conflict_mode": "ask"})
+        out = s.to_dict()
+        assert "conflict_mode" not in out
+
+    def test_drops_legacy_clock_skew(self) -> None:
+        s = SaveSyncSettings.from_dict({"clock_skew_tolerance_sec": 60})
+        out = s.to_dict()
+        assert "clock_skew_tolerance_sec" not in out
+
+    def test_unknown_keys_preserved_in_extra(self) -> None:
+        s = SaveSyncSettings.from_dict({"future_toggle": True})
+        assert s.extra == {"future_toggle": True}
+        assert s.to_dict()["future_toggle"] is True
+
+
+# ---------------------------------------------------------------------------
+# SaveSyncState
+# ---------------------------------------------------------------------------
+
+
+def _default_state_dict() -> dict:
+    return {
+        "version": 1,
+        "device_id": None,
+        "device_name": None,
+        "server_device_id": None,
+        "saves": {},
+        "playtime": {},
+        "settings": {
+            "save_sync_enabled": False,
+            "sync_before_launch": True,
+            "sync_after_exit": True,
+            "default_slot": "default",
+            "autocleanup_limit": 10,
+        },
+    }
+
+
+class TestSaveSyncState:
+    def test_defaults_match_legacy_default_dict(self) -> None:
+        s = SaveSyncState()
+        assert s.to_dict() == _default_state_dict()
+
+    def test_round_trip_default(self) -> None:
+        s = SaveSyncState.from_dict(_default_state_dict())
+        assert s.to_dict() == _default_state_dict()
+
+    def test_round_trip_populated(self) -> None:
+        payload = {
+            "version": 1,
+            "device_id": "abc",
+            "device_name": "deck",
+            "server_device_id": "server-1",
+            "saves": {
+                "42": {
+                    "active_slot": "default",
+                    "slot_confirmed": True,
+                    "emulator": "retroarch",
+                    "system": "gba",
+                    "last_synced_core": "mgba_libretro",
+                    "own_upload_ids": [1, 2],
+                    "slots": {"default": {"source": "server", "count": 1}},
+                    "files": {
+                        "pokemon.srm": {
+                            "tracked_save_id": 1,
+                            "last_sync_hash": "abc",
+                            "last_sync_at": "2026-05-14T00:00:00",
+                            "last_sync_server_updated_at": "2026-05-14T00:00:01",
+                            "last_sync_server_save_id": 1,
+                            "last_sync_server_size": 1024,
+                            "last_sync_local_mtime": 100.0,
+                            "last_sync_local_size": 1024,
+                        },
+                    },
+                    "last_sync_check_at": "2026-05-14T00:00:02",
+                },
+            },
+            "playtime": {
+                "42": {
+                    "total_seconds": 1800,
+                    "session_count": 2,
+                    "last_session_start": None,
+                    "last_session_duration_sec": 900,
+                    "offline_deltas": [],
+                    "note_id": 7,
+                },
+            },
+            "settings": {
+                "save_sync_enabled": True,
+                "sync_before_launch": True,
+                "sync_after_exit": True,
+                "default_slot": "default",
+                "autocleanup_limit": 10,
+            },
+        }
+        s = SaveSyncState.from_dict(payload)
+        assert s.to_dict() == payload
+
+    def test_round_trip_stability_via_from_to_from(self) -> None:
+        # The contract: from_dict(s.to_dict()) == s for any valid s.
+        payload = {
+            "version": 1,
+            "device_id": "d",
+            "device_name": None,
+            "server_device_id": None,
+            "saves": {"7": {"emulator": "retroarch", "system": "snes"}},
+            "playtime": {"7": {"total_seconds": 100}},
+            "settings": {"save_sync_enabled": True},
+        }
+        s = SaveSyncState.from_dict(payload)
+        s2 = SaveSyncState.from_dict(s.to_dict())
+        assert s == s2
+
+    def test_active_core_migration(self) -> None:
+        s = SaveSyncState.from_dict(
+            {"saves": {"1": {"active_core": "core_libretro"}}},
+        )
+        assert s.saves["1"].last_synced_core == "core_libretro"
+        assert "active_core" not in s.to_dict()["saves"]["1"]
+
+    def test_legacy_settings_keys_stripped(self) -> None:
+        s = SaveSyncState.from_dict(
+            {"settings": {"conflict_mode": "ask", "clock_skew_tolerance_sec": 60, "save_sync_enabled": True}},
+        )
+        out = s.to_dict()["settings"]
+        assert "conflict_mode" not in out
+        assert "clock_skew_tolerance_sec" not in out
+        assert out["save_sync_enabled"] is True
+
+    def test_dismissed_newer_save_id_stripped(self) -> None:
+        s = SaveSyncState.from_dict(
+            {
+                "saves": {
+                    "1": {
+                        "files": {
+                            "f.srm": {
+                                "tracked_save_id": 1,
+                                "dismissed_newer_save_id": 999,
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        out = s.to_dict()
+        assert "dismissed_newer_save_id" not in out["saves"]["1"]["files"]["f.srm"]
+
+    def test_from_dict_non_dict_input_yields_defaults(self) -> None:
+        assert SaveSyncState.from_dict("garbage") == SaveSyncState()  # type: ignore[arg-type]
+
+    def test_malformed_saves_defaults_to_empty(self) -> None:
+        s = SaveSyncState.from_dict({"saves": "not-a-dict"})
+        assert s.saves == {}
+
+    def test_malformed_playtime_defaults_to_empty(self) -> None:
+        s = SaveSyncState.from_dict({"playtime": []})
+        assert s.playtime == {}
+
+    def test_replace_with_mutates_in_place(self) -> None:
+        s = SaveSyncState()
+        ref = s
+        new_state = SaveSyncState(device_id="x", saves={"1": RomSaveState(system="gba")})
+        s.replace_with(new_state)
+        # The original reference now reflects the new state.
+        assert ref is s
+        assert s.device_id == "x"
+        assert "1" in s.saves
+        assert s.saves["1"].system == "gba"
+
+    def test_equality(self) -> None:
+        a = SaveSyncState(device_id="abc")
+        b = SaveSyncState(device_id="abc")
+        assert a == b
+        b.device_id = "xyz"
+        assert a != b

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -6,6 +6,7 @@ import pytest
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_state import SaveSyncState
 
 # conftest.py patches decky before this import
 from main import Plugin
@@ -79,7 +80,7 @@ def plugin(clock):
     bios_checker = MagicMock()
     bios_checker.check_platform_bios_cached.return_value = None
     bios_checker.check_platform_bios = AsyncMock(return_value={"needs_bios": False})
-    p._save_sync_state = {"settings": {}, "saves": {}}
+    p._save_sync_state = SaveSyncState()
     p._game_detail_service = GameDetailService(
         state=p._state,
         metadata_cache=p._metadata_cache,
@@ -898,8 +899,7 @@ class TestGetCachedGameDetailAchievements:
                 "cached_at": svc._clock.time(),
             },
         }
-        plugin._save_sync_state.clear()
-        plugin._save_sync_state.update({"settings": {}, "saves": {}})
+        plugin._save_sync_state.replace_with(SaveSyncState())
 
         result = await plugin.get_cached_game_detail(100)
 
@@ -920,8 +920,7 @@ class TestGetCachedGameDetailAchievements:
             "name": "Test Game",
             "platform_slug": "",
         }
-        plugin._save_sync_state.clear()
-        plugin._save_sync_state.update({"settings": {}, "saves": {}})
+        plugin._save_sync_state.replace_with(SaveSyncState())
 
         result = await plugin.get_cached_game_detail(100)
 
@@ -938,8 +937,7 @@ class TestGetCachedGameDetailAchievements:
             "name": "Test Game",
             "platform_slug": "",
         }
-        plugin._save_sync_state.clear()
-        plugin._save_sync_state.update({"settings": {}, "saves": {}})
+        plugin._save_sync_state.replace_with(SaveSyncState())
 
         result = await plugin.get_cached_game_detail(100)
 
@@ -957,8 +955,7 @@ class TestGetCachedGameDetailAchievements:
             "name": "Test Game",
             "platform_slug": "",
         }
-        plugin._save_sync_state.clear()
-        plugin._save_sync_state.update({"settings": {}, "saves": {}})
+        plugin._save_sync_state.replace_with(SaveSyncState())
 
         result = await plugin.get_cached_game_detail(100)
 
@@ -984,8 +981,7 @@ class TestGetCachedGameDetailAchievements:
                 "cached_at": svc._clock.time() - (2 * 3600),  # expired
             },
         }
-        plugin._save_sync_state.clear()
-        plugin._save_sync_state.update({"settings": {}, "saves": {}})
+        plugin._save_sync_state.replace_with(SaveSyncState())
 
         result = await plugin.get_cached_game_detail(100)
 

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -14,6 +14,7 @@ from adapters.download_file import DownloadFileAdapter
 from adapters.download_queue import DownloadQueueAdapter
 from adapters.rom_files import RomFileAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_state import SaveSyncState
 from services.downloads import DownloadService, DownloadServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
@@ -53,7 +54,7 @@ def plugin():
             log_debug=p._log_debug,
         ),
     )
-    p._save_sync_state = {"saves": {}, "playtime": {}, "settings": {}}
+    p._save_sync_state = SaveSyncState()
     p._download_service = DownloadService(
         romm_api=p._romm_api,
         state=p._state,
@@ -1741,11 +1742,11 @@ class TestRemoveRomCleansSaveSyncState:
             "file_path": str(rom_file),
             "system": "n64",
         }
-        save_sync_state = {
-            "saves": {"42": {"last_sync": "2024-01-01"}, "99": {"last_sync": "2024-02-01"}},
-            "playtime": {"42": {"total_seconds": 3600}, "99": {"total_seconds": 7200}},
-            "settings": {"save_sync_enabled": False},
-        }
+        save_sync_state = SaveSyncState()
+        save_sync_state.saves["42"] = {"last_sync": "2024-01-01"}  # type: ignore[assignment]
+        save_sync_state.saves["99"] = {"last_sync": "2024-02-01"}  # type: ignore[assignment]
+        save_sync_state.playtime["42"] = {"total_seconds": 3600}  # type: ignore[assignment]
+        save_sync_state.playtime["99"] = {"total_seconds": 7200}  # type: ignore[assignment]
         plugin._rom_removal_service._save_sync_state = save_sync_state
         save_calls = []
         plugin._rom_removal_service._save_save_sync_state = lambda: save_calls.append(1)
@@ -1753,11 +1754,11 @@ class TestRemoveRomCleansSaveSyncState:
         result = await plugin.remove_rom(42)
         assert result["success"] is True
         # Save sync state for ROM 42 should be cleaned
-        assert "42" not in save_sync_state["saves"]
-        assert "42" not in save_sync_state["playtime"]
+        assert "42" not in save_sync_state.saves
+        assert "42" not in save_sync_state.playtime
         # Other ROM's state should be untouched
-        assert "99" in save_sync_state["saves"]
-        assert "99" in save_sync_state["playtime"]
+        assert "99" in save_sync_state.saves
+        assert "99" in save_sync_state.playtime
         # _save_save_sync_state should have been called
         assert len(save_calls) == 1
 
@@ -1782,11 +1783,11 @@ class TestRemoveRomCleansSaveSyncState:
             "1": {"rom_id": 1, "file_path": str(file_a), "system": "n64"},
             "2": {"rom_id": 2, "file_path": str(file_b), "system": "n64"},
         }
-        save_sync_state = {
-            "saves": {"1": {"last_sync": "2024-01-01"}, "2": {"last_sync": "2024-02-01"}},
-            "playtime": {"1": {"total_seconds": 100}, "2": {"total_seconds": 200}},
-            "settings": {"save_sync_enabled": False},
-        }
+        save_sync_state = SaveSyncState()
+        save_sync_state.saves["1"] = {"last_sync": "2024-01-01"}  # type: ignore[assignment]
+        save_sync_state.saves["2"] = {"last_sync": "2024-02-01"}  # type: ignore[assignment]
+        save_sync_state.playtime["1"] = {"total_seconds": 100}  # type: ignore[assignment]
+        save_sync_state.playtime["2"] = {"total_seconds": 200}  # type: ignore[assignment]
         plugin._rom_removal_service._save_sync_state = save_sync_state
         save_calls = []
         plugin._rom_removal_service._save_save_sync_state = lambda: save_calls.append(1)
@@ -1795,8 +1796,8 @@ class TestRemoveRomCleansSaveSyncState:
         assert result["success"] is True
         assert result["removed_count"] == 2
         # All save sync state should be cleaned
-        assert save_sync_state["saves"] == {}
-        assert save_sync_state["playtime"] == {}
+        assert save_sync_state.saves == {}
+        assert save_sync_state.playtime == {}
         # _save_save_sync_state should have been called
         assert len(save_calls) == 1
 

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -14,6 +14,7 @@ from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_state import FileSyncState, RomSaveState
 from services.achievements import AchievementsService
 from services.firmware import FirmwareService, FirmwareServiceConfig
 from services.game_detail import GameDetailService
@@ -147,7 +148,7 @@ def plugin(tmp_path):
     # Store fake_api on plugin for test access
     p._fake_api = fake_api
 
-    p._save_sync_state["settings"]["save_sync_enabled"] = False
+    p._save_sync_state.settings.save_sync_enabled = False
     return p
 
 
@@ -231,16 +232,16 @@ class TestGetCachedGameDetailFound:
             "file_path": "/roms/snes/smw.sfc",
             "system": "snes",
         }
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = True
-        plugin._save_sync_state["saves"]["123"] = {
-            "files": {
-                "smw.srm": {
-                    "last_sync_at": "2025-01-01T00:00:00Z",
-                    "last_sync_hash": "abc123",
-                },
+        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin._save_sync_state.saves["123"] = RomSaveState(
+            files={
+                "smw.srm": FileSyncState(
+                    last_sync_at="2025-01-01T00:00:00Z",
+                    last_sync_hash="abc123",
+                ),
             },
-            "last_sync_check_at": "2025-01-01T00:00:00Z",
-        }
+            last_sync_check_at="2025-01-01T00:00:00Z",
+        )
         plugin._metadata_cache["123"] = {
             "summary": "Classic SNES platformer",
             "genres": ["Platformer"],
@@ -344,7 +345,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_slug": "snes",
             "platform_name": "Super Nintendo",
         }
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = game_detail_service.get_cached_game_detail(50000)
         assert result["save_sync_enabled"] is False
 
@@ -652,11 +653,11 @@ class TestGetCachedGameDetailSaveStatusConflicts:
             "platform_slug": "gba",
             "platform_name": "GBA",
         }
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = True
-        plugin._save_sync_state["saves"]["42"] = {
-            "files": {"test.srm": {"last_sync_hash": "abc", "last_sync_at": "2026-01-01T00:00:00Z"}},
-            "last_sync_check_at": "2026-01-01T00:00:00Z",
-        }
+        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin._save_sync_state.saves["42"] = RomSaveState(
+            files={"test.srm": FileSyncState(last_sync_hash="abc", last_sync_at="2026-01-01T00:00:00Z")},
+            last_sync_check_at="2026-01-01T00:00:00Z",
+        )
         result = game_detail_service.get_cached_game_detail(99999)
         assert result["save_status"] is not None
         assert "conflicts" in result["save_status"]
@@ -764,11 +765,11 @@ class TestComputedFields:
             "platform_slug": "gba",
             "platform_name": "GBA",
         }
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = True
-        plugin._save_sync_state["saves"]["42"] = {
-            "files": {"test.srm": {"last_sync_hash": "abc", "last_sync_at": "2026-01-01T00:00:00Z"}},
-            "last_sync_check_at": "2026-01-01T00:00:00Z",
-        }
+        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin._save_sync_state.saves["42"] = RomSaveState(
+            files={"test.srm": FileSyncState(last_sync_hash="abc", last_sync_at="2026-01-01T00:00:00Z")},
+            last_sync_check_at="2026-01-01T00:00:00Z",
+        )
         result = game_detail_service.get_cached_game_detail(99999)
         assert result["save_sync_display"] is not None
         assert result["save_sync_display"]["status"] == "synced"

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -15,6 +15,7 @@ import pytest
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
+from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.errors import RommApiError
 from services.playtime import PlaytimeService
 
@@ -33,7 +34,7 @@ def _make_retry():
 def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):
     """Create a PlaytimeService with sensible defaults."""
     fake = fake_api or FakeSaveApi()
-    state: dict[str, Any] = {"playtime": {}}
+    state = SaveSyncState()
     saved: list[bool] = []
     clk = clock or FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
 
@@ -62,8 +63,8 @@ class TestRecordSession:
         svc, _, state, saved = make_service()
         result = svc.record_session_start(42)
         assert result["success"] is True
-        assert "42" in state["playtime"]
-        assert state["playtime"]["42"]["last_session_start"] is not None
+        assert "42" in state.playtime
+        assert state.playtime["42"].last_session_start is not None
         assert len(saved) == 1
 
     @pytest.mark.asyncio
@@ -75,7 +76,7 @@ class TestRecordSession:
 
         # Backdate session start by 60 seconds (relative to the fake clock)
         start = svc._clock.now() - timedelta(seconds=60)
-        state["playtime"]["42"]["last_session_start"] = start.isoformat()
+        state.playtime["42"].last_session_start = start.isoformat()
 
         result = await svc.record_session_end(42)
         assert result["success"] is True
@@ -93,13 +94,7 @@ class TestRecordSession:
     async def test_end_with_unparseable_start(self):
         """Malformed last_session_start -> parse_iso returns None -> failure."""
         svc, _, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 0,
-            "session_count": 0,
-            "last_session_start": "not-a-date",
-            "last_session_duration_sec": None,
-            "offline_deltas": [],
-        }
+        state.playtime["42"] = PlaytimeEntry(last_session_start="not-a-date")
         result = await svc.record_session_end(42)
         assert result["success"] is False
         assert "Failed to calculate session duration" in result["message"]
@@ -111,13 +106,13 @@ class TestRecordSession:
         # Session 1
         svc.record_session_start(42)
         start = svc._clock.now() - timedelta(seconds=30)
-        state["playtime"]["42"]["last_session_start"] = start.isoformat()
+        state.playtime["42"].last_session_start = start.isoformat()
         await svc.record_session_end(42)
 
         # Session 2
         svc.record_session_start(42)
         start = svc._clock.now() - timedelta(seconds=45)
-        state["playtime"]["42"]["last_session_start"] = start.isoformat()
+        state.playtime["42"].last_session_start = start.isoformat()
         result2 = await svc.record_session_end(42)
 
         assert result2["session_count"] == 2
@@ -133,14 +128,12 @@ class TestSyncPlaytime:
     @pytest.mark.asyncio
     async def test_creates_note_on_first_sync(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 120,
-            "session_count": 1,
-            "last_session_start": None,
-            "last_session_duration_sec": 120,
-            "offline_deltas": [],
-        }
-        state["device_name"] = "deck"
+        state.playtime["42"] = PlaytimeEntry(
+            total_seconds=120,
+            session_count=1,
+            last_session_duration_sec=120,
+        )
+        state.device_name = "deck"
 
         svc._sync_playtime_to_romm(42, 120)
 
@@ -154,14 +147,12 @@ class TestSyncPlaytime:
     @pytest.mark.asyncio
     async def test_updates_existing_note(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 200,
-            "session_count": 2,
-            "last_session_start": None,
-            "last_session_duration_sec": 80,
-            "offline_deltas": [],
-        }
-        state["device_name"] = "deck"
+        state.playtime["42"] = PlaytimeEntry(
+            total_seconds=200,
+            session_count=2,
+            last_session_duration_sec=80,
+        )
+        state.device_name = "deck"
 
         # Pre-existing note on server
         fake.notes[42] = [
@@ -182,14 +173,12 @@ class TestSyncPlaytime:
     async def test_merge_takes_max(self):
         """new_total = max(local_total, server_seconds + session_duration)"""
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 300,
-            "session_count": 3,
-            "last_session_start": None,
-            "last_session_duration_sec": 60,
-            "offline_deltas": [],
-        }
-        state["device_name"] = "deck"
+        state.playtime["42"] = PlaytimeEntry(
+            total_seconds=300,
+            session_count=3,
+            last_session_duration_sec=60,
+        )
+        state.device_name = "deck"
 
         fake.notes[42] = [
             {
@@ -204,8 +193,8 @@ class TestSyncPlaytime:
         svc._sync_playtime_to_romm(42, 60)
 
         # max(300, 200+60) = 300
-        entry = state["playtime"]["42"]
-        assert entry["total_seconds"] == 300
+        entry = state.playtime["42"]
+        assert entry.total_seconds == 300
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +206,7 @@ class TestGetPlaytime:
     @pytest.mark.asyncio
     async def test_get_server_playtime(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {"total_seconds": 100, "session_count": 2}
+        state.playtime["42"] = PlaytimeEntry(total_seconds=100, session_count=2)
 
         fake.notes[42] = [
             {
@@ -237,7 +226,7 @@ class TestGetPlaytime:
     @pytest.mark.asyncio
     async def test_get_server_playtime_no_note(self):
         svc, _, state, _ = make_service()
-        state["playtime"]["42"] = {"total_seconds": 50, "session_count": 1}
+        state.playtime["42"] = PlaytimeEntry(total_seconds=50, session_count=1)
 
         result = await svc.get_server_playtime(42)
         assert result["local_seconds"] == 50
@@ -247,8 +236,8 @@ class TestGetPlaytime:
     @pytest.mark.asyncio
     async def test_get_all_playtime(self):
         svc, _, state, _ = make_service()
-        state["playtime"]["42"] = {"total_seconds": 100}
-        state["playtime"]["99"] = {"total_seconds": 200}
+        state.playtime["42"] = PlaytimeEntry(total_seconds=100)
+        state.playtime["99"] = PlaytimeEntry(total_seconds=200)
 
         result = svc.get_all_playtime()
         assert len(result["playtime"]) == 2
@@ -299,7 +288,7 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_api_error_on_server_playtime(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {"total_seconds": 100, "session_count": 1}
+        state.playtime["42"] = PlaytimeEntry(total_seconds=100, session_count=1)
         fake.fail_on_next(RommApiError("Server down"))
 
         result = await svc.get_server_playtime(42)
@@ -310,14 +299,12 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_sync_playtime_error_logged_not_raised(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 100,
-            "session_count": 1,
-            "last_session_start": None,
-            "last_session_duration_sec": 60,
-            "offline_deltas": [],
-        }
-        state["device_name"] = "deck"
+        state.playtime["42"] = PlaytimeEntry(
+            total_seconds=100,
+            session_count=1,
+            last_session_duration_sec=60,
+        )
+        state.device_name = "deck"
         fake.fail_on_next(RommApiError("Oops"))
 
         # Should not raise
@@ -326,14 +313,12 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_corrupted_note_content(self):
         svc, fake, state, _ = make_service()
-        state["playtime"]["42"] = {
-            "total_seconds": 100,
-            "session_count": 1,
-            "last_session_start": None,
-            "last_session_duration_sec": 60,
-            "offline_deltas": [],
-        }
-        state["device_name"] = "deck"
+        state.playtime["42"] = PlaytimeEntry(
+            total_seconds=100,
+            session_count=1,
+            last_session_duration_sec=60,
+        )
+        state.device_name = "deck"
 
         fake.notes[42] = [
             {
@@ -358,7 +343,7 @@ class TestEdgeCases:
 
         # Backdate by 25 hours
         start = svc._clock.now() - timedelta(hours=25)
-        state["playtime"]["42"]["last_session_start"] = start.isoformat()
+        state.playtime["42"].last_session_start = start.isoformat()
 
         result = await svc.record_session_end(42)
         assert result["success"] is True

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 sys.path.insert(0, os.path.dirname(__file__))
 
 # conftest.py patches decky before this import
+from domain.save_state import SaveSyncState
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 
 # Synthetic roms-base path used by the fake fs throughout this module.
@@ -26,7 +27,7 @@ def state():
 
 @pytest.fixture
 def save_sync_state():
-    return {"saves": {}, "playtime": {}, "settings": {}}
+    return SaveSyncState()
 
 
 @pytest.fixture
@@ -164,11 +165,11 @@ class TestRemoveRom:
         rom_path = f"{_ROMS_BASE}/n64/zelda.z64"
         rom_files.files[rom_path] = b"\x00" * 100
         state["installed_roms"]["42"] = {"rom_id": 42, "file_path": rom_path, "system": "n64"}
-        save_sync_state["saves"]["42"] = {"last_sync": "2024-01-01"}
-        save_sync_state["playtime"]["42"] = {"total_seconds": 3600}
+        save_sync_state.saves["42"] = {"last_sync": "2024-01-01"}
+        save_sync_state.playtime["42"] = {"total_seconds": 3600}
         # Add another ROM's state that should be preserved
-        save_sync_state["saves"]["99"] = {"last_sync": "2024-02-01"}
-        save_sync_state["playtime"]["99"] = {"total_seconds": 7200}
+        save_sync_state.saves["99"] = {"last_sync": "2024-02-01"}
+        save_sync_state.playtime["99"] = {"total_seconds": 7200}
 
         save_calls: list[int] = []
         service._save_save_sync_state = lambda: save_calls.append(1)
@@ -176,10 +177,10 @@ class TestRemoveRom:
         result = await service.remove_rom(42)
 
         assert result["success"] is True
-        assert "42" not in save_sync_state["saves"]
-        assert "42" not in save_sync_state["playtime"]
-        assert "99" in save_sync_state["saves"]
-        assert "99" in save_sync_state["playtime"]
+        assert "42" not in save_sync_state.saves
+        assert "42" not in save_sync_state.playtime
+        assert "99" in save_sync_state.saves
+        assert "99" in save_sync_state.playtime
         assert len(save_calls) == 1
 
     @pytest.mark.asyncio
@@ -304,16 +305,16 @@ class TestUninstallAllRoms:
             "1": {"rom_id": 1, "file_path": file_a, "system": "n64"},
             "2": {"rom_id": 2, "file_path": file_b, "system": "n64"},
         }
-        save_sync_state["saves"] = {"1": {"last_sync": "2024-01-01"}, "2": {"last_sync": "2024-02-01"}}
-        save_sync_state["playtime"] = {"1": {"total_seconds": 100}, "2": {"total_seconds": 200}}
+        save_sync_state.saves = {"1": {"last_sync": "2024-01-01"}, "2": {"last_sync": "2024-02-01"}}
+        save_sync_state.playtime = {"1": {"total_seconds": 100}, "2": {"total_seconds": 200}}
 
         save_calls: list[int] = []
         service._save_save_sync_state = lambda: save_calls.append(1)
 
         result = await service.uninstall_all_roms()
         assert result["success"] is True
-        assert save_sync_state["saves"] == {}
-        assert save_sync_state["playtime"] == {}
+        assert save_sync_state.saves == {}
+        assert save_sync_state.playtime == {}
         assert len(save_calls) == 1
 
     @pytest.mark.asyncio

--- a/tests/services/test_saves.py
+++ b/tests/services/test_saves.py
@@ -16,6 +16,12 @@ from fakes.system_time import FakeClock
 
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.save_file import SaveFileAdapter
+from domain.save_state import (
+    FileSyncState,
+    PlaytimeEntry,
+    RomSaveState,
+    SaveSyncState,
+)
 from lib.errors import RommApiError
 from services.saves import SaveService, SaveServiceConfig
 
@@ -167,20 +173,20 @@ def _file_md5(path):
 class TestStateManagement:
     def test_make_default_state(self):
         state = SaveService.make_default_state()
-        assert state["device_id"] is None
-        assert state["saves"] == {}
-        assert state["settings"]["save_sync_enabled"] is False
+        assert state.device_id is None
+        assert state.saves == {}
+        assert state.settings.save_sync_enabled is False
 
     def test_init_state_populates_defaults(self, tmp_path):
-        svc, _ = make_service(tmp_path, save_sync_state={})
-        assert svc._save_sync_state["settings"]["save_sync_enabled"] is False
-        assert svc._save_sync_state["saves"] == {}
+        svc, _ = make_service(tmp_path, save_sync_state=SaveSyncState())
+        assert svc._save_sync_state.settings.save_sync_enabled is False
+        assert svc._save_sync_state.saves == {}
 
     def test_init_state_preserves_existing(self, tmp_path):
         state = SaveService.make_default_state()
-        state["device_id"] = "existing-id"
+        state.device_id = "existing-id"
         svc, _ = make_service(tmp_path, save_sync_state=state)
-        assert svc._save_sync_state["device_id"] == "existing-id"
+        assert svc._save_sync_state.device_id == "existing-id"
 
     def test_load_state_drops_legacy_dismissed_newer_save_id(self, tmp_path):
         """v0.15.0 user state with the obsolete dismissed_newer_save_id field
@@ -210,12 +216,12 @@ class TestStateManagement:
         svc, _ = make_service(tmp_path)  # calls init_state internally
         svc.load_state()
 
-        files = svc._save_sync_state["saves"]["42"]["files"]
-        assert "dismissed_newer_save_id" not in files["game.srm"]
-        assert "dismissed_newer_save_id" not in files["game.rtc"]
-        assert files["game.srm"]["tracked_save_id"] == 100
-        assert files["game.srm"]["last_sync_hash"] == "abc"
-        assert files["game.rtc"]["tracked_save_id"] == 101
+        files = svc._save_sync_state.saves["42"].files
+        # The legacy field is dropped on load (verified at the domain level
+        # via FileSyncState.from_dict — see tests/domain/test_save_state.py).
+        assert files["game.srm"].tracked_save_id == 100
+        assert files["game.srm"].last_sync_hash == "abc"
+        assert files["game.rtc"].tracked_save_id == 101
 
     def test_load_state_drops_legacy_dismissed_newer_save_id_persists_to_disk(self, tmp_path):
         """End-to-end: legacy field on disk → init_state → load_state →
@@ -258,9 +264,12 @@ class TestStateManagement:
         svc, _ = make_service(tmp_path)
         svc.load_state()
 
-        entry = svc._save_sync_state["saves"]["42"]
-        assert "active_core" not in entry
-        assert entry["last_synced_core"] == "mgba_libretro"
+        entry = svc._save_sync_state.saves["42"]
+        # Legacy ``active_core`` migration is verified at the domain level
+        # (tests/domain/test_save_state.py). Confirm the service-level
+        # round-trip wires it up to ``last_synced_core``.
+        assert entry.last_synced_core == "mgba_libretro"
+        assert "active_core" not in entry.to_dict()
 
     def test_load_state_skips_migration_for_malformed_entries(self, tmp_path):
         """Migration is defensive: non-dict values don't crash."""
@@ -279,87 +288,66 @@ class TestStateManagement:
         svc, _ = make_service(tmp_path)
         svc.load_state()  # should not raise
 
-        files = svc._save_sync_state["saves"]["42"]["files"]
-        assert "dismissed_newer_save_id" not in files["good.srm"]
+        files = svc._save_sync_state.saves["42"].files
+        # Malformed sub-entries default to empty FileSyncState — see the
+        # domain-level coverage in tests/domain/test_save_state.py.
+        assert files["good.srm"].tracked_save_id == 100
 
-    def test_migrate_loaded_state_strips_legacy_settings_keys(self, tmp_path):
+    def test_settings_legacy_keys_stripped_on_load(self, tmp_path):
         """Legacy ``conflict_mode`` and ``clock_skew_tolerance_sec`` settings
-        are dropped on state load. Other settings keys survive."""
-        svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"] = {
-            "conflict_mode": "ask_me",
-            "clock_skew_tolerance_sec": 60,
-            "save_sync_enabled": True,
+        are dropped when state loads from disk. Other keys survive."""
+        legacy = {
+            "settings": {
+                "conflict_mode": "ask_me",
+                "clock_skew_tolerance_sec": 60,
+                "save_sync_enabled": True,
+            },
         }
+        (tmp_path / "save_sync_state.json").write_text(json.dumps(legacy))
 
-        svc._migrate_loaded_state()
-
-        settings = svc._save_sync_state["settings"]
-        assert "conflict_mode" not in settings
-        assert "clock_skew_tolerance_sec" not in settings
-        assert settings["save_sync_enabled"] is True
-
-    def test_migrate_loaded_state_strip_legacy_settings_idempotent(self, tmp_path):
-        """Stripping legacy settings is a no-op when they aren't present."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"] = {"save_sync_enabled": True}
+        svc.load_state()
+        svc.save_state()
 
-        svc._migrate_loaded_state()  # should not raise
-
-        assert svc._save_sync_state["settings"] == {"save_sync_enabled": True}
-
-    def test_migrate_loaded_state_handles_missing_settings(self, tmp_path):
-        """Migration is defensive: missing ``settings`` key doesn't crash."""
-        svc, _ = make_service(tmp_path)
-        svc._save_sync_state.pop("settings", None)
-
-        svc._migrate_loaded_state()  # should not raise
-
-        assert "settings" not in svc._save_sync_state
-
-    def test_migrate_loaded_state_handles_non_dict_settings(self, tmp_path):
-        """Migration is defensive: non-dict ``settings`` is left untouched."""
-        svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"] = "broken"
-
-        svc._migrate_loaded_state()  # should not raise
-
-        assert svc._save_sync_state["settings"] == "broken"
+        on_disk = json.loads((tmp_path / "save_sync_state.json").read_text())
+        assert "conflict_mode" not in on_disk["settings"]
+        assert "clock_skew_tolerance_sec" not in on_disk["settings"]
+        assert on_disk["settings"]["save_sync_enabled"] is True
 
     def test_save_and_load_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["device_id"] = "test-device"
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.device_id = "test-device"
+        svc._save_sync_state.saves["42"] = RomSaveState()
         svc.save_state()
 
         # Load into a fresh service
         svc2, _ = make_service(tmp_path)
         svc2.load_state()
-        assert svc2._save_sync_state["device_id"] == "test-device"
-        assert "42" in svc2._save_sync_state["saves"]
+        assert svc2._save_sync_state.device_id == "test-device"
+        assert "42" in svc2._save_sync_state.saves
 
     def test_load_state_missing_file(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc.load_state()  # should not raise
-        assert svc._save_sync_state["device_id"] is None
+        assert svc._save_sync_state.device_id is None
 
     def test_prune_orphaned_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"]["99"] = {"files": {}}
-        svc._save_sync_state["playtime"]["99"] = {"total_seconds": 100}
+        svc._save_sync_state.saves["99"] = RomSaveState()
+        svc._save_sync_state.playtime["99"] = PlaytimeEntry.from_dict({"total_seconds": 100})
         svc._state["shortcut_registry"]["42"] = {}
 
         svc.prune_orphaned_state()
-        assert "99" not in svc._save_sync_state["saves"]
-        assert "99" not in svc._save_sync_state["playtime"]
+        assert "99" not in svc._save_sync_state.saves
+        assert "99" not in svc._save_sync_state.playtime
 
     def test_prune_keeps_registered(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState()
         svc._state["shortcut_registry"]["42"] = {}
 
         svc.prune_orphaned_state()
-        assert "42" in svc._save_sync_state["saves"]
+        assert "42" in svc._save_sync_state.saves
 
 
 # ---------------------------------------------------------------------------
@@ -371,22 +359,22 @@ class TestDeviceRegistration:
     @pytest.mark.asyncio
     async def test_registers_new_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result["device_id"]
         assert result["device_name"]
         # Persisted
-        assert svc._save_sync_state["device_id"] == result["device_id"]
+        assert svc._save_sync_state.device_id == result["device_id"]
 
     @pytest.mark.asyncio
     async def test_returns_existing_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "existing"
-        svc._save_sync_state["device_name"] = "deck"
-        svc._save_sync_state["server_device_id"] = "server-existing"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "existing"
+        svc._save_sync_state.device_name = "deck"
+        svc._save_sync_state.server_device_id = "server-existing"
 
         result = await svc.ensure_device_registered()
         assert result["device_id"] == "existing"
@@ -412,12 +400,12 @@ class TestDeviceRegistrationServer:
     async def test_registers_with_server(self, tmp_path):
         """Calls register_device and stores server_device_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result.get("server_device_id") is not None
-        assert svc._save_sync_state["server_device_id"] == result["server_device_id"]
+        assert svc._save_sync_state.server_device_id == result["server_device_id"]
         # Verify register_device was called
         reg_calls = [c for c in fake.call_log if c[0] == "register_device"]
         assert len(reg_calls) == 1
@@ -431,21 +419,21 @@ class TestDeviceRegistrationServer:
         fake = FakeSaveApi()
         fake.fail_on_next(Exception("server error"))
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is False
         assert result.get("error") == "registration_failed"
-        assert svc._save_sync_state.get("server_device_id") is None
+        assert svc._save_sync_state.server_device_id is None
 
     @pytest.mark.asyncio
     async def test_returns_existing_with_server_device_id(self, tmp_path):
         """If already registered, returns existing IDs including server_device_id."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "existing-id"
-        svc._save_sync_state["device_name"] = "deck"
-        svc._save_sync_state["server_device_id"] = "server-id-123"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "existing-id"
+        svc._save_sync_state.device_name = "deck"
+        svc._save_sync_state.server_device_id = "server-id-123"
 
         result = await svc.ensure_device_registered()
         assert result["device_id"] == "existing-id"
@@ -455,16 +443,16 @@ class TestDeviceRegistrationServer:
     async def test_upgrades_local_uuid_to_server(self, tmp_path):
         """Local-only UUID gets upgraded to server registration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # Simulate existing local-only UUID (from failed registration)
-        svc._save_sync_state["device_id"] = "local-only-uuid"
-        svc._save_sync_state["device_name"] = "deck"
-        svc._save_sync_state["server_device_id"] = None
+        svc._save_sync_state.device_id = "local-only-uuid"
+        svc._save_sync_state.device_name = "deck"
+        svc._save_sync_state.server_device_id = None
 
         result = await svc.ensure_device_registered()
         assert result["success"] is True
         assert result.get("server_device_id") is not None
-        assert svc._save_sync_state["server_device_id"] is not None
+        assert svc._save_sync_state.server_device_id is not None
         # register_device was called
         reg_calls = [c for c in fake.call_log if c[0] == "register_device"]
         assert len(reg_calls) == 1
@@ -473,10 +461,10 @@ class TestDeviceRegistrationServer:
     async def test_ensure_device_registered_reconciles_client_version(self, tmp_path):
         """Already-registered path calls update_device with current plugin_version."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "existing-id"
-        svc._save_sync_state["device_name"] = "deck"
-        svc._save_sync_state["server_device_id"] = "server-abc"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "existing-id"
+        svc._save_sync_state.device_name = "deck"
+        svc._save_sync_state.server_device_id = "server-abc"
 
         result = await svc.ensure_device_registered()
 
@@ -491,10 +479,10 @@ class TestDeviceRegistrationServer:
         """PUT raises, ensure_device_registered still returns success."""
         fake = FakeSaveApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "existing-id"
-        svc._save_sync_state["device_name"] = "deck"
-        svc._save_sync_state["server_device_id"] = "server-abc"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "existing-id"
+        svc._save_sync_state.device_name = "deck"
+        svc._save_sync_state.server_device_id = "server-abc"
 
         # Make update_device fail silently
         fake.fail_on_next(Exception("network error"))
@@ -518,7 +506,7 @@ class TestDeviceRegistrationServer:
 
         fake = VersionedFakeApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         await svc.ensure_device_registered()
 
@@ -541,7 +529,7 @@ class TestDeviceRegistrationServer:
         fake = VersionedFakeApi()
         fake.set_version("4.8.1")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         await svc.ensure_device_registered()
 
@@ -554,7 +542,7 @@ class TestDeviceRegistrationServer:
         fake = FakeSaveApi()
         fake.heartbeat_raises = ConnectionError("offline")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         result = await svc.ensure_device_registered()
 
@@ -594,8 +582,8 @@ class TestListDevices:
     async def test_list_devices_marks_own_device(self, tmp_path):
         """own device_id present in state — is_current_device is True on matching entry."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "device-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "device-1"
 
         # Register two devices in fake
         fake._registered_devices = [
@@ -627,7 +615,7 @@ class TestListDevices:
         """Adapter raises — returns error response."""
         fake = FakeSaveApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         fake.fail_on_next(Exception("server unavailable"))
         result = await svc.list_devices()
@@ -638,8 +626,8 @@ class TestListDevices:
     async def test_list_devices_no_own_id_all_false(self, tmp_path):
         """No server_device_id in state — all is_current_device are False."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = None
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = None
 
         fake._registered_devices = [{"id": "device-1", "name": "steamdeck"}]
         result = await svc.list_devices()
@@ -651,8 +639,8 @@ class TestListDevices:
     async def test_list_devices_handles_null_id(self, tmp_path):
         """Device with id=None must not match own_id=None (avoid 'None'=='None' trap)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = None
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = None
 
         fake._registered_devices = [{"id": None, "name": "unknown"}]
         result = await svc.list_devices()
@@ -671,7 +659,7 @@ class TestListDevices:
 class TestSyncRomSaves:
     def test_local_only_uploads(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
 
@@ -683,7 +671,7 @@ class TestSyncRomSaves:
 
     def test_server_only_downloads(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         # Add server save but no local file
         ss = _server_save()
@@ -722,7 +710,7 @@ class TestSyncRomSaves:
     def test_sync_rom_saves_skips_server_only_downloads_during_pending_migration(self, tmp_path):
         """server_only matches must be skipped while migration is pending (#238)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         # Mark migration pending — detect has fired, user hasn't resolved yet.
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
@@ -745,7 +733,7 @@ class TestSyncRomSaves:
     def test_sync_rom_saves_uploads_local_only_during_pending_migration(self, tmp_path):
         """local_only matches must still upload during pending migration (#238)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
         svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
@@ -776,8 +764,8 @@ class TestSyncRomSaves:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
 
@@ -805,8 +793,8 @@ class TestSyncRomSaves:
         was needed.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
         # Stub _sync_rom_saves to return 1 conflict, 0 synced, 0 errors
@@ -832,8 +820,8 @@ class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_syncs_multiple_roms(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
@@ -855,8 +843,8 @@ class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_partial_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
@@ -894,8 +882,8 @@ class TestSyncAllSaves:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
 
@@ -923,8 +911,8 @@ class TestSyncAllSaves:
         flag must stay reserved for actual errors.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
 
         # Stub internal sync to produce conflicts but no errors
@@ -949,8 +937,8 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_downloads_server_saves(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
         ss = _server_save()
@@ -970,9 +958,9 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_pre_launch_disabled_in_settings(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["settings"]["sync_before_launch"] = False
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.settings.sync_before_launch = False
+        svc._save_sync_state.device_id = "test-device"
 
         result = await svc.pre_launch_sync(42)
         assert result["synced"] == 0
@@ -987,8 +975,8 @@ class TestPreLaunchSync:
             order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
 
         # Track when _is_save_sort_changed is consulted.
         orig_gate = svc._is_save_sort_changed
@@ -1010,8 +998,8 @@ class TestRetroDeckMigrationBlocksSaveSync:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
         svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
         result = await svc.pre_launch_sync(42)
@@ -1023,8 +1011,8 @@ class TestRetroDeckMigrationBlocksSaveSync:
     @pytest.mark.asyncio
     async def test_post_exit_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
         svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
 
@@ -1044,8 +1032,8 @@ class TestRetroDeckMigrationBlocksSaveSync:
         from main import Plugin
 
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
         plugin = Plugin()
@@ -1072,8 +1060,8 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_uploads_changed_saves(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"new save data")
 
@@ -1091,9 +1079,9 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_post_exit_disabled_in_settings(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["settings"]["sync_after_exit"] = False
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.settings.sync_after_exit = False
+        svc._save_sync_state.device_id = "test-device"
 
         result = await svc.post_exit_sync(42)
         assert result["synced"] == 0
@@ -1101,14 +1089,14 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_auto_registers_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # No device_id set
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
 
         result = await svc.post_exit_sync(42)
         assert result["success"] is True
-        assert svc._save_sync_state["device_id"] is not None
+        assert svc._save_sync_state.device_id is not None
 
     # ------------------------------------------------------------------
     # Regression tests for issue #238 — detect-first invariant.
@@ -1128,8 +1116,8 @@ class TestPostExitSync:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
 
@@ -1157,8 +1145,8 @@ class TestPostExitSync:
             raise RuntimeError("cfg file unreadable")
 
         svc, _ = make_service(tmp_path, detect_sort_change=boom)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
 
@@ -1176,8 +1164,8 @@ class TestPostExitSync:
         """Default detect_sort_change=None: post_exit_sync still runs without error (#238)."""
         svc, _ = make_service(tmp_path)  # detect_sort_change not passed → None
         assert svc._detect_sort_change is None
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
 
@@ -1194,8 +1182,8 @@ class TestPostExitSync:
         signal that sync is blocked on manual resolution.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
         def stub_sync(rom_id):
@@ -1222,8 +1210,8 @@ class TestPostExitSyncConnectivity:
         fake = FakeSaveApi()
         fake.heartbeat_raises = ConnectionError("unreachable")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
 
         result = await svc.post_exit_sync(42)
 
@@ -1235,8 +1223,8 @@ class TestPostExitSyncConnectivity:
     async def test_proceeds_when_heartbeat_succeeds(self, tmp_path):
         """post_exit_sync proceeds normally when server is reachable."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "test-device"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
 
@@ -1251,14 +1239,14 @@ class TestPostExitSyncConnectivity:
         fake = FakeSaveApi()
         fake.heartbeat_raises = OSError("connection refused")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # No device_id — would trigger registration if heartbeat passed
 
         result = await svc.post_exit_sync(42)
 
         assert result.get("offline") is True
         # Device should not have been registered
-        assert not svc._save_sync_state.get("device_id")
+        assert not svc._save_sync_state.device_id
 
 
 # ---------------------------------------------------------------------------
@@ -1305,8 +1293,8 @@ class TestSaveStatus:
         svc, fake = make_service(tmp_path)
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
-        svc._save_sync_state["device_id"] = "server-dev-1"
+        svc._save_sync_state.server_device_id = "server-dev-1"
+        svc._save_sync_state.device_id = "server-dev-1"
 
         ss = _server_save()
         ss["device_syncs"] = [
@@ -1342,7 +1330,7 @@ class TestSaveStatus:
         # Server save in slot "default", but active_slot is "other"
         ss = _server_save(slot="default")
         fake.saves[100] = ss
-        svc._save_sync_state["saves"]["42"] = {"active_slot": "other", "files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState(active_slot="other")
 
         result = await svc.get_save_status(42)
         # Local file exists → should show as upload (local-only), not synced against wrong slot
@@ -1446,15 +1434,15 @@ class TestDeleteSaves:
         save_path = _create_save(tmp_path)
         assert save_path.exists()
 
-        svc._save_sync_state["saves"]["42"] = {"files": {"pokemon.srm": {}}}
+        svc._save_sync_state.saves["42"] = RomSaveState(files={"pokemon.srm": FileSyncState()})
 
         result = svc.delete_local_saves(42)
         assert result["success"] is True
         assert result["deleted_count"] == 1
         assert not save_path.exists()
         # Entry survives — only files are cleared.
-        assert "42" in svc._save_sync_state["saves"]
-        assert svc._save_sync_state["saves"]["42"]["files"] == {}
+        assert "42" in svc._save_sync_state.saves
+        assert svc._save_sync_state.saves["42"].files == {}
 
     @pytest.mark.asyncio
     async def test_delete_local_saves_preserves_slot_config(self, tmp_path):
@@ -1464,31 +1452,33 @@ class TestDeleteSaves:
         save_path = _create_save(tmp_path)
         assert save_path.exists()
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
-            "active_slot": "desktop",
-            "slot_confirmed": True,
-            "emulator": "retroarch-mgba",
-            "last_synced_core": "mgba_libretro",
-            "own_upload_ids": ["save-1", "save-2"],
-            "slots": {"default": {}, "desktop": {}},
-            "system": "gba",
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
+                "active_slot": "desktop",
+                "slot_confirmed": True,
+                "emulator": "retroarch-mgba",
+                "last_synced_core": "mgba_libretro",
+                "own_upload_ids": ["save-1", "save-2"],
+                "slots": {"default": {}, "desktop": {}},
+                "system": "gba",
+            }
+        )
 
         result = svc.delete_local_saves(42)
         assert result["success"] is True
         assert result["deleted_count"] == 1
         assert not save_path.exists()
 
-        entry = svc._save_sync_state["saves"]["42"]
-        assert entry["files"] == {}
-        assert entry["active_slot"] == "desktop"
-        assert entry["slot_confirmed"] is True
-        assert entry["emulator"] == "retroarch-mgba"
-        assert entry["last_synced_core"] == "mgba_libretro"
-        assert entry["own_upload_ids"] == ["save-1", "save-2"]
-        assert entry["slots"] == {"default": {}, "desktop": {}}
-        assert entry["system"] == "gba"
+        entry = svc._save_sync_state.saves["42"]
+        assert entry.files == {}
+        assert entry.active_slot == "desktop"
+        assert entry.slot_confirmed is True
+        assert entry.emulator == "retroarch-mgba"
+        assert entry.last_synced_core == "mgba_libretro"
+        assert entry.own_upload_ids == ["save-1", "save-2"]
+        assert entry.slots == {"default": {}, "desktop": {}}
+        assert entry.system == "gba"
 
     @pytest.mark.asyncio
     async def test_delete_local_saves_no_prior_state_entry(self, tmp_path):
@@ -1497,15 +1487,15 @@ class TestDeleteSaves:
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
-        # No svc._save_sync_state["saves"]["42"] set up.
-        assert "42" not in svc._save_sync_state["saves"]
+        # No svc._save_sync_state.saves["42"] set up.
+        assert "42" not in svc._save_sync_state.saves
 
         result = svc.delete_local_saves(42)
         assert result["success"] is True
         assert result["deleted_count"] == 1
         assert not save_path.exists()
         # clear_files_state creates an empty entry with files={}.
-        assert svc._save_sync_state["saves"]["42"] == {"files": {}}
+        assert svc._save_sync_state.saves["42"].files == {}
 
     @pytest.mark.asyncio
     async def test_delete_no_saves(self, tmp_path):
@@ -1529,7 +1519,7 @@ class TestEmulatorTag:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -1545,7 +1535,7 @@ class TestEmulatorTag:
     def test_upload_uses_fallback_when_no_core(self, tmp_path):
         """When core resolver returns None, upload falls back to 'retroarch'."""
         svc, fake = make_service(tmp_path)  # default: get_active_core returns (None, None)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -1579,36 +1569,40 @@ class TestEmulatorTag:
         _create_save(tmp_path, system="gba", rom_name="game1")
         _create_save(tmp_path, system="gba", rom_name="game2")
 
-        svc._save_sync_state["saves"]["1"] = {
-            "files": {"game1.srm": {}},
-            "active_slot": "desktop",
-            "slot_confirmed": True,
-            "emulator": "retroarch-mgba",
-            "system": "gba",
-        }
-        svc._save_sync_state["saves"]["2"] = {
-            "files": {"game2.srm": {}},
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "own_upload_ids": ["save-x"],
-            "system": "gba",
-        }
+        svc._save_sync_state.saves["1"] = RomSaveState.from_dict(
+            {
+                "files": {"game1.srm": {}},
+                "active_slot": "desktop",
+                "slot_confirmed": True,
+                "emulator": "retroarch-mgba",
+                "system": "gba",
+            }
+        )
+        svc._save_sync_state.saves["2"] = RomSaveState.from_dict(
+            {
+                "files": {"game2.srm": {}},
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "own_upload_ids": ["save-x"],
+                "system": "gba",
+            }
+        )
 
         result = svc.delete_platform_saves("gba")
         assert result["success"] is True
         assert result["deleted_count"] == 2
 
-        entry1 = svc._save_sync_state["saves"]["1"]
-        assert entry1["files"] == {}
-        assert entry1["active_slot"] == "desktop"
-        assert entry1["slot_confirmed"] is True
-        assert entry1["emulator"] == "retroarch-mgba"
+        entry1 = svc._save_sync_state.saves["1"]
+        assert entry1.files == {}
+        assert entry1.active_slot == "desktop"
+        assert entry1.slot_confirmed is True
+        assert entry1.emulator == "retroarch-mgba"
 
-        entry2 = svc._save_sync_state["saves"]["2"]
-        assert entry2["files"] == {}
-        assert entry2["active_slot"] == "default"
-        assert entry2["slot_confirmed"] is True
-        assert entry2["own_upload_ids"] == ["save-x"]
+        entry2 = svc._save_sync_state.saves["2"]
+        assert entry2.files == {}
+        assert entry2.active_slot == "default"
+        assert entry2.slot_confirmed is True
+        assert entry2.own_upload_ids == ["save-x"]
 
     @pytest.mark.asyncio
     async def test_delete_platform_saves_other_platform_untouched(self, tmp_path):
@@ -1618,20 +1612,22 @@ class TestEmulatorTag:
         _create_save(tmp_path, system="gba", rom_name="game1")
         snes_save = _create_save(tmp_path, system="snes", rom_name="game2")
 
-        svc._save_sync_state["saves"]["2"] = {
-            "files": {"game2.srm": {}},
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "system": "snes",
-        }
+        svc._save_sync_state.saves["2"] = RomSaveState.from_dict(
+            {
+                "files": {"game2.srm": {}},
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "system": "snes",
+            }
+        )
 
         svc.delete_platform_saves("gba")
         assert snes_save.exists()
         # Other-platform entry must be entirely untouched.
-        snes_entry = svc._save_sync_state["saves"]["2"]
-        assert snes_entry["files"] == {"game2.srm": {}}
-        assert snes_entry["active_slot"] == "default"
-        assert snes_entry["slot_confirmed"] is True
+        snes_entry = svc._save_sync_state.saves["2"]
+        assert "game2.srm" in snes_entry.files
+        assert snes_entry.active_slot == "default"
+        assert snes_entry.slot_confirmed is True
 
 
 # ---------------------------------------------------------------------------
@@ -2065,10 +2061,10 @@ class TestUpdateFileSyncState:
 
         svc._sync_engine._update_file_sync_state("42", "pokemon.srm", server_resp, str(save_file), "gba")
 
-        entry = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert entry["last_sync_hash"] == svc._file_md5(str(save_file))
-        assert entry["last_sync_at"] is not None
-        assert entry["last_sync_server_save_id"] == 200
+        entry = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert entry.last_sync_hash == svc._file_md5(str(save_file))
+        assert entry.last_sync_at is not None
+        assert entry.last_sync_server_save_id == 200
 
     def test_creates_entry_with_new_fields(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -2085,26 +2081,28 @@ class TestUpdateFileSyncState:
             core_so="mgba_libretro",
         )
 
-        game_state = svc._save_sync_state["saves"]["42"]
-        assert game_state["emulator"] == "retroarch-mgba"
-        assert game_state["last_synced_core"] == "mgba_libretro"
-        assert game_state["active_slot"] == "default"
+        game_state = svc._save_sync_state.saves["42"]
+        assert game_state.emulator == "retroarch-mgba"
+        assert game_state.last_synced_core == "mgba_libretro"
+        assert game_state.active_slot == "default"
 
-        file_state = game_state["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 200
-        assert file_state["last_sync_server_save_id"] == 200
+        file_state = game_state.files["pokemon.srm"]
+        assert file_state.tracked_save_id == 200
+        assert file_state.last_sync_server_save_id == 200
 
     def test_updates_emulator_on_existing_entry(self, tmp_path):
         svc, _ = make_service(tmp_path)
         save_file = _create_save(tmp_path)
         # Pre-populate with old emulator tag
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},
-            "emulator": "retroarch",
-            "system": "gba",
-            "last_synced_core": None,
-            "active_slot": "default",
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},
+                "emulator": "retroarch",
+                "system": "gba",
+                "last_synced_core": None,
+                "active_slot": "default",
+            }
+        )
         server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}
 
         svc._sync_engine._update_file_sync_state(
@@ -2117,21 +2115,23 @@ class TestUpdateFileSyncState:
             core_so="mgba_libretro",
         )
 
-        game_state = svc._save_sync_state["saves"]["42"]
-        assert game_state["emulator"] == "retroarch-mgba"
-        assert game_state["last_synced_core"] == "mgba_libretro"
+        game_state = svc._save_sync_state.saves["42"]
+        assert game_state.emulator == "retroarch-mgba"
+        assert game_state.last_synced_core == "mgba_libretro"
 
     def test_core_so_none_does_not_overwrite(self, tmp_path):
         """core_so=None should not reset an already-set last_synced_core."""
         svc, _ = make_service(tmp_path)
         save_file = _create_save(tmp_path)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},
-            "emulator": "retroarch-mgba",
-            "system": "gba",
-            "last_synced_core": "mgba_libretro",
-            "active_slot": "default",
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},
+                "emulator": "retroarch-mgba",
+                "system": "gba",
+                "last_synced_core": "mgba_libretro",
+                "active_slot": "default",
+            }
+        )
         server_resp = {"id": 200, "updated_at": "2026-02-17T15:00:00Z"}
 
         svc._sync_engine._update_file_sync_state(
@@ -2144,8 +2144,8 @@ class TestUpdateFileSyncState:
         )
 
         # last_synced_core unchanged because core_so=None
-        game_state = svc._save_sync_state["saves"]["42"]
-        assert game_state["last_synced_core"] == "mgba_libretro"
+        game_state = svc._save_sync_state.saves["42"]
+        assert game_state.last_synced_core == "mgba_libretro"
 
     def test_writes_last_sync_local_mtime_as_float(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -2155,9 +2155,9 @@ class TestUpdateFileSyncState:
 
         svc._sync_engine._update_file_sync_state("42", "pokemon.srm", server_response, local_path, "gba")
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert isinstance(file_state["last_sync_local_mtime"], float)
-        assert file_state["last_sync_local_mtime"] == pytest.approx(os.path.getmtime(local_path))
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert isinstance(file_state.last_sync_local_mtime, float)
+        assert file_state.last_sync_local_mtime == pytest.approx(os.path.getmtime(local_path))
 
     def test_writes_last_sync_local_size_as_int(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -2167,9 +2167,9 @@ class TestUpdateFileSyncState:
 
         svc._sync_engine._update_file_sync_state("42", "pokemon.srm", server_response, local_path, "gba")
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert isinstance(file_state["last_sync_local_size"], int)
-        assert file_state["last_sync_local_size"] == 2048
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert isinstance(file_state.last_sync_local_size, int)
+        assert file_state.last_sync_local_size == 2048
 
     def test_does_not_write_old_local_mtime_at_last_sync_key(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -2179,8 +2179,10 @@ class TestUpdateFileSyncState:
 
         svc._sync_engine._update_file_sync_state("42", "pokemon.srm", server_response, local_path, "gba")
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert "local_mtime_at_last_sync" not in file_state
+        # The legacy field name was never part of FileSyncState; ensure the
+        # serialised on-disk shape doesn't carry it either.
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert "local_mtime_at_last_sync" not in file_state.to_dict()
 
     def test_writes_none_for_missing_file(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -2189,9 +2191,9 @@ class TestUpdateFileSyncState:
 
         svc._sync_engine._update_file_sync_state("42", "missing.srm", server_response, local_path, "gba")
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["missing.srm"]
-        assert file_state["last_sync_local_mtime"] is None
-        assert file_state["last_sync_local_size"] is None
+        file_state = svc._save_sync_state.saves["42"].files["missing.srm"]
+        assert file_state.last_sync_local_mtime is None
+        assert file_state.last_sync_local_size is None
 
 
 # ---------------------------------------------------------------------------
@@ -2204,14 +2206,14 @@ class TestPruneOrphanedEdgeCase:
 
     def test_empty_state_no_crash(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"] = {}
-        svc._save_sync_state["playtime"] = {}
+        svc._save_sync_state.saves = {}
+        svc._save_sync_state.playtime = {}
         svc._state["shortcut_registry"] = {}
 
         svc.prune_orphaned_state()  # should not raise
 
-        assert svc._save_sync_state["saves"] == {}
-        assert svc._save_sync_state["playtime"] == {}
+        assert svc._save_sync_state.saves == {}
+        assert svc._save_sync_state.playtime == {}
 
 
 # ---------------------------------------------------------------------------
@@ -2226,14 +2228,16 @@ class TestStateBackwardCompat:
         """Existing state files without server_device_id should load without errors."""
         svc, _ = make_service(tmp_path)
         # Simulate old state without server_device_id
-        svc._save_sync_state["device_id"] = "old-local-uuid"
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
-            "emulator": "retroarch",
-            "system": "gba",
-        }
+        svc._save_sync_state.device_id = "old-local-uuid"
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
+                "emulator": "retroarch",
+                "system": "gba",
+            }
+        )
         # Remove the new field to simulate an old state file
-        del svc._save_sync_state["server_device_id"]
+        del svc._save_sync_state.server_device_id
         svc.save_state()
 
         # Reload into fresh service
@@ -2241,44 +2245,47 @@ class TestStateBackwardCompat:
         svc2.load_state()
 
         # New field should be None (from init_state default)
-        assert svc2._save_sync_state.get("server_device_id") is None
+        assert svc2._save_sync_state.server_device_id is None
         # Old data preserved
-        assert svc2._save_sync_state["device_id"] == "old-local-uuid"
-        assert "42" in svc2._save_sync_state["saves"]
+        assert svc2._save_sync_state.device_id == "old-local-uuid"
+        assert "42" in svc2._save_sync_state.saves
 
     def test_old_per_game_entry_missing_new_fields_works_via_get(self, tmp_path):
         """Per-game entries without last_synced_core/active_slot still work via .get()."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["device_id"] = "old-local-uuid"
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
-            "emulator": "retroarch",
-            "system": "gba",
-        }
+        svc._save_sync_state.device_id = "old-local-uuid"
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"last_sync_hash": "abc123"}},
+                "emulator": "retroarch",
+                "system": "gba",
+            }
+        )
         svc.save_state()
 
         svc2, _ = make_service(tmp_path)
         svc2.load_state()
 
-        game_state = svc2._save_sync_state["saves"]["42"]
-        assert game_state.get("last_synced_core") is None
-        assert game_state.get("active_slot", "default") == "default"
+        game_state = svc2._save_sync_state.saves["42"]
+        assert game_state.last_synced_core is None
+        # Missing ``active_slot`` defaults to None on the typed aggregate;
+        # callers fall back to the global default_slot when they need a value.
+        assert game_state.active_slot is None
 
     def test_make_default_state_includes_server_device_id(self):
         """make_default_state() must include server_device_id field."""
         state = SaveService.make_default_state()
-        assert "server_device_id" in state
-        assert state["server_device_id"] is None
+        assert state.server_device_id is None
 
     def test_load_state_restores_server_device_id(self, tmp_path):
         """server_device_id saved to disk is restored on load_state."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "romm-server-uuid"
+        svc._save_sync_state.server_device_id = "romm-server-uuid"
         svc.save_state()
 
         svc2, _ = make_service(tmp_path)
         svc2.load_state()
-        assert svc2._save_sync_state["server_device_id"] == "romm-server-uuid"
+        assert svc2._save_sync_state.server_device_id == "romm-server-uuid"
 
     def test_state_stores_emulator_tag_and_core(self, tmp_path):
         """After upload sync, state should contain emulator tag and core info."""
@@ -2286,20 +2293,20 @@ class TestStateBackwardCompat:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
         svc._sync_engine._do_upload_save(42, str(save_path), "pokemon.srm", "42", "gba")
 
-        game_state = svc._save_sync_state["saves"]["42"]
-        assert game_state["emulator"] == "retroarch-mgba"
-        assert game_state["last_synced_core"] == "mgba_libretro"
-        assert game_state.get("active_slot") == "default"
+        game_state = svc._save_sync_state.saves["42"]
+        assert game_state.emulator == "retroarch-mgba"
+        assert game_state.last_synced_core == "mgba_libretro"
+        assert game_state.active_slot == "default"
 
         # Per-file should have tracked_save_id
-        file_state = game_state["files"]["pokemon.srm"]
-        assert file_state.get("tracked_save_id") is not None
+        file_state = game_state.files["pokemon.srm"]
+        assert file_state.tracked_save_id is not None
 
     def test_download_sets_tracked_save_id_in_file_state(self, tmp_path):
         """After download sync, per-file state should contain tracked_save_id."""
@@ -2310,9 +2317,9 @@ class TestStateBackwardCompat:
 
         svc._sync_engine._do_download_save(server_save, saves_dir, "pokemon.srm", "42", "gba")
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state.get("tracked_save_id") == 99
-        assert file_state.get("last_sync_server_save_id") == 99
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 99
+        assert file_state.last_sync_server_save_id == 99
 
 
 # ---------------------------------------------------------------------------
@@ -2324,9 +2331,9 @@ class TestV47SyncFlow:
     def test_list_saves_passes_device_id(self, tmp_path):
         """v4.7: list_saves receives server_device_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "local-id"
-        svc._save_sync_state["server_device_id"] = "server-dev-123"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "local-id"
+        svc._save_sync_state.server_device_id = "server-dev-123"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -2339,9 +2346,9 @@ class TestV47SyncFlow:
     def test_upload_passes_device_id_and_slot(self, tmp_path):
         """v4.7: upload_save receives device_id and slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "local-id"
-        svc._save_sync_state["server_device_id"] = "server-dev-123"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "local-id"
+        svc._save_sync_state.server_device_id = "server-dev-123"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -2355,24 +2362,26 @@ class TestV47SyncFlow:
     def test_v47_skip_when_is_current(self, tmp_path):
         """v4.7: server says is_current=True, local unchanged → skip."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         content = b"same content"
         _create_save(tmp_path, content=content)
         local_hash = hashlib.md5(content).hexdigest()
 
         # Pre-populate sync state (simulating previous sync)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
-                    "last_sync_server_save_id": 100,
-                    "last_sync_server_size": len(content),
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                        "last_sync_server_save_id": 100,
+                        "last_sync_server_size": len(content),
+                    }
                 }
             }
-        }
+        )
 
         # Set up server save with device_syncs showing is_current=True
         fake.saves[100] = {
@@ -2392,23 +2401,25 @@ class TestV47SyncFlow:
     def test_v47_download_when_not_current(self, tmp_path):
         """v4.7: server says is_current=False, local unchanged → download."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         content = b"old content"
         _create_save(tmp_path, content=content)
         local_hash = hashlib.md5(content).hexdigest()
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
-                    "last_sync_server_save_id": 100,
-                    "last_sync_server_size": len(content),
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2026-02-17T06:00:00Z",
+                        "last_sync_server_save_id": 100,
+                        "last_sync_server_size": len(content),
+                    }
                 }
             }
-        }
+        )
 
         # Server has newer save, device is not current
         fake.saves[100] = {
@@ -2447,7 +2458,7 @@ class TestConfirmDownloadAfterSync:
     def test_do_upload_save_post_calls_confirm_download(self, tmp_path):
         """POST (no save_id) → confirm_download fires for the new save_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -2465,7 +2476,7 @@ class TestConfirmDownloadAfterSync:
     def test_do_upload_save_put_calls_confirm_download(self, tmp_path):
         """PUT (existing save_id) → confirm_download fires for that save_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -2499,7 +2510,7 @@ class TestConfirmDownloadAfterSync:
     def test_do_upload_save_swallows_confirm_download_error(self, tmp_path):
         """confirm_download failure must NOT bubble — upload is reported successful."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -2521,8 +2532,8 @@ class TestConfirmDownloadAfterSync:
         confirm_calls = [c for c in fake.call_log if c[0] == "confirm_download"]
         assert len(confirm_calls) == 1
         # File state still recorded the upload (not blocked by confirm failure)
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state.get("tracked_save_id") is not None
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id is not None
 
     def test_do_download_save_passes_device_id_and_optimistic(self, tmp_path):
         """download_save_content must pass device_id + optimistic=True so the
@@ -2530,7 +2541,7 @@ class TestConfirmDownloadAfterSync:
         follow-up confirm_download unnecessary for the download path.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         saves_dir = str(tmp_path / "saves" / "gba")
         os.makedirs(saves_dir, exist_ok=True)
         server_save = _server_save(save_id=99)
@@ -2549,15 +2560,15 @@ class TestSaveSyncSettingsSlotAndCleanup:
 
     def test_update_default_slot(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         result = svc.update_save_sync_settings({"default_slot": "desktop"})
         assert result["success"] is True
         assert result["settings"]["default_slot"] == "desktop"
 
     def test_update_default_slot_empty_string_becomes_none(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["settings"]["default_slot"] = "default"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.settings.default_slot = "default"
         result = svc.update_save_sync_settings({"default_slot": ""})
         assert result["settings"]["default_slot"] is None
 
@@ -2594,14 +2605,14 @@ class TestSaveSyncSettingsSlotAndCleanup:
 
     def test_update_autocleanup_limit(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         result = svc.update_save_sync_settings({"autocleanup_limit": 5})
         assert result["success"] is True
         assert result["settings"]["autocleanup_limit"] == 5
 
     def test_update_autocleanup_limit_clamped(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         result = svc.update_save_sync_settings({"autocleanup_limit": 0})
         assert result["settings"]["autocleanup_limit"] == 1
 
@@ -2618,9 +2629,9 @@ class TestSaveSlots:
     @pytest.mark.asyncio
     async def test_get_save_slots(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "server-dev-1"
 
         fake.saves[1] = {
             "id": 1,
@@ -2646,9 +2657,9 @@ class TestSaveSlots:
     async def test_get_save_slots_latest_updated_at_from_server(self, tmp_path):
         """latest_updated_at is populated from nested latest.updated_at, not a flat key."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "server-dev-1"
 
         # Two saves in the default slot; the later one should win.
         fake.saves[1] = {
@@ -2672,7 +2683,7 @@ class TestSaveSlots:
         assert slot["latest_updated_at"] == "2026-04-17T20:00:00"
 
         # Also verify the value is persisted in state (not None)
-        persisted = svc._save_sync_state["saves"]["123"]["slots"]["default"]
+        persisted = svc._save_sync_state.saves["123"].slots["default"]
         assert persisted["latest_updated_at"] == "2026-04-17T20:00:00"
 
     @pytest.mark.asyncio
@@ -2683,20 +2694,18 @@ class TestSaveSlots:
 
     def test_set_active_slot(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"] = {
-            "123": {"system": "gba", "active_slot": "default", "files": {}},
-        }
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["123"] = RomSaveState(system="gba", active_slot="default")
         result = svc._slots._set_active_slot(123, "desktop")
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["123"]["active_slot"] == "desktop"
+        assert svc._save_sync_state.saves["123"].active_slot == "desktop"
 
     def test_set_active_slot_creates_entry(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         result = svc._slots._set_active_slot(456, "my-slot")
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["456"]["active_slot"] == "my-slot"
+        assert svc._save_sync_state.saves["456"].active_slot == "my-slot"
 
     def test_set_active_slot_empty_sets_none(self, tmp_path):
         """Empty string sets active_slot to None (legacy mode)."""
@@ -2704,7 +2713,7 @@ class TestSaveSlots:
         result = svc._slots._set_active_slot(123, "")
         assert result["success"] is True
         assert result["active_slot"] is None
-        assert svc._save_sync_state["saves"]["123"]["active_slot"] is None
+        assert svc._save_sync_state.saves["123"].active_slot is None
 
     @pytest.mark.asyncio
     async def test_set_active_slot_triggers_background_check(self, tmp_path):
@@ -2739,29 +2748,33 @@ class TestSaveTrackingConfigured:
 
     def test_configured_after_setting_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"]["42"] = {
-            "slot_confirmed": True,
-            "active_slot": "default",
-            "files": {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "slot_confirmed": True,
+                "active_slot": "default",
+                "files": {},
+            }
+        )
         result = svc.is_save_tracking_configured(42)
         assert result["configured"] is True
         assert result["active_slot"] == "default"
 
     def test_not_configured_when_slot_confirmed_false(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"]["42"] = {
-            "slot_confirmed": False,
-            "active_slot": "default",
-            "files": {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "slot_confirmed": False,
+                "active_slot": "default",
+                "files": {},
+            }
+        )
         result = svc.is_save_tracking_configured(42)
         assert result["configured"] is False
         assert result["active_slot"] is None
 
     def test_handles_missing_saves_section(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"] = {}
+        svc._save_sync_state.saves = {}
         result = svc.is_save_tracking_configured(999)
         assert result["configured"] is False
 
@@ -2776,8 +2789,8 @@ class TestGetSaveSetupInfo:
     async def test_scenario_a_no_local_server_has_saves(self, tmp_path):
         """Scenario A: No local save, server has saves."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # Don't create local save
         fake.saves[1] = _server_save(save_id=1, slot=None)
@@ -2795,8 +2808,8 @@ class TestGetSaveSetupInfo:
     async def test_scenario_b_local_no_server(self, tmp_path):
         """Scenario B: Local save exists, no server saves."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -2811,8 +2824,8 @@ class TestGetSaveSetupInfo:
     async def test_scenario_c_local_and_server_different_slots(self, tmp_path):
         """Scenario C: Local save, server has saves in different slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot="desktop")
@@ -2827,8 +2840,8 @@ class TestGetSaveSetupInfo:
     async def test_scenario_e_local_and_server_same_default_slot(self, tmp_path):
         """Scenario E: Local save, server has saves in default slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot="default")
@@ -2843,13 +2856,15 @@ class TestGetSaveSetupInfo:
     async def test_already_confirmed(self, tmp_path):
         """When slot is already confirmed, report it."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["saves"]["42"] = {
-            "slot_confirmed": True,
-            "active_slot": "desktop",
-            "files": {},
-        }
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "slot_confirmed": True,
+                "active_slot": "desktop",
+                "files": {},
+            }
+        )
         _install_rom(svc, tmp_path)
 
         result = await svc.get_save_setup_info(42)
@@ -2860,8 +2875,8 @@ class TestGetSaveSetupInfo:
     async def test_multiple_server_slots(self, tmp_path):
         """Server saves across multiple slots are grouped correctly."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot="default")
         fake.saves[2] = _server_save(save_id=2, slot="desktop", filename="pokemon.srm")
@@ -2875,8 +2890,8 @@ class TestGetSaveSetupInfo:
     async def test_server_error_returns_empty_slots(self, tmp_path):
         """Server API failure still returns local info with empty server_slots."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.fail_on_next(RommApiError(500, "Server error"))
@@ -2889,7 +2904,7 @@ class TestGetSaveSetupInfo:
     async def test_no_rom_installed(self, tmp_path):
         """No installed ROM means no local files."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # Don't install any ROM
         result = await svc.get_save_setup_info(42)
         assert result["has_local_saves"] is False
@@ -2905,12 +2920,12 @@ class TestConfirmSlotChoice:
     @pytest.mark.asyncio
     async def test_confirm_sets_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         result = await svc.confirm_slot_choice(42, "default")
         assert result["success"] is True
-        state = svc._save_sync_state["saves"]["42"]
-        assert state["slot_confirmed"] is True
-        assert state["active_slot"] == "default"
+        state = svc._save_sync_state.saves["42"]
+        assert state.slot_confirmed is True
+        assert state.active_slot == "default"
 
     @pytest.mark.asyncio
     async def test_confirm_empty_slot_rejected(self, tmp_path):
@@ -2928,17 +2943,19 @@ class TestConfirmSlotChoice:
     @pytest.mark.asyncio
     async def test_confirm_preserves_existing_files_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
-            "active_slot": "old",
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
+                "active_slot": "old",
+            }
+        )
         result = await svc.confirm_slot_choice(42, "new-slot")
         assert result["success"] is True
-        state = svc._save_sync_state["saves"]["42"]
-        assert state["active_slot"] == "new-slot"
-        assert state["slot_confirmed"] is True
+        state = svc._save_sync_state.saves["42"]
+        assert state.active_slot == "new-slot"
+        assert state.slot_confirmed is True
         # Existing files state preserved
-        assert state["files"]["pokemon.srm"]["last_sync_hash"] == "abc"
+        assert state.files["pokemon.srm"].last_sync_hash == "abc"
 
     @pytest.mark.asyncio
     async def test_confirm_persists_to_disk(self, tmp_path):
@@ -2962,9 +2979,9 @@ class TestConfirmSlotChoice:
         where the legacy ``None`` semantics still live.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         # Old save on server with slot=None (legacy)
@@ -2986,9 +3003,9 @@ class TestConfirmSlotChoice:
     async def test_confirm_migration_no_old_saves(self, tmp_path):
         """Migration with no matching old saves is a no-op."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         # Server save is in "default" slot, but we're migrating from "desktop"
@@ -3011,9 +3028,9 @@ class TestConfirmSlotChoice:
         semantics live on the slots service.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot=None)
@@ -3028,15 +3045,15 @@ class TestConfirmSlotChoice:
         assert result["success"] is True
         assert "migration failed" in result["message"].lower()
         # Slot is still confirmed despite migration failure
-        assert svc._save_sync_state["saves"]["42"]["slot_confirmed"] is True
+        assert svc._save_sync_state.saves["42"].slot_confirmed is True
 
     @pytest.mark.asyncio
     async def test_facade_translates_none_to_no_migration(self, tmp_path):
         """Facade: ``None`` for ``migrate_from_slot`` skips migration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot=None)
@@ -3048,15 +3065,15 @@ class TestConfirmSlotChoice:
         assert len(upload_calls) == 0
         delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
         assert len(delete_calls) == 0
-        assert svc._save_sync_state["saves"]["42"]["slot_confirmed"] is True
+        assert svc._save_sync_state.saves["42"].slot_confirmed is True
 
     @pytest.mark.asyncio
     async def test_facade_translates_no_migration_string_to_no_migration(self, tmp_path):
         """Facade: ``"__no_migration__"`` string (from frontend) skips migration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot=None)
@@ -3068,7 +3085,7 @@ class TestConfirmSlotChoice:
         assert len(upload_calls) == 0
         delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
         assert len(delete_calls) == 0
-        assert svc._save_sync_state["saves"]["42"]["slot_confirmed"] is True
+        assert svc._save_sync_state.saves["42"].slot_confirmed is True
 
     @pytest.mark.asyncio
     async def test_is_configured_after_confirm(self, tmp_path):
@@ -3092,8 +3109,8 @@ class TestTrackedSaveIdMatching:
     def test_timestamp_server_save_not_treated_as_separate_download(self, tmp_path):
         """Server save matched by tracked_save_id should not appear as server-only download."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -3108,22 +3125,24 @@ class TestTrackedSaveIdMatching:
             "download_path": "/saves/pokemon [2026-03-24_15-18-50].srm",
         }
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 42,
-                    "last_sync_hash": local_hash,
-                    "last_sync_at": "2026-03-20T10:00:00",
-                    "last_sync_server_updated_at": "2026-03-20T10:00:00",
-                    "last_sync_server_save_id": 42,
-                    "last_sync_server_size": 1024,
-                    "local_mtime_at_last_sync": "2026-03-20T10:00:00",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 42,
+                        "last_sync_hash": local_hash,
+                        "last_sync_at": "2026-03-20T10:00:00",
+                        "last_sync_server_updated_at": "2026-03-20T10:00:00",
+                        "last_sync_server_save_id": 42,
+                        "last_sync_server_size": 1024,
+                        "local_mtime_at_last_sync": "2026-03-20T10:00:00",
+                    },
                 },
-            },
-        }
+            }
+        )
 
         # Sync should NOT download the timestamp-named file as a new server-only save
         _synced, errors, _conflicts = svc._sync_engine._sync_rom_saves(42)
@@ -3136,8 +3155,8 @@ class TestTrackedSaveIdMatching:
     async def test_get_save_status_uses_tracked_save_id(self, tmp_path):
         """get_save_status should not show timestamp-named server save as separate file."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -3151,22 +3170,24 @@ class TestTrackedSaveIdMatching:
             "download_path": "/saves/pokemon [2026-03-24_15-18-50].srm",
         }
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 42,
-                    "last_sync_hash": hashlib.md5(b"\x00" * 1024).hexdigest(),
-                    "last_sync_at": "2026-03-20T10:00:00",
-                    "last_sync_server_updated_at": "2026-03-20T10:00:00",
-                    "last_sync_server_save_id": 42,
-                    "last_sync_server_size": 1024,
-                    "local_mtime_at_last_sync": "2026-03-20T10:00:00",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 42,
+                        "last_sync_hash": hashlib.md5(b"\x00" * 1024).hexdigest(),
+                        "last_sync_at": "2026-03-20T10:00:00",
+                        "last_sync_server_updated_at": "2026-03-20T10:00:00",
+                        "last_sync_server_save_id": 42,
+                        "last_sync_server_size": 1024,
+                        "local_mtime_at_last_sync": "2026-03-20T10:00:00",
+                    },
                 },
-            },
-        }
+            }
+        )
 
         result = await svc.get_save_status(42)
         filenames = [f["filename"] for f in result["files"]]
@@ -3179,8 +3200,8 @@ class TestTrackedSaveIdMatching:
     async def test_status_fallback_matches_newest_no_phantom_downloads(self, tmp_path):
         """Status with no tracked_save_id matches newest server save, no phantom downloads."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -3205,12 +3226,14 @@ class TestTrackedSaveIdMatching:
             "slot": "default",
         }
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {},
+            }
+        )
 
         result = await svc.get_save_status(42)
         filenames = [f["filename"] for f in result["files"]]
@@ -3225,8 +3248,8 @@ class TestTrackedSaveIdMatching:
         """Case 2: no local file, server has multiple timestamped saves.
         Should download only the newest, saved as the correct local filename."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # NO local save created — Case 2
 
@@ -3245,12 +3268,14 @@ class TestTrackedSaveIdMatching:
                 "download_path": f"/saves/pokemon [2026-03-24_{ts}].srm",
             }
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {},
+            }
+        )
 
         synced, errors, _conflicts = svc._sync_engine._sync_rom_saves(42)
         assert len(errors) == 0
@@ -3270,8 +3295,8 @@ class TestTrackedSaveIdMatching:
     async def test_status_server_only_shows_local_filename(self, tmp_path):
         """Status display should show local filename for server-only saves, not timestamp."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # NO local save
 
@@ -3288,12 +3313,14 @@ class TestTrackedSaveIdMatching:
             "download_path": "/saves/pokemon [2026-03-24_15-19-26].srm",
         }
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {},
+            }
+        )
 
         result = await svc.get_save_status(42)
         filenames = [f["filename"] for f in result["files"]]
@@ -3307,8 +3334,8 @@ class TestOlderVersionSkipping:
     def test_different_slot_filtered_out(self, tmp_path):
         """Saves in a different slot should be filtered out entirely."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"local save")
 
@@ -3328,22 +3355,24 @@ class TestOlderVersionSkipping:
         )
 
         local_hash = _file_md5(tmp_path / "saves" / "gba" / "pokemon.srm")
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "slot_confirmed": True,
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 10,
-                    "last_sync_hash": local_hash,
-                    "last_sync_at": "2026-03-24T15:00:00",
-                    "last_sync_server_updated_at": "2026-03-24T15:00:00",
-                    "last_sync_server_save_id": 10,
-                    "last_sync_server_size": 1024,
-                    "local_mtime_at_last_sync": "2026-03-24T15:00:00",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 10,
+                        "last_sync_hash": local_hash,
+                        "last_sync_at": "2026-03-24T15:00:00",
+                        "last_sync_server_updated_at": "2026-03-24T15:00:00",
+                        "last_sync_server_save_id": 10,
+                        "last_sync_server_size": 1024,
+                        "local_mtime_at_last_sync": "2026-03-24T15:00:00",
+                    },
                 },
-            },
-        }
+            }
+        )
 
         _synced, _errors, _conflicts = svc._sync_engine._sync_rom_saves(42)
         # pokemon [old].srm in slot=portable is filtered out — no download
@@ -3364,14 +3393,13 @@ class TestCheckCoreChange:
         system="snes",
         last_synced_core: str | None = "snes9x_libretro",
         active_slot="default",
-    ):
+    ) -> RomSaveState:
         """Return a minimal save state entry for rom_id 42."""
-        return {
-            "system": system,
-            "last_synced_core": last_synced_core,
-            "active_slot": active_slot,
-            "files": {},
-        }
+        return RomSaveState(
+            system=system,
+            last_synced_core=last_synced_core,
+            active_slot=active_slot,
+        )
 
     def test_core_changed(self, tmp_path):
         """Returns changed=True with core names when active core differs from stored."""
@@ -3379,8 +3407,8 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("supafaust_libretro", "Supafaust"),
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
         )
@@ -3399,8 +3427,8 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
         )
@@ -3412,7 +3440,7 @@ class TestCheckCoreChange:
     def test_never_synced(self, tmp_path):
         """Returns changed=False when rom_id has no save entry (never synced)."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # No entry for rom_id 42
 
         result = svc.check_core_change(42)
@@ -3425,8 +3453,8 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core=None,
         )
@@ -3441,8 +3469,8 @@ class TestCheckCoreChange:
             tmp_path,
             # default: get_active_core returns (None, None)
         )
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
         )
@@ -3458,7 +3486,7 @@ class TestCheckCoreChange:
             get_active_core=lambda system_name, rom_filename=None: ("supafaust_libretro", "Supafaust"),
         )
         # save_sync_enabled defaults to False
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(
+        svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
         )
@@ -3476,8 +3504,8 @@ class TestCheckCoreChange:
             return ("supafaust_libretro", "Supafaust")
 
         svc, _ = make_service(tmp_path, get_active_core=capture_core)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["saves"]["42"] = self._make_save_entry(system="snes")
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.saves["42"] = self._make_save_entry(system="snes")
         _install_rom(svc, tmp_path, rom_id=42, system="snes", file_name="mario.sfc")
 
         svc.check_core_change(42)
@@ -3498,8 +3526,8 @@ class TestGetSlotSaves:
     async def test_happy_path(self, tmp_path):
         """Returns mapped save dicts for the requested slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "server-dev-1"
 
         fake.saves[1] = {
             "id": 1,
@@ -3537,8 +3565,8 @@ class TestGetSlotSaves:
     async def test_empty_slot(self, tmp_path):
         """Returns empty saves list when server has no saves for the slot."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "server-dev-1"
         # No saves added to fake
 
         result = await svc.get_slot_saves(42, "desktop")
@@ -3551,8 +3579,8 @@ class TestGetSlotSaves:
     async def test_server_error(self, tmp_path):
         """Returns error response when list_saves raises an exception."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.server_device_id = "server-dev-1"
         fake.fail_on_next(RommApiError("connection timeout"))
 
         result = await svc.get_slot_saves(42, "default")
@@ -3584,34 +3612,34 @@ class TestGetSlotSaves:
 class TestSwitchSlot:
     """Tests for SaveService.switch_slot — guarded slot switch with immediate download."""
 
-    def _synced_state(self, local_hash: str, save_id: int = 100) -> dict:
-        """Return a save state dict where the file appears fully synced."""
-        return {
-            "files": {
-                "pokemon.srm": {
-                    "last_sync_hash": local_hash,
-                    "last_sync_at": "2026-01-01T00:00:00Z",
-                    "last_sync_server_updated_at": "2026-01-01T00:00:00Z",
-                    "last_sync_server_save_id": save_id,
-                    "last_sync_server_size": 1024,
-                    "tracked_save_id": save_id,
-                },
+    def _synced_state(self, local_hash: str, save_id: int = 100) -> RomSaveState:
+        """Return a save state where the file appears fully synced."""
+        return RomSaveState(
+            active_slot="default",
+            slot_confirmed=True,
+            files={
+                "pokemon.srm": FileSyncState(
+                    last_sync_hash=local_hash,
+                    last_sync_at="2026-01-01T00:00:00Z",
+                    last_sync_server_updated_at="2026-01-01T00:00:00Z",
+                    last_sync_server_save_id=save_id,
+                    last_sync_server_size=1024,
+                    tracked_save_id=save_id,
+                ),
             },
-            "active_slot": "default",
-            "slot_confirmed": True,
-        }
+        )
 
     @pytest.mark.asyncio
     async def test_happy_path(self, tmp_path):
         """Files fully synced + server has saves in new slot → downloads and returns success."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
 
         # Slot already synced — hash matches
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
 
         # Server has a save in "desktop" slot
         fake.saves[200] = _server_save(save_id=200, slot="desktop")
@@ -3621,7 +3649,7 @@ class TestSwitchSlot:
         assert result["success"] is True
         assert "save_status" in result
         # active_slot was updated
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] == "desktop"
+        assert svc._save_sync_state.saves["42"].active_slot == "desktop"
         # The server save was downloaded
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert len(download_calls) >= 1
@@ -3630,23 +3658,25 @@ class TestSwitchSlot:
     async def test_pending_uploads_blocked(self, tmp_path):
         """Local file changed since last sync → switch blocked with reason + file list."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"modified save data")
 
         # State records an *old* hash — hash mismatch simulates pending upload
         old_hash = hashlib.md5(b"original save data").hexdigest()
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "last_sync_hash": old_hash,
-                    "last_sync_at": "2026-01-01T00:00:00Z",
-                    "tracked_save_id": 100,
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "last_sync_hash": old_hash,
+                        "last_sync_at": "2026-01-01T00:00:00Z",
+                        "tracked_save_id": 100,
+                    },
                 },
-            },
-            "active_slot": "default",
-            "slot_confirmed": True,
-        }
+                "active_slot": "default",
+                "slot_confirmed": True,
+            }
+        )
 
         result = await svc.switch_slot(42, "desktop")
 
@@ -3665,16 +3695,18 @@ class TestSwitchSlot:
         After the switch to an empty slot the local file should be gone.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
         # State has the game entry but no last_sync_hash for the file
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},  # no entry for pokemon.srm at all
-            "active_slot": "default",
-            "slot_confirmed": True,
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},  # no entry for pokemon.srm at all
+                "active_slot": "default",
+                "slot_confirmed": True,
+            }
+        )
 
         # No server saves in "desktop" slot → switch succeeds and deletes local file
         result = await svc.switch_slot(42, "desktop")
@@ -3686,13 +3718,13 @@ class TestSwitchSlot:
     async def test_server_unreachable(self, tmp_path):
         """list_saves raises → switch blocked with reason=server_unreachable."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
 
         # Files synced so readiness check passes
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
 
         fake.fail_on_next(RommApiError(503, "Service unavailable"))
 
@@ -3718,7 +3750,7 @@ class TestSwitchSlot:
     async def test_not_installed(self, tmp_path):
         """ROM not installed → returns not_installed error."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # ROM 42 is NOT installed
 
         result = await svc.switch_slot(42, "desktop")
@@ -3730,13 +3762,13 @@ class TestSwitchSlot:
     async def test_empty_new_slot(self, tmp_path):
         """New slot has no saves on server → deletes local files and updates active_slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
 
         # Files synced so readiness check passes
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
 
         # Server has no saves in "newslot" (all fake saves are in other slots)
         fake.saves[300] = _server_save(save_id=300, slot="other")
@@ -3744,36 +3776,36 @@ class TestSwitchSlot:
         result = await svc.switch_slot(42, "newslot")
 
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] == "newslot"
+        assert svc._save_sync_state.saves["42"].active_slot == "newslot"
         # No downloads
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert len(download_calls) == 0
         # Local file deleted (fresh start for empty slot)
         assert not save_path.exists()
         # File tracking state cleared
-        assert svc._save_sync_state["saves"]["42"]["files"] == {}
+        assert svc._save_sync_state.saves["42"].files == {}
 
     @pytest.mark.asyncio
     async def test_empty_slot_deletes_local_files(self, tmp_path):
         """New slot is empty → local save files deleted and file tracking cleared."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
 
         # Current slot is fully synced
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
 
         # No server saves for "brand-new-slot"
         result = await svc.switch_slot(42, "brand-new-slot")
 
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] == "brand-new-slot"
+        assert svc._save_sync_state.saves["42"].active_slot == "brand-new-slot"
         # Local save file removed
         assert not save_path.exists()
         # File tracking state cleared so next play starts fresh
-        assert svc._save_sync_state["saves"]["42"]["files"] == {}
+        assert svc._save_sync_state.saves["42"].files == {}
         # No downloads happened
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert len(download_calls) == 0
@@ -3782,13 +3814,13 @@ class TestSwitchSlot:
     async def test_with_server_saves_downloads(self, tmp_path):
         """New slot has server saves → downloads them, replacing local file."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path, content=b"old local save")
         local_hash = _file_md5(str(save_path))
 
         # Current slot is fully synced
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
 
         # Target slot has a server save
         fake.saves[500] = _server_save(save_id=500, slot="target-slot")
@@ -3796,7 +3828,7 @@ class TestSwitchSlot:
         result = await svc.switch_slot(42, "target-slot")
 
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] == "target-slot"
+        assert svc._save_sync_state.saves["42"].active_slot == "target-slot"
         # Server save was downloaded (replaces local)
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert len(download_calls) >= 1
@@ -3805,34 +3837,36 @@ class TestSwitchSlot:
     async def test_no_local_files_is_ready(self, tmp_path):
         """ROM installed but no local save files → readiness check passes (nothing pending)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         # No save file created on disk
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},
-            "active_slot": "default",
-            "slot_confirmed": True,
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},
+                "active_slot": "default",
+                "slot_confirmed": True,
+            }
+        )
 
         fake.saves[100] = _server_save(save_id=100, slot="desktop")
 
         result = await svc.switch_slot(42, "desktop")
 
         assert result["success"] is True
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] == "desktop"
+        assert svc._save_sync_state.saves["42"].active_slot == "desktop"
 
     @pytest.mark.asyncio
     async def test_switch_to_legacy_slot(self, tmp_path):
         """switch_slot("") sets active_slot=None, persists "" in slots dict, returns success."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
 
         # Start in a named slot, fully synced
-        svc._save_sync_state["saves"]["42"] = self._synced_state(local_hash)
-        svc._save_sync_state["saves"]["42"]["active_slot"] = "default"
+        svc._save_sync_state.saves["42"] = self._synced_state(local_hash)
+        svc._save_sync_state.saves["42"].active_slot = "default"
 
         # Server has a legacy save (slot=None)
         fake.saves[200] = _server_save(save_id=200, slot=None)
@@ -3842,24 +3876,26 @@ class TestSwitchSlot:
         assert result["success"] is True
         assert "save_status" in result
         # active_slot in state is None (legacy)
-        assert svc._save_sync_state["saves"]["42"]["active_slot"] is None
+        assert svc._save_sync_state.saves["42"].active_slot is None
         # Legacy slot "" appears in the slots dict
-        slots_dict = svc._save_sync_state["saves"]["42"].get("slots", {})
+        slots_dict = svc._save_sync_state.saves["42"].slots
         assert "" in slots_dict
 
     @pytest.mark.asyncio
     async def test_legacy_slot_persisted_in_get_save_slots(self, tmp_path):
         """get_save_slots includes the "" entry when active_slot is None and "" is in slots dict."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         # Set up state with legacy slot explicitly
-        svc._save_sync_state["saves"]["99"] = {
-            "active_slot": None,
-            "slot_confirmed": True,
-            "files": {},
-            "slots": {"": {"source": "local", "count": 0, "latest_updated_at": None}},
-        }
+        svc._save_sync_state.saves["99"] = RomSaveState.from_dict(
+            {
+                "active_slot": None,
+                "slot_confirmed": True,
+                "files": {},
+                "slots": {"": {"source": "local", "count": 0, "latest_updated_at": None}},
+            }
+        )
 
         # Server returns no slots
         result = await svc.get_save_slots(99)
@@ -3875,9 +3911,9 @@ class TestSwitchSlot:
     async def test_server_legacy_save_maps_to_empty_string_not_default(self, tmp_path):
         """Server saves with slot=None (legacy) must map to "" not "default" in get_save_slots."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
 
         # Server has a legacy save with slot=None
         fake.saves[1] = {
@@ -3907,13 +3943,15 @@ class TestListFileVersions:
 
     def _setup_state(self, svc, tracked_id: int | None) -> None:
         """Populate save state with a tracked save id for rom 42, pokemon.srm."""
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "files": {
-                "pokemon.srm": {"tracked_save_id": tracked_id},
-            },
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {
+                    "pokemon.srm": {"tracked_save_id": tracked_id},
+                },
+            }
+        )
 
     @pytest.mark.asyncio
     async def test_happy_path_excludes_tracked(self, tmp_path):
@@ -4077,14 +4115,16 @@ class TestListFileVersions:
         fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-03-05T10:00:00Z")
         fake.saves[30] = _server_save(save_id=30, rom_id=42, slot="default", updated_at="2026-03-01T10:00:00Z")
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "own_upload_ids": [50],
-            "files": {
-                "pokemon.srm": {"tracked_save_id": 100},
-            },
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "own_upload_ids": [50],
+                "files": {
+                    "pokemon.srm": {"tracked_save_id": 100},
+                },
+            }
+        )
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
@@ -4101,14 +4141,16 @@ class TestListFileVersions:
         fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default", updated_at="2026-03-10T10:00:00Z")
         fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-03-05T10:00:00Z")
 
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            # own_upload_ids key intentionally absent — legacy state
-            "files": {
-                "pokemon.srm": {"tracked_save_id": 100},
-            },
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                # own_upload_ids key intentionally absent — legacy state
+                "files": {
+                    "pokemon.srm": {"tracked_save_id": 100},
+                },
+            }
+        )
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
@@ -4127,16 +4169,18 @@ class TestRollbackToVersion:
     def _setup_state(self, svc, tmp_path, tracked_id: int, last_sync_hash: str | None = None) -> None:
         _install_rom(svc, tmp_path)
         _enable_sync_with_device(svc)
-        svc._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": tracked_id,
-                    "last_sync_hash": last_sync_hash,
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": tracked_id,
+                        "last_sync_hash": last_sync_hash,
+                    },
                 },
-            },
-        }
+            }
+        )
 
     @staticmethod
     def _tracked_save(save_id: int, *, updated_at: str = "2026-03-10T10:00:00Z") -> dict:
@@ -4291,8 +4335,8 @@ class TestRollbackToVersion:
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert any(c[1][0] == 50 for c in download_calls)
         # State updated: tracked_save_id should now point to the rolled-back save
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 50
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 50
 
     @pytest.mark.asyncio
     async def test_no_local_file_pre_flight_downloads_then_switch_proceeds(self, tmp_path):
@@ -4374,7 +4418,7 @@ class TestRollbackToVersion:
         """Rollback marks our device as current on the target save via confirm_download."""
         svc, fake = make_service(tmp_path)
         # device_id must be set for confirm_download to fire
-        svc._save_sync_state["server_device_id"] = "device-1"
+        svc._save_sync_state.server_device_id = "device-1"
 
         _create_save(tmp_path)
         local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
@@ -4404,14 +4448,14 @@ class TestRollbackToVersion:
         result = await svc.rollback_to_version(42, "default", 50)
 
         assert result["status"] == "ok"
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 50
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 50
         # Hash should match the (re-uploaded) local file content
         local_path = tmp_path / "saves" / "gba" / "pokemon.srm"
-        assert file_state["last_sync_hash"] == _file_md5(str(local_path))
+        assert file_state.last_sync_hash == _file_md5(str(local_path))
         # last_sync_server_updated_at reflects the post-PUT response (NOT the
         # pre-PUT target.updated_at), confirming the bump propagated locally.
-        assert file_state["last_sync_server_updated_at"] != "2026-02-01T10:00:00Z"
+        assert file_state.last_sync_server_updated_at != "2026-02-01T10:00:00Z"
 
     @pytest.mark.asyncio
     async def test_rollback_returns_put_failed_when_upload_raises(self, tmp_path):
@@ -4451,8 +4495,8 @@ class TestRollbackToVersion:
         assert any(c[1][0] == 50 for c in download_calls)
         # Local state still updated to point at target — save_state was called
         # so disk file and state file remain consistent.
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 50
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 50
 
     @pytest.mark.asyncio
     async def test_rollback_ignores_confirm_download_failure(self, tmp_path):
@@ -4466,7 +4510,7 @@ class TestRollbackToVersion:
         detect tracked_save_id==server.id and Skip.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["server_device_id"] = "device-1"
+        svc._save_sync_state.server_device_id = "device-1"
 
         _create_save(tmp_path)
         local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
@@ -4491,8 +4535,8 @@ class TestRollbackToVersion:
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
         assert any(c[2].get("save_id") == 50 for c in upload_calls)
         # State updated
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 50
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 50
 
     @pytest.mark.asyncio
     async def test_rollback_to_already_tracked_save_is_idempotent(self, tmp_path):
@@ -4512,8 +4556,8 @@ class TestRollbackToVersion:
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
         assert any(c[2].get("save_id") == 50 for c in upload_calls)
         # tracked_save_id still 50
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 50
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 50
 
 
 # ---------------------------------------------------------------------------
@@ -4534,9 +4578,9 @@ class TestDeleteSlot:
         files_state=None,
     ):
         """Set up a ROM with slot state for deletion tests."""
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
-        svc._save_sync_state["device_id"] = "dev-1"
-        svc._save_sync_state["server_device_id"] = "server-dev-1"
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "server-dev-1"
         _install_rom(svc, tmp_path)
 
         slots = {
@@ -4545,12 +4589,14 @@ class TestDeleteSlot:
         if extra_slots:
             slots.update(extra_slots)
 
-        svc._save_sync_state["saves"]["42"] = {
-            "active_slot": active_slot,
-            "slot_confirmed": True,
-            "slots": slots,
-            "files": files_state or {},
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "active_slot": active_slot,
+                "slot_confirmed": True,
+                "slots": slots,
+                "files": files_state or {},
+            }
+        )
 
     @pytest.mark.asyncio
     async def test_get_slot_delete_info_server_slot(self, tmp_path):
@@ -4642,10 +4688,10 @@ class TestDeleteSlot:
         assert result["deleted_server_saves"] == 2
         assert result["cleaned_files"] == 2
         # Slot removed from state
-        assert "save1" not in svc._save_sync_state["saves"]["42"]["slots"]
+        assert "save1" not in svc._save_sync_state.saves["42"].slots
         # File entries cleaned
-        assert "pokemon.srm" not in svc._save_sync_state["saves"]["42"]["files"]
-        assert "zelda.srm" not in svc._save_sync_state["saves"]["42"]["files"]
+        assert "pokemon.srm" not in svc._save_sync_state.saves["42"].files
+        assert "zelda.srm" not in svc._save_sync_state.saves["42"].files
         # delete_server_saves called with correct IDs
         delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
         assert len(delete_calls) == 1
@@ -4665,7 +4711,7 @@ class TestDeleteSlot:
 
         assert result["success"] is True
         assert result["deleted_server_saves"] == 0
-        assert "local1" not in svc._save_sync_state["saves"]["42"]["slots"]
+        assert "local1" not in svc._save_sync_state.saves["42"].slots
         # No server calls made
         delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
         assert len(delete_calls) == 0
@@ -4681,7 +4727,7 @@ class TestDeleteSlot:
         assert result["success"] is False
         assert result["reason"] == "active_slot"
         # Slot still exists
-        assert "default" in svc._save_sync_state["saves"]["42"]["slots"]
+        assert "default" in svc._save_sync_state.saves["42"].slots
 
     @pytest.mark.asyncio
     async def test_delete_slot_server_error(self, tmp_path):
@@ -4706,7 +4752,7 @@ class TestDeleteSlot:
         assert result["success"] is False
         assert result["reason"] == "server_error"
         # Slot NOT removed from state (rollback on failure)
-        assert "save1" in svc._save_sync_state["saves"]["42"]["slots"]
+        assert "save1" in svc._save_sync_state.saves["42"].slots
 
         fake.delete_server_saves = original_delete
 
@@ -4730,17 +4776,17 @@ class TestDeleteSlot:
         result = await svc.delete_slot(42, "save1")
 
         assert result["success"] is True
-        files = svc._save_sync_state["saves"]["42"]["files"]
+        files = svc._save_sync_state.saves["42"].files
         assert "pokemon.srm" not in files
         assert "zelda.srm" not in files
         assert "unrelated.srm" in files
-        assert files["unrelated.srm"]["tracked_save_id"] == 99
+        assert files["unrelated.srm"].tracked_save_id == 99
 
     @pytest.mark.asyncio
     async def test_delete_slot_not_installed_rom(self, tmp_path):
         """ROM not installed returns failure."""
         svc, _fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         # Don't install any ROM
 
         result = await svc.delete_slot(42, "default")
@@ -4772,7 +4818,7 @@ class TestOwnUploadIds:
     async def test_post_upload_appends_own_upload_id(self, tmp_path):
         """After a POST upload (new save), the returned save_id is added to own_upload_ids."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -4785,8 +4831,8 @@ class TestOwnUploadIds:
         # The save_id passed to upload_save should be None (POST path)
         assert returned_id is None
 
-        rom_state = svc._save_sync_state["saves"]["42"]
-        own_ids = rom_state.get("own_upload_ids", [])
+        rom_state = svc._save_sync_state.saves["42"]
+        own_ids = rom_state.own_upload_ids or []
         assert len(own_ids) == 1
         # The id in the list must match what fake returned
         new_save_id = next(iter(fake.saves.values()))["id"]
@@ -4800,21 +4846,24 @@ class TestOwnUploadIds:
         save_file = _create_save(tmp_path)
 
         # Pre-populate own_upload_ids with the id that fake will return (1000)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},
-            "system": "gba",
-            "active_slot": "default",
-            "own_upload_ids": [1000],
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},
+                "system": "gba",
+                "active_slot": "default",
+                "own_upload_ids": [1000],
+            }
+        )
         # Fake will return the same id=1000 because filename matches existing
         fake.saves[1000] = _server_save(save_id=1000, rom_id=42)
 
         # Call internal upload with no server_save (POST path)
         svc._sync_engine._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=None)
 
-        rom_state = svc._save_sync_state["saves"]["42"]
+        rom_state = svc._save_sync_state.saves["42"]
+        assert rom_state.own_upload_ids is not None
         # Should still have exactly one entry for that id
-        assert rom_state["own_upload_ids"].count(1000) == 1
+        assert rom_state.own_upload_ids.count(1000) == 1
 
     @pytest.mark.asyncio
     async def test_put_upload_does_not_touch_own_list(self, tmp_path):
@@ -4825,36 +4874,40 @@ class TestOwnUploadIds:
 
         # Pre-existing server save (id=100) — upload_save called with save_id=100 → PUT
         fake.saves[100] = _server_save(save_id=100, rom_id=42)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "old"}},
-            "system": "gba",
-            "active_slot": "default",
-            "own_upload_ids": [99],  # pre-existing unrelated id
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "old"}},
+                "system": "gba",
+                "active_slot": "default",
+                "own_upload_ids": [99],  # pre-existing unrelated id
+            }
+        )
 
         server_save = fake.saves[100]
         svc._sync_engine._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=server_save)
 
-        rom_state = svc._save_sync_state["saves"]["42"]
+        rom_state = svc._save_sync_state.saves["42"]
         # own_upload_ids must not have changed (100 not added, 99 still there)
-        assert rom_state["own_upload_ids"] == [99]
+        assert rom_state.own_upload_ids == [99]
 
     @pytest.mark.asyncio
     async def test_get_save_status_legacy_rom_state_returns_none(self, tmp_path):
         """When rom state exists but own_upload_ids key is absent, uploaded_by_us is None."""
         svc, fake = make_service(tmp_path)
         _install_rom(svc, tmp_path)
-        svc._save_sync_state["settings"]["save_sync_enabled"] = True
+        svc._save_sync_state.settings.save_sync_enabled = True
 
         fake.saves[26] = _server_save(save_id=26, rom_id=42, filename="pokemon.srm")
 
         # Legacy state: own_upload_ids key is absent
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {},
-            "system": "gba",
-            "active_slot": None,
-            # no own_upload_ids key
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {},
+                "system": "gba",
+                "active_slot": None,
+                # no own_upload_ids key
+            }
+        )
 
         result = await svc.get_save_status(42)
 
@@ -4871,17 +4924,19 @@ class TestOwnUploadIds:
         local_hash = _file_md5(str(save_file))
 
         # own save is 26, tracked is 26 (clean state)
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 26,
-                    "last_sync_hash": local_hash,
-                }
-            },
-            "system": "gba",
-            "active_slot": "default",
-            "own_upload_ids": [26],
-        }
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 26,
+                        "last_sync_hash": local_hash,
+                    }
+                },
+                "system": "gba",
+                "active_slot": "default",
+                "own_upload_ids": [26],
+            }
+        )
         fake.saves[26] = _server_save(save_id=26, rom_id=42, slot="default")
         # Foreign older version to roll back to
         fake.saves[27] = _server_save(save_id=27, rom_id=42, slot="default", updated_at="2026-01-01T00:00:00Z")
@@ -4890,8 +4945,8 @@ class TestOwnUploadIds:
 
         assert result["status"] == "ok"
         # own_upload_ids must be unchanged — 27 was not POSTed by us
-        rom_state = svc._save_sync_state["saves"]["42"]
-        assert rom_state["own_upload_ids"] == [26]
+        rom_state = svc._save_sync_state.saves["42"]
+        assert rom_state.own_upload_ids == [26]
 
 
 # ---------------------------------------------------------------------------
@@ -4907,9 +4962,9 @@ class TestOwnUploadIds:
 
 def _enable_sync_with_device(svc, device_id: str = "device-1") -> None:
     """Flip on save sync and bind a server device id (matches FakeSaveApi)."""
-    svc._save_sync_state["settings"]["save_sync_enabled"] = True
-    svc._save_sync_state["device_id"] = device_id
-    svc._save_sync_state["server_device_id"] = device_id
+    svc._save_sync_state.settings.save_sync_enabled = True
+    svc._save_sync_state.device_id = device_id
+    svc._save_sync_state.server_device_id = device_id
 
 
 def _server_save_with_syncs(
@@ -4955,15 +5010,17 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": ss["updated_at"],
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": ss["updated_at"],
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -4990,9 +5047,9 @@ class TestSyncRomSavesDispatch:
         # POST → save_id is None
         assert upload_calls[0][2]["save_id"] is None
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] is not None
-        assert file_state["last_sync_hash"]
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id is not None
+        assert file_state.last_sync_hash
 
     def test_sync_rom_saves_download_when_server_changed(self, tmp_path):
         """is_current=false + local hash matches last_sync_hash → Download."""
@@ -5007,15 +5064,17 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5027,9 +5086,9 @@ class TestSyncRomSavesDispatch:
         assert len(download_calls) == 1
         assert download_calls[0][1][0] == 100
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 100
-        assert file_state["last_sync_hash"]  # updated to downloaded content's hash
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 100
+        assert file_state.last_sync_hash  # updated to downloaded content's hash
 
     def test_sync_rom_saves_conflict_when_both_changed(self, tmp_path):
         """is_current=false + local hash diverges → Conflict, no I/O."""
@@ -5044,15 +5103,17 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "deadbeef" * 4,  # baseline differs from current local
-                    "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "deadbeef" * 4,  # baseline differs from current local
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5106,15 +5167,17 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "0" * 32,  # baseline differs from current local
-                    "last_sync_server_updated_at": ss["updated_at"],
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,  # baseline differs from current local
+                        "last_sync_server_updated_at": ss["updated_at"],
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5126,8 +5189,8 @@ class TestSyncRomSavesDispatch:
         # PUT — save_id is the existing server save id
         assert upload_calls[0][2]["save_id"] == 100
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["last_sync_hash"] == local_hash
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.last_sync_hash == local_hash
 
     def test_sync_rom_saves_skip_with_adopt_baseline_writes_hash(self, tmp_path):
         """is_current=true + local present + no baseline → Skip + adopt_baseline:
@@ -5144,7 +5207,7 @@ class TestSyncRomSavesDispatch:
         fake.saves[100] = ss
 
         # No file_state at all — no baseline yet.
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState()
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5154,8 +5217,8 @@ class TestSyncRomSavesDispatch:
         # No I/O initiated.
         assert not any(c[0] in ("upload_save", "download_save_content", "download_save") for c in fake.call_log)
         # Baseline now persisted.
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["last_sync_hash"] == local_hash
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.last_sync_hash == local_hash
 
     def test_sync_rom_saves_recovery_download_when_no_local(self, tmp_path):
         """is_current=true on the picked save but local file is gone → Download
@@ -5170,15 +5233,17 @@ class TestSyncRomSavesDispatch:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "abc",
-                    "last_sync_server_updated_at": ss["updated_at"],
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "abc",
+                        "last_sync_server_updated_at": ss["updated_at"],
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5207,15 +5272,17 @@ class TestSyncRomSavesDispatch:
 
         # Build a state where compute_sync_action emits Upload(target_save_id=100)
         # via the is_current=true + diverged hash branch.
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "0" * 32,
-                    "last_sync_server_updated_at": ss["updated_at"],
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,
+                        "last_sync_server_updated_at": ss["updated_at"],
+                    }
                 }
             }
-        }
+        )
 
         synced, errors, conflicts = svc._sync_engine._sync_rom_saves(42)
 
@@ -5236,12 +5303,12 @@ class TestSyncRomSavesDispatch:
         _install_rom(svc, tmp_path)
         # Pure no-op: no local, no server saves.
 
-        before = svc._save_sync_state["saves"].get("42", {}).get("last_sync_check_at")
-        assert before is None
+        before_entry = svc._save_sync_state.saves.get("42")
+        assert before_entry is None or before_entry.last_sync_check_at is None
 
         svc._sync_engine._sync_rom_saves(42)
 
-        after = svc._save_sync_state["saves"]["42"]["last_sync_check_at"]
+        after = svc._save_sync_state.saves["42"].last_sync_check_at
         assert after is not None and isinstance(after, str)
 
 
@@ -5264,15 +5331,17 @@ class TestGetSaveStatusComputeAction:
         )
         fake.saves[100] = ss
 
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "0" * 32,
-                    "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
                 }
             }
-        }
+        )
 
         result = svc._status._get_save_status_io(42, [ss])
 
@@ -5297,21 +5366,23 @@ class TestGetSaveStatusComputeAction:
         ss_skip = _server_save_with_syncs(
             device_syncs=[{"device_id": "device-1", "is_current": True}],
         )
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": ss_skip["updated_at"],
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": ss_skip["updated_at"],
+                    }
                 }
             }
-        }
+        )
         result_skip = svc._status._get_save_status_io(42, [ss_skip])
         assert result_skip["files"][0]["status"] == "synced"
 
         # ---------- Upload ----------
         # Reset state for next case: no server saves
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState()
         result_upload = svc._status._get_save_status_io(42, [])
         assert result_upload["files"][0]["status"] == "upload"
 
@@ -5321,28 +5392,32 @@ class TestGetSaveStatusComputeAction:
             device_syncs=[{"device_id": "device-1", "is_current": False}],
         )
         fake.saves[100] = ss_dl
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": local_hash,
-                    "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
                 }
             }
-        }
+        )
         result_dl = svc._status._get_save_status_io(42, [ss_dl])
         assert result_dl["files"][0]["status"] == "download"
 
         # ---------- Conflict ----------
-        svc._save_sync_state["saves"]["42"] = {
-            "files": {
-                "pokemon.srm": {
-                    "tracked_save_id": 100,
-                    "last_sync_hash": "0" * 32,
-                    "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
                 }
             }
-        }
+        )
         result_conflict = svc._status._get_save_status_io(42, [ss_dl])
         assert result_conflict["files"][0]["status"] == "conflict"
 
@@ -5368,7 +5443,7 @@ class TestGetSaveStatusComputeAction:
         fake.saves[200] = ss_old
         fake.saves[201] = ss_new
 
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState()
 
         result = svc._status._get_save_status_io(42, [ss_old, ss_new])
 
@@ -5384,7 +5459,7 @@ class TestGetSaveStatusComputeAction:
         _enable_sync_with_device(svc)
         _install_rom(svc, tmp_path)
 
-        svc._save_sync_state["saves"]["42"] = {"files": {}}
+        svc._save_sync_state.saves["42"] = RomSaveState()
 
         result = svc._status._get_save_status_io(42, [])
 
@@ -5421,9 +5496,9 @@ class TestResolveSyncConflict:
         assert result["action"] == "keep_local"
         assert not any(c[0] == "upload_save" for c in fake.call_log)
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 100
-        assert file_state["last_sync_hash"] == local_hash
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 100
+        assert file_state.last_sync_hash == local_hash
 
     @pytest.mark.asyncio
     async def test_resolve_keep_local_hash_mismatch_uploads_put(self, tmp_path):
@@ -5451,8 +5526,8 @@ class TestResolveSyncConflict:
         # PUT — save_id was passed
         assert upload_calls[0][2]["save_id"] == 100
 
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["last_sync_hash"] == local_hash
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.last_sync_hash == local_hash
 
     @pytest.mark.asyncio
     async def test_resolve_use_server_downloads_and_persists(self, tmp_path):
@@ -5476,9 +5551,9 @@ class TestResolveSyncConflict:
         assert result["success"] is True
         # Local file overwritten with server content
         assert save_path.read_bytes() == b"server-truth"
-        file_state = svc._save_sync_state["saves"]["42"]["files"]["pokemon.srm"]
-        assert file_state["tracked_save_id"] == 100
-        assert file_state["last_sync_hash"] == _file_md5(str(save_path))
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.tracked_save_id == 100
+        assert file_state.last_sync_hash == _file_md5(str(save_path))
 
     @pytest.mark.asyncio
     async def test_resolve_invalid_action_returns_error(self, tmp_path):
@@ -5510,12 +5585,10 @@ class TestResolveSyncConflict:
         _create_save(tmp_path, content=b"x")
 
         # Pre-populate state to assert it stays untouched.
-        original_state = {
-            "files": {
-                "pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "abc"},
-            }
-        }
-        svc._save_sync_state["saves"]["42"] = original_state
+        original_state = RomSaveState(
+            files={"pokemon.srm": FileSyncState(tracked_save_id=100, last_sync_hash="abc")},
+        )
+        svc._save_sync_state.saves["42"] = original_state
 
         fake.fail_on_next(RommApiError("network"))
 
@@ -5524,7 +5597,7 @@ class TestResolveSyncConflict:
         assert result["success"] is False
         assert "Failed to fetch saves" in result["message"]
         # State left as-is — no mutation
-        assert svc._save_sync_state["saves"]["42"] == original_state
+        assert svc._save_sync_state.saves["42"] == original_state
 
     @pytest.mark.asyncio
     async def test_resolve_no_server_saves_in_slot(self, tmp_path):

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -4,6 +4,7 @@ import logging
 
 from conftest import FakeSaveSyncStatePersister
 
+from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
 from services.saves.state import StateService
 
 
@@ -27,41 +28,41 @@ def _make_state_svc(
 class TestClearFilesState:
     def test_clears_files_preserves_slot_config(self):
         svc, _ = _make_state_svc()
-        svc.data["saves"]["42"] = {
-            "files": {"pokemon.srm": {"last_sync_hash": "abc"}},
-            "active_slot": "desktop",
-            "slot_confirmed": True,
-            "emulator": "retroarch-mgba",
-            "last_synced_core": "mgba_libretro",
-            "own_upload_ids": ["save-1"],
-            "slots": {"default": {}, "desktop": {}},
-            "system": "gba",
-        }
+        svc.state.saves["42"] = RomSaveState(
+            files={"pokemon.srm": FileSyncState(last_sync_hash="abc")},
+            active_slot="desktop",
+            slot_confirmed=True,
+            emulator="retroarch-mgba",
+            last_synced_core="mgba_libretro",
+            own_upload_ids=[1],
+            slots={"default": {}, "desktop": {}},
+            system="gba",
+        )
 
         svc.clear_files_state("42")
 
-        entry = svc.data["saves"]["42"]
-        assert entry["files"] == {}
-        assert entry["active_slot"] == "desktop"
-        assert entry["slot_confirmed"] is True
-        assert entry["emulator"] == "retroarch-mgba"
-        assert entry["last_synced_core"] == "mgba_libretro"
-        assert entry["own_upload_ids"] == ["save-1"]
-        assert entry["slots"] == {"default": {}, "desktop": {}}
-        assert entry["system"] == "gba"
+        entry = svc.state.saves["42"]
+        assert entry.files == {}
+        assert entry.active_slot == "desktop"
+        assert entry.slot_confirmed is True
+        assert entry.emulator == "retroarch-mgba"
+        assert entry.last_synced_core == "mgba_libretro"
+        assert entry.own_upload_ids == [1]
+        assert entry.slots == {"default": {}, "desktop": {}}
+        assert entry.system == "gba"
 
     def test_creates_empty_entry_when_missing(self):
         svc, _ = _make_state_svc()
-        assert "999" not in svc.data["saves"]
+        assert "999" not in svc.state.saves
 
         svc.clear_files_state("999")
 
-        assert svc.data["saves"]["999"] == {"files": {}}
+        assert svc.state.saves["999"].files == {}
 
     def test_does_not_persist_on_its_own(self):
         """clear_files_state must not write to disk — caller orchestrates persistence."""
         svc, persister = _make_state_svc()
-        svc.data["saves"]["42"] = {"files": {"pokemon.srm": {}}}
+        svc.state.saves["42"] = RomSaveState(files={"pokemon.srm": FileSyncState()})
 
         svc.clear_files_state("42")
 
@@ -69,35 +70,28 @@ class TestClearFilesState:
 
     def test_idempotent(self):
         svc, _ = _make_state_svc()
-        svc.data["saves"]["42"] = {
-            "files": {"pokemon.srm": {}},
-            "active_slot": "desktop",
-            "slot_confirmed": True,
-        }
+        svc.state.saves["42"] = RomSaveState(
+            files={"pokemon.srm": FileSyncState()},
+            active_slot="desktop",
+            slot_confirmed=True,
+        )
 
         svc.clear_files_state("42")
         svc.clear_files_state("42")
 
-        entry = svc.data["saves"]["42"]
-        assert entry["files"] == {}
-        assert entry["active_slot"] == "desktop"
-        assert entry["slot_confirmed"] is True
-
-    def test_creates_saves_dict_if_missing(self):
-        """Defensive: if the top-level 'saves' key were missing, recreate it."""
-        svc, _ = _make_state_svc()
-        del svc.data["saves"]
-
-        svc.clear_files_state("42")
-
-        assert svc.data["saves"] == {"42": {"files": {}}}
+        entry = svc.state.saves["42"]
+        assert entry.files == {}
+        assert entry.active_slot == "desktop"
+        assert entry.slot_confirmed is True
 
 
 class TestSaveState:
-    def test_save_state_forwards_in_memory_dict_to_persister(self):
+    def test_save_state_forwards_aggregate_to_persister(self):
         svc, persister = _make_state_svc()
-        svc.data["device_id"] = "abc123"
-        svc.data["saves"]["42"] = {"files": {"game.srm": {"tracked_save_id": 7}}}
+        svc.state.device_id = "abc123"
+        svc.state.saves["42"] = RomSaveState(
+            files={"game.srm": FileSyncState(tracked_save_id=7)},
+        )
 
         svc.save_state()
 
@@ -113,14 +107,14 @@ class TestLoadState:
         svc, persister = _make_state_svc(FakeSaveSyncStatePersister(canned_load=None))
 
         # Mutate one default so we can detect it was preserved (load did NOT clobber it).
-        svc.data["device_id"] = "preserved"
+        svc.state.device_id = "preserved"
 
         svc.load_state()
 
         assert persister.load_count == 1
-        assert svc.data["device_id"] == "preserved"
+        assert svc.state.device_id == "preserved"
         # Default settings still present (not wiped or overwritten with None).
-        assert svc.data["settings"]["save_sync_enabled"] is False
+        assert svc.state.settings.save_sync_enabled is False
 
     def test_load_state_merges_top_level_fields(self):
         canned = {
@@ -129,22 +123,22 @@ class TestLoadState:
             "device_name": "deck",
             "server_device_id": "srv-1",
             "saves": {"42": {"files": {}}},
-            "playtime": {"42": {"seconds": 3600}},
+            "playtime": {"42": {"total_seconds": 3600}},
             "settings": {"save_sync_enabled": True, "default_slot": "alt"},
         }
         svc, _ = _make_state_svc(FakeSaveSyncStatePersister(canned_load=canned))
 
         svc.load_state()
 
-        assert svc.data["device_id"] == "dev-1"
-        assert svc.data["device_name"] == "deck"
-        assert svc.data["server_device_id"] == "srv-1"
-        assert svc.data["saves"] == {"42": {"files": {}}}
-        assert svc.data["playtime"] == {"42": {"seconds": 3600}}
+        assert svc.state.device_id == "dev-1"
+        assert svc.state.device_name == "deck"
+        assert svc.state.server_device_id == "srv-1"
+        assert "42" in svc.state.saves
+        assert svc.state.playtime["42"].total_seconds == 3600
         # Settings merge with defaults — explicit keys win, others stay default.
-        assert svc.data["settings"]["save_sync_enabled"] is True
-        assert svc.data["settings"]["default_slot"] == "alt"
-        assert svc.data["settings"]["sync_before_launch"] is True  # default kept
+        assert svc.state.settings.save_sync_enabled is True
+        assert svc.state.settings.default_slot == "alt"
+        assert svc.state.settings.sync_before_launch is True  # default kept
 
     def test_load_state_runs_migration_on_loaded_payload(self):
         """active_core → last_synced_core, drops dismissed_newer_save_id, strips legacy settings."""
@@ -167,33 +161,37 @@ class TestLoadState:
 
         svc.load_state()
 
-        entry = svc.data["saves"]["42"]
-        assert "active_core" not in entry
-        assert entry["last_synced_core"] == "mgba_libretro"
-        assert "dismissed_newer_save_id" not in entry["files"]["game.srm"]
-        assert "conflict_mode" not in svc.data["settings"]
-        assert "clock_skew_tolerance_sec" not in svc.data["settings"]
+        entry = svc.state.saves["42"]
+        assert entry.last_synced_core == "mgba_libretro"
+        # ``active_core`` and ``dismissed_newer_save_id`` are stripped via
+        # SaveSyncState.from_dict — verified at the domain layer in
+        # tests/domain/test_save_state.py.
+        on_disk = svc.state.to_dict()
+        assert "active_core" not in on_disk["saves"]["42"]
+        assert "dismissed_newer_save_id" not in on_disk["saves"]["42"]["files"]["game.srm"]
+        assert "conflict_mode" not in on_disk["settings"]
+        assert "clock_skew_tolerance_sec" not in on_disk["settings"]
 
 
 class TestPruneOrphanedState:
     def test_prune_persists_when_entries_removed(self):
         svc, persister = _make_state_svc()
         svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
-        svc.data["saves"]["42"] = {"files": {}}
-        svc.data["saves"]["999"] = {"files": {}}  # orphaned
-        svc.data["playtime"]["888"] = {"seconds": 0}  # orphaned
+        svc.state.saves["42"] = RomSaveState()
+        svc.state.saves["999"] = RomSaveState()  # orphaned
+        svc.state.playtime["888"] = PlaytimeEntry()  # orphaned
 
         svc.prune_orphaned_state()
 
-        assert "999" not in svc.data["saves"]
-        assert "888" not in svc.data["playtime"]
-        assert "42" in svc.data["saves"]
+        assert "999" not in svc.state.saves
+        assert "888" not in svc.state.playtime
+        assert "42" in svc.state.saves
         assert persister.save_count == 1
 
     def test_prune_does_not_persist_when_nothing_removed(self):
         svc, persister = _make_state_svc()
         svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
-        svc.data["saves"]["42"] = {"files": {}}
+        svc.state.saves["42"] = RomSaveState()
 
         svc.prune_orphaned_state()
 

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -16,6 +16,7 @@ from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapt
 from adapters.romm.http import RommHttpAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
 from services.library import LibraryService, LibraryServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService
@@ -129,7 +130,7 @@ def plugin(tmp_path):
     p._migration_service.is_retrodeck_migration_pending.return_value = False
 
     # Enable save sync for tests — matches pre-feature-flag behavior
-    p._save_sync_state["settings"]["save_sync_enabled"] = True
+    p._save_sync_state.settings.save_sync_enabled = True
     return p
 
 
@@ -194,7 +195,7 @@ class TestDeviceRegistration:
         assert result["success"] is True
         assert result["device_id"]
         assert result.get("server_device_id") is not None
-        assert plugin._save_sync_state["device_id"] == result["device_id"]
+        assert plugin._save_sync_state.device_id == result["device_id"]
 
         # Persisted to disk
         path = tmp_path / "save_sync_state.json"
@@ -205,9 +206,9 @@ class TestDeviceRegistration:
     @pytest.mark.asyncio
     async def test_already_registered_returns_cached(self, plugin):
         """If device_id and server_device_id already set, returns immediately."""
-        plugin._save_sync_state["device_id"] = "existing-uuid"
-        plugin._save_sync_state["device_name"] = "myhost"
-        plugin._save_sync_state["server_device_id"] = "server-uuid"
+        plugin._save_sync_state.device_id = "existing-uuid"
+        plugin._save_sync_state.device_name = "myhost"
+        plugin._save_sync_state.server_device_id = "server-uuid"
 
         result = await plugin.ensure_device_registered()
 
@@ -223,7 +224,7 @@ class TestDeviceRegistration:
             result = await plugin.ensure_device_registered()
 
         assert result["device_name"] == "steamdeck"
-        assert plugin._save_sync_state["device_name"] == "steamdeck"
+        assert plugin._save_sync_state.device_name == "steamdeck"
 
     @pytest.mark.asyncio
     async def test_generates_unique_ids(self, plugin):
@@ -232,8 +233,8 @@ class TestDeviceRegistration:
         id1 = result1["device_id"]
 
         # Reset state to force new registration
-        plugin._save_sync_state["device_id"] = None
-        plugin._save_sync_state["server_device_id"] = None
+        plugin._save_sync_state.device_id = None
+        plugin._save_sync_state.server_device_id = None
         result2 = await plugin.ensure_device_registered()
         id2 = result2["device_id"]
 
@@ -254,7 +255,7 @@ class TestListDevices:
         plugin._fake_api._registered_devices = [
             {"id": "device-1", "name": "steamdeck"},
         ]
-        plugin._save_sync_state["server_device_id"] = "device-1"
+        plugin._save_sync_state.server_device_id = "device-1"
 
         result = await plugin.list_devices()
 
@@ -265,7 +266,7 @@ class TestListDevices:
     @pytest.mark.asyncio
     async def test_list_devices_disabled_when_sync_off(self, plugin):
         """Returns disabled=True when save sync is disabled."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
 
         result = await plugin.list_devices()
 
@@ -284,7 +285,7 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_skips_when_disabled(self, plugin):
         """Returns early when sync_before_launch is false."""
-        plugin._save_sync_state["settings"]["sync_before_launch"] = False
+        plugin._save_sync_state.settings.sync_before_launch = False
 
         result = await plugin.pre_launch_sync(42)
 
@@ -303,7 +304,7 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_skips_when_disabled(self, plugin):
         """Returns early when sync_after_exit is false."""
-        plugin._save_sync_state["settings"]["sync_after_exit"] = False
+        plugin._save_sync_state.settings.sync_after_exit = False
 
         result = await plugin.post_exit_sync(42)
 
@@ -507,23 +508,18 @@ class TestPlaytimeTracking:
         result = await plugin.record_session_start(42)
 
         assert result["success"] is True
-        entry = plugin._save_sync_state["playtime"]["42"]
-        assert entry["last_session_start"] is not None
+        entry = plugin._save_sync_state.playtime["42"]
+        assert entry.last_session_start is not None
         # Should be a valid ISO datetime
-        datetime.fromisoformat(entry["last_session_start"])
+        datetime.fromisoformat(entry.last_session_start)
 
     @pytest.mark.asyncio
     async def test_session_end_calculates_delta(self, plugin):
         """record_session_end computes correct duration."""
-        plugin._save_sync_state.setdefault("playtime", {})
         start_time = plugin._playtime_service._clock.now() - timedelta(seconds=600)
-        plugin._save_sync_state["playtime"]["42"] = {
-            "total_seconds": 0,
-            "session_count": 0,
-            "last_session_start": start_time.isoformat(),
-            "last_session_duration_sec": None,
-            "offline_deltas": [],
-        }
+        plugin._save_sync_state.playtime["42"] = PlaytimeEntry(
+            last_session_start=start_time.isoformat(),
+        )
 
         result = await plugin.record_session_end(42)
 
@@ -535,34 +531,25 @@ class TestPlaytimeTracking:
     async def test_delta_accumulated(self, plugin):
         """Playtime delta added to existing total."""
         start_time = plugin._playtime_service._clock.now() - timedelta(seconds=300)
-        plugin._save_sync_state["playtime"] = {
-            "42": {
-                "total_seconds": 1000,
-                "session_count": 5,
-                "last_session_start": start_time.isoformat(),
-                "last_session_duration_sec": None,
-                "offline_deltas": [],
-            }
-        }
+        plugin._save_sync_state.playtime["42"] = PlaytimeEntry(
+            total_seconds=1000,
+            session_count=5,
+            last_session_start=start_time.isoformat(),
+        )
 
         await plugin.record_session_end(42)
 
-        total = plugin._save_sync_state["playtime"]["42"]["total_seconds"]
+        total = plugin._save_sync_state.playtime["42"].total_seconds
         assert total >= 1290  # 1000 + ~300
 
     @pytest.mark.asyncio
     async def test_session_count_incremented(self, plugin):
         """Session count goes up on end."""
         start_time = plugin._playtime_service._clock.now() - timedelta(seconds=10)
-        plugin._save_sync_state["playtime"] = {
-            "42": {
-                "total_seconds": 0,
-                "session_count": 5,
-                "last_session_start": start_time.isoformat(),
-                "last_session_duration_sec": None,
-                "offline_deltas": [],
-            }
-        }
+        plugin._save_sync_state.playtime["42"] = PlaytimeEntry(
+            session_count=5,
+            last_session_start=start_time.isoformat(),
+        )
 
         result = await plugin.record_session_end(42)
 
@@ -579,32 +566,31 @@ class TestPlaytimeTracking:
     async def test_session_start_clears_on_end(self, plugin):
         """last_session_start is cleared after session end."""
         start_time = plugin._playtime_service._clock.now() - timedelta(seconds=10)
-        plugin._save_sync_state["playtime"] = {
-            "42": {
-                "total_seconds": 0,
-                "session_count": 0,
-                "last_session_start": start_time.isoformat(),
-                "last_session_duration_sec": None,
-                "offline_deltas": [],
-            }
-        }
+        plugin._save_sync_state.playtime["42"] = PlaytimeEntry(
+            last_session_start=start_time.isoformat(),
+        )
 
         await plugin.record_session_end(42)
 
-        assert plugin._save_sync_state["playtime"]["42"]["last_session_start"] is None
+        assert plugin._save_sync_state.playtime["42"].last_session_start is None
 
     @pytest.mark.asyncio
     async def test_duration_clamped_to_24h(self, plugin):
         """Duration clamped to max 24 hours."""
         start_time = plugin._playtime_service._clock.now() - timedelta(hours=48)
-        plugin._save_sync_state["playtime"] = {
-            "42": {
-                "total_seconds": 0,
-                "session_count": 0,
-                "last_session_start": start_time.isoformat(),
-                "last_session_duration_sec": None,
-                "offline_deltas": [],
-            }
+        plugin._save_sync_state.playtime = {
+            rid: PlaytimeEntry.from_dict(entry)
+            for rid, entry in (
+                {
+                    "42": {
+                        "total_seconds": 0,
+                        "session_count": 0,
+                        "last_session_start": start_time.isoformat(),
+                        "last_session_duration_sec": None,
+                        "offline_deltas": [],
+                    }
+                }
+            ).items()
         }
 
         result = await plugin.record_session_end(42)
@@ -623,9 +609,14 @@ class TestGetAllPlaytime:
     @pytest.mark.asyncio
     async def test_returns_all_playtime_entries(self, plugin):
         """Returns all playtime entries from state."""
-        plugin._save_sync_state["playtime"] = {
-            "42": {"total_seconds": 3000, "session_count": 5},
-            "99": {"total_seconds": 600, "session_count": 1},
+        plugin._save_sync_state.playtime = {
+            rid: PlaytimeEntry.from_dict(entry)
+            for rid, entry in (
+                {
+                    "42": {"total_seconds": 3000, "session_count": 5},
+                    "99": {"total_seconds": 600, "session_count": 1},
+                }
+            ).items()
         }
         result = await plugin.get_all_playtime()
         assert result["playtime"]["42"]["total_seconds"] == 3000
@@ -634,7 +625,7 @@ class TestGetAllPlaytime:
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_playtime(self, plugin):
         """Returns empty dict when no playtime data exists."""
-        plugin._save_sync_state["playtime"] = {}
+        plugin._save_sync_state.playtime = {}
         result = await plugin.get_all_playtime()
         assert result["playtime"] == {}
 
@@ -716,7 +707,7 @@ class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_no_installed_roms(self, plugin):
         """Empty installed_roms completes gracefully."""
-        plugin._save_sync_state["device_id"] = "dev-1"
+        plugin._save_sync_state.device_id = "dev-1"
 
         result = await plugin.sync_all_saves()
 
@@ -736,7 +727,7 @@ class TestSyncRomSaves:
     @pytest.mark.asyncio
     async def test_rom_not_installed(self, plugin):
         """Non-installed ROM returns 0 synced."""
-        plugin._save_sync_state["device_id"] = "dev-1"
+        plugin._save_sync_state.device_id = "dev-1"
 
         result = await plugin.sync_rom_saves(999)
 
@@ -771,23 +762,23 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_default_disabled(self, plugin):
         """save_sync_enabled defaults to False in fresh state."""
-        plugin._save_sync_state.update(SaveService.make_default_state())  # Reset to defaults (no test fixture override)
-        settings = plugin._save_sync_state["settings"]
-        assert settings["save_sync_enabled"] is False
+        # Reset to defaults (no test fixture override).
+        plugin._save_sync_state.replace_with(SaveService.make_default_state())
+        assert plugin._save_sync_state.settings.save_sync_enabled is False
 
     @pytest.mark.asyncio
     async def test_ensure_device_disabled(self, plugin):
         """ensure_device_registered returns disabled marker when save sync off."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.ensure_device_registered()
         assert result["success"] is False
         assert result.get("disabled") is True
-        assert plugin._save_sync_state["device_id"] is None
+        assert plugin._save_sync_state.device_id is None
 
     @pytest.mark.asyncio
     async def test_pre_launch_sync_disabled(self, plugin):
         """pre_launch_sync skips when save sync disabled."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.pre_launch_sync(42)
         assert result["success"] is True
         assert result["synced"] == 0
@@ -796,7 +787,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_post_exit_sync_disabled(self, plugin):
         """post_exit_sync skips when save sync disabled."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.post_exit_sync(42)
         assert result["success"] is True
         assert result["synced"] == 0
@@ -805,7 +796,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_sync_rom_saves_disabled(self, plugin):
         """sync_rom_saves returns error when save sync disabled."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.sync_rom_saves(42)
         assert result["success"] is False
         assert "disabled" in result["message"].lower()
@@ -813,7 +804,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_sync_all_saves_disabled(self, plugin):
         """sync_all_saves returns error when save sync disabled."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.sync_all_saves()
         assert result["success"] is False
         assert "disabled" in result["message"].lower()
@@ -821,17 +812,17 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_enable_via_settings_update(self, plugin):
         """save_sync_enabled can be toggled via update_save_sync_settings."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         result = await plugin.update_save_sync_settings({"save_sync_enabled": True})
         assert result["success"] is True
-        assert plugin._save_sync_state["settings"]["save_sync_enabled"] is True
+        assert plugin._save_sync_state.settings.save_sync_enabled is True
 
     @pytest.mark.asyncio
     async def test_disable_via_settings_update(self, plugin):
         """save_sync_enabled can be disabled via update_save_sync_settings."""
         result = await plugin.update_save_sync_settings({"save_sync_enabled": False})
         assert result["success"] is True
-        assert plugin._save_sync_state["settings"]["save_sync_enabled"] is False
+        assert plugin._save_sync_state.settings.save_sync_enabled is False
 
     @pytest.mark.asyncio
     async def test_get_settings_includes_flag(self, plugin):
@@ -842,9 +833,9 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_is_save_sync_enabled_helper(self, plugin):
         """_is_save_sync_enabled reflects the settings value."""
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = True
+        plugin._save_sync_state.settings.save_sync_enabled = True
         assert plugin._save_sync_service._is_save_sync_enabled() is True
-        plugin._save_sync_state["settings"]["save_sync_enabled"] = False
+        plugin._save_sync_state.settings.save_sync_enabled = False
         assert plugin._save_sync_service._is_save_sync_enabled() is False
 
 
@@ -878,13 +869,15 @@ async def test_delete_local_saves_happy_path(plugin, tmp_path):
     rtc.write_bytes(b"\x00" * 16)
 
     # Set up sync state
-    plugin._save_sync_state["saves"]["100"] = {
-        "files": {
-            f"{rom_name}.srm": {"last_sync_hash": "abc123"},
-            f"{rom_name}.rtc": {"last_sync_hash": "def456"},
-        },
-        "system": system,
-    }
+    plugin._save_sync_state.saves["100"] = RomSaveState.from_dict(
+        {
+            "files": {
+                f"{rom_name}.srm": {"last_sync_hash": "abc123"},
+                f"{rom_name}.rtc": {"last_sync_hash": "def456"},
+            },
+            "system": system,
+        }
+    )
 
     result = await plugin.delete_local_saves(rom_id)
     assert result["success"] is True
@@ -892,9 +885,9 @@ async def test_delete_local_saves_happy_path(plugin, tmp_path):
     assert not srm.exists()
     assert not rtc.exists()
     # Entry survives — only files are cleared (#279).
-    assert "100" in plugin._save_sync_state["saves"]
-    assert plugin._save_sync_state["saves"]["100"]["files"] == {}
-    assert plugin._save_sync_state["saves"]["100"]["system"] == system
+    assert "100" in plugin._save_sync_state.saves
+    assert plugin._save_sync_state.saves["100"].files == {}
+    assert plugin._save_sync_state.saves["100"].system == system
 
 
 @pytest.mark.asyncio
@@ -917,31 +910,33 @@ async def test_delete_local_saves_preserves_slot_config(plugin, tmp_path):
     srm = saves_dir / f"{rom_name}.srm"
     srm.write_bytes(b"\x00" * 32)
 
-    plugin._save_sync_state["saves"]["101"] = {
-        "files": {f"{rom_name}.srm": {"last_sync_hash": "hash"}},
-        "active_slot": "desktop",
-        "slot_confirmed": True,
-        "emulator": "retroarch-snes9x",
-        "last_synced_core": "snes9x_libretro",
-        "own_upload_ids": ["save-9"],
-        "slots": {"default": {}, "desktop": {}},
-        "system": system,
-    }
+    plugin._save_sync_state.saves["101"] = RomSaveState.from_dict(
+        {
+            "files": {f"{rom_name}.srm": {"last_sync_hash": "hash"}},
+            "active_slot": "desktop",
+            "slot_confirmed": True,
+            "emulator": "retroarch-snes9x",
+            "last_synced_core": "snes9x_libretro",
+            "own_upload_ids": ["save-9"],
+            "slots": {"default": {}, "desktop": {}},
+            "system": system,
+        }
+    )
 
     result = await plugin.delete_local_saves(rom_id)
     assert result["success"] is True
     assert result["deleted_count"] == 1
     assert not srm.exists()
 
-    entry = plugin._save_sync_state["saves"]["101"]
-    assert entry["files"] == {}
-    assert entry["active_slot"] == "desktop"
-    assert entry["slot_confirmed"] is True
-    assert entry["emulator"] == "retroarch-snes9x"
-    assert entry["last_synced_core"] == "snes9x_libretro"
-    assert entry["own_upload_ids"] == ["save-9"]
-    assert entry["slots"] == {"default": {}, "desktop": {}}
-    assert entry["system"] == system
+    entry = plugin._save_sync_state.saves["101"]
+    assert entry.files == {}
+    assert entry.active_slot == "desktop"
+    assert entry.slot_confirmed is True
+    assert entry.emulator == "retroarch-snes9x"
+    assert entry.last_synced_core == "snes9x_libretro"
+    assert entry.own_upload_ids == ["save-9"]
+    assert entry.slots == {"default": {}, "desktop": {}}
+    assert entry.system == system
 
 
 @pytest.mark.asyncio
@@ -1006,8 +1001,8 @@ async def test_delete_platform_saves(plugin, tmp_path):
         "platform_slug": "gba",
     }
 
-    plugin._save_sync_state["saves"]["10"] = {"files": {"Game1.srm": {}}, "system": "snes"}
-    plugin._save_sync_state["saves"]["20"] = {"files": {"Game2.srm": {}}, "system": "snes"}
+    plugin._save_sync_state.saves["10"] = RomSaveState(files={"Game1.srm": FileSyncState()}, system="snes")
+    plugin._save_sync_state.saves["20"] = RomSaveState(files={"Game2.srm": FileSyncState()}, system="snes")
 
     result = await plugin.delete_platform_saves("snes")
     assert result["success"] is True
@@ -1015,12 +1010,12 @@ async def test_delete_platform_saves(plugin, tmp_path):
     assert not srm1.exists()
     assert not srm2.exists()
     # Entries survive — only files are cleared (#279).
-    assert "10" in plugin._save_sync_state["saves"]
-    assert plugin._save_sync_state["saves"]["10"]["files"] == {}
-    assert plugin._save_sync_state["saves"]["10"]["system"] == "snes"
-    assert "20" in plugin._save_sync_state["saves"]
-    assert plugin._save_sync_state["saves"]["20"]["files"] == {}
-    assert plugin._save_sync_state["saves"]["20"]["system"] == "snes"
+    assert "10" in plugin._save_sync_state.saves
+    assert plugin._save_sync_state.saves["10"].files == {}
+    assert plugin._save_sync_state.saves["10"].system == "snes"
+    assert "20" in plugin._save_sync_state.saves
+    assert plugin._save_sync_state.saves["20"].files == {}
+    assert plugin._save_sync_state.saves["20"].system == "snes"
 
 
 # ============================================================================
@@ -1034,11 +1029,13 @@ class TestSavesVersionHistoryCallables:
     @pytest.mark.asyncio
     async def test_saves_list_file_versions_happy_path(self, plugin, tmp_path):
         """saves_list_file_versions returns filtered older versions."""
-        plugin._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "files": {"pokemon.srm": {"tracked_save_id": 100}},
-        }
+        plugin._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {"pokemon.srm": {"tracked_save_id": 100}},
+            }
+        )
         plugin._fake_api.saves[100] = {
             "id": 100,
             "rom_id": 42,
@@ -1078,11 +1075,13 @@ class TestSavesVersionHistoryCallables:
 
         local_hash = hashlib.md5(b"\x00" * 1024).hexdigest()
 
-        plugin._save_sync_state["saves"]["42"] = {
-            "system": "gba",
-            "active_slot": "default",
-            "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": local_hash}},
-        }
+        plugin._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": local_hash}},
+            }
+        )
         plugin._fake_api.saves[100] = {
             "id": 100,
             "rom_id": 42,


### PR DESCRIPTION
Fourth sub-issue of the saves vertical (#254). Replaces the anemic nested dict (\`self._save_sync_state[\"roms\"][rom_id_str][\"saves\"][filename]\`) with typed dataclasses. Typos now fail at type-check time instead of runtime.

## Changes

### New domain module \`py_modules/domain/save_state.py\` (400 LOC, pure)

Five dataclasses + \`from_dict\` / \`to_dict\` for JSON persistence:

- \`FileSyncState\` — per-file tracking (\`tracked_save_id\`, \`last_sync_hash\`, mtimes/sizes, server-side IDs)
- \`RomSaveState\` — per-ROM state (\`active_slot\`, \`slot_confirmed\`, \`emulator\`, \`system\`, \`last_synced_core\`, \`own_upload_ids\`, \`slots\`, \`files\`)
- \`PlaytimeEntry\` — runtime fields (\`total_seconds\`, \`session_count\`, …)
- \`SaveSyncSettings\` — feature flags + defaults
- \`SaveSyncState\` — aggregate root + \`replace_with\` for in-place updates

Schema migrations live inside \`from_dict\` (preserved from the old \`StateService._migrate_loaded_state\`): \`active_core\`→\`last_synced_core\`, drop \`dismissed_newer_save_id\`, strip legacy \`conflict_mode\`/\`clock_skew_tolerance_sec\` settings keys.

### \`StateService\` rewrite

Owns the typed aggregate. Exposes \`.state\` property + typed accessors (\`get_rom_state\`, \`ensure_rom_state\`, \`get_file_state\`, \`get_settings\`, \`get_playtime\`). \`load_state\` mutates the live aggregate via \`replace_with\` so references held by sub-services and peer services stay valid.

### Sweep of consumers (20 files)

All saves sub-services (facade, sync_engine, slots, status, versions) plus three peer services (\`PlaytimeService\`, \`RomRemovalService\`, \`GameDetailService\`) plus \`bootstrap.py\` migrated from dict access to typed attribute access. 34 production dict-access sites + ~12 peer-service sites all rewritten.

### Three deliberate nuances

1. **\`own_upload_ids: list[int] | None\`** (not \`list[int]\`). Preserves the legacy distinction: \"missing key = attribution unknown\" → \`None\`; \"explicit empty list = we uploaded nothing\" → \`[]\`. \`to_dict\` omits the key when \`None\` so the round-trip is stable. Existing legacy-state tests still assert \`uploaded_by_us=None\` for unattributed rows.
2. **\`PlaytimeEntry\` field names** match actual \`PlaytimeService\` runtime (\`total_seconds\`, \`session_count\`, \`last_session_start\`, …) rather than the original issue body's idealized field list. Runtime wins.
3. **\`SaveSyncSettings.default_slot: str | None\`** — preserves the legacy \"no-slot\" mode where the setting is absent. Empty-string input is normalized to \`None\` on load (consistent with the existing \`_sanitize_setting\` path in the facade).

## Behavior preservation

- **On-disk format byte-identical**. Round-trip \`SaveSyncState.from_dict(s.to_dict()) == s\` enforced by test.
- **Schema migrations** preserved with dedicated tests.
- **Persistence trigger points** unchanged.
- **Public \`SaveService\` callable signatures** unchanged. Frontend contract intact.

## Test results

- 2167 → 2204 (+37 new domain tests covering round-trip, migrations, defensive parsing, defaults, equality, in-place mutation)
- \`domain/save_state.py\` — 96% branch coverage

## Gates

- ruff: PASS
- basedpyright (full scope incl tests/): PASS (0/0/0)
- pytest: PASS (2204)
- \`scripts/check_cosmic_call_bans.sh\`: PASS
- \`lint-imports\` (7 contracts): PASS
- \`pnpm build\`: PASS

## Cosmic Python

Final access-surface check:

\`\`\`
grep -rnE '_save_sync_state\\[\"|_state_svc\\.data\\[|state_svc\\.data\\.get\\(' py_modules/services/
\`\`\`

Zero matches in services. Domain stays pure (only stdlib \`dataclasses\` / \`typing\` imports).

## Closes

#273. Saves vertical (#254): 4 of 5 sub-issues complete. One remaining: #275 (test file restructure).