### PR TITLE
hardening(main): drop _persistence lazy-property fallback (#350)

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ from bootstrap import (
 
 from adapters.persistence import (
     FirmwareCachePersisterAdapter,
-    PersistenceAdapter,
     SaveSyncStatePersisterAdapter,
 )
 from adapters.retroarch_config import RetroArchConfigAdapter
@@ -47,21 +46,6 @@ class Plugin:
 
     # -- persistence delegates -------------------------------------------------
 
-    @property
-    def _persistence(self) -> PersistenceAdapter:
-        """Lazy-init persistence adapter; overwritten by _main() with the bootstrap instance."""
-        if not hasattr(self, "_persistence_instance"):
-            self._persistence_instance = PersistenceAdapter(
-                decky.DECKY_PLUGIN_SETTINGS_DIR,
-                decky.DECKY_PLUGIN_RUNTIME_DIR,
-                decky.logger,
-            )
-        return self._persistence_instance
-
-    @_persistence.setter
-    def _persistence(self, value: PersistenceAdapter) -> None:
-        self._persistence_instance = value
-
     def _save_state(self):
         self._persistence.save_state(self._state)
 
@@ -77,23 +61,18 @@ class Plugin:
     async def _main(self):  # Decky lifecycle — must be async
         self.loop = asyncio.get_event_loop()
 
-        # ── 1. Load settings & run migrations ───────────────────────────────
-        from domain.state_migrations import migrate_settings, migrate_state
-
-        self.settings = self._persistence.load_settings()
-        self.settings = migrate_settings(self.settings)
-        self._save_settings_to_disk()
-
-        # ── 2. Wire adapters ────────────────────────────────────────────────
+        # ── 1. Wire adapters ────────────────────────────────────────────────
+        # Bootstrap loads + migrates settings as part of adapter construction
+        # so RommHttpAdapter binds the live, migrated dict in one pass.
         adapters = bootstrap(
             settings_dir=decky.DECKY_PLUGIN_SETTINGS_DIR,
             runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             user_home=decky.DECKY_USER_HOME,
             logger=decky.logger,
-            settings=self.settings,
         )
         self._persistence = adapters["persistence"]
+        self.settings = adapters["settings"]
         self._http_adapter = adapters["http_adapter"]
         self._romm_api = adapters["romm_api"]
         self._steam_config = adapters["steam_config"]
@@ -113,6 +92,8 @@ class Plugin:
             "save_sort_settings": None,
         }
         self._metadata_cache = {}
+        from domain.state_migrations import migrate_state
+
         self._state = self._persistence.load_state(self._state)
         self._state = migrate_state(self._state)
         self._metadata_cache = self._persistence.load_metadata_cache()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -1,9 +1,10 @@
-"""Composition root — wires adapters and services for the plugin.
+"""Composition root — instantiates adapters and wires services.
 
-Called from ``Plugin._main()`` to create adapter instances with
-the correct Decky paths and logger.  Returns a dict so that
-``_main()`` can assign them to the plugin's lazy-property backing
-attributes (bypassing auto-creation from ``self.settings``).
+Adapter construction lives here so ``main.py`` only deals with the
+Decky lifecycle and the callable surface. ``bootstrap()`` also loads
+and migrates settings as part of adapter wiring so ``RommHttpAdapter``
+binds the live, migrated dict in a single pass; that same dict is
+returned for the caller to keep as its source of truth.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from domain.save_state import SaveSyncState
+from domain.state_migrations import migrate_settings
 from lib.late_binding import LateBinding
 from services.achievements import AchievementsService
 from services.artwork import ArtworkService, ArtworkServiceConfig
@@ -165,9 +167,16 @@ def bootstrap(
     plugin_dir: str,
     user_home: str,
     logger: logging.Logger,
-    settings: dict,
 ) -> dict:
     """Create and return all adapters.
+
+    Bootstrap owns adapter instantiation and is the only path that
+    constructs ``PersistenceAdapter``. Settings are loaded + migrated
+    inside here so ``RommHttpAdapter`` receives a stable reference to
+    the live dict; the migrated dict is written back to disk before
+    return and shared with the caller under the ``"settings"`` key —
+    mutating that dict from the caller side is visible to all
+    adapters/services that bound the same reference.
 
     Parameters
     ----------
@@ -177,15 +186,15 @@ def bootstrap(
         ``decky.DECKY_PLUGIN_RUNTIME_DIR``
     plugin_dir:
         ``decky.DECKY_PLUGIN_DIR``
+    user_home:
+        ``decky.DECKY_USER_HOME`` — base for RetroDECK and Steam path lookups.
     logger:
         ``decky.logger``
-    settings:
-        The live settings dict (passed by reference to ``RommHttpAdapter``).
 
     Returns
     -------
-    dict with keys ``persistence``, ``http_adapter``, and ``wire_services``
-    (a factory callable for deferred service creation).
+    Mapping of adapter name to instance, plus ``"settings"`` (the live
+    migrated settings dict shared with ``RommHttpAdapter``).
     """
     retrodeck_paths = RetroDeckPathsAdapter(user_home=user_home, logger=logger)
     retroarch_config = RetroArchConfigAdapter(user_home=user_home, logger=logger)
@@ -198,6 +207,9 @@ def bootstrap(
     gamelist_editor = GamelistXmlEditor(logger=logger)
 
     persistence = PersistenceAdapter(settings_dir, runtime_dir, logger)
+    settings = persistence.load_settings()
+    settings = migrate_settings(settings)
+    persistence.save_settings(settings)
     http_adapter = RommHttpAdapter(settings, plugin_dir, logger)
     romm_api = RommApi(http_adapter)
     steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
@@ -217,6 +229,7 @@ def bootstrap(
 
     return {
         "persistence": persistence,
+        "settings": settings,
         "http_adapter": http_adapter,
         "romm_api": romm_api,
         "steam_config": steam_config,

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -20,7 +20,7 @@ from services.shortcut_removal import ShortcutRemovalService
 
 
 @pytest.fixture
-def plugin():
+def plugin(tmp_path):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._romm_api = MagicMock()
@@ -29,6 +29,9 @@ def plugin():
 
     import decky
 
+    # _persistence is no longer a lazy property; tests that touch persistence
+    # via _save_metadata_cache / _save_state need it wired up explicitly.
+    p._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -20,7 +20,7 @@ from services.migration import MigrationService, MigrationServiceConfig
 
 
 @pytest.fixture
-def plugin():
+def plugin(tmp_path):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
@@ -36,6 +36,7 @@ def plugin():
 
     import decky
 
+    p._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -54,7 +54,6 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert "persistence" in result
         assert isinstance(result["persistence"], PersistenceAdapter)
@@ -66,24 +65,23 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert "http_adapter" in result
         assert isinstance(result["http_adapter"], RommHttpAdapter)
 
     def test_http_adapter_shares_settings_reference(self, tmp_path):
-        settings = {"romm_url": "http://example.com"}
+        """RommHttpAdapter binds the same dict bootstrap returns under "settings"."""
         result = bootstrap(
             settings_dir=str(tmp_path / "settings"),
             runtime_dir=str(tmp_path / "runtime"),
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings=settings,
         )
-        # Mutate original — client should see the change
-        settings["romm_url"] = "http://changed.com"
+        # Mutate the dict bootstrap returned — http_adapter holds the same ref.
+        result["settings"]["romm_url"] = "http://changed.com"
         assert result["http_adapter"]._settings["romm_url"] == "http://changed.com"
+        assert result["http_adapter"]._settings is result["settings"]
 
     def test_persistence_has_correct_paths(self, tmp_path):
         settings_dir = str(tmp_path / "s")
@@ -94,7 +92,6 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "p"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert result["persistence"]._settings_dir == settings_dir
         assert result["persistence"]._runtime_dir == runtime_dir
@@ -106,7 +103,6 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert "steam_config" in result
         assert isinstance(result["steam_config"], SteamConfigAdapter)
@@ -118,7 +114,6 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert "romm_api" in result
         assert isinstance(result["romm_api"], RommApi)
@@ -131,7 +126,6 @@ class TestBootstrap:
             plugin_dir=str(tmp_path / "plugin"),
             user_home=str(tmp_path / "home"),
             logger=logging.getLogger("test"),
-            settings={},
         )
         assert isinstance(result["retrodeck_paths"], RetroDeckPathsAdapter)
         assert isinstance(result["retroarch_config"], RetroArchConfigAdapter)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -110,6 +110,44 @@ def plugin():
     return p
 
 
+class TestPersistenceAttributeIsLoud:
+    """Regression for #350: dropped the lazy-property fallback.
+
+    Pre-``_main()`` access to ``self._persistence`` must raise
+    ``AttributeError`` instead of silently constructing a second
+    ``PersistenceAdapter`` instance.
+    """
+
+    def test_attribute_missing_on_bare_plugin(self):
+        """Direct access to _persistence pre-_main() raises — no lazy fallback."""
+        from main import Plugin
+
+        bare = Plugin()
+
+        with pytest.raises(AttributeError, match="_persistence"):
+            _ = bare._persistence
+
+    def test_save_state_without_main_raises(self):
+        """Calling _save_state before _main() sets _persistence raises."""
+        from main import Plugin
+
+        bare = Plugin()
+        bare._state = {}
+
+        with pytest.raises(AttributeError, match="_persistence"):
+            bare._save_state()
+
+    def test_save_settings_without_main_raises(self):
+        """Calling _save_settings_to_disk before _main() raises."""
+        from main import Plugin
+
+        bare = Plugin()
+        bare.settings = {}
+
+        with pytest.raises(AttributeError, match="_persistence"):
+            bare._save_settings_to_disk()
+
+
 class TestSettings:
     @pytest.mark.asyncio
     async def test_get_settings_masks_password(self, plugin):
@@ -803,6 +841,7 @@ class TestMainStartupOrdering:
 
         bootstrapped_adapters = {
             "persistence": plugin._persistence,
+            "settings": {},
             "http_adapter": MagicMock(),
             "romm_api": MagicMock(),
             "steam_config": MagicMock(),


### PR DESCRIPTION
## Summary

- `Plugin._persistence` was a `@property` with a lazy getter that constructed a *second* `PersistenceAdapter` whenever accessed before `_main()` ran. `_main()` itself triggered the fallback — `load_settings()` on the pre-bootstrap path ran before the bootstrap-built adapter overwrote the attribute — so every successful startup briefly held two adapters over the same files.
- Move settings load + migrate + save into `bootstrap()` so `RommHttpAdapter` binds the migrated dict in one pass and the persistence adapter is constructed exactly once. `main.py` reads both `adapters["persistence"]` and `adapters["settings"]` back as plain attributes; the `@property` + `@setter` and the pre-bootstrap migration block are gone.
- Pre-`_main()` access now raises `AttributeError` loudly. Regression test asserts the contract directly (`Plugin()._persistence` raises) plus belt-and-braces tests via `_save_state` / `_save_settings_to_disk`.

## Test plan

- [x] `python -m pytest tests/ -q` (2221 pass, +3 new tests this issue)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] `TestPersistenceAttributeIsLoud` — three tests covering bare attribute access, `_save_state`, `_save_settings_to_disk`.
- [x] `test_http_adapter_shares_settings_reference` reworked: bootstrap no longer takes `settings=` kwarg; test mutates `result["settings"]` and asserts `http_adapter._settings is result["settings"]`.
- [x] `test_main_calls_detect_path_change_before_prune` mock bootstrap return updated to include `"settings": {}`.
- [x] `tests/services/test_library.py::plugin` and `tests/services/test_migration.py::plugin` fixtures now wire `p._persistence` explicitly (no lazy fallback to silently produce one).

## Notes

- Bootstrap docstring (module + function) rewritten — old text claimed the dict served "lazy-property backing attributes" and listed a non-existent `wire_services` key. Now describes the actual contract: adapter instantiation lives here, settings loaded+migrated inside, returned `"settings"` is the live shared dict.

Closes #350. Part of #347 (Phase 1 — Startup Hardening).