### PR TITLE
refactor(tests): extract _make_retry / _no_retry to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,21 @@ mock_decky.emit = AsyncMock()
 sys.modules["decky"] = mock_decky
 
 
+def _no_retry(fn, *a, **kw):
+    """Pass-through Retry side_effect: invoke the wrapped callable once, no backoff."""
+    return fn(*a, **kw)
+
+
+def _make_retry():
+    """Build a Retry ``MagicMock`` that runs ``with_retry`` callables exactly once
+    and reports every exception as non-retryable. Used everywhere services
+    take a ``Retry`` Protocol injection in tests."""
+    retry = MagicMock()
+    retry.with_retry.side_effect = _no_retry
+    retry.is_retryable.return_value = False
+    return retry
+
+
 def _make_testable_plugin():
     """Return a TestablePlugin instance with test-only attributes declared.
 

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -5,8 +5,8 @@ import hashlib
 import logging
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import MagicMock
 
+from conftest import _make_retry
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
@@ -24,22 +24,6 @@ def _make_save_sync_state_persister(tmp_path) -> SaveSyncStatePersisterAdapter:
             logger=logging.getLogger("test"),
         )
     )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _no_retry(fn, *a, **kw):
-    return fn(*a, **kw)
-
-
-def _make_retry():
-    retry = MagicMock()
-    retry.with_retry.side_effect = _no_retry
-    retry.is_retryable.return_value = False
-    return retry
 
 
 _CONFIG_FIELDS = frozenset(

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, _make_testable_plugin
+from conftest import FakeCoreInfoProvider, FakeFirmwareCachePersister, _make_retry, _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -21,17 +21,6 @@ from services.game_detail import GameDetailService
 from services.library import LibraryService, LibraryServiceConfig
 from services.playtime import PlaytimeService
 from services.saves import SaveService, SaveServiceConfig
-
-
-def _no_retry(fn, *a, **kw):
-    return fn(*a, **kw)
-
-
-def _make_retry():
-    retry = MagicMock()
-    retry.with_retry.side_effect = _no_retry
-    retry.is_retryable.return_value = False
-    return retry
 
 
 @pytest.fixture

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -6,29 +6,14 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-from unittest.mock import MagicMock
-
 import pytest
+from conftest import _make_retry
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.errors import RommApiError
 from services.playtime import PlaytimeService
-
-
-def _no_retry(fn, *a, **kw):
-    return fn(*a, **kw)
-
-
-def _make_retry():
-    retry = MagicMock()
-    retry.with_retry.side_effect = _no_retry
-    retry.is_retryable.return_value = False
-    return retry
 
 
 def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import _make_testable_plugin
+from conftest import _make_retry, _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -21,17 +21,6 @@ from services.library import LibraryService, LibraryServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService
 from services.saves import SaveService, SaveServiceConfig
-
-
-def _no_retry(fn, *a, **kw):
-    return fn(*a, **kw)
-
-
-def _make_retry():
-    retry = MagicMock()
-    retry.with_retry.side_effect = _no_retry
-    retry.is_retryable.return_value = False
-    return retry
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- The identical `_make_retry` / `_no_retry` helper pair was duplicated across four test files (`test_plugin_saves.py`, `services/saves/_helpers.py`, `services/test_game_detail.py`, `services/test_playtime.py`). Drift risk if the `Retry` Protocol ever changes shape.
- Consolidated into `tests/conftest.py`. Call sites import from `conftest` the same way they already import `_make_testable_plugin`.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues
- [ ] All 2234 tests pass locally

Closes #361. Part of #353.