### PR TITLE
feat(session): collapse handleGameStop into finalize_game_session (#459)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -114,6 +114,7 @@ modules =
     services.playtime
     services.rom_removal
     services.saves
+    services.session_lifecycle
     services.settings
     services.shortcut_removal
     services.startup_healing

--- a/main.py
+++ b/main.py
@@ -155,6 +155,7 @@ class Plugin:
         self._connection_service = services["connection_service"]
         self._startup_healing_service = services["startup_healing_service"]
         self._launch_gate_service = services["launch_gate_service"]
+        self._session_lifecycle_service = services["session_lifecycle_service"]
 
         # ── 5. Startup healing ──────────────────────────────────────────────
         self._save_sync_service.init_state()
@@ -372,6 +373,10 @@ class Plugin:
     async def evaluate_launch(self, steam_app_id):
         verdict = await self._launch_gate_service.evaluate(int(steam_app_id))
         return asdict(verdict)
+
+    async def finalize_game_session(self, rom_id):
+        result = await self._session_lifecycle_service.finalize(int(rom_id))
+        return asdict(result)
 
     # ── Download delegation to DownloadService ──────────────
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -86,6 +86,7 @@ from services.protocols import (
 from services.protocols import SteamConfigAdapter as SteamConfigProtocol
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 from services.saves import SaveService, SaveServiceConfig
+from services.session_lifecycle import SessionLifecycleService, SessionLifecycleServiceConfig
 from services.settings import SettingsService, SettingsServiceConfig
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
@@ -584,6 +585,16 @@ def wire_services(cfg: WiringConfig) -> dict:
         ),
     )
 
+    session_lifecycle_service = SessionLifecycleService(
+        config=SessionLifecycleServiceConfig(
+            playtime_recorder=playtime_service,
+            post_exit_sync=save_sync_service,
+            achievement_sync=achievements_service,
+            migration_reader=migration_service,
+            logger=cfg.runtime.logger,
+        ),
+    )
+
     return {
         "save_sync_service": save_sync_service,
         "playtime_service": playtime_service,
@@ -603,4 +614,5 @@ def wire_services(cfg: WiringConfig) -> dict:
         "connection_service": connection_service,
         "startup_healing_service": startup_healing_service,
         "launch_gate_service": launch_gate_service,
+        "session_lifecycle_service": session_lifecycle_service,
     }

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -33,6 +33,10 @@ from services.protocols.cross_service import (
     LaunchGateSaveStatusReader,
     MetadataExtractor,
     RetryStrategy,
+    SessionAchievementSync,
+    SessionMigrationReader,
+    SessionPlaytimeRecorder,
+    SessionPostExitSync,
 )
 from services.protocols.determinism import Clock, Sleeper, UuidGen
 from services.protocols.files import (
@@ -127,6 +131,10 @@ __all__ = [
     "RommVersion",
     "SaveFileAdapter",
     "SaveSyncStatePersister",
+    "SessionAchievementSync",
+    "SessionMigrationReader",
+    "SessionPlaytimeRecorder",
+    "SessionPostExitSync",
     "SettingsPersister",
     "SgdbArtworkCache",
     "Sleeper",

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -110,3 +110,58 @@ class LaunchGateSaveStatusReader(Protocol):
     """
 
     async def get_save_status(self, rom_id: int) -> dict: ...
+
+
+class SessionPlaytimeRecorder(Protocol):
+    """Playtime end-of-session record consumed by SessionLifecycleService.
+
+    The composition root satisfies this with ``PlaytimeService``'s
+    ``record_session_end``. The lifecycle service forwards the
+    ``total_seconds`` field to the frontend so the playtime display can
+    be updated; a falsy ``success`` value yields ``total_seconds=None``
+    on the returned DTO so the frontend leaves the display untouched.
+    """
+
+    async def record_session_end(self, rom_id: int) -> dict: ...
+
+
+class SessionPostExitSync(Protocol):
+    """Post-exit save sync consumed by SessionLifecycleService.
+
+    The composition root satisfies this with ``SaveService``'s
+    ``post_exit_sync``. Returned shape carries ``offline`` / ``success``
+    / ``synced`` / ``conflicts`` which the lifecycle service maps into
+    toast strings; any raised exception is collapsed to the "failed"
+    toast.
+    """
+
+    async def post_exit_sync(self, rom_id: int) -> dict: ...
+
+
+class SessionAchievementSync(Protocol):
+    """Post-session achievement refresh consumed by SessionLifecycleService.
+
+    The composition root satisfies this with ``AchievementsService``'s
+    ``sync_achievements_after_session``. The lifecycle service kicks
+    this off as a background task — its result and any failure are
+    logged backend-side; the frontend never observes the outcome.
+    """
+
+    async def sync_achievements_after_session(self, rom_id: int) -> dict: ...
+
+
+class SessionMigrationReader(Protocol):
+    """Migration-state refresh + pending check consumed by SessionLifecycleService.
+
+    The composition root satisfies this with ``MigrationService``'s
+    ``refresh_state`` and ``is_retrodeck_migration_pending``. The
+    refresh result is repacked into the typed DTO the frontend feeds
+    into its migration stores; the pending check matches the safety
+    net the ``@migration_blocked`` decorator provides for other
+    callables, gating the destructive post-exit save sync from inside
+    the lifecycle orchestration.
+    """
+
+    async def refresh_state(self) -> dict: ...
+
+    def is_retrodeck_migration_pending(self) -> bool: ...

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -1,0 +1,303 @@
+"""SessionLifecycleService — single-callable end-of-session orchestration.
+
+Composes the four cross-service reads the frontend's game-stop handler
+used to interleave into one round-trip: end-of-session playtime
+record, fire-and-forget achievement refresh, post-exit save sync, and
+the migration-state refresh. Returns a typed ``SessionFinalizeResult``
+carrying the playtime delta plus the rendered toast strings and the
+migration-status payloads the frontend feeds into its in-memory
+stores. The playtime-display update (Steam's ``appStore`` mutation)
+stays on the frontend because it touches Steam IPC; everything else
+about the end-of-session flow is now a backend decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+    from services.protocols.cross_service import (
+        SessionAchievementSync,
+        SessionMigrationReader,
+        SessionPlaytimeRecorder,
+        SessionPostExitSync,
+    )
+
+
+_TOAST_TITLE = "RomM Save Sync"
+_TOAST_BODY_OFFLINE = "Server offline — saves will sync next time"
+_TOAST_BODY_SYNCED = "Saves synced with RomM"
+_TOAST_BODY_FAILED = "Failed to sync saves after exit"
+
+
+@dataclass(frozen=True)
+class SessionFinalizeSyncResult:
+    """Post-exit-sync verdict rendered for the frontend.
+
+    Carries the raw outcome flags the frontend still needs for event
+    dispatch (``offline`` / ``success``) plus the pre-rendered toast
+    strings. ``toast_body=None`` means "do not fire a toast for this
+    scenario" — for example a successful sync that uploaded nothing.
+    ``conflicts_toast`` is the second, additive toast fired when the
+    sync surfaces unresolved conflicts; ``None`` when there are no
+    conflicts. Pre-rendering the conflict string here matches the
+    previous frontend ``notifyConflicts`` output byte-for-byte.
+    """
+
+    offline: bool
+    success: bool
+    synced: int | None
+    conflicts: list[dict]
+    toast_title: str | None
+    toast_body: str | None
+    conflicts_toast: str | None
+
+
+@dataclass(frozen=True)
+class SessionFinalizeMigration:
+    """Migration-status payloads returned from ``MigrationService.refresh_state``.
+
+    Repacked into a typed aggregate so the frontend feeds each field
+    into its dedicated store (``migrationStore`` / ``saveSortMigrationStore``)
+    without re-deriving them from a loose dict.
+    """
+
+    retrodeck: dict
+    save_sort: dict
+
+
+@dataclass(frozen=True)
+class SessionFinalizeResult:
+    """End-of-session verdict consumed by the frontend session manager.
+
+    ``total_seconds`` is ``None`` when the playtime record failed (no
+    active session, malformed timestamp, etc.) — the frontend then
+    leaves Steam's playtime display untouched. ``sync`` is always
+    present; its fields encode whatever action the frontend still
+    needs to take (toast, event dispatch). ``migration`` is ``None``
+    when the migration-state refresh raised — matching the pre-PR
+    frontend behavior where a refresh failure logged a warning and
+    left the migration stores untouched (any stale ``pending`` badge
+    keeps showing). When the refresh succeeds, ``migration`` carries
+    the two typed status payloads the frontend feeds into its stores.
+    """
+
+    total_seconds: int | None
+    sync: SessionFinalizeSyncResult
+    migration: SessionFinalizeMigration | None
+
+
+@dataclass(frozen=True)
+class SessionLifecycleServiceConfig:
+    """Frozen wiring bundle handed to ``SessionLifecycleService.__init__``.
+
+    All four deps are Protocol-typed cross-service seams that the
+    composition root satisfies with the existing playtime, save,
+    achievement, and migration services. ``logger`` is carried for
+    backend-side reporting of the fire-and-forget achievement sync —
+    its result and failures never reach the frontend.
+    """
+
+    playtime_recorder: SessionPlaytimeRecorder
+    post_exit_sync: SessionPostExitSync
+    achievement_sync: SessionAchievementSync
+    migration_reader: SessionMigrationReader
+    logger: logging.Logger
+
+
+def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> tuple[str | None, str | None]:
+    """Map the raw post-exit-sync flags onto the (title, body) toast pair.
+
+    Mirrors the pre-PR frontend branching exactly: offline wins over
+    success, success-with-uploads renders the synced toast, a successful
+    no-op produces no toast at all, and any non-success/non-offline
+    state falls through to the failure toast.
+    """
+    if offline:
+        return _TOAST_TITLE, _TOAST_BODY_OFFLINE
+    if success and synced is not None and synced > 0:
+        return _TOAST_TITLE, _TOAST_BODY_SYNCED
+    if success:
+        return None, None
+    return _TOAST_TITLE, _TOAST_BODY_FAILED
+
+
+def _render_conflicts_toast(conflicts: list[dict]) -> str | None:
+    """Render the additive "N save conflict(s) need resolution" body.
+
+    Matches the pre-PR frontend ``notifyConflicts`` output byte-for-byte:
+    singular when ``count == 1``, plural otherwise. Returns ``None``
+    when there are no conflicts so the frontend skips the second toast.
+    """
+    count = len(conflicts)
+    if count == 0:
+        return None
+    plural = "" if count == 1 else "s"
+    return f"{count} save conflict{plural} need resolution"
+
+
+class SessionLifecycleService:
+    """End-of-session orchestration composed from four cross-service reads."""
+
+    def __init__(self, *, config: SessionLifecycleServiceConfig) -> None:
+        self._playtime_recorder = config.playtime_recorder
+        self._post_exit_sync = config.post_exit_sync
+        self._achievement_sync = config.achievement_sync
+        self._migration_reader = config.migration_reader
+        self._logger = config.logger
+        # Strong refs to in-flight background tasks. ``asyncio.create_task``
+        # alone is not enough — without a strong ref, the loop is free to
+        # garbage-collect the task before it completes. ``add_done_callback``
+        # prunes finished entries to keep the set bounded.
+        self._background_tasks: set[asyncio.Task] = set()
+
+    async def finalize(self, rom_id: int) -> SessionFinalizeResult:
+        """Run the four end-of-session steps and return the combined verdict.
+
+        Parameters
+        ----------
+        rom_id:
+            RomM ROM id whose session just ended.
+
+        Returns
+        -------
+        SessionFinalizeResult
+            ``total_seconds`` carries the updated total when the
+            playtime record succeeded, ``None`` otherwise. ``sync``
+            carries the pre-rendered toast strings and the raw offline /
+            success flags the frontend still needs for the
+            ``romm_data_changed`` event dispatch. ``migration`` carries
+            the two migration-status payloads.
+        """
+        total_seconds = await self._record_playtime(rom_id)
+        self._schedule_achievement_sync(rom_id)
+        sync_result = await self._build_sync_result(rom_id)
+        migration = await self._refresh_migration()
+
+        return SessionFinalizeResult(
+            total_seconds=total_seconds,
+            sync=sync_result,
+            migration=migration,
+        )
+
+    async def _record_playtime(self, rom_id: int) -> int | None:
+        """Record session end and return the updated ``total_seconds``.
+
+        Returns ``None`` on any non-success outcome (no active session,
+        malformed timestamp, downstream exception) so the frontend
+        knows to leave Steam's playtime display alone.
+        """
+        try:
+            result = await self._playtime_recorder.record_session_end(rom_id)
+        except Exception as e:
+            self._logger.warning(f"SessionLifecycle playtime record failed for rom_id={rom_id}: {e}")
+            return None
+
+        if not result.get("success"):
+            return None
+        total = result.get("total_seconds")
+        if not isinstance(total, int):
+            return None
+        return total
+
+    def _schedule_achievement_sync(self, rom_id: int) -> None:
+        """Kick off the achievement refresh as a background task.
+
+        The frontend does not surface achievement-sync progress, so the
+        call runs detached from the lifecycle return value. A strong
+        ref into ``_background_tasks`` keeps the task alive long enough
+        for the executor to finish; ``add_done_callback`` prunes the set
+        once the task completes.
+        """
+        task = asyncio.create_task(self._run_achievement_sync(rom_id))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _run_achievement_sync(self, rom_id: int) -> None:
+        """Wrap the achievement-sync call so its failure is logged backend-side."""
+        try:
+            await self._achievement_sync.sync_achievements_after_session(rom_id)
+        except Exception as e:
+            self._logger.warning(f"SessionLifecycle achievement sync failed for rom_id={rom_id}: {e}")
+
+    async def _build_sync_result(self, rom_id: int) -> SessionFinalizeSyncResult:
+        """Run post-exit sync and render the resulting toast strings.
+
+        Mirrors the ``@migration_blocked`` decorator's gate: when a
+        RetroDECK migration is pending the destructive post-exit sync is
+        skipped and rendered as the standard "failed to sync saves
+        after exit" toast — the same outcome the pre-PR flow produced
+        when the decorator returned ``blocked_by_migration``.
+        """
+        if self._migration_reader.is_retrodeck_migration_pending():
+            return SessionFinalizeSyncResult(
+                offline=False,
+                success=False,
+                synced=None,
+                conflicts=[],
+                toast_title=_TOAST_TITLE,
+                toast_body=_TOAST_BODY_FAILED,
+                conflicts_toast=None,
+            )
+
+        try:
+            result = await self._post_exit_sync.post_exit_sync(rom_id)
+        except Exception as e:
+            self._logger.warning(f"SessionLifecycle post-exit sync failed for rom_id={rom_id}: {e}")
+            return SessionFinalizeSyncResult(
+                offline=False,
+                success=False,
+                synced=None,
+                conflicts=[],
+                toast_title=_TOAST_TITLE,
+                toast_body=_TOAST_BODY_FAILED,
+                conflicts_toast=None,
+            )
+
+        offline = bool(result.get("offline"))
+        success = bool(result.get("success"))
+        raw_synced = result.get("synced")
+        synced = raw_synced if isinstance(raw_synced, int) else None
+        raw_conflicts = result.get("conflicts")
+        conflicts: list[dict] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
+
+        toast_title, toast_body = _render_sync_toast(offline=offline, success=success, synced=synced)
+        conflicts_toast = _render_conflicts_toast(conflicts)
+
+        return SessionFinalizeSyncResult(
+            offline=offline,
+            success=success,
+            synced=synced,
+            conflicts=conflicts,
+            toast_title=toast_title,
+            toast_body=toast_body,
+            conflicts_toast=conflicts_toast,
+        )
+
+    async def _refresh_migration(self) -> SessionFinalizeMigration | None:
+        """Re-detect migration state and return the typed status pair.
+
+        Returns ``None`` on refresh failure (exception or non-dict
+        payload) — the frontend then leaves the migration stores
+        untouched, matching the pre-PR ``refreshMigrationState().catch``
+        behavior where a failure logged a warning without clearing any
+        stale ``pending`` badge.
+        """
+        try:
+            payload = await self._migration_reader.refresh_state()
+        except Exception as e:
+            self._logger.warning(f"SessionLifecycle migration refresh failed: {e}")
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        retrodeck = payload.get("retrodeck")
+        save_sort = payload.get("save_sort")
+        return SessionFinalizeMigration(
+            retrodeck=retrodeck if isinstance(retrodeck, dict) else {"pending": False},
+            save_sort=save_sort if isinstance(save_sort, dict) else {"pending": False},
+        )

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -251,6 +251,36 @@ export const migrateSaveSortFiles = callable<[string | null], MigrationResult>("
 export const dismissSaveSortMigration = callable<[], { success: boolean }>("dismiss_save_sort_migration");
 export const refreshMigrationState = callable<[], { retrodeck: MigrationStatus; save_sort: SaveSortMigrationStatus }>("refresh_migration_state");
 
+// End-of-session orchestration — collapses recordSessionEnd + syncAchievementsAfterSession
+// + postExitSync + refreshMigrationState into a single backend round-trip.
+// See SessionLifecycleService in py_modules/services/session_lifecycle.py.
+export interface SessionFinalizeSyncResult {
+  offline: boolean;
+  success: boolean;
+  synced: number | null;
+  conflicts: SyncConflict[];
+  toast_title: string | null;
+  toast_body: string | null;
+  conflicts_toast: string | null;
+}
+
+export interface SessionFinalizeMigration {
+  retrodeck: MigrationStatus;
+  save_sort: SaveSortMigrationStatus;
+}
+
+export interface SessionFinalizeResult {
+  total_seconds: number | null;
+  sync: SessionFinalizeSyncResult;
+  // ``null`` when the backend's migration-state refresh raised — the
+  // frontend then leaves the migration stores untouched (any stale
+  // ``pending`` badge keeps showing), matching the pre-PR behavior
+  // where ``refreshMigrationState().catch`` logged without clearing.
+  migration: SessionFinalizeMigration | null;
+}
+
+export const finalizeGameSession = callable<[number], SessionFinalizeResult>("finalize_game_session");
+
 // Delete operations
 export const deleteLocalSaves = callable<[number], { success: boolean; deleted_count: number; message: string }>("delete_local_saves");
 export const deletePlatformSaves = callable<[string], { success: boolean; deleted_count: number; message: string }>("delete_platform_saves");

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -8,18 +8,14 @@
 
 import { toaster } from "@decky/api";
 import {
-  postExitSync,
   recordSessionStart,
-  recordSessionEnd,
   getAppIdRomIdMap,
-  syncAchievementsAfterSession,
-  refreshMigrationState,
+  finalizeGameSession,
   logInfo,
   logError,
 } from "../api/backend";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
-import type { SyncConflict } from "../types";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 
 declare var Router: {
@@ -94,68 +90,46 @@ async function handleGameStop(): Promise<void> {
   sessionStartTime = null;
   totalPausedMs = 0;
 
-  // Record session end for playtime tracking
   try {
-    const result = await recordSessionEnd(romId);
-    if (result.success && result.total_seconds) {
-      // Find the Steam app ID for this rom and update the display
+    const result = await finalizeGameSession(romId);
+
+    // Playtime display update — appStore mutation must stay frontend.
+    if (result.total_seconds != null) {
       const appId = getAppIdForRom(romId);
       if (appId) {
         updatePlaytimeDisplay(appId, result.total_seconds);
       }
     }
-  } catch (e) {
-    logError(`Failed to record session end: ${e}`);
-  }
 
-  // Post-session achievement sync (fire-and-forget, non-blocking)
-  syncAchievementsAfterSession(romId)
-    .then(() => logInfo(`Achievement sync complete for romId=${romId}`))
-    .catch((e) => logError(`Achievement sync failed for romId=${romId}: ${e}`));
-
-  // Post-exit save sync — backend reads the previous save-sort layout when a
-  // migration is pending (#238), so this call is order-independent wrt
-  // refreshMigrationState below. The ordering here is incidental, not
-  // load-bearing.
-  try {
-    const result = await postExitSync(romId);
-    if (result.offline) {
-      toaster.toast({ title: "RomM Save Sync", body: "Server offline — saves will sync next time" });
-      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-    } else if (result.success) {
-      if (result.synced && result.synced > 0) {
-        toaster.toast({ title: "RomM Save Sync", body: "Saves synced with RomM" });
-      }
-      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-    } else {
-      toaster.toast({ title: "RomM Save Sync", body: "Failed to sync saves after exit" });
+    // Post-exit sync toast (backend rendered).
+    if (result.sync.toast_title && result.sync.toast_body) {
+      toaster.toast({ title: result.sync.toast_title, body: result.sync.toast_body });
     }
-    if (result.conflicts && result.conflicts.length > 0) {
-      notifyConflicts(result.conflicts);
+
+    // Save-sync event dispatch — fires for offline OR success (pre-PR parity:
+    // offline branch dispatched, success branch dispatched, failure did not).
+    if (result.sync.offline || result.sync.success) {
+      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+    }
+
+    // Additive conflicts toast — backend renders the count string.
+    if (result.sync.conflicts_toast) {
+      toaster.toast({ title: "RomM Save Sync", body: result.sync.conflicts_toast });
+    }
+
+    // Migration store updates — backend ran refresh_state, frontend just
+    // feeds the typed payloads into the stores. When backend refresh
+    // failed (``migration == null``) leave the stores untouched, matching
+    // the pre-PR ``refreshMigrationState().catch`` behavior where a
+    // refresh failure logged a warning without clearing any stale
+    // "pending" badge.
+    if (result.migration) {
+      setMigrationStatus(result.migration.retrodeck);
+      setSaveSortMigrationStatus(result.migration.save_sort);
     }
   } catch (e) {
-    logError(`Post-exit sync failed: ${e}`);
+    logError(`Failed to finalize game session: ${e}`);
   }
-
-  // Post-game migration detection — runs unconditionally. refreshMigrationState
-  // only reads config files + state and emits events on genuine change; it
-  // does not touch user save files. Actual migration runs only when the user
-  // explicitly clicks the migrate button in Settings.
-  refreshMigrationState()
-    .then(({ retrodeck, save_sort }) => {
-      setMigrationStatus(retrodeck);
-      setSaveSortMigrationStatus(save_sort);
-    })
-    .catch((e) => logError(`Post-exit migration refresh failed: ${e}`));
-}
-
-function notifyConflicts(conflicts: SyncConflict[]): void {
-  const count = conflicts.length;
-  if (count === 0) return;
-  toaster.toast({
-    title: "RomM Save Sync",
-    body: `${count} save conflict${count === 1 ? "" : "s"} need resolution`,
-  });
 }
 
 function handleSuspend(): void {

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -1,0 +1,646 @@
+"""Tests for SessionLifecycleService."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from services.session_lifecycle import (
+    SessionFinalizeMigration,
+    SessionFinalizeResult,
+    SessionFinalizeSyncResult,
+    SessionLifecycleService,
+    SessionLifecycleServiceConfig,
+)
+
+
+class FakePlaytimeRecorder:
+    """In-memory ``SessionPlaytimeRecorder`` for tests."""
+
+    def __init__(
+        self,
+        *,
+        payload: dict | None = None,
+        side_effect: BaseException | None = None,
+    ) -> None:
+        self.payload: dict = payload if payload is not None else {"success": True, "total_seconds": 3600}
+        self.side_effect = side_effect
+        self.calls: list[int] = []
+
+    async def record_session_end(self, rom_id: int) -> dict:
+        self.calls.append(rom_id)
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.payload
+
+
+class FakePostExitSync:
+    """In-memory ``SessionPostExitSync`` for tests."""
+
+    def __init__(
+        self,
+        *,
+        payload: dict | None = None,
+        side_effect: BaseException | None = None,
+    ) -> None:
+        self.payload: dict = payload if payload is not None else {"success": True, "synced": 0, "conflicts": []}
+        self.side_effect = side_effect
+        self.calls: list[int] = []
+
+    async def post_exit_sync(self, rom_id: int) -> dict:
+        self.calls.append(rom_id)
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.payload
+
+
+class FakeAchievementSync:
+    """In-memory ``SessionAchievementSync`` for tests."""
+
+    def __init__(
+        self,
+        *,
+        payload: dict | None = None,
+        side_effect: BaseException | None = None,
+        completion_event: asyncio.Event | None = None,
+    ) -> None:
+        self.payload: dict = payload if payload is not None else {"success": True}
+        self.side_effect = side_effect
+        self.completion_event = completion_event
+        self.calls: list[int] = []
+
+    async def sync_achievements_after_session(self, rom_id: int) -> dict:
+        self.calls.append(rom_id)
+        try:
+            if self.side_effect is not None:
+                raise self.side_effect
+            return self.payload
+        finally:
+            if self.completion_event is not None:
+                self.completion_event.set()
+
+
+class FakeMigrationReader:
+    """In-memory ``SessionMigrationReader`` for tests."""
+
+    def __init__(
+        self,
+        *,
+        payload: dict | None = None,
+        side_effect: BaseException | None = None,
+        pending: bool = False,
+    ) -> None:
+        self.payload: dict = (
+            payload if payload is not None else {"retrodeck": {"pending": False}, "save_sort": {"pending": False}}
+        )
+        self.side_effect = side_effect
+        self.pending = pending
+        self.refresh_calls = 0
+        self.pending_calls = 0
+
+    async def refresh_state(self) -> dict:
+        self.refresh_calls += 1
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.payload
+
+    def is_retrodeck_migration_pending(self) -> bool:
+        self.pending_calls += 1
+        return self.pending
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test_session_lifecycle")
+
+
+def _make_service(
+    *,
+    playtime_recorder: FakePlaytimeRecorder,
+    post_exit_sync: FakePostExitSync,
+    achievement_sync: FakeAchievementSync,
+    migration_reader: FakeMigrationReader,
+    logger: logging.Logger,
+) -> SessionLifecycleService:
+    return SessionLifecycleService(
+        config=SessionLifecycleServiceConfig(
+            playtime_recorder=playtime_recorder,
+            post_exit_sync=post_exit_sync,
+            achievement_sync=achievement_sync,
+            migration_reader=migration_reader,
+            logger=logger,
+        ),
+    )
+
+
+async def _drain_background_tasks(service: SessionLifecycleService) -> None:
+    """Await any in-flight fire-and-forget tasks so the loop can finish them.
+
+    ``finalize`` schedules the achievement sync detached from its return
+    value — tests that assert the achievement sync ran (or didn't) need
+    to give the loop a chance to execute it before inspecting fakes.
+    """
+    tasks = list(service._background_tasks)
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+class TestFinalizePlaytime:
+    def test_success_returns_total_seconds(self, event_loop, logger):
+        """Playtime record success → ``total_seconds`` carries the updated total."""
+        playtime = FakePlaytimeRecorder(payload={"success": True, "total_seconds": 7200})
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.total_seconds == 7200
+        assert playtime.calls == [99]
+
+    def test_no_session_returns_none(self, event_loop, logger):
+        """Playtime record returns ``success=False`` → ``total_seconds=None``."""
+        playtime = FakePlaytimeRecorder(payload={"success": False, "message": "No active session"})
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.total_seconds is None
+
+    def test_exception_returns_none(self, event_loop, logger):
+        """Playtime recorder raises → ``total_seconds=None``, downstream still runs."""
+        playtime = FakePlaytimeRecorder(side_effect=RuntimeError("boom"))
+        post = FakePostExitSync()
+        migration = FakeMigrationReader()
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.total_seconds is None
+        # Playtime failure must NOT short-circuit the rest of the orchestration.
+        assert post.calls == [99]
+        assert migration.refresh_calls == 1
+
+    def test_missing_total_seconds_key_returns_none(self, event_loop, logger):
+        """``success=True`` but no ``total_seconds`` key → ``total_seconds=None``."""
+        playtime = FakePlaytimeRecorder(payload={"success": True})
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.total_seconds is None
+
+    def test_non_int_total_seconds_returns_none(self, event_loop, logger):
+        """Non-int ``total_seconds`` (e.g. None, str) → ``total_seconds=None``."""
+        playtime = FakePlaytimeRecorder(payload={"success": True, "total_seconds": None})
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.total_seconds is None
+
+
+class TestFinalizeSyncToasts:
+    def test_offline_renders_offline_toast_with_dispatch_flag(self, event_loop, logger):
+        """``offline=True`` → offline-body toast, offline flag preserved for dispatch."""
+        post = FakePostExitSync(payload={"offline": True, "success": False})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.offline is True
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Server offline — saves will sync next time"
+
+    def test_success_with_uploads_renders_synced_toast(self, event_loop, logger):
+        """``success=True, synced>0`` → synced toast."""
+        post = FakePostExitSync(payload={"success": True, "synced": 3, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.success is True
+        assert result.sync.synced == 3
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Saves synced with RomM"
+
+    def test_success_with_no_uploads_renders_no_toast(self, event_loop, logger):
+        """``success=True, synced=0`` → no toast (frontend still dispatches event)."""
+        post = FakePostExitSync(payload={"success": True, "synced": 0, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.success is True
+        assert result.sync.synced == 0
+        assert result.sync.toast_title is None
+        assert result.sync.toast_body is None
+
+    def test_failure_renders_failure_toast(self, event_loop, logger):
+        """``success=False, offline=False`` → failure toast."""
+        post = FakePostExitSync(payload={"success": False})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+
+    def test_post_exit_exception_renders_failure_toast(self, event_loop, logger):
+        """Post-exit sync raises → failure toast, downstream still runs."""
+        post = FakePostExitSync(side_effect=RuntimeError("network down"))
+        migration = FakeMigrationReader()
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.offline is False
+        assert result.sync.success is False
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+        assert result.sync.conflicts == []
+        # Post-exit failure must NOT short-circuit migration refresh.
+        assert migration.refresh_calls == 1
+
+    def test_synced_field_non_int_treated_as_falsy(self, event_loop, logger):
+        """``synced`` not an int (None, str) → no synced toast even when success=True."""
+        post = FakePostExitSync(payload={"success": True, "synced": None, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        # synced was None → treated as no uploads → no toast
+        assert result.sync.synced is None
+        assert result.sync.toast_title is None
+        assert result.sync.toast_body is None
+
+
+class TestFinalizeConflicts:
+    def test_single_conflict_renders_singular_string(self, event_loop, logger):
+        """One conflict → "1 save conflict need resolution" (singular form)."""
+        conflict = {
+            "type": "sync_conflict",
+            "rom_id": 99,
+            "filename": "game.srm",
+            "server_save_id": 7,
+        }
+        post = FakePostExitSync(payload={"success": True, "synced": 1, "conflicts": [conflict]})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.conflicts == [conflict]
+        assert result.sync.conflicts_toast == "1 save conflict need resolution"
+
+    def test_multiple_conflicts_renders_plural_string(self, event_loop, logger):
+        """Multiple conflicts → "N save conflicts need resolution" (plural)."""
+        conflicts = [
+            {"type": "sync_conflict", "rom_id": 99, "filename": "a.srm", "server_save_id": 1},
+            {"type": "sync_conflict", "rom_id": 99, "filename": "b.srm", "server_save_id": 2},
+            {"type": "sync_conflict", "rom_id": 99, "filename": "c.srm", "server_save_id": 3},
+        ]
+        post = FakePostExitSync(payload={"success": True, "synced": 0, "conflicts": conflicts})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.conflicts_toast == "3 save conflicts need resolution"
+
+    def test_no_conflicts_renders_none(self, event_loop, logger):
+        """Empty ``conflicts`` → ``conflicts_toast=None``."""
+        post = FakePostExitSync(payload={"success": True, "synced": 1, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.conflicts == []
+        assert result.sync.conflicts_toast is None
+
+    def test_missing_conflicts_key_treated_as_empty(self, event_loop, logger):
+        """No ``conflicts`` key → empty list, no conflicts toast."""
+        post = FakePostExitSync(payload={"success": True, "synced": 1})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.conflicts == []
+        assert result.sync.conflicts_toast is None
+
+
+class TestFinalizeMigrationRefresh:
+    def test_typed_pair_returned(self, event_loop, logger):
+        """``refresh_state`` payload is repacked into the typed migration aggregate."""
+        migration_payload = {
+            "retrodeck": {"pending": True, "old_path": "/old", "new_path": "/new"},
+            "save_sort": {"pending": False},
+        }
+        migration = FakeMigrationReader(payload=migration_payload)
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.migration.retrodeck == migration_payload["retrodeck"]
+        assert result.migration.save_sort == migration_payload["save_sort"]
+        assert migration.refresh_calls == 1
+
+    def test_refresh_success_returns_populated_aggregate(self, event_loop, logger):
+        """Happy path returns a populated ``SessionFinalizeMigration``, not ``None``."""
+        migration_payload = {
+            "retrodeck": {"pending": False},
+            "save_sort": {"pending": False},
+        }
+        migration = FakeMigrationReader(payload=migration_payload)
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert isinstance(result.migration, SessionFinalizeMigration)
+        assert result.migration.retrodeck == {"pending": False}
+        assert result.migration.save_sort == {"pending": False}
+
+    def test_refresh_exception_returns_none(self, event_loop, logger):
+        """``refresh_state`` raises → ``migration`` is ``None`` (frontend leaves stores untouched)."""
+        migration = FakeMigrationReader(side_effect=RuntimeError("config parse fail"))
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.migration is None
+
+    def test_refresh_returns_non_dict_returns_none(self, event_loop, logger):
+        """``refresh_state`` returns a non-dict → ``migration`` is ``None``."""
+        migration = FakeMigrationReader(payload="garbage")  # type: ignore[arg-type]
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.migration is None
+
+    def test_refresh_partial_payload_keeps_aggregate(self, event_loop, logger):
+        """``refresh_state`` returns a dict with non-dict fields → aggregate present, fields cleared."""
+        migration = FakeMigrationReader(payload={"retrodeck": None, "save_sort": "garbage"})  # type: ignore[arg-type]
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        # Outer payload was a dict — the aggregate is still returned, but
+        # each non-dict field falls back to the safe "not pending" default.
+        assert isinstance(result.migration, SessionFinalizeMigration)
+        assert result.migration.retrodeck == {"pending": False}
+        assert result.migration.save_sort == {"pending": False}
+
+
+class TestFinalizeMigrationGate:
+    def test_pending_migration_skips_post_exit_sync(self, event_loop, logger):
+        """``is_retrodeck_migration_pending=True`` → skip post-exit sync, render failure toast."""
+        post = FakePostExitSync()
+        migration = FakeMigrationReader(pending=True)
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        # Post-exit sync must not be called when migration is pending.
+        assert post.calls == []
+        assert result.sync.offline is False
+        assert result.sync.success is False
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+        # Playtime + migration refresh still ran.
+        assert result.total_seconds == 3600
+        assert migration.refresh_calls == 1
+
+
+class TestFinalizeAchievementSync:
+    def test_achievement_sync_runs_as_background_task(self, event_loop, logger):
+        """Achievement sync is scheduled but not awaited by ``finalize``."""
+        completion = asyncio.Event()
+        achievements = FakeAchievementSync(completion_event=completion)
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=achievements,
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        # Drain background tasks so the achievement call actually executes.
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert achievements.calls == [99]
+        assert completion.is_set()
+        # Result is constructed from playtime + post-exit + migration, never
+        # waits on achievement sync.
+        assert isinstance(result, SessionFinalizeResult)
+
+    def test_achievement_sync_failure_does_not_affect_result(self, event_loop, logger):
+        """Achievement sync raises → logged, but ``finalize`` still returns success."""
+        achievements = FakeAchievementSync(side_effect=RuntimeError("RA down"))
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=achievements,
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        # The failing fire-and-forget call did run, but did not affect the
+        # returned DTO.
+        assert achievements.calls == [99]
+        assert isinstance(result.sync, SessionFinalizeSyncResult)
+        assert isinstance(result.migration, SessionFinalizeMigration)
+
+
+class TestFinalizeResultShape:
+    def test_happy_path_full_dto(self, event_loop, logger):
+        """Happy path returns a fully populated ``SessionFinalizeResult``."""
+        conflicts = [
+            {"type": "sync_conflict", "rom_id": 99, "filename": "a.srm", "server_save_id": 1},
+        ]
+        playtime = FakePlaytimeRecorder(payload={"success": True, "total_seconds": 1234})
+        post = FakePostExitSync(payload={"success": True, "synced": 2, "conflicts": conflicts})
+        migration = FakeMigrationReader(payload={"retrodeck": {"pending": False}, "save_sort": {"pending": False}})
+        service = _make_service(
+            playtime_recorder=playtime,
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=migration,
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result == SessionFinalizeResult(
+            total_seconds=1234,
+            sync=SessionFinalizeSyncResult(
+                offline=False,
+                success=True,
+                synced=2,
+                conflicts=conflicts,
+                toast_title="RomM Save Sync",
+                toast_body="Saves synced with RomM",
+                conflicts_toast="1 save conflict need resolution",
+            ),
+            migration=SessionFinalizeMigration(
+                retrodeck={"pending": False},
+                save_sort={"pending": False},
+            ),
+        )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -269,7 +269,7 @@ class TestWireServices:
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(self._make_config(deps))
-        assert len(result) == 18
+        assert len(result) == 19
         assert "migration_service" in result
         assert "game_detail_service" in result
         assert "rom_removal_service" in result
@@ -279,6 +279,7 @@ class TestWireServices:
         assert "connection_service" in result
         assert "startup_healing_service" in result
         assert "launch_gate_service" in result
+        assert "session_lifecycle_service" in result
         deps["loop"].close()
 
     def test_pending_sync_binding_observes_library_rebinds(self, tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -691,6 +691,15 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_download_queue",
     "get_installed_rom",
     "evaluate_launch",
+    # End-of-session orchestration — composes record_session_end (whitelisted),
+    # post_exit_sync (decorator-gated, but SessionLifecycleService applies its
+    # own ``is_retrodeck_migration_pending`` check internally so the
+    # destructive sync stays gated), the fire-and-forget achievement refresh,
+    # and refresh_migration_state (whitelisted). Whitelisting the umbrella
+    # callable matches pre-PR behaviour: the playtime record and migration
+    # refresh ran regardless of pending migration; only the save sync was
+    # gated, and the lifecycle service preserves that gate inline.
+    "finalize_game_session",
     # Firmware / BIOS read-only checks.
     "get_firmware_status",
     "check_platform_bios",
@@ -861,6 +870,7 @@ class TestMainStartupOrdering:
             "connection_service": MagicMock(),
             "startup_healing_service": startup_healing_service,
             "launch_gate_service": MagicMock(),
+            "session_lifecycle_service": MagicMock(),
         }
 
         bootstrapped_adapters = {


### PR DESCRIPTION
## Summary

Fourth Phase 7 implementation. Mirror of #458 for the game-stop path. `sessionManager.handleGameStop` chained four callables (two awaited + two fire-and-forget) per game exit with toast + dispatch interleaved between them. This PR collapses them into one `finalize_game_session(rom_id) → SessionFinalizeResult` round-trip.

## Architecture

New service `py_modules/services/session_lifecycle.py` (Cosmic Python compliant):
- Frozen `SessionLifecycleServiceConfig`
- Four narrow cross-service Protocols — one per upstream surface
- Pure orchestration; zero raw I/O
- Added to `service-independence` import-linter contract

`SessionFinalizeResult` DTO is render-ready: backend pre-resolves toast titles/bodies, the dispatch flag, the conflict-count string (singular/plural matched to frontend byte-for-byte).

Achievement sync moves backend-side as `asyncio.create_task` with a done-callback to discard the task reference. Failures log server-side; never propagate to the umbrella.

## What stays frontend (per audit #455)

- `updatePlaytimeDisplay(appId, total_seconds)` — Steam `appStore` mutation
- Lifecycle chain promise serialization
- `RegisterForAppLifetimeNotifications` / `RegisterForOnSuspend/Resume` hooks
- The synchronous `migrationStore.pending` check (separate from the inline gate this PR adds backend-side)

## Migration-block parity

Pre-PR: `post_exit_sync` carried `@migration_blocked` decorator that returned a synthetic blocked-response. Preserved here by adding `is_retrodeck_migration_pending` to `SessionMigrationReader`; the service gates `post_exit_sync` inline. When pending, the umbrella renders the same "Failed to sync saves after exit" toast.

## Migration-refresh failure parity (LOW finding from reviewer, fixed)

Pre-PR: `refreshMigrationState().catch(...)` left stores untouched on failure (stale `pending=true` badge preserved). The first cut of this PR changed that to clear the badge on failure. Reviewer flagged; restored strict parity by making `migration` nullable in the DTO and gating the frontend writes behind `if (result.migration)`.

## Test plan

- [x] `pytest tests/ -q` — 2304/2304 passed (was 2280; +24 new tests)
- [x] `ruff check py_modules tests` — clean
- [x] `basedpyright py_modules tests` — 0 errors / warnings / notes
- [x] `lint-imports` — 7 contracts kept, 0 broken
- [x] `check_cosmic_call_bans.sh` — clean (`asyncio.create_task` not banned)
- [x] `pnpm build` — TS compiles
- [x] Coverage on `services/session_lifecycle.py`: **100%** (108 stmts, 14 branches)
- [x] All 8 behaviour-parity scenarios verified byte-for-byte
- [ ] CI green
- [ ] SonarCloud 0 new issues

11 files. New service + new test file dominate the LOC count.

Closes #459. Part of #386.