### PR TITLE
fix(saves): persist slot promotion in PUT-path upload (#346)

### DIFF
--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -193,6 +193,7 @@ class SyncEngine:
         if slot_entry and slot_entry.get("source") == "local":
             slot_entry["source"] = "server"
             slot_entry["count"] = 1
+            self._state_svc.save_state()
 
     def _confirm_upload_sync(self, upload_id: int | None, device_id: str | None) -> None:
         """Ack the uploaded save on the server's DeviceSaveSync row (non-fatal)."""

--- a/tests/services/saves/test_sync_engine.py
+++ b/tests/services/saves/test_sync_engine.py
@@ -1330,6 +1330,50 @@ class TestOwnUploadIds:
         assert rom_state.own_upload_ids == [26]
 
 
+class TestPromoteLocalSlotPersistsState:
+    """Regression for #346.
+
+    The PUT-path edge case from the issue: server save tracked but the slot
+    marker is still ``'local'`` (stale). On promotion, the in-memory mutation
+    must reach disk so the next plugin start sees ``source='server'``.
+    """
+
+    def test_put_path_promotion_survives_reload(self, tmp_path):
+        """A PUT upload that promotes a stale local-slot marker persists to disk."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc, device_id="dev-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+
+        # Pre-existing tracked server save → upload_save called with save_id=100 (PUT path).
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default")
+        server_save = fake.saves[100]
+
+        # rom_state has the slot still flagged 'local' (stale marker).
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "old"}},
+                "system": "gba",
+                "active_slot": "default",
+                "slots": {"default": {"source": "local", "count": 1}},
+            }
+        )
+
+        svc._sync_engine._do_upload_save(42, str(save_path), "pokemon.srm", "42", "gba", server_save=server_save)
+
+        in_mem = svc._save_sync_state.saves["42"].slots["default"]
+        assert in_mem["source"] == "server"
+        assert in_mem["count"] == 1
+
+        # A fresh service reading from the same on-disk state sees the promotion —
+        # the in-memory mutation reached disk.
+        reloaded_svc, _ = make_service(tmp_path)
+        reloaded_svc.load_state()
+        reloaded = reloaded_svc._save_sync_state.saves["42"].slots["default"]
+        assert reloaded["source"] == "server"
+        assert reloaded["count"] == 1
+
+
 class TestSyncRomSavesDispatch:
     def test_sync_rom_saves_skip_when_synced(self, tmp_path):
         """is_current=true + matching hash + tracked → Skip, no I/O."""


### PR DESCRIPTION
## Summary

- `SyncEngine._promote_local_slot_to_server` flipped `slot.source` from `"local"` to `"server"` in memory but never called `self._state_svc.save_state()`. The POST path piggybacks on `_record_own_upload`'s `save_state()` call, so the slot promotion survived a restart. The PUT path (existing tracked save → `save_id` passed, `is_post=False`) had no other persistence trigger, so the slot promotion was lost on the next plugin start.
- Fix: call `save_state()` inside the mutating branch only (no-op promotions don't trigger disk writes).

## Test plan

- [x] `python -m pytest tests/ -q` (2208 pass, +1 new test)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] Regression test added: `TestPromoteLocalSlotPersistsState::test_put_path_promotion_survives_reload` — reproduces the PUT-path scenario from the issue (tracked `save_id=100`, stale `slots["default"].source = "local"`), calls `_do_upload_save(... server_save=...)`, then builds a SECOND service rooted at the same `tmp_path`, calls `load_state()`, and asserts the reload sees `source="server"`. Verified the test fails without the production fix and passes with it.

## Follow-up

Review surfaced an adjacent persistence gap on the same PUT path: `_update_file_sync_state` writes `last_sync_hash` / `tracked_save_id` / `last_sync_at` to the in-memory aggregate but, when no slot promotion happens (slot already `"server"`), nothing persists those file-level updates either. Same root cause, narrower-than-#346 scope — will open a follow-up after merge rather than expand this PR.

Closes #346.