### PR TITLE
refactor(bootstrap): move min_required_version out of RuntimeBundle

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,6 @@ class Plugin:
                     clock=adapters["clock"],
                     uuid_gen=adapters["uuid_gen"],
                     sleeper=adapters["sleeper"],
-                    min_required_version=self._MIN_REQUIRED_VERSION,
                 ),
                 callbacks=CallbackBundle(
                     get_saves_path=self._retrodeck_paths.get_saves_path,
@@ -152,6 +151,7 @@ class Plugin:
                     save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
                     log_debug=self._log_debug,
                 ),
+                min_required_version=self._MIN_REQUIRED_VERSION,
             )
         )
         self._save_sync_service = services["save_sync_service"]

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -128,7 +128,6 @@ class RuntimeBundle:
     clock: Clock
     uuid_gen: UuidGen
     sleeper: Sleeper
-    min_required_version: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -152,12 +151,18 @@ class CallbackBundle:
 
 @dataclass(frozen=True)
 class WiringConfig:
-    """Composition-root inputs for ``wire_services`` grouped into four bundles."""
+    """Composition-root inputs for ``wire_services``.
+
+    Four bundles carry the wiring; ``min_required_version`` sits at the
+    top level — it's plugin metadata, not a runtime seam, and only
+    ConnectionService consumes it.
+    """
 
     adapters: AdapterBundle
     stores: StateBundle
     runtime: RuntimeBundle
     callbacks: CallbackBundle
+    min_required_version: tuple[int, ...]
 
 
 def bootstrap(
@@ -518,7 +523,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             romm_api=cfg.adapters.romm_api,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
-            min_required_version=cfg.runtime.min_required_version,
+            min_required_version=cfg.min_required_version,
         ),
     )
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -226,7 +226,6 @@ class TestWireServices:
                 clock=deps["clock"],
                 uuid_gen=deps["uuid_gen"],
                 sleeper=deps["sleeper"],
-                min_required_version=deps["min_required_version"],
             ),
             callbacks=CallbackBundle(
                 get_saves_path=deps["get_saves_path"],
@@ -243,6 +242,7 @@ class TestWireServices:
                 save_sync_state_persister=deps["save_sync_state_persister"],
                 log_debug=deps["log_debug"],
             ),
+            min_required_version=deps["min_required_version"],
         )
 
     def test_returns_all_services(self, tmp_path):


### PR DESCRIPTION
## Summary
- `RuntimeBundle` carries process-level runtime infrastructure (loop, logger, paths, time/UUID/sleep seams). The minimum RomM version is plugin metadata, not a runtime seam — only `ConnectionService` consumes it.
- Promoted `min_required_version` to a top-level `WiringConfig` field. `bootstrap.wire_services()` and `main.py` updated accordingly; tests follow.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues

Closes #358. Part of #353.