### PR TITLE
refactor(adapters): rename RommApi to RommApiAdapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,9 +116,9 @@ When a service-level decomposition produces sub-services with shared state (e.g.
 
 Decision rule by how the package is consumed:
 
-- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): `__init__.py` is empty (a docstring is acceptable but not required). These exist as namespace markers; consumers always deep-import (`from adapters.romm.romm_api import RommApi`).
+- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): `__init__.py` is empty (a docstring is acceptable but not required). These exist as namespace markers; consumers always deep-import (`from adapters.romm.romm_api import RommApiAdapter`).
 - **Sub-package consumed via package import** (consumers write `from package import X`): `__init__.py` holds the package's contract-style module docstring, re-exports of the public class(es), and optional `__all__`. Examples: `services/saves/`, `services/saves/sync_engine/`, `services/saves/slots/`, `services/saves/status/`.
-- **Sub-package only consumed via deep-import** (consumers always write `from package.module import X`): empty or just docstring, no re-exports. Example: `adapters/romm/` — `bootstrap` deep-imports `from adapters.romm.romm_api import RommApi`.
+- **Sub-package only consumed via deep-import** (consumers always write `from package.module import X`): empty or just docstring, no re-exports. Example: `adapters/romm/` — `bootstrap` deep-imports `from adapters.romm.romm_api import RommApiAdapter`.
 
 Implementation never lives in `__init__.py`. Don't put 500+ LOC class definitions there — that obscures the package's public surface and breaks the "init = namespace marker + re-export" Python convention.
 

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -11,7 +11,7 @@ import urllib.parse
 from adapters.romm.http import RommHttpAdapter
 
 
-class RommApi:
+class RommApiAdapter:
     """Concrete RomM API adapter for RomM >= 4.8.1."""
 
     def __init__(self, client: RommHttpAdapter) -> None:

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -32,7 +32,7 @@ from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.rom_files import RomFileAdapter as RomFileAdapterImpl
 from adapters.romm.http import RommHttpAdapter
-from adapters.romm.romm_api import RommApi
+from adapters.romm.romm_api import RommApiAdapter
 from adapters.save_file import SaveFileAdapter as SaveFileAdapterImpl
 from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
 from adapters.steam_config import SteamConfigAdapter
@@ -223,7 +223,7 @@ def bootstrap(
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
     http_adapter = RommHttpAdapter(settings, plugin_dir, logger)
-    romm_api = RommApi(http_adapter)
+    romm_api = RommApiAdapter(http_adapter)
     steam_config = SteamConfigAdapter(user_home=user_home, logger=logger)
     sgdb_adapter = SteamGridDbAdapter(settings=settings, logger=logger)
     cover_art_file_store = CoverArtFileStoreAdapter()

--- a/py_modules/services/protocols.py
+++ b/py_modules/services/protocols.py
@@ -27,7 +27,7 @@ class RommApiProtocol(Protocol):
     """Domain-oriented interface for all RomM server operations.
 
     Replaces raw HTTP path construction in services with semantic methods.
-    Concrete implementation: ``adapters.romm.romm_api.RommApi``.
+    Concrete implementation: ``adapters.romm.romm_api.RommApiAdapter``.
     Requires RomM >= 4.8.1.
     """
 

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -1,4 +1,4 @@
-"""Tests for RommApi — the consolidated RomM API adapter (>= 4.7.0)."""
+"""Tests for RommApiAdapter — the consolidated RomM API adapter (>= 4.7.0)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from adapters.romm.romm_api import RommApi
+from adapters.romm.romm_api import RommApiAdapter
 
 
 def _make_api():
@@ -16,7 +16,7 @@ def _make_api():
     client.post_json = MagicMock()
     client.put_json = MagicMock()
     client.upload_multipart = MagicMock()
-    return RommApi(client), client
+    return RommApiAdapter(client), client
 
 
 class TestHeartbeat:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -33,7 +33,7 @@ from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
-from adapters.romm.romm_api import RommApi
+from adapters.romm.romm_api import RommApiAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.achievements import AchievementsService
 from services.cores import CoreService
@@ -116,7 +116,7 @@ class TestBootstrap:
             logger=logging.getLogger("test"),
         )
         assert "romm_api" in result
-        assert isinstance(result["romm_api"], RommApi)
+        assert isinstance(result["romm_api"], RommApiAdapter)
 
     def test_returns_split_retrodeck_adapters(self, tmp_path):
         """Bootstrap instantiates all three split adapters (paths, cfg, core_info)."""
@@ -147,7 +147,7 @@ class TestWireServices:
             "sync_stats": {},
             "downloaded_bios": {},
         }
-        romm_api = MagicMock(spec=RommApi)
+        romm_api = MagicMock(spec=RommApiAdapter)
         return {
             "http_adapter": http_adapter,
             "romm_api": romm_api,


### PR DESCRIPTION
## Summary
Every other adapter class ends in `Adapter`; `RommApi` didn't, so `grep -l Adapter py_modules/adapters/` quietly missed it. Mechanical rename of the class across the four call sites, plus the `protocols.py` docstring reference and the `CLAUDE.md` example block. The file name stays `romm_api.py` — only the class is renamed.

## Test plan
- [ ] CI green (build, lint, test)
- [ ] Sonar: 0 new issues
- [ ] 2236 tests pass locally

Closes #364. Part of #353.