### PR TITLE
refactor(services): apply always-config rule to 11 services (#355)

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -42,17 +42,17 @@ from adapters.system_uuid_gen import SystemUuidGen
 from domain.save_state import SaveSyncState
 from domain.state_migrations import migrate_settings
 from lib.late_binding import LateBinding
-from services.achievements import AchievementsService
+from services.achievements import AchievementsService, AchievementsServiceConfig
 from services.artwork import ArtworkService, ArtworkServiceConfig
 from services.connection import ConnectionService, ConnectionServiceConfig
 from services.cores import CoreService, CoreServiceConfig
 from services.downloads import DownloadService, DownloadServiceConfig
 from services.firmware import FirmwareService, FirmwareServiceConfig
-from services.game_detail import GameDetailService
+from services.game_detail import GameDetailService, GameDetailServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
-from services.metadata import MetadataService
+from services.metadata import MetadataService, MetadataServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
-from services.playtime import PlaytimeService
+from services.playtime import PlaytimeService, PlaytimeServiceConfig
 from services.protocols import (
     BiosPathProvider,
     Clock,
@@ -86,7 +86,7 @@ from services.protocols import SteamConfigAdapter as SteamConfigProtocol
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 from services.saves import SaveService, SaveServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
-from services.shortcut_removal import ShortcutRemovalService
+from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridConfig, SteamGridService
 
@@ -307,8 +307,8 @@ def wire_services(cfg: WiringConfig) -> dict:
     # ``migration_service.detect_save_sort_change``. SaveService must observe
     # fresh sort state before computing saves_dir (#238).
     migration_service = MigrationService(
-        migration_files=cfg.adapters.migration_files,
         config=MigrationServiceConfig(
+            migration_files=cfg.adapters.migration_files,
             state=cfg.stores.state,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
@@ -326,6 +326,11 @@ def wire_services(cfg: WiringConfig) -> dict:
     )
 
     save_service_config = SaveServiceConfig(
+        romm_api=cfg.adapters.romm_api,
+        retry=cfg.adapters.http_adapter,
+        settings=cfg.stores.settings,
+        state=cfg.stores.state,
+        save_sync_state=cfg.stores.save_sync_state,
         runtime_dir=cfg.runtime.runtime_dir,
         save_sync_state_persister=cfg.callbacks.save_sync_state_persister,
         save_file=cfg.adapters.save_file,
@@ -343,43 +348,40 @@ def wire_services(cfg: WiringConfig) -> dict:
         detect_sort_change=migration_service.detect_save_sort_change,
         is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,
     )
-    save_sync_service = SaveService(
-        romm_api=cfg.adapters.romm_api,
-        retry=cfg.adapters.http_adapter,
-        settings=cfg.stores.settings,
-        state=cfg.stores.state,
-        save_sync_state=cfg.stores.save_sync_state,
-        config=save_service_config,
-    )
+    save_sync_service = SaveService(config=save_service_config)
 
     playtime_service = PlaytimeService(
-        romm_api=cfg.adapters.romm_api,
-        retry=cfg.adapters.http_adapter,
-        save_sync_state=cfg.stores.save_sync_state,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        clock=cfg.runtime.clock,
-        save_state=save_sync_service.save_state,
-        log_debug=cfg.callbacks.log_debug,
+        config=PlaytimeServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            retry=cfg.adapters.http_adapter,
+            save_sync_state=cfg.stores.save_sync_state,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            clock=cfg.runtime.clock,
+            save_state=save_sync_service.save_state,
+            log_debug=cfg.callbacks.log_debug,
+        ),
     )
 
     metadata_service = MetadataService(
-        romm_api=cfg.adapters.romm_api,
-        state=cfg.stores.state,
-        metadata_cache=cfg.stores.metadata_cache,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        clock=cfg.runtime.clock,
-        save_metadata_cache=cfg.callbacks.save_metadata_cache,
-        log_debug=cfg.callbacks.log_debug,
+        config=MetadataServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            state=cfg.stores.state,
+            metadata_cache=cfg.stores.metadata_cache,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            clock=cfg.runtime.clock,
+            save_metadata_cache=cfg.callbacks.save_metadata_cache,
+            log_debug=cfg.callbacks.log_debug,
+        ),
     )
 
     artwork_service = ArtworkService(
-        romm_api=cfg.adapters.romm_api,
-        steam_config=cfg.adapters.steam_config,
-        cover_art_file_store=cfg.adapters.cover_art_file_store,
-        state=cfg.stores.state,
         config=ArtworkServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            steam_config=cfg.adapters.steam_config,
+            cover_art_file_store=cfg.adapters.cover_art_file_store,
+            state=cfg.stores.state,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
             get_pending_sync=pending_sync_binding.get,
@@ -387,23 +389,25 @@ def wire_services(cfg: WiringConfig) -> dict:
     )
 
     shortcut_removal_service = ShortcutRemovalService(
-        romm_api=cfg.adapters.romm_api,
-        steam_config=cfg.adapters.steam_config,
-        state=cfg.stores.state,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        emit=cfg.runtime.emit,
-        save_state=cfg.callbacks.save_state,
-        artwork_remover=artwork_service,
+        config=ShortcutRemovalServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            steam_config=cfg.adapters.steam_config,
+            state=cfg.stores.state,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            emit=cfg.runtime.emit,
+            save_state=cfg.callbacks.save_state,
+            artwork_remover=artwork_service,
+        ),
     )
 
     sync_service = LibraryService(
-        romm_api=cfg.adapters.romm_api,
-        steam_config=cfg.adapters.steam_config,
-        state=cfg.stores.state,
-        settings=cfg.stores.settings,
-        metadata_cache=cfg.stores.metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            steam_config=cfg.adapters.steam_config,
+            state=cfg.stores.state,
+            settings=cfg.stores.settings,
+            metadata_cache=cfg.stores.metadata_cache,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
             plugin_dir=cfg.runtime.plugin_dir,
@@ -414,18 +418,18 @@ def wire_services(cfg: WiringConfig) -> dict:
             save_state=cfg.callbacks.save_state,
             save_settings_to_disk=cfg.callbacks.save_settings_to_disk,
             log_debug=cfg.callbacks.log_debug,
+            metadata_service=metadata_service,
+            artwork=artwork_service,
         ),
-        metadata_service=metadata_service,
-        artwork=artwork_service,
     )
     pending_sync_binding.set(lambda: sync_service.pending_sync)
 
     download_service = DownloadService(
-        romm_api=cfg.adapters.romm_api,
-        state=cfg.stores.state,
-        download_files=cfg.adapters.download_files,
-        download_queue=cfg.adapters.download_queue,
         config=DownloadServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            state=cfg.stores.state,
+            download_files=cfg.adapters.download_files,
+            download_queue=cfg.adapters.download_queue,
             resolve_system=cfg.adapters.http_adapter.resolve_system,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
@@ -475,13 +479,13 @@ def wire_services(cfg: WiringConfig) -> dict:
     bios_files_index_binding.set(lambda: firmware_service.bios_files_index)
 
     sgdb_service = SteamGridService(
-        sgdb_api=cfg.adapters.sgdb_adapter,
-        romm_api=cfg.adapters.romm_api,
-        steam_config=cfg.adapters.steam_config,
-        sgdb_artwork_cache=cfg.adapters.sgdb_artwork_cache,
-        state=cfg.stores.state,
-        settings=cfg.stores.settings,
         config=SteamGridConfig(
+            sgdb_api=cfg.adapters.sgdb_adapter,
+            romm_api=cfg.adapters.romm_api,
+            steam_config=cfg.adapters.steam_config,
+            sgdb_artwork_cache=cfg.adapters.sgdb_artwork_cache,
+            state=cfg.stores.state,
+            settings=cfg.stores.settings,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
             save_state=cfg.callbacks.save_state,
@@ -492,22 +496,26 @@ def wire_services(cfg: WiringConfig) -> dict:
     )
 
     achievements_service = AchievementsService(
-        romm_api=cfg.adapters.romm_api,
-        state=cfg.stores.state,
-        loop=cfg.runtime.loop,
-        logger=cfg.runtime.logger,
-        clock=cfg.runtime.clock,
-        log_debug=cfg.callbacks.log_debug,
+        config=AchievementsServiceConfig(
+            romm_api=cfg.adapters.romm_api,
+            state=cfg.stores.state,
+            loop=cfg.runtime.loop,
+            logger=cfg.runtime.logger,
+            clock=cfg.runtime.clock,
+            log_debug=cfg.callbacks.log_debug,
+        ),
     )
 
     game_detail_service = GameDetailService(
-        state=cfg.stores.state,
-        metadata_cache=cfg.stores.metadata_cache,
-        save_sync_state=cfg.stores.save_sync_state,
-        logger=cfg.runtime.logger,
-        clock=cfg.runtime.clock,
-        bios_checker=firmware_service,
-        achievements=achievements_service,
+        config=GameDetailServiceConfig(
+            state=cfg.stores.state,
+            metadata_cache=cfg.stores.metadata_cache,
+            save_sync_state=cfg.stores.save_sync_state,
+            logger=cfg.runtime.logger,
+            clock=cfg.runtime.clock,
+            bios_checker=firmware_service,
+            achievements=achievements_service,
+        ),
     )
 
     settings_service = SettingsService(

--- a/py_modules/services/achievements.py
+++ b/py_modules/services/achievements.py
@@ -6,6 +6,7 @@ user progress tracking, and post-session refresh.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.achievements import extract_achievements_from_rom, extract_game_progress
@@ -17,6 +18,23 @@ if TYPE_CHECKING:
     from services.protocols import Clock, DebugLogger, RommApiProtocol
 
 
+@dataclass(frozen=True)
+class AchievementsServiceConfig:
+    """Frozen wiring bundle handed to ``AchievementsService.__init__``.
+
+    Holds the Protocol-typed RomM adapter, the live state dict, runtime
+    infrastructure, and the clock/debug-logger seams AchievementsService
+    needs at construction time.
+    """
+
+    romm_api: RommApiProtocol
+    state: dict
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    clock: Clock
+    log_debug: DebugLogger
+
+
 class AchievementsService:
     """RetroAchievements data fetching via RomM server."""
 
@@ -24,22 +42,13 @@ class AchievementsService:
     PROGRESS_CACHE_TTL = 3600  # 1h for user progress
     RA_USERNAME_CACHE_TTL = 3600  # 1h for RA username detection
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        state: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        clock: Clock,
-        log_debug: DebugLogger,
-    ) -> None:
-        self._romm_api = romm_api
-        self._state = state
-        self._loop = loop
-        self._logger = logger
-        self._clock = clock
-        self._log_debug = log_debug
+    def __init__(self, *, config: AchievementsServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._state = config.state
+        self._loop = config.loop
+        self._logger = config.logger
+        self._clock = config.clock
+        self._log_debug = config.log_debug
 
         self._achievements_cache: dict = {}
 

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -21,12 +21,15 @@ if TYPE_CHECKING:
 class ArtworkServiceConfig:
     """Frozen wiring bundle handed to ``ArtworkService.__init__``.
 
-    Holds the asyncio loop, logger, and the read seam ArtworkService
-    uses to consult the in-flight sync's pending cover paths. Protocol-
-    typed adapters and the live state dict remain explicit ctor params
-    because they have different lifecycles from this immutable bundle.
+    Holds the Protocol-typed adapters, the live state dict, runtime
+    infrastructure, and the read seam ArtworkService uses to consult
+    the in-flight sync's pending cover paths.
     """
 
+    romm_api: RommApiProtocol
+    steam_config: SteamConfigAdapter
+    cover_art_file_store: CoverArtFileStore
+    state: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     get_pending_sync: PendingSyncReader
@@ -35,19 +38,11 @@ class ArtworkServiceConfig:
 class ArtworkService:
     """Manages artwork downloading, staging, finalisation, and cleanup."""
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        steam_config: SteamConfigAdapter,
-        cover_art_file_store: CoverArtFileStore,
-        state: dict,
-        config: ArtworkServiceConfig,
-    ) -> None:
-        self._romm_api = romm_api
-        self._steam_config = steam_config
-        self._cover_art_file_store = cover_art_file_store
-        self._state = state
+    def __init__(self, *, config: ArtworkServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._steam_config = config.steam_config
+        self._cover_art_file_store = config.cover_art_file_store
+        self._state = config.state
         self._loop = config.loop
         self._logger = config.logger
         self._get_pending_sync = config.get_pending_sync

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -42,13 +42,15 @@ _TMP_EXT = ".tmp"
 class DownloadServiceConfig:
     """Frozen wiring bundle handed to ``DownloadService.__init__``.
 
-    Holds the runtime infrastructure, time/sleep seams, path providers,
-    and migration-aware callbacks DownloadService needs at construction
-    time. Protocol-typed adapters and the live state dict remain
-    explicit ctor parameters because they have different lifecycles
-    from this immutable wiring bundle.
+    Holds the Protocol-typed adapters, the live state dict, runtime
+    infrastructure, time/sleep seams, path providers, and migration-
+    aware callbacks DownloadService needs at construction time.
     """
 
+    romm_api: RommApiProtocol
+    state: dict
+    download_files: DownloadFileAdapter
+    download_queue: DownloadQueueAdapter
     resolve_system: SystemResolver
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
@@ -65,19 +67,11 @@ class DownloadServiceConfig:
 class DownloadService:
     """ROM download engine: downloads and queue management."""
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        state: dict,
-        download_files: DownloadFileAdapter,
-        download_queue: DownloadQueueAdapter,
-        config: DownloadServiceConfig,
-    ):
-        self._romm_api = romm_api
-        self._state = state
-        self._download_files = download_files
-        self._download_queue_io = download_queue
+    def __init__(self, *, config: DownloadServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._state = config.state
+        self._download_files = config.download_files
+        self._download_queue_io = config.download_queue
         self._resolve_system = config.resolve_system
         self._loop = config.loop
         self._logger = config.logger

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -8,7 +8,7 @@ independent of other service modules.
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from models.metadata import AchievementSummary
@@ -27,27 +27,36 @@ BIOS_TTL_SEC = 3600  # 1 hour
 ACHIEVEMENT_TTL_SEC = 3600  # 1 hour
 
 
+@dataclass(frozen=True)
+class GameDetailServiceConfig:
+    """Frozen wiring bundle handed to ``GameDetailService.__init__``.
+
+    Holds the live state and metadata cache dicts, the typed save-sync
+    aggregate, runtime infrastructure, clock seam, and the Protocol-
+    typed reader adapters (``BiosChecker``, ``AchievementsReader``)
+    GameDetailService consults to assemble the game-detail payload.
+    """
+
+    state: dict
+    metadata_cache: dict
+    save_sync_state: SaveSyncState
+    logger: logging.Logger
+    clock: Clock
+    bios_checker: BiosChecker
+    achievements: AchievementsReader
+
+
 class GameDetailService:
     """Aggregates game detail page data from multiple state sources."""
 
-    def __init__(
-        self,
-        *,
-        state: dict,
-        metadata_cache: dict,
-        save_sync_state: SaveSyncState,
-        logger: logging.Logger,
-        clock: Clock,
-        bios_checker: BiosChecker,
-        achievements: AchievementsReader,
-    ) -> None:
-        self._state = state
-        self._metadata_cache = metadata_cache
-        self._save_sync_state = save_sync_state
-        self._logger = logger
-        self._clock = clock
-        self._bios_checker = bios_checker
-        self._achievements = achievements
+    def __init__(self, *, config: GameDetailServiceConfig) -> None:
+        self._state = config.state
+        self._metadata_cache = config.metadata_cache
+        self._save_sync_state = config.save_sync_state
+        self._logger = config.logger
+        self._clock = config.clock
+        self._bios_checker = config.bios_checker
+        self._achievements = config.achievements
 
     def _resolve_rom_by_app_id(self, app_id: int) -> tuple[int | None, dict | None]:
         """Reverse lookup: find rom_id by app_id in shortcut_registry."""

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -49,14 +49,18 @@ _PREVIEW_MAX_AGE_SECONDS = 1800  # 30 minutes — preview snapshots stale beyond
 class LibraryServiceConfig:
     """Frozen wiring bundle handed to ``LibraryService.__init__``.
 
-    Holds the immutable runtime infrastructure, time/sleep/uuid seams,
-    plugin-dir reference, event emitter, and persistence callbacks
-    LibraryService needs at construction time. Protocol-typed adapters
-    and the live state/settings dicts remain explicit ctor parameters
-    because they have different lifecycles from this immutable wiring
-    bundle.
+    Holds the Protocol-typed adapters, the live state/settings/metadata
+    cache dicts, runtime infrastructure, time/sleep/uuid seams, plugin-
+    dir reference, event emitter, persistence callbacks, debug-logger
+    seam, and the optional metadata/artwork peer services LibraryService
+    needs at construction time.
     """
 
+    romm_api: RommApiProtocol
+    steam_config: SteamConfigAdapter
+    state: dict
+    settings: dict
+    metadata_cache: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -67,28 +71,19 @@ class LibraryServiceConfig:
     save_state: StatePersister
     save_settings_to_disk: SettingsPersister
     log_debug: DebugLogger
+    metadata_service: MetadataExtractor | None = None
+    artwork: ArtworkManager | None = None
 
 
 class LibraryService:
     """Sync engine: fetch ROMs, prepare shortcuts, manage registry."""
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        steam_config: SteamConfigAdapter,
-        state: dict,
-        settings: dict,
-        metadata_cache: dict,
-        config: LibraryServiceConfig,
-        metadata_service: MetadataExtractor | None = None,
-        artwork: ArtworkManager | None = None,
-    ) -> None:
-        self._romm_api = romm_api
-        self._steam_config = steam_config
-        self._state = state
-        self._settings = settings
-        self._metadata_cache = metadata_cache
+    def __init__(self, *, config: LibraryServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._steam_config = config.steam_config
+        self._state = config.state
+        self._settings = config.settings
+        self._metadata_cache = config.metadata_cache
         self._loop = config.loop
         self._logger = config.logger
         self._plugin_dir = config.plugin_dir
@@ -99,8 +94,8 @@ class LibraryService:
         self._save_state = config.save_state
         self._save_settings_to_disk = config.save_settings_to_disk
         self._log_debug = config.log_debug
-        self._metadata_service = metadata_service
-        self._artwork = artwork
+        self._metadata_service = config.metadata_service
+        self._artwork = config.artwork
 
         # Sync-specific state (owned by this service)
         self._sync_state = SyncState.IDLE

--- a/py_modules/services/metadata.py
+++ b/py_modules/services/metadata.py
@@ -7,7 +7,7 @@ the list API and served from cache on demand (no detail API calls).
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from models.metadata import RomMetadata
@@ -21,29 +21,37 @@ if TYPE_CHECKING:
     from services.protocols import Clock, DebugLogger, RommApiProtocol, StatePersister
 
 
+@dataclass(frozen=True)
+class MetadataServiceConfig:
+    """Frozen wiring bundle handed to ``MetadataService.__init__``.
+
+    Holds the Protocol-typed RomM adapter, the live state and metadata
+    cache dicts, runtime infrastructure, persistence callback, and the
+    clock/debug-logger seams MetadataService needs at construction time.
+    """
+
+    romm_api: RommApiProtocol
+    state: dict
+    metadata_cache: dict
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    clock: Clock
+    save_metadata_cache: StatePersister
+    log_debug: DebugLogger
+
+
 class MetadataService:
     """ROM metadata cache: extract, store, flush, and fetch on demand."""
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        state: dict,
-        metadata_cache: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        clock: Clock,
-        save_metadata_cache: StatePersister,
-        log_debug: DebugLogger,
-    ) -> None:
-        self._romm_api = romm_api
-        self._state = state
-        self._metadata_cache = metadata_cache
-        self._loop = loop
-        self._logger = logger
-        self._clock = clock
-        self._save_metadata_cache = save_metadata_cache
-        self._log_debug = log_debug
+    def __init__(self, *, config: MetadataServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._state = config.state
+        self._metadata_cache = config.metadata_cache
+        self._loop = config.loop
+        self._logger = config.logger
+        self._clock = config.clock
+        self._save_metadata_cache = config.save_metadata_cache
+        self._log_debug = config.log_debug
 
         self._metadata_dirty_count = 0
         self._METADATA_FLUSH_INTERVAL = 50

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -39,13 +39,13 @@ if TYPE_CHECKING:
 class MigrationServiceConfig:
     """Frozen wiring bundle handed to ``MigrationService.__init__``.
 
-    Holds the live state dict, runtime infrastructure, persistence
-    callback, event emitter, and the provider callables MigrationService
-    needs at construction time. Protocol-typed adapters remain explicit
-    ctor parameters because they have different lifecycles from this
-    immutable wiring bundle.
+    Holds the Protocol-typed migration-file adapter, the live state
+    dict, runtime infrastructure, persistence callback, event emitter,
+    and the provider callables MigrationService needs at construction
+    time.
     """
 
+    migration_files: MigrationFileAdapter
     state: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
@@ -64,13 +64,8 @@ class MigrationServiceConfig:
 class MigrationService:
     """Handles RetroDECK path change detection and file migration."""
 
-    def __init__(
-        self,
-        *,
-        migration_files: MigrationFileAdapter,
-        config: MigrationServiceConfig,
-    ) -> None:
-        self._migration_files = migration_files
+    def __init__(self, *, config: MigrationServiceConfig) -> None:
+        self._migration_files = config.migration_files
         self._state = config.state
         self._loop = config.loop
         self._logger = config.logger

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
@@ -19,51 +20,40 @@ if TYPE_CHECKING:
     import logging
 
 
-class PlaytimeService:
-    """Playtime tracking: record sessions and sync to RomM notes.
+@dataclass(frozen=True)
+class PlaytimeServiceConfig:
+    """Frozen wiring bundle handed to ``PlaytimeService.__init__``.
 
-    Parameters
-    ----------
-    romm_api:
-        Protocol adapter for RomM HTTP operations.
-    retry:
-        Retry strategy — provides ``with_retry`` and ``is_retryable``.
-    save_sync_state:
-        Live reference to the typed :class:`SaveSyncState` aggregate.
-        Playtime data lives in ``save_sync_state.playtime``.
-    loop:
-        The plugin's ``asyncio`` event loop (for ``run_in_executor``).
-    logger:
-        Standard-library logger.
-    save_state:
-        Callable to persist the save_sync_state dict to disk.
-    log_debug:
-        ``DebugLogger`` Protocol seam — routes through the user's QAM
-        log-level filter.
+    Holds the Protocol-typed RomM adapter and retry strategy, the typed
+    save-sync aggregate, runtime infrastructure, clock/debug-logger
+    seams, and the persistence callback PlaytimeService needs at
+    construction time.
     """
+
+    romm_api: RommApiProtocol
+    retry: RetryStrategy
+    save_sync_state: SaveSyncState
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    clock: Clock
+    save_state: StatePersister
+    log_debug: DebugLogger
+
+
+class PlaytimeService:
+    """Playtime tracking: record sessions and sync to RomM notes."""
 
     PLAYTIME_NOTE_TITLE = "romm-sync:playtime"
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        retry: RetryStrategy,
-        save_sync_state: SaveSyncState,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        clock: Clock,
-        save_state: StatePersister,
-        log_debug: DebugLogger,
-    ) -> None:
-        self._romm_api = romm_api
-        self._retry = retry
-        self._save_sync_state = save_sync_state
-        self._loop = loop
-        self._logger = logger
-        self._clock = clock
-        self._save_state = save_state
-        self._log_debug = log_debug
+    def __init__(self, *, config: PlaytimeServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._save_sync_state = config.save_sync_state
+        self._loop = config.loop
+        self._logger = config.logger
+        self._clock = config.clock
+        self._save_state = config.save_state
+        self._log_debug = config.log_debug
 
     # ------------------------------------------------------------------
     # Playtime Notes API Helpers

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -1,19 +1,16 @@
 """Construction-time wiring bundle for ``SaveService``.
 
-Holds the environment-bound dependencies SaveService needs at
-construction time — runtime paths, callbacks into other services,
-the asyncio loop, the logger, plugin metadata. Live mutable state
-references (``settings``, ``state``, ``save_sync_state``) and abstract
-protocol deps (``romm_api``, ``retry``) are intentionally NOT bundled
-here — they remain explicit ``SaveService`` ctor parameters because
-they have different lifecycles and ownership semantics from this
-immutable wiring bundle.
+Holds every dependency SaveService needs at construction time —
+Protocol-typed adapters, runtime infrastructure, live mutable state
+references, plugin metadata, and callbacks into other services.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from domain.save_state import SaveSyncState
 
 if TYPE_CHECKING:
     import asyncio
@@ -26,6 +23,8 @@ if TYPE_CHECKING:
         CoreResolverFn,
         DebugLogger,
         EventEmitter,
+        RetryStrategy,
+        RommApiProtocol,
         RomsPathProvider,
         SaveFileAdapter,
         SavesPathProvider,
@@ -39,6 +38,20 @@ class SaveServiceConfig:
 
     Parameters
     ----------
+    romm_api:
+        Protocol adapter for all RomM save/notes HTTP operations.
+    retry:
+        Retry strategy — provides ``with_retry`` and ``is_retryable``.
+    settings:
+        Live reference to the main plugin settings dict.
+    state:
+        Live reference to the main plugin state dict (``installed_roms``,
+        ``shortcut_registry``).
+    save_sync_state:
+        Live reference to the typed :class:`SaveSyncState` aggregate.
+        Caller should pre-populate via :meth:`SaveService.load_state`
+        after construction; the aggregate ships with defaults out of
+        the box.
     runtime_dir:
         Absolute path to the plugin runtime directory. Consumed by
         SaveService for ad-hoc runtime files; ``save_sync_state.json``
@@ -106,6 +119,11 @@ class SaveServiceConfig:
         ``_save_service._log_debug`` back-ref.
     """
 
+    romm_api: RommApiProtocol
+    retry: RetryStrategy
+    settings: dict
+    state: dict
+    save_sync_state: SaveSyncState
     runtime_dir: str
     save_sync_state_persister: SaveSyncStatePersister
     save_file: SaveFileAdapter

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -14,10 +14,6 @@ from domain.save_path import resolve_save_dir, sanitize_save_filename
 from domain.save_state import FileSyncState, SaveSyncState
 from lib.errors import classify_error
 from lib.iso_time import parse_iso_to_epoch
-from services.protocols import (
-    RetryStrategy,
-    RommApiProtocol,
-)
 from services.saves._config import SaveServiceConfig
 from services.saves._helpers import _local_save_target
 from services.saves._messages import DEVICE_NOT_REGISTERED, SAVE_SYNC_DISABLED
@@ -39,43 +35,24 @@ class SaveService:
 
     Parameters
     ----------
-    romm_api:
-        Protocol adapter for all RomM save/notes HTTP operations.
-    retry:
-        Retry strategy — provides ``with_retry`` and ``is_retryable``.
-    settings:
-        Live reference to the main plugin settings dict.
-    state:
-        Live reference to the main plugin state dict (``installed_roms``,
-        ``shortcut_registry``).
-    save_sync_state:
-        Live reference to the typed :class:`SaveSyncState` aggregate.
-        Caller should pre-populate via :meth:`load_state` after
-        construction; the aggregate ships with defaults out of the box.
     config:
-        Construction-time wiring bundle (paths, callbacks, asyncio loop,
-        logger, plugin metadata). See :class:`SaveServiceConfig` for the
+        Construction-time wiring bundle holding every dependency
+        SaveService consumes: the Protocol-typed RomM adapter, retry
+        strategy, live settings/state dicts, the typed save-sync
+        aggregate, runtime infrastructure, persistence callbacks, and
+        cross-service callbacks. See :class:`SaveServiceConfig` for the
         per-field rationale.
     """
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        retry: RetryStrategy,
-        settings: dict,
-        state: dict,
-        save_sync_state: SaveSyncState,
-        config: SaveServiceConfig,
-    ) -> None:
-        self._romm_api = romm_api
-        self._retry = retry
-        self._settings = settings
-        self._state = state
+    def __init__(self, *, config: SaveServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._settings = config.settings
+        self._state = config.state
         self._config = config
         self._state_svc = StateService(
-            save_sync_state=save_sync_state,
-            state=state,
+            save_sync_state=config.save_sync_state,
+            state=config.state,
             persister=config.save_sync_state_persister,
             logger=config.logger,
         )

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,29 +18,37 @@ if TYPE_CHECKING:
     )
 
 
+@dataclass(frozen=True)
+class ShortcutRemovalServiceConfig:
+    """Frozen wiring bundle handed to ``ShortcutRemovalService.__init__``.
+
+    Holds the Protocol-typed adapters, the live state dict, runtime
+    infrastructure, event emitter, and persistence callbacks
+    ShortcutRemovalService needs at construction time.
+    """
+
+    romm_api: RommApiProtocol
+    steam_config: SteamConfigAdapter
+    state: dict
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    emit: EventEmitter
+    save_state: StatePersister
+    artwork_remover: ArtworkRemover
+
+
 class ShortcutRemovalService:
     """Handles shortcut removal: identifies app_ids/rom_ids and cleans up state."""
 
-    def __init__(
-        self,
-        *,
-        romm_api: RommApiProtocol,
-        steam_config: SteamConfigAdapter,
-        state: dict,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        emit: EventEmitter,
-        save_state: StatePersister,
-        artwork_remover: ArtworkRemover,
-    ) -> None:
-        self._romm_api = romm_api
-        self._steam_config = steam_config
-        self._state = state
-        self._loop = loop
-        self._logger = logger
-        self._emit = emit
-        self._save_state = save_state
-        self._artwork_remover = artwork_remover
+    def __init__(self, *, config: ShortcutRemovalServiceConfig) -> None:
+        self._romm_api = config.romm_api
+        self._steam_config = config.steam_config
+        self._state = config.state
+        self._loop = config.loop
+        self._logger = config.logger
+        self._emit = config.emit
+        self._save_state = config.save_state
+        self._artwork_remover = config.artwork_remover
 
     # ── Registry helpers ───────────────────────────────────────────────────
 

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -43,31 +43,25 @@ if TYPE_CHECKING:
 class SteamGridConfig:
     """Frozen wiring bundle handed to ``SteamGridService.__init__``.
 
-    Holds the runtime infrastructure and external callbacks SteamGridService
-    needs at construction time. Live mutable state references (``state``,
-    ``settings``) and abstract Protocol-typed adapters remain explicit ctor
-    parameters because they have different lifecycles from this immutable
-    wiring bundle.
+    Holds the Protocol-typed adapters (``sgdb_api``, ``romm_api``,
+    ``steam_config``, ``sgdb_artwork_cache``), the live state and
+    settings dicts, runtime infrastructure, persistence callbacks, the
+    pending-sync read seam, and the debug-logger seam SteamGridService
+    needs at construction time.
 
-    Parameters
-    ----------
-    loop:
-        The plugin's ``asyncio`` event loop (for ``run_in_executor``).
-    logger:
-        Standard-library logger (replaces ``decky.logger``).
-    save_state:
-        Persists the main plugin state dict to disk.
-    save_settings_to_disk:
-        Persists the live settings dict to disk after API-key updates.
-    get_pending_sync:
-        Read seam returning the current LibraryService pending-sync map.
-        Used to resolve SGDB IDs for ROMs mid-sync that are not yet in
-        the registry.
-    log_debug:
-        ``DebugLogger`` Protocol seam — routes through the user's QAM
-        log-level filter.
+    Note
+    ----
+    The dataclass is named ``SteamGridConfig`` rather than
+    ``SteamGridServiceConfig`` for transitional reasons; renaming is
+    tracked separately and does not affect the Always-Config shape.
     """
 
+    sgdb_api: SteamGridDbApi
+    romm_api: RommApiProtocol
+    steam_config: SteamConfigAdapter
+    sgdb_artwork_cache: SgdbArtworkCache
+    state: dict
+    settings: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     save_state: StatePersister
@@ -79,23 +73,13 @@ class SteamGridConfig:
 class SteamGridService:
     """SteamGridDB orchestration: API key flow, artwork fetch/cache, icon save."""
 
-    def __init__(
-        self,
-        *,
-        sgdb_api: SteamGridDbApi,
-        romm_api: RommApiProtocol,
-        steam_config: SteamConfigAdapter,
-        sgdb_artwork_cache: SgdbArtworkCache,
-        state: dict,
-        settings: dict,
-        config: SteamGridConfig,
-    ) -> None:
-        self._sgdb_api = sgdb_api
-        self._romm_api = romm_api
-        self._steam_config = steam_config
-        self._sgdb_artwork_cache = sgdb_artwork_cache
-        self._state = state
-        self._settings = settings
+    def __init__(self, *, config: SteamGridConfig) -> None:
+        self._sgdb_api = config.sgdb_api
+        self._romm_api = config.romm_api
+        self._steam_config = config.steam_config
+        self._sgdb_artwork_cache = config.sgdb_artwork_cache
+        self._state = config.state
+        self._settings = config.settings
         self._loop = config.loop
         self._logger = config.logger
         self._save_state = config.save_state

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -44,12 +44,12 @@ def plugin():
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -26,27 +26,6 @@ def _make_save_sync_state_persister(tmp_path) -> SaveSyncStatePersisterAdapter:
     )
 
 
-_CONFIG_FIELDS = frozenset(
-    {
-        "runtime_dir",
-        "save_sync_state_persister",
-        "save_file",
-        "loop",
-        "logger",
-        "clock",
-        "get_saves_path",
-        "get_roms_path",
-        "get_active_core",
-        "get_core_name",
-        "plugin_version",
-        "emit",
-        "detect_sort_change",
-        "is_retrodeck_migration_pending",
-        "log_debug",
-    }
-)
-
-
 def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["SaveService", "FakeSaveApi"]:
     """Create a SaveService with sensible defaults for testing."""
     save_file = SaveFileAdapter()
@@ -57,6 +36,11 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
     if fake.save_file is None:
         fake.save_file = save_file
     config_kwargs: dict[str, Any] = dict(
+        romm_api=fake,
+        retry=_make_retry(),
+        settings={"log_level": "debug"},
+        state={"shortcut_registry": {}, "installed_roms": {}},
+        save_sync_state=SaveService.make_default_state(),
         runtime_dir=str(tmp_path),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
         save_file=save_file,
@@ -70,19 +54,8 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         plugin_version="0.14.0",
         emit=emit,
     )
-    ctor_kwargs: dict[str, Any] = dict(
-        romm_api=fake,
-        retry=_make_retry(),
-        settings={"log_level": "debug"},
-        state={"shortcut_registry": {}, "installed_roms": {}},
-        save_sync_state=SaveService.make_default_state(),
-    )
-    for key, value in overrides.items():
-        if key in _CONFIG_FIELDS:
-            config_kwargs[key] = value
-        else:
-            ctor_kwargs[key] = value
-    svc = SaveService(**ctor_kwargs, config=SaveServiceConfig(**config_kwargs))
+    config_kwargs.update(overrides)
+    svc = SaveService(config=SaveServiceConfig(**config_kwargs))
     svc.init_state()
     return svc, fake
 

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -10,8 +10,8 @@ from domain.save_state import SaveSyncState
 
 # conftest.py patches decky before this import
 from main import Plugin
-from services.achievements import AchievementsService
-from services.game_detail import GameDetailService
+from services.achievements import AchievementsService, AchievementsServiceConfig
+from services.game_detail import GameDetailService, GameDetailServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 
 
@@ -51,12 +51,12 @@ def plugin(clock):
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -70,25 +70,29 @@ def plugin(clock):
         ),
     )
     p._achievements_service = AchievementsService(
-        romm_api=p._romm_api,
-        state=p._state,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        clock=clock,
-        log_debug=p._log_debug,
+        config=AchievementsServiceConfig(
+            romm_api=p._romm_api,
+            state=p._state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            clock=clock,
+            log_debug=p._log_debug,
+        ),
     )
     bios_checker = MagicMock()
     bios_checker.check_platform_bios_cached.return_value = None
     bios_checker.check_platform_bios = AsyncMock(return_value={"needs_bios": False})
     p._save_sync_state = SaveSyncState()
     p._game_detail_service = GameDetailService(
-        state=p._state,
-        metadata_cache=p._metadata_cache,
-        save_sync_state=p._save_sync_state,
-        logger=decky.logger,
-        clock=clock,
-        bios_checker=bios_checker,
-        achievements=p._achievements_service,
+        config=GameDetailServiceConfig(
+            state=p._state,
+            metadata_cache=p._metadata_cache,
+            save_sync_state=p._save_sync_state,
+            logger=decky.logger,
+            clock=clock,
+            bios_checker=bios_checker,
+            achievements=p._achievements_service,
+        ),
     )
     return p
 

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -49,11 +49,11 @@ def artwork_service(state, steam_config, file_store, romm_api, pending_sync_data
     # _loop is replaced by the autouse fixture below for async tests; for
     # sync tests it is never touched, so a MagicMock is fine here.
     return ArtworkService(
-        romm_api=romm_api,
-        steam_config=steam_config,
-        cover_art_file_store=file_store,
-        state=state,
         config=ArtworkServiceConfig(
+            romm_api=romm_api,
+            steam_config=steam_config,
+            cover_art_file_store=file_store,
+            state=state,
             loop=MagicMock(),
             logger=decky.logger,
             get_pending_sync=lambda: pending_sync_data,

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -36,12 +36,12 @@ def plugin():
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -56,11 +56,11 @@ def plugin():
     )
     p._save_sync_state = SaveSyncState()
     p._download_service = DownloadService(
-        romm_api=p._romm_api,
-        state=p._state,
-        download_files=DownloadFileAdapter(),
-        download_queue=DownloadQueueAdapter(),
         config=DownloadServiceConfig(
+            romm_api=p._romm_api,
+            state=p._state,
+            download_files=DownloadFileAdapter(),
+            download_queue=DownloadQueueAdapter(),
             resolve_system=p._resolve_system,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -63,12 +63,12 @@ def plugin():
     p._firmware_service.load_bios_registry()
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -15,11 +15,11 @@ from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapt
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import FileSyncState, RomSaveState
-from services.achievements import AchievementsService
+from services.achievements import AchievementsService, AchievementsServiceConfig
 from services.firmware import FirmwareService, FirmwareServiceConfig
-from services.game_detail import GameDetailService
+from services.game_detail import GameDetailService, GameDetailServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
-from services.playtime import PlaytimeService
+from services.playtime import PlaytimeService, PlaytimeServiceConfig
 from services.saves import SaveService, SaveServiceConfig
 
 
@@ -48,12 +48,12 @@ def plugin(tmp_path):
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=MagicMock(),
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -74,12 +74,12 @@ def plugin(tmp_path):
     saves_path = str(tmp_path / "retrodeck" / "saves")
 
     p._save_sync_service = SaveService(
-        romm_api=fake_api,
-        retry=_make_retry(),
-        settings={"log_level": "debug"},
-        state=p._state,
-        save_sync_state=p._save_sync_state,
         config=SaveServiceConfig(
+            romm_api=fake_api,
+            retry=_make_retry(),
+            settings={"log_level": "debug"},
+            state=p._state,
+            save_sync_state=p._save_sync_state,
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -101,23 +101,27 @@ def plugin(tmp_path):
     p._save_sync_service.init_state()
 
     p._playtime_service = PlaytimeService(
-        romm_api=fake_api,
-        retry=_make_retry(),
-        save_sync_state=p._save_sync_state,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-        save_state=p._save_sync_service.save_state,
-        log_debug=p._log_debug,
+        config=PlaytimeServiceConfig(
+            romm_api=fake_api,
+            retry=_make_retry(),
+            save_sync_state=p._save_sync_state,
+            loop=asyncio.get_event_loop(),
+            logger=logging.getLogger("test"),
+            clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
+            save_state=p._save_sync_service.save_state,
+            log_debug=p._log_debug,
+        ),
     )
 
     p._achievements_service = AchievementsService(
-        romm_api=MagicMock(),
-        state=p._state,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-        log_debug=p._log_debug,
+        config=AchievementsServiceConfig(
+            romm_api=MagicMock(),
+            state=p._state,
+            loop=asyncio.get_event_loop(),
+            logger=logging.getLogger("test"),
+            clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
+            log_debug=p._log_debug,
+        ),
     )
 
     p._firmware_service = FirmwareService(
@@ -154,13 +158,15 @@ def clock():
 def game_detail_service(plugin, clock):
     """Create a GameDetailService wired to the plugin's state and the pinned clock fixture."""
     return GameDetailService(
-        state=plugin._state,
-        metadata_cache=plugin._metadata_cache,
-        save_sync_state=plugin._save_sync_state,
-        logger=logging.getLogger("test"),
-        clock=clock,
-        bios_checker=plugin._firmware_service,
-        achievements=plugin._achievements_service,
+        config=GameDetailServiceConfig(
+            state=plugin._state,
+            metadata_cache=plugin._metadata_cache,
+            save_sync_state=plugin._save_sync_state,
+            logger=logging.getLogger("test"),
+            clock=clock,
+            bios_checker=plugin._firmware_service,
+            achievements=plugin._achievements_service,
+        ),
     )
 
 

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -15,8 +15,8 @@ from domain.sync_state import SyncState
 from main import Plugin
 from services.artwork import ArtworkService, ArtworkServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
-from services.metadata import MetadataService
-from services.shortcut_removal import ShortcutRemovalService
+from services.metadata import MetadataService, MetadataServiceConfig
+from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 
 
 @pytest.fixture
@@ -36,23 +36,25 @@ def plugin(tmp_path):
     p._steam_config = steam_config
 
     metadata_service = MetadataService(
-        romm_api=p._romm_api,
-        state=p._state,
-        metadata_cache=p._metadata_cache,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        clock=FakeClock(),
-        save_metadata_cache=p._save_metadata_cache,
-        log_debug=p._log_debug,
+        config=MetadataServiceConfig(
+            romm_api=p._romm_api,
+            state=p._state,
+            metadata_cache=p._metadata_cache,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            clock=FakeClock(),
+            save_metadata_cache=p._save_metadata_cache,
+            log_debug=p._log_debug,
+        ),
     )
     p._metadata_service = metadata_service
 
     artwork_service = ArtworkService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        cover_art_file_store=CoverArtFileStoreAdapter(),
-        state=p._state,
         config=ArtworkServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            cover_art_file_store=CoverArtFileStoreAdapter(),
+            state=p._state,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             get_pending_sync=dict,
@@ -61,12 +63,12 @@ def plugin(tmp_path):
     p._artwork_service = artwork_service
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -77,20 +79,22 @@ def plugin(tmp_path):
             save_state=p._save_state,
             save_settings_to_disk=p._save_settings_to_disk,
             log_debug=p._log_debug,
+            metadata_service=metadata_service,
+            artwork=artwork_service,
         ),
-        metadata_service=metadata_service,
-        artwork=artwork_service,
     )
 
     p._shortcut_removal_service = ShortcutRemovalService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        emit=decky.emit,
-        save_state=p._save_state,
-        artwork_remover=artwork_service,
+        config=ShortcutRemovalServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            save_state=p._save_state,
+            artwork_remover=artwork_service,
+        ),
     )
     # Default migration service mock — no migration pending. Tests that need
     # to exercise the @migration_blocked gate override this.

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -14,7 +14,7 @@ from adapters.steam_config import SteamConfigAdapter
 # conftest.py patches decky before this import
 from main import Plugin
 from services.library import LibraryService, LibraryServiceConfig
-from services.metadata import MetadataService
+from services.metadata import MetadataService, MetadataServiceConfig
 
 
 @pytest.fixture
@@ -33,24 +33,26 @@ def plugin():
     p._steam_config = steam_config
 
     metadata_service = MetadataService(
-        romm_api=p._romm_api,
-        state=p._state,
-        metadata_cache=p._metadata_cache,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        clock=FakeClock(),
-        save_metadata_cache=p._save_metadata_cache,
-        log_debug=p._log_debug,
+        config=MetadataServiceConfig(
+            romm_api=p._romm_api,
+            state=p._state,
+            metadata_cache=p._metadata_cache,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            clock=FakeClock(),
+            save_metadata_cache=p._save_metadata_cache,
+            log_debug=p._log_debug,
+        ),
     )
     p._metadata_service = metadata_service
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -61,8 +63,8 @@ def plugin():
             save_state=p._save_state,
             save_settings_to_disk=p._save_settings_to_disk,
             log_debug=p._log_debug,
+            metadata_service=metadata_service,
         ),
-        metadata_service=metadata_service,
     )
     return p
 

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -59,12 +59,12 @@ def plugin(tmp_path):
     p._firmware_service.load_bios_registry()
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -79,8 +79,8 @@ def plugin(tmp_path):
     )
 
     p._migration_service = MigrationService(
-        migration_files=MigrationFileAdapter(),
         config=MigrationServiceConfig(
+            migration_files=MigrationFileAdapter(),
             state=p._state,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
@@ -880,8 +880,7 @@ class TestMigrationFailureInjection:
         }
         defaults.update(overrides)
         return MigrationService(
-            migration_files=fake_files,
-            config=MigrationServiceConfig(**defaults),
+            config=MigrationServiceConfig(migration_files=fake_files, **defaults),
         )
 
     def test_move_failure_records_error_and_continues(self):

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -49,8 +49,8 @@ def _make_service(
     save_state_mock = MagicMock()
 
     svc = MigrationService(
-        migration_files=MigrationFileAdapter(),
         config=MigrationServiceConfig(
+            migration_files=MigrationFileAdapter(),
             state=state,
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
@@ -141,8 +141,8 @@ class TestDetectSaveSortChange:
         """No get_retroarch_save_sorting callback — method is a no-op."""
         save_state_mock = MagicMock()
         svc = MigrationService(
-            migration_files=MigrationFileAdapter(),
             config=MigrationServiceConfig(
+                migration_files=MigrationFileAdapter(),
                 state={"save_sort_settings": None, "installed_roms": {}},
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),
@@ -765,8 +765,8 @@ class TestResolveRetroArchCorename:
             return ("snes9x_libretro", "Snes9x - Current")
 
         svc = MigrationService(
-            migration_files=MigrationFileAdapter(),
             config=MigrationServiceConfig(
+                migration_files=MigrationFileAdapter(),
                 state={"installed_roms": {}, "save_sort_settings": None},
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),
@@ -782,8 +782,8 @@ class TestResolveRetroArchCorename:
     def test_no_active_core_callback_returns_none(self, tmp_path):
         """Service constructed without ``get_active_core`` — method returns (None, None)."""
         svc = MigrationService(
-            migration_files=MigrationFileAdapter(),
             config=MigrationServiceConfig(
+                migration_files=MigrationFileAdapter(),
                 state={"installed_roms": {}, "save_sort_settings": None},
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -13,7 +13,7 @@ from fakes.system_time import FakeClock
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.errors import RommApiError
-from services.playtime import PlaytimeService
+from services.playtime import PlaytimeService, PlaytimeServiceConfig
 
 
 def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):
@@ -34,7 +34,7 @@ def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):
         log_debug=lambda _msg: None,
     )
     defaults.update(overrides)
-    svc = PlaytimeService(**defaults)
+    svc = PlaytimeService(config=PlaytimeServiceConfig(**defaults))
     return svc, fake, state, saved
 
 

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -8,7 +8,7 @@ import decky
 import pytest
 
 from adapters.steam_config import SteamConfigAdapter
-from services.shortcut_removal import ShortcutRemovalService
+from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 
 
 @pytest.fixture
@@ -29,14 +29,16 @@ def artwork_remover_mock():
 @pytest.fixture
 def svc(state, steam_config, artwork_remover_mock):
     service = ShortcutRemovalService(
-        romm_api=MagicMock(),
-        steam_config=steam_config,
-        state=state,
-        loop=asyncio.get_event_loop(),
-        logger=decky.logger,
-        emit=decky.emit,
-        save_state=MagicMock(),
-        artwork_remover=artwork_remover_mock,
+        config=ShortcutRemovalServiceConfig(
+            romm_api=MagicMock(),
+            steam_config=steam_config,
+            state=state,
+            loop=asyncio.get_event_loop(),
+            logger=decky.logger,
+            emit=decky.emit,
+            save_state=MagicMock(),
+            artwork_remover=artwork_remover_mock,
+        ),
     )
     return service
 
@@ -228,11 +230,11 @@ class TestRemovalCleansUpArtwork:
         from services.artwork import ArtworkService, ArtworkServiceConfig
 
         artwork_svc = ArtworkService(
-            romm_api=MagicMock(),
-            steam_config=steam_config,
-            cover_art_file_store=CoverArtFileStoreAdapter(),
-            state=state,
             config=ArtworkServiceConfig(
+                romm_api=MagicMock(),
+                steam_config=steam_config,
+                cover_art_file_store=CoverArtFileStoreAdapter(),
+                state=state,
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 get_pending_sync=dict,
@@ -240,14 +242,16 @@ class TestRemovalCleansUpArtwork:
         )
 
         svc = ShortcutRemovalService(
-            romm_api=MagicMock(),
-            steam_config=steam_config,
-            state=state,
-            loop=asyncio.get_event_loop(),
-            logger=decky.logger,
-            emit=decky.emit,
-            save_state=MagicMock(),
-            artwork_remover=artwork_svc,
+            config=ShortcutRemovalServiceConfig(
+                romm_api=MagicMock(),
+                steam_config=steam_config,
+                state=state,
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                emit=decky.emit,
+                save_state=MagicMock(),
+                artwork_remover=artwork_svc,
+            ),
         )
         svc._loop = asyncio.get_event_loop()
 
@@ -268,11 +272,11 @@ class TestRemovalCleansUpArtwork:
         from services.artwork import ArtworkService, ArtworkServiceConfig
 
         artwork_svc = ArtworkService(
-            romm_api=MagicMock(),
-            steam_config=steam_config,
-            cover_art_file_store=CoverArtFileStoreAdapter(),
-            state=state,
             config=ArtworkServiceConfig(
+                romm_api=MagicMock(),
+                steam_config=steam_config,
+                cover_art_file_store=CoverArtFileStoreAdapter(),
+                state=state,
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 get_pending_sync=dict,
@@ -280,14 +284,16 @@ class TestRemovalCleansUpArtwork:
         )
 
         svc = ShortcutRemovalService(
-            romm_api=MagicMock(),
-            steam_config=steam_config,
-            state=state,
-            loop=asyncio.get_event_loop(),
-            logger=decky.logger,
-            emit=decky.emit,
-            save_state=MagicMock(),
-            artwork_remover=artwork_svc,
+            config=ShortcutRemovalServiceConfig(
+                romm_api=MagicMock(),
+                steam_config=steam_config,
+                state=state,
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                emit=decky.emit,
+                save_state=MagicMock(),
+                artwork_remover=artwork_svc,
+            ),
         )
         svc._loop = asyncio.get_event_loop()
 

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -39,12 +39,12 @@ def plugin(sgdb_artwork_cache):
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -61,13 +61,13 @@ def plugin(sgdb_artwork_cache):
     sgdb_api = MagicMock()
 
     p._sgdb_service = SteamGridService(
-        sgdb_api=sgdb_api,
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        sgdb_artwork_cache=sgdb_artwork_cache,
-        state=p._state,
-        settings=p.settings,
         config=SteamGridConfig(
+            sgdb_api=sgdb_api,
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            sgdb_artwork_cache=sgdb_artwork_cache,
+            state=p._state,
+            settings=p.settings,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             save_state=MagicMock(),
@@ -730,12 +730,12 @@ class TestDebugLoggerProtocolSeam:
         p._steam_config = steam_config
 
         p._sync_service = LibraryService(
-            romm_api=p._romm_api,
-            steam_config=steam_config,
-            state=p._state,
-            settings=p.settings,
-            metadata_cache=p._metadata_cache,
             config=LibraryServiceConfig(
+                romm_api=p._romm_api,
+                steam_config=steam_config,
+                state=p._state,
+                settings=p.settings,
+                metadata_cache=p._metadata_cache,
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -750,13 +750,13 @@ class TestDebugLoggerProtocolSeam:
         )
 
         p._sgdb_service = SteamGridService(
-            sgdb_api=MM(),
-            romm_api=p._romm_api,
-            steam_config=steam_config,
-            sgdb_artwork_cache=sgdb_artwork_cache,
-            state=p._state,
-            settings=p.settings,
             config=SteamGridConfig(
+                sgdb_api=MM(),
+                romm_api=p._romm_api,
+                steam_config=steam_config,
+                sgdb_artwork_cache=sgdb_artwork_cache,
+                state=p._state,
+                settings=p.settings,
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 save_state=MM(),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -45,12 +45,12 @@ def plugin():
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -65,13 +65,13 @@ def plugin():
     )
 
     p._sgdb_service = SteamGridService(
-        sgdb_api=MagicMock(),
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        sgdb_artwork_cache=FakeSgdbArtworkCache(cache_root=decky.DECKY_PLUGIN_RUNTIME_DIR),
-        state=p._state,
-        settings=p.settings,
         config=SteamGridConfig(
+            sgdb_api=MagicMock(),
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            sgdb_artwork_cache=FakeSgdbArtworkCache(cache_root=decky.DECKY_PLUGIN_RUNTIME_DIR),
+            state=p._state,
+            settings=p.settings,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             save_state=MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -19,7 +19,7 @@ from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
 from services.library import LibraryService, LibraryServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
-from services.playtime import PlaytimeService
+from services.playtime import PlaytimeService, PlaytimeServiceConfig
 from services.saves import SaveService, SaveServiceConfig
 
 
@@ -49,12 +49,12 @@ def plugin(tmp_path):
     p._steam_config = steam_config
 
     p._sync_service = LibraryService(
-        romm_api=p._romm_api,
-        steam_config=steam_config,
-        state=p._state,
-        settings=p.settings,
-        metadata_cache=p._metadata_cache,
         config=LibraryServiceConfig(
+            romm_api=p._romm_api,
+            steam_config=steam_config,
+            state=p._state,
+            settings=p.settings,
+            metadata_cache=p._metadata_cache,
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -77,12 +77,12 @@ def plugin(tmp_path):
     saves_path = str(tmp_path / "retrodeck" / "saves")
 
     p._save_sync_service = SaveService(
-        romm_api=fake_api,
-        retry=_make_retry(),
-        settings={"log_level": "debug"},
-        state=p._state,
-        save_sync_state=p._save_sync_state,
         config=SaveServiceConfig(
+            romm_api=fake_api,
+            retry=_make_retry(),
+            settings={"log_level": "debug"},
+            state=p._state,
+            save_sync_state=p._save_sync_state,
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -104,14 +104,16 @@ def plugin(tmp_path):
     p._save_sync_service.init_state()
 
     p._playtime_service = PlaytimeService(
-        romm_api=fake_api,
-        retry=_make_retry(),
-        save_sync_state=p._save_sync_state,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-        save_state=p._save_sync_service.save_state,
-        log_debug=p._log_debug,
+        config=PlaytimeServiceConfig(
+            romm_api=fake_api,
+            retry=_make_retry(),
+            save_sync_state=p._save_sync_state,
+            loop=asyncio.get_event_loop(),
+            logger=logging.getLogger("test"),
+            clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
+            save_state=p._save_sync_service.save_state,
+            log_debug=p._log_debug,
+        ),
     )
 
     # Store fake_api on plugin for test access
@@ -433,8 +435,8 @@ class TestPostExitSync:
         # (NEW: sort_by_content=False, sort_by_core=False) — the mismatch
         # with state is what detect will discover.
         real_migration = MigrationService(
-            migration_files=MigrationFileAdapter(),
             config=MigrationServiceConfig(
+                migration_files=MigrationFileAdapter(),
                 state=plugin._state,
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),


### PR DESCRIPTION
## Summary
CLAUDE.md (PR #342) mandates: every service takes a single `config: XxxServiceConfig` kwarg, all deps in the config. 5 services were bare-param, 6 were mixed (some-explicit + some-in-config). All 11 migrated to the Always-Config shape in one coordinated pass.

### Bare-param → new `*ServiceConfig` dataclass
- `AchievementsService` → `AchievementsServiceConfig`
- `MetadataService` → `MetadataServiceConfig`
- `ShortcutRemovalService` → `ShortcutRemovalServiceConfig`
- `GameDetailService` → `GameDetailServiceConfig`
- `PlaytimeService` → `PlaytimeServiceConfig`

### Mixed → explicit ctor params consolidated into existing config
- `ArtworkService`, `DownloadService`, `LibraryService`, `MigrationService`, `SteamGridService`, `SaveService`

`bootstrap.wire_services()` rewires every service. Test setup is uniform `XxxServiceConfig(...)` + `XxxService(config=cfg)`.

### Out of scope
- `SteamGridConfig` → `SteamGridServiceConfig` rename — tracked in #356, deliberately left alone here to avoid two PRs touching the same file.

## Test plan
- [ ] CI green (build, lint, test)
- [ ] Sonar: 0 new issues
- [ ] 2236 tests pass locally (same as `main`)
- [ ] import-linter: 7 contracts kept, 0 broken
- [ ] cosmic call bans: no violations
- [ ] basedpyright: 0 errors

Closes #355. Part of #353.