### PR TITLE
fix(python): align dev/CI Python to Decky's embedded 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install Python test dependencies
         run: pip install pytest pytest-asyncio pytest-cov
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install lint dependencies
         run: pip install import-linter ruff basedpyright

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 node = "lts"
 pnpm = "latest"
-python = "3.12"
+python = "3.11"  # match Decky Loader's embedded Python (libpython3.11)
 
 [env]
 _.python.venv = { path = ".venv", create = true }

--- a/py_modules/lib/late_binding.py
+++ b/py_modules/lib/late_binding.py
@@ -17,9 +17,12 @@ underlying object).
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
 
 
-class LateBinding[T]:
+class LateBinding(Generic[T]):
     """Typed forward-reference for service wiring."""
 
     __slots__ = ("_name", "_reader")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.basedpyright]
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 extraPaths = ["py_modules"]
 stubPath = "typings"
 typeCheckingMode = "basic"
@@ -11,7 +11,7 @@ reportUnusedParameter = "none"
 reportUnusedVariable = "warning"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 120
 extend-exclude = ["py_modules/vdf", "scripts"]
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=danielcopper
 # Sources
 sonar.sources=py_modules,src,main.py
 sonar.tests=tests
-sonar.python.version=3.12
+sonar.python.version=3.11
 
 # Coverage
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## Symptom
Decky Loader crashes with React error #130 in `UpdaterSettings` after deploying the latest plugin code:

```
File "/home/deck/homebrew/plugins/decky-romm-sync/py_modules/lib/late_binding.py", line 22
    class LateBinding[T]:
                     ^
SyntaxError: invalid syntax
```

Plugin import fails → Decky's plugin updater panel renders an `undefined` entry → React error #130.

## Cause
Decky Loader bundles **Python 3.11** (`libpython3.11.so.1.0` verified in `/home/deck/homebrew/services/PluginLoader`). Our dev environment and CI were pinned to **3.12**, which let PEP 695 generic syntax (`class Foo[T]:`) into `lib/late_binding.py` (introduced in #411). Locally and in CI it parsed; on the Deck it didn't.

I had assumed `mise` was keeping us on Decky's Python version. It wasn't — mise installs whatever we ask for; Decky bundles its own interpreter independently. The two were decoupled and we picked the wrong number.

## Fix — two parts
**Symptom:** rewrite `LateBinding` with the pre-3.12 `Generic[T]` + `TypeVar` form. Functionally identical, parses on 3.11.

**Gap:** lower the version floor everywhere so 3.12-only syntax fails locally and in CI before it reaches the Deck:
- `mise.toml`: `python = "3.11"`
- `.github/workflows/ci.yml`: `python-version: "3.11"` (test + lint jobs)
- `pyproject.toml`: ruff `target-version = "py311"`, basedpyright `pythonVersion = "3.11"`

## Test plan
Verified locally under `mise exec -- python` resolving to 3.11.15:
- [x] `python -m pytest tests/ -q` → **2261 passed**
- [x] `ruff check py_modules/ tests/ main.py` → clean
- [x] `basedpyright py_modules/ main.py` → 0 errors
- [x] `import-linter` → 7 contracts kept
- [x] `scripts/check_cosmic_call_bans.sh` → clean

CI to confirm:
- [ ] All checks green on 3.11 in CI
- [ ] After deploy on Steam Deck: plugin loads, Decky settings panel renders normally