### PR TITLE
hardening(firmware): bios_files_index raises before load_bios_registry (#348)

### DIFF
--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -76,14 +76,20 @@ class FirmwareService:
         self._get_bios_path = config.get_bios_path
         self._core_info = config.core_info
         self._bios_registry: dict = {}
-        self._bios_files_index: dict = {}
+        self._bios_files_index: dict | None = None
         self._firmware_cache: list | None = None
         self._firmware_cache_epoch: float = 0
         self._restore_firmware_cache()
 
     @property
     def bios_files_index(self) -> dict:
-        """Flat reverse index of BIOS files: {filename: entry_data}."""
+        """Flat reverse index of BIOS files: {filename: entry_data}.
+
+        Raises ``RuntimeError`` if accessed before ``load_bios_registry()`` —
+        a silent empty dict at startup masks order-sensitive wiring bugs.
+        """
+        if self._bios_files_index is None:
+            raise RuntimeError("firmware registry not loaded — call load_bios_registry() first")
         return self._bios_files_index
 
     # ── Registry loading ─────────────────────────────────────
@@ -111,7 +117,7 @@ class FirmwareService:
     # ── Internal helpers ─────────────────────────────────────
 
     def _enrich_firmware_file(self, file_dict, core_so=None):
-        entry = self._bios_files_index.get(file_dict.get("file_name", ""))
+        entry = self.bios_files_index.get(file_dict.get("file_name", ""))
         if entry:
             # Use per-core required value if active core is known
             if core_so and "cores" in entry and core_so in entry["cores"]:
@@ -146,7 +152,7 @@ class FirmwareService:
         """
         bios_base = self._get_bios_path()
         file_name = firmware.get("file_name", "")
-        reg_entry = self._bios_files_index.get(file_name)
+        reg_entry = self.bios_files_index.get(file_name)
         if reg_entry and reg_entry.get("firmware_path"):
             return os.path.join(bios_base, reg_entry["firmware_path"])
         return os.path.join(bios_base, file_name)
@@ -342,7 +348,7 @@ class FirmwareService:
 
         # Compute local MD5 once (used for both server-hash and registry-hash checks)
         expected_md5 = fw.get("md5_hash", "")
-        reg_entry = self._bios_files_index.get(file_name)
+        reg_entry = self.bios_files_index.get(file_name)
         reg_md5 = reg_entry.get("md5", "") if reg_entry else ""
 
         local_md5 = self._firmware_files.checksum_md5(dest) if (expected_md5 or reg_md5) else None
@@ -427,7 +433,7 @@ class FirmwareService:
 
     def _is_firmware_required(self, file_name, core_so):
         """Check if a firmware file is required for the given core."""
-        index_entry = self._bios_files_index.get(file_name)
+        index_entry = self.bios_files_index.get(file_name)
         if not index_entry:
             return None  # Unknown file
         if core_so and "cores" in index_entry and core_so in index_entry["cores"]:

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -58,6 +58,9 @@ def plugin():
             core_info=FakeCoreInfoProvider(),
         ),
     )
+    # Mirror main.py: load_bios_registry runs at startup so the index is a
+    # ready-to-use empty dict (or populated, if a fake registry is on disk).
+    p._firmware_service.load_bios_registry()
 
     p._sync_service = LibraryService(
         romm_api=p._romm_api,
@@ -1424,6 +1427,57 @@ class TestLoadBiosRegistryErrors:
         assert fw._bios_registry == {}
 
 
+class TestBiosFilesIndexUnloadedRaises:
+    """Regression for #348: the property must raise before load_bios_registry()."""
+
+    def test_property_raises_before_load(self):
+        """Accessing bios_files_index before load_bios_registry() raises RuntimeError."""
+        import decky
+
+        fw = FirmwareService(
+            config=FirmwareServiceConfig(
+                romm_api=MagicMock(),
+                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                plugin_dir=decky.DECKY_PLUGIN_DIR,
+                clock=_make_clock(),
+                save_state=MagicMock(),
+                firmware_cache_persister=FakeFirmwareCachePersister(),
+                firmware_files=FirmwareFileAdapter(),
+                get_bios_path=MagicMock(return_value=""),
+                core_info=FakeCoreInfoProvider(),
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="firmware registry not loaded"):
+            _ = fw.bios_files_index
+
+    def test_property_returns_dict_after_load(self):
+        """After load_bios_registry(), the property returns a dict (possibly empty)."""
+        import decky
+
+        fw = FirmwareService(
+            config=FirmwareServiceConfig(
+                romm_api=MagicMock(),
+                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                plugin_dir="/nonexistent",
+                clock=_make_clock(),
+                save_state=MagicMock(),
+                firmware_cache_persister=FakeFirmwareCachePersister(),
+                firmware_files=FirmwareFileAdapter(),
+                get_bios_path=MagicMock(return_value=""),
+                core_info=FakeCoreInfoProvider(),
+            ),
+        )
+
+        fw.load_bios_registry()
+        # FileNotFoundError path still leaves _bios_files_index initialized to {}.
+        assert fw.bios_files_index == {}
+
+
 class TestDownloadFirmwarePostIORegistryHash:
     """Tests for _download_firmware_post_io registry hash verification."""
 
@@ -1550,7 +1604,7 @@ class TestFirmwareListCache:
     def _make_service(self, romm_api):
         import decky
 
-        return FirmwareService(
+        fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=romm_api,
                 state={"shortcut_registry": {}, "downloaded_bios": {}},
@@ -1565,6 +1619,8 @@ class TestFirmwareListCache:
                 core_info=FakeCoreInfoProvider(),
             ),
         )
+        fw.load_bios_registry()
+        return fw
 
     def test_firmware_list_cached(self):
         """Second call returns cached data without hitting the API again."""
@@ -1714,6 +1770,7 @@ class TestCheckPlatformBiosCached:
                 core_info=core_info,
             ),
         )
+        fw.load_bios_registry()
         fw._firmware_cache = firmware_cache
         fw._firmware_cache_epoch = firmware_cache_epoch
         if bios_registry:

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -144,6 +144,7 @@ def plugin(tmp_path):
             core_info=FakeCoreInfoProvider(),
         ),
     )
+    p._firmware_service.load_bios_registry()
 
     # Store fake_api on plugin for test access
     p._fake_api = fake_api
@@ -635,7 +636,7 @@ class TestGetBiosStatusNotFound:
             "name": "Game",
             "platform_slug": "gba",
         }
-        game_detail_service._check_platform_bios = AsyncMock(side_effect=Exception("fail"))
+        game_detail_service._bios_checker.check_platform_bios = AsyncMock(side_effect=Exception("fail"))
 
         result = await game_detail_service.get_bios_status(42)
         assert result["bios_status"] is None

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -55,6 +55,7 @@ def plugin():
             core_info=FakeCoreInfoProvider(),
         ),
     )
+    p._firmware_service.load_bios_registry()
 
     p._sync_service = LibraryService(
         romm_api=p._romm_api,


### PR DESCRIPTION
## Summary

- `FirmwareService.bios_files_index` used to return `{}` until `load_bios_registry()` was called. Migration code in `bootstrap.py` reads it via lambda; any future startup reordering in `main.py` would silently get an empty index instead of the registry data.
- Phase 1 thesis: replace silent empty result with a loud `RuntimeError`. Initialize `_bios_files_index = None`; have the property raise when accessed pre-load.
- Internal callers now go through the property (instead of `self._bios_files_index.get(...)`), so any future caller that runs pre-load also fails loudly.

## Test plan

- [x] `python -m pytest tests/ -q` (2210 pass, +2 new tests)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] Regression tests added: `TestBiosFilesIndexUnloadedRaises` — (1) pre-load access raises `RuntimeError`; (2) post-load (even with no registry file) returns `{}`.
- [x] Test fixtures in `test_firmware.py`, `test_game_detail.py`, `test_migration.py` now call `load_bios_registry()` after construction, mirroring `main.py`'s lifecycle.

## Collateral fix

`test_game_detail.py::test_firmware_error_returns_none` was patching `game_detail_service._check_platform_bios` — a non-existent attribute. The mock was dead code; the test only passed because `_bios_files_index = {}` made the real path return `needs_bios: False`. After the fixture now loads the real registry, the test failed correctly; corrected the mock target to `game_detail_service._bios_checker.check_platform_bios`.

Closes #348. Part of #347 (Phase 1 — Startup Hardening).