### PR TITLE
fix(saves): persist file sync state on every upload path (#409)

### DIFF
--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -221,7 +221,12 @@ class SyncEngine:
         return "default"
 
     def _promote_local_slot_to_server(self, rom_id_str: str, slot: str) -> None:
-        """Mark *slot* as having a server copy after a successful upload of a local-only slot."""
+        """Mark *slot* as having a server copy after a successful upload of a local-only slot.
+
+        Pure in-memory mutation. The caller (:meth:`_do_upload_save`) owns the
+        single persistence point so every upload outcome lands on disk exactly
+        once, regardless of which branch of this method (promote / no-op) fired.
+        """
         rom_state = self._state_svc.state.saves.get(rom_id_str)
         if not rom_state:
             return
@@ -229,7 +234,6 @@ class SyncEngine:
         if slot_entry and slot_entry.get("source") == "local":
             slot_entry["source"] = "server"
             slot_entry["count"] = 1
-            self._state_svc.save_state()
 
     def _confirm_upload_sync(self, upload_id: int | None, device_id: str | None) -> None:
         """Ack the uploaded save on the server's DeviceSaveSync row (non-fatal)."""
@@ -281,6 +285,11 @@ class SyncEngine:
         if slot:
             self._promote_local_slot_to_server(rom_id_str, slot)
 
+        # Single persistence point for every upload outcome — covers the
+        # file-level sync state written by ``_update_file_sync_state`` plus the
+        # in-memory mutations from ``_record_own_upload`` / ``_promote_local_slot_to_server``.
+        self._state_svc.save_state()
+
         self._confirm_upload_sync(result.get("id"), device_id)
 
         self._log_debug(f"Uploaded save: {filename} for rom {rom_id_str} (emulator={emulator})")
@@ -292,6 +301,10 @@ class SyncEngine:
         POST = brand-new save; PUT updates an existing tracked save without
         changing ownership. Assumes POST is not upsert-by-filename on the
         server — if RomM ever changes that, revisit this tracker.
+
+        Pure in-memory mutation. The caller (:meth:`_do_upload_save`) owns the
+        single persistence point so every upload outcome lands on disk exactly
+        once, regardless of POST vs PUT.
         """
         if new_id is None:
             return
@@ -301,7 +314,6 @@ class SyncEngine:
         if new_id in rom_state.own_upload_ids:
             return
         rom_state.own_upload_ids.append(new_id)
-        self._state_svc.save_state()
 
     def _handle_unexpected_error(
         self,

--- a/tests/services/saves/test_sync_engine.py
+++ b/tests/services/saves/test_sync_engine.py
@@ -1374,6 +1374,61 @@ class TestPromoteLocalSlotPersistsState:
         assert reloaded["count"] == 1
 
 
+class TestDoUploadSaveFileStatePersistence:
+    """Regression for #409.
+
+    The PUT branch with a slot already marked ``source='server'`` is a no-op
+    for slot promotion. Without an unconditional persist at the end of
+    ``_do_upload_save``, the per-file ``last_sync_hash`` / ``tracked_save_id``
+    written by ``_update_file_sync_state`` never reaches disk on that path —
+    so after a plugin restart the next sync re-detects drift and re-uploads
+    the same content. This test asserts the upload outcome is persisted
+    regardless of which slot-promotion branch fired.
+    """
+
+    def test_put_path_persists_file_sync_state_when_slot_already_server(self, tmp_path):
+        """PUT with slot.source='server' (no promotion) still persists file sync state."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc, device_id="dev-1")
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"freshly-edited save")
+        expected_hash = _file_md5(str(save_path))
+
+        # Pre-existing tracked server save → upload_save called with save_id=100 (PUT path).
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default")
+        server_save = fake.saves[100]
+
+        # Slot already known-server: _promote_local_slot_to_server is a no-op
+        # on this branch, so the file-state writes have no incidental persist
+        # to ride on. File state holds a stale baseline hash to make the
+        # regression visible — after the upload, the on-disk hash must be the
+        # current local hash (not the stale one).
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "stale-pre-upload"}},
+                "system": "gba",
+                "active_slot": "default",
+                "slots": {"default": {"source": "server", "count": 1}},
+            }
+        )
+
+        svc._sync_engine._do_upload_save(42, str(save_path), "pokemon.srm", "42", "gba", server_save=server_save)
+
+        # In-memory state captured the fresh hash.
+        in_mem_file = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert in_mem_file.last_sync_hash == expected_hash
+        assert in_mem_file.tracked_save_id == 100
+
+        # A fresh service reading from the same on-disk state must see the
+        # fresh hash — without it, the next sync re-detects drift and uploads
+        # the same content again (#409 leak).
+        reloaded_svc, _ = make_service(tmp_path)
+        reloaded_svc.load_state()
+        reloaded_file = reloaded_svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert reloaded_file.last_sync_hash == expected_hash
+        assert reloaded_file.tracked_save_id == 100
+
+
 class TestSyncRomSavesDispatch:
     def test_sync_rom_saves_skip_when_synced(self, tmp_path):
         """is_current=true + matching hash + tracked → Skip, no I/O."""


### PR DESCRIPTION
## Summary

Second of three PRs in Phase 6 (Save-Sync Integrity, #383). Closes #409.

`_do_upload_save`'s `_update_file_sync_state` writes (hash, sync time, tracked save id) only reached disk on two branches: POST via `_record_own_upload`, or a PUT that promoted a `local` slot via `_promote_local_slot_to_server`. PUT against an already-`source="server"` slot persisted nothing — next restart saw the stale hash and re-uploaded identical content.

Fix: end `_do_upload_save` with a single explicit `save_state()`. The two helpers lose their inner persistence (both have only this one caller — contract change is local).

The sync decision algorithm and Decision Matrix (`Save-File-Sync-Architecture.md`) are unchanged.

2 files, +70/-3.

## Test plan

- [x] New regression test `TestDoUploadSaveFileStatePersistence::test_put_path_persists_file_sync_state_when_slot_already_server` — PUT path with pre-`server` slot; asserts hash + tracked id survive `load_state()` round-trip
- [x] `pytest tests/services/saves -q` — 271/271 passed
- [x] `pytest tests/ -q` — 2265/2265 passed (matrix tests untouched, all green)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `services.saves` coverage 94% line / 92% branch (`engine.py` 91%)
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #409. Part of #383.