### PR TITLE
hardening(persistence): state.json .prev backup + auto-recovery (#352)

### DIFF
--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -55,13 +55,23 @@ class PersistenceAdapter:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _locked_write(self, path: str, data: dict) -> None:
-        """Atomic write of *data* to *path* under an exclusive file lock."""
+    def _locked_write(self, path: str, data: dict, *, rotate_to: str | None = None) -> None:
+        """Atomic write of *data* to *path* under an exclusive file lock.
+
+        When ``rotate_to`` is provided, the existing file at ``path`` is
+        atomically renamed to that path before the new contents are
+        written — a one-deep backup that callers can fall back to if a
+        crash leaves the primary file empty or corrupt. Missing primary
+        is fine: rotation is a no-op in that case.
+        """
         os.makedirs(os.path.dirname(path), exist_ok=True)
         tmp_path = path + ".tmp"
         lock_fd = os.open(path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            if rotate_to is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    os.replace(path, rotate_to)
             fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
                 with os.fdopen(fd, "w") as f:
@@ -120,29 +130,54 @@ class PersistenceAdapter:
     def load_state(self, defaults: dict) -> dict:
         """Read ``state.json`` and merge with *defaults*.
 
-        Returns the merged dict.  If the file is missing or corrupt the
-        returned dict is a copy of *defaults* with the version stamp.
+        If the primary file is missing/corrupt or its ``shortcut_registry``
+        is empty, falls back to the one-deep ``state.json.prev`` backup
+        when that file has a non-empty registry — a crash mid-write
+        otherwise wipes the user's shortcut library.
         """
         state_path = os.path.join(self._runtime_dir, "state.json")
+        backup_path = state_path + ".prev"
         state = dict(defaults)
-        try:
-            with open(state_path) as f:
-                saved = json.load(f)
-            if not isinstance(saved, dict):
-                saved = {}
-            if "version" not in saved:
-                saved["version"] = _STATE_VERSION
-            state.update(saved)
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+
+        primary = self._read_state_json(state_path)
+        if primary is not None and primary.get("shortcut_registry"):
+            saved = primary
+        else:
+            backup = self._read_state_json(backup_path)
+            if backup is not None and backup.get("shortcut_registry"):
+                self._logger.warning(
+                    "state.json empty/corrupt; recovered %d shortcut_registry entries from state.json.prev",
+                    len(backup["shortcut_registry"]),
+                )
+                saved = backup
+            else:
+                saved = primary if primary is not None else {}
+
+        if "version" not in saved:
+            saved["version"] = _STATE_VERSION
+        state.update(saved)
         state.setdefault("version", _STATE_VERSION)
         return state
 
+    def _read_state_json(self, path: str) -> dict | None:
+        """Read a state.json-shaped file. Returns ``None`` on missing or corrupt input."""
+        try:
+            with open(path) as f:
+                loaded = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+        return loaded if isinstance(loaded, dict) else None
+
     def save_state(self, data: dict) -> None:
-        """Atomic write of *data* to ``state.json`` with flock, stamping version."""
+        """Atomic write of *data* to ``state.json`` with flock, stamping version.
+
+        Rotates the current ``state.json`` to ``state.json.prev`` before
+        the write — that backup is the recovery source if a subsequent
+        crash leaves the primary empty (see :meth:`load_state`).
+        """
         data["version"] = _STATE_VERSION
         state_path = os.path.join(self._runtime_dir, "state.json")
-        self._locked_write(state_path, data)
+        self._locked_write(state_path, data, rotate_to=state_path + ".prev")
 
     # ------------------------------------------------------------------
     # Metadata cache

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -291,6 +291,116 @@ class TestLoadingEdgeCases:
         assert result["shortcut_registry"] == {}
         assert result["version"] == _STATE_VERSION
 
+    def test_save_state_rotates_existing_to_prev(self, adapter):
+        """Each save_state call rotates the current state.json to state.json.prev."""
+        adapter.save_state({"shortcut_registry": {"1": {"name": "Game A"}}})
+        adapter.save_state({"shortcut_registry": {"2": {"name": "Game B"}}})
+
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(state_path) as f:
+            current = json.load(f)
+        with open(prev_path) as f:
+            prev = json.load(f)
+
+        assert current["shortcut_registry"] == {"2": {"name": "Game B"}}
+        assert prev["shortcut_registry"] == {"1": {"name": "Game A"}}
+
+    def test_save_state_first_write_creates_no_prev(self, adapter):
+        """First save_state has nothing to rotate; .prev should not be created."""
+        adapter.save_state({"shortcut_registry": {"1": {"name": "Game A"}}})
+
+        prev_path = os.path.join(adapter._runtime_dir, "state.json.prev")
+        assert not os.path.exists(prev_path)
+
+    def test_load_state_recovers_from_prev_when_primary_empty(self, adapter, caplog):
+        """state.json with empty registry → recovery from state.json.prev (full dict, not just registry)."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(prev_path, "w") as f:
+            json.dump(
+                {
+                    "version": _STATE_VERSION,
+                    "shortcut_registry": {"42": {"name": "Game A"}},
+                    "last_sync": "2026-05-15T10:00:00",
+                },
+                f,
+            )
+        with open(state_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {}}, f)
+
+        with caplog.at_level(logging.WARNING):
+            result = adapter.load_state({"shortcut_registry": {}, "last_sync": None})
+
+        assert result["shortcut_registry"] == {"42": {"name": "Game A"}}
+        # Non-registry fields recovered too — caller sees the full prior state.
+        assert result["last_sync"] == "2026-05-15T10:00:00"
+        assert any("state.json.prev" in rec.message for rec in caplog.records)
+
+    def test_load_state_recovers_from_prev_when_primary_corrupt(self, adapter):
+        """state.json with corrupt JSON → recovery from state.json.prev."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(prev_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {"42": {"name": "Game A"}}}, f)
+        with open(state_path, "w") as f:
+            f.write("{not valid json")
+
+        result = adapter.load_state({"shortcut_registry": {}})
+
+        assert result["shortcut_registry"] == {"42": {"name": "Game A"}}
+
+    def test_load_state_no_recovery_when_prev_also_empty(self, adapter, caplog):
+        """Both primary and .prev empty → no recovery, no warning."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(state_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {}}, f)
+        with open(prev_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {}}, f)
+
+        with caplog.at_level(logging.WARNING):
+            result = adapter.load_state({"shortcut_registry": {}})
+
+        assert result["shortcut_registry"] == {}
+        assert not any("recovered" in rec.message for rec in caplog.records)
+
+    def test_load_state_no_recovery_when_prev_missing(self, adapter):
+        """Empty primary + missing .prev → no crash, returns defaults."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {}}, f)
+
+        result = adapter.load_state({"shortcut_registry": {}})
+
+        assert result["shortcut_registry"] == {}
+
+    def test_load_state_no_recovery_when_prev_corrupt(self, adapter):
+        """Empty primary + corrupt .prev → no crash, no recovery."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(state_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {}}, f)
+        with open(prev_path, "w") as f:
+            f.write("garbage{")
+
+        result = adapter.load_state({"shortcut_registry": {}})
+
+        assert result["shortcut_registry"] == {}
+
+    def test_load_state_prefers_primary_when_registry_populated(self, adapter):
+        """Primary with populated registry → use it, ignore .prev."""
+        state_path = os.path.join(adapter._runtime_dir, "state.json")
+        prev_path = state_path + ".prev"
+        with open(state_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {"1": {"name": "Current"}}}, f)
+        with open(prev_path, "w") as f:
+            json.dump({"version": _STATE_VERSION, "shortcut_registry": {"2": {"name": "Stale"}}}, f)
+
+        result = adapter.load_state({"shortcut_registry": {}})
+
+        assert result["shortcut_registry"] == {"1": {"name": "Current"}}
+
     def test_load_metadata_cache_non_dict_json_returns_empty(self, adapter):
         cache_path = os.path.join(adapter._runtime_dir, "metadata_cache.json")
         with open(cache_path, "w") as f:


### PR DESCRIPTION
## Summary

- A CEF crash mid-write could leave `state.json` present but empty, wiping the user's shortcut registry on next start — a real user-visible loss (hundreds of shortcuts to re-sync).
- Add a rolling one-deep backup: every `save_state` rotates `state.json` → `state.json.prev` (atomic `os.replace` inside the existing flock) before writing the new contents. `load_state` falls back to `.prev` when the primary is missing/corrupt or has an empty `shortcut_registry`, and logs a warning when recovery fires.
- Pattern proposed in stale PR #218 (Christopher Blaisdell); intent preserved here.

## Test plan

- [x] `python -m pytest tests/ -q` (2234 pass, +8 new tests this issue)
- [x] `ruff check py_modules/ tests/ main.py` clean
- [x] `basedpyright py_modules/ tests/ main.py` clean
- [x] `scripts/check_cosmic_call_bans.sh` clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] Regression tests added:
  - `test_save_state_rotates_existing_to_prev` — two consecutive saves; `.prev` holds the previous payload.
  - `test_save_state_first_write_creates_no_prev` — first save has nothing to rotate.
  - `test_load_state_recovers_from_prev_when_primary_empty` — recovers full dict (registry + other fields), warning logged.
  - `test_load_state_recovers_from_prev_when_primary_corrupt` — corrupt JSON primary triggers recovery.
  - `test_load_state_no_recovery_when_prev_also_empty` — both empty → defaults, no warning.
  - `test_load_state_no_recovery_when_prev_missing` — empty primary + missing .prev → defaults, no crash.
  - `test_load_state_no_recovery_when_prev_corrupt` — empty primary + corrupt .prev → defaults, no crash.
  - `test_load_state_prefers_primary_when_registry_populated` — populated primary → use it, ignore .prev.

## Design notes

- Rotation happens inside the same flock that protects the tmp+rename of the new contents. Single-process atomicity preserved; cross-process readers without the lock could observe the gap-between-replaces, which then falls through to `.prev` — the same recovery path.
- Scope intentionally limited to `state.json`. `save_sync_state.json`, `metadata_cache.json`, `firmware_cache.json`, and `settings.json` rebuild from authoritative sources (RomM / user input) and don't need a rolling backup.

Closes #352. Part of #347 (Phase 1 — Startup Hardening).