### PR TITLE
ci(sonar): exclude vendored vdf from analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,8 +10,9 @@ sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Exclusions
-sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pycache__/**
-sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/**
+# py_modules/vdf is Rossen Georgiev's vendored vdf library — not our code.
+sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pycache__/**,py_modules/vdf/**
+sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/**,py_modules/vdf/**
 
 # Suppress false positives
 # S6926: "async without await" — Decky Loader callable framework requires all


### PR DESCRIPTION
## Summary
- Adds `py_modules/vdf/**` to `sonar.exclusions` and `sonar.coverage.exclusions` so the vendored vdf library (Rossen Georgiev's, see `vdf-3.4.dist-info`) stops generating Sonar findings.
- All 10 currently-open Python Sonar issues live in that vendored tree.

## Test plan
- [ ] CI green
- [ ] After Sonar re-analyses the PR/main: 0 open Python issues, Quality Gate green

Closes #363. Part of #353.