### PR TITLE
refactor(logging): consolidate debug logging onto DebugLogger Protocol

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import sys
-from typing import ClassVar
 
 plugin_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(plugin_dir, "py_modules"))
@@ -31,14 +30,24 @@ class Plugin:
     _MIN_REQUIRED_VERSION = (4, 8, 1)
 
     # -- logging ---------------------------------------------------------------
-
-    LOG_LEVELS: ClassVar[dict] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
+    #
+    # ``_debug_logger`` is wired by ``_main()`` to the
+    # ``SettingsAwareDebugLogger`` adapter built in ``bootstrap``. The
+    # class-level default is a no-op so a bare ``Plugin()`` (used in test
+    # fixtures that don't reach ``_main``) does not raise on
+    # ``_log_debug`` — production always replaces it before any service
+    # consumes the callback.
+    _debug_logger = staticmethod(lambda _msg: None)
 
     def _log_debug(self, msg):
-        """Log a message only when log_level allows debug messages."""
-        configured = self.settings.get("log_level", "warn")
-        if self.LOG_LEVELS.get("debug", 0) >= self.LOG_LEVELS.get(configured, 2):
-            decky.logger.info(msg)
+        """Forward a debug message through the wired ``DebugLogger`` adapter.
+
+        Thin compatibility shim: production wiring sets ``_debug_logger``
+        from bootstrap; tests construct ``Plugin`` bare and may patch in
+        their own logger. The actual filtering logic lives in
+        :class:`adapters.debug_logger.SettingsAwareDebugLogger`.
+        """
+        self._debug_logger(msg)
 
     # -- persistence delegates -------------------------------------------------
 
@@ -76,6 +85,7 @@ class Plugin:
         self._retrodeck_paths: RetroDeckPathsAdapter = adapters["retrodeck_paths"]
         self._retroarch_config: RetroArchConfigAdapter = adapters["retroarch_config"]
         self._retroarch_core_info: RetroArchCoreInfoAdapter = adapters["retroarch_core_info"]
+        self._debug_logger = adapters["debug_logger"]
 
         # ── 3. Load state ───────────────────────────────────────────────────
         self._state = {
@@ -145,7 +155,7 @@ class Plugin:
                     firmware_cache_persister=adapters["firmware_cache_persister"],
                     core_info_provider=adapters["core_resolver"],
                     save_sync_state_persister=adapters["save_sync_state_persister"],
-                    log_debug=self._log_debug,
+                    log_debug=self._debug_logger,
                 ),
                 min_required_version=self._MIN_REQUIRED_VERSION,
             )

--- a/py_modules/adapters/debug_logger.py
+++ b/py_modules/adapters/debug_logger.py
@@ -1,0 +1,38 @@
+"""Settings-aware debug logger adapter — concrete ``DebugLogger`` Protocol implementation.
+
+Routes debug-level messages through a standard-library logger only when
+the user's QAM-configured ``log_level`` setting is at least ``debug``.
+Holds a live reference to the settings dict (so level changes from the
+QAM panel take effect on the next call without restart) and the
+underlying :class:`logging.Logger` it emits through.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import logging
+
+
+class SettingsAwareDebugLogger:
+    """``DebugLogger`` impl that honors the live ``log_level`` setting.
+
+    The settings dict is bound by reference at construction so QAM-side
+    edits are observed without restart. Messages route through
+    ``logger.info`` (matching the existing frontend-log surface so users
+    see both their own frontend messages and backend debug traces in the
+    same stream) when ``log_level`` is ``"debug"``; any other level
+    silently drops the message.
+    """
+
+    _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
+
+    def __init__(self, *, settings: dict, logger: logging.Logger) -> None:
+        self._settings = settings
+        self._logger = logger
+
+    def __call__(self, msg: str) -> None:
+        configured = self._settings.get("log_level", "warn")
+        if self._LOG_LEVELS.get("debug", 0) >= self._LOG_LEVELS.get(configured, 2):
+            self._logger.info(msg)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 
 from adapters.asyncio_sleeper import AsyncioSleeper
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
+from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.download_file import DownloadFileAdapter as DownloadFileAdapterImpl
 from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapterImpl
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
@@ -237,6 +238,7 @@ def bootstrap(
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
+    debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
 
     return {
         "persistence": persistence,
@@ -262,6 +264,7 @@ def bootstrap(
         "clock": clock,
         "uuid_gen": uuid_gen,
         "sleeper": sleeper,
+        "debug_logger": debug_logger,
         "core_resolver": core_resolver,
         "gamelist_editor": gamelist_editor,
     }
@@ -332,6 +335,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         get_saves_path=cfg.callbacks.get_saves_path,
         get_roms_path=cfg.callbacks.get_roms_path,
         get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+        log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
         plugin_version=_read_plugin_version(cfg.runtime.plugin_dir),
         emit=cfg.runtime.emit,
@@ -356,6 +360,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         logger=cfg.runtime.logger,
         clock=cfg.runtime.clock,
         save_state=save_sync_service.save_state,
+        log_debug=cfg.callbacks.log_debug,
     )
 
     metadata_service = MetadataService(
@@ -482,6 +487,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             save_state=cfg.callbacks.save_state,
             save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
             get_pending_sync=pending_sync_binding.get,
+            log_debug=cfg.callbacks.log_debug,
         ),
     )
 

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.iso_time import parse_iso
-from services.protocols import Clock, RetryStrategy, RommApiProtocol, StatePersister
+from services.protocols import Clock, DebugLogger, RetryStrategy, RommApiProtocol, StatePersister
 
 if TYPE_CHECKING:
     import asyncio
@@ -37,6 +37,9 @@ class PlaytimeService:
         Standard-library logger.
     save_state:
         Callable to persist the save_sync_state dict to disk.
+    log_debug:
+        ``DebugLogger`` Protocol seam — routes through the user's QAM
+        log-level filter.
     """
 
     PLAYTIME_NOTE_TITLE = "romm-sync:playtime"
@@ -51,6 +54,7 @@ class PlaytimeService:
         logger: logging.Logger,
         clock: Clock,
         save_state: StatePersister,
+        log_debug: DebugLogger,
     ) -> None:
         self._romm_api = romm_api
         self._retry = retry
@@ -59,13 +63,7 @@ class PlaytimeService:
         self._logger = logger
         self._clock = clock
         self._save_state = save_state
-
-    # ------------------------------------------------------------------
-    # Debug logging helper
-    # ------------------------------------------------------------------
-
-    def _log_debug(self, msg: str) -> None:
-        self._logger.debug(msg)
+        self._log_debug = log_debug
 
     # ------------------------------------------------------------------
     # Playtime Notes API Helpers

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         Clock,
         CoreNameProviderFn,
         CoreResolverFn,
+        DebugLogger,
         EventEmitter,
         RomsPathProvider,
         SaveFileAdapter,
@@ -99,6 +100,10 @@ class SaveServiceConfig:
         Optional callback returning ``True`` when a RetroDECK migration
         is in flight; SaveService gates destructive operations on this
         signal. ``None`` disables the gate (unit tests).
+    log_debug:
+        ``DebugLogger`` Protocol seam — routes through the user's QAM
+        log-level filter. Sub-services access this via the
+        ``_save_service._log_debug`` back-ref.
     """
 
     runtime_dir: str
@@ -110,6 +115,7 @@ class SaveServiceConfig:
     get_saves_path: SavesPathProvider
     get_roms_path: RomsPathProvider
     get_active_core: CoreResolverFn
+    log_debug: DebugLogger
     get_core_name: CoreNameProviderFn | None = None
     plugin_version: str = "0.0.0"
     emit: EventEmitter | None = None

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -5,7 +5,6 @@ import contextlib
 import os
 import socket
 from dataclasses import asdict
-from typing import ClassVar
 
 from models.saves import SaveConflict
 
@@ -59,8 +58,6 @@ class SaveService:
         per-field rationale.
     """
 
-    _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
-
     def __init__(
         self,
         *,
@@ -98,6 +95,7 @@ class SaveService:
         self._emit = config.emit
         self._detect_sort_change = config.detect_sort_change
         self._is_retrodeck_migration_pending = config.is_retrodeck_migration_pending
+        self._log_debug = config.log_debug
         # Per-rom lock dict — serializes concurrent sync operations on the
         # same rom_id (pre_launch_sync, post_exit_sync, manual sync, resolve).
         self._rom_sync_locks: dict[int, asyncio.Lock] = {}
@@ -140,15 +138,6 @@ class SaveService:
         if rom_id not in self._rom_sync_locks:
             self._rom_sync_locks[rom_id] = asyncio.Lock()
         return self._rom_sync_locks[rom_id]
-
-    # ------------------------------------------------------------------
-    # Debug logging helper
-    # ------------------------------------------------------------------
-
-    def _log_debug(self, msg: str) -> None:
-        configured = self._settings.get("log_level", "warn")
-        if self._LOG_LEVELS.get("debug", 0) >= self._LOG_LEVELS.get(configured, 2):
-            self._logger.info(msg)
 
     def _get_server_device_id(self) -> str | None:
         """Return the server device ID if registered, else None."""

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import base64
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from domain.sgdb_artwork import (
     asset_type_endpoint,
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     import logging
 
     from services.protocols import (
+        DebugLogger,
         PendingSyncReader,
         RommApiProtocol,
         SettingsPersister,
@@ -62,6 +63,9 @@ class SteamGridConfig:
         Read seam returning the current LibraryService pending-sync map.
         Used to resolve SGDB IDs for ROMs mid-sync that are not yet in
         the registry.
+    log_debug:
+        ``DebugLogger`` Protocol seam — routes through the user's QAM
+        log-level filter.
     """
 
     loop: asyncio.AbstractEventLoop
@@ -69,6 +73,7 @@ class SteamGridConfig:
     save_state: StatePersister
     save_settings_to_disk: SettingsPersister
     get_pending_sync: PendingSyncReader
+    log_debug: DebugLogger
 
 
 class SteamGridService:
@@ -96,15 +101,7 @@ class SteamGridService:
         self._save_state = config.save_state
         self._save_settings_to_disk = config.save_settings_to_disk
         self._get_pending_sync = config.get_pending_sync
-
-    # -- logging -----------------------------------------------------------
-
-    _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
-
-    def _log_debug(self, msg: str) -> None:
-        configured = self._settings.get("log_level", "warn")
-        if self._LOG_LEVELS.get("debug", 0) >= self._LOG_LEVELS.get(configured, 2):
-            self._logger.info(msg)
+        self._log_debug = config.log_debug
 
     # -- SGDB lookup -------------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,12 @@ def _make_testable_plugin():
     ``@migration_blocked`` decorator does not raise AttributeError in tests
     that don't otherwise wire migration state. Tests that exercise the
     block can override ``is_retrodeck_migration_pending`` per-test.
+
+    Also pre-wires a no-op ``_debug_logger`` so any service that consumes
+    ``Plugin._log_debug`` (which forwards through ``_debug_logger``) works
+    out of the box. Tests that want to assert on debug-log behaviour can
+    override ``_debug_logger`` after construction (e.g. with the real
+    ``SettingsAwareDebugLogger`` bound to a settings dict they control).
     """
     # Import here to ensure decky mock is already installed
     from main import Plugin
@@ -63,6 +69,7 @@ def _make_testable_plugin():
     instance = TestablePlugin()
     instance._migration_service = MagicMock()
     instance._migration_service.is_retrodeck_migration_pending.return_value = False
+    instance._debug_logger = lambda _msg: None
     return instance
 
 

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -42,6 +42,7 @@ _CONFIG_FIELDS = frozenset(
         "emit",
         "detect_sort_change",
         "is_retrodeck_migration_pending",
+        "log_debug",
     }
 )
 
@@ -65,6 +66,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         get_saves_path=lambda: str(tmp_path / "saves"),
         get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
         get_active_core=lambda system_name, rom_filename=None: (None, None),
+        log_debug=lambda _msg: None,
         plugin_version="0.14.0",
         emit=emit,
     )

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -95,6 +95,7 @@ def plugin(tmp_path):
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
+            log_debug=p._log_debug,
         ),
     )
     p._save_sync_service.init_state()
@@ -107,6 +108,7 @@ def plugin(tmp_path):
         logger=logging.getLogger("test"),
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=p._save_sync_service.save_state,
+        log_debug=p._log_debug,
     )
 
     p._achievements_service = AchievementsService(

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
 
@@ -27,6 +28,7 @@ def plugin():
 
     import decky
 
+    p._debug_logger = SettingsAwareDebugLogger(settings=p.settings, logger=decky.logger)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -31,6 +31,7 @@ def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):
         logger=logging.getLogger("test"),
         clock=clk,
         save_state=lambda: saved.append(True),
+        log_debug=lambda _msg: None,
     )
     defaults.update(overrides)
     svc = PlaytimeService(**defaults)

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.steam_config import SteamConfigAdapter
 from lib.errors import SgdbApiError, SteamGridDirMissingError
 
@@ -33,6 +34,7 @@ def plugin(sgdb_artwork_cache):
 
     import decky
 
+    p._debug_logger = SettingsAwareDebugLogger(settings=p.settings, logger=decky.logger)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 
@@ -71,6 +73,7 @@ def plugin(sgdb_artwork_cache):
             save_state=MagicMock(),
             save_settings_to_disk=MagicMock(),
             get_pending_sync=lambda: p._sync_service._pending_sync,
+            log_debug=p._log_debug,
         ),
     )
     return p
@@ -693,6 +696,129 @@ class TestSaveShortcutIcon:
         result = await plugin.save_shortcut_icon(12345, "not-valid-base64!!!")
 
         assert result["success"] is False
+
+
+class TestDebugLoggerProtocolSeam:
+    """SteamGridService routes debug messages through the injected ``DebugLogger``.
+
+    Locks in the consolidation from #354: SteamGridService no longer owns a
+    per-service ``_log_debug`` method that re-reads settings; the protocol
+    seam is the sole knob. A no-op injection must suppress every SGDB
+    debug message, regardless of log-level settings.
+    """
+
+    @pytest.fixture
+    def plugin_with_captured_log(self, sgdb_artwork_cache):
+        """Plugin fixture where ``log_debug`` is a list-capturing fake."""
+        from unittest.mock import MagicMock as MM
+
+        import decky
+
+        p = Plugin()
+        p.settings = {"log_level": "debug", "steamgriddb_api_key": ""}
+        p._http_adapter = MM()
+        p._romm_api = MM()
+        p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+        p._metadata_cache = {}
+
+        captured: list[str] = []
+
+        def capture(msg: str) -> None:
+            captured.append(msg)
+
+        steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
+        p._steam_config = steam_config
+
+        p._sync_service = LibraryService(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
+            config=LibraryServiceConfig(
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                plugin_dir=decky.DECKY_PLUGIN_DIR,
+                emit=decky.emit,
+                clock=FakeClock(),
+                uuid_gen=FakeUuidGen(),
+                sleeper=FakeSleeper(),
+                save_state=MM(),
+                save_settings_to_disk=MM(),
+                log_debug=capture,
+            ),
+        )
+
+        p._sgdb_service = SteamGridService(
+            sgdb_api=MM(),
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            sgdb_artwork_cache=sgdb_artwork_cache,
+            state=p._state,
+            settings=p.settings,
+            config=SteamGridConfig(
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                save_state=MM(),
+                save_settings_to_disk=MM(),
+                get_pending_sync=lambda: p._sync_service._pending_sync,
+                log_debug=capture,
+            ),
+        )
+        return p, captured
+
+    @pytest.mark.asyncio
+    async def test_sgdb_messages_route_through_injected_debug_logger(self, plugin_with_captured_log):
+        """SGDB debug messages reach the injected ``log_debug``, not a hidden ``.info()`` seam."""
+        plugin, captured = plugin_with_captured_log
+        plugin._sgdb_service._loop = asyncio.get_event_loop()
+
+        # No API key configured -> early "skipped" debug message
+        await plugin.get_sgdb_artwork_base64(42, 1)
+
+        sgdb_msgs = [m for m in captured if "SGDB artwork" in m]
+        assert sgdb_msgs, f"Expected SGDB debug messages on injected seam, got: {captured}"
+
+    @pytest.mark.asyncio
+    async def test_sgdb_debug_does_not_call_logger_info_directly(self, plugin_with_captured_log):
+        """SGDB debug must reach the injected callback only — never ``decky.logger.info``.
+
+        Regression for #354: pre-consolidation, ``SteamGridService._log_debug``
+        was a per-service method that re-read settings and called
+        ``self._logger.info(msg)`` directly whenever
+        ``log_level == "debug"``. That meant the injected ``DebugLogger``
+        callback was ignored — any consumer that wanted to silence
+        SGDB output had no working knob. The protocol consolidation
+        replaces the method with an injected callable, so the only
+        sink is what bootstrap (or this fixture) provides.
+
+        Would fail on ``main``: there a debug-level config would push
+        every SGDB message through ``decky.logger.info`` in addition
+        to (and bypassing) the injected callback.
+        """
+        from unittest.mock import patch
+
+        import decky
+
+        plugin, captured = plugin_with_captured_log
+        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        # log_level=debug — pre-fix this is exactly the state where the
+        # per-service ``_log_debug`` emitted via ``self._logger.info``.
+        plugin.settings["log_level"] = "debug"
+
+        with patch.object(decky.logger, "info") as mock_info:
+            await plugin.get_sgdb_artwork_base64(42, 1)
+
+        # SGDB messages MUST land on the injected seam …
+        assert any("SGDB artwork" in m for m in captured), (
+            f"SGDB debug must reach the injected log_debug; captured={captured}"
+        )
+        # … and NOT on decky.logger.info.
+        sgdb_info_calls = [c for c in mock_info.call_args_list if "SGDB artwork" in str(c)]
+        assert not sgdb_info_calls, (
+            "SGDB debug must NOT leak to logger.info — the injected "
+            f"DebugLogger is the only sink. Observed leaks: {sgdb_info_calls}"
+        )
 
 
 class TestFakeSgdbArtworkCacheAtomicWrite:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import FakePathProbe, FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
+from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
 
@@ -39,6 +40,7 @@ def plugin():
 
     import decky
 
+    p._debug_logger = SettingsAwareDebugLogger(settings=p.settings, logger=decky.logger)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 
@@ -75,6 +77,7 @@ def plugin():
             save_state=MagicMock(),
             save_settings_to_disk=MagicMock(),
             get_pending_sync=lambda: p._sync_service._pending_sync,
+            log_debug=p._log_debug,
         ),
     )
 
@@ -863,6 +866,7 @@ class TestMainStartupOrdering:
             "clock": MagicMock(),
             "uuid_gen": MagicMock(),
             "sleeper": MagicMock(),
+            "debug_logger": MagicMock(),
             "core_resolver": MagicMock(),
             "gamelist_editor": MagicMock(),
         }

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -98,6 +98,7 @@ def plugin(tmp_path):
             get_saves_path=lambda: saves_path,
             get_roms_path=lambda: str(tmp_path / "retrodeck" / "roms"),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
+            log_debug=p._log_debug,
         ),
     )
     p._save_sync_service.init_state()
@@ -110,6 +111,7 @@ def plugin(tmp_path):
         logger=logging.getLogger("test"),
         clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         save_state=p._save_sync_service.save_state,
+        log_debug=p._log_debug,
     )
 
     # Store fake_api on plugin for test access


### PR DESCRIPTION
## Summary
Three competing debug-log patterns existed: per-service `_log_debug` methods (PlaytimeService / SaveService / SteamGridService), `Plugin._log_debug` with its own `LOG_LEVELS` dict, and the `DebugLogger` Protocol used by the rest of the services. SteamGrid's per-service method also called `logger.info()` inside the level check, so SGDB debug output leaked at info regardless of the user's configured QAM log level.

- Extracted a single `SettingsAwareDebugLogger` adapter (`py_modules/adapters/debug_logger.py`) that holds the live settings dict + the underlying logger by reference, so QAM-side `log_level` changes take effect on the next call without restart.
- Bootstrap constructs the adapter once and wires it through `CallbackBundle.log_debug` and per-service `*ServiceConfig` fields. Every service now consumes the Protocol — no per-service `_log_debug` methods anywhere.
- `Plugin._log_debug` survives as a thin forwarder (`self._debug_logger(msg)`) because existing test fixtures grab the bound method to inject into services. A class-level no-op default keeps bare `Plugin()` constructions in test fixtures from crashing.
- SteamGrid no longer calls `.info()` for debug; debug messages route through the Protocol like everywhere else. Two new tests in `tests/services/test_steamgrid.py::TestDebugLoggerProtocolSeam` lock this in.

## Test plan
- [ ] CI green (build, lint, test)
- [ ] Sonar: 0 new issues
- [ ] 2236 tests pass locally (+2 new SGDB regression tests)
- [ ] On real hardware: setting log_level to "warn" silences SGDB debug output (regression fix is observable)

Closes #354. Part of #353.