### PR TITLE
refactor(romm): extract RommFirmwareApi Protocol (#378)

### DIFF
--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         FirmwareCachePersister,
         FirmwareFileAdapter,
         RetroDeckPaths,
-        RommApiProtocol,
+        RommFirmwareApi,
         StatePersister,
     )
 
@@ -43,7 +43,7 @@ class FirmwareServiceConfig:
     limit.
     """
 
-    romm_api: RommApiProtocol
+    romm_api: RommFirmwareApi
     state: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -67,6 +67,7 @@ from services.protocols.persistence import (
 )
 from services.protocols.transport import (
     RommApiProtocol,
+    RommFirmwareApi,
     RommPlatformReader,
     RommPlaytimeApi,
     SteamConfigAdapter,
@@ -101,6 +102,7 @@ __all__ = [
     "RetryStrategy",
     "RomFileAdapter",
     "RommApiProtocol",
+    "RommFirmwareApi",
     "RommPlatformReader",
     "RommPlaytimeApi",
     "SaveFileAdapter",

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -60,6 +60,31 @@ class RommPlaytimeApi(Protocol):
         ...
 
 
+class RommFirmwareApi(Protocol):
+    """RomM firmware/BIOS API surface."""
+
+    def list_firmware(self) -> list[dict]:
+        """Fetch all available firmware/BIOS files from the server.
+
+        Returns a list of firmware dicts from /api/firmware.
+        """
+        ...
+
+    def get_firmware(self, firmware_id: int) -> dict:
+        """Fetch metadata for a single firmware file.
+
+        Returns firmware dict from /api/firmware/{firmware_id}.
+        """
+        ...
+
+    def download_firmware(self, firmware_id: int, filename: str, dest: str) -> None:
+        """Download a firmware/BIOS file to a local path.
+
+        Streams /api/firmware/{firmware_id}/content/{filename} to dest.
+        """
+        ...
+
+
 class RommApiProtocol(Protocol):
     """Domain-oriented interface for all RomM server operations.
 


### PR DESCRIPTION
## Summary

Third of 7 PRs in Phase 5 (RommApi ISP, #375). Same sister pattern as #437 and #438.

- **New**: `RommFirmwareApi` Protocol covering `list_firmware`, `get_firmware`, `download_firmware`.
- **Narrowed**: `FirmwareService` is the only consumer of those methods; typed against `RommFirmwareApi`.
- `RommApiAdapter` unchanged — structural subtyping covers it.

3 files, +29/-2.

## Test plan

- [x] `pytest tests/services/test_firmware.py -q` — 71/71 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `firmware.py` coverage 93%
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #378. Part of #375.