### PR TITLE
refactor(ui): split applyAllPlaytime into tryWritePlaytime + retry driver (#395)

### DIFF
--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -118,6 +118,22 @@ export function updatePlaytimeDisplay(appId: number, totalSeconds: number, updat
   return true;
 }
 
+type PlaytimeItem = { appId: number; totalSeconds: number };
+
+/**
+ * Attempt one pass of playtime writes. Returns items whose appStore overview
+ * wasn't available yet, so the caller can retry them after a delay.
+ */
+function tryWritePlaytime(items: PlaytimeItem[]): PlaytimeItem[] {
+  const notWritten: PlaytimeItem[] = [];
+  for (const item of items) {
+    if (!updatePlaytimeDisplay(item.appId, item.totalSeconds, false)) {
+      notWritten.push(item);
+    }
+  }
+  return notWritten;
+}
+
 /**
  * Apply playtime data for all known apps from the bulk playtime map.
  * Retries apps whose appStore overview isn't available yet (Steam may
@@ -135,7 +151,7 @@ export async function applyAllPlaytime(
   }
 
   // Build list of {appId, totalSeconds} to apply
-  let pending: { appId: number; totalSeconds: number }[] = [];
+  let pending: PlaytimeItem[] = [];
   for (const [romIdStr, entry] of Object.entries(playtimeMap)) {
     const appId = romIdToAppId[romIdStr];
     if (appId && entry.total_seconds > 0) {
@@ -154,13 +170,7 @@ export async function applyAllPlaytime(
       await new Promise((r) => setTimeout(r, delays[attempt]));
     }
 
-    const failed: typeof pending = [];
-    for (const item of pending) {
-      if (!updatePlaytimeDisplay(item.appId, item.totalSeconds, false)) {
-        failed.push(item);
-      }
-    }
-    pending = failed;
+    pending = tryWritePlaytime(pending);
 
     if (pending.length > 0 && attempt < delays.length - 1) {
       debugLog(`applyAllPlaytime: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`);


### PR DESCRIPTION
## Summary

`applyAllPlaytime` was at Sonar c=19. The complexity is retry-loop complexity (Steam appStore hydration timing), not decision logic — can't move backend per the audit. Decompose in-place:

- `tryWritePlaytime(items): notWritten[]` — pure single-pass helper
- `applyAllPlaytime` becomes a thin retry driver iterating `[0, 1000, 3000, 5000]` delays

Driver hand-counts to ~13 complexity. Retry timing, predicate, reverse-lookup preamble, `stateTransaction` wrapper untouched.

1 file, +18/-8.

## Test plan

- [x] `pnpm build` — clean
- [x] `pytest tests/ -q` — 2304/2304 passed
- [x] `ruff` + `basedpyright` — clean
- [x] Reviewer verified byte-identical behaviour
- [ ] CI green
- [ ] SonarCloud — c=19 finding resolves

Closes #395. Part of #386.