### PR TITLE
refactor(ui): split DangerZone god component into sub-sections (#393)

### DIFF
--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -38,6 +38,22 @@ const DEFAULT_WHITELIST_PATTERNS: string[] = [
   "nonsteamlaunchers",
 ];
 
+// Fuzzy match: each character of the query must appear in order in the target (like fzf)
+const fuzzyMatch = (query: string, target: string): boolean => {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++;
+  }
+  return qi === q.length;
+};
+
+interface NonSteamApp {
+  appId: number;
+  name: string;
+}
+
 const PlatformActionModal: FC<{
   platform: RegistryPlatform;
   closeModal?: () => void;
@@ -68,127 +84,27 @@ const PlatformActionModal: FC<{
   </ModalRoot>
 );
 
-interface DangerZoneProps {
-  onBack: () => void;
+interface ShortcutRemovalSectionProps {
+  platforms: RegistryPlatform[];
+  loading: boolean;
+  refreshPlatforms: () => Promise<void>;
+  loadNonSteamApps: () => void;
+  status: string;
+  setStatus: (s: string) => void;
 }
 
-export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
-  const [status, setStatus] = useState("");
-  const [platforms, setPlatforms] = useState<RegistryPlatform[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [showWhitelist, setShowWhitelist] = useState(false);
-  const [disabledDefaults, setDisabledDefaults] = useState<string[]>([]);
-  const [customNames, setCustomNames] = useState<string[]>([]);
-  const [settingsLoaded, setSettingsLoaded] = useState(false);
-  const [nonSteamApps, setNonSteamApps] = useState<{ appId: number; name: string }[]>([]);
-  const [confirmRemoveAllRomm, setConfirmRemoveAllRomm] = useState(false);
-  const [confirmRemoveAll, setConfirmRemoveAll] = useState(false);
-  const [confirmRetrodeck, setConfirmRetrodeck] = useState(false);
-  const [confirmUninstall, setConfirmUninstall] = useState(false);
-  const [uninstallStatus, setUninstallStatus] = useState("");
+const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
+  platforms,
+  loading,
+  refreshPlatforms,
+  loadNonSteamApps,
+  status,
+  setStatus,
+}) => {
   const [actionStatus, setActionStatus] = useState("");
-  const [whitelistSearch, setWhitelistSearch] = useState("");
-
-  const activeDefaults = useMemo(
-    () => DEFAULT_WHITELIST_PATTERNS.filter((p) => !disabledDefaults.includes(p)),
-    [disabledDefaults]
-  );
-
-  const getMatchingPattern = (name: string): string | undefined => {
-    const lower = name.toLowerCase();
-    return activeDefaults.find((p) => lower.includes(p));
-  };
-
-  const isWhitelisted = (app: { appId: number; name: string }): boolean => {
-    return !!getMatchingPattern(app.name) || customNames.includes(app.name);
-  };
-
-  const whitelistedIds = useMemo(() => {
-    const set = new Set<number>();
-    for (const app of nonSteamApps) {
-      if (isWhitelisted(app)) set.add(app.appId);
-    }
-    return set;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nonSteamApps, activeDefaults, customNames]);
-
-  const refreshPlatforms = async () => {
-    setLoading(true);
-    try {
-      const result = await getRegistryPlatforms();
-      setPlatforms(result.platforms || []);
-    } catch {
-      setPlatforms([]);
-    }
-    setLoading(false);
-  };
-
-  const loadNonSteamApps = () => {
-    const apps: { appId: number; name: string }[] = [];
-    try {
-      if (typeof collectionStore === "undefined") {
-        logWarn("collectionStore not available");
-        setNonSteamApps([]);
-        return;
-      }
-      const deckApps = collectionStore.deckDesktopApps?.apps;
-      if (!deckApps) {
-        logWarn("deckDesktopApps.apps not available");
-        setNonSteamApps([]);
-        return;
-      }
-      logInfo(`deckDesktopApps.apps size: ${deckApps.size}`);
-      const appIds = Array.from(deckApps.keys());
-      for (const appId of appIds) {
-        let name = `Unknown (${appId})`;
-        if (typeof appStore !== "undefined") {
-          const overview = appStore.GetAppOverviewByAppID(appId);
-          if (overview) {
-            name = (overview as any).strDisplayName || (overview as any).display_name || name;
-          }
-        }
-        apps.push({ appId, name });
-      }
-    } catch (e) {
-      logError(`Failed to enumerate non-steam games: ${e}`);
-    }
-    apps.sort((a, b) => a.name.localeCompare(b.name));
-    setNonSteamApps(apps);
-  };
-
-  // Fuzzy match: each character of the query must appear in order in the target (like fzf)
-  const fuzzyMatch = (query: string, target: string): boolean => {
-    const q = query.toLowerCase();
-    const t = target.toLowerCase();
-    let qi = 0;
-    for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-      if (t[ti] === q[qi]) qi++;
-    }
-    return qi === q.length;
-  };
-
-  const filteredApps = useMemo(
-    () => whitelistSearch
-      ? nonSteamApps.filter((app) => fuzzyMatch(whitelistSearch, app.name))
-      : nonSteamApps,
-    [nonSteamApps, whitelistSearch]
-  );
-
-  useEffect(() => {
-    refreshPlatforms();
-    loadNonSteamApps();
-    getWhitelistSettings().then((s) => {
-      setDisabledDefaults(s.disabled_defaults);
-      setCustomNames(s.custom_names);
-      setSettingsLoaded(true);
-    });
-  }, []);
-
-  const persistWhitelist = (newDisabled: string[], newCustom: string[]) => {
-    setDisabledDefaults(newDisabled);
-    setCustomNames(newCustom);
-    updateWhitelistSettings(newDisabled, newCustom);
-  };
+  const [uninstallStatus, setUninstallStatus] = useState("");
+  const [confirmRemoveAllRomm, setConfirmRemoveAllRomm] = useState(false);
+  const [confirmUninstall, setConfirmUninstall] = useState(false);
 
   const handleRemoveShortcuts = async (p: RegistryPlatform) => {
     setActionStatus(`Removing ${p.name} shortcuts...`);
@@ -244,47 +160,50 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
     }
   };
 
+  const handleRemoveAllRomm = async () => {
+    if (!confirmRemoveAllRomm) {
+      setConfirmRemoveAllRomm(true);
+      return;
+    }
+    setConfirmRemoveAllRomm(false);
+    setStatus("Removing all shortcuts...");
+    const result = await removeAllShortcuts();
+    if (result.app_ids) {
+      for (const appId of result.app_ids) {
+        removeShortcut(appId);
+      }
+    }
+    if (result.rom_ids?.length) {
+      await reportRemovalResults(result.rom_ids);
+    }
+    await clearAllRomMCollections();
+    setStatus(result.message);
+    await refreshPlatforms();
+    loadNonSteamApps();
+  };
+
+  const handleUninstallAll = async () => {
+    if (!confirmUninstall) {
+      setConfirmUninstall(true);
+      return;
+    }
+    try {
+      setUninstallStatus("Uninstalling...");
+      const result = await uninstallAllRoms();
+      setUninstallStatus(result.message);
+    } catch {
+      setUninstallStatus("Failed to uninstall ROMs");
+    }
+    setConfirmUninstall(false);
+    await refreshPlatforms();
+    loadNonSteamApps();
+  };
+
   return (
     <>
-      <PanelSection>
-        <PanelSectionRow>
-          <ButtonItem
-            layout="below"
-            onClick={onBack}
-            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-            onFocus={scrollToTop}
-          >
-            Back
-          </ButtonItem>
-        </PanelSectionRow>
-      </PanelSection>
-
       <PanelSection title="Remove Shortcuts">
         <PanelSectionRow>
-          <ButtonItem
-            layout="below"
-            onClick={async () => {
-              if (!confirmRemoveAllRomm) {
-                setConfirmRemoveAllRomm(true);
-                return;
-              }
-              setConfirmRemoveAllRomm(false);
-              setStatus("Removing all shortcuts...");
-              const result = await removeAllShortcuts();
-              if (result.app_ids) {
-                for (const appId of result.app_ids) {
-                  removeShortcut(appId);
-                }
-              }
-              if (result.rom_ids?.length) {
-                await reportRemovalResults(result.rom_ids);
-              }
-              await clearAllRomMCollections();
-              setStatus(result.message);
-              await refreshPlatforms();
-              loadNonSteamApps();
-            }}
-          >
+          <ButtonItem layout="below" onClick={handleRemoveAllRomm}>
             {confirmRemoveAllRomm
               ? <span style={{ color: "#ff8800" }}>Confirm: remove all RomM shortcuts?</span>
               : "Remove All RomM Shortcuts"}
@@ -336,25 +255,7 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
 
       <PanelSection title="Installed ROMs">
         <PanelSectionRow>
-          <ButtonItem
-            layout="below"
-            onClick={async () => {
-              if (!confirmUninstall) {
-                setConfirmUninstall(true);
-                return;
-              }
-              try {
-                setUninstallStatus("Uninstalling...");
-                const result = await uninstallAllRoms();
-                setUninstallStatus(result.message);
-              } catch {
-                setUninstallStatus("Failed to uninstall ROMs");
-              }
-              setConfirmUninstall(false);
-              await refreshPlatforms();
-              loadNonSteamApps();
-            }}
-          >
+          <ButtonItem layout="below" onClick={handleUninstallAll}>
             {confirmUninstall
               ? <span style={{ color: "#ff8800" }}>Confirm: delete all ROM files?</span>
               : "Uninstall All Installed ROMs"}
@@ -371,129 +272,344 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
           </PanelSectionRow>
         )}
       </PanelSection>
+    </>
+  );
+};
 
-      <PanelSection title="Remove Non-Steam Games">
-        {nonSteamApps.length === 0 ? (
+interface WhitelistSectionProps {
+  nonSteamApps: NonSteamApp[];
+  whitelistedIds: Set<number>;
+  disabledDefaults: string[];
+  customNames: string[];
+  settingsLoaded: boolean;
+  persistWhitelist: (newDisabled: string[], newCustom: string[]) => void;
+  resetRemoveConfirms: () => void;
+}
+
+const WhitelistSection: FC<WhitelistSectionProps> = ({
+  nonSteamApps,
+  whitelistedIds,
+  disabledDefaults,
+  customNames,
+  settingsLoaded,
+  persistWhitelist,
+  resetRemoveConfirms,
+}) => {
+  const [showWhitelist, setShowWhitelist] = useState(false);
+  const [whitelistSearch, setWhitelistSearch] = useState("");
+
+  const filteredApps = useMemo(
+    () => whitelistSearch
+      ? nonSteamApps.filter((app) => fuzzyMatch(whitelistSearch, app.name))
+      : nonSteamApps,
+    [nonSteamApps, whitelistSearch]
+  );
+
+  const handleToggle = (app: NonSteamApp, checked: boolean) => {
+    const matchingPattern = DEFAULT_WHITELIST_PATTERNS.find(
+      (p) => app.name.toLowerCase().includes(p)
+    );
+    let newDisabled = [...disabledDefaults];
+    let newCustom = [...customNames];
+
+    if (checked) {
+      if (matchingPattern && disabledDefaults.includes(matchingPattern)) {
+        newDisabled = newDisabled.filter((p) => p !== matchingPattern);
+      } else if (!matchingPattern) {
+        if (!newCustom.includes(app.name)) {
+          newCustom.push(app.name);
+        }
+      }
+    } else {
+      if (matchingPattern) {
+        if (!newDisabled.includes(matchingPattern)) {
+          newDisabled.push(matchingPattern);
+        }
+      }
+      newCustom = newCustom.filter((n) => n !== app.name);
+    }
+
+    persistWhitelist(newDisabled, newCustom);
+    resetRemoveConfirms();
+  };
+
+  return (
+    <>
+      <PanelSectionRow>
+        <ButtonItem
+          layout="below"
+          onClick={() => {
+            setShowWhitelist(!showWhitelist);
+            resetRemoveConfirms();
+          }}
+        >
+          {showWhitelist ? "Hide Whitelist" : `Configure Whitelist (${whitelistedIds.size} protected)`}
+        </ButtonItem>
+      </PanelSectionRow>
+
+      {showWhitelist && !settingsLoaded && (
+        <PanelSectionRow>
+          <Spinner />
+        </PanelSectionRow>
+      )}
+      {showWhitelist && settingsLoaded && (
+        <>
           <PanelSectionRow>
-            <Field label="No non-steam games found" />
+            <TextField
+              label="Search games"
+              value={whitelistSearch}
+              onChange={(e) => setWhitelistSearch(e?.target?.value ?? "")}
+            />
           </PanelSectionRow>
-        ) : (
-          <>
-            <PanelSectionRow>
-              <ButtonItem
-                layout="below"
-                onClick={async () => {
-                  const retrodeckAtRisk = nonSteamApps.some(
-                    (a) => !whitelistedIds.has(a.appId) && a.name.toLowerCase().includes("retrodeck")
-                  );
-                  if (!confirmRemoveAll) {
-                    setConfirmRemoveAll(true);
-                    return;
-                  }
-                  if (retrodeckAtRisk && !confirmRetrodeck) {
-                    setConfirmRetrodeck(true);
-                    return;
-                  }
-                  const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
-                  setStatus(`Removing ${toRemove.length} non-steam games...`);
-                  for (const app of toRemove) {
-                    SteamClient.Apps.RemoveShortcut(app.appId);
-                  }
-                  setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length !== 1 ? "s" : ""}`);
-                  setConfirmRemoveAll(false);
-                  setConfirmRetrodeck(false);
-                  loadNonSteamApps();
-                  refreshPlatforms();
-                }}
-              >
-                {confirmRetrodeck
-                  ? <span style={{ color: "#ff4444", fontWeight: "bold" }}>!! RETRODECK WILL BE REMOVED !! Click to confirm</span>
-                  : confirmRemoveAll
-                    ? nonSteamApps.some((a) => !whitelistedIds.has(a.appId) && a.name.toLowerCase().includes("retrodeck"))
-                      ? <span style={{ color: "#ff8800" }}>WARNING: RetroDECK not protected! Remove {nonSteamApps.length - whitelistedIds.size} games?</span>
-                      : `Are you sure? Remove ${nonSteamApps.length - whitelistedIds.size} games (${whitelistedIds.size} whitelisted)?`
-                    : `Remove ${nonSteamApps.length - whitelistedIds.size} Non-Steam Games${whitelistedIds.size > 0 ? ` (${whitelistedIds.size} excluded)` : ""}`}
-              </ButtonItem>
+          <PanelSectionRow>
+            <Field label={`Toggle ON to protect (${filteredApps.length}/${nonSteamApps.length}):`} />
+          </PanelSectionRow>
+          {filteredApps.map((app) => (
+            <PanelSectionRow key={app.appId}>
+              <ToggleField
+                label={
+                  DEFAULT_WHITELIST_PATTERNS.some((p) => app.name.toLowerCase().includes(p))
+                    ? `${app.name} (auto)`
+                    : app.name
+                }
+                checked={whitelistedIds.has(app.appId)}
+                onChange={(checked: boolean) => handleToggle(app, checked)}
+              />
             </PanelSectionRow>
-            {confirmRetrodeck && (
-              <PanelSectionRow>
-                <Field label={<span style={{ color: "#ff4444" }}>RetroDECK is NOT in the whitelist and will be permanently removed!</span>} />
-              </PanelSectionRow>
-            )}
+          ))}
+        </>
+      )}
+    </>
+  );
+};
+
+interface RetroDeckSectionProps {
+  nonSteamApps: NonSteamApp[];
+  whitelistedIds: Set<number>;
+  disabledDefaults: string[];
+  customNames: string[];
+  settingsLoaded: boolean;
+  persistWhitelist: (newDisabled: string[], newCustom: string[]) => void;
+  refreshPlatforms: () => Promise<void>;
+  loadNonSteamApps: () => void;
+  setStatus: (s: string) => void;
+}
+
+const RetroDeckSection: FC<RetroDeckSectionProps> = ({
+  nonSteamApps,
+  whitelistedIds,
+  disabledDefaults,
+  customNames,
+  settingsLoaded,
+  persistWhitelist,
+  refreshPlatforms,
+  loadNonSteamApps,
+  setStatus,
+}) => {
+  const [confirmRemoveAll, setConfirmRemoveAll] = useState(false);
+  const [confirmRetrodeck, setConfirmRetrodeck] = useState(false);
+
+  const resetRemoveConfirms = () => {
+    setConfirmRemoveAll(false);
+    setConfirmRetrodeck(false);
+  };
+
+  const retrodeckAtRisk = nonSteamApps.some(
+    (a) => !whitelistedIds.has(a.appId) && a.name.toLowerCase().includes("retrodeck")
+  );
+
+  const handleRemoveAll = async () => {
+    if (!confirmRemoveAll) {
+      setConfirmRemoveAll(true);
+      return;
+    }
+    if (retrodeckAtRisk && !confirmRetrodeck) {
+      setConfirmRetrodeck(true);
+      return;
+    }
+    const toRemove = nonSteamApps.filter((a) => !whitelistedIds.has(a.appId));
+    setStatus(`Removing ${toRemove.length} non-steam games...`);
+    for (const app of toRemove) {
+      SteamClient.Apps.RemoveShortcut(app.appId);
+    }
+    setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length !== 1 ? "s" : ""}`);
+    setConfirmRemoveAll(false);
+    setConfirmRetrodeck(false);
+    loadNonSteamApps();
+    refreshPlatforms();
+  };
+
+  const removeButtonLabel = () => {
+    if (confirmRetrodeck) {
+      return <span style={{ color: "#ff4444", fontWeight: "bold" }}>!! RETRODECK WILL BE REMOVED !! Click to confirm</span>;
+    }
+    if (confirmRemoveAll) {
+      if (retrodeckAtRisk) {
+        return <span style={{ color: "#ff8800" }}>WARNING: RetroDECK not protected! Remove {nonSteamApps.length - whitelistedIds.size} games?</span>;
+      }
+      return `Are you sure? Remove ${nonSteamApps.length - whitelistedIds.size} games (${whitelistedIds.size} whitelisted)?`;
+    }
+    return `Remove ${nonSteamApps.length - whitelistedIds.size} Non-Steam Games${whitelistedIds.size > 0 ? ` (${whitelistedIds.size} excluded)` : ""}`;
+  };
+
+  return (
+    <PanelSection title="Remove Non-Steam Games">
+      {nonSteamApps.length === 0 ? (
+        <PanelSectionRow>
+          <Field label="No non-steam games found" />
+        </PanelSectionRow>
+      ) : (
+        <>
+          <PanelSectionRow>
+            <ButtonItem layout="below" onClick={handleRemoveAll}>
+              {removeButtonLabel()}
+            </ButtonItem>
+          </PanelSectionRow>
+          {confirmRetrodeck && (
             <PanelSectionRow>
-              <ButtonItem
-                layout="below"
-                onClick={() => {
-                  setShowWhitelist(!showWhitelist);
-                  setConfirmRemoveAll(false);
-                }}
-              >
-                {showWhitelist ? "Hide Whitelist" : `Configure Whitelist (${whitelistedIds.size} protected)`}
-              </ButtonItem>
+              <Field label={<span style={{ color: "#ff4444" }}>RetroDECK is NOT in the whitelist and will be permanently removed!</span>} />
             </PanelSectionRow>
+          )}
+          <WhitelistSection
+            nonSteamApps={nonSteamApps}
+            whitelistedIds={whitelistedIds}
+            disabledDefaults={disabledDefaults}
+            customNames={customNames}
+            settingsLoaded={settingsLoaded}
+            persistWhitelist={persistWhitelist}
+            resetRemoveConfirms={resetRemoveConfirms}
+          />
+        </>
+      )}
+    </PanelSection>
+  );
+};
 
-            {showWhitelist && !settingsLoaded && (
-              <PanelSectionRow>
-                <Spinner />
-              </PanelSectionRow>
-            )}
-            {showWhitelist && settingsLoaded && (
-              <>
-                <PanelSectionRow>
-                  <TextField
-                    label="Search games"
-                    value={whitelistSearch}
-                    onChange={(e) => setWhitelistSearch(e?.target?.value ?? "")}
-                  />
-                </PanelSectionRow>
-                <PanelSectionRow>
-                  <Field label={`Toggle ON to protect (${filteredApps.length}/${nonSteamApps.length}):`} />
-                </PanelSectionRow>
-                {filteredApps.map((app) => (
-                  <PanelSectionRow key={app.appId}>
-                    <ToggleField
-                      label={
-                        DEFAULT_WHITELIST_PATTERNS.some((p) => app.name.toLowerCase().includes(p))
-                          ? `${app.name} (auto)`
-                          : app.name
-                      }
-                      checked={whitelistedIds.has(app.appId)}
-                      onChange={(checked: boolean) => {
-                        const matchingPattern = DEFAULT_WHITELIST_PATTERNS.find(
-                          (p) => app.name.toLowerCase().includes(p)
-                        );
-                        let newDisabled = [...disabledDefaults];
-                        let newCustom = [...customNames];
+interface DangerZoneProps {
+  onBack: () => void;
+}
 
-                        if (checked) {
-                          if (matchingPattern && disabledDefaults.includes(matchingPattern)) {
-                            newDisabled = newDisabled.filter((p) => p !== matchingPattern);
-                          } else if (!matchingPattern) {
-                            if (!newCustom.includes(app.name)) {
-                              newCustom.push(app.name);
-                            }
-                          }
-                        } else {
-                          if (matchingPattern) {
-                            if (!newDisabled.includes(matchingPattern)) {
-                              newDisabled.push(matchingPattern);
-                            }
-                          }
-                          newCustom = newCustom.filter((n) => n !== app.name);
-                        }
+export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
+  const [status, setStatus] = useState("");
+  const [platforms, setPlatforms] = useState<RegistryPlatform[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [disabledDefaults, setDisabledDefaults] = useState<string[]>([]);
+  const [customNames, setCustomNames] = useState<string[]>([]);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [nonSteamApps, setNonSteamApps] = useState<NonSteamApp[]>([]);
 
-                        persistWhitelist(newDisabled, newCustom);
-                        setConfirmRemoveAll(false);
-                        setConfirmRetrodeck(false);
-                      }}
-                    />
-                  </PanelSectionRow>
-                ))}
-              </>
-            )}
-          </>
-        )}
+  const activeDefaults = useMemo(
+    () => DEFAULT_WHITELIST_PATTERNS.filter((p) => !disabledDefaults.includes(p)),
+    [disabledDefaults]
+  );
+
+  const whitelistedIds = useMemo(() => {
+    const set = new Set<number>();
+    for (const app of nonSteamApps) {
+      const lower = app.name.toLowerCase();
+      const matchesDefault = activeDefaults.some((p) => lower.includes(p));
+      if (matchesDefault || customNames.includes(app.name)) {
+        set.add(app.appId);
+      }
+    }
+    return set;
+  }, [nonSteamApps, activeDefaults, customNames]);
+
+  const refreshPlatforms = async () => {
+    setLoading(true);
+    try {
+      const result = await getRegistryPlatforms();
+      setPlatforms(result.platforms || []);
+    } catch {
+      setPlatforms([]);
+    }
+    setLoading(false);
+  };
+
+  const loadNonSteamApps = () => {
+    const apps: NonSteamApp[] = [];
+    try {
+      if (typeof collectionStore === "undefined") {
+        logWarn("collectionStore not available");
+        setNonSteamApps([]);
+        return;
+      }
+      const deckApps = collectionStore.deckDesktopApps?.apps;
+      if (!deckApps) {
+        logWarn("deckDesktopApps.apps not available");
+        setNonSteamApps([]);
+        return;
+      }
+      logInfo(`deckDesktopApps.apps size: ${deckApps.size}`);
+      const appIds = Array.from(deckApps.keys());
+      for (const appId of appIds) {
+        let name = `Unknown (${appId})`;
+        if (typeof appStore !== "undefined") {
+          const overview = appStore.GetAppOverviewByAppID(appId);
+          if (overview) {
+            name = (overview as any).strDisplayName || (overview as any).display_name || name;
+          }
+        }
+        apps.push({ appId, name });
+      }
+    } catch (e) {
+      logError(`Failed to enumerate non-steam games: ${e}`);
+    }
+    apps.sort((a, b) => a.name.localeCompare(b.name));
+    setNonSteamApps(apps);
+  };
+
+  useEffect(() => {
+    refreshPlatforms();
+    loadNonSteamApps();
+    getWhitelistSettings().then((s) => {
+      setDisabledDefaults(s.disabled_defaults);
+      setCustomNames(s.custom_names);
+      setSettingsLoaded(true);
+    });
+  }, []);
+
+  const persistWhitelist = (newDisabled: string[], newCustom: string[]) => {
+    setDisabledDefaults(newDisabled);
+    setCustomNames(newCustom);
+    updateWhitelistSettings(newDisabled, newCustom);
+  };
+
+  return (
+    <>
+      <PanelSection>
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            onClick={onBack}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
+            Back
+          </ButtonItem>
+        </PanelSectionRow>
       </PanelSection>
+
+      <ShortcutRemovalSection
+        platforms={platforms}
+        loading={loading}
+        refreshPlatforms={refreshPlatforms}
+        loadNonSteamApps={loadNonSteamApps}
+        status={status}
+        setStatus={setStatus}
+      />
+
+      <RetroDeckSection
+        nonSteamApps={nonSteamApps}
+        whitelistedIds={whitelistedIds}
+        disabledDefaults={disabledDefaults}
+        customNames={customNames}
+        settingsLoaded={settingsLoaded}
+        persistWhitelist={persistWhitelist}
+        refreshPlatforms={refreshPlatforms}
+        loadNonSteamApps={loadNonSteamApps}
+        setStatus={setStatus}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Sonar c=21 god-component split. `DangerZone` decomposed into three sub-components in the same file:

- `ShortcutRemovalSection` (~182 LOC) — Remove All RomM, per-platform actions, Installed ROMs. Hosts the shared `status` display.
- `WhitelistSection` (~96 LOC) — Configure Whitelist toggle UI + search + per-app toggles.
- `RetroDeckSection` (~89 LOC) — Remove all non-Steam games double-confirm + RetroDECK escalation. Renders `WhitelistSection` inline.

Parent `DangerZone` (~124 LOC) is a thin coordinator. Cross-panel `status` quirk (writes from two flows, displays in one panel header) preserved by parent-hoisting.

## Micro-deviation flagged by reviewer (LOW confidence ~55)

`WhitelistSection`'s "Configure Whitelist" button now resets BOTH `confirmRemoveAll` AND `confirmRetrodeck` (pre-split only reset the first, leaving a potentially stale `confirmRetrodeck=true`). Reachability narrow; new behaviour arguably more correct. Calling out for transparency rather than reverting.

1 file, +404/-288 (structure cost for the split).

## Test plan

- [x] `pnpm build` — clean
- [x] `pytest tests/ -q` — 2304/2304 passed
- [x] `ruff` + `basedpyright` — clean
- [x] Reviewer verified byte-equivalence of every confirm flow, toast string, callable invocation, and render order
- [ ] CI green
- [ ] SonarCloud — c=21 finding resolves

Closes #393. Part of #386.