### PR TITLE
refactor(romm): extract RommDeviceApi + RommVersion Protocols (#379)

### DIFF
--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -67,9 +67,11 @@ from services.protocols.persistence import (
 )
 from services.protocols.transport import (
     RommApiProtocol,
+    RommDeviceApi,
     RommFirmwareApi,
     RommPlatformReader,
     RommPlaytimeApi,
+    RommVersion,
     SteamConfigAdapter,
     SteamGridDbApi,
 )
@@ -102,9 +104,11 @@ __all__ = [
     "RetryStrategy",
     "RomFileAdapter",
     "RommApiProtocol",
+    "RommDeviceApi",
     "RommFirmwareApi",
     "RommPlatformReader",
     "RommPlaytimeApi",
+    "RommVersion",
     "SaveFileAdapter",
     "SaveSyncStatePersister",
     "SettingsPersister",

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -85,6 +85,65 @@ class RommFirmwareApi(Protocol):
         ...
 
 
+class RommDeviceApi(Protocol):
+    """RomM device registration / sync API surface."""
+
+    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
+        """Register this client as a sync device on the RomM server.
+
+        Returns device dict with id, name, created_at.
+        """
+        ...
+
+    def list_devices(self) -> list[dict]:
+        """List all devices registered with the RomM server for the current user.
+
+        Returns a list of device dicts from /api/devices.
+        """
+        ...
+
+    def update_device(self, device_id: str, **fields) -> dict:
+        """Update a registered device's metadata on the RomM server.
+
+        Currently the plugin only sends ``client_version`` via the reconciliation
+        loop; the server accepts additional fields per its OpenAPI schema (name,
+        platform, client, ip_address, mac_address, hostname, sync_enabled) but
+        they are not exercised by this plugin.
+        """
+        ...
+
+
+class RommVersion(Protocol):
+    """RomM server identity & health-check surface."""
+
+    def set_version(self, version: str | None) -> None:
+        """Store the detected RomM server version string.
+
+        Passing ``None`` clears the cached version (used when the server
+        becomes unreachable and the cached version should no longer be
+        trusted).
+        """
+        ...
+
+    def get_version(self) -> str | None:
+        """Return the detected RomM server version string, or ``None`` if unset."""
+        ...
+
+    def heartbeat(self) -> dict:
+        """Check server connectivity and retrieve version info.
+
+        Returns the raw heartbeat response dict from /api/heartbeat.
+        """
+        ...
+
+    def get_current_user(self) -> dict:
+        """Fetch the currently authenticated user profile.
+
+        Returns user dict from /api/users/me.
+        """
+        ...
+
+
 class RommApiProtocol(Protocol):
     """Domain-oriented interface for all RomM server operations.
 


### PR DESCRIPTION
## Summary

Fourth of 7 PRs in Phase 5 (RommApi ISP, #375). Introduces TWO Protocols at once per the issue's grouping:

- **New**: `RommDeviceApi` — `register_device`, `list_devices`, `update_device`
- **New**: `RommVersion` — `set_version`, `get_version`, `heartbeat`, `get_current_user`

**No consumer narrowing in this PR — intentional.** Every consumer that touches these methods today also touches methods not yet extracted into sub-Protocols (`RommRomReader` lands in #380, `RommSaveApi` in #381). To keep the sister-PR diff small and uniform, all multi-Protocol consumer narrowing (Connection, Achievements, Library, Saves — each needing intersection typing across 2+ sub-Protocols) is consolidated into the cleanup PR #382.

`RommApiAdapter` unchanged — structural subtyping covers all 7 methods.

2 files, +63/-0.

## Test plan

- [x] `pytest tests/ -q` — 2261/2261 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [ ] CI green
- [ ] SonarCloud 0 new issues (may flag the new Protocols as unused until #380/#381/#382; expected)

Closes #379. Part of #375.