### PR TITLE
feat(saves): add recommended_action to SaveSetupInfo; collapse SlotSetupWizard auto-confirm (#457)

### DIFF
--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -470,6 +470,13 @@ class SlotsService:
         slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
         active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
 
+        # Pre-computed wizard recommendation: auto-confirm the default slot only
+        # when there are local saves and the server has no slots yet. Every other
+        # combination needs the wizard so the user can choose.
+        recommended_action = (
+            "auto_confirm_default" if (len(local_files) > 0 and len(server_slots) == 0) else "show_wizard"
+        )
+
         return {
             "has_local_saves": len(local_files) > 0,
             "local_files": local_file_info,
@@ -477,6 +484,7 @@ class SlotsService:
             "default_slot": default_slot,
             "slot_confirmed": slot_confirmed,
             "active_slot": active_slot,
+            "recommended_action": recommended_action,
         }
 
     async def confirm_slot_choice(

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -70,23 +70,6 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
   useEffect(() => {
     let cancelled = false;
 
-    const autoConfirmIfNeeded = async (result: SaveSetupInfo): Promise<boolean> => {
-      if (!result.has_local_saves || result.server_slots.length > 0) return false;
-      setConfirming(true);
-      try {
-        await confirmSlotChoice(romId, result.default_slot, null);
-        if (!cancelled) onComplete();
-      } catch (e) {
-        if (!cancelled) {
-          setError(`Auto-setup failed: ${e}`);
-          logError(`SlotSetupWizard auto-confirm failed: ${e}`);
-          setConfirming(false);
-          setInfo(result);
-        }
-      }
-      return true;
-    };
-
     const fetchInfo = async () => {
       setLoading(true);
       setError(null);
@@ -94,9 +77,19 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         const result = await getSaveSetupInfo(romId);
         if (cancelled) return;
 
-        const autoConfirmed = await autoConfirmIfNeeded(result);
-        if (autoConfirmed) {
-          if (!cancelled) setLoading(false);
+        if (result.recommended_action === "auto_confirm_default") {
+          setConfirming(true);
+          try {
+            await confirmSlotChoice(romId, result.default_slot, null);
+            if (!cancelled) onComplete();
+          } catch (e) {
+            if (!cancelled) {
+              setError(`Auto-setup failed: ${e}`);
+              logError(`SlotSetupWizard auto-confirm failed: ${e}`);
+              setConfirming(false);
+              setInfo(result);
+            }
+          }
           return;
         }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -410,6 +410,7 @@ export interface SaveSetupInfo {
   default_slot: string;
   slot_confirmed: boolean;
   active_slot: string | null;
+  recommended_action: "auto_confirm_default" | "show_wizard";
 }
 
 export interface RomLookupResult {

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -294,6 +294,49 @@ class TestGetSaveSetupInfo:
         assert result["has_local_saves"] is False
         assert result["local_files"] == []
 
+    @pytest.mark.asyncio
+    async def test_get_save_setup_info_recommends_auto_confirm_when_local_saves_no_server_slots(self, tmp_path):
+        """Local saves + no server slots -> wizard should auto-confirm the default slot."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        result = await svc.get_save_setup_info(42)
+        assert result["has_local_saves"] is True
+        assert result["server_slots"] == []
+        assert result["recommended_action"] == "auto_confirm_default"
+
+    @pytest.mark.asyncio
+    async def test_get_save_setup_info_recommends_wizard_when_server_has_slots(self, tmp_path):
+        """Local saves + server has slots -> user must choose, wizard required."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[1] = _server_save(save_id=1, slot="desktop")
+
+        result = await svc.get_save_setup_info(42)
+        assert result["has_local_saves"] is True
+        assert len(result["server_slots"]) == 1
+        assert result["recommended_action"] == "show_wizard"
+
+    @pytest.mark.asyncio
+    async def test_get_save_setup_info_recommends_wizard_when_no_local_saves(self, tmp_path):
+        """No local saves -> wizard required regardless of server state."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        _install_rom(svc, tmp_path)
+        # No _create_save call - no local saves
+        fake.saves[1] = _server_save(save_id=1, slot=None)
+
+        result = await svc.get_save_setup_info(42)
+        assert result["has_local_saves"] is False
+        assert result["recommended_action"] == "show_wizard"
+
 
 class TestConfirmSlotChoice:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Second Phase 7 implementation. Moves the trivial wizard auto-confirm predicate from frontend TS to backend Python, behind an additive DTO field.

- **New backend field**: `SaveSetupInfo.recommended_action: "auto_confirm_default" | "show_wizard"`. Computed via `len(local_files) > 0 and len(server_slots) == 0` — bit-identical to the frontend's pre-PR `has_local_saves && server_slots.length === 0` predicate.
- **Frontend**: `autoConfirmIfNeeded` (16 LOC) deleted from `SlotSetupWizard.tsx`. The auto-confirm path inlines into `fetchInfo`, gated on `result.recommended_action === "auto_confirm_default"`.

Behaviour is bit-identical pre/post — same `confirmSlotChoice` args, same `onComplete` trigger, same error fallback to wizard with the info populated, same `cancelled` flag gating.

4 files, +67/-20.

## Test plan

- [x] `pytest tests/ -q` — 2272/2272 passed (was 2269; +3 new tests)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `pnpm build` — TS compiles
- [x] Three new tests cover `auto_confirm_default` / `show_wizard` (server slots) / `show_wizard` (no local saves); all fail on origin/main (the field doesn't exist there)
- [x] Coverage on `services/saves/slots/service.py` 95%
- [ ] CI green
- [ ] SonarCloud 0 new issues

Closes #457. Part of #386.