### PR TITLE
fix(saves): use server-canonical filename for both conflict-resolution paths (#385)

### DIFF
--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -1070,16 +1070,20 @@ class SyncEngine:
                     )
                     return {"success": True, "action": "use_server"}
 
-                # keep_local
+                # keep_local — resolve on-disk name via the same canonical
+                # ``<rom_name>.<server.file_extension>`` rule use_server uses.
+                # The frontend-supplied ``filename`` is kept for logging only;
+                # using it as the on-disk path would let an extension drift
+                # between the two resolution paths produce divergent states.
                 await self._loop.run_in_executor(
                     None,
                     self._resolve_conflict_keep_local,
                     rom_id,
                     rom_id_str,
-                    filename,
                     server,
                     saves_dir,
                     system,
+                    info["rom_name"],
                 )
                 self._logger.info(
                     "resolve_sync_conflict(rom_id=%d, filename=%s, action=%s) -> success",
@@ -1115,15 +1119,26 @@ class SyncEngine:
         self,
         rom_id: int,
         rom_id_str: str,
-        filename: str,
         server: dict,
         saves_dir: str,
         system: str,
+        rom_name: str,
     ) -> None:
         """Push the local file to *server* (PUT). Adopt-without-upload when the
         local content already matches the server's content hash.
+
+        The on-disk name is resolved from the server save's ``file_extension``
+        via :func:`_local_save_target` — the same canonical
+        ``<rom_name>.<server.file_extension>`` rule ``_resolve_conflict_use_server``
+        and every other download path uses. This keeps the two resolve paths
+        symmetric: the state key and on-disk path are identical regardless of
+        which side the user picked. If the local file is not at the canonical
+        path (e.g. ``Mario.sav`` locally but the server save has
+        ``file_extension=srm``), :class:`FileNotFoundError` is raised — we
+        never silently rename across extensions.
         """
-        local_path = os.path.join(saves_dir, filename)
+        target = _local_save_target(server, rom_name)
+        local_path = os.path.join(saves_dir, target)
         if not self._save_file.is_file(local_path):
             raise FileNotFoundError(f"Local save not found: {local_path}")
         local_hash = self._save_file.checksum_md5(local_path)
@@ -1135,10 +1150,10 @@ class SyncEngine:
         if server_hash and local_hash == server_hash:
             # Hashes match — adopt server's id without re-uploading.
             self._log_debug(
-                f"keep_local: hash matches server, adopting without upload (rom={rom_id} filename={filename})"
+                f"keep_local: hash matches server, adopting without upload (rom={rom_id} filename={target})"
             )
             rom_state = self._state_svc.ensure_rom_state(rom_id_str)
-            file_state = rom_state.files.setdefault(filename, FileSyncState())
+            file_state = rom_state.files.setdefault(target, FileSyncState())
             file_state.tracked_save_id = server.get("id")
             file_state.last_sync_hash = local_hash
             file_state.last_sync_at = self._clock.now().isoformat()
@@ -1150,5 +1165,5 @@ class SyncEngine:
             return
 
         # Upload local content as a PUT against the existing server save.
-        self._do_upload_save(rom_id, local_path, filename, rom_id_str, system, server)
+        self._do_upload_save(rom_id, local_path, target, rom_id_str, system, server)
         self._state_svc.save_state()

--- a/tests/services/saves/test_sync_engine.py
+++ b/tests/services/saves/test_sync_engine.py
@@ -1833,3 +1833,128 @@ class TestResolveSyncConflict:
 
         assert result["success"] is False
         assert "no server save" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_resolve_filename_symmetry_keep_local_uses_canonical_target(self, tmp_path):
+        """keep_local and use_server must resolve the on-disk path the same way.
+
+        Both branches must derive ``<rom_name>.<server.file_extension>`` from
+        the server save, ignoring the frontend-supplied ``filename`` for I/O.
+        Otherwise an extension drift between the frontend label and the
+        canonical name produces divergent disk and state outcomes for the
+        same conflict.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        # Canonical local save: pokemon.srm (matches server.file_extension).
+        canonical_path = _create_save(tmp_path, content=b"local-progress")
+        canonical_hash = _file_md5(str(canonical_path))
+
+        # Server save advertises file_extension=srm; frontend will send a
+        # mismatched filename (pokemon.sav). Server hash differs so the
+        # adopt-without-upload short-circuit doesn't fire.
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        ss["file_extension"] = "srm"
+        other = tmp_path / "server-bytes.bin"
+        other.write_bytes(b"server-flavor")
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(other)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.sav",  # diverges from server canonical
+            action="keep_local",
+        )
+
+        assert result["success"] is True
+        # Canonical local file remained — no rename, no orphan at the
+        # frontend-supplied name.
+        assert canonical_path.read_bytes() == b"local-progress"
+        assert not (tmp_path / "saves" / "gba" / "pokemon.sav").exists()
+        # Upload PUT used the canonical filename, not the user-supplied one.
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        upload_path = upload_calls[0][1][1]
+        assert os.path.basename(upload_path) == "pokemon.srm"
+        # State keyed by canonical filename — never by the frontend label.
+        files_state = svc._save_sync_state.saves["42"].files
+        assert "pokemon.srm" in files_state
+        assert "pokemon.sav" not in files_state
+        assert files_state["pokemon.srm"].last_sync_hash == canonical_hash
+
+    @pytest.mark.asyncio
+    async def test_resolve_filename_symmetry_use_server_keys_state_on_canonical(self, tmp_path):
+        """use_server with a mismatched frontend filename still writes at the canonical path.
+
+        Pairs with ``test_resolve_filename_symmetry_keep_local_uses_canonical_target``
+        to assert both branches converge on the same end state regardless of
+        the frontend label.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"local-stale")
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        ss["file_extension"] = "srm"
+        server_bytes = tmp_path / "server-content.bin"
+        server_bytes.write_bytes(b"server-truth")
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(server_bytes)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.sav",  # frontend label diverges from canonical
+            action="use_server",
+        )
+
+        assert result["success"] is True
+        # Download landed at the canonical path, not the frontend label.
+        canonical_path = tmp_path / "saves" / "gba" / "pokemon.srm"
+        assert canonical_path.read_bytes() == b"server-truth"
+        assert not (tmp_path / "saves" / "gba" / "pokemon.sav").exists()
+        files_state = svc._save_sync_state.saves["42"].files
+        assert "pokemon.srm" in files_state
+        assert "pokemon.sav" not in files_state
+        assert files_state["pokemon.srm"].tracked_save_id == 100
+
+    @pytest.mark.asyncio
+    async def test_resolve_keep_local_raises_when_canonical_path_missing(self, tmp_path):
+        """If the local file is not at the canonical path, keep_local raises.
+
+        Defensive companion to the symmetry fix: we never silently rename
+        across extensions to satisfy a frontend label. A file named
+        ``pokemon.sav`` on disk while the server save's canonical target is
+        ``pokemon.srm`` must surface as ``FileNotFoundError`` so the user
+        can rectify the mismatch instead of having two divergent files
+        appear from a successful-looking resolve.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        # Local file only at the non-canonical path.
+        saves_dir = tmp_path / "saves" / "gba"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        (saves_dir / "pokemon.sav").write_bytes(b"local-noncanonical")
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        ss["file_extension"] = "srm"
+        fake.saves[100] = ss
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.sav",
+            action="keep_local",
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["message"].lower()
+        # No upload was attempted.
+        assert not any(c[0] == "upload_save" for c in fake.call_log)


### PR DESCRIPTION
## Summary

First of three PRs in Phase 6 (Save-Sync Integrity, #383). Closes #385.

`_resolve_conflict_use_server` always derived the local target via `_local_save_target(server, rom_name)` (server-canonical: `<rom_name>.<server.file_extension>`). `_resolve_conflict_keep_local` used the frontend-supplied `filename` directly. Same conflict → different on-disk + state-key outcomes depending on which button the user clicked.

Fix: keep_local now uses the same canonical derivation. Frontend `filename` is retained for log correlation only and no longer reaches any I/O path. Missing canonical local file raises `FileNotFoundError` rather than silently renaming.

The sync decision algorithm (`compute_sync_plan` / `SyncDecision` / Decision Matrix in `Save-File-Sync-Architecture.md`) is unchanged.

2 files, +147/-7.

## Test plan

- [x] 3 new regression tests in `tests/services/saves/test_sync_engine.py::TestResolveSyncConflict` (no mocking of `_local_save_target` — symmetry is asserted end-to-end on disk + state)
- [x] `pytest tests/services/saves -q` — 270/270 passed
- [x] `pytest tests/ -q` — 2264/2264 passed (matrix tests untouched, all green)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `services.saves` coverage 94% line / 92% branch
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #385. Part of #383.