### PR TITLE
docs(adapters/romm): add contract docstring to package init

### DIFF
--- a/py_modules/adapters/romm/__init__.py
+++ b/py_modules/adapters/romm/__init__.py
@@ -1,0 +1,8 @@
+"""RomM adapter — REST API surface and its HTTP transport.
+
+Anything that speaks the RomM REST protocol lives here. ``romm_api``
+is the public surface consumed by services through ``RommApiProtocol``;
+``http`` is the transport it sits on top of. Both modules are
+deep-imported by bootstrap and tests, so this package intentionally
+re-exports nothing.
+"""


### PR DESCRIPTION
## Summary
- Fills the empty `py_modules/adapters/romm/__init__.py` with a contract-style module docstring, matching the convention from `services/saves/` sub-packages (PR #342 / CLAUDE.md).
- No re-exports: `adapters/romm` is deep-imported only (bootstrap + tests + the internal `http → romm_api` hop), so the empty public surface is intentional and now documented.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues

Closes #365. Part of #353.