### PR TITLE
hardening(bootstrap): LateBinding[T] replaces forward-ref lambdas (#349)

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,6 @@ class Plugin:
         self._core_service = services["core_service"]
         self._connection_service = services["connection_service"]
         self._startup_healing_service = services["startup_healing_service"]
-        self._firmware_service.load_bios_registry()
 
         # ── 5. Startup healing ──────────────────────────────────────────────
         self._save_sync_service.init_state()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -34,6 +34,7 @@ from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from domain.save_state import SaveSyncState
+from lib.late_binding import LateBinding
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService, ArtworkServiceConfig
 from services.connection import ConnectionService, ConnectionServiceConfig
@@ -264,13 +265,18 @@ def wire_services(cfg: WiringConfig) -> dict:
     dict with keys ``save_sync_service``, ``playtime_service``,
     ``sync_service``, ``download_service``, and ``firmware_service``.
     """
+    # Forward-reference bindings for producers constructed later in this
+    # function. Consumers receive ``binding.get`` (a bound method); the
+    # binding is populated via ``.set(...)`` once the producer exists.
+    # Accessing ``.get()`` before ``.set()`` raises RuntimeError instead of
+    # the NameError a bare forward-ref lambda would produce.
+    bios_files_index_binding: LateBinding[dict] = LateBinding("bios_files_index")
+    pending_sync_binding: LateBinding[dict] = LateBinding("pending_sync")
+
     # MigrationService is constructed before SaveService so that
     # save_sync_service can receive a bound reference to
     # ``migration_service.detect_save_sort_change``. SaveService must observe
     # fresh sort state before computing saves_dir (#238).
-    # ``get_bios_files_index`` is a lambda that defers the ``firmware_service``
-    # lookup to call time, so it is safe to reference here even though
-    # ``firmware_service`` is constructed later in this function.
     migration_service = MigrationService(
         migration_files=cfg.adapters.migration_files,
         config=MigrationServiceConfig(
@@ -279,7 +285,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             logger=cfg.runtime.logger,
             save_state=cfg.callbacks.save_state,
             emit=cfg.runtime.emit,
-            get_bios_files_index=lambda: firmware_service.bios_files_index,
+            get_bios_files_index=bios_files_index_binding.get,
             get_retrodeck_home=cfg.callbacks.get_retrodeck_home,
             get_saves_path=cfg.callbacks.get_saves_path,
             get_bios_path=cfg.callbacks.get_bios_path,
@@ -345,11 +351,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         config=ArtworkServiceConfig(
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
-            # ``sync_service`` is constructed after ArtworkService; the
-            # lambda binds at call time, so the deferred lookup is safe
-            # as long as ``get_artwork_base64`` is only invoked after
-            # wire_services returns.
-            get_pending_sync=lambda: sync_service.pending_sync,
+            get_pending_sync=pending_sync_binding.get,
         ),
     )
 
@@ -385,6 +387,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         metadata_service=metadata_service,
         artwork=artwork_service,
     )
+    pending_sync_binding.set(lambda: sync_service.pending_sync)
 
     download_service = DownloadService(
         romm_api=cfg.adapters.romm_api,
@@ -435,6 +438,10 @@ def wire_services(cfg: WiringConfig) -> dict:
             core_info=cfg.callbacks.core_info_provider,
         ),
     )
+    # Load the BIOS registry from disk now so the property does not raise
+    # the pre-load RuntimeError when the binding's reader is later invoked.
+    firmware_service.load_bios_registry()
+    bios_files_index_binding.set(lambda: firmware_service.bios_files_index)
 
     sgdb_service = SteamGridService(
         sgdb_api=cfg.adapters.sgdb_adapter,
@@ -448,7 +455,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             logger=cfg.runtime.logger,
             save_state=cfg.callbacks.save_state,
             save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
-            get_pending_sync=lambda: sync_service.pending_sync,
+            get_pending_sync=pending_sync_binding.get,
         ),
     )
 

--- a/py_modules/lib/late_binding.py
+++ b/py_modules/lib/late_binding.py
@@ -1,0 +1,47 @@
+"""Two-phase binding helper for forward references during service wiring.
+
+Bootstrap constructs services in an order where some consumers must hold a
+read seam for a producer that is built later in the same function. A plain
+forward-referencing lambda (``lambda: producer.attr``) closes over a
+yet-undefined local — works at call time but produces ``NameError`` with no
+explicit trail if the order is ever broken. ``LateBinding`` swaps that
+implicit closure for an explicit two-phase contract: callers receive the
+binding at construction time, the producer plugs a *reader function* in
+afterwards via :meth:`set`, and any read before that raises a clear
+``RuntimeError``. Each :meth:`get` re-invokes the reader, so consumers
+observe live producer state — not a snapshot taken at bind time — which
+matters when the producer rebinds its attribute (not just mutates the
+underlying object).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+class LateBinding[T]:
+    """Typed forward-reference for service wiring."""
+
+    __slots__ = ("_name", "_reader")
+
+    def __init__(self, name: str) -> None:
+        """Create an unset binding tagged ``name`` for error reporting."""
+        self._name = name
+        self._reader: Callable[[], T] | None = None
+
+    def set(self, reader: Callable[[], T]) -> None:
+        """Bind a *reader* callable that returns the current value on demand.
+
+        Calling more than once overwrites the reader; intentional.
+        """
+        self._reader = reader
+
+    def get(self) -> T:
+        """Invoke the bound reader and return its value.
+
+        Raises ``RuntimeError`` if :meth:`set` has not been called yet.
+        """
+        reader = self._reader
+        if reader is None:
+            raise RuntimeError(f"LateBinding[{self._name}] accessed before set() was called — startup ordering bug")
+        return reader()

--- a/tests/lib/test_late_binding.py
+++ b/tests/lib/test_late_binding.py
@@ -1,0 +1,80 @@
+"""Tests for ``lib.late_binding`` — typed two-phase forward reference."""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.late_binding import LateBinding
+
+
+def test_get_before_set_raises():
+    """Accessing an unset binding must raise RuntimeError tagged with the name."""
+    binding: LateBinding[dict] = LateBinding("bios_files_index")
+
+    with pytest.raises(RuntimeError, match="bios_files_index"):
+        binding.get()
+
+
+def test_get_invokes_bound_reader():
+    """After set(), get() returns whatever the reader returns."""
+    binding: LateBinding[dict] = LateBinding("pending_sync")
+    binding.set(lambda: {"42": {"name": "Game"}})
+
+    assert binding.get() == {"42": {"name": "Game"}}
+
+
+def test_get_reflects_producer_rebinding():
+    """get() observes producer-side attribute rebinds, not a snapshot.
+
+    Regression for the captured-value design: ``LateBinding`` must hold a
+    *reader function*, so each ``get()`` resolves the producer's current
+    attribute rather than a reference taken at bind time.
+    """
+
+    class Producer:
+        def __init__(self) -> None:
+            self.value: dict = {"initial": True}
+
+    producer = Producer()
+    binding: LateBinding[dict] = LateBinding("producer_value")
+    binding.set(lambda: producer.value)
+
+    assert binding.get() == {"initial": True}
+
+    # Producer rebinds the attribute (not just mutates the existing object).
+    producer.value = {"rebound": True}
+
+    assert binding.get() == {"rebound": True}
+
+
+def test_set_overwrites_previous_reader():
+    """Calling set() a second time replaces the bound reader."""
+    binding: LateBinding[int] = LateBinding("counter")
+    binding.set(lambda: 1)
+    binding.set(lambda: 2)
+
+    assert binding.get() == 2
+
+
+def test_get_reflects_mutation_of_shared_reference():
+    """When the reader returns a shared mutable object, mutations are visible."""
+    data: dict = {}
+    binding: LateBinding[dict] = LateBinding("pending_sync")
+    binding.set(lambda: data)
+
+    data["42"] = {"name": "Game"}
+
+    assert binding.get() == {"42": {"name": "Game"}}
+
+
+def test_error_message_includes_name_and_hint():
+    """The RuntimeError text names the binding and points at the cause."""
+    binding: LateBinding[dict] = LateBinding("bios_files_index")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        binding.get()
+
+    msg = str(excinfo.value)
+    assert "bios_files_index" in msg
+    assert "set" in msg
+    assert "startup ordering bug" in msg

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -286,6 +286,49 @@ class TestWireServices:
         assert "startup_healing_service" in result
         deps["loop"].close()
 
+    def test_pending_sync_binding_observes_library_rebinds(self, tmp_path):
+        """ArtworkService/SgdbService see live LibraryService._pending_sync rebinds.
+
+        Regression for #349: the bootstrap binding must defer the read so
+        post-bind reassignments of ``_pending_sync`` (e.g., line 417 of
+        library.py after a sync diff) are visible to consumers.
+        """
+        deps = self._make_deps(tmp_path)
+        result = wire_services(self._make_config(deps))
+        sync_service = result["sync_service"]
+        artwork_service = result["artwork_service"]
+        sgdb_service = result["sgdb_service"]
+
+        # Producer rebinds _pending_sync to a fresh dict (mirrors sync_apply_delta).
+        sync_service._pending_sync = {42: {"name": "Game", "platform_name": "N64"}}
+
+        assert artwork_service._get_pending_sync() == {42: {"name": "Game", "platform_name": "N64"}}
+        assert sgdb_service._get_pending_sync() == {42: {"name": "Game", "platform_name": "N64"}}
+        deps["loop"].close()
+
+    def test_bios_files_index_binding_observes_firmware_rebinds(self, tmp_path):
+        """MigrationService sees post-load reassignments of bios_files_index.
+
+        Regression for #349: ``firmware_service.load_bios_registry()`` rebinds
+        ``_bios_files_index`` to a fresh dict each call; the binding must
+        re-resolve the property on every read.
+        """
+        deps = self._make_deps(tmp_path)
+        result = wire_services(self._make_config(deps))
+        firmware_service = result["firmware_service"]
+        migration_service = result["migration_service"]
+
+        # Re-loading reassigns _bios_files_index; mutate the new dict and
+        # confirm migration's deferred-read picks up the change.
+        firmware_service.load_bios_registry()
+        firmware_service._bios_files_index["scph5501.bin"] = {
+            "platform": "psx",
+            "description": "PS1 BIOS",
+        }
+
+        assert "scph5501.bin" in migration_service._get_bios_files_index()
+        deps["loop"].close()
+
     def test_migration_service_receives_get_core_name(self, tmp_path):
         """MigrationService must receive the get_core_name callback from wire_services."""
         deps = self._make_deps(tmp_path)


### PR DESCRIPTION
## Summary

- `bootstrap.wire_services()` constructed MigrationService, ArtworkService, and SgdbService with lambdas closing over `firmware_service` / `sync_service` — locals defined LATER in the same function. Works today only because nothing evaluates them in `__init__`. Any future service that did would hit `NameError` with no useful trail.
- New helper `lib.late_binding.LateBinding[T]`: typed two-phase forward reference. `set(reader)` binds a reader function; `get()` invokes it (live read) or raises a clear `RuntimeError("LateBinding[<name>] accessed before set() was called — startup ordering bug")` if unset.
- Bootstrap now creates the two bindings upfront, hands `binding.get` to consumers, and calls `binding.set(lambda)` once each producer is constructed. `load_bios_registry()` moves from `main.py` into bootstrap so the firmware binding's reader is safe to invoke as soon as `wire_services()` returns.

## Design

- **Deferred read, not captured value.** First attempt stored the value at `.set()` time, which silently regressed `_pending_sync` consumers (LibraryService reassigns `_pending_sync` at library.py:417, 857, 970 — captured-value pattern saw stale data). Caught in review; fixed by holding a reader function.
- Service configs still type these as `Callable[[], dict]` / `PendingSyncReader`. The binding is internal to bootstrap; services don't import `LateBinding`.

## Test plan

- [x] `python -m pytest tests/ -q` (2218 pass, +8 new tests)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] Unit tests `tests/lib/test_late_binding.py` — 6 tests: get-before-set raises (with name); get invokes reader; get reflects producer rebinding; set overwrites; mutation visible through shared ref; error message format.
- [x] Bootstrap integration tests `tests/test_bootstrap.py`:
  - `test_pending_sync_binding_observes_library_rebinds` — rebinds `sync_service._pending_sync`, asserts both ArtworkService AND SgdbService see the new dict.
  - `test_bios_files_index_binding_observes_firmware_rebinds` — calls `load_bios_registry()` again, mutates the new dict, asserts MigrationService sees the change.

Closes #349. Part of #347 (Phase 1 — Startup Hardening).