### PR TITLE
refactor(saves): narrow back-ref cleanup — _log_debug, _get_active_core, _file_md5

### DIFF
--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -115,8 +115,8 @@ class SaveServiceConfig:
         signal. ``None`` disables the gate (unit tests).
     log_debug:
         ``DebugLogger`` Protocol seam — routes through the user's QAM
-        log-level filter. Sub-services access this via the
-        ``_save_service._log_debug`` back-ref.
+        log-level filter. Injected directly into each sub-service that
+        needs it; not reached through the ``_save_service`` back-ref.
     """
 
     romm_api: RommApiProtocol

--- a/py_modules/services/saves/facade.py
+++ b/py_modules/services/saves/facade.py
@@ -83,6 +83,8 @@ class SaveService:
             logger=self._logger,
             clock=self._clock,
             save_file=self._save_file,
+            log_debug=self._log_debug,
+            get_active_core=self._get_active_core,
         )
         self._versions = VersionsService(
             save_service=self,
@@ -90,6 +92,7 @@ class SaveService:
             sync_engine=self._sync_engine,
             romm_api=self._romm_api,
             logger=self._logger,
+            log_debug=self._log_debug,
         )
         self._status = StatusService(
             save_service=self,
@@ -97,6 +100,7 @@ class SaveService:
             sync_engine=self._sync_engine,
             romm_api=self._romm_api,
             logger=self._logger,
+            log_debug=self._log_debug,
         )
         self._slots = SlotsService(
             save_service=self,
@@ -107,6 +111,8 @@ class SaveService:
             logger=self._logger,
             clock=self._clock,
             save_file=self._save_file,
+            log_debug=self._log_debug,
+            get_active_core=self._get_active_core,
         )
 
     def _rom_lock(self, rom_id: int) -> asyncio.Lock:
@@ -277,17 +283,6 @@ class SaveService:
     # ------------------------------------------------------------------
     # File Helpers
     # ------------------------------------------------------------------
-
-    def _file_md5(self, path: str) -> str:
-        """Compute MD5 hash of a file for sync drift detection.
-
-        Delegates to the injected ``SaveFileAdapter``. The hash is used
-        for content-comparison only — drift detection between local
-        file and the recorded ``last_sync_hash`` baseline. A collision
-        here would mean two different save files treated as identical
-        → "sync misses an update", not a security breach.
-        """
-        return self._save_file.checksum_md5(path)
 
     def _find_save_files(self, rom_id: int) -> list[dict]:
         """Find local save files for a ROM.
@@ -904,7 +899,7 @@ class SaveService:
         local_path = os.path.join(saves_dir, filename)
         if not self._save_file.is_file(local_path):
             raise FileNotFoundError(f"Local save not found: {local_path}")
-        local_hash = self._file_md5(local_path)
+        local_hash = self._save_file.checksum_md5(local_path)
         try:
             server_hash = self._retry.with_retry(self._sync_engine._get_server_save_hash, server)
         except Exception:

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -11,7 +11,14 @@ from services.saves._messages import SAVE_SYNC_DISABLED
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import Clock, RetryStrategy, RommApiProtocol, SaveFileAdapter
+    from services.protocols import (
+        Clock,
+        CoreResolverFn,
+        DebugLogger,
+        RetryStrategy,
+        RommApiProtocol,
+        SaveFileAdapter,
+    )
     from services.saves import SaveService
     from services.saves.state import StateService
     from services.saves.sync_engine import SyncEngine
@@ -34,6 +41,8 @@ class SlotsService:
         logger: logging.Logger,
         clock: Clock,
         save_file: SaveFileAdapter,
+        log_debug: DebugLogger,
+        get_active_core: CoreResolverFn,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
@@ -43,6 +52,8 @@ class SlotsService:
         self._logger = logger
         self._clock = clock
         self._save_file = save_file
+        self._log_debug = log_debug
+        self._get_active_core = get_active_core
 
     # ------------------------------------------------------------------
     # Slot listing
@@ -85,7 +96,7 @@ class SlotsService:
             )
             server_slots_list = summary.get("slots", [])
         except Exception as e:
-            self._save_service._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
+            self._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
 
         # Merge: update persisted slots with server data, promote local→server
         merged: dict[str, dict] = {}
@@ -228,7 +239,7 @@ class SlotsService:
             file_state = files_state.get(filename)
             last_sync_hash = file_state.last_sync_hash if file_state else None
             if last_sync_hash:
-                current_hash = self._save_service._file_md5(lf["path"])
+                current_hash = self._save_file.checksum_md5(lf["path"])
                 if current_hash != last_sync_hash:
                     pending.append(filename)
 
@@ -362,9 +373,9 @@ class SlotsService:
         for lf in local_files:
             try:
                 self._save_file.remove(lf["path"])
-                self._save_service._log_debug(f"Deleted local save for switch: {lf['filename']}")
+                self._log_debug(f"Deleted local save for switch: {lf['filename']}")
             except Exception as e:
-                self._save_service._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
+                self._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
 
         # Clear file tracking state (but keep slot config)
         self._state_svc.clear_files_state(rom_id_str)
@@ -416,7 +427,7 @@ class SlotsService:
                 ),
             )
         except Exception as e:
-            self._save_service._log_debug(f"get_save_setup_info({rom_id}): failed to list saves: {e}")
+            self._log_debug(f"get_save_setup_info({rom_id}): failed to list saves: {e}")
 
         # Group server saves by slot
         slots_map: dict[str | None, list[dict]] = {}
@@ -537,7 +548,7 @@ class SlotsService:
         system = info["system"] if info else ""
         installed = self._save_service._state["installed_roms"].get(rom_id_str, {})
         rom_filename = os.path.basename(installed.get("file_path", "")) or None
-        core_so, _label = self._save_service._get_active_core(system, rom_filename)
+        core_so, _label = self._get_active_core(system, rom_filename)
         emulator = build_emulator_tag(core_so)
 
         ids_to_delete: list[int] = []
@@ -623,7 +634,7 @@ class SlotsService:
                 )
                 server_save_ids = [s["id"] for s in server_saves]
             except Exception as e:
-                self._save_service._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
+                self._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
 
         # Local tracked files pointing to server saves in this slot
         files_state = save_state.files

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -16,7 +16,7 @@ from services.saves.status.builders import (
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import RommApiProtocol
+    from services.protocols import DebugLogger, RommApiProtocol
     from services.saves import SaveService
     from services.saves.state import StateService
     from services.saves.sync_engine import MatrixOutcome, SyncEngine
@@ -33,12 +33,14 @@ class StatusService:
         sync_engine: SyncEngine,
         romm_api: RommApiProtocol,
         logger: logging.Logger,
+        log_debug: DebugLogger,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
         self._sync_engine = sync_engine
         self._romm_api = romm_api
         self._logger = logger
+        self._log_debug = log_debug
 
     def _status_entry_from_outcome(
         self,
@@ -70,7 +72,7 @@ class StatusService:
         )
         conflict_entry: dict | None = None
         if isinstance(action, Conflict):
-            self._save_service._log_debug(
+            self._log_debug(
                 f"_get_save_status_io({rom_id}): conflict {outcome.filename} "
                 f"server_save_id={action.server_save.get('id')}"
             )

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -25,7 +25,14 @@ from services.saves._helpers import _local_save_target
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import Clock, RetryStrategy, RommApiProtocol, SaveFileAdapter
+    from services.protocols import (
+        Clock,
+        CoreResolverFn,
+        DebugLogger,
+        RetryStrategy,
+        RommApiProtocol,
+        SaveFileAdapter,
+    )
     from services.saves import SaveService
     from services.saves.state import StateService
 
@@ -63,6 +70,8 @@ class SyncEngine:
         logger: logging.Logger,
         clock: Clock,
         save_file: SaveFileAdapter,
+        log_debug: DebugLogger,
+        get_active_core: CoreResolverFn,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
@@ -71,6 +80,8 @@ class SyncEngine:
         self._logger = logger
         self._clock = clock
         self._save_file = save_file
+        self._log_debug = log_debug
+        self._get_active_core = get_active_core
 
     # ------------------------------------------------------------------
     # Server Save Hash Helper
@@ -90,9 +101,9 @@ class SyncEngine:
         try:
             tmp_path = self._save_file.make_temp_path(suffix=".tmp")
             self._romm_api.download_save(save_id, tmp_path)
-            return self._save_service._file_md5(tmp_path)
+            return self._save_file.checksum_md5(tmp_path)
         except Exception as e:
-            self._save_service._log_debug(f"Failed to hash server save {save_id}: {e}")
+            self._log_debug(f"Failed to hash server save {save_id}: {e}")
             if self._retry.is_retryable(e):
                 raise
             return None
@@ -130,7 +141,7 @@ class SyncEngine:
 
         now = self._clock.now().isoformat()
         local_exists = self._save_file.is_file(local_path)
-        local_hash = self._save_service._file_md5(local_path) if local_exists else ""
+        local_hash = self._save_file.checksum_md5(local_path) if local_exists else ""
 
         save_entry.files[filename] = FileSyncState(
             last_sync_hash=local_hash,
@@ -173,7 +184,7 @@ class SyncEngine:
 
         self._save_file.rename(tmp_path, local_path)
         self._update_file_sync_state(rom_id_str, filename, server_save, local_path, system)
-        self._save_service._log_debug(f"Downloaded save: {filename} for rom {rom_id_str}")
+        self._log_debug(f"Downloaded save: {filename} for rom {rom_id_str}")
 
     def _resolve_upload_slot(self, rom_id_str: str, device_id: str | None) -> str | None:
         """The slot field to send with an upload; ``None`` when device sync is off."""
@@ -204,7 +215,7 @@ class SyncEngine:
         try:
             self._romm_api.confirm_download(upload_id, device_id)
         except Exception:
-            self._save_service._log_debug(f"confirm_download after upload failed for save {upload_id} (non-fatal)")
+            self._log_debug(f"confirm_download after upload failed for save {upload_id} (non-fatal)")
 
     def _do_upload_save(
         self,
@@ -221,7 +232,7 @@ class SyncEngine:
         # Resolve active core for emulator tag
         installed = self._save_service._state["installed_roms"].get(rom_id_str, {})
         rom_filename = os.path.basename(installed.get("file_path", "")) or None
-        core_so, _label = self._save_service._get_active_core(system, rom_filename)
+        core_so, _label = self._get_active_core(system, rom_filename)
         emulator = build_emulator_tag(core_so)
 
         # v4.7: pass device_id and slot
@@ -247,7 +258,7 @@ class SyncEngine:
 
         self._confirm_upload_sync(result.get("id"), device_id)
 
-        self._save_service._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
+        self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
         return result
 
     def _record_own_upload(self, rom_id_str: str, new_id: int | None) -> None:
@@ -342,12 +353,10 @@ class SyncEngine:
         if action.adopt_baseline and local_hash is not None:
             # State-only mutation: write the current local_hash as the baseline
             # so future runs can detect drift. No I/O, no synced count.
-            self._save_service._log_debug(
-                f"_sync_rom_saves({rom_id}): skip + adopt_baseline {filename} ({action.reason})"
-            )
+            self._log_debug(f"_sync_rom_saves({rom_id}): skip + adopt_baseline {filename} ({action.reason})")
             self._adopt_baseline_hash(rom_id_str, filename, local_hash)
         else:
-            self._save_service._log_debug(f"_sync_rom_saves({rom_id}): skip {filename} ({action.reason})")
+            self._log_debug(f"_sync_rom_saves({rom_id}): skip {filename} ({action.reason})")
 
     def _dispatch_upload(
         self,
@@ -374,7 +383,7 @@ class SyncEngine:
         server_save = next((s for s in server_saves if s.get("id") == action.target_save_id), None)
         if server_save is None:
             # Picked save vanished between read and dispatch — best-effort.
-            self._save_service._log_debug(
+            self._log_debug(
                 f"_dispatch_sync_action: target_save_id={action.target_save_id} not in server_saves; skipping",
             )
             return False
@@ -480,7 +489,7 @@ class SyncEngine:
             local_path = lf["path"]
             handled_filenames.add(filename)
             local_exists = self._save_file.is_file(local_path)
-            local_hash = self._save_service._file_md5(local_path) if local_exists else None
+            local_hash = self._save_file.checksum_md5(local_path) if local_exists else None
             file_state = files_state.get(filename, FileSyncState())
             local_mtime_iso = (
                 datetime.fromtimestamp(self._save_file.get_mtime(local_path), tz=UTC).isoformat()
@@ -549,7 +558,7 @@ class SyncEngine:
 
         info = self._save_service._get_rom_save_info(rom_id)
         if not info:
-            self._save_service._log_debug(f"_sync_rom_saves({rom_id}): no save info, skipping")
+            self._log_debug(f"_sync_rom_saves({rom_id}): no save info, skipping")
             return 0, [], []
         system = info["system"]
         saves_dir = info["saves_dir"]
@@ -562,13 +571,13 @@ class SyncEngine:
             self._logger.error(f"_sync_rom_saves({rom_id}): failed to list saves: {e}")
             _code, _msg = classify_error(e)
             return 0, [f"Failed to fetch saves: {_msg}"], []
-        self._save_service._log_debug(f"[TIMING] _sync_rom_saves({rom_id}): list_saves {self._clock.time() - t0:.3f}s")
+        self._log_debug(f"[TIMING] _sync_rom_saves({rom_id}): list_saves {self._clock.time() - t0:.3f}s")
 
         save_state = self._state_svc.state.saves.get(rom_id_str)
         active_slot = save_state.active_slot if save_state else None
         server_in_slot = self._filter_server_saves_to_slot(server_saves, active_slot)
 
-        self._save_service._log_debug(
+        self._log_debug(
             f"_sync_rom_saves({rom_id}): system={system}, rom_name={info['rom_name']}, "
             f"server_saves={len(server_saves)}, saves_dir={saves_dir}"
         )
@@ -580,11 +589,11 @@ class SyncEngine:
         pending_migration = self._save_service._is_save_sort_changed()
         for outcome in self.iter_matrix_outcomes(rom_id, server_in_slot, info=info):
             origin = "local" if outcome.local_path is not None else "server-only"
-            self._save_service._log_debug(
+            self._log_debug(
                 f"_sync_rom_saves({rom_id}): {origin} {outcome.filename} -> {type(outcome.action).__name__}"
             )
             if outcome.local_path is None and pending_migration:
-                self._save_service._log_debug(
+                self._log_debug(
                     f"_sync_rom_saves({rom_id}): skipping server_only {outcome.filename} — migration pending"
                 )
                 continue
@@ -607,7 +616,7 @@ class SyncEngine:
         save_entry = self._state_svc.ensure_rom_state(rom_id_str)
         save_entry.last_sync_check_at = self._clock.now().isoformat()
 
-        self._save_service._log_debug(
+        self._log_debug(
             f"[TIMING] _sync_rom_saves({rom_id}): TOTAL {self._clock.time() - t_total:.3f}s"
             f" synced={synced} errors={len(errors)}"
         )

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import logging
 
     from domain.save_state import FileSyncState
-    from services.protocols import RommApiProtocol
+    from services.protocols import DebugLogger, RommApiProtocol
     from services.saves import SaveService
     from services.saves.state import StateService
     from services.saves.sync_engine import SyncEngine
@@ -41,12 +41,14 @@ class VersionsService:
         sync_engine: SyncEngine,
         romm_api: RommApiProtocol,
         logger: logging.Logger,
+        log_debug: DebugLogger,
     ) -> None:
         self._save_service = save_service
         self._state_svc = state_svc
         self._sync_engine = sync_engine
         self._romm_api = romm_api
         self._logger = logger
+        self._log_debug = log_debug
 
     # ------------------------------------------------------------------
     # Version History API
@@ -262,7 +264,7 @@ class VersionsService:
                     ),
                 )
             except Exception as e:
-                self._save_service._log_debug(f"rollback_to_version: failed to list saves: {e}")
+                self._log_debug(f"rollback_to_version: failed to list saves: {e}")
                 return {"status": "not_found"}
 
             result = await self._save_service._loop.run_in_executor(

--- a/tests/services/saves/test_facade.py
+++ b/tests/services/saves/test_facade.py
@@ -1,7 +1,6 @@
 """Tests for SaveService aggregate facade — public callable surface and cross-service coordination."""
 
 import asyncio
-import hashlib
 import logging
 import os
 import time
@@ -706,45 +705,6 @@ class TestFindSaveFiles:
         result = svc._find_save_files(999)
 
         assert result == []
-
-
-class TestFileMd5:
-    """Tests for _file_md5."""
-
-    def test_known_content(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        f = tmp_path / "test.srm"
-        content = b"Hello, save file!"
-        f.write_bytes(content)
-
-        assert svc._file_md5(str(f)) == hashlib.md5(content).hexdigest()
-
-    def test_empty_file(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        f = tmp_path / "empty.srm"
-        f.write_bytes(b"")
-
-        assert svc._file_md5(str(f)) == hashlib.md5(b"").hexdigest()
-
-    def test_large_file_chunked(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        f = tmp_path / "large.srm"
-        content = os.urandom(2 * 1024 * 1024)
-        f.write_bytes(content)
-
-        assert svc._file_md5(str(f)) == hashlib.md5(content).hexdigest()
-
-    def test_permission_error(self, tmp_path):
-        svc, _ = make_service(tmp_path)
-        f = tmp_path / "locked.srm"
-        f.write_bytes(b"data")
-        f.chmod(0o000)
-
-        try:
-            with pytest.raises(PermissionError):
-                svc._file_md5(str(f))
-        finally:
-            f.chmod(0o644)
 
 
 class TestGetRomSaveInfo:

--- a/tests/services/saves/test_sync_engine.py
+++ b/tests/services/saves/test_sync_engine.py
@@ -558,7 +558,7 @@ class TestUpdateFileSyncState:
         svc._sync_engine._update_file_sync_state("42", "pokemon.srm", server_resp, str(save_file), "gba")
 
         entry = svc._save_sync_state.saves["42"].files["pokemon.srm"]
-        assert entry.last_sync_hash == svc._file_md5(str(save_file))
+        assert entry.last_sync_hash == svc._save_file.checksum_md5(str(save_file))
         assert entry.last_sync_at is not None
         assert entry.last_sync_server_save_id == 200
 


### PR DESCRIPTION
## Summary
Saves sub-services (`SyncEngine`, `SlotsService`, `StatusService`, `VersionsService`) reached through `self._save_service.<X>` for three deps that already have Protocol equivalents — bypassing the seams that exist precisely so those deps can be injected directly:

- `_log_debug` → inject `DebugLogger` Protocol (consolidated in #423)
- `_get_active_core` → inject `CoreResolverFn` Protocol (already on `SaveServiceConfig`)
- `_file_md5` → call `self._save_file.checksum_md5(path)` directly; the wrapper on `SaveService` was a one-line passthrough — deleted

The other ~9 back-refs (`_state`, `_retry`, `rom_lock`, `_loop`, `_settings`, `_save_sync_state`, `_find_save_files`, `_get_rom_save_info`, etc.) stay — those are legitimate aggregate-root composition.

## Counts (per sub-service)
- `SyncEngine`: 13 `_log_debug` + 1 `_get_active_core` + 3 `_file_md5` sites rewired
- `SlotsService`: 5 + 1 + 1 sites rewired
- `StatusService`: 1 `_log_debug` site
- `VersionsService`: 1 `_log_debug` site
- `SaveService.facade`: 1 self-call to `_file_md5` rewired, wrapper method deleted

## Test plan
- [ ] CI green
- [ ] Sonar: 0 new issues
- [ ] 2237 tests pass locally (-4 from the deleted `TestFileMd5` passthrough class — coverage stays via `tests/adapters/test_save_file.py::TestChecksumMd5`)
- [ ] `git grep -nw '_file_md5' py_modules/` returns no hits
- [ ] import-linter: 7 contracts kept

Closes #373. Part of #369.