### PR TITLE
fix(saves): round-trip server_save_id through resolve_sync_conflict to close TOCTOU (#384)

### DIFF
--- a/main.py
+++ b/main.py
@@ -452,8 +452,8 @@ class Plugin:
         return await self._save_sync_service.sync_all_saves()
 
     @migration_blocked
-    async def resolve_sync_conflict(self, rom_id, filename, action):
-        return await self._save_sync_service.resolve_sync_conflict(rom_id, filename, action)
+    async def resolve_sync_conflict(self, rom_id, filename, server_save_id, action):
+        return await self._save_sync_service.resolve_sync_conflict(rom_id, filename, server_save_id, action)
 
     async def get_save_sync_settings(self):
         return self._save_sync_service.get_save_sync_settings()

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -189,10 +189,11 @@ class SaveService:
         self,
         rom_id: int,
         filename: str,
+        server_save_id: int,
         action: str,
     ) -> dict:
         """Resolve a pending sync conflict (true two-sided divergence)."""
-        return await self._sync_engine.resolve_sync_conflict(rom_id, filename, action)
+        return await self._sync_engine.resolve_sync_conflict(rom_id, filename, server_save_id, action)
 
     # ------------------------------------------------------------------
     # Slots (delegated to SlotsService)

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -995,6 +995,7 @@ class SyncEngine:
         self,
         rom_id: int,
         filename: str,
+        server_save_id: int,
         action: str,
     ) -> dict:
         """Resolve a pending sync conflict (true two-sided divergence).
@@ -1002,6 +1003,13 @@ class SyncEngine:
         Reached when ``compute_sync_action`` returned ``Conflict`` — the
         server moved AND local diverged from baseline, so the user picked a
         side via the conflict UI.
+
+        ``server_save_id`` is the id of the server save that was surfaced to
+        the user in the conflict modal. The backend round-trips it: if a
+        third device has uploaded a newer save into the slot since the modal
+        opened, the picked server head won't match and we return
+        ``error_code="stale_conflict"`` instead of silently overwriting the
+        third device's work.
 
         ``action`` is one of:
 
@@ -1062,6 +1070,21 @@ class SyncEngine:
             if not server_in_slot:
                 return {"success": False, "message": "No server save in active slot"}
             server = max(server_in_slot, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
+
+            actual_server_id = server.get("id")
+            if actual_server_id != server_save_id:
+                self._logger.warning(
+                    "resolve_sync_conflict(rom_id=%d, action=%s) stale: client server_save_id=%s, head=%s",
+                    rom_id,
+                    action,
+                    server_save_id,
+                    actual_server_id,
+                )
+                return {
+                    "success": False,
+                    "error_code": "stale_conflict",
+                    "message": "Server save changed since conflict was shown; please retry sync.",
+                }
 
             try:
                 if action == "use_server":

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -151,7 +151,10 @@ export const preLaunchSync = callable<[number], { success: boolean; message: str
 export const postExitSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[]; offline?: boolean }>("post_exit_sync");
 export const syncRomSaves = callable<[number], { success: boolean; message: string; synced: number; errors?: string[] }>("sync_rom_saves");
 export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>("sync_all_saves");
-export const resolveSyncConflict = callable<[number, string, "keep_local" | "use_server"], { success: boolean; message?: string; action?: "keep_local" | "use_server" }>("resolve_sync_conflict");
+export const resolveSyncConflict = callable<
+  [number, string, number, "keep_local" | "use_server"],
+  { success: boolean; message?: string; error_code?: string; action?: "keep_local" | "use_server" }
+>("resolve_sync_conflict");
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const recordSessionEnd = callable<[number], { success: boolean; duration_sec?: number; total_seconds?: number; session_count?: number; message?: string }>("record_session_end");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");

--- a/src/components/SyncConflictModal.tsx
+++ b/src/components/SyncConflictModal.tsx
@@ -165,8 +165,23 @@ const SyncConflictModalHost: FC<SyncConflictModalHostProps> = ({ conflict, close
     setIsLoading(true);
     setErrorMessage(null);
     try {
-      const result = await resolveSyncConflict(conflict.rom_id, conflict.filename, action);
+      const result = await resolveSyncConflict(
+        conflict.rom_id,
+        conflict.filename,
+        conflict.server_save_id,
+        action,
+      );
       if (!result.success) {
+        if (result.error_code === "stale_conflict") {
+          const staleMsg =
+            "The server save has been updated by another device. Please cancel and retry sync to get the latest version.";
+          logError(
+            `resolveSyncConflict(${conflict.rom_id}, ${conflict.filename}, ${action}) stale: ${result.message ?? ""}`,
+          );
+          setErrorMessage(staleMsg);
+          setIsLoading(false);
+          return;
+        }
         const msg = result.message ?? "Failed to resolve conflict";
         logError(`resolveSyncConflict(${conflict.rom_id}, ${conflict.filename}, ${action}) failed: ${msg}`);
         setErrorMessage(msg);

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -889,6 +889,7 @@ class TestPathTraversalDefense:
             result = await svc.resolve_sync_conflict(
                 rom_id=42,
                 filename="../../etc/passwd",
+                server_save_id=100,
                 action="keep_local",
             )
 
@@ -913,6 +914,7 @@ class TestPathTraversalDefense:
         result = await svc.resolve_sync_conflict(
             rom_id=42,
             filename="pokemon\x00.srm",
+            server_save_id=100,
             action="keep_local",
         )
 

--- a/tests/services/saves/test_sync_engine.py
+++ b/tests/services/saves/test_sync_engine.py
@@ -1763,7 +1763,12 @@ class TestResolveSyncConflict:
         fake.saves[100] = ss
         fake.uploaded_files[100] = str(save_path)
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="keep_local")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
 
         assert result["success"] is True
         assert result["action"] == "keep_local"
@@ -1791,7 +1796,12 @@ class TestResolveSyncConflict:
         fake.saves[100] = ss
         fake.uploaded_files[100] = str(other)
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="keep_local")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
 
         assert result["success"] is True
         upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
@@ -1819,7 +1829,12 @@ class TestResolveSyncConflict:
         fake.saves[100] = ss
         fake.uploaded_files[100] = str(server_content)
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="use_server")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="use_server",
+        )
 
         assert result["success"] is True
         # Local file overwritten with server content
@@ -1834,7 +1849,12 @@ class TestResolveSyncConflict:
         _enable_sync_with_device(svc)
         _install_rom(svc, tmp_path)
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="foo")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="foo",
+        )
 
         assert result["success"] is False
         assert "invalid" in result["message"].lower()
@@ -1844,7 +1864,12 @@ class TestResolveSyncConflict:
         svc, _ = make_service(tmp_path)
         _enable_sync_with_device(svc)
 
-        result = await svc.resolve_sync_conflict(rom_id=999, filename="pokemon.srm", action="keep_local")
+        result = await svc.resolve_sync_conflict(
+            rom_id=999,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
 
         assert result["success"] is False
         assert result["message"]
@@ -1865,7 +1890,12 @@ class TestResolveSyncConflict:
 
         fake.fail_on_next(RommApiError("network"))
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="keep_local")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
 
         assert result["success"] is False
         assert "Failed to fetch saves" in result["message"]
@@ -1884,7 +1914,12 @@ class TestResolveSyncConflict:
         _enable_sync_with_device(svc)
         _install_rom(svc, tmp_path)
 
-        result = await svc.resolve_sync_conflict(rom_id=42, filename="pokemon.srm", action="keep_local")
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
 
         assert result["success"] is False
         assert "no server save" in result["message"].lower()
@@ -1921,6 +1956,7 @@ class TestResolveSyncConflict:
         result = await svc.resolve_sync_conflict(
             rom_id=42,
             filename="pokemon.sav",  # diverges from server canonical
+            server_save_id=100,
             action="keep_local",
         )
 
@@ -1965,6 +2001,7 @@ class TestResolveSyncConflict:
         result = await svc.resolve_sync_conflict(
             rom_id=42,
             filename="pokemon.sav",  # frontend label diverges from canonical
+            server_save_id=100,
             action="use_server",
         )
 
@@ -2006,6 +2043,7 @@ class TestResolveSyncConflict:
         result = await svc.resolve_sync_conflict(
             rom_id=42,
             filename="pokemon.sav",
+            server_save_id=100,
             action="keep_local",
         )
 
@@ -2013,3 +2051,115 @@ class TestResolveSyncConflict:
         assert "not found" in result["message"].lower()
         # No upload was attempted.
         assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+
+class TestResolveSyncConflictStaleConflict:
+    """Round-trip validation of ``server_save_id`` guards against a third-device
+    race: another device PUTs into the slot while the conflict modal is open,
+    and the client's stale id should not be silently rewritten."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_keep_local_rejects_when_server_head_advanced(self, tmp_path):
+        """Client passes server_save_id=100; server head is id=200 → stale_conflict.
+
+        Asserts the dangerous PUT never fires and state stays untouched.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"local-edited")
+
+        # The id=100 save the modal was opened against is no longer the head:
+        # a third device uploaded id=200 with a newer updated_at into the slot.
+        newer_server = _server_save_with_syncs(
+            save_id=200,
+            updated_at="2026-01-02T00:00:00Z",
+            device_syncs=[{"device_id": "device-2", "is_current": True}],
+        )
+        fake.saves[200] = newer_server
+
+        # Snapshot state so the no-mutation assertion is exact.
+        state_before = svc._save_sync_state.to_dict()
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
+
+        assert result["success"] is False
+        assert result["error_code"] == "stale_conflict"
+        assert result["message"]
+        # No PUT/POST fired against the head save — the whole point of the guard.
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        # State unchanged.
+        assert svc._save_sync_state.to_dict() == state_before
+
+    @pytest.mark.asyncio
+    async def test_resolve_use_server_rejects_when_server_head_advanced(self, tmp_path):
+        """use_server with a stale server_save_id is also rejected — the user
+        chose to download id=100, not id=200; surfacing id=200 silently would
+        also be a silent overwrite of the user's intent."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local-stale")
+
+        newer_server = _server_save_with_syncs(
+            save_id=200,
+            updated_at="2026-01-02T00:00:00Z",
+            device_syncs=[{"device_id": "device-2", "is_current": True}],
+        )
+        # Make the server's "newer" save downloadable so we can prove the
+        # download never fired.
+        server_bytes = tmp_path / "third-device-bytes.bin"
+        server_bytes.write_bytes(b"third-device-content")
+        fake.saves[200] = newer_server
+        fake.uploaded_files[200] = str(server_bytes)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="use_server",
+        )
+
+        assert result["success"] is False
+        assert result["error_code"] == "stale_conflict"
+        # Local file untouched — no silent download of the wrong server save.
+        assert save_path.read_bytes() == b"local-stale"
+
+    @pytest.mark.asyncio
+    async def test_resolve_succeeds_when_server_head_matches(self, tmp_path):
+        """Same flow but id=100 is still the head — resolution proceeds normally."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local-edited")
+        local_hash = _file_md5(str(save_path))
+
+        ss = _server_save_with_syncs(
+            save_id=100,
+            updated_at="2026-01-01T00:00:00Z",
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        other = tmp_path / "server-bytes.bin"
+        other.write_bytes(b"server-flavor")
+        fake.saves[100] = ss
+        fake.uploaded_files[100] = str(other)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "keep_local"
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["save_id"] == 100
+        file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
+        assert file_state.last_sync_hash == local_hash


### PR DESCRIPTION
## Summary

Third and final PR in Phase 6 (Save-Sync Integrity, #383). Closes #384.

Previous `resolve_sync_conflict` re-resolved with `max(server_in_slot)` on the user's click — if a third device uploaded a newer save in between, the re-resolve picked the third device's save and `keep_local` PUT user's local content over it. Silent data loss.

Fix: client now passes back the `server_save_id` it was shown. The engine compares against the freshly-picked head's id after `max(...)` resolves; mismatch → `{success: False, error_code: "stale_conflict", message: ...}` and dispatch is skipped. The frontend renders the message in-modal; user cancels and the next sync surfaces the fresh conflict.

### UX deviation from the issue text

The issue mentions "Frontend handles stale_conflict (re-fetch + show fresh modal)". This PR implements the simpler **cancel-and-retry** flow:
- Modal stays mounted on stale_conflict with an informative error
- User clicks Cancel
- Next sync re-evaluates the matrix; if still a conflict, the descriptor builder produces a fresh `SyncConflict` with the new `server_save_id` and the modal re-opens automatically

This achieves the safety goal (silent overwrite is prevented) without adding a "fetch single conflict descriptor" callable. Happy to revisit and add the auto re-fetch path in a follow-up if the extra click is too costly UX-wise.

## Test plan

- [x] 3 new regression tests in `TestResolveSyncConflictStaleConflict` (keep_local, use_server, positive control)
- [x] 10+2 existing call sites updated to pass `server_save_id`
- [x] `pytest tests/ -q` — 2268/2268 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `pnpm build` — TS compiles cleanly
- [x] `services.saves` coverage 94% line / branch (`engine.py` 91%)
- [x] Wiki updated: `Save-File-Sync-Architecture.md` Decision Matrix row + `resolve_sync_conflict callable` section both document the new round-trip + error path (committed separately to the wiki repo)
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #384. Closes #383 (Phase 6 epic).