### PR TITLE
refactor(services): move asyncio/logging imports under TYPE_CHECKING

### DIFF
--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -10,9 +10,7 @@ this service remains a pure orchestration layer.
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -20,6 +18,9 @@ from domain.version import meets_min_version
 from lib.errors import error_response
 
 if TYPE_CHECKING:
+    import asyncio
+    import logging
+
     from services.protocols import RommApiProtocol
 
 

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -13,12 +13,13 @@ cross-service BIOS recheck are this service's concern.
 
 from __future__ import annotations
 
-import asyncio
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import asyncio
+    import logging
+
     from services.protocols import (
         CoreInfoProvider,
         GamelistXmlEditorProtocol,

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -10,13 +10,14 @@ mounting don't get wiped on the next reload.
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.installed_roms import is_pending_migration_path
 
 if TYPE_CHECKING:
+    import logging
+
     from services.protocols import PathExistsProbe, RetroDeckHomeProvider, StatePersister
 
 


### PR DESCRIPTION
## Summary
- `connection.py`, `cores.py`, and `startup_healing.py` only reference `asyncio` and `logging` from dataclass field annotations.
- With `from __future__ import annotations` already in place, those references are forward strings, so the imports belong under `TYPE_CHECKING` — matching the rest of the service layer.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues

Closes #360. Part of #353.