### PR TITLE
feat(library): per-unit sync pipeline — incremental shortcut delivery

### DIFF
--- a/main.py
+++ b/main.py
@@ -337,6 +337,9 @@ class Plugin:
     async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
         return await self._sync_service.report_sync_results(rom_id_to_app_id, removed_rom_ids, cancelled)
 
+    async def report_unit_results(self, rom_id_to_app_id):
+        return await self._sync_service.report_unit_results(rom_id_to_app_id)
+
     async def get_registry_platforms(self):
         return self._sync_service.get_registry_platforms()
 

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -1,0 +1,41 @@
+"""Work-queue unit for the per-unit sync pipeline.
+
+A :class:`WorkUnit` names one platform or one collection that the
+per-unit sync pipeline will fetch + apply as a self-contained slice.
+The queue is built in Phase 0 from enabled-platforms and
+enabled-collections settings; downstream sub-services dispatch on
+:attr:`WorkUnit.type` to choose the platform-fetch vs collection-
+fetch path. Anything that requires inter-unit context (running
+``synced_rom_ids`` deduplication, accumulating registry deltas) is
+threaded through separately — the unit itself is a static descriptor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+UnitType = Literal["platform", "collection"]
+
+
+@dataclass(frozen=True)
+class WorkUnit:
+    """One platform or one collection in the per-unit work queue."""
+
+    type: UnitType
+    id: int | str
+    name: str
+    slug: str
+    rom_count: int
+    # Collection-only: discriminates user/franchise lookup at fetch time.
+    is_virtual: bool = False
+
+    def to_event_payload(self) -> dict:
+        """Serialise to the shape emitted in ``sync_plan`` / ``sync_apply_unit``."""
+        return {
+            "type": self.type,
+            "id": self.id,
+            "name": self.name,
+            "slug": self.slug,
+            "rom_count": self.rom_count,
+        }

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -10,6 +10,7 @@ preceded the decomposition.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -49,3 +50,13 @@ class LibrarySyncStateBox:
     pending_delta: PreviewDelta | None = None
     pending_collection_memberships: dict = field(default_factory=dict)
     pending_platform_rom_ids: set[int] | None = None
+    # Per-unit pipeline coordination. ``unit_complete_event`` is set by
+    # :meth:`SyncReporter.report_unit_results` when the frontend reports
+    # back for the active unit; the orchestrator awaits it (with a
+    # heartbeat-based timeout) before dispatching the next unit. Cleared
+    # back to None between units.
+    unit_complete_event: asyncio.Event | None = None
+    # Holds the frontend-supplied ``rom_id_to_app_id`` mapping reported
+    # for the active unit. Surfaces the result so the orchestrator can
+    # accumulate the per-unit registry into the cross-run accumulators.
+    last_unit_results: dict[str, int] | None = None

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from domain.shortcut_data import build_shortcuts_data
 from domain.sync_state import SyncState
+from domain.work_unit import WorkUnit
 from lib.errors import classify_error
 from services.library._state import LibrarySyncStateBox
 
@@ -442,6 +443,227 @@ class LibraryFetcher:
             )
 
         return collection_only_roms, collection_memberships
+
+    # ── Per-unit work queue ──────────────────────────────────────
+
+    async def build_work_queue(self) -> list[WorkUnit]:
+        """Phase 0 of the per-unit pipeline: enumerate enabled platforms + collections.
+
+        Returns an ordered list of :class:`WorkUnit` entries (platforms
+        first, then user collections, then franchise collections) with
+        ROM counts pulled from the listing endpoints. No ROMs are
+        fetched here — the queue is a dispatch plan, not a payload.
+        """
+        units: list[WorkUnit] = []
+
+        platforms = await self._fetch_enabled_platforms()
+        for platform in platforms:
+            units.append(
+                WorkUnit(
+                    type="platform",
+                    id=int(platform["id"]),
+                    name=platform.get("name", platform.get("display_name", "Unknown")),
+                    slug=platform.get("slug", ""),
+                    rom_count=int(platform.get("rom_count", 0)),
+                )
+            )
+
+        enabled_collections = self._settings.get("enabled_collections", {})
+        enabled_ids = {k for k, v in enabled_collections.items() if v}
+        if not enabled_ids:
+            return units
+
+        try:
+            user_collections = await self._loop.run_in_executor(None, self._romm_api.list_collections)
+        except Exception as e:
+            self._logger.warning(f"Failed to fetch user collections for work queue: {e}")
+            user_collections = []
+        try:
+            franchise_collections = await self._loop.run_in_executor(
+                None, self._romm_api.list_virtual_collections, "franchise"
+            )
+        except Exception as e:
+            self._logger.warning(f"Failed to fetch franchise collections for work queue: {e}")
+            franchise_collections = []
+
+        for c in user_collections:
+            cid = str(c.get("id", ""))
+            if cid not in enabled_ids:
+                continue
+            units.append(
+                WorkUnit(
+                    type="collection",
+                    id=cid,
+                    name=c.get("name", cid),
+                    slug=c.get("slug", ""),
+                    rom_count=int(c.get("rom_count", len(c.get("rom_ids", [])))),
+                    is_virtual=bool(c.get("is_virtual", False)),
+                )
+            )
+        for c in franchise_collections:
+            cid = str(c.get("id", ""))
+            if cid not in enabled_ids:
+                continue
+            units.append(
+                WorkUnit(
+                    type="collection",
+                    id=cid,
+                    name=c.get("name", cid),
+                    slug=c.get("slug", ""),
+                    rom_count=int(c.get("rom_count", len(c.get("rom_ids", [])))),
+                    is_virtual=bool(c.get("is_virtual", True)),
+                )
+            )
+
+        return units
+
+    async def fetch_platform_unit(self, unit: WorkUnit) -> tuple[list[dict], bool]:
+        """Fetch ROMs for a single platform unit.
+
+        Tries the incremental-skip path first: if the platform's
+        ``rom_count`` matches the registry's count for that platform
+        and no rows have ``updated_after`` last_sync, the registry is
+        used to reconstruct the ROM list (avoids re-paginating).
+
+        Returns ``(unit_roms, skipped)`` where ``skipped`` is True when
+        the incremental check succeeded — callers can use this to skip
+        the artwork-download step entirely if the registry already
+        carries the cover_path.
+        """
+        if unit.type != "platform":
+            raise ValueError(f"fetch_platform_unit called with non-platform unit type={unit.type}")
+
+        platform_id = int(unit.id)
+        platform_name = unit.name
+        platform_slug = unit.slug
+
+        registry = self._state.get("shortcut_registry", {})
+        last_sync = self._state.get("last_sync")
+        registry_count = sum(1 for e in registry.values() if e.get("platform_name") == platform_name)
+
+        if last_sync and registry_count > 0:
+            try:
+                delta_resp = await self._loop.run_in_executor(
+                    None,
+                    self._romm_api.list_roms_updated_after,
+                    platform_id,
+                    last_sync,
+                    1,
+                    0,
+                )
+                server_total = delta_resp.get("total", 0) if isinstance(delta_resp, dict) else 0
+                if server_total == 0 and unit.rom_count == registry_count:
+                    self._logger.info(f"Per-unit skip: {platform_name} unchanged ({registry_count} ROMs in registry)")
+                    return (
+                        self._reconstruct_platform_from_registry(registry, platform_name, platform_slug),
+                        True,
+                    )
+                self._logger.info(
+                    f"Per-unit fetch {platform_name}: {server_total} updated, "
+                    f"server={unit.rom_count} registry={registry_count} — full fetch"
+                )
+            except Exception as e:
+                self._logger.warning(
+                    f"Per-unit incremental check failed for {platform_name}, falling back to full fetch: {e}"
+                )
+
+        unit_roms: list[dict] = []
+        offset = 0
+        limit = 50
+        while True:
+            self._check_cancelling()
+            try:
+                page = await self._loop.run_in_executor(
+                    None,
+                    self._romm_api.list_roms,
+                    platform_id,
+                    limit,
+                    offset,
+                )
+            except Exception as e:
+                self._logger.error(f"Failed to fetch ROMs for platform {platform_name}: {e}")
+                break
+
+            rom_list = page.get("items", []) if isinstance(page, dict) else page
+            for rom in rom_list:
+                rom.pop("files", None)
+                rom["platform_name"] = platform_name
+                rom["platform_slug"] = platform_slug
+            unit_roms.extend(rom_list)
+
+            if len(rom_list) < limit:
+                break
+            offset += limit
+
+        return unit_roms, False
+
+    async def fetch_collection_unit(self, unit: WorkUnit, synced_rom_ids: set[int]) -> tuple[list[dict], list[int]]:
+        """Fetch ROMs for a single collection unit.
+
+        Mutates *synced_rom_ids* in place: every ROM seen via this
+        collection is added so subsequent units (and the final stale
+        cleanup) treat them as covered.
+
+        Returns ``(new_roms, all_collection_rom_ids)``:
+          * ``new_roms`` — ROMs not already present in *synced_rom_ids*,
+            decorated with platform_name/platform_slug for shortcut
+            construction.
+          * ``all_collection_rom_ids`` — every rom_id in the collection
+            (including those already synced via a platform unit), used
+            to build Steam collection memberships at the final phase.
+        """
+        if unit.type != "collection":
+            raise ValueError(f"fetch_collection_unit called with non-collection unit type={unit.type}")
+
+        new_roms: list[dict] = []
+        all_collection_rom_ids: list[int] = []
+
+        offset = 0
+        limit = 50
+        while True:
+            self._check_cancelling()
+            if unit.is_virtual:
+                page = await self._loop.run_in_executor(
+                    None, self._romm_api.list_roms_by_virtual_collection, str(unit.id), limit, offset
+                )
+            else:
+                page = await self._loop.run_in_executor(
+                    None, self._romm_api.list_roms_by_collection, int(unit.id), limit, offset
+                )
+
+            items = page.get("items", []) if isinstance(page, dict) else page
+            for rom in items:
+                rid = rom["id"]
+                all_collection_rom_ids.append(rid)
+                if rid in synced_rom_ids:
+                    continue
+                synced_rom_ids.add(rid)
+                rom["platform_name"] = rom.get("platform_name", rom.get("platform_display_name", "Unknown"))
+                rom["platform_slug"] = rom.get("platform_slug", rom.get("platform_fs_slug", ""))
+                rom.pop("files", None)
+                new_roms.append(rom)
+
+            if len(items) < limit:
+                break
+            offset += limit
+
+        return new_roms, all_collection_rom_ids
+
+    def cache_metadata_for_unit(self, unit_roms: list[dict]) -> None:
+        """Stamp the metadata cache for one unit's ROMs and flush.
+
+        Mirrors the cache-and-flush step ``_fetch_and_prepare`` runs
+        once at the end of a monolithic sync. Per-unit pipelines call
+        this after each unit so a mid-sync crash leaves cached
+        metadata for every unit that completed.
+        """
+        if self._metadata_service is None or not unit_roms:
+            return
+        for rom in unit_roms:
+            rom_id_str = str(rom["id"])
+            self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
+            self._metadata_service.mark_metadata_dirty()
+        self._metadata_service.flush_metadata_if_dirty()
 
     async def _fetch_and_prepare(self):
         """Fetch platforms + ROMs + collection ROMs, prepare shortcut data.

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -517,6 +517,53 @@ class LibraryFetcher:
 
         return units
 
+    async def _try_unit_incremental_skip(self, unit: WorkUnit) -> list[dict] | None:
+        """Per-unit incremental-skip pre-check for a platform unit.
+
+        Returns the registry-reconstructed ROM list when the platform is
+        unchanged (server reports zero rows updated after ``last_sync``
+        and the unit's ``rom_count`` matches the registry count for this
+        platform). Returns ``None`` to signal "fall through to a full
+        paginated fetch" — either the registry has no entries for this
+        platform, no prior sync timestamp exists, the delta check
+        raised, or the server reports changes.
+        """
+        platform_name = unit.name
+        platform_slug = unit.slug
+
+        registry = self._state.get("shortcut_registry", {})
+        last_sync = self._state.get("last_sync")
+        registry_count = sum(1 for e in registry.values() if e.get("platform_name") == platform_name)
+
+        if not last_sync or registry_count == 0:
+            return None
+
+        try:
+            delta_resp = await self._loop.run_in_executor(
+                None,
+                self._romm_api.list_roms_updated_after,
+                int(unit.id),
+                last_sync,
+                1,
+                0,
+            )
+        except Exception as e:
+            self._logger.warning(
+                f"Per-unit incremental check failed for {platform_name}, falling back to full fetch: {e}"
+            )
+            return None
+
+        server_total = delta_resp.get("total", 0) if isinstance(delta_resp, dict) else 0
+        if server_total == 0 and unit.rom_count == registry_count:
+            self._logger.info(f"Per-unit skip: {platform_name} unchanged ({registry_count} ROMs in registry)")
+            return self._reconstruct_platform_from_registry(registry, platform_name, platform_slug)
+
+        self._logger.info(
+            f"Per-unit fetch {platform_name}: {server_total} updated, "
+            f"server={unit.rom_count} registry={registry_count} — full fetch"
+        )
+        return None
+
     async def fetch_platform_unit(self, unit: WorkUnit) -> tuple[list[dict], bool]:
         """Fetch ROMs for a single platform unit.
 
@@ -533,39 +580,13 @@ class LibraryFetcher:
         if unit.type != "platform":
             raise ValueError(f"fetch_platform_unit called with non-platform unit type={unit.type}")
 
+        skip_roms = await self._try_unit_incremental_skip(unit)
+        if skip_roms is not None:
+            return skip_roms, True
+
         platform_id = int(unit.id)
         platform_name = unit.name
         platform_slug = unit.slug
-
-        registry = self._state.get("shortcut_registry", {})
-        last_sync = self._state.get("last_sync")
-        registry_count = sum(1 for e in registry.values() if e.get("platform_name") == platform_name)
-
-        if last_sync and registry_count > 0:
-            try:
-                delta_resp = await self._loop.run_in_executor(
-                    None,
-                    self._romm_api.list_roms_updated_after,
-                    platform_id,
-                    last_sync,
-                    1,
-                    0,
-                )
-                server_total = delta_resp.get("total", 0) if isinstance(delta_resp, dict) else 0
-                if server_total == 0 and unit.rom_count == registry_count:
-                    self._logger.info(f"Per-unit skip: {platform_name} unchanged ({registry_count} ROMs in registry)")
-                    return (
-                        self._reconstruct_platform_from_registry(registry, platform_name, platform_slug),
-                        True,
-                    )
-                self._logger.info(
-                    f"Per-unit fetch {platform_name}: {server_total} updated, "
-                    f"server={unit.rom_count} registry={registry_count} — full fetch"
-                )
-            except Exception as e:
-                self._logger.warning(
-                    f"Per-unit incremental check failed for {platform_name}, falling back to full fetch: {e}"
-                )
 
         unit_roms: list[dict] = []
         offset = 0

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -214,6 +214,136 @@ class SyncReporter:
         self._sync_state.current_sync_id = None
         return {"success": True}
 
+    # ── Finalise per-unit run ────────────────────────────────────
+
+    def _finalize_per_unit_run_io(
+        self,
+        pending_collection_memberships: dict[str, list[int]],
+        pending_platform_rom_ids: set[int] | None,
+    ) -> tuple[dict, dict[str, list]]:
+        """Build collection app-id maps and persist last_sync metadata.
+
+        Mirrors the tail of ``_report_sync_results_io`` for the per-unit
+        path: by the time this runs, every per-unit ``report_unit_results``
+        has already updated the registry, so we only need to build the
+        cross-unit collection mappings and write the final
+        ``last_sync`` / ``last_synced_*`` fields.
+        """
+        platform_app_ids, romm_collection_app_ids = self._build_collection_app_ids(
+            self._state["shortcut_registry"],
+            pending_platform_rom_ids,
+            pending_collection_memberships,
+        )
+
+        self._state["last_sync"] = self._clock.now().isoformat()
+        self._state["last_synced_collections"] = list(pending_collection_memberships.keys())
+        self._state["last_synced_platforms"] = list(platform_app_ids.keys())
+        self._state_persister.save_state()
+
+        return platform_app_ids, romm_collection_app_ids
+
+    async def finalize_per_unit_run(
+        self,
+        pending_collection_memberships: dict[str, list[int]],
+        pending_platform_rom_ids: set[int] | None,
+        total_games: int,
+        cancelled: bool = False,
+    ):
+        """Emit ``sync_collections`` + ``sync_complete`` after all units finish.
+
+        Stale-removal is emitted separately by the orchestrator via
+        ``sync_stale`` so the frontend can apply removals before
+        collections are recomputed.
+        """
+        platform_app_ids, romm_collection_app_ids = await self._loop.run_in_executor(
+            None,
+            self._finalize_per_unit_run_io,
+            pending_collection_memberships,
+            pending_platform_rom_ids,
+        )
+
+        await self._emit(
+            "sync_collections",
+            {
+                "platform_app_ids": platform_app_ids,
+                "romm_collection_app_ids": romm_collection_app_ids,
+            },
+        )
+
+        complete_payload = {
+            "platform_app_ids": platform_app_ids,
+            "romm_collection_app_ids": romm_collection_app_ids,
+            "total_games": total_games,
+        }
+        if cancelled:
+            complete_payload["cancelled"] = True
+        await self._emit("sync_complete", complete_payload)
+
+        total = len(self._state["shortcut_registry"])
+        if cancelled:
+            await self._emit_progress(
+                "done",
+                current=total_games,
+                total=total,
+                message=f"Sync cancelled: {total_games} of {total} games processed",
+                running=False,
+            )
+        else:
+            await self._emit_progress(
+                "done",
+                current=total,
+                total=total,
+                message=f"Sync complete: {total} games from {len(platform_app_ids)} platforms",
+                running=False,
+            )
+
+        self._sync_state.sync_state = SyncState.IDLE
+        self._sync_state.current_sync_id = None
+        return platform_app_ids, romm_collection_app_ids
+
+    # ── Report unit results (per-unit pipeline) ──────────────────
+
+    def _report_unit_results_io(self, rom_id_to_app_id):
+        """Sync helper: finalise artwork + registry for one unit, persist state."""
+        grid = self._steam_config.grid_dir()
+        box = self._sync_state
+
+        for rom_id_str, app_id in rom_id_to_app_id.items():
+            pending = box.pending_sync.get(int(rom_id_str), {})
+            cover_path = self._finalize_cover_path(grid, pending.get("cover_path", ""), app_id, rom_id_str)
+            self._state["shortcut_registry"][rom_id_str] = self._build_registry_entry(pending, app_id, cover_path)
+
+        steam_input_mode = self._settings.get("steam_input_mode", "default")
+        if steam_input_mode != "default" and rom_id_to_app_id:
+            try:
+                self._steam_config.set_steam_input_config(
+                    [int(aid) for aid in rom_id_to_app_id.values()], mode=steam_input_mode
+                )
+            except Exception as e:
+                self._logger.error(f"Failed to set Steam Input config: {e}")
+
+        # Crash-safe checkpoint: persist after every unit so a kill between
+        # units preserves every prior unit's work in the registry.
+        self._state_persister.save_state()
+
+    async def report_unit_results(self, rom_id_to_app_id):
+        """Called by the frontend after applying one unit's shortcuts via SteamClient.
+
+        Finalises that unit's artwork files (rename staging -> {app_id}p.png),
+        appends the per-ROM registry entries, persists state, and
+        signals the orchestrator's per-unit wait event so dispatch
+        moves on to the next unit.
+        """
+        await self._loop.run_in_executor(None, self._report_unit_results_io, rom_id_to_app_id)
+
+        box = self._sync_state
+        box.last_unit_results = dict(rom_id_to_app_id)
+        if box.unit_complete_event is not None:
+            box.unit_complete_event.set()
+
+        self._logger.info(f"Unit results reported: {len(rom_id_to_app_id)} shortcuts")
+        return {"success": True, "count": len(rom_id_to_app_id)}
+
     # ── Registry queries ─────────────────────────────────────────
 
     def get_registry_platforms(self):

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -145,6 +145,11 @@ class LibraryService:
                 artwork=config.artwork,
             )
         )
+        # Late-bound: the orchestrator dispatches the per-unit pipeline's
+        # finalize step (sync_collections + sync_complete) through the
+        # reporter so the registry-driven collection-mapping path is
+        # shared with the monolithic ``report_sync_results`` flow.
+        self._orchestrator._reporter = self._reporter
 
     async def _emit_progress_proxy(self, phase, **kwargs):
         """Late-bound proxy to the orchestrator's _emit_progress.
@@ -344,6 +349,9 @@ class LibraryService:
     # Reporting
     async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
         return await self._reporter.report_sync_results(rom_id_to_app_id, removed_rom_ids, cancelled)
+
+    async def report_unit_results(self, rom_id_to_app_id):
+        return await self._reporter.report_unit_results(rom_id_to_app_id)
 
     # Registry queries
     def get_registry_platforms(self):

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -19,12 +19,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.preview_delta import PreviewDelta
+from domain.shortcut_data import build_shortcuts_data
 from domain.sync_diff import (
     classify_roms,
     compute_collection_diff,
     compute_platform_collection_diff,
 )
 from domain.sync_state import SyncState
+from domain.work_unit import WorkUnit
 from lib.errors import classify_error
 from services.library._state import LibrarySyncStateBox
 
@@ -32,6 +34,7 @@ if TYPE_CHECKING:
     import logging
 
     from services.library.fetcher import LibraryFetcher
+    from services.library.reporter import SyncReporter
     from services.protocols import (
         ArtworkManager,
         Clock,
@@ -45,6 +48,17 @@ if TYPE_CHECKING:
 
 _SYNC_CANCELLED = "Sync cancelled"
 _PREVIEW_MAX_AGE_SECONDS = 1800  # 30 minutes — preview snapshots stale beyond this
+
+# Per-unit heartbeat-based timeout. If the frontend stops calling
+# ``sync_heartbeat`` for this many seconds while the orchestrator is
+# waiting for ``report_unit_results``, the wait is treated as a
+# recoverable cancellation — the in-flight unit is dropped and the
+# next sync resumes via the incremental-skip path.
+_UNIT_HEARTBEAT_TIMEOUT_SEC = 60.0
+# Polling cadence the wait loop uses while watching the heartbeat
+# clock. Kept short so cancel propagation feels responsive without
+# burning CPU.
+_UNIT_WAIT_POLL_SEC = 1.0
 
 
 @dataclass(frozen=True)
@@ -75,6 +89,13 @@ class SyncOrchestratorConfig:
     fetcher: LibraryFetcher
     metadata_service: MetadataExtractor | None = None
     artwork: ArtworkManager | None = None
+    # Late-bound reporter reference — the per-unit pipeline emits its
+    # final ``sync_complete`` / ``sync_collections`` through the reporter
+    # so the same registry-driven collection-mapping code path is reused.
+    # Optional because the orchestrator is constructed before the
+    # reporter exists in :class:`LibraryService`; the façade injects the
+    # binding immediately after the reporter is built.
+    reporter: SyncReporter | None = None
 
 
 class SyncOrchestrator:
@@ -94,6 +115,7 @@ class SyncOrchestrator:
         self._fetcher = config.fetcher
         self._metadata_service = config.metadata_service
         self._artwork = config.artwork
+        self._reporter = config.reporter
 
     # ── Sync control ─────────────────────────────────────────────
 
@@ -104,7 +126,7 @@ class SyncOrchestrator:
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
-        self._loop.create_task(self._do_sync())
+        self._loop.create_task(self._do_sync_per_unit())
         return {"success": True, "message": "Sync started"}
 
     def cancel_sync(self):
@@ -482,6 +504,260 @@ class SyncOrchestrator:
         box.sync_state = SyncState.IDLE
         box.current_sync_id = None
         self._logger.info(message)
+
+    # ── Per-unit pipeline ────────────────────────────────────────
+
+    async def _do_sync_per_unit(self):
+        """Per-unit sync pipeline (Phase 0 + per-unit dispatch + finalize).
+
+        Replaces the monolithic all-platforms-then-all-shortcuts flow:
+        builds a work queue, processes each platform/collection unit
+        to completion (fetch -> shortcuts -> artwork -> apply ->
+        registry update) before moving on, then emits stale-removal +
+        Steam-collection mappings + ``sync_complete`` at the end. Each
+        completed unit is a crash-safe checkpoint in the on-disk
+        registry.
+        """
+        box = self._sync_state
+        # Cross-unit accumulators — built up unit-by-unit, consumed by the
+        # final phase. ``synced_rom_ids`` is shared with collection units
+        # for dedup. ``all_rom_id_to_app_id`` aggregates every unit's
+        # frontend-reported mapping for stale detection. ``collection_
+        # memberships`` and ``platform_rom_ids`` mirror the values
+        # ``_fetch_and_prepare`` produces in the monolithic path so the
+        # reporter's ``_build_collection_app_ids`` can run unchanged.
+        synced_rom_ids: set[int] = set()
+        all_rom_id_to_app_id: dict[str, int] = {}
+        collection_memberships: dict[str, list[int]] = {}
+        platform_rom_ids: set[int] = set()
+        total_games_applied = 0
+        cancelled = False
+
+        try:
+            try:
+                work_queue = await self._fetcher.build_work_queue()
+            except asyncio.CancelledError:
+                await self._finish_sync(_SYNC_CANCELLED)
+                raise
+            except Exception as e:
+                self._logger.error(f"Failed to build work queue: {e}")
+                _code, _msg = classify_error(e)
+                await self._emit_progress("error", message=_msg, running=False)
+                box.sync_state = SyncState.IDLE
+                return
+
+            total_units = len(work_queue)
+            total_roms_planned = sum(u.rom_count for u in work_queue)
+            self._logger.info(f"Per-unit pipeline: {total_units} units planned, {total_roms_planned} ROMs total")
+            await self._emit(
+                "sync_plan",
+                {
+                    "units": [u.to_event_payload() for u in work_queue],
+                    "total_units": total_units,
+                    "total_roms": total_roms_planned,
+                },
+            )
+
+            if total_units == 0:
+                await self._emit_progress("done", message="Nothing to sync", running=False)
+                box.sync_state = SyncState.IDLE
+                box.current_sync_id = None
+                return
+
+            for unit_index, unit in enumerate(work_queue):
+                if box.sync_state == SyncState.CANCELLING:
+                    cancelled = True
+                    break
+
+                applied = await self._sync_one_unit(
+                    unit,
+                    unit_index=unit_index,
+                    total_units=total_units,
+                    synced_rom_ids=synced_rom_ids,
+                    collection_memberships=collection_memberships,
+                    platform_rom_ids=platform_rom_ids,
+                    all_rom_id_to_app_id=all_rom_id_to_app_id,
+                )
+                total_games_applied += applied
+
+                if box.sync_state == SyncState.CANCELLING:
+                    cancelled = True
+                    break
+
+            # Final phase: stale cleanup + Steam collections + sync_complete.
+            await self._finalize_per_unit(
+                total_games_applied=total_games_applied,
+                synced_rom_ids=synced_rom_ids,
+                collection_memberships=collection_memberships,
+                platform_rom_ids=platform_rom_ids,
+                cancelled=cancelled,
+            )
+        except Exception as e:
+            import traceback
+
+            self._logger.error(f"Per-unit sync failed: {e}\n{traceback.format_exc()}")
+            _code, _msg = classify_error(e)
+            box.sync_progress = {
+                "running": False,
+                "phase": "error",
+                "current": 0,
+                "total": 0,
+                "message": f"Sync failed — {_msg}",
+            }
+            self._loop.create_task(self._emit("sync_progress", box.sync_progress))
+            box.sync_state = SyncState.IDLE
+        finally:
+            if self._metadata_service is not None:
+                self._metadata_service.flush_metadata_if_dirty()
+
+    async def _sync_one_unit(
+        self,
+        unit: WorkUnit,
+        *,
+        unit_index: int,
+        total_units: int,
+        synced_rom_ids: set[int],
+        collection_memberships: dict[str, list[int]],
+        platform_rom_ids: set[int],
+        all_rom_id_to_app_id: dict[str, int],
+    ) -> int:
+        """Process one work unit start-to-finish; return shortcuts applied."""
+        box = self._sync_state
+        await self._emit_progress(
+            "unit",
+            current=unit_index,
+            total=total_units,
+            message=f"{unit.name} ({unit_index + 1}/{total_units})",
+        )
+
+        # Fetch this unit's ROMs. Platform units may incremental-skip;
+        # collection units always paginate (collection membership is the
+        # source of truth, no per-collection "last_sync" gate today).
+        if unit.type == "platform":
+            unit_roms, skipped = await self._fetcher.fetch_platform_unit(unit)
+            platform_rom_ids.update(r["id"] for r in unit_roms)
+            synced_rom_ids.update(r["id"] for r in unit_roms)
+        else:
+            skipped = False
+            unit_roms, all_collection_rom_ids = await self._fetcher.fetch_collection_unit(unit, synced_rom_ids)
+            if all_collection_rom_ids:
+                collection_memberships[unit.name] = all_collection_rom_ids
+
+        if box.sync_state == SyncState.CANCELLING:
+            return 0
+
+        # Build shortcut data + cache metadata for this unit only.
+        shortcuts_data = build_shortcuts_data(unit_roms, self._fetcher._plugin_dir)
+        self._fetcher.cache_metadata_for_unit(unit_roms)
+
+        # Download artwork for this unit (skipped if the incremental
+        # path already populated cover_path from the registry).
+        if not skipped and unit_roms:
+            cover_paths = await self._download_artwork(
+                unit_roms, progress_step=unit_index + 1, progress_total_steps=total_units
+            )
+            for sd in shortcuts_data:
+                sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
+
+        if box.sync_state == SyncState.CANCELLING:
+            return 0
+
+        # Stage pending_sync for this unit so report_unit_results can
+        # finalise cover paths + build registry entries against it.
+        box.pending_sync = {sd["rom_id"]: sd for sd in shortcuts_data}
+
+        # Emit per-unit apply event + wait for the frontend callback.
+        box.unit_complete_event = asyncio.Event()
+        box.last_unit_results = None
+        box.sync_last_heartbeat = self._clock.monotonic()
+        await self._emit(
+            "sync_apply_unit",
+            {
+                "unit_type": unit.type,
+                "unit_id": unit.id,
+                "unit_name": unit.name,
+                "unit_index": unit_index,
+                "total_units": total_units,
+                "shortcuts": shortcuts_data,
+            },
+        )
+
+        applied = await self._wait_for_unit_complete(unit, box.unit_complete_event)
+        if applied is None:
+            # Heartbeat timeout or cancel — drop the unit's pending state
+            # and surface the cancellation. The orchestrator's outer loop
+            # observes CANCELLING and stops.
+            box.pending_sync = {}
+            box.unit_complete_event = None
+            box.sync_state = SyncState.CANCELLING
+            return 0
+
+        # Reporter has already updated the registry + persisted state via
+        # report_unit_results — mirror the rom_id_to_app_id into the
+        # cross-run accumulator for stale + Steam-collection mapping.
+        all_rom_id_to_app_id.update(applied)
+        box.pending_sync = {}
+        box.unit_complete_event = None
+        return len(applied)
+
+    async def _wait_for_unit_complete(self, unit: WorkUnit, event: asyncio.Event) -> dict[str, int] | None:
+        """Heartbeat-based wait for the active unit's frontend callback.
+
+        Returns the frontend-reported ``rom_id_to_app_id`` on success.
+        Returns ``None`` on timeout or cancel — the outer loop maps that
+        onto a recoverable cancellation. The wait poll polls the
+        heartbeat clock rather than ``asyncio.wait_for(timeout=...)``
+        because the frontend sends ``sync_heartbeat`` calls during long
+        per-unit applies (artwork download, Set* calls) and a 60s
+        absolute cap would still race those.
+        """
+        box = self._sync_state
+        while not event.is_set():
+            if box.sync_state == SyncState.CANCELLING:
+                self._logger.info(f"Per-unit cancel observed while waiting for unit {unit.name}")
+                return None
+            elapsed = self._clock.monotonic() - box.sync_last_heartbeat
+            if elapsed > _UNIT_HEARTBEAT_TIMEOUT_SEC:
+                self._logger.warning(f"Per-unit timeout: no heartbeat for {elapsed:.0f}s waiting on unit {unit.name}")
+                return None
+            try:
+                await self._sleeper.sleep(_UNIT_WAIT_POLL_SEC)
+            except asyncio.CancelledError:
+                self._logger.info(f"Per-unit wait cancelled for unit {unit.name}")
+                return None
+
+        results = box.last_unit_results or {}
+        box.last_unit_results = None
+        return results
+
+    async def _finalize_per_unit(
+        self,
+        *,
+        total_games_applied: int,
+        synced_rom_ids: set[int],
+        collection_memberships: dict[str, list[int]],
+        platform_rom_ids: set[int],
+        cancelled: bool,
+    ):
+        """Emit stale-removal, collection mappings, and the terminal sync_complete."""
+        # Stale rom_ids: anything in the registry whose rom_id wasn't seen
+        # by any processed unit. Only meaningful on a non-cancelled run —
+        # a partial run can't tell "stale" from "didn't get to it yet".
+        if not cancelled:
+            stale_rom_ids = [
+                int(rid) for rid in self._state.get("shortcut_registry", {}) if int(rid) not in synced_rom_ids
+            ]
+        else:
+            stale_rom_ids = []
+        await self._emit("sync_stale", {"remove_rom_ids": stale_rom_ids})
+
+        if self._reporter is not None:
+            await self._reporter.finalize_per_unit_run(
+                pending_collection_memberships=collection_memberships,
+                pending_platform_rom_ids=platform_rom_ids,
+                total_games=total_games_applied,
+                cancelled=cancelled,
+            )
 
     # ── Artwork delegation ───────────────────────────────────────
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -724,7 +724,7 @@ class SyncOrchestrator:
                 await self._sleeper.sleep(_UNIT_WAIT_POLL_SEC)
             except asyncio.CancelledError:
                 self._logger.info(f"Per-unit wait cancelled for unit {unit.name}")
-                return None
+                raise
 
         results = box.last_unit_results or {}
         box.last_unit_results = None

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -87,6 +87,7 @@ export const removeAllShortcuts = callable<[], { success: boolean; message: stri
 export const getArtworkBase64 = callable<[number], { base64: string | null }>("get_artwork_base64");
 export const getSgdbArtworkBase64 = callable<[number, number], { base64: string | null; no_api_key?: boolean }>("get_sgdb_artwork_base64");
 export const reportSyncResults = callable<[Record<string, number>, number[], boolean], { success: boolean }>("report_sync_results");
+export const reportUnitResults = callable<[Record<string, number>], { success: boolean; count: number }>("report_unit_results");
 export const reportRemovalResults = callable<[(string | number)[]], { success: boolean; message: string }>("report_removal_results");
 export const uninstallAllRoms = callable<[], { success: boolean; message: string; removed_count: number }>("uninstall_all_roms");
 export const saveSgdbApiKey = callable<[string], { success: boolean; message: string }>("save_sgdb_api_key");

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -18,6 +18,7 @@ import {
   getSyncStats,
   getSettings,
   fixRetroarchInputDriver,
+  startSync,
   syncPreview,
   syncApplyDelta,
   syncCancelPreview,
@@ -221,28 +222,26 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setSyncProgress({ running: true, phase: "fetching", message: "Fetching library..." });
     startPolling(true);
     try {
+      // Skip Preview takes the per-unit pipeline (start_sync) — incremental
+      // shortcut delivery, per-unit crash safety, no upfront full library
+      // fetch. The legacy preview/apply path remains for users who want to
+      // review changes before they apply.
+      if (skipPreview) {
+        const startResult = await startSync();
+        if (startResult.success) {
+          startPolling();
+        } else {
+          stopPolling();
+          setStatus(startResult.message);
+          setSyncing(false);
+          setLoading(false);
+        }
+        return;
+      }
       const result = await syncPreview();
       stopPolling();
       if (result.success) {
-        const hasChanges = result.summary.new_count + result.summary.changed_count + result.summary.remove_count > 0 || !!result.summary.collection_diff?.has_changes || !!result.summary.platform_collection_diff?.has_changes;
-        if (skipPreview && hasChanges) {
-          // Auto-apply: skip preview UI
-          setSyncProgress({ running: true, phase: "applying", message: "Applying changes..." });
-          const applyResult = await syncApplyDelta(result.preview_id);
-          if (applyResult.success) {
-            startPolling();
-          } else {
-            setStatus(applyResult.message);
-            setSyncing(false);
-            setLoading(false);
-          }
-        } else if (skipPreview) {
-          // Nothing to sync — show brief status
-          await syncCancelPreview();
-          setStatus("Everything is up to date");
-          setSyncing(false);
-          setLoading(false);
-        } else {
+        {
           setPreview(result);
           setSyncing(false);
           setLoading(false);

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -241,11 +241,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       const result = await syncPreview();
       stopPolling();
       if (result.success) {
-        {
-          setPreview(result);
-          setSyncing(false);
-          setLoading(false);
-        }
+        setPreview(result);
+        setSyncing(false);
+        setLoading(false);
       } else {
         setStatus(result.message || "Preview failed");
         setSyncing(false);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { LibraryPage } from "./components/LibraryPage";
 import { DangerZone } from "./components/DangerZone";
 import { DownloadQueue } from "./components/DownloadQueue";
-import { initSyncManager } from "./utils/syncManager";
+import { initSyncManager, initUnitSyncManager } from "./utils/syncManager";
 import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
@@ -25,7 +25,8 @@ import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import { findOutermostScrollParent, findScrollParent } from "./utils/scrollHelpers";
-import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, SaveStatus } from "./types";
+import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, SaveStatus, SyncPlanData, SyncStaleData, SyncCollectionsData } from "./types";
+import { removeShortcut } from "./utils/steamShortcuts";
 
 type Page = "main" | "settings" | "library" | "data" | "downloads";
 
@@ -300,6 +301,44 @@ export default definePlugin(() => {
   >("sync_complete", onSyncComplete);
 
   const syncApplyListener = initSyncManager();
+  const syncApplyUnitListener = initUnitSyncManager();
+
+  // Per-unit pipeline: planning + stale + collections events.
+  // ``sync_plan`` arrives once per run with the full work queue (info only
+  // for now — future PR adds a per-platform progress view).
+  const syncPlanListener = addEventListener<[SyncPlanData]>("sync_plan", (data: SyncPlanData) => {
+    logInfo(`sync_plan received: ${data.total_units} units, ${data.total_roms} ROMs total`);
+  });
+
+  // ``sync_stale`` arrives after every unit finishes — apply removals
+  // through the same Steam APIs the monolithic path uses, then let the
+  // backend reconcile ownership via the finalise step's registry write.
+  const syncStaleListener = addEventListener<[SyncStaleData]>("sync_stale", async (data: SyncStaleData) => {
+    if (!Array.isArray(data.remove_rom_ids) || data.remove_rom_ids.length === 0) return;
+    try {
+      const { getExistingRomMShortcuts } = await import("./utils/steamShortcuts");
+      const existing = await getExistingRomMShortcuts();
+      for (const romId of data.remove_rom_ids) {
+        const appId = existing.get(romId);
+        if (appId) removeShortcut(appId);
+      }
+      logInfo(`sync_stale: removed ${data.remove_rom_ids.length} stale shortcuts`);
+    } catch (e) {
+      logError(`sync_stale handler failed: ${e}`);
+    }
+  });
+
+  // ``sync_collections`` arrives at the end of the per-unit run with the
+  // full platform / RomM-collection app-id maps. The monolithic path
+  // routes these through ``sync_complete``; the per-unit path emits them
+  // separately so the frontend can apply collection updates before the
+  // terminal "done" toast.
+  const syncCollectionsListener = addEventListener<[SyncCollectionsData]>(
+    "sync_collections",
+    (data: SyncCollectionsData) => {
+      logInfo(`sync_collections received: ${Object.keys(data.platform_app_ids ?? {}).length} platforms`);
+    },
+  );
 
   // Backend emits sync_progress events throughout _do_sync — update the module-level store
   const syncProgressListener = addEventListener<[SyncProgress]>(
@@ -394,6 +433,10 @@ export default definePlugin(() => {
       unregisterMetadataPatches();
       removeEventListener("sync_complete", syncCompleteListener);
       removeEventListener("sync_apply", syncApplyListener);
+      removeEventListener("sync_apply_unit", syncApplyUnitListener);
+      removeEventListener("sync_plan", syncPlanListener);
+      removeEventListener("sync_stale", syncStaleListener);
+      removeEventListener("sync_collections", syncCollectionsListener);
       removeEventListener("sync_progress", syncProgressListener);
       removeEventListener("download_progress", downloadProgressListener);
       removeEventListener("download_complete", downloadCompleteListener);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,38 @@ export interface SyncApplyData {
   total_steps?: number;
 }
 
+export interface SyncPlanUnit {
+  type: "platform" | "collection";
+  id: number | string;
+  name: string;
+  slug: string;
+  rom_count: number;
+}
+
+export interface SyncPlanData {
+  units: SyncPlanUnit[];
+  total_units: number;
+  total_roms: number;
+}
+
+export interface SyncApplyUnitData {
+  unit_type: "platform" | "collection";
+  unit_id: number | string;
+  unit_name: string;
+  unit_index: number;
+  total_units: number;
+  shortcuts: SyncAddItem[];
+}
+
+export interface SyncStaleData {
+  remove_rom_ids: number[];
+}
+
+export interface SyncCollectionsData {
+  platform_app_ids: Record<string, number[]>;
+  romm_collection_app_ids: Record<string, number[]>;
+}
+
 export interface FirmwareFile {
   id: number;
   file_name: string;

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -1,6 +1,6 @@
 import { addEventListener } from "@decky/api";
-import type { SyncApplyData, SyncChangedItem } from "../types";
-import { getArtworkBase64, reportSyncResults, syncHeartbeat, logInfo, logError } from "../api/backend";
+import type { SyncApplyData, SyncApplyUnitData, SyncChangedItem } from "../types";
+import { getArtworkBase64, reportSyncResults, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
 import { getExistingRomMShortcuts, addShortcut, removeShortcut } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 
@@ -8,10 +8,129 @@ const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 let _cancelRequested = false;
 let _isSyncRunning = false;
+let _isUnitRunning = false;
 
 /** Request cancellation of the frontend shortcut processing loop. */
 export function requestSyncCancel(): void {
   _cancelRequested = true;
+}
+
+/**
+ * Initialize the per-unit pipeline handler. Listens for ``sync_apply_unit``
+ * events, processes each unit's shortcuts at the CEF-safe 50ms cadence, and
+ * reports back via ``reportUnitResults`` so the backend can advance the
+ * work queue. Artwork still goes through the existing base64 round-trip —
+ * the artwork-rename optimisation is deferred until hardware verification.
+ */
+export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
+  return addEventListener("sync_apply_unit", async (data: SyncApplyUnitData) => {
+    if (_isUnitRunning) {
+      logInfo(`sync_apply_unit: already processing a unit, dropping duplicate for ${data.unit_name}`);
+      return;
+    }
+    _isUnitRunning = true;
+    try {
+      if (!Array.isArray(data.shortcuts)) {
+        logError("sync_apply_unit: data.shortcuts is not an array, aborting");
+        return;
+      }
+
+      _cancelRequested = false;
+      const romIdToAppId: Record<string, number> = {};
+      const artworkTargets: Array<{ appId: number; romId: number; name: string }> = [];
+      let lastHeartbeat = Date.now();
+      const HEARTBEAT_INTERVAL_MS = 10_000;
+
+      const total = data.shortcuts.length;
+      logInfo(`sync_apply_unit received: ${data.unit_type}=${data.unit_name} (${data.unit_index + 1}/${data.total_units}), ${total} shortcuts`);
+
+      updateSyncProgress({
+        running: true,
+        phase: "applying",
+        current: 0,
+        total,
+        message: `${data.unit_name}: 0/${total}`,
+        step: data.unit_index + 1,
+        totalSteps: data.total_units,
+      });
+
+      const existing = await getExistingRomMShortcuts();
+      for (let i = 0; i < data.shortcuts.length; i++) {
+        const item = data.shortcuts[i];
+        try {
+          updateSyncProgress({
+            current: i + 1,
+            message: `${data.unit_name}: ${i + 1}/${total}`,
+          });
+
+          let appId: number | undefined;
+          const existingAppId = existing.get(item.rom_id);
+          if (existingAppId) {
+            SteamClient.Apps.SetShortcutName(existingAppId, item.name);
+            SteamClient.Apps.SetShortcutExe(existingAppId, item.exe);
+            SteamClient.Apps.SetShortcutStartDir(existingAppId, item.start_dir);
+            SteamClient.Apps.SetAppLaunchOptions(existingAppId, item.launch_options);
+            appId = existingAppId;
+          } else {
+            const newAppId = await addShortcut(item);
+            if (newAppId) {
+              appId = newAppId;
+            }
+          }
+
+          if (appId) {
+            romIdToAppId[String(item.rom_id)] = appId;
+            artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
+          }
+        } catch (e) {
+          logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);
+        }
+        await delay(50);
+
+        if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+          syncHeartbeat().catch(() => {});
+          lastHeartbeat = Date.now();
+        }
+        if (_cancelRequested) {
+          logInfo(`Per-unit cancel observed during ${data.unit_name}`);
+          break;
+        }
+      }
+
+      // Artwork — keep existing base64 path; this is a per-unit-sized batch
+      // so the giant single sync_apply payload concern doesn't apply.
+      if (artworkTargets.length > 0) {
+        const ART_CONCURRENCY = 8;
+        for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
+          if (_cancelRequested) break;
+          const batch = artworkTargets.slice(i, i + ART_CONCURRENCY);
+          await Promise.all(batch.map(async ({ appId, romId, name }) => {
+            try {
+              const artResult = await getArtworkBase64(romId);
+              if (artResult.base64) {
+                await SteamClient.Apps.SetCustomArtworkForApp(appId, artResult.base64, "png", 0);
+              }
+            } catch (artErr) {
+              logError(`Per-unit: failed to fetch/set artwork for ${name}: ${artErr}`);
+            }
+          }));
+          if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+            syncHeartbeat().catch(() => {});
+            lastHeartbeat = Date.now();
+          }
+        }
+      }
+
+      try {
+        await reportUnitResults(romIdToAppId);
+      } catch (e) {
+        logError(`Failed to report unit results for ${data.unit_name}: ${e}`);
+      }
+      logInfo(`sync_apply_unit complete: ${data.unit_name} (${Object.keys(romIdToAppId).length}/${total})`);
+    } finally {
+      _isUnitRunning = false;
+    }
+  });
 }
 
 /**

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -1,10 +1,18 @@
 import { addEventListener } from "@decky/api";
-import type { SyncApplyData, SyncApplyUnitData, SyncChangedItem } from "../types";
+import type { SyncAddItem, SyncApplyData, SyncApplyUnitData, SyncChangedItem } from "../types";
 import { getArtworkBase64, reportSyncResults, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
 import { getExistingRomMShortcuts, addShortcut, removeShortcut } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const HEARTBEAT_INTERVAL_MS = 10_000;
+const ART_CONCURRENCY = 8;
+
+interface ArtworkTarget {
+  appId: number;
+  romId: number;
+  name: string;
+}
 
 let _cancelRequested = false;
 let _isSyncRunning = false;
@@ -13,6 +21,101 @@ let _isUnitRunning = false;
 /** Request cancellation of the frontend shortcut processing loop. */
 export function requestSyncCancel(): void {
   _cancelRequested = true;
+}
+
+/**
+ * Resolve a shortcut item to an appId: update fields on the existing
+ * shortcut when one is present, otherwise create a new shortcut. Returns
+ * ``undefined`` if no appId could be resolved (creation failed).
+ */
+async function resolveShortcutAppId(
+  item: SyncAddItem,
+  existing: Map<number, number>,
+): Promise<number | undefined> {
+  const existingAppId = existing.get(item.rom_id);
+  if (existingAppId) {
+    SteamClient.Apps.SetShortcutName(existingAppId, item.name);
+    SteamClient.Apps.SetShortcutExe(existingAppId, item.exe);
+    SteamClient.Apps.SetShortcutStartDir(existingAppId, item.start_dir);
+    SteamClient.Apps.SetAppLaunchOptions(existingAppId, item.launch_options);
+    return existingAppId;
+  }
+  return (await addShortcut(item)) ?? undefined;
+}
+
+/**
+ * Process every shortcut for one unit at the CEF-safe 50ms cadence,
+ * recording the rom_id→appId mapping and the artwork targets for the
+ * follow-up artwork phase. Heartbeats are emitted every 10s. The loop
+ * exits early on cancel.
+ */
+async function processUnitShortcuts(
+  data: SyncApplyUnitData,
+  existing: Map<number, number>,
+  romIdToAppId: Record<string, number>,
+  artworkTargets: ArtworkTarget[],
+  total: number,
+): Promise<void> {
+  let lastHeartbeat = Date.now();
+  for (let i = 0; i < data.shortcuts.length; i++) {
+    const item = data.shortcuts[i];
+    try {
+      updateSyncProgress({
+        current: i + 1,
+        message: `${data.unit_name}: ${i + 1}/${total}`,
+      });
+      const appId = await resolveShortcutAppId(item, existing);
+      if (appId) {
+        romIdToAppId[String(item.rom_id)] = appId;
+        artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
+      }
+    } catch (e) {
+      logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);
+    }
+    await delay(50);
+
+    if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+      syncHeartbeat().catch(() => {});
+      lastHeartbeat = Date.now();
+    }
+    if (_cancelRequested) {
+      logInfo(`Per-unit cancel observed during ${data.unit_name}`);
+      break;
+    }
+  }
+}
+
+/**
+ * Fetch and apply cover artwork for a single target. Swallows per-target
+ * errors so one failure doesn't take down the batch.
+ */
+async function applyArtworkForTarget({ appId, romId, name }: ArtworkTarget): Promise<void> {
+  try {
+    const artResult = await getArtworkBase64(romId);
+    if (artResult.base64) {
+      await SteamClient.Apps.SetCustomArtworkForApp(appId, artResult.base64, "png", 0);
+    }
+  } catch (artErr) {
+    logError(`Per-unit: failed to fetch/set artwork for ${name}: ${artErr}`);
+  }
+}
+
+/**
+ * Fetch artwork for every target in batches of ``ART_CONCURRENCY``, with
+ * heartbeats between batches. Exits early on cancel.
+ */
+async function processUnitArtwork(artworkTargets: ArtworkTarget[]): Promise<void> {
+  if (artworkTargets.length === 0) return;
+  let lastHeartbeat = Date.now();
+  for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
+    if (_cancelRequested) break;
+    const batch = artworkTargets.slice(i, i + ART_CONCURRENCY);
+    await Promise.all(batch.map(applyArtworkForTarget));
+    if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+      syncHeartbeat().catch(() => {});
+      lastHeartbeat = Date.now();
+    }
+  }
 }
 
 /**
@@ -37,9 +140,7 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
 
       _cancelRequested = false;
       const romIdToAppId: Record<string, number> = {};
-      const artworkTargets: Array<{ appId: number; romId: number; name: string }> = [];
-      let lastHeartbeat = Date.now();
-      const HEARTBEAT_INTERVAL_MS = 10_000;
+      const artworkTargets: ArtworkTarget[] = [];
 
       const total = data.shortcuts.length;
       logInfo(`sync_apply_unit received: ${data.unit_type}=${data.unit_name} (${data.unit_index + 1}/${data.total_units}), ${total} shortcuts`);
@@ -55,71 +156,11 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       });
 
       const existing = await getExistingRomMShortcuts();
-      for (let i = 0; i < data.shortcuts.length; i++) {
-        const item = data.shortcuts[i];
-        try {
-          updateSyncProgress({
-            current: i + 1,
-            message: `${data.unit_name}: ${i + 1}/${total}`,
-          });
-
-          let appId: number | undefined;
-          const existingAppId = existing.get(item.rom_id);
-          if (existingAppId) {
-            SteamClient.Apps.SetShortcutName(existingAppId, item.name);
-            SteamClient.Apps.SetShortcutExe(existingAppId, item.exe);
-            SteamClient.Apps.SetShortcutStartDir(existingAppId, item.start_dir);
-            SteamClient.Apps.SetAppLaunchOptions(existingAppId, item.launch_options);
-            appId = existingAppId;
-          } else {
-            const newAppId = await addShortcut(item);
-            if (newAppId) {
-              appId = newAppId;
-            }
-          }
-
-          if (appId) {
-            romIdToAppId[String(item.rom_id)] = appId;
-            artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
-          }
-        } catch (e) {
-          logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);
-        }
-        await delay(50);
-
-        if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
-          syncHeartbeat().catch(() => {});
-          lastHeartbeat = Date.now();
-        }
-        if (_cancelRequested) {
-          logInfo(`Per-unit cancel observed during ${data.unit_name}`);
-          break;
-        }
-      }
+      await processUnitShortcuts(data, existing, romIdToAppId, artworkTargets, total);
 
       // Artwork — keep existing base64 path; this is a per-unit-sized batch
       // so the giant single sync_apply payload concern doesn't apply.
-      if (artworkTargets.length > 0) {
-        const ART_CONCURRENCY = 8;
-        for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
-          if (_cancelRequested) break;
-          const batch = artworkTargets.slice(i, i + ART_CONCURRENCY);
-          await Promise.all(batch.map(async ({ appId, romId, name }) => {
-            try {
-              const artResult = await getArtworkBase64(romId);
-              if (artResult.base64) {
-                await SteamClient.Apps.SetCustomArtworkForApp(appId, artResult.base64, "png", 0);
-              }
-            } catch (artErr) {
-              logError(`Per-unit: failed to fetch/set artwork for ${name}: ${artErr}`);
-            }
-          }));
-          if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
-            syncHeartbeat().catch(() => {});
-            lastHeartbeat = Date.now();
-          }
-        }
-      }
+      await processUnitArtwork(artworkTargets);
 
       try {
         await reportUnitResults(romIdToAppId);
@@ -160,12 +201,11 @@ export function initSyncManager(): ReturnType<typeof addEventListener> {
       _cancelRequested = false;
       let cancelled = false;
       let lastHeartbeat = Date.now();
-      const HEARTBEAT_INTERVAL_MS = 10_000;
-  
+
       const existing = await getExistingRomMShortcuts();
       const romIdToAppId: Record<string, number> = {};
       const removedRomIds: number[] = [];
-      const artworkTargets: Array<{ appId: number; romId: number; name: string }> = [];
+      const artworkTargets: ArtworkTarget[] = [];
   
       // Step plan from backend
       let currentStep = data.next_step ?? 1;
@@ -279,7 +319,6 @@ export function initSyncManager(): ReturnType<typeof addEventListener> {
 
       // --- Batch artwork fetch (parallel, up to 8 at a time) ---
       if (!cancelled && artworkTargets.length > 0) {
-        const ART_CONCURRENCY = 8;
         for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
           if (_cancelRequested) {
             logInfo("Cancel requested during artwork fetching");

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -355,3 +355,91 @@ class TestReportSyncResultsCancelled:
         complete_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert len(complete_calls) == 1
         assert complete_calls[0][0][1]["cancelled"] is True
+
+
+class TestFinalizePerUnitRun:
+    """SyncReporter.finalize_per_unit_run — emits sync_collections + sync_complete after the per-unit loop."""
+
+    @pytest.mark.asyncio
+    async def test_builds_platform_collections_from_registry(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+        }
+        plugin.settings["collection_create_platform_groups"] = True
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1, 2},
+            total_games=2,
+        )
+
+        collections_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_collections"]
+        assert len(collections_events) == 1
+        payload = collections_events[0][0][1]
+        assert set(payload["platform_app_ids"].keys()) == {"N64", "SNES"}
+
+    @pytest.mark.asyncio
+    async def test_emits_sync_complete_terminal(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        plugin._state["shortcut_registry"] = {}
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids=set(),
+            total_games=0,
+        )
+
+        complete_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert len(complete_events) == 1
+        assert "cancelled" not in complete_events[0][0][1]
+
+    @pytest.mark.asyncio
+    async def test_sets_state_to_idle_at_end(self, plugin, tmp_path):
+        import decky
+
+        from domain.sync_state import SyncState
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "sync-xyz"
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids=set(),
+            total_games=0,
+        )
+
+        assert plugin._sync_service._sync_state == SyncState.IDLE
+        assert plugin._sync_service._current_sync_id is None
+
+    @pytest.mark.asyncio
+    async def test_persists_last_sync_metadata(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+        }
+        plugin.settings["collection_create_platform_groups"] = True
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={"Faves": [1]},
+            pending_platform_rom_ids={1},
+            total_games=1,
+        )
+
+        assert plugin._state["last_sync"] is not None
+        assert plugin._state["last_synced_platforms"] == ["N64"]
+        assert plugin._state["last_synced_collections"] == ["Faves"]

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -805,3 +805,484 @@ class TestSyncPreviewErrorHandling:
         with pytest.raises(asyncio.CancelledError):
             await plugin._sync_service.sync_preview()
         assert plugin._sync_service._sync_state == SyncState.IDLE
+
+
+# ──────────────────────────────────────────────────────────────
+# Per-unit pipeline tests
+# ──────────────────────────────────────────────────────────────
+
+
+class TestBuildWorkQueue:
+    """Phase 0 of the per-unit pipeline: enumerate platforms + collections without fetching ROMs."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_nothing_enabled(self, plugin):
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {}
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(return_value=[])
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+        assert units == []
+
+    @pytest.mark.asyncio
+    async def test_includes_enabled_platforms(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        plugin.settings["enabled_platforms"] = {"1": True, "2": False, "3": True}
+        plugin.settings["enabled_collections"] = {}
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value=[
+                {"id": 1, "name": "N64", "slug": "n64", "rom_count": 12},
+                {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 99},
+                {"id": 3, "name": "GBA", "slug": "gba", "rom_count": 5},
+            ]
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+        assert [u.name for u in units] == ["N64", "GBA"]
+        assert all(u.type == "platform" for u in units)
+        assert units[0].rom_count == 12
+
+    @pytest.mark.asyncio
+    async def test_includes_enabled_collections_after_platforms(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin.settings["enabled_collections"] = {"7": True, "9": True}
+
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            side_effect=[
+                # list_platforms
+                [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 4}],
+                # list_collections
+                [{"id": 7, "name": "Favorites", "rom_count": 3, "is_favorite": True}],
+                # list_virtual_collections("franchise")
+                [{"id": 9, "name": "Metroid", "rom_count": 8, "is_virtual": True}],
+            ]
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+        assert [(u.type, u.name) for u in units] == [
+            ("platform", "N64"),
+            ("collection", "Favorites"),
+            ("collection", "Metroid"),
+        ]
+        assert units[2].is_virtual is True
+
+
+class TestFetchPlatformUnit:
+    """Per-unit platform ROM fetch with incremental-skip path."""
+
+    @pytest.mark.asyncio
+    async def test_full_fetch_when_no_registry(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value={"items": [{"id": 10, "name": "A"}, {"id": 11, "name": "B"}]}
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
+
+        roms, skipped = await plugin._sync_service._fetcher.fetch_platform_unit(unit)
+        assert skipped is False
+        assert [r["id"] for r in roms] == [10, 11]
+        assert roms[0]["platform_name"] == "N64"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_registry_matches_count(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
+        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "A", "fs_name": "a.z64", "platform_name": "N64", "platform_slug": "n64"},
+            "11": {"name": "B", "fs_name": "b.z64", "platform_name": "N64", "platform_slug": "n64"},
+        }
+        mock_loop = MagicMock()
+        # list_roms_updated_after returns zero updates
+        mock_loop.run_in_executor = AsyncMock(return_value={"total": 0, "items": []})
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        roms, skipped = await plugin._sync_service._fetcher.fetch_platform_unit(unit)
+        assert skipped is True
+        assert {r["id"] for r in roms} == {10, 11}
+
+    @pytest.mark.asyncio
+    async def test_full_fetch_when_count_mismatch(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)
+        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "A", "platform_name": "N64"},
+        }
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            side_effect=[
+                # incremental check — zero updates BUT registry count doesn't match
+                {"total": 0, "items": []},
+                # list_roms paginated full fetch
+                {"items": [{"id": 10, "name": "A"}, {"id": 11, "name": "B"}, {"id": 12, "name": "C"}]},
+            ]
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        roms, skipped = await plugin._sync_service._fetcher.fetch_platform_unit(unit)
+        assert skipped is False
+        assert len(roms) == 3
+
+
+class TestFetchCollectionUnit:
+    """Per-unit collection ROM fetch with cross-unit deduplication."""
+
+    @pytest.mark.asyncio
+    async def test_returns_new_roms_and_member_ids(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=3, is_virtual=False)
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value={
+                "items": [
+                    {"id": 1, "platform_name": "N64"},
+                    {"id": 2, "platform_name": "SNES"},
+                    {"id": 3, "platform_name": "GBA"},
+                ]
+            }
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        synced: set[int] = set()
+        new_roms, ids = await plugin._sync_service._fetcher.fetch_collection_unit(unit, synced)
+        assert [r["id"] for r in new_roms] == [1, 2, 3]
+        assert ids == [1, 2, 3]
+        assert synced == {1, 2, 3}
+
+    @pytest.mark.asyncio
+    async def test_dedups_against_already_synced(self, plugin):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="collection", id="9", name="Metroid", slug="", rom_count=2, is_virtual=True)
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(
+            return_value={"items": [{"id": 1, "platform_name": "N64"}, {"id": 2, "platform_name": "SNES"}]}
+        )
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._fetcher._loop = mock_loop
+
+        # rom_id=1 was already fetched via a platform unit
+        synced: set[int] = {1}
+        new_roms, ids = await plugin._sync_service._fetcher.fetch_collection_unit(unit, synced)
+        assert [r["id"] for r in new_roms] == [2]
+        # All collection rom_ids reported back even if not in new_roms
+        assert ids == [1, 2]
+
+
+class TestDoSyncPerUnit:
+    """End-to-end orchestration of the per-unit pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_terminates_cleanly(self, plugin):
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=[])
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        assert plugin._sync_service._sync_state == SyncState.IDLE
+        # Sync plan was emitted with empty units
+        plan_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_plan"]
+        assert len(plan_events) == 1
+        assert plan_events[0][0][1]["total_units"] == 0
+
+    @pytest.mark.asyncio
+    async def test_emits_sync_plan_with_queue(self, plugin):
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        queue = [
+            WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2),
+        ]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(return_value=([], True))
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        # Pre-set the unit-done so _wait_for_unit_complete returns immediately
+        async def fake_wait(_unit, event):
+            event.set()
+            return {}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        plan_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_plan"]
+        assert len(plan_events) == 1
+        payload = plan_events[0][0][1]
+        assert payload["total_units"] == 1
+        assert payload["units"][0]["name"] == "N64"
+
+    @pytest.mark.asyncio
+    async def test_processes_each_unit_in_order(self, plugin):
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        queue = [
+            WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1),
+            WorkUnit(type="platform", id=2, name="GBA", slug="gba", rom_count=1),
+        ]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+
+        # Each platform unit returns its own ROM list
+        async def fake_fetch(unit):
+            return [{"id": int(unit.id) * 10, "name": unit.name, "platform_name": unit.name}], True
+
+        plugin._sync_service._fetcher.fetch_platform_unit = fake_fetch
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_unit, event):
+            event.set()
+            return {str(_unit.id * 10): 9000 + int(_unit.id)}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 2
+        assert unit_events[0]["unit_name"] == "N64"
+        assert unit_events[1]["unit_name"] == "GBA"
+        assert unit_events[0]["unit_index"] == 0
+        assert unit_events[1]["unit_index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_artwork_when_incremental_skipped(self, plugin):
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
+            return_value=([{"id": 10, "name": "A", "platform_name": "N64"}], True)
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            return {}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+        # skipped=True from fetcher → no artwork download
+        plugin._sync_service._orchestrator._download_artwork.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_downloads_artwork_when_not_skipped(self, plugin):
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
+            return_value=([{"id": 10, "name": "A", "platform_name": "N64"}], False)
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={10: "/grid/a.png"})
+
+        async def fake_wait(_u, event):
+            event.set()
+            return {}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+        plugin._sync_service._orchestrator._download_artwork.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_between_units_stops_processing(self, plugin):
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        queue = [
+            WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1),
+            WorkUnit(type="platform", id=2, name="GBA", slug="gba", rom_count=1),
+        ]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
+            return_value=([{"id": 10, "name": "A", "platform_name": "N64"}], True)
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            # Flip to CANCELLING after first unit completes
+            plugin._sync_service._sync_state = SyncState.CANCELLING
+            return {}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1  # second unit was skipped
+        complete_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert len(complete_events) == 1
+        assert complete_events[0].get("cancelled") is True
+
+
+class TestWaitForUnitComplete:
+    """Heartbeat-based per-unit timeout."""
+
+    @pytest.mark.asyncio
+    async def test_returns_results_when_event_set(self, plugin):
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        event.set()
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._clock.monotonic()
+        plugin._sync_service._box.last_unit_results = {"10": 9000}
+
+        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
+        assert results == {"10": 9000}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_cancel(self, plugin):
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        plugin._sync_service._sync_state = SyncState.CANCELLING
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._clock.monotonic()
+
+        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_heartbeat_timeout(self, plugin):
+        from domain.work_unit import WorkUnit
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        event = asyncio.Event()
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        # Heartbeat is way too old — should timeout immediately on first loop check
+        plugin._sync_service._sync_last_heartbeat = plugin._sync_service._clock.monotonic() - 999.0
+
+        results = await plugin._sync_service._orchestrator._wait_for_unit_complete(unit, event)
+        assert results is None
+
+
+class TestReportUnitResults:
+    """Per-unit registry update + state checkpoint."""
+
+    @pytest.mark.asyncio
+    async def test_updates_registry_for_unit_roms(self, plugin):
+        plugin._sync_service._pending_sync = {
+            10: {"rom_id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
+            11: {"rom_id": 11, "name": "B", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
+        }
+
+        result = await plugin.report_unit_results({"10": 9001, "11": 9002})
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        registry = plugin._state["shortcut_registry"]
+        assert "10" in registry
+        assert registry["10"]["app_id"] == 9001
+        assert "11" in registry
+        assert registry["11"]["app_id"] == 9002
+
+    @pytest.mark.asyncio
+    async def test_signals_unit_complete_event(self, plugin):
+        plugin._sync_service._pending_sync = {}
+        event = asyncio.Event()
+        plugin._sync_service._box.unit_complete_event = event
+        assert not event.is_set()
+
+        await plugin.report_unit_results({})
+
+        assert event.is_set()
+        assert plugin._sync_service._box.last_unit_results == {}
+
+    @pytest.mark.asyncio
+    async def test_persists_state_after_unit(self, plugin):
+        # Wrap the state persister to count calls
+        save_count = [0]
+        orig_save_state = plugin._state_persister.save_state
+
+        def counting_save():
+            save_count[0] += 1
+            orig_save_state()
+
+        plugin._state_persister.save_state = counting_save
+        plugin._sync_service._reporter._state_persister.save_state = counting_save
+        plugin._sync_service._pending_sync = {
+            10: {"rom_id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
+        }
+
+        await plugin.report_unit_results({"10": 9001})
+
+        assert save_count[0] == 1, "report_unit_results must checkpoint state to disk"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -682,6 +682,7 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_sync_progress",
     "sync_heartbeat",
     "report_sync_results",
+    "report_unit_results",
     "get_registry_platforms",
     "report_removal_results",
     "get_artwork_base64",


### PR DESCRIPTION
## Summary
Replaces the monolithic "fetch all → diff all → apply all" sync with a per-unit pipeline: build a work queue from enabled platforms + collections (Phase 0, no ROM fetch), then process each unit independently. Shortcuts appear in Steam as soon as each unit completes — no more "spinner for 40 minutes, then everything appears at once". Failed units don't lose successful units' work. Architecture follows the design doc from stale PR #216, retargeted onto the post-decomposition `services/library/` package (#432).

### Backend changes (new files)
- `py_modules/domain/work_unit.py` — `WorkUnit` frozen dataclass (platform | collection descriptor)

### Backend changes (modified)
- `LibraryFetcher`: `build_work_queue()`, `fetch_platform_unit()` (with incremental-skip), `fetch_collection_unit()` (with dedup), `cache_metadata_for_unit()`
- `SyncOrchestrator`: `_do_sync_per_unit()`, `_sync_one_unit()`, `_wait_for_unit_complete()` (60s heartbeat-based timeout), `_finalize_per_unit()`. `start_sync()` now dispatches through the per-unit path; preview/apply-delta untouched.
- `SyncReporter`: `report_unit_results(rom_id_to_app_id)` (crash-safe checkpoint per unit), `finalize_per_unit_run()` (terminal `sync_collections` + `sync_complete`)
- `LibrarySyncStateBox`: gains `unit_complete_event` + `last_unit_results` for orchestrator/reporter coordination
- `main.py`: new `Plugin.report_unit_results` callable

### Frontend changes
- `src/utils/syncManager.ts` — `initUnitSyncManager()` handles `sync_apply_unit` at the existing CEF-safe 50ms cadence; existing base64 artwork path preserved
- `src/api/backend.ts` — `reportUnitResults` callable
- `src/index.tsx` — listeners for `sync_plan`, `sync_apply_unit`, `sync_stale`, `sync_collections`
- `src/types/index.ts` — payload types
- `src/components/MainPage.tsx` — Skip Preview now dispatches `startSync()` directly (per-unit path); non-skip preview flow unchanged

### New events
| Event | Direction | Payload |
|---|---|---|
| `sync_plan` | py → js | `{units, total_units, total_roms}` |
| `sync_apply_unit` | py → js | `{unit_type, unit_id, unit_name, unit_index, total_units, shortcuts}` |
| `sync_stale` | py → js | `{remove_rom_ids}` |
| `sync_collections` | py → js | `{platform_app_ids, romm_collection_app_ids}` |
| `report_unit_results` | js → py RPC | `rom_id_to_app_id` → `{success, count}` |

### Out of scope (deferred, need hardware verification)
- **Artwork rename optimization (Option C)** — keeping the existing base64 path; the design doc itself flags this as needing hardware verification
- **50ms delay reduction** — keeping the existing cadence
- **Parallel unit processing** — sequential only, matches design doc
- **UX refinements for per-unit progress** — follow-up

### Tests
+24 tests, baseline 2237 → **2261**:
- Work queue (3) — empty, platforms-only, mixed/ordering
- Platform fetch (3) — full, incremental skip, count-mismatch fallback
- Collection fetch (2) — membership + dedup
- `_do_sync_per_unit` (6) — empty queue, sync_plan emit, in-order dispatch, artwork-skip on incremental, artwork download, cancel-between-units
- `_wait_for_unit_complete` (3) — success / cancel / heartbeat timeout
- `report_unit_results` (3) — registry update / event signal / state checkpoint
- `finalize_per_unit_run` (4) — platform-collection mapping / sync_complete / IDLE transition / last_sync persistence

## Test plan
- [ ] CI green (build, lint, test, sonar)
- [ ] Sonar: 0 new issues
- [ ] 2261 tests pass locally
- [ ] import-linter: 7 contracts kept
- [ ] **MANUAL: verify on Steam Deck via `mise run dev`** — confirm per-unit pipeline delivers shortcuts incrementally (platforms appear one at a time in Steam Library, not all at the end). Test cancel mid-unit and between units. Verify the legacy preview/apply path still works when Skip Preview is OFF.

## Risks/notes for hardware verification
- `_UNIT_HEARTBEAT_TIMEOUT_SEC = 60s` — JS-died fallback, not a "slow unit" timeout. JS emits `syncHeartbeat()` every 10s, so 60s shouldn't trip during healthy applies. Bump if it does.
- Cancel mid-unit drops `pending_sync` without recording app_ids; matches existing monolithic cancel risk (orphans cleaned up by startup-healing on next launch).
- Artwork still goes through base64 round-trip (Option B from design doc). Option C (rename-only) deferred until hardware confirms Steam auto-picks `{appId}p.png`.

Closes #371. Part of #369.