### PR TITLE
feat(saves+ui): ship pre-computed display fields on getSaveStatus/getBiosStatus (#456)

### DIFF
--- a/py_modules/domain/save_status.py
+++ b/py_modules/domain/save_status.py
@@ -5,48 +5,51 @@ No I/O, no service/adapter imports. Stateless functions only.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from typing import Literal
 
-from lib.iso_time import parse_iso
+SaveSyncStatus = Literal["synced", "conflict", "none"]
 
 
-def _format_time_ago(iso_timestamp: str) -> str | None:
-    """Format an ISO timestamp as a human-readable time-ago label, or None on error."""
-    check_dt = parse_iso(iso_timestamp)
-    if check_dt is None:
-        return None
-    if check_dt.tzinfo is None:
-        check_dt = check_dt.replace(tzinfo=UTC)
-    diff_min = int((datetime.now(UTC) - check_dt).total_seconds() // 60)
-    if diff_min < 1:
-        return "Just now"
-    if diff_min < 60:
-        return f"{diff_min}m ago"
-    if diff_min < 1440:
-        return f"{diff_min // 60}h ago"
-    return f"{diff_min // 1440}d ago"
+@dataclass(frozen=True)
+class SaveSyncDisplay:
+    """Backend-computed save-sync display fields shipped to the frontend.
+
+    Time-relative formatting of ``last_sync_check_at`` is intentionally a
+    frontend concern: the backend cannot keep an "Xm ago" label fresh
+    between fetches. For the only time-relative case (``synced`` with a
+    recorded sync check), ``label`` is ``None`` and the frontend renders
+    a time-ago label from ``last_sync_check_at``. For every other case
+    ``label`` is a fully-formed static string and ``last_sync_check_at``
+    is ``None``.
+    """
+
+    status: SaveSyncStatus
+    label: str | None
+    last_sync_check_at: str | None
 
 
 def compute_save_sync_display(
     files: list[dict] | None,
     last_sync_check_at: str | None,
-) -> dict:
+) -> SaveSyncDisplay:
     """Compute save sync display status and label.
 
-    Returns dict with 'status' ('synced' | 'conflict' | 'none') and 'label' (str).
+    Returns ``SaveSyncDisplay`` with ``status`` ('synced' | 'conflict' |
+    'none'), ``label`` (static text or ``None`` when the frontend formats
+    a time-ago label), and ``last_sync_check_at`` (passthrough for the
+    time-ago case).
     """
     if not files:
-        return {"status": "none", "label": "No saves"}
+        return SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)
 
     if any(f.get("status") == "conflict" for f in files):
-        return {"status": "conflict", "label": "Conflict"}
+        return SaveSyncDisplay(status="conflict", label="Conflict", last_sync_check_at=None)
 
     has_local = any(f.get("local_path") or f.get("status") in ("synced", "upload") for f in files)
     if has_local:
         if last_sync_check_at:
-            label = _format_time_ago(last_sync_check_at)
-            if label:
-                return {"status": "synced", "label": label}
-        return {"status": "synced", "label": "Not synced"}
+            return SaveSyncDisplay(status="synced", label=None, last_sync_check_at=last_sync_check_at)
+        return SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)
 
-    return {"status": "none", "label": "No local saves"}
+    return SaveSyncDisplay(status="none", label="No local saves", last_sync_check_at=None)

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -162,9 +162,11 @@ class GameDetailService:
         save_status = self._build_save_status(rom_id_str)
         save_sync_display = None
         if save_status is not None:
-            save_sync_display = compute_save_sync_display(
-                save_status["files"],
-                save_status.get("last_sync_check_at"),
+            save_sync_display = asdict(
+                compute_save_sync_display(
+                    save_status["files"],
+                    save_status.get("last_sync_check_at"),
+                )
             )
 
         # Metadata from cache
@@ -222,15 +224,21 @@ class GameDetailService:
         }
 
     async def get_bios_status(self, rom_id) -> dict:
-        """Return BIOS status for a ROM by looking up platform/rom_file from registry."""
+        """Return BIOS status for a ROM by looking up platform/rom_file from registry.
+
+        Response always includes ``bios_status`` (dict or ``None``), ``bios_level``
+        (``"ok"`` / ``"partial"`` / ``"missing"`` or ``None``), and ``bios_label``
+        (str or ``None``). The pre-computed level + label match what the cached
+        ``get_cached_game_detail`` ships so the frontend never re-derives them.
+        """
         rom_id_str = str(rom_id)
         entry = self._state["shortcut_registry"].get(rom_id_str)
         if not entry:
-            return {"bios_status": None}
+            return {"bios_status": None, "bios_level": None, "bios_label": None}
 
         platform_slug = entry.get("platform_slug", "")
         if not platform_slug:
-            return {"bios_status": None}
+            return {"bios_status": None, "bios_level": None, "bios_label": None}
 
         # Resolve rom_file for per-game core override detection
         rom_file = self._resolve_rom_file(rom_id_str, entry)
@@ -238,8 +246,13 @@ class GameDetailService:
         try:
             bios = await self._bios_checker.check_platform_bios(platform_slug, rom_filename=rom_file or None)
             if bios.get("needs_bios"):
-                return {"bios_status": asdict(format_bios_status(bios, platform_slug))}
+                bios_obj = format_bios_status(bios, platform_slug)
+                return {
+                    "bios_status": asdict(bios_obj),
+                    "bios_level": compute_bios_level(bios_obj),
+                    "bios_label": compute_bios_label(bios_obj),
+                }
         except Exception as e:
             self._logger.warning(f"BIOS status check failed for {platform_slug}: {e}")
 
-        return {"bios_status": None}
+        return {"bios_status": None, "bios_level": None, "bios_label": None}

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import os
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 from models.saves import SaveConflict
 
 from domain.emulator_tag import detect_core_change
 from domain.save_attribution import compute_uploaded_by_us
+from domain.save_status import compute_save_sync_display
 from domain.sync_action import Conflict, Skip
 from lib.iso_time import parse_iso_to_epoch
 from services.saves.status.builders import (
@@ -186,15 +188,17 @@ class StatusService:
         playtime_entry = self._state_svc.state.playtime.get(rom_id_str)
         playtime = playtime_entry.to_dict() if playtime_entry is not None else {}
         save_entry = self._state_svc.state.saves.get(rom_id_str)
+        last_sync_check_at = save_entry.last_sync_check_at if save_entry else None
 
         return {
             "rom_id": rom_id,
             "files": file_statuses,
             "playtime": playtime,
             "device_id": self._state_svc.state.device_id or "",
-            "last_sync_check_at": save_entry.last_sync_check_at if save_entry else None,
+            "last_sync_check_at": last_sync_check_at,
             "conflicts": conflicts,
             "save_sort_changed": self._rom_info.is_save_sort_changed(),
+            "save_sync_display": asdict(compute_save_sync_display(file_statuses, last_sync_check_at)),
         }
 
     # ------------------------------------------------------------------

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,5 @@
 import { callable } from "@decky/api";
-import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SyncConflict, RomLookupResult, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse } from "../types";
+import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, RomLookupResult, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse } from "../types";
 
 export interface BackendResult {
   success: boolean;
@@ -27,7 +27,7 @@ export interface CachedGameDetail {
   achievement_summary?: AchievementSummary | null;
   bios_level?: "ok" | "partial" | "missing" | null;
   bios_label?: string | null;
-  save_sync_display?: { status: "synced" | "conflict" | "none"; label: string } | null;
+  save_sync_display?: SaveSyncDisplay | null;
   stale_fields?: string[];
 }
 
@@ -99,7 +99,14 @@ export const downloadFirmware = callable<[number], FirmwareDownloadResult>("down
 export const downloadAllFirmware = callable<[string], FirmwareDownloadResult>("download_all_firmware");
 export const downloadRequiredFirmware = callable<[string], FirmwareDownloadResult>("download_required_firmware");
 export const checkPlatformBios = callable<[string], BiosStatus>("check_platform_bios");
-export const getBiosStatus = callable<[number], { bios_status: CachedGameDetail["bios_status"] }>("get_bios_status");
+export const getBiosStatus = callable<
+  [number],
+  {
+    bios_status: CachedGameDetail["bios_status"];
+    bios_level: "ok" | "partial" | "missing" | null;
+    bios_label: string | null;
+  }
+>("get_bios_status");
 export const getAvailableCores = callable<[string], { cores: AvailableCore[]; active_core: string | null; active_core_label: string | null }>("get_available_cores");
 export const setSystemCore = callable<[string, string], { success: boolean; message?: string; bios_status?: BiosStatus }>("set_system_core");
 export const setGameCore = callable<[string, string, string], { success: boolean; message?: string; bios_status?: BiosStatus }>("set_game_core");

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -32,7 +32,6 @@ import {
   _cachedGameDetailCache,
   testConnection,
   getSaveStatus,
-  checkPlatformBios,
   getBiosStatus,
   getSgdbArtworkBase64,
   getRomMetadata,
@@ -45,7 +44,8 @@ import {
   getAchievementProgress,
   debugLog,
 } from "../api/backend";
-import type { AvailableCore, BiosStatus, SaveStatus } from "../types";
+import type { AvailableCore, BiosStatus, SaveStatus, SaveSyncDisplay } from "../types";
+import { formatTimeAgo } from "../utils/formatters";
 
 /** Track which appIds have had auto-artwork applied this session */
 const artworkApplied = new Set<number>();
@@ -146,56 +146,29 @@ function formatPlaytime(minutes: number): string {
   return `${hours}h ${remainingMin}m`;
 }
 
-/** Format BIOS status counts into a label */
-function formatBiosLabel(bios: BiosStatus): string {
-  const reqCount = bios.required_count;
-  const reqDone = bios.required_downloaded;
-  if (reqCount != null && reqDone != null) {
-    if (reqDone >= reqCount) return "OK";
-    if (reqDone > 0) return `${reqDone}/${reqCount} required`;
-    return "Missing";
+/** Resolve the human-readable save-sync label from the backend's typed display payload.
+ *  Backend ships a static `label` for every case except `synced + has-recent-check`,
+ *  where it leaves `label` null and passes `last_sync_check_at` through for time-ago
+ *  formatting at render time. */
+function resolveSaveSyncLabel(display: SaveSyncDisplay): string {
+  if (display.label !== null) return display.label;
+  if (display.last_sync_check_at) {
+    return formatTimeAgo(display.last_sync_check_at) ?? "Not synced";
   }
-  if (bios.all_downloaded) return "OK";
-  if ((bios.local_count ?? 0) > 0) return `${bios.local_count}/${bios.server_count}`;
-  return "Missing";
+  return "Not synced";
 }
 
-/** Determine BIOS status level */
-function getBiosLevel(bios: BiosStatus): "ok" | "partial" | "missing" {
-  const reqCount = bios.required_count;
-  const reqDone = bios.required_downloaded;
-  if (reqCount != null && reqDone != null) {
-    if (reqDone >= reqCount) return "ok";
-    if (reqDone > 0) return "partial";
-    return "missing";
+/** Apply a typed SaveSyncDisplay to InfoState, deriving the rendered label. */
+function applySaveSyncDisplay(
+  display: SaveSyncDisplay | undefined,
+  saveStatus: SaveStatus | null,
+): { status: "synced" | "conflict" | "none"; label: string } {
+  if (display) {
+    return { status: display.status, label: resolveSaveSyncLabel(display) };
   }
-  if (bios.all_downloaded) return "ok";
-  if ((bios.local_count ?? 0) > 0) return "partial";
-  return "missing";
-}
-
-/** Compute save sync display status and label from a SaveStatus response */
-function computeSaveSyncDisplay(saveStatus: SaveStatus | null): { status: "synced" | "conflict" | "none"; label: string } {
-  const hasConflict = hasAnySaveConflict(saveStatus);
-  if (hasConflict) return { status: "conflict", label: "Conflict" };
-
-  const hasLocalFiles = saveStatus?.files?.some((f) => f.local_path || f.status === "synced" || f.status === "upload") ?? false;
-  if (hasLocalFiles) {
-    const lastCheck = saveStatus?.last_sync_check_at;
-    if (lastCheck) {
-      const diffMs = Date.now() - new Date(lastCheck).getTime();
-      const diffMin = Math.floor(diffMs / 60000);
-      let label: string;
-      if (diffMin < 1) label = "Just now";
-      else if (diffMin < 60) label = `${diffMin}m ago`;
-      else if (diffMin < 1440) label = `${Math.floor(diffMin / 60)}h ago`;
-      else label = `${Math.floor(diffMin / 1440)}d ago`;
-      return { status: "synced", label };
-    }
-    return { status: "synced", label: "Not synced" };
-  }
-
-  if (saveStatus && saveStatus.files.length > 0) return { status: "none", label: "No local saves" };
+  // Defensive fallback: a SaveStatus payload missing the pre-computed field.
+  // Should not occur in current callers; keep behaviour conservative.
+  if (hasAnySaveConflict(saveStatus)) return { status: "conflict", label: "Conflict" };
   return { status: "none", label: "No saves" };
 }
 
@@ -203,16 +176,22 @@ import { setRommConnectionState, setVersionError } from "../utils/connectionStat
 import { useVersionError } from "./VersionErrorCard";
 import { useMigrationStatus } from "./MigrationBlockedPage";
 
-/** Extract BIOS fields from a bios_status response into an InfoState partial. */
-function extractBiosInfo(b: BiosStatus): Partial<InfoState> {
+/** Extract BIOS fields from a bios_status response into an InfoState partial.
+ *  `bios_level` and `bios_label` are pre-computed by the backend so the frontend
+ *  never re-derives them. */
+function extractBiosInfo(
+  b: BiosStatus,
+  level: "ok" | "partial" | "missing" | null,
+  label: string | null,
+): Partial<InfoState> {
   const activeCoreLabel = b.active_core_label ?? null;
   const availableCores = b.available_cores ?? [];
   const defaultCore = availableCores.find((c) => c.is_default);
   const activeCoreIsDefault = !activeCoreLabel || activeCoreLabel === defaultCore?.label;
   return {
     biosNeeded: true,
-    biosStatus: getBiosLevel(b),
-    biosLabel: formatBiosLabel(b),
+    biosStatus: level,
+    biosLabel: label ?? "",
     activeCoreLabel,
     activeCoreIsDefault,
     availableCores,
@@ -245,7 +224,9 @@ function refreshBiosInBackground(
 ) {
   getBiosStatus(romId).then((result) => {
     const b = result.bios_status;
-    if (!cancelled && b) setter((prev) => ({ ...prev, ...extractBiosInfo(b as BiosStatus) }));
+    if (!cancelled && b) {
+      setter((prev) => ({ ...prev, ...extractBiosInfo(b as BiosStatus, result.bios_level, result.bios_label) }));
+    }
   }).catch((e) => debugLog(`Background BIOS status fetch error: ${e}`));
 }
 
@@ -302,7 +283,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         let saveSyncLabel = "";
         if (cached.save_sync_enabled && cached.save_sync_display) {
           saveSyncStatus = cached.save_sync_display.status;
-          saveSyncLabel = cached.save_sync_display.label;
+          saveSyncLabel = resolveSaveSyncLabel(cached.save_sync_display);
         }
 
         if (cancelled) return;
@@ -395,7 +376,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
           const rid = romIdRef.current;
           if (rid) {
             const saveStatus = await getSaveStatus(rid).catch((): SaveStatus | null => null);
-            const { status: ss, label: sl } = computeSaveSyncDisplay(saveStatus);
+            const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
             setInfo((prev) => ({ ...prev, saveSyncEnabled: true, saveSyncStatus: ss, saveSyncLabel: sl }));
           } else {
             setInfo((prev) => ({ ...prev, saveSyncEnabled: true }));
@@ -423,8 +404,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
             activeCoreLabel,
             activeCoreIsDefault,
             availableCores,
-            biosStatus: getBiosLevel(b as BiosStatus),
-            biosLabel: formatBiosLabel(b as BiosStatus),
+            biosStatus: result.bios_level,
+            biosLabel: result.bios_label ?? "",
           }));
         }
         return;
@@ -436,7 +417,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       // If event specifies a rom_id, skip if it's not for this game
       if (detail.rom_id && romIdRef.current && detail.rom_id !== romIdRef.current) return;
       const saveStatus: SaveStatus | null = detail.save_status ?? await getSaveStatus(romId).catch((): SaveStatus | null => null);
-      const { status: saveSyncStatus, label: saveSyncLabel } = computeSaveSyncDisplay(saveStatus);
+      const { status: saveSyncStatus, label: saveSyncLabel } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
       setInfo((prev) => ({ ...prev, saveSyncStatus, saveSyncLabel, activeSlot: saveStatus && "active_slot" in saveStatus ? saveStatus.active_slot ?? null : prev.activeSlot }));
       } catch (err) {
         debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
@@ -465,7 +446,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
           detail: { type: "save_sync", rom_id: romId, has_conflict: hasConflict },
         }));
-        const { status: ss, label: sl } = computeSaveSyncDisplay(saveStatus);
+        const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
         setInfo((prev) => ({ ...prev, saveSyncStatus: ss, saveSyncLabel: sl, activeSlot: saveStatus && "active_slot" in saveStatus ? saveStatus.active_slot ?? null : prev.activeSlot }));
       } catch (e) {
         debugLog(`RomMPlaySection: background save check error: ${e}`);
@@ -597,14 +578,20 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `BIOS downloaded (${result.downloaded ?? 0} files)` });
         window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: info.platformSlug } }));
-        // Refresh BIOS status
-        const updated = await checkPlatformBios(info.platformSlug).catch((): BiosStatus => ({ needs_bios: false }));
-        if (updated.needs_bios) {
-          setInfo((prev) => ({
-            ...prev,
-            biosStatus: getBiosLevel(updated),
-            biosLabel: formatBiosLabel(updated),
+        // Refresh BIOS status — getBiosStatus ships pre-computed level/label so we don't re-derive.
+        if (info.romId) {
+          const refreshed = await getBiosStatus(info.romId).catch(() => ({
+            bios_status: null as BiosStatus | null,
+            bios_level: null as "ok" | "partial" | "missing" | null,
+            bios_label: null as string | null,
           }));
+          if (refreshed.bios_status) {
+            setInfo((prev) => ({
+              ...prev,
+              biosStatus: refreshed.bios_level,
+              biosLabel: refreshed.bios_label ?? "",
+            }));
+          }
         }
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "BIOS download failed" });
@@ -674,20 +661,26 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       debugLog(`handleChangeGameCore: result=${JSON.stringify(result)}`);
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `Core set to ${coreLabel}` });
-        // Use bios_status from the set_game_core response directly (avoids cache staleness)
+        // Use bios_status from the set_game_core response directly (avoids cache staleness).
+        // For pre-computed level/label, re-fetch via getBiosStatus which ships them.
         const bios = result.bios_status;
         debugLog(`handleChangeGameCore: bios active_core_label=${bios?.active_core_label}`);
-        if (bios) {
+        if (bios && info.romId) {
           const newLabel = bios.active_core_label ?? null;
           const cores = bios.available_cores ?? info.availableCores;
           const defaultC = cores.find((c: AvailableCore) => c.is_default);
+          const refreshed = await getBiosStatus(info.romId).catch(() => ({
+            bios_status: null as BiosStatus | null,
+            bios_level: null as "ok" | "partial" | "missing" | null,
+            bios_label: null as string | null,
+          }));
           setInfo((prev) => ({
             ...prev,
             activeCoreLabel: newLabel,
             activeCoreIsDefault: !newLabel || (defaultC != null && newLabel === defaultC.label),
             availableCores: cores,
-            biosStatus: getBiosLevel(bios as BiosStatus),
-            biosLabel: formatBiosLabel(bios as BiosStatus),
+            biosStatus: refreshed.bios_level,
+            biosLabel: refreshed.bios_label ?? "",
           }));
         }
         // Invalidate the frontend cache and notify other components (e.g. GameInfoPanel)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -339,6 +339,17 @@ export interface PlaytimeEntry {
   last_session_duration_sec: number | null;
 }
 
+export interface SaveSyncDisplay {
+  status: "synced" | "conflict" | "none";
+  /** Static label, e.g. "No saves" / "Conflict" / "Not synced". `null` for the
+   *  synced+recent-check case, where the frontend formats a time-ago label
+   *  from `last_sync_check_at`. */
+  label: string | null;
+  /** Raw ISO-8601 timestamp passed through from the backend for time-ago
+   *  formatting. `null` whenever `label` carries a fully-formed string. */
+  last_sync_check_at: string | null;
+}
+
 export interface SaveStatus {
   rom_id: number;
   files: SaveFileStatus[];
@@ -347,6 +358,7 @@ export interface SaveStatus {
   last_sync_check_at: string | null;
   conflicts?: SyncConflict[];
   active_slot?: string | null;
+  save_sync_display?: SaveSyncDisplay;
 }
 
 export interface SaveSlotSummary {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -13,3 +13,20 @@ export function formatTimestamp(iso: string | null): string {
     return iso;
   }
 }
+
+/**
+ * Format an ISO-8601 timestamp as a coarse "Xm ago" label, recomputed at call time.
+ * Mirrors what the backend used to emit but stays fresh between fetches —
+ * the backend now ships only the raw ISO timestamp.
+ *
+ * Returns `null` when the input cannot be parsed; callers decide the fallback label.
+ */
+export function formatTimeAgo(iso: string): string | null {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  const diffMin = Math.floor((Date.now() - ms) / 60000);
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 1440) return `${Math.floor(diffMin / 60)}h ago`;
+  return `${Math.floor(diffMin / 1440)}d ago`;
+}

--- a/tests/domain/test_save_status.py
+++ b/tests/domain/test_save_status.py
@@ -2,82 +2,60 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
-
-from domain.save_status import compute_save_sync_display
+from domain.save_status import SaveSyncDisplay, compute_save_sync_display
 
 
 class TestComputeSaveSyncDisplay:
     def test_none_input(self):
         result = compute_save_sync_display(None, None)
-        assert result == {"status": "none", "label": "No saves"}
+        assert result == SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)
 
     def test_empty_files(self):
         result = compute_save_sync_display([], None)
-        assert result == {"status": "none", "label": "No saves"}
+        assert result == SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)
 
     def test_has_conflict(self):
         files = [{"status": "conflict", "local_path": "/saves/test.srm"}]
         result = compute_save_sync_display(files, None)
-        assert result == {"status": "conflict", "label": "Conflict"}
+        assert result == SaveSyncDisplay(status="conflict", label="Conflict", last_sync_check_at=None)
 
     def test_has_local_files_no_last_check(self):
         files = [{"status": "synced", "local_path": "/saves/test.srm"}]
         result = compute_save_sync_display(files, None)
-        assert result == {"status": "synced", "label": "Not synced"}
+        assert result == SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)
 
-    def test_synced_just_now(self):
-        now = datetime.now(UTC).isoformat()
+    def test_synced_with_last_check_passes_through_timestamp(self):
+        """Time-relative formatting is the frontend's job — backend passes the timestamp through."""
+        iso = "2026-02-17T10:31:00+00:00"
         files = [{"status": "synced", "local_path": "/saves/test.srm"}]
-        result = compute_save_sync_display(files, now)
-        assert result == {"status": "synced", "label": "Just now"}
+        result = compute_save_sync_display(files, iso)
+        assert result == SaveSyncDisplay(status="synced", label=None, last_sync_check_at=iso)
 
-    def test_synced_minutes_ago(self):
-        past = (datetime.now(UTC) - timedelta(minutes=15)).isoformat()
+    def test_synced_with_naive_timestamp_passes_through(self):
+        """Naive (no-tz) timestamps pass through verbatim — frontend handles parsing."""
+        iso = "2026-02-17T10:31:00"
         files = [{"status": "synced", "local_path": "/saves/test.srm"}]
-        result = compute_save_sync_display(files, past)
-        assert result == {"status": "synced", "label": "15m ago"}
-
-    def test_synced_hours_ago(self):
-        past = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
-        files = [{"status": "synced", "local_path": "/saves/test.srm"}]
-        result = compute_save_sync_display(files, past)
-        assert result == {"status": "synced", "label": "3h ago"}
-
-    def test_synced_days_ago(self):
-        past = (datetime.now(UTC) - timedelta(days=2)).isoformat()
-        files = [{"status": "synced", "local_path": "/saves/test.srm"}]
-        result = compute_save_sync_display(files, past)
-        assert result == {"status": "synced", "label": "2d ago"}
+        result = compute_save_sync_display(files, iso)
+        assert result == SaveSyncDisplay(status="synced", label=None, last_sync_check_at=iso)
 
     def test_files_without_local_path_or_synced(self):
         """Files that are only 'download' or 'skip' with no local_path = no local saves."""
         files = [{"status": "download", "local_path": None}]
         result = compute_save_sync_display(files, None)
-        assert result == {"status": "none", "label": "No local saves"}
+        assert result == SaveSyncDisplay(status="none", label="No local saves", last_sync_check_at=None)
 
     def test_upload_status_counts_as_local(self):
         files = [{"status": "upload", "local_path": None}]
         result = compute_save_sync_display(files, None)
-        assert result == {"status": "synced", "label": "Not synced"}
+        assert result == SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)
 
     def test_local_path_present_counts_as_local(self):
         files = [{"status": "skip", "local_path": "/saves/test.srm"}]
         result = compute_save_sync_display(files, None)
-        assert result == {"status": "synced", "label": "Not synced"}
+        assert result == SaveSyncDisplay(status="synced", label="Not synced", last_sync_check_at=None)
 
-    def test_unparseable_last_check_falls_back_to_not_synced(self):
-        """Malformed timestamp -> _format_time_ago returns None -> 'Not synced' fallback."""
+    def test_malformed_timestamp_passes_through_unchanged(self):
+        """Backend no longer parses the timestamp; an unparseable value is shipped as-is."""
         files = [{"status": "synced", "local_path": "/saves/test.srm"}]
         result = compute_save_sync_display(files, "not-a-date")
-        assert result == {"status": "synced", "label": "Not synced"}
-
-    def test_naive_timestamp_treated_as_utc(self):
-        """A naive ISO timestamp (no tzinfo) is treated as UTC, not crashed on."""
-        # Recent enough that we get a sane label rather than something like '20000d ago'.
-        recent_naive = (datetime.now(UTC) - timedelta(minutes=5)).replace(tzinfo=None).isoformat()
-        files = [{"status": "synced", "local_path": "/saves/test.srm"}]
-        result = compute_save_sync_display(files, recent_naive)
-        assert result["status"] == "synced"
-        # Allow a small tolerance band — clock-edge flake protection.
-        assert result["label"] in {"4m ago", "5m ago", "6m ago"}
+        assert result == SaveSyncDisplay(status="synced", label=None, last_sync_check_at="not-a-date")

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -247,3 +247,79 @@ class TestGetSaveStatusComputeAction:
 
         assert result["files"] == []
         assert result["conflicts"] == []
+
+
+class TestSaveSyncDisplayEnrichment:
+    """get_save_status ships a pre-computed save_sync_display alongside files/conflicts."""
+
+    def test_empty_slot_display_no_saves(self, tmp_path):
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        svc._save_sync_state.saves["42"] = RomSaveState()
+
+        result = svc._status._get_save_status_io(42, [])
+
+        assert result["save_sync_display"] == {
+            "status": "none",
+            "label": "No saves",
+            "last_sync_check_at": None,
+        }
+
+    def test_synced_display_passes_through_check_timestamp(self, tmp_path):
+        """Synced state with a recorded sync check passes the ISO through; frontend formats time-ago."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"matches baseline")
+        local_hash = _file_md5(str(save_path))
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": True}],
+        )
+        fake.saves[100] = ss
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": local_hash,
+                        "last_sync_server_updated_at": ss["updated_at"],
+                    }
+                },
+                "last_sync_check_at": "2026-04-01T08:00:00+00:00",
+            }
+        )
+
+        result = svc._status._get_save_status_io(42, [ss])
+
+        assert result["save_sync_display"] == {
+            "status": "synced",
+            "label": None,
+            "last_sync_check_at": "2026-04-01T08:00:00+00:00",
+        }
+
+    def test_conflict_display(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"diverged local")
+        ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": False}])
+        fake.saves[100] = ss
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
+                }
+            }
+        )
+
+        result = svc._status._get_save_status_io(42, [ss])
+
+        assert result["save_sync_display"]["status"] == "conflict"
+        assert result["save_sync_display"]["label"] == "Conflict"
+        assert result["save_sync_display"]["last_sync_check_at"] is None

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -538,7 +538,7 @@ class TestGetBiosStatusFound:
 
     @pytest.mark.asyncio
     async def test_returns_bios_status(self, plugin, game_detail_service):
-        """ROM with needs_bios=True returns full bios_status dict."""
+        """ROM with needs_bios=True returns full bios_status dict + pre-computed level/label."""
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 50000,
             "name": "Game",
@@ -571,10 +571,13 @@ class TestGetBiosStatusFound:
         assert bs["required_count"] == 2
         assert bs["required_downloaded"] == 1
         assert bs["active_core_label"] == "mGBA"
+        # Pre-computed display fields removed from the frontend.
+        assert result["bios_level"] == "partial"
+        assert result["bios_label"] == "1/2 required"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_bios_needed(self, plugin, game_detail_service):
-        """ROM with needs_bios=False returns bios_status=None."""
+        """ROM with needs_bios=False returns bios_status / level / label all None."""
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 50000,
             "name": "Game",
@@ -585,6 +588,8 @@ class TestGetBiosStatusFound:
 
         result = await game_detail_service.get_bios_status(42)
         assert result["bios_status"] is None
+        assert result["bios_level"] is None
+        assert result["bios_label"] is None
 
     @pytest.mark.asyncio
     async def test_uses_rom_file_from_installed(self, plugin, game_detail_service):
@@ -619,23 +624,23 @@ class TestGetBiosStatusNotFound:
 
     @pytest.mark.asyncio
     async def test_unknown_rom_id(self, game_detail_service):
-        """Unknown rom_id returns bios_status=None."""
+        """Unknown rom_id returns bios_status / level / label all None."""
         result = await game_detail_service.get_bios_status(999)
-        assert result["bios_status"] is None
+        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
 
     @pytest.mark.asyncio
     async def test_no_platform_slug(self, plugin, game_detail_service):
-        """Registry entry without platform_slug returns bios_status=None."""
+        """Registry entry without platform_slug returns bios_status / level / label all None."""
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 50000,
             "name": "Game",
         }
         result = await game_detail_service.get_bios_status(42)
-        assert result["bios_status"] is None
+        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
 
     @pytest.mark.asyncio
     async def test_firmware_error_returns_none(self, plugin, game_detail_service):
-        """Firmware service exception returns bios_status=None."""
+        """Firmware service exception returns bios_status / level / label all None."""
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 50000,
             "name": "Game",
@@ -644,7 +649,7 @@ class TestGetBiosStatusNotFound:
         game_detail_service._bios_checker.check_platform_bios = AsyncMock(side_effect=Exception("fail"))
 
         result = await game_detail_service.get_bios_status(42)
-        assert result["bios_status"] is None
+        assert result == {"bios_status": None, "bios_level": None, "bios_label": None}
 
 
 class TestGetCachedGameDetailSaveStatusConflicts:
@@ -764,7 +769,7 @@ class TestComputedFields:
 
     @pytest.mark.asyncio
     async def test_save_sync_display_with_saves(self, plugin, game_detail_service):
-        """When save data exists, save_sync_display should be computed."""
+        """When save data exists, save_sync_display is the typed dataclass payload."""
         plugin._state["shortcut_registry"]["42"] = {
             "app_id": 99999,
             "name": "Test",
@@ -779,8 +784,9 @@ class TestComputedFields:
         result = game_detail_service.get_cached_game_detail(99999)
         assert result["save_sync_display"] is not None
         assert result["save_sync_display"]["status"] == "synced"
-        label = result["save_sync_display"]["label"]
-        assert "ago" in label or label in ("Just now", "Not synced")
+        # Synced + recorded check → backend leaves label None for frontend formatTimeAgo.
+        assert result["save_sync_display"]["label"] is None
+        assert result["save_sync_display"]["last_sync_check_at"] == "2026-01-01T00:00:00Z"
 
     @pytest.mark.asyncio
     async def test_save_sync_display_none_when_no_saves(self, plugin, game_detail_service):


### PR DESCRIPTION
## Summary

First implementation under the audit-driven Phase 7 (#386). Eliminates frontend re-derivation of `compute_save_sync_display` / `compute_bios_label` / `compute_bios_level`.

**Backend** already owned the canonical logic for `getCachedGameDetail`. This PR makes the refetch callables (`getSaveStatus`, `getBiosStatus`) ship the same pre-computed fields, so frontend reads them directly instead of re-deriving on every `romm_data_changed` event.

**Time-relative label freshness handled**: the old backend bake "5m ago" went stale frontend-side. New design — backend ships status + base label + raw `last_sync_check_at`; frontend's `formatTimeAgo(iso)` formats per render so labels stay fresh.

### Shape change

```python
@dataclass(frozen=True)
class SaveSyncDisplay:
    status: Literal["synced", "conflict", "none"]
    label: str | None                    # static label OR None when time-relative
    last_sync_check_at: str | None       # raw ISO when time-relative; else None
```

`bios_level` (`"ok" | "partial" | "missing"`) and `bios_label` (`str`) added to bios responses.

### Frontend cleanup

- Deleted `computeSaveSyncDisplay` (~25 LOC), `formatBiosLabel` (~12 LOC), `getBiosLevel` (~12 LOC) from `RomMPlaySection.tsx`
- Added `formatTimeAgo(iso): string | null` to `formatters.ts` (Tier-1 pure)
- `handleDownloadBios` + `handleChangeGameCore` refetch via `getBiosStatus` (+1 round-trip on rare user actions; scope-limited trade-off)

### Out of scope (follow-up)

`RomMGameInfoPanel.tsx` left untouched — its inline BIOS computation (lines 604-616) produces *different* user-visible text than `compute_bios_label`. Migrating would change UX without sign-off.

10 files, +271/-162.

## Test plan

- [x] `pytest tests/ -q` — 2269/2269 passed (was 2268; +1 from new tests minus deleted ones)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `pnpm build` — TS compiles clean
- [x] Matrix tests untouched: `tests/domain/test_sync_action.py` 20/20 green
- [x] Time-ago threshold parity verified: Python old `int((now - check_dt).total_seconds() // 60)` matches JS new `Math.floor((Date.now() - ms) / 60000)` for all thresholds (<1m / <60m / <1440m / ≥1440m)
- [x] Coverage on `services/saves/` 94%; `domain/save_status.py` 100%
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #456. Part of #386.