### PR TITLE
refactor(library): replace _pending_delta dict with typed PreviewDelta dataclass

### DIFF
--- a/py_modules/domain/preview_delta.py
+++ b/py_modules/domain/preview_delta.py
@@ -1,0 +1,37 @@
+"""Pending sync-preview snapshot held between ``sync_preview`` and ``sync_apply_delta``.
+
+Owns the typed shape of the data ``LibraryService`` stashes after a preview
+run so the subsequent apply call can act on the exact snapshot the user saw.
+Pure data — construction, attribute reads, no I/O, no clock or randomness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PreviewDelta:
+    """Snapshot produced by ``sync_preview`` and consumed by ``sync_apply_delta``.
+
+    ``preview_id`` ties the snapshot to the frontend's apply call; mismatched
+    ids cause the apply to be rejected as stale. ``created_at`` is the wall
+    clock at preview time so apply can reject snapshots older than the TTL.
+    All other fields are the classified-ROM buckets, the full shortcut map
+    (used by downstream artwork and result reporting), the ROM payloads
+    needed for artwork download, and the collection/platform context that
+    feeds the result-aggregation step.
+    """
+
+    preview_id: str
+    created_at: float
+    new: list[dict]
+    changed: list[dict]
+    unchanged_ids: list[int]
+    remove_rom_ids: list[int]
+    all_shortcuts: dict[int, dict]
+    delta_roms: list[dict]
+    platforms_count: int
+    total_roms: int
+    collection_memberships: dict[str, list[int]]
+    platform_rom_ids: set[int]

--- a/py_modules/services/library.py
+++ b/py_modules/services/library.py
@@ -13,6 +13,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import build_registry_entry, build_shortcuts_data
 from domain.sync_diff import (
     classify_roms,
@@ -114,7 +115,7 @@ class LibraryService:
             "message": "",
         }
         self._pending_sync: dict = {}
-        self._pending_delta: dict | None = None
+        self._pending_delta: PreviewDelta | None = None
         self._pending_collection_memberships: dict = {}
         self._pending_platform_rom_ids: set[int] | None = None
 
@@ -315,20 +316,20 @@ class LibraryService:
             delta_roms = [roms_by_id[rid] for rid in delta_rom_ids if rid in roms_by_id]
 
             preview_id = self._uuid_gen.uuid4()
-            self._pending_delta = {
-                "preview_id": preview_id,
-                "created_at": self._clock.time(),
-                "new": new,
-                "changed": changed,
-                "unchanged_ids": unchanged_ids,
-                "remove_rom_ids": stale,
-                "all_shortcuts": {sd["rom_id"]: sd for sd in shortcuts_data},
-                "delta_roms": delta_roms,
-                "platforms_count": len(platforms),
-                "total_roms": len(all_roms),
-                "collection_memberships": collection_memberships,
-                "platform_rom_ids": platform_rom_ids,
-            }
+            self._pending_delta = PreviewDelta(
+                preview_id=preview_id,
+                created_at=self._clock.time(),
+                new=new,
+                changed=changed,
+                unchanged_ids=unchanged_ids,
+                remove_rom_ids=stale,
+                all_shortcuts={sd["rom_id"]: sd for sd in shortcuts_data},
+                delta_roms=delta_roms,
+                platforms_count=len(platforms),
+                total_roms=len(all_roms),
+                collection_memberships=collection_memberships,
+                platform_rom_ids=platform_rom_ids,
+            )
 
             await self._emit_progress("done", message="Preview ready", running=False)
 
@@ -369,9 +370,9 @@ class LibraryService:
             self._sync_state = SyncState.IDLE
 
     async def sync_apply_delta(self, preview_id):
-        if not self._pending_delta or self._pending_delta["preview_id"] != preview_id:
+        if not self._pending_delta or self._pending_delta.preview_id != preview_id:
             return {"success": False, "message": "Preview expired, please re-sync", "error_code": "stale_preview"}
-        age = self._clock.time() - self._pending_delta.get("created_at", 0)
+        age = self._clock.time() - self._pending_delta.created_at
         if age > _PREVIEW_MAX_AGE_SECONDS:
             self._pending_delta = None
             return {
@@ -386,10 +387,10 @@ class LibraryService:
         self._sync_last_heartbeat = self._clock.monotonic()
 
         # Calculate apply step plan
-        delta_roms = delta.get("delta_roms", [])
+        delta_roms = delta.delta_roms
         has_artwork = len(delta_roms) > 0
-        has_shortcuts = len(delta["new"]) + len(delta["changed"]) > 0
-        has_removals = len(delta["remove_rom_ids"]) > 0
+        has_shortcuts = len(delta.new) + len(delta.changed) > 0
+        has_removals = len(delta.remove_rom_ids) > 0
 
         apply_steps = []
         if has_artwork:
@@ -414,25 +415,25 @@ class LibraryService:
             cover_paths = await self._download_artwork(
                 delta_roms, progress_step=current_step, progress_total_steps=total_steps
             )
-            for sd in delta["new"] + delta["changed"]:
+            for sd in delta.new + delta.changed:
                 sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
 
         # Populate _pending_sync for report_sync_results and get_artwork_base64
-        self._pending_sync = delta["all_shortcuts"]
-        self._pending_collection_memberships = delta.get("collection_memberships", {})
-        self._pending_platform_rom_ids = delta.get("platform_rom_ids", set())
+        self._pending_sync = delta.all_shortcuts
+        self._pending_collection_memberships = delta.collection_memberships
+        self._pending_platform_rom_ids = delta.platform_rom_ids
 
         # Update sync_stats
         self._state["sync_stats"] = {
-            "platforms": delta["platforms_count"],
-            "roms": delta["total_roms"],
+            "platforms": delta.platforms_count,
+            "roms": delta.total_roms,
         }
         self._state_persister.save_state()
 
         # Figure out which step the frontend starts at
         next_step = current_step + 1
 
-        total_changes = len(delta["new"]) + len(delta["changed"])
+        total_changes = len(delta.new) + len(delta.changed)
         await self._emit_progress(
             "applying",
             total=total_changes,
@@ -445,17 +446,17 @@ class LibraryService:
         await self._emit(
             "sync_apply",
             {
-                "shortcuts": delta["new"],
-                "changed_shortcuts": delta["changed"],
-                "remove_rom_ids": delta["remove_rom_ids"],
+                "shortcuts": delta.new,
+                "changed_shortcuts": delta.changed,
+                "remove_rom_ids": delta.remove_rom_ids,
                 "next_step": next_step,
                 "total_steps": total_steps,
             },
         )
 
         self._logger.info(
-            f"Delta sync emitted: {len(delta['new'])} new, {len(delta['changed'])} changed, "
-            f"{len(delta['remove_rom_ids'])} removed"
+            f"Delta sync emitted: {len(delta.new)} new, {len(delta.changed)} changed, "
+            f"{len(delta.remove_rom_ids)} removed"
         )
 
         # Heartbeat safety timeout

--- a/tests/domain/test_preview_delta.py
+++ b/tests/domain/test_preview_delta.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``domain.preview_delta.PreviewDelta``.
+
+The dataclass is pure data — its contract is "all 12 fields are required,
+immutable, and exposed as typed attributes". Tests cover construction,
+frozen semantics, and the empty-collections boundary case.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from domain.preview_delta import PreviewDelta
+
+
+def _build(**overrides) -> PreviewDelta:
+    defaults: dict = {
+        "preview_id": "preview-abc",
+        "created_at": 1_700_000_000.0,
+        "new": [{"rom_id": 1, "name": "Game A"}],
+        "changed": [{"rom_id": 2, "name": "Game B", "existing_app_id": 1002}],
+        "unchanged_ids": [3],
+        "remove_rom_ids": [4],
+        "all_shortcuts": {1: {"rom_id": 1}, 2: {"rom_id": 2}, 3: {"rom_id": 3}},
+        "delta_roms": [{"id": 1}, {"id": 2}],
+        "platforms_count": 2,
+        "total_roms": 3,
+        "collection_memberships": {"Favorites": [1, 2]},
+        "platform_rom_ids": {1, 2, 3},
+    }
+    defaults.update(overrides)
+    return PreviewDelta(**defaults)
+
+
+def test_construction_exposes_all_fields_as_attributes() -> None:
+    delta = _build()
+    assert delta.preview_id == "preview-abc"
+    assert delta.created_at == 1_700_000_000.0
+    assert delta.new == [{"rom_id": 1, "name": "Game A"}]
+    assert delta.changed == [{"rom_id": 2, "name": "Game B", "existing_app_id": 1002}]
+    assert delta.unchanged_ids == [3]
+    assert delta.remove_rom_ids == [4]
+    assert delta.all_shortcuts == {1: {"rom_id": 1}, 2: {"rom_id": 2}, 3: {"rom_id": 3}}
+    assert delta.delta_roms == [{"id": 1}, {"id": 2}]
+    assert delta.platforms_count == 2
+    assert delta.total_roms == 3
+    assert delta.collection_memberships == {"Favorites": [1, 2]}
+    assert delta.platform_rom_ids == {1, 2, 3}
+
+
+def test_is_frozen_attribute_rebinding_raises() -> None:
+    delta = _build()
+    with pytest.raises(FrozenInstanceError):
+        delta.preview_id = "other"  # type: ignore[misc]
+
+
+def test_empty_collections_are_accepted() -> None:
+    delta = _build(
+        new=[],
+        changed=[],
+        unchanged_ids=[],
+        remove_rom_ids=[],
+        all_shortcuts={},
+        delta_roms=[],
+        platforms_count=0,
+        total_roms=0,
+        collection_memberships={},
+        platform_rom_ids=set(),
+    )
+    assert delta.new == []
+    assert delta.all_shortcuts == {}
+    assert delta.platform_rom_ids == set()
+
+
+def test_equality_by_field_values() -> None:
+    a = _build()
+    b = _build()
+    assert a == b
+    c = _build(preview_id="preview-xyz")
+    assert a != c

--- a/tests/services/test_library.py
+++ b/tests/services/test_library.py
@@ -13,6 +13,7 @@ from adapters.persistence import (
     StatePersisterAdapter,
 )
 from adapters.steam_config import SteamConfigAdapter
+from domain.preview_delta import PreviewDelta
 from domain.sync_diff import classify_roms
 from domain.sync_state import SyncState
 
@@ -807,11 +808,11 @@ class TestSyncPreview:
 
         result = await plugin.sync_preview()
         assert plugin._sync_service._pending_delta is not None
-        assert plugin._sync_service._pending_delta["preview_id"] == result["preview_id"]
-        assert plugin._sync_service._pending_delta["created_at"] == plugin._sync_service._clock.time()
-        assert len(plugin._sync_service._pending_delta["new"]) == 1
-        assert plugin._sync_service._pending_delta["platforms_count"] == 1
-        assert plugin._sync_service._pending_delta["total_roms"] == 1
+        assert plugin._sync_service._pending_delta.preview_id == result["preview_id"]
+        assert plugin._sync_service._pending_delta.created_at == plugin._sync_service._clock.time()
+        assert len(plugin._sync_service._pending_delta.new) == 1
+        assert plugin._sync_service._pending_delta.platforms_count == 1
+        assert plugin._sync_service._pending_delta.total_roms == 1
 
     @pytest.mark.asyncio
     async def test_returns_error_when_sync_running(self, plugin):
@@ -848,10 +849,10 @@ class TestSyncApplyDelta:
 
     def _setup_pending_delta(self, plugin, preview_id="test-preview-123"):
         """Helper to populate _pending_delta with valid data."""
-        plugin._sync_service._pending_delta = {
-            "preview_id": preview_id,
-            "created_at": plugin._sync_service._clock.time(),
-            "new": [
+        plugin._sync_service._pending_delta = PreviewDelta(
+            preview_id=preview_id,
+            created_at=plugin._sync_service._clock.time(),
+            new=[
                 {
                     "rom_id": 3,
                     "name": "Game C",
@@ -861,7 +862,7 @@ class TestSyncApplyDelta:
                     "cover_path": "",
                 },
             ],
-            "changed": [
+            changed=[
                 {
                     "rom_id": 2,
                     "name": "New B",
@@ -872,16 +873,19 @@ class TestSyncApplyDelta:
                     "cover_path": "",
                 },
             ],
-            "unchanged_ids": [1],
-            "remove_rom_ids": [99],
-            "all_shortcuts": {
+            unchanged_ids=[1],
+            remove_rom_ids=[99],
+            all_shortcuts={
                 1: {"rom_id": 1, "name": "Game A", "platform_name": "N64"},
                 2: {"rom_id": 2, "name": "New B", "platform_name": "N64"},
                 3: {"rom_id": 3, "name": "Game C", "platform_name": "N64"},
             },
-            "platforms_count": 1,
-            "total_roms": 3,
-        }
+            delta_roms=[],
+            platforms_count=1,
+            total_roms=3,
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
 
     @pytest.mark.asyncio
     async def test_rejects_wrong_preview_id(self, plugin):
@@ -1022,20 +1026,23 @@ class TestSyncApplyDelta:
             "5": {"app_id": 1005, "name": "Game E", "platform_name": "SNES"},
         }
         # Include both rom 1 and 5 as unchanged
-        plugin._sync_service._pending_delta = {
-            "preview_id": "test-preview-123",
-            "created_at": plugin._sync_service._clock.time(),
-            "new": [],
-            "changed": [],
-            "unchanged_ids": [1, 5],
-            "remove_rom_ids": [],
-            "all_shortcuts": {
+        plugin._sync_service._pending_delta = PreviewDelta(
+            preview_id="test-preview-123",
+            created_at=plugin._sync_service._clock.time(),
+            new=[],
+            changed=[],
+            unchanged_ids=[1, 5],
+            remove_rom_ids=[],
+            all_shortcuts={
                 1: {"rom_id": 1, "name": "Game A", "platform_name": "N64"},
                 5: {"rom_id": 5, "name": "Game E", "platform_name": "SNES"},
             },
-            "platforms_count": 2,
-            "total_roms": 2,
-        }
+            delta_roms=[],
+            platforms_count=2,
+            total_roms=2,
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
         plugin._sync_service._emit_progress = AsyncMock()
 
         await plugin.sync_apply_delta("test-preview-123")
@@ -1053,16 +1060,20 @@ class TestSyncCancelPreview:
 
     @pytest.mark.asyncio
     async def test_clears_pending_delta(self, plugin):
-        plugin._sync_service._pending_delta = {
-            "preview_id": "some-id",
-            "new": [],
-            "changed": [],
-            "unchanged_ids": [],
-            "remove_rom_ids": [],
-            "all_shortcuts": {},
-            "platforms_count": 0,
-            "total_roms": 0,
-        }
+        plugin._sync_service._pending_delta = PreviewDelta(
+            preview_id="some-id",
+            created_at=plugin._sync_service._clock.time(),
+            new=[],
+            changed=[],
+            unchanged_ids=[],
+            remove_rom_ids=[],
+            all_shortcuts={},
+            delta_roms=[],
+            platforms_count=0,
+            total_roms=0,
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
         result = await plugin.sync_cancel_preview()
         assert plugin._sync_service._pending_delta is None
         assert result["success"] is True


### PR DESCRIPTION
## Summary
`LibraryService._pending_delta` was a 12-key god-dict consumed with `delta["new"]` string-indexed accesses across `sync_apply_delta` — typo'd keys and wrong types were invisible to the type checker. Replaced with a frozen `PreviewDelta` dataclass in `py_modules/domain/preview_delta.py`.

```python
@dataclass(frozen=True)
class PreviewDelta:
    preview_id: str
    created_at: float
    new: list[dict]
    changed: list[dict]
    unchanged_ids: list[int]
    remove_rom_ids: list[int]
    all_shortcuts: dict[int, dict]
    delta_roms: list[dict]
    platforms_count: int
    total_roms: int
    collection_memberships: dict[str, list[int]]
    platform_rom_ids: set[int]
```

- `created_at` is already part of the in-memory dict (#345); keeping it preserves existing stale-preview rejection behaviour.
- No `.to_dict()` helper: `_pending_delta` is purely in-memory state; the only cross-language boundary in `sync_apply_delta` picks individual fields into a fresh dict. Wire format unchanged.

## Type-safety win
Swapping `delta.new` for `delta.unchanged_ids` (incompatible — `list[int]` vs `list[dict]`) in `sync_apply_delta` lights up basedpyright:
```
"__setitem__" ist für den Typ "int" nicht definiert. (reportIndexIssue)
"__getitem__" ist für den Typ "int" nicht definiert. (reportIndexIssue)
```
Typo'd attributes (`delta.nwe`) also caught with `reportAttributeAccessIssue`.

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues
- [ ] 2241 tests pass locally (+4 new PreviewDelta dataclass tests)
- [ ] import-linter: 7 contracts kept

Closes #372. Part of #369.