### PR TITLE
refactor(romm): extract RommPlatformReader Protocol (#376)

### DIFF
--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -65,7 +65,12 @@ from services.protocols.persistence import (
     SettingsPersister,
     StatePersister,
 )
-from services.protocols.transport import RommApiProtocol, SteamConfigAdapter, SteamGridDbApi
+from services.protocols.transport import (
+    RommApiProtocol,
+    RommPlatformReader,
+    SteamConfigAdapter,
+    SteamGridDbApi,
+)
 
 __all__ = [
     "AchievementsReader",
@@ -95,6 +100,7 @@ __all__ = [
     "RetryStrategy",
     "RomFileAdapter",
     "RommApiProtocol",
+    "RommPlatformReader",
     "SaveFileAdapter",
     "SaveSyncStatePersister",
     "SettingsPersister",

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -24,6 +24,17 @@ class SteamConfigAdapter(Protocol):
     def fix_retroarch_input_driver(self) -> dict: ...
 
 
+class RommPlatformReader(Protocol):
+    """Read-only RomM platform listing surface."""
+
+    def list_platforms(self) -> list[dict]:
+        """Fetch all platforms configured on the RomM server.
+
+        Returns a list of platform dicts from /api/platforms.
+        """
+        ...
+
+
 class RommApiProtocol(Protocol):
     """Domain-oriented interface for all RomM server operations.
 

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from services.protocols import (
         ArtworkRemover,
         EventEmitter,
-        RommApiProtocol,
+        RommPlatformReader,
         StatePersister,
         SteamConfigAdapter,
     )
@@ -27,7 +27,7 @@ class ShortcutRemovalServiceConfig:
     ShortcutRemovalService needs at construction time.
     """
 
-    romm_api: RommApiProtocol
+    romm_api: RommPlatformReader
     steam_config: SteamConfigAdapter
     state: dict
     loop: asyncio.AbstractEventLoop


### PR DESCRIPTION
## Summary

First of 7 PRs in Phase 5 (RommApi ISP Split, #375). Splits the 31-method `RommApiProtocol` god-interface into 6 cohesive sub-Protocols. This PR ships #1 of 6:

- **New**: `RommPlatformReader` Protocol — single method (`list_platforms`), lives next to `RommApiProtocol` in `services/protocols/transport.py`.
- **Narrowed**: `ShortcutRemovalService` — typed against `RommPlatformReader` instead of `RommApiProtocol`. It's the only consumer that uses `list_platforms` exclusively today.

`RommApiAdapter` is unchanged: it already implements `list_platforms` with the matching signature, so structural subtyping covers it.

## Deferred narrowings

The issue's "Done When" mentions `ConnectionService` accepting `RommPlatformReader`. Holding that for a later PR — ConnectionService also calls `heartbeat`/`set_version`/`get_version`, which are `RommVersion`-bucket and not yet extracted. Same for `LibraryService.fetcher` (needs `RommRomReader`, lands in #380). They'll narrow as later Phase 5 splits land.

This is the validate-the-playbook PR for the remaining 5 splits — minimal blast radius (3 files, +20/-3), no behavior change, structural-subtyping-only.

## Test plan

- [x] `pytest tests/ -q` — 2261 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors, 0 warnings
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `shortcut_removal.py` coverage 99% line / branch (above 80% Sonar gate)
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #376. Part of #375.