### PR TITLE
hardening(library): sync generation-id guards safety-timeout race (#351)

### DIFF
--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -105,6 +105,12 @@ class LibraryService:
         # Sync-specific state (owned by this service)
         self._sync_state = SyncState.IDLE
         self._sync_last_heartbeat = 0.0
+        # Generation id for the active sync run. Background tasks
+        # (safety timeout) capture this at start and check it still
+        # matches before mutating state — prevents a late timeout from
+        # overwriting the post-cancel/error transition done by
+        # ``_finish_sync``.
+        self._current_sync_id: str | None = None
         self._sync_progress: dict = {
             "running": False,
             "phase": "",
@@ -271,6 +277,7 @@ class LibraryService:
         if self._sync_state != SyncState.IDLE:
             return {"success": False, "message": "Sync already in progress"}
         self._sync_state = SyncState.RUNNING
+        self._current_sync_id = self._uuid_gen.uuid4()
         self._sync_last_heartbeat = self._clock.monotonic()
         self._loop.create_task(self._do_sync())
         return {"success": True, "message": "Sync started"}
@@ -295,6 +302,7 @@ class LibraryService:
         if self._sync_state != SyncState.IDLE:
             return {"success": False, "message": "Sync already in progress"}
         self._sync_state = SyncState.RUNNING
+        self._current_sync_id = self._uuid_gen.uuid4()
         self._sync_last_heartbeat = self._clock.monotonic()
         try:
             fetch_result = await self._fetch_and_prepare()
@@ -379,6 +387,7 @@ class LibraryService:
         delta = self._pending_delta
         self._pending_delta = None
         self._sync_state = SyncState.RUNNING
+        self._current_sync_id = self._uuid_gen.uuid4()
         self._sync_last_heartbeat = self._clock.monotonic()
 
         # Calculate apply step plan
@@ -478,13 +487,24 @@ class LibraryService:
         }
         await self._emit("sync_progress", self._sync_progress)
 
-    def _start_safety_timeout(self, heartbeat_timeout_sec=30):
-        """Launch a background task that auto-completes sync if no heartbeat arrives."""
+    def _start_safety_timeout(self, heartbeat_timeout_sec=30) -> asyncio.Task:
+        """Launch a background task that auto-completes sync if no heartbeat arrives.
+
+        Returns the spawned task so tests can deterministically await its
+        completion; production callers ignore the return value.
+        """
         self._sync_last_heartbeat = self._clock.monotonic()
+        captured_sync_id = self._current_sync_id
 
         async def _safety_timeout():
             while self._sync_progress.get("running"):
                 await self._sleeper.sleep(10)
+                # Generation guard: if our sync has ended (cancel, error,
+                # normal completion), _current_sync_id was cleared or
+                # replaced. Don't fire stale "done" or overwrite the new
+                # sync state.
+                if self._current_sync_id != captured_sync_id:
+                    return
                 elapsed = self._clock.monotonic() - self._sync_last_heartbeat
                 if elapsed > heartbeat_timeout_sec:
                     self._logger.warning(f"Sync safety timeout: no heartbeat for {elapsed:.0f}s")
@@ -498,10 +518,16 @@ class LibraryService:
                         ),
                         running=False,
                     )
+                    # Second generation check: the await above yielded the
+                    # event loop, so a new sync may have started during
+                    # _emit_progress. Don't stomp its state.
+                    if self._current_sync_id != captured_sync_id:
+                        return
                     self._sync_state = SyncState.IDLE
+                    self._current_sync_id = None
                     return
 
-        self._loop.create_task(_safety_timeout())
+        return self._loop.create_task(_safety_timeout())
 
     # ── Fetch & prepare ──────────────────────────────────────
 
@@ -899,6 +925,7 @@ class LibraryService:
         }
         await self._emit("sync_progress", self._sync_progress)
         self._sync_state = SyncState.IDLE
+        self._current_sync_id = None
         self._logger.info(message)
 
     # ── Sync results (called by frontend) ────────────────────
@@ -1029,6 +1056,9 @@ class LibraryService:
             )
             self._logger.info(f"Sync results reported: {total} games")
         self._sync_state = SyncState.IDLE
+        # Invalidate any in-flight safety timeout — sync is over, no
+        # late "done" event should fire on top of the one we just emitted.
+        self._current_sync_id = None
         return {"success": True}
 
     # ── Artwork delegation ───────────────────────────────────

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -1826,6 +1826,194 @@ class TestFinishSync:
         assert plugin._sync_service._sync_progress["phase"] == "cancelled"
         assert plugin._sync_service._sync_progress["message"] == "Sync cancelled"
 
+    @pytest.mark.asyncio
+    async def test_clears_current_sync_id(self, plugin):
+        """_finish_sync invalidates _current_sync_id so any in-flight safety
+        timeout for the cancelled sync sees a stale generation."""
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._sync_progress = {"running": True}
+        plugin._sync_service._current_sync_id = "sync-abc"
+
+        await plugin._sync_service._finish_sync("Sync cancelled")
+
+        assert plugin._sync_service._current_sync_id is None
+
+
+class TestSafetyTimeoutGenerationGuard:
+    """Regression for #351 — safety timeout must not emit a stale "done"
+    after _finish_sync (cancel/error) or report_sync_results (happy end)
+    has already transitioned the sync."""
+
+    @staticmethod
+    def _gated_sleeper(release: "asyncio.Event"):
+        """A sleeper that blocks until ``release`` is set."""
+
+        class _Gated:
+            async def sleep(self, _seconds: float) -> None:
+                await release.wait()
+
+        return _Gated()
+
+    @pytest.mark.asyncio
+    async def test_safety_timeout_silenced_after_finish_sync(self, plugin):
+        """Cancel during sync → safety timeout's late wake-up emits nothing.
+
+        Reproduces the original glitch: UI receiving `cancelled` followed by
+        a phantom `done` because the background timeout fired after
+        ``_finish_sync`` had already transitioned to IDLE.
+        """
+        import decky
+
+        svc = plugin._sync_service
+        loop = asyncio.get_event_loop()
+        plugin.loop = loop
+        svc._loop = loop
+
+        release = asyncio.Event()
+        svc._sleeper = self._gated_sleeper(release)
+        svc._sync_state = SyncState.RUNNING
+        svc._current_sync_id = "sync-abc"
+        svc._sync_progress = {"running": True, "current": 5, "total": 10}
+
+        decky.emit.reset_mock()
+        task = svc._start_safety_timeout(heartbeat_timeout_sec=1)
+        # Advance past the heartbeat timeout so the elapsed check would
+        # otherwise fire — the generation guard must override it.
+        svc._clock.advance(999)
+
+        # Let the safety-timeout task park on the gated sleep.
+        await asyncio.sleep(0)
+        # Cancel completes — clears _current_sync_id while timeout is parked.
+        await svc._finish_sync("Sync cancelled")
+        # Release the timeout; its generation guard should fire and exit.
+        release.set()
+        await task
+
+        progress_phases = [
+            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
+        ]
+        assert "cancelled" in progress_phases
+        # The original glitch: a phantom "done" landing after "cancelled".
+        assert "done" not in progress_phases
+
+    @pytest.mark.asyncio
+    async def test_safety_timeout_fires_when_generation_unchanged(self, plugin):
+        """Sanity check the guard isn't over-eager: same generation → still fires."""
+        import decky
+
+        svc = plugin._sync_service
+        loop = asyncio.get_event_loop()
+        plugin.loop = loop
+        svc._loop = loop
+
+        release = asyncio.Event()
+        svc._sleeper = self._gated_sleeper(release)
+        svc._sync_state = SyncState.RUNNING
+        svc._current_sync_id = "sync-xyz"
+        svc._sync_progress = {"running": True, "current": 5, "total": 10}
+        svc._state["sync_stats"] = {"roms": 5, "platforms": 1}
+
+        decky.emit.reset_mock()
+        task = svc._start_safety_timeout(heartbeat_timeout_sec=1)
+        # Advance the FakeClock past the timeout so elapsed > heartbeat_timeout.
+        svc._clock.advance(999)
+
+        await asyncio.sleep(0)
+        # No cancel — generation id unchanged. Release the sleep; timeout fires.
+        release.set()
+        await task
+
+        progress_phases = [
+            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
+        ]
+        assert "done" in progress_phases
+        assert svc._sync_state == SyncState.IDLE
+        assert svc._current_sync_id is None
+
+    @pytest.mark.asyncio
+    async def test_safety_timeout_silenced_after_report_sync_results(self, plugin, tmp_path):
+        """Happy-end path → safety timeout's late wake-up emits nothing.
+
+        Mirrors the cancel scenario for the report_sync_results clearing
+        path: frontend reports successfully, _current_sync_id is cleared,
+        any in-flight safety timeout sees the stale captured id and exits.
+        """
+        import decky
+
+        from adapters.persistence import PersistenceAdapter
+
+        svc = plugin._sync_service
+        loop = asyncio.get_event_loop()
+        plugin.loop = loop
+        svc._loop = loop
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        plugin._save_state = lambda: None
+
+        release = asyncio.Event()
+        svc._sleeper = self._gated_sleeper(release)
+        svc._sync_state = SyncState.RUNNING
+        svc._current_sync_id = "sync-happy"
+        svc._sync_progress = {"running": True, "current": 5, "total": 10}
+        svc._pending_sync = {}
+
+        decky.emit.reset_mock()
+        task = svc._start_safety_timeout(heartbeat_timeout_sec=1)
+        svc._clock.advance(999)
+
+        await asyncio.sleep(0)
+        # Happy end: report_sync_results clears the id and transitions to IDLE.
+        await plugin.report_sync_results({}, [])
+        release.set()
+        await task
+
+        progress_phases = [
+            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
+        ]
+        # report_sync_results emits its own "done"; the safety timeout's
+        # captured id no longer matches, so it does NOT emit a second one.
+        assert progress_phases.count("done") == 1
+        assert svc._current_sync_id is None
+
+    @pytest.mark.asyncio
+    async def test_safety_timeout_does_not_stomp_new_sync_started_during_emit(self, plugin):
+        """Post-emit re-check: a new sync starting between safety timeout's
+        emit and its IDLE/clear must not have its state stomped."""
+        import decky
+
+        svc = plugin._sync_service
+        loop = asyncio.get_event_loop()
+        plugin.loop = loop
+        svc._loop = loop
+
+        release = asyncio.Event()
+        svc._sleeper = self._gated_sleeper(release)
+        svc._sync_state = SyncState.RUNNING
+        svc._current_sync_id = "sync-old"
+        svc._sync_progress = {"running": True, "current": 5, "total": 10}
+        svc._state["sync_stats"] = {"roms": 5, "platforms": 1}
+
+        # Inject a new-sync start during the safety timeout's _emit_progress
+        # await by stubbing _emit_progress to mutate the live state mid-call.
+        async def _emit_progress_mid_start(*_a, **_kw):
+            # Simulate a fresh sync racing in between emit and stomp.
+            svc._sync_state = SyncState.RUNNING
+            svc._current_sync_id = "sync-new"
+
+        svc._emit_progress = _emit_progress_mid_start
+
+        decky.emit.reset_mock()
+        task = svc._start_safety_timeout(heartbeat_timeout_sec=1)
+        svc._clock.advance(999)
+
+        await asyncio.sleep(0)
+        release.set()
+        await task
+
+        # The new sync's state must be intact — safety timeout's second
+        # generation check observed the change and exited.
+        assert svc._sync_state == SyncState.RUNNING
+        assert svc._current_sync_id == "sync-new"
+
 
 class TestSyncPreviewErrorHandling:
     """Tests for sync_preview error paths — lines 210-219."""


### PR DESCRIPTION
## Summary

- `LibraryService._start_safety_timeout()` ran as a background task that could emit a phantom `done` event AFTER `_finish_sync` had already emitted `cancelled` — its `elapsed > timeout` check fired between sleep wake-up and the next while-loop top, racing the cancel transition. UI symptom: `cancelled` followed by `done`.
- Stamp every sync entry with a UUID generation id (`_current_sync_id`). The safety timeout captures it at start and short-circuits any state mutation if the id has moved on (cancel, error, normal completion). A second generation check after the `_emit_progress("done", ...)` await protects against a fresh sync racing in during the emit yield.
- `_finish_sync` and the end of `report_sync_results` clear the id; other IDLE transitions intentionally leave it alive because their paths either never started a safety_timeout or are the IDLE-but-frontend-still-working window the safety_timeout legitimately monitors.

## Test plan

- [x] `python -m pytest tests/ -q` (2226 pass, +5 new tests this issue)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] Regression tests added (all under `TestSafetyTimeoutGenerationGuard`):
  - `test_safety_timeout_silenced_after_finish_sync` — cancel during sync; safety timeout's late wake-up sees stale gen id, exits silently. No phantom `done`.
  - `test_safety_timeout_silenced_after_report_sync_results` — happy-end path: report_sync_results clears the id; safety timeout's late wake-up is silenced. Only ONE `done` emit.
  - `test_safety_timeout_fires_when_generation_unchanged` — sanity check: same gen id → safety timeout still fires normally on heartbeat timeout.
  - `test_safety_timeout_does_not_stomp_new_sync_started_during_emit` — post-emit re-check: a new sync started during the emit's await yield is not stomped by the safety timeout's IDLE/clear.
  - `TestFinishSync::test_clears_current_sync_id` — `_finish_sync` invalidates `_current_sync_id`.

Tests use a `_GatedSleeper` that parks on an `asyncio.Event` so interleaving is deterministic. `_start_safety_timeout` now returns the spawned `asyncio.Task` so tests can `await` it; production callers ignore the return.

Closes #351. Part of #347 (Phase 1 — Startup Hardening).