### PR TITLE
refactor(ui): replace window with globalThis (S7764)

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -206,7 +206,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
       setState((prev) => prev === "uninstalling" ? prev : "download");
       setActionPending(false);
     };
-    window.addEventListener("romm_rom_uninstalled", onUninstall);
+    globalThis.addEventListener("romm_rom_uninstalled", onUninstall);
 
     // Listen for save sync updates (e.g. background check found a conflict)
     const onDataChanged = (e: Event) => {
@@ -221,20 +221,20 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
         });
       }
     };
-    window.addEventListener("romm_data_changed", onDataChanged);
+    globalThis.addEventListener("romm_data_changed", onDataChanged);
 
     const onConnectionChanged = (e: Event) => {
       const connState = (e as CustomEvent).detail?.state;
       setIsOffline(connState === "offline");
     };
-    window.addEventListener("romm_connection_changed", onConnectionChanged);
+    globalThis.addEventListener("romm_connection_changed", onConnectionChanged);
 
     return () => {
       removeEventListener("download_progress", progressListener);
       removeEventListener("download_complete", completeListener);
-      window.removeEventListener("romm_rom_uninstalled", onUninstall);
-      window.removeEventListener("romm_data_changed", onDataChanged);
-      window.removeEventListener("romm_connection_changed", onConnectionChanged);
+      globalThis.removeEventListener("romm_rom_uninstalled", onUninstall);
+      globalThis.removeEventListener("romm_data_changed", onDataChanged);
+      globalThis.removeEventListener("romm_connection_changed", onConnectionChanged);
     };
   }, []);
 

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -141,7 +141,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
           try {
             const result = await deletePlatformSaves(p.slug);
             setActionStatus(result.message);
-            window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
+            globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
           } catch {
             setActionStatus("Failed to delete saves");
           }

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -333,7 +333,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         setState((prev) => ({ ...prev, installed: false, installedRom: null }));
       }
     };
-    window.addEventListener("romm_rom_uninstalled", onUninstall);
+    globalThis.addEventListener("romm_rom_uninstalled", onUninstall);
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/appId/romIdRef/setState closure.
@@ -408,19 +408,19 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
       }
     };
-    window.addEventListener("romm_data_changed", onDataChanged);
+    globalThis.addEventListener("romm_data_changed", onDataChanged);
 
     const onTabSwitch = (e: Event) => {
       const tab = (e as CustomEvent).detail?.tab;
       if (tab) setState((prev) => ({ ...prev, activeTab: tab }));
     };
-    window.addEventListener("romm_tab_switch", onTabSwitch);
+    globalThis.addEventListener("romm_tab_switch", onTabSwitch);
 
     return () => {
       cancelled = true;
-      window.removeEventListener("romm_rom_uninstalled", onUninstall);
-      window.removeEventListener("romm_data_changed", onDataChanged);
-      window.removeEventListener("romm_tab_switch", onTabSwitch);
+      globalThis.removeEventListener("romm_rom_uninstalled", onUninstall);
+      globalThis.removeEventListener("romm_data_changed", onDataChanged);
+      globalThis.removeEventListener("romm_tab_switch", onTabSwitch);
     };
   }, [appId]);
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -432,11 +432,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
       }
     };
-    window.addEventListener("romm_data_changed", onDataChanged);
+    globalThis.addEventListener("romm_data_changed", onDataChanged);
 
     return () => {
       cancelled = true;
-      window.removeEventListener("romm_data_changed", onDataChanged);
+      globalThis.removeEventListener("romm_data_changed", onDataChanged);
     };
   }, [appId]);
 
@@ -540,7 +540,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     try {
       await getRomMetadata(info.romId);
       toaster.toast({ title: "RomM Sync", body: "Metadata refreshed" });
-      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "metadata", rom_id: info.romId } }));
+      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "metadata", rom_id: info.romId } }));
     } catch {
       toaster.toast({ title: "RomM Sync", body: "Failed to refresh metadata" });
     } finally {
@@ -566,7 +566,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         }
         if (c > 0) label += `, ${c} conflict(s) need resolution`;
         toaster.toast({ title: "RomM Sync", body: `Saves synced (${label})` });
-        window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: info.romId } }));
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: info.romId } }));
         // Refresh save sync status — last_sync_check_at was just set by the backend
         setInfo((prev) => ({ ...prev, saveSyncStatus: "synced" as const, saveSyncLabel: "Just now" }));
       } else {
@@ -586,7 +586,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
       const result = await downloadAllFirmware(info.platformSlug);
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `BIOS downloaded (${result.downloaded ?? 0} files)` });
-        window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: info.platformSlug } }));
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: info.platformSlug } }));
         // Refresh BIOS status — getBiosStatus ships pre-computed level/label so we don't re-derive.
         if (info.romId) {
           const refreshed = await getBiosStatus(info.romId).catch(() => ({
@@ -618,7 +618,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     try {
       const result = await removeRom(info.romId);
       if (result.success) {
-        window.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: info.romId } }));
+        globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: info.romId } }));
         toaster.toast({ title: "RomM Sync", body: `${info.romName || "ROM"} uninstalled` });
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "Uninstall failed" });
@@ -647,7 +647,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
               toaster.toast({ title: "RomM Sync", body: result.message });
               // Directly update PlaySection status — no local saves remain
               setInfo((prev) => ({ ...prev, saveSyncStatus: "none" as const, saveSyncLabel: "No saves" }));
-              window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+              globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
             } else {
               toaster.toast({ title: "RomM Sync", body: result.message || "Failed to delete saves" });
             }
@@ -694,7 +694,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         }
         // Invalidate the frontend cache and notify other components (e.g. GameInfoPanel)
         delete (_cachedGameDetailCache as Record<number, unknown>)[appId];
-        window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: info.platformSlug } }));
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: info.platformSlug } }));
       } else {
         toaster.toast({ title: "RomM Sync", body: result.message || "Failed to set core" });
       }
@@ -831,7 +831,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         key: "achievements",
         className: "romm-info-item romm-cheevo-badge",
         onClick: () => {
-          window.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "achievements" } }));
+          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "achievements" } }));
         },
       },
         createElement("div", { className: "romm-info-header" }, "ACHIEVEMENTS"),
@@ -874,7 +874,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         key: "bios",
         className: "romm-info-item",
         onClick: () => {
-          window.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
         },
         style: { cursor: "pointer" },
       },

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -10,7 +10,7 @@ let registeredAppIds: Set<number> = new Set();
  * Wrap MobX state mutations so Steam's observable stores allow changes.
  */
 function stateTransaction<T>(block: () => T): T {
-  const globals = (window as any).__mobxGlobals;
+  const globals = (globalThis as any).__mobxGlobals;
   if (!globals) return block();
   const prev = globals.allowStateChanges;
   globals.allowStateChanges = true;

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -109,7 +109,7 @@ async function handleGameStop(): Promise<void> {
     // Save-sync event dispatch — fires for offline OR success (pre-PR parity:
     // offline branch dispatched, success branch dispatched, failure did not).
     if (result.sync.offline || result.sync.success) {
-      window.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
     }
 
     // Additive conflicts toast — backend renders the count string.


### PR DESCRIPTION
## Summary

- Mechanical swap of bare `window.<x>` → `globalThis.<x>` across 6 frontend files (25 sites).
- Silences Sonar rule **S7764** (`Prefer 'globalThis' over 'window'`).
- Zero behavior change — every line is identical except the global identifier.

## Scope

| File | Sites |
| --- | --- |
| `src/utils/sessionManager.ts` | 1 |
| `src/components/RomMGameInfoPanel.tsx` | 6 |
| `src/components/CustomPlayButton.tsx` | 6 |
| `src/components/DangerZone.tsx` | 1 |
| `src/components/RomMPlaySection.tsx` | 10 |
| `src/patches/metadataPatches.ts` | 1 (`(window as any)` → `(globalThis as any)`) |

`src/utils/styleInjector.ts` left untouched — its `sp.window.document.*` calls reference the Decky `ServerAPI`-provided Steam Picture window, not the browser global, and are not flagged by S7764.

## Test plan

- [x] `pnpm build` clean (Rollup OK, no warnings).
- [x] `pnpm exec tsc --noEmit --skipLibCheck` zero errors.
- [x] Post-edit grep confirms zero remaining bare `window.` references in the sweep scope.

Closes #399