### PR TITLE
refactor(ui): lift nested callbacks to named helpers (#397)

### DIFF
--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -35,22 +35,26 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     }
   };
 
+  // Un-clear rom_ids that have new active downloads (re-download case)
+  const unclearRestarted = (current: DownloadItem[]) => (prev: Set<number>): Set<number> => {
+    const restarted = current.filter(
+      (d) => (d.status === "downloading" || d.status === "queued") && prev.has(d.rom_id),
+    );
+    if (restarted.length === 0) return prev;
+    const next = new Set(prev);
+    for (const d of restarted) next.delete(d.rom_id);
+    return next;
+  };
+
+  const pollTick = () => {
+    const current = getDownloadState();
+    setCleared(unclearRestarted(current));
+    setLocalDownloads([...current]);
+  };
+
   const startPolling = () => {
     stopPolling();
-    pollRef.current = setInterval(() => {
-      const current = getDownloadState();
-      // Un-clear rom_ids that have new active downloads (re-download case)
-      setCleared((prev) => {
-        const restarted = current.filter(
-          (d) => (d.status === "downloading" || d.status === "queued") && prev.has(d.rom_id),
-        );
-        if (restarted.length === 0) return prev;
-        const next = new Set(prev);
-        restarted.forEach((d) => next.delete(d.rom_id));
-        return next;
-      });
-      setLocalDownloads([...current]);
-    }, 500);
+    pollRef.current = setInterval(pollTick, 500);
   };
 
   useEffect(() => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -103,6 +103,45 @@ function refreshSlotState(
     .catch(() => {});
 }
 
+/** Fire-and-forget installed-rom fetch — kept at module scope to avoid nesting. */
+function refreshInstalledRomInBackground(
+  romId: number,
+  cancelled: () => boolean,
+  setter: React.Dispatch<React.SetStateAction<PanelState>>,
+): Promise<void> {
+  return getInstalledRom(romId).then((installed) => {
+    if (!cancelled() && installed) {
+      setter((prev) => ({ ...prev, installedRom: installed }));
+    }
+  }).catch(() => {});
+}
+
+/** Fire-and-forget cover-art fetch — kept at module scope to avoid nesting. */
+function refreshCoverArtInBackground(
+  romId: number,
+  cancelled: () => boolean,
+  setter: React.Dispatch<React.SetStateAction<PanelState>>,
+): Promise<void> {
+  return getArtworkBase64(romId).then((result) => {
+    if (!cancelled() && result.base64) {
+      setter((prev) => ({ ...prev, coverBase64: result.base64 }));
+    }
+  }).catch(() => {});
+}
+
+/** Fire-and-forget metadata fetch — kept at module scope to avoid nesting. */
+function refreshMetadataInBackground(
+  romId: number,
+  cancelled: () => boolean,
+  setter: React.Dispatch<React.SetStateAction<PanelState>>,
+): Promise<void> {
+  return getRomMetadata(romId).then((meta) => {
+    if (!cancelled() && meta) {
+      setter((prev) => ({ ...prev, metadata: meta }));
+    }
+  }).catch(() => {});
+}
+
 export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
@@ -245,38 +284,21 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
 
         // Phase 2: Background fetch for data not available in cache
         // (installed ROM details, cover art, full save/BIOS detail, metadata if missing)
+        const isCancelled = () => cancelled;
         const bgPromises: Promise<void>[] = [];
 
         // Installed ROM details (for filename display)
         if (cached.installed) {
-          bgPromises.push(
-            getInstalledRom(romId).then((installed) => {
-              if (!cancelled && installed) {
-                setState((prev) => ({ ...prev, installedRom: installed }));
-              }
-            }).catch(() => {}),
-          );
+          bgPromises.push(refreshInstalledRomInBackground(romId, isCancelled, setState));
         }
 
         // Cover art
-        bgPromises.push(
-          getArtworkBase64(romId).then((result) => {
-            if (!cancelled && result.base64) {
-              setState((prev) => ({ ...prev, coverBase64: result.base64 }));
-            }
-          }).catch(() => {}),
-        );
+        bgPromises.push(refreshCoverArtInBackground(romId, isCancelled, setState));
 
         // Metadata (if missing or stale)
         const metaStale = cached.stale_fields?.includes("metadata") ?? true;
         if (!cached.metadata || metaStale) {
-          bgPromises.push(
-            getRomMetadata(romId).then((meta) => {
-              if (!cancelled && meta) {
-                setState((prev) => ({ ...prev, metadata: meta }));
-              }
-            }).catch(() => {}),
-          );
+          bgPromises.push(refreshMetadataInBackground(romId, isCancelled, setState));
         }
 
         await Promise.all(bgPromises);

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -230,6 +230,23 @@ function refreshBiosInBackground(
   }).catch((e) => debugLog(`Background BIOS status fetch error: ${e}`));
 }
 
+/** Fire-and-forget achievement progress refresh — kept at module scope to avoid nesting. */
+function refreshAchievementsInBackground(
+  romId: number,
+  cancelled: () => boolean,
+  setter: React.Dispatch<React.SetStateAction<InfoState>>,
+) {
+  getAchievementProgress(romId).then((result) => {
+    if (!cancelled() && result.success) {
+      setter((prev) => ({
+        ...prev,
+        achievementEarned: result.earned,
+        achievementTotal: result.total,
+      }));
+    }
+  }).catch((e) => debugLog(`Background achievement progress fetch error: ${e}`));
+}
+
 export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
@@ -322,36 +339,19 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         }
 
         // Achievements: render from cache, background refresh if stale
-        const refreshAchievements = (result: { success: boolean; earned: number; total: number }) => {
-          if (!cancelled && result.success) {
-            setInfo((prev) => ({
-              ...prev,
-              achievementEarned: result.earned,
-              achievementTotal: result.total,
-            }));
-          }
-        };
         if (cached.ra_id && staleFields.includes("achievements")) {
-          getAchievementProgress(romId).then(refreshAchievements)
-            .catch((e) => debugLog(`Background achievement progress fetch error: ${e}`));
+          refreshAchievementsInBackground(romId, () => cancelled, setInfo);
         }
 
         // BIOS: render from cache first, background refresh if stale
         const cachedBios = cached.bios_status;
         if (cachedBios) {
-          const activeCoreLabel = cachedBios.active_core_label ?? null;
-          const availableCores = cachedBios.available_cores ?? [];
-          const defaultCore = availableCores.find((c) => c.is_default);
-          const activeCoreIsDefault = !activeCoreLabel || activeCoreLabel === defaultCore?.label;
-          setInfo((prev) => ({
-            ...prev,
-            biosNeeded: true,
-            biosStatus: cached.bios_level ?? null,
-            biosLabel: cached.bios_label ?? "",
-            activeCoreLabel,
-            activeCoreIsDefault,
-            availableCores,
-          }));
+          const biosPartial = extractBiosInfo(
+            cachedBios as BiosStatus,
+            cached.bios_level ?? null,
+            cached.bios_label ?? "",
+          );
+          setInfo((prev) => ({ ...prev, ...biosPartial }));
         }
 
         if (staleFields.includes("bios")) {


### PR DESCRIPTION
## Summary

Sonar S2004 (nested function depth > 4) mechanical lift across three components.

- **`DownloadQueue.tsx`** — `setInterval → setCleared → forEach` was depth 5. Lifted `unclearRestarted` (curried updater using `for...of`) + `pollTick`.
- **`RomMGameInfoPanel.tsx`** — three `.then((x) => { if (!cancelled && x) setState(...) })` were depth 5. Lifted to module-scope helpers (`refreshInstalledRomInBackground` / `refreshCoverArtInBackground` / `refreshMetadataInBackground`). Call sites bridge `cancelled` via `const isCancelled = () => cancelled` — getter closure reading at call-time, matching the original inline `.then` arrow semantics byte-for-byte.
- **`RomMPlaySection.tsx`** — `setInfo((prev) => ...)` inside inline `refreshAchievements` was depth 5. Lifted to module-scope `refreshAchievementsInBackground` mirroring `refreshBiosInBackground`. Bonus: collapsed inline BIOS extraction at lines 339-355 into the existing `extractBiosInfo` helper (reviewer verified field-by-field equivalence).

Tier-3 files. Behaviour byte-identical pre/post.

3 files, +85/-59 (post-rebase onto current main with #391/#396 merged; no conflicts).

## Test plan

- [x] `pnpm build` — clean
- [x] `pytest tests/ -q` — 2304/2304 passed
- [x] `ruff` + `basedpyright` — clean
- [x] Reviewer verified `isCancelled` closure reads at call-time + `extractBiosInfo` produces identical field output
- [x] Each previous Sonar S2004 site verified depth ≤ 3 post-lift
- [ ] CI green
- [ ] SonarCloud — S2004 findings resolve

Closes #397. Part of #386.