### PR TITLE
refactor(saves): drop redundant save_state() after _do_upload_save in keep_local (#449)

### DIFF
--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -1201,4 +1201,3 @@ class SyncEngine:
 
         # Upload local content as a PUT against the existing server save.
         self._do_upload_save(rom_id, local_path, target, rom_id_str, system, server)
-        self._state_svc.save_state()


### PR DESCRIPTION
## Summary

Phase 6 follow-up (both audit reviewers flagged independently).

After #409, `_do_upload_save` always persists internally (`engine.py:291`). The trailing `save_state()` at `engine.py:1204` (inside `_resolve_conflict_keep_local`'s PUT branch) writes the same JSON to disk a second time within the same call. Single-line deletion.

The earlier `save_state()` in the same method (inside the adopt-without-upload short-circuit at line 1199) is untouched — that path does not go through `_do_upload_save` and still owns its own persistence.

1 file, +0/-1.

## Test plan

- [x] `pytest tests/services/saves -q` — 274/274 passed
- [x] `pytest tests/ -q` — 2268/2268 passed
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #449.