### PR TITLE
refactor(types): widen RommErrorCode + tighten resolveSyncConflict.error_code (#450)

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -153,7 +153,7 @@ export const syncRomSaves = callable<[number], { success: boolean; message: stri
 export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>("sync_all_saves");
 export const resolveSyncConflict = callable<
   [number, string, number, "keep_local" | "use_server"],
-  { success: boolean; message?: string; error_code?: string; action?: "keep_local" | "use_server" }
+  { success: boolean; message?: string; error_code?: "stale_conflict"; action?: "keep_local" | "use_server" }
 >("resolve_sync_conflict");
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const recordSessionEnd = callable<[number], { success: boolean; duration_sec?: number; total_seconds?: number; session_count?: number; message?: string }>("record_session_end");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export type RommErrorCode =
   | "config_error"
   | "disk_error"
   | "api_error"
+  | "stale_conflict"
+  | "stale_preview"
   | "unknown_error";
 
 export interface RomMPlatform {


### PR DESCRIPTION
## Summary

Phase 6 audit follow-up. Tightens TypeScript error-code typing so future Phase 7 frontend work gets exhaustive narrowing on callable returns.

- **Adds** `stale_conflict` (#384) and `stale_preview` (sync_orchestrator) to `RommErrorCode`. Total union now 15 literals — matches everything the Python backend actually emits today.
- **Tightens** `resolveSyncConflict`'s `error_code?: string` → `"stale_conflict"`. That callable only produces that single literal at `engine.py:1085`.

Sibling callables in `backend.ts` already used `RommErrorCode` (`BackendResult`, `getCollections`); no further tightening needed in this PR.

## Known gap (out of scope, follow-up)

`SyncPreview` interface (`types/index.ts:150-158`) doesn't declare `error_code?` even though `sync_orchestrator.py:224` returns one via `classify_error`. Interface-shape gap; separate fix.

2 files, +3/-1.

## Test plan

- [x] `pnpm build` — clean
- [x] `pytest tests/ -q` — 2268/2268 (sanity, no backend changes)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] Backend literal audit cross-checked: 15 distinct `error_code` producers in `py_modules/`, all now in union
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #450.