### PR TITLE
refactor(ui): use content-derived keys for sparkle dots (S6479)

### DIFF
--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -924,9 +924,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
           ? createElement("div", { className: "romm-cheevo-img-wrap" },
               imgEl,
               createElement("span", { className: "romm-cheevo-img-sparkles" },
-                ...makeHcSparkles(a.ra_id).map((sp, i) =>
+                ...makeHcSparkles(a.ra_id).map((sp) =>
                   createElement("span", {
-                    key: `hc-sp-${i}`,
+                    key: `hc-sp-${sp.top}-${sp.left}`,
                     className: "romm-cheevo-img-sparkle-dot",
                     style: {
                       "--romm-sparkle-top": sp.top,

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -815,7 +815,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
     const sparkleDelays = [0, 0.9, 0.3, 1.6, 1.1];
     const sparkleDots = hasEarned ? sparklePositions.map((pos, i) =>
       createElement("span", {
-        key: `sparkle-${i}`,
+        key: `sparkle-${pos.top}-${pos.left}`,
         className: "romm-sparkle-dot",
         style: {
           "--romm-sparkle-top": pos.top,


### PR DESCRIPTION
## Summary

- Replace 2 array-index React keys (`sparkle-${i}` / `hc-sp-${i}`) with position-derived keys.
- Silences Sonar **S6479** (`Do not use Array index in keys`).
- Behaviour-neutral — within each parent container the sparkle positions are unique by construction, so the new keys are stable and collision-free.

## Sites

| File | Before | After |
| --- | --- | --- |
| `src/components/RomMPlaySection.tsx:818` | `key: \`sparkle-${i}\`` | `key: \`sparkle-${pos.top}-${pos.left}\`` |
| `src/components/RomMGameInfoPanel.tsx:929` | `key: \`hc-sp-${i}\`` | `key: \`hc-sp-${sp.top}-${sp.left}\`` |

The unused `i` parameter is dropped in `RomMGameInfoPanel`. In `RomMPlaySection`, `i` is kept because `sparkleDelays[i]` / `sparkleDurs[i]` still read by index inside the same callback.

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm exec tsc --noEmit --skipLibCheck` zero errors.
- [x] No remaining array-index keys in either file.

Closes #401