### PR TITLE
refactor(services): rename SteamGridConfig to SteamGridServiceConfig

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -88,7 +88,7 @@ from services.saves import SaveService, SaveServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
-from services.steamgrid import SteamGridConfig, SteamGridService
+from services.steamgrid import SteamGridService, SteamGridServiceConfig
 
 
 @dataclass(frozen=True)
@@ -479,7 +479,7 @@ def wire_services(cfg: WiringConfig) -> dict:
     bios_files_index_binding.set(lambda: firmware_service.bios_files_index)
 
     sgdb_service = SteamGridService(
-        config=SteamGridConfig(
+        config=SteamGridServiceConfig(
             sgdb_api=cfg.adapters.sgdb_adapter,
             romm_api=cfg.adapters.romm_api,
             steam_config=cfg.adapters.steam_config,

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class SteamGridConfig:
+class SteamGridServiceConfig:
     """Frozen wiring bundle handed to ``SteamGridService.__init__``.
 
     Holds the Protocol-typed adapters (``sgdb_api``, ``romm_api``,
@@ -48,12 +48,6 @@ class SteamGridConfig:
     settings dicts, runtime infrastructure, persistence callbacks, the
     pending-sync read seam, and the debug-logger seam SteamGridService
     needs at construction time.
-
-    Note
-    ----
-    The dataclass is named ``SteamGridConfig`` rather than
-    ``SteamGridServiceConfig`` for transitional reasons; renaming is
-    tracked separately and does not affect the Always-Config shape.
     """
 
     sgdb_api: SteamGridDbApi
@@ -73,7 +67,7 @@ class SteamGridConfig:
 class SteamGridService:
     """SteamGridDB orchestration: API key flow, artwork fetch/cache, icon save."""
 
-    def __init__(self, *, config: SteamGridConfig) -> None:
+    def __init__(self, *, config: SteamGridServiceConfig) -> None:
         self._sgdb_api = config.sgdb_api
         self._romm_api = config.romm_api
         self._steam_config = config.steam_config

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -14,7 +14,7 @@ from lib.errors import SgdbApiError, SteamGridDirMissingError
 # conftest.py patches decky before this import
 from main import Plugin
 from services.library import LibraryService, LibraryServiceConfig
-from services.steamgrid import SteamGridConfig, SteamGridService
+from services.steamgrid import SteamGridService, SteamGridServiceConfig
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ def plugin(sgdb_artwork_cache):
     sgdb_api = MagicMock()
 
     p._sgdb_service = SteamGridService(
-        config=SteamGridConfig(
+        config=SteamGridServiceConfig(
             sgdb_api=sgdb_api,
             romm_api=p._romm_api,
             steam_config=steam_config,
@@ -750,7 +750,7 @@ class TestDebugLoggerProtocolSeam:
         )
 
         p._sgdb_service = SteamGridService(
-            config=SteamGridConfig(
+            config=SteamGridServiceConfig(
                 sgdb_api=MM(),
                 romm_api=p._romm_api,
                 steam_config=steam_config,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,7 +17,7 @@ from services.connection import ConnectionService, ConnectionServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
-from services.steamgrid import SteamGridConfig, SteamGridService
+from services.steamgrid import SteamGridService, SteamGridServiceConfig
 
 
 @pytest.fixture
@@ -65,7 +65,7 @@ def plugin():
     )
 
     p._sgdb_service = SteamGridService(
-        config=SteamGridConfig(
+        config=SteamGridServiceConfig(
             sgdb_api=MagicMock(),
             romm_api=p._romm_api,
             steam_config=steam_config,


### PR DESCRIPTION
## Summary
CLAUDE.md mandates `*ServiceConfig` naming on every service config dataclass — the `Service` component is part of the name. `SteamGridConfig` was the lone holdout (left alone in #424 specifically to land here). Mechanical rename across the four call sites; drops the now-obsolete transitional-name docstring.

## Test plan
- [ ] CI green (build, lint, test)
- [ ] Sonar: 0 new issues
- [ ] 2236 tests pass locally

Closes #356. Part of #353.