### PR TITLE
refactor(romm): extract RommPlaytimeApi Protocol (#377)

### DIFF
--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -1,6 +1,6 @@
 """PlaytimeService — playtime tracking via RomM Notes API.
 
-All RomM communication goes through ``RommApiProtocol``.
+All RomM communication goes through ``RommPlaytimeApi``.
 No ``import decky``.
 """
 
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.iso_time import parse_iso
-from services.protocols import Clock, DebugLogger, RetryStrategy, RommApiProtocol, StatePersister
+from services.protocols import Clock, DebugLogger, RetryStrategy, RommPlaytimeApi, StatePersister
 
 if TYPE_CHECKING:
     import asyncio
@@ -30,7 +30,7 @@ class PlaytimeServiceConfig:
     construction time.
     """
 
-    romm_api: RommApiProtocol
+    romm_api: RommPlaytimeApi
     retry: RetryStrategy
     save_sync_state: SaveSyncState
     loop: asyncio.AbstractEventLoop

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -68,6 +68,7 @@ from services.protocols.persistence import (
 from services.protocols.transport import (
     RommApiProtocol,
     RommPlatformReader,
+    RommPlaytimeApi,
     SteamConfigAdapter,
     SteamGridDbApi,
 )
@@ -101,6 +102,7 @@ __all__ = [
     "RomFileAdapter",
     "RommApiProtocol",
     "RommPlatformReader",
+    "RommPlaytimeApi",
     "SaveFileAdapter",
     "SaveSyncStatePersister",
     "SettingsPersister",

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -35,6 +35,31 @@ class RommPlatformReader(Protocol):
         ...
 
 
+class RommPlaytimeApi(Protocol):
+    """RomM Notes API surface for playtime tracking."""
+
+    def get_rom_with_notes(self, rom_id: int) -> dict:
+        """Fetch full ROM detail including user notes.
+
+        Used for playtime tracking. Notes are in the all_user_notes field.
+        """
+        ...
+
+    def create_note(self, rom_id: int, data: dict) -> dict:
+        """Create a note on a ROM.
+
+        Used for playtime tracking. POST /api/roms/{rom_id}/notes.
+        """
+        ...
+
+    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+        """Update an existing note on a ROM.
+
+        PUT /api/roms/{rom_id}/notes/{note_id}.
+        """
+        ...
+
+
 class RommApiProtocol(Protocol):
     """Domain-oriented interface for all RomM server operations.
 


### PR DESCRIPTION
## Summary

Second of 7 PRs in Phase 5 (RommApi ISP, #375). Same sister pattern as #437.

- **New**: `RommPlaytimeApi` Protocol covering `get_rom_with_notes`, `create_note`, `update_note`.
- **Narrowed**: `PlaytimeService` is the only consumer of those methods; typed against `RommPlaytimeApi`.
- `RommApiAdapter` unchanged — already implements all three with matching signatures.

3 files, +30/-3.

## Test plan

- [x] `pytest tests/services/test_playtime.py -q` — 21/21 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `playtime.py` coverage 93%
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #377. Part of #375.