### PR TITLE
refactor(library): delete dead _do_sync function (#388)

### DIFF
--- a/py_modules/services/library/__init__.py
+++ b/py_modules/services/library/__init__.py
@@ -5,7 +5,7 @@ composes the library sync sub-services (:class:`LibraryFetcher`,
 :class:`SyncOrchestrator`, :class:`SyncReporter`) over a shared
 :class:`LibrarySyncStateBox` and exposes the callable surface consumed
 by the Decky entrypoints (platform/collection metadata, sync preview/
-apply, full sync, post-apply reporting, registry queries). RomM
+apply, post-apply reporting, registry queries). RomM
 communication goes through Protocol-typed adapters; no ``import decky``.
 """
 

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -38,8 +38,7 @@ class LibrarySyncStateBox:
     generation id used by the safety-timeout guard, the heartbeat
     timestamp, the live progress dict emitted to the frontend, and the
     apply-staging dicts populated during ``sync_preview`` /
-    ``sync_apply_delta`` / ``_do_sync`` and consumed by
-    ``report_sync_results``.
+    ``sync_apply_delta`` and consumed by ``report_sync_results``.
     """
 
     sync_state: SyncState = SyncState.IDLE

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -1,11 +1,11 @@
 """LibraryService façade.
 
 Owns the public callable surface exposed via ``main.py`` (platform/
-collection metadata, sync preview/apply/cancel, full sync, reporting,
+collection metadata, sync preview/apply/cancel, reporting,
 registry queries) and the shared :class:`LibrarySyncStateBox` that
 threads through every sub-service. Implementation lives in the
 sub-service modules: :class:`LibraryFetcher` for ROM/metadata
-roundtrips, :class:`SyncOrchestrator` for the preview/apply/full-sync
+roundtrips, :class:`SyncOrchestrator` for the preview/apply
 lifecycle and safety heartbeat, :class:`SyncReporter` for post-apply
 finalisation and registry queries. The façade itself only wires the
 pieces together and delegates — anything that touches RomM or mutates
@@ -78,7 +78,7 @@ class LibraryService:
 
     Composes :class:`LibraryFetcher` (platform/collection roundtrips +
     metadata-cache stamping), :class:`SyncOrchestrator` (preview/apply
-    /full-sync lifecycle + safety heartbeat), and :class:`SyncReporter`
+    lifecycle + safety heartbeat), and :class:`SyncReporter`
     (post-apply finalisation + registry queries) over a single shared
     :class:`LibrarySyncStateBox`. The façade itself owns the box and
     exposes the callable surface; every implementation method lives on

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1,15 +1,15 @@
-"""Preview / apply / full-sync lifecycle and the safety heartbeat.
+"""Preview / apply / per-unit sync lifecycle and the safety heartbeat.
 
 Owns every async path the user triggers from the QAM that mutates
 in-flight sync state: starting and cancelling syncs, building a
 preview delta from a fetch result, applying that delta back via the
-``sync_apply`` event, and the safety-timeout watchdog that closes
-out stuck "applying" phases. Progress emission also lives here —
-sub-services that need to surface progress receive the orchestrator's
-``_emit_progress`` callback through their config. Anything that
-fetches ROMs belongs in :class:`LibraryFetcher`; anything that
-finalises shortcuts after the apply completes belongs in
-:class:`SyncReporter`.
+``sync_apply`` event, driving the per-unit sync pipeline, and the
+safety-timeout watchdog that closes out stuck "applying" phases.
+Progress emission also lives here — sub-services that need to
+surface progress receive the orchestrator's ``_emit_progress``
+callback through their config. Anything that fetches ROMs belongs in
+:class:`LibraryFetcher`; anything that finalises shortcuts after the
+apply completes belongs in :class:`SyncReporter`.
 """
 
 from __future__ import annotations
@@ -383,113 +383,7 @@ class SyncOrchestrator:
 
         return self._loop.create_task(_safety_timeout())
 
-    # ── Full sync ────────────────────────────────────────────────
-
-    async def _do_sync(self):
-        box = self._sync_state
-        try:
-            try:
-                fetch_result = await self._fetcher._fetch_and_prepare()
-                all_roms, shortcuts_data, platforms, collection_memberships, platform_rom_ids = fetch_result
-            except asyncio.CancelledError:
-                await self._finish_sync(_SYNC_CANCELLED)
-                raise
-            except Exception as e:
-                self._logger.error(f"Failed to fetch platforms: {e}")
-                _code, _msg = classify_error(e)
-                await self._emit_progress("error", message=_msg, running=False)
-                box.sync_state = SyncState.IDLE
-                return
-
-            # Calculate step plan for full sync
-            has_artwork = len(all_roms) > 0
-            has_shortcuts = len(shortcuts_data) > 0
-            full_steps = []
-            if has_artwork:
-                full_steps.append("artwork")
-            if has_shortcuts:
-                full_steps.append("shortcuts")
-            full_total_steps = len(full_steps)
-            full_current_step = 0
-
-            if has_artwork:
-                full_current_step += 1
-                await self._emit_progress(
-                    "applying",
-                    total=len(all_roms),
-                    message=f"Downloading artwork 0/{len(all_roms)}",
-                    step=full_current_step,
-                    total_steps=full_total_steps,
-                )
-                cover_paths = await self._download_artwork(
-                    all_roms, progress_step=full_current_step, progress_total_steps=full_total_steps
-                )
-            else:
-                cover_paths = {}
-
-            if box.sync_state == SyncState.CANCELLING:
-                await self._finish_sync(_SYNC_CANCELLED)
-                return
-
-            for sd in shortcuts_data:
-                sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
-
-            # Determine stale rom_ids by comparing current sync with registry
-            current_rom_ids = {r["id"] for r in all_roms}
-            stale_rom_ids = [int(rid) for rid in self._state["shortcut_registry"] if int(rid) not in current_rom_ids]
-
-            # Emit sync_apply for frontend to process via SteamClient
-            next_step = full_current_step + 1
-            await self._emit_progress(
-                "applying",
-                total=len(shortcuts_data),
-                message=f"Applying shortcuts 0/{len(shortcuts_data)}",
-                step=next_step,
-                total_steps=full_total_steps,
-            )
-
-            # Save sync stats (registry updated by report_sync_results)
-            self._state["sync_stats"] = {
-                "platforms": len(platforms),
-                "roms": len(all_roms),
-            }
-            self._state_persister.save_state()
-
-            # Store pending data for report_sync_results to reference
-            box.pending_sync = {sd["rom_id"]: sd for sd in shortcuts_data}
-            box.pending_collection_memberships = collection_memberships
-            box.pending_platform_rom_ids = platform_rom_ids
-
-            await self._emit(
-                "sync_apply",
-                {
-                    "shortcuts": shortcuts_data,
-                    "remove_rom_ids": stale_rom_ids,
-                    "next_step": next_step,
-                    "total_steps": full_total_steps,
-                },
-            )
-
-            self._logger.info(f"Sync data emitted: {len(shortcuts_data)} shortcuts, {len(stale_rom_ids)} stale")
-        except Exception as e:
-            import traceback
-
-            self._logger.error(f"Sync failed: {e}\n{traceback.format_exc()}")
-            _code, _msg = classify_error(e)
-            box.sync_progress = {
-                "running": False,
-                "phase": "error",
-                "current": 0,
-                "total": 0,
-                "message": f"Sync failed — {_msg}",
-            }
-            self._loop.create_task(self._emit("sync_progress", box.sync_progress))
-        finally:
-            if self._metadata_service is not None:
-                self._metadata_service.flush_metadata_if_dirty()
-            box.sync_state = SyncState.IDLE
-            if box.sync_progress.get("phase") != "error" and box.sync_progress.get("running"):
-                self._start_safety_timeout()
+    # ── Sync termination ─────────────────────────────────────────
 
     async def _finish_sync(self, message):
         box = self._sync_state

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -340,7 +340,7 @@ export default definePlugin(() => {
     },
   );
 
-  // Backend emits sync_progress events throughout _do_sync — update the module-level store
+  // Backend emits sync_progress events throughout the sync run — update the module-level store
   const syncProgressListener = addEventListener<[SyncProgress]>(
     "sync_progress",
     (progress: SyncProgress) => {

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -22,71 +22,6 @@ class TestShortcutDataFormat:
     The backend prepares shortcut data that the frontend uses to create
     Steam shortcuts. These tests ensure the data is well-formed.
     """
-
-    @pytest.mark.asyncio
-    async def test_shortcut_data_has_required_fields(self, plugin):
-        """Every shortcut entry must have all required fields."""
-
-        plugin.settings["romm_url"] = "http://romm.local"
-        plugin.settings["enabled_platforms"] = {"gba": True}
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(
-            side_effect=[
-                # _fetch_platforms
-                [{"id": 1, "slug": "gba", "name": "Game Boy Advance", "rom_count": 1}],
-                # _fetch_roms_for_platform
-                [
-                    {
-                        "id": 42,
-                        "name": "Test Game",
-                        "platform_name": "Game Boy Advance",
-                        "platform_slug": "gba",
-                        "igdb_id": 100,
-                        "sgdb_id": 200,
-                        "path_cover_large": "/cover.png",
-                    }
-                ],
-            ]
-        )
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-        plugin._sync_service._sync_state = SyncState.IDLE
-
-        # Mock decky.emit to capture the shortcuts
-        import decky
-
-        emitted_events = []
-        original_emit = getattr(decky, "emit", None)
-
-        async def mock_emit(event, *args):
-            emitted_events.append((event, args))
-
-        decky.emit = mock_emit
-        plugin._sync_service._orchestrator._emit = mock_emit
-
-        try:
-            # Call _do_sync directly (start_sync creates a background task
-            # that never runs with a mock loop)
-            await plugin._sync_service._orchestrator._do_sync()
-        except Exception:
-            pass
-        finally:
-            if original_emit:
-                decky.emit = original_emit
-
-        # Find the sync_apply emission
-        sync_items = None
-        for event, args in emitted_events:
-            if event == "sync_apply" and args:
-                sync_items = args[0] if args else None
-                break
-
-        assert sync_items is not None, "sync_apply event should have been emitted"
-        required_fields = {"rom_id", "name", "exe", "start_dir", "launch_options", "platform_name", "platform_slug"}
-        for item in sync_items.get("shortcuts", sync_items):
-            for field in required_fields:
-                assert field in item, f"Missing field '{field}' in shortcut data"
 
     @pytest.mark.asyncio
     async def test_exe_path_points_to_romm_launcher(self, plugin):
@@ -512,65 +447,6 @@ class TestSyncControl:
         result = plugin._sync_service.sync_heartbeat()
         assert result["success"] is True
         assert plugin._sync_service._sync_last_heartbeat > old
-
-
-class TestDoSyncErrorHandling:
-    """Tests for _do_sync error/edge handling — lines 587-695."""
-
-    @pytest.mark.asyncio
-    async def test_fetch_error_emits_error_progress(self, plugin):
-
-        plugin._sync_service._sync_state = SyncState.RUNNING
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(side_effect=Exception("API down"))
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
-        await plugin._sync_service._orchestrator._do_sync()
-
-        # Should have emitted error progress
-        error_calls = [
-            c for c in plugin._sync_service._orchestrator._emit_progress.call_args_list if c[0][0] == "error"
-        ]
-        assert len(error_calls) >= 1
-        assert plugin._sync_service._sync_state == SyncState.IDLE
-
-    @pytest.mark.asyncio
-    async def test_cancel_during_sync(self, plugin):
-
-        import decky
-
-        decky.emit.reset_mock()
-
-        plugin._sync_service._sync_state = SyncState.RUNNING
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(
-            side_effect=asyncio.CancelledError("Sync cancelled")
-        )
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
-        # CancelledError is caught, _finish_sync called, then re-raised
-        with pytest.raises(asyncio.CancelledError):
-            await plugin._sync_service._orchestrator._do_sync()
-
-        # Should be idle after _finish_sync
-        assert plugin._sync_service._sync_state == SyncState.IDLE
-
-    @pytest.mark.asyncio
-    async def test_general_exception_in_do_sync(self, plugin):
-
-        import decky
-
-        decky.emit.reset_mock()
-
-        plugin._sync_service._sync_state = SyncState.RUNNING
-
-        async def failing_fetch():
-            # Successfully fetch but then fail during artwork
-            raise RuntimeError("Unexpected error")
-
-        plugin._sync_service._fetcher._fetch_and_prepare = failing_fetch
-
-        await plugin._sync_service._orchestrator._do_sync()
-
-        assert plugin._sync_service._sync_state == SyncState.IDLE
 
 
 class TestFinishSync:

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -369,7 +369,7 @@ class TestLoadMetadataCache:
 
 
 class TestSyncMetadataCapture:
-    """Tests for metadata capture during _do_sync."""
+    """Tests for metadata capture during a sync run."""
 
     def test_extract_metadata_during_sync(self, plugin, tmp_path):
         """Verify that extract_metadata produces correct cache entries for ROM list items."""


### PR DESCRIPTION
## Summary

**Scope revised from the original audit recommendation.** Audit (#455) said "delete frontend `initSyncManager`". Investigation showed `sync_apply_delta` (active callable at `sync_orchestrator.py:228`) still emits `sync_apply` at line 304 — the legacy event the frontend listener consumes. **Frontend listener is still needed; not deleted.**

What's actually deletable: the backend `_do_sync` function (line ~388, ~104 LOC) has ZERO callers. Its emit at line 464 is unreachable. Dead since the per-unit pipeline (#433) became the sole "sync now" path.

## Changes

- Delete `_do_sync` function from `sync_orchestrator.py`
- Audited every helper called by it (`_finish_sync`, `_download_artwork`, `_emit_progress`, `_start_safety_timeout`) — all shared with other paths, nothing was `_do_sync`-only
- Drop docstring/comment rot referencing the deleted function across `_state.py`, `services/library/__init__.py`, `services/library/service.py`, and `src/index.tsx`
- Delete `TestDoSyncErrorHandling` (3 tests) + `test_shortcut_data_has_required_fields` — superseded by per-unit pipeline tests
- Update test docstring rot in `test_metadata.py`

**Frontend `syncManager.ts` UNTOUCHED.** A follow-up tracks the bigger migration: `sync_apply_delta` → per-unit chunks → then drop the frontend listener.

7 files, +17/-248. ~231 LOC net deletion.

## Test plan

- [x] `pytest tests/ -q` — 2300/2300 passed
- [x] `ruff` + `basedpyright` — clean
- [x] `lint-imports` — 7 contracts kept, 0 broken
- [x] `check_cosmic_call_bans.sh` — clean
- [x] `pnpm build` — TS compiles
- [x] `grep -rn '_do_sync\b' py_modules/ tests/` — zero references remain
- [ ] CI green
- [ ] SonarCloud — sync_orchestrator complexity finding (S3776) related to `_do_sync` should resolve

Closes #388. Part of #386 (Phase 7 epic).