### PR TITLE
refactor(protocols): delete PlatformBiosChecker, fold into BiosChecker

### DIFF
--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
     import logging
 
     from services.protocols import (
+        BiosChecker,
         CoreInfoProvider,
         GamelistXmlEditorProtocol,
-        PlatformBiosChecker,
         RetroDeckHomeProvider,
     )
 
@@ -43,7 +43,7 @@ class CoreServiceConfig:
     core_info: CoreInfoProvider
     gamelist_editor: GamelistXmlEditorProtocol
     retrodeck_home: RetroDeckHomeProvider
-    bios_checker: PlatformBiosChecker
+    bios_checker: BiosChecker
 
 
 class CoreService:

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -984,23 +984,6 @@ class BiosChecker(Protocol):
     async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict: ...
 
 
-class PlatformBiosChecker(Protocol):
-    """Cross-service read seam: ask the firmware service whether a
-    platform's required BIOS files are present, optionally narrowed
-    by a per-game core override.
-
-    Exposes only the single async ``check_platform_bios`` entry point
-    CoreService needs after writing a core override, without dragging
-    in the rest of FirmwareService's surface.
-    """
-
-    async def check_platform_bios(
-        self,
-        platform_slug: str,
-        rom_filename: str | None = None,
-    ) -> dict: ...
-
-
 class AchievementsReader(Protocol):
     """Achievement data access consumed by GameDetailService."""
 

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -41,7 +41,7 @@ class FakeGamelistEditor:
 
 
 class FakeBiosChecker:
-    """In-memory ``PlatformBiosChecker`` for tests."""
+    """In-memory ``BiosChecker`` for tests (only implements the async entry CoreService uses)."""
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str | None]] = []


### PR DESCRIPTION
## Summary
- `PlatformBiosChecker` was a strict subset of `BiosChecker` (one async method); both were satisfied by `FirmwareService`. Two protocols, one need — dead weight.
- `CoreService` now depends on `BiosChecker` directly. Structural typing means no caller, no fake, and no wiring site needs to change beyond the import.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues

Closes #359. Part of #353.