### PR TITLE
refactor(bootstrap): move *PersisterAdapter wrappers out of main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,10 +18,6 @@ from bootstrap import (
     wire_services,
 )
 
-from adapters.persistence import (
-    FirmwareCachePersisterAdapter,
-    SaveSyncStatePersisterAdapter,
-)
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -146,9 +142,9 @@ class Plugin:
                     save_state=self._save_state,
                     save_settings_to_disk=self._save_settings_to_disk,
                     save_metadata_cache=self._save_metadata_cache,
-                    firmware_cache_persister=FirmwareCachePersisterAdapter(self._persistence),
+                    firmware_cache_persister=adapters["firmware_cache_persister"],
                     core_info_provider=adapters["core_resolver"],
-                    save_sync_state_persister=SaveSyncStatePersisterAdapter(self._persistence),
+                    save_sync_state_persister=adapters["save_sync_state_persister"],
                     log_debug=self._log_debug,
                 ),
                 min_required_version=self._MIN_REQUIRED_VERSION,

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -21,7 +21,11 @@ from adapters.es_de_config import CoreResolver, GamelistXmlEditor
 from adapters.firmware_file import FirmwareFileAdapter as FirmwareFileAdapterImpl
 from adapters.migration_file import MigrationFileAdapter as MigrationFileAdapterImpl
 from adapters.path_probe import PathProbeAdapter
-from adapters.persistence import PersistenceAdapter
+from adapters.persistence import (
+    FirmwareCachePersisterAdapter,
+    PersistenceAdapter,
+    SaveSyncStatePersisterAdapter,
+)
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -212,6 +216,8 @@ def bootstrap(
     gamelist_editor = GamelistXmlEditor(logger=logger)
 
     persistence = PersistenceAdapter(settings_dir, runtime_dir, logger)
+    firmware_cache_persister = FirmwareCachePersisterAdapter(persistence)
+    save_sync_state_persister = SaveSyncStatePersisterAdapter(persistence)
     settings = persistence.load_settings()
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
@@ -234,6 +240,8 @@ def bootstrap(
 
     return {
         "persistence": persistence,
+        "firmware_cache_persister": firmware_cache_persister,
+        "save_sync_state_persister": save_sync_state_persister,
         "settings": settings,
         "http_adapter": http_adapter,
         "romm_api": romm_api,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -841,6 +841,8 @@ class TestMainStartupOrdering:
 
         bootstrapped_adapters = {
             "persistence": plugin._persistence,
+            "firmware_cache_persister": MagicMock(),
+            "save_sync_state_persister": MagicMock(),
             "settings": {},
             "http_adapter": MagicMock(),
             "romm_api": MagicMock(),


### PR DESCRIPTION
## Summary
- CLAUDE.md (PR #342) is explicit: *"Adapter instantiation never happens in `main.py`."* `FirmwareCachePersisterAdapter` and `SaveSyncStatePersisterAdapter` were the last violations — constructed inside the `CallbackBundle(...)` literal at the wiring site.
- Both wrappers now build in `bootstrap()` next to their backing `PersistenceAdapter`. `main.py` just reads them from the adapters dict.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues

Closes #357. Part of #353.