### PR TITLE
refactor(tests): FakeSaveApi delegates filesystem I/O to save_file adapter

### DIFF
--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -86,3 +86,13 @@ class SaveFileAdapter:
         fd, path = tempfile.mkstemp(suffix=suffix)
         os.close(fd)
         return path
+
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        with open(path, "rb") as f:
+            return f.read()
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Write *data* to *path*, overwriting any existing contents."""
+        with open(path, "wb") as f:
+            f.write(data)

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -914,6 +914,14 @@ class SaveFileAdapter(Protocol):
         """
         ...
 
+    def read_bytes(self, path: str) -> bytes:
+        """Return the contents of *path* as raw bytes."""
+        ...
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Write *data* to *path*, overwriting any existing contents."""
+        ...
+
 
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -760,6 +760,15 @@ class FakeSaveFileAdapter:
         self._ensure_mtime(path)
         return path
 
+    def read_bytes(self, path: str) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        self.files[path] = data
+        self._ensure_mtime(path)
+
 
 class FakePathProbe:
     """In-memory ``PathExistsProbe`` for tests.

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from services.protocols import SaveFileAdapter
 
 
 class FakeSaveApi:
@@ -12,14 +15,22 @@ class FakeSaveApi:
     Only save, note, and download_save methods are implemented.
     ROM, firmware, and platform methods raise NotImplementedError — use MagicMock()
     when those methods are needed.
+
+    Server-side save bytes live in ``_save_content`` (``save_id -> bytes``).
+    All filesystem I/O is delegated to the injected ``save_file`` adapter so
+    this fake never imports ``os``, ``open``, or ``shutil`` directly. When
+    ``save_file`` is None the fake is fully in-memory: uploads record a zero-
+    byte snapshot and downloads write the default zero-byte payload nowhere.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, save_file: SaveFileAdapter | None = None) -> None:
+        self.save_file: SaveFileAdapter | None = save_file
         self.saves: dict[int, dict] = {}  # save_id -> save dict
         self.roms: dict[int, dict] = {}  # rom_id -> rom detail dict
         self.notes: dict[int, list[dict]] = {}  # rom_id -> [note dicts]
-        self.uploaded_files: dict[int, str] = {}  # save_id -> file_path
-        self.downloaded_files: dict[int, str] = {}  # save_id -> dest_path
+        self.uploaded_files: dict[int, str] = {}  # save_id -> source file_path (log only)
+        self.downloaded_files: dict[int, str] = {}  # save_id -> dest_path (log only)
+        self._save_content: dict[int, bytes] = {}  # save_id -> server-side bytes
         self.call_log: list[tuple[str, tuple, dict]] = []
         self._next_save_id = 1000
         self._next_note_id = 2000
@@ -32,11 +43,62 @@ class FakeSaveApi:
         """Make the next call raise the given exception."""
         self._fail_on_next = exc
 
+    def set_server_save_content(self, save_id: int, content: bytes) -> None:
+        """Stage server-side bytes for *save_id* without writing to disk.
+
+        Tests use this to seed the bytes a later ``download_save_content``
+        will write to ``dest_path``. Mirrors the in-memory ``_save_content``
+        dict directly so callers don't have to reach into a private name.
+        """
+        self._save_content[save_id] = content
+
     def _check_fail(self) -> None:
         if self._fail_on_next is not None:
             exc = self._fail_on_next
             self._fail_on_next = None
             raise exc
+
+    def _basename(self, path: str) -> str:
+        # Path algebra only — split on both separators so callers using
+        # tmp_path style absolute paths still get the file component.
+        last_sep = max(path.rfind("/"), path.rfind("\\"))
+        return path[last_sep + 1 :] if last_sep >= 0 else path
+
+    def _capture_upload(self, save_id: int, file_path: str) -> int:
+        """Read bytes from *file_path* via the injected adapter and return size.
+
+        When no ``save_file`` adapter is wired, records empty bytes (size 0)
+        — tests that exercise size/hash semantics must wire an adapter.
+        """
+        if self.save_file is None:
+            self._save_content[save_id] = b""
+            return 0
+        if not self.save_file.is_file(file_path):
+            self._save_content[save_id] = b""
+            return 0
+        data = self.save_file.read_bytes(file_path)
+        self._save_content[save_id] = data
+        return len(data)
+
+    def _materialize_download(self, save_id: int, dest_path: str) -> None:
+        """Write the staged bytes for *save_id* to *dest_path* via the adapter.
+
+        Resolution order:
+        1. ``_save_content[save_id]`` — bytes captured at upload or staged
+           via ``set_server_save_content``.
+        2. ``uploaded_files[save_id]`` — legacy staging where a test wrote
+           a file to disk and pointed at it; we re-read via the adapter.
+        3. Fallback to 1024 zero-bytes so callers always get a file.
+        """
+        if self.save_file is None:
+            return
+        if save_id in self._save_content:
+            data = self._save_content[save_id]
+        elif save_id in self.uploaded_files and self.save_file.is_file(self.uploaded_files[save_id]):
+            data = self.save_file.read_bytes(self.uploaded_files[save_id])
+        else:
+            data = b"\x00" * 1024
+        self.save_file.write_bytes(dest_path, data)
 
     # ------------------------------------------------------------------
     # Unimplemented RommApiProtocol methods (use MagicMock for these)
@@ -112,6 +174,7 @@ class FakeSaveApi:
         self._check_fail()
         for sid in save_ids:
             self.saves.pop(sid, None)
+            self._save_content.pop(sid, None)
         return {"deleted": len(save_ids)}
 
     def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
@@ -151,20 +214,7 @@ class FakeSaveApi:
         self._check_fail()
 
         self.downloaded_files[save_id] = dest_path
-
-        # If we have uploaded content for this save, copy it
-        if save_id in self.uploaded_files:
-            import os
-            import shutil
-
-            src = self.uploaded_files[save_id]
-            if os.path.isfile(src):
-                shutil.copy2(src, dest_path)
-                return
-
-        # Write default content so the file exists
-        with open(dest_path, "wb") as f:
-            f.write(b"\x00" * 1024)
+        self._materialize_download(save_id, dest_path)
 
     def confirm_download(self, save_id: int, device_id: str) -> dict:
         self.call_log.append(("confirm_download", (save_id, device_id), {}))
@@ -239,13 +289,11 @@ class FakeSaveApi:
         )
         self._check_fail()
 
-        import os
-
-        filename = os.path.basename(file_path)
+        filename = self._basename(file_path)
         now = datetime.now(UTC).isoformat()
-        size = os.path.getsize(file_path) if os.path.isfile(file_path) else 0
 
         if save_id and save_id in self.saves:
+            size = self._capture_upload(save_id, file_path)
             entry = self.saves[save_id]
             entry["updated_at"] = now
             entry["file_size_bytes"] = size
@@ -259,6 +307,8 @@ class FakeSaveApi:
                     break
             if existing:
                 save_id = existing["id"]
+                assert save_id is not None
+                size = self._capture_upload(save_id, file_path)
                 existing["updated_at"] = now
                 existing["file_size_bytes"] = size
                 existing["emulator"] = emulator
@@ -266,6 +316,7 @@ class FakeSaveApi:
             else:
                 save_id = self._next_save_id
                 self._next_save_id += 1
+                size = self._capture_upload(save_id, file_path)
                 entry = {
                     "id": save_id,
                     "rom_id": rom_id,
@@ -286,21 +337,7 @@ class FakeSaveApi:
         self._check_fail()
 
         self.downloaded_files[save_id] = dest_path
-
-        # If we have uploaded content for this save, copy it
-        if save_id in self.uploaded_files:
-            import shutil
-
-            src = self.uploaded_files[save_id]
-            import os
-
-            if os.path.isfile(src):
-                shutil.copy2(src, dest_path)
-                return
-
-        # Write default content so the file exists
-        with open(dest_path, "wb") as f:
-            f.write(b"\x00" * 1024)
+        self._materialize_download(save_id, dest_path)
 
     def get_save_metadata(self, save_id: int) -> dict:
         self.call_log.append(("get_save_metadata", (save_id,), {}))

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -64,11 +64,17 @@ _CONFIG_FIELDS = frozenset(
 
 def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["SaveService", "FakeSaveApi"]:
     """Create a SaveService with sensible defaults for testing."""
-    fake: FakeSaveApi = fake_api or FakeSaveApi()
+    save_file = SaveFileAdapter()
+    fake: FakeSaveApi = fake_api or FakeSaveApi(save_file=save_file)
+    # Tests that build their own FakeSaveApi without wiring the adapter get
+    # the same instance as the service so download_save_content materializes
+    # bytes onto the shared filesystem view.
+    if fake.save_file is None:
+        fake.save_file = save_file
     config_kwargs: dict[str, Any] = dict(
         runtime_dir=str(tmp_path),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
-        save_file=SaveFileAdapter(),
+        save_file=save_file,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -80,8 +80,10 @@ def plugin(tmp_path):
     )
     decky.DECKY_USER_HOME = str(tmp_path)
 
-    # Wire services with FakeSaveApi
-    fake_api = FakeSaveApi()
+    # Wire services with FakeSaveApi sharing the SaveFileAdapter so download
+    # bytes land on the same filesystem view the service inspects.
+    save_file_adapter = SaveFileAdapter()
+    fake_api = FakeSaveApi(save_file=save_file_adapter)
     p._save_sync_state = SaveService.make_default_state()
     saves_path = str(tmp_path / "retrodeck" / "saves")
 
@@ -103,7 +105,7 @@ def plugin(tmp_path):
                     logger=logging.getLogger("test"),
                 )
             ),
-            save_file=SaveFileAdapter(),
+            save_file=save_file_adapter,
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),


### PR DESCRIPTION
## Summary
- `FakeSaveApi` now keeps server-side bytes in an in-memory `_save_content: dict[int, bytes]` dict and routes every file read/write through an injected `SaveFileAdapter`. The fake itself contains zero `open` / `shutil` / `os.path` calls.
- Adds `read_bytes` / `write_bytes` to the `SaveFileAdapter` Protocol + concrete adapter + `FakeSaveFileAdapter`.
- Test helpers (`tests/services/saves/_helpers.py`) and `tests/test_plugin_saves.py` share **one** `SaveFileAdapter` instance between `SaveService` and the fake so the legacy `uploaded_files` staging continues to work end-to-end.

## Why this shape
Saves tests rely on a real-filesystem view (30+ `(saves_dir / "x.srm").exists()` assertions). Faking out the entire `SaveFileAdapter` would have meant rewriting the saves test pattern. Instead, the fake's own code becomes I/O-free; the syscalls are owned by the adapter the service already uses. Pure in-memory mode (`save_file=None`) is still supported for new tests that don't want a disk view.

## Test plan
- [ ] CI green (build, lint, test)
- [ ] Sonar: 0 new issues
- [ ] All 2234 tests pass locally — same count as before

Closes #362. Part of #353.