### PR TITLE
refactor(ui): extract nested ternaries (S3358)

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -558,18 +558,24 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
       ? lerpColor(BLUE_LEFT, GREEN_LEFT, t)
       : "rgba(26,159,255,0.7)";
 
-    const dlLabel = downloading
-      ? formatProgress(dlProgress.bytesDownloaded, dlProgress.totalBytes)
-      : actionPending
-        ? "Starting..."
-        : "Download";
+    let dlLabel: string;
+    if (downloading) {
+      dlLabel = formatProgress(dlProgress.bytesDownloaded, dlProgress.totalBytes);
+    } else if (actionPending) {
+      dlLabel = "Starting...";
+    } else {
+      dlLabel = "Download";
+    }
 
     // Unfilled portion: darker shade of the current fill color
-    const baseBg = isOffline
-      ? "linear-gradient(to right, #6b7b8b, #5a6a7a)"
-      : downloading
-        ? `linear-gradient(to right, ${lerpColor([10, 50, 90], [5, 35, 65], t)}, ${lerpColor([5, 35, 65], [5, 50, 30], t)})`
-        : "linear-gradient(to right, #1a9fff, #0078d4)";
+    let baseBg: string;
+    if (isOffline) {
+      baseBg = "linear-gradient(to right, #6b7b8b, #5a6a7a)";
+    } else if (downloading) {
+      baseBg = `linear-gradient(to right, ${lerpColor([10, 50, 90], [5, 35, 65], t)}, ${lerpColor([5, 35, 65], [5, 50, 30], t)})`;
+    } else {
+      baseBg = "linear-gradient(to right, #1a9fff, #0078d4)";
+    }
 
     return (
       <Focusable

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, FC, createElement } from "react";
+import { useState, useEffect, useMemo, FC, ReactNode, createElement } from "react";
 import {
   PanelSection,
   PanelSectionRow,
@@ -199,6 +199,41 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     loadNonSteamApps();
   };
 
+  let platformsBody: ReactNode;
+  if (loading) {
+    platformsBody = (
+      <PanelSectionRow>
+        <Spinner />
+      </PanelSectionRow>
+    );
+  } else if (platforms.length === 0) {
+    platformsBody = (
+      <PanelSectionRow>
+        <Field label="No synced platforms" />
+      </PanelSectionRow>
+    );
+  } else {
+    platformsBody = platforms.map((p) => (
+      <PanelSectionRow key={p.slug || p.name}>
+        <ButtonItem
+          layout="below"
+          onClick={() => {
+            showModal(
+              <PlatformActionModal
+                platform={p}
+                onRemoveShortcuts={() => handleRemoveShortcuts(p)}
+                onDeleteSaves={() => handleDeleteSaves(p)}
+                onDeleteBios={() => handleDeleteBios(p)}
+              />
+            );
+          }}
+        >
+          {p.name} ({p.count})
+        </ButtonItem>
+      </PanelSectionRow>
+    ));
+  }
+
   return (
     <>
       <PanelSection title="Remove Shortcuts">
@@ -217,35 +252,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
       </PanelSection>
 
       <PanelSection title="Per-Platform Actions">
-        {loading ? (
-          <PanelSectionRow>
-            <Spinner />
-          </PanelSectionRow>
-        ) : platforms.length === 0 ? (
-          <PanelSectionRow>
-            <Field label="No synced platforms" />
-          </PanelSectionRow>
-        ) : (
-          platforms.map((p) => (
-            <PanelSectionRow key={p.slug || p.name}>
-              <ButtonItem
-                layout="below"
-                onClick={() => {
-                  showModal(
-                    <PlatformActionModal
-                      platform={p}
-                      onRemoveShortcuts={() => handleRemoveShortcuts(p)}
-                      onDeleteSaves={() => handleDeleteSaves(p)}
-                      onDeleteBios={() => handleDeleteBios(p)}
-                    />
-                  );
-                }}
-              >
-                {p.name} ({p.count})
-              </ButtonItem>
-            </PanelSectionRow>
-          ))
-        )}
+        {platformsBody}
         {actionStatus && (
           <PanelSectionRow>
             <Field label={actionStatus} />

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -23,6 +23,15 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
+function formatFinishedDescription(item: DownloadItem): string {
+  if (item.status === "completed") return `Completed — ${formatBytes(item.total_bytes)}`;
+  if (item.status === "failed") {
+    const detail = item.error ? `: ${item.error}` : "";
+    return `Failed${detail}`;
+  }
+  return "Cancelled";
+}
+
 export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
   const [downloads, setLocalDownloads] = useState<DownloadItem[]>([]);
   const [cleared, setCleared] = useState<Set<number>>(new Set());
@@ -159,13 +168,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
               <PanelSectionRow key={item.rom_id}>
                 <Field
                   label={item.rom_name}
-                  description={
-                    item.status === "completed"
-                      ? `Completed — ${formatBytes(item.total_bytes)}`
-                      : item.status === "failed"
-                        ? `Failed${item.error ? `: ${item.error}` : ""}`
-                        : "Cancelled"
-                  }
+                  description={formatFinishedDescription(item)}
                 />
               </PanelSectionRow>
             ))}

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, FC } from "react";
+import { useState, useEffect, useRef, FC, ReactNode } from "react";
 import {
   PanelSection,
   PanelSectionRow,
@@ -323,6 +323,130 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     return <MigrationBlockedPage migration={migration} />;
   }
 
+  let syncBody: ReactNode;
+  if (preview) {
+    const hasChanges = preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0
+      || preview.summary.collection_diff?.has_changes
+      || preview.summary.platform_collection_diff?.has_changes;
+    syncBody = (
+      <>
+        <PanelSectionRow>
+          <Field
+            label="Preview"
+            description={formatPreviewDescription(preview.summary)}
+          />
+        </PanelSectionRow>
+        {hasChanges ? (
+          <>
+            <PanelSectionRow>
+              <ButtonItem
+                layout="below"
+                onClick={handleApply}
+                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+                onFocus={scrollToTop}
+              >
+                Apply Sync
+              </ButtonItem>
+            </PanelSectionRow>
+            <PanelSectionRow>
+              <ButtonItem layout="below" onClick={handleDismiss}>
+                Cancel
+              </ButtonItem>
+            </PanelSectionRow>
+          </>
+        ) : (
+          <PanelSectionRow>
+            <ButtonItem
+              layout="below"
+              onClick={handleDismiss}
+              // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+              onFocus={scrollToTop}
+            >
+              Dismiss
+            </ButtonItem>
+          </PanelSectionRow>
+        )}
+      </>
+    );
+  } else if (syncing) {
+    syncBody = (
+      <>
+        {syncProgress && syncProgress.step && syncProgress.totalSteps ? (
+          <PanelSectionRow>
+            <ProgressBarWithInfo
+              indeterminate={progressFraction === undefined}
+              nProgress={progressFraction}
+              sOperationText={formatProgressText(syncProgress)}
+            />
+          </PanelSectionRow>
+        ) : (
+          <PanelSectionRow>
+            <Field
+              label={
+                <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                  <Spinner width={16} height={16} />
+                  {syncProgress?.message || "Fetching..."}
+                </div>
+              }
+            />
+          </PanelSectionRow>
+        )}
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            onClick={handleCancel}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
+            Cancel Sync
+          </ButtonItem>
+        </PanelSectionRow>
+      </>
+    );
+  } else {
+    syncBody = (
+      <>
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            onClick={handleSync}
+            disabled={loading || connected === false}
+            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
+            onFocus={scrollToTop}
+          >
+            Sync Library
+          </ButtonItem>
+        </PanelSectionRow>
+        <PanelSectionRow>
+          <ToggleField
+            label="Skip Preview"
+            description="Apply changes immediately without preview"
+            checked={skipPreview}
+            onChange={setSkipPreview}
+          />
+        </PanelSectionRow>
+        {stats?.last_sync && (
+          <PanelSectionRow>
+            <ButtonItem
+              layout="below"
+              description="Clear cached sync data to re-fetch all platforms"
+              onClick={async () => {
+                const result = await clearSyncCache();
+                setStatus(result.message);
+                if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
+                statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
+                getSyncStats().then(setStats);
+              }}
+              disabled={loading || connected === false}
+            >
+              Force Full Sync
+            </ButtonItem>
+          </PanelSectionRow>
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       <PanelSection title="Status">
@@ -421,119 +545,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       </PanelSection>
 
       <PanelSection title="Sync">
-        {preview ? (
-          <>
-            <PanelSectionRow>
-              <Field
-                label="Preview"
-                description={formatPreviewDescription(preview.summary)}
-              />
-            </PanelSectionRow>
-            {preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0 || preview.summary.collection_diff?.has_changes || preview.summary.platform_collection_diff?.has_changes ? (
-              <>
-                <PanelSectionRow>
-                  <ButtonItem
-                    layout="below"
-                    onClick={handleApply}
-                    // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                    onFocus={scrollToTop}
-                  >
-                    Apply Sync
-                  </ButtonItem>
-                </PanelSectionRow>
-                <PanelSectionRow>
-                  <ButtonItem layout="below" onClick={handleDismiss}>
-                    Cancel
-                  </ButtonItem>
-                </PanelSectionRow>
-              </>
-            ) : (
-              <PanelSectionRow>
-                <ButtonItem
-                  layout="below"
-                  onClick={handleDismiss}
-                  // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                  onFocus={scrollToTop}
-                >
-                  Dismiss
-                </ButtonItem>
-              </PanelSectionRow>
-            )}
-          </>
-        ) : !syncing ? (
-          <>
-            <PanelSectionRow>
-              <ButtonItem
-                layout="below"
-                onClick={handleSync}
-                disabled={loading || connected === false}
-                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                onFocus={scrollToTop}
-              >
-                Sync Library
-              </ButtonItem>
-            </PanelSectionRow>
-            <PanelSectionRow>
-              <ToggleField
-                label="Skip Preview"
-                description="Apply changes immediately without preview"
-                checked={skipPreview}
-                onChange={setSkipPreview}
-              />
-            </PanelSectionRow>
-            {stats?.last_sync && (
-              <PanelSectionRow>
-                <ButtonItem
-                  layout="below"
-                  description="Clear cached sync data to re-fetch all platforms"
-                  onClick={async () => {
-                    const result = await clearSyncCache();
-                    setStatus(result.message);
-                    if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-                    statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
-                    getSyncStats().then(setStats);
-                  }}
-                  disabled={loading || connected === false}
-                >
-                  Force Full Sync
-                </ButtonItem>
-              </PanelSectionRow>
-            )}
-          </>
-        ) : (
-          <>
-            {syncProgress && syncProgress.step && syncProgress.totalSteps ? (
-              <PanelSectionRow>
-                <ProgressBarWithInfo
-                  indeterminate={progressFraction === undefined}
-                  nProgress={progressFraction}
-                  sOperationText={formatProgressText(syncProgress)}
-                />
-              </PanelSectionRow>
-            ) : (
-              <PanelSectionRow>
-                <Field
-                  label={
-                    <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                      <Spinner width={16} height={16} />
-                      {syncProgress?.message || "Fetching..."}
-                    </div>
-                  }
-                />
-              </PanelSectionRow>
-            )}
-            <PanelSectionRow>
-              <ButtonItem
-                layout="below"
-                onClick={handleCancel}
-                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                onFocus={scrollToTop}
-              >
-                Cancel Sync
-              </ButtonItem>
-            </PanelSectionRow>
-          </>
-        )}
+        {syncBody}
         {status && !syncing && !preview && (
           <PanelSectionRow>
             <Field label={status} />

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -81,6 +81,16 @@ function formatReleaseDate(timestamp: number | null): string | null {
   return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
 }
 
+/**
+ * BIOS readiness indicator color: green when complete, amber on partial progress,
+ * red when nothing is downloaded yet.
+ */
+function pickBiosColor(done: number, total: number): string {
+  if (done >= total) return "#5ba32b";
+  if (done > 0) return "#d4a72c";
+  return "#d94126";
+}
+
 /** Refresh slot configuration and available slots — extracted to reduce nesting depth. */
 function refreshSlotState(
   romId: number,
@@ -659,12 +669,18 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     let biosColor: string;
     let biosLabel: string;
     if (reqCount != null && reqDone != null) {
-      biosColor = reqDone >= reqCount ? "#5ba32b" : reqDone > 0 ? "#d4a72c" : "#d94126";
+      biosColor = pickBiosColor(reqDone, reqCount);
       biosLabel = reqDone >= reqCount
         ? `All required ready (${localCount}/${serverCount})`
         : `${reqDone}/${reqCount} required files ready`;
     } else {
-      biosColor = bios.all_downloaded ? "#5ba32b" : localCount > 0 ? "#d4a72c" : "#d94126";
+      if (bios.all_downloaded) {
+        biosColor = "#5ba32b";
+      } else if (localCount > 0) {
+        biosColor = "#d4a72c";
+      } else {
+        biosColor = "#d94126";
+      }
       biosLabel = bios.all_downloaded
         ? `All ready (${localCount}/${serverCount})`
         : `${localCount}/${serverCount} files ready`;

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -20,6 +20,17 @@ const rommAppIds = new Set<number>();
 let treeDumped = false;
 
 /**
+ * Best-effort display name for a React element's `type` field.
+ * Anonymous function components surface as "(anonymous fn)" so they remain
+ * distinguishable from the string fallback.
+ */
+function resolveTypeName(node: any): string {
+  if (typeof node?.type === "string") return node.type;
+  if (typeof node?.type === "function") return "(anonymous fn)";
+  return String(node?.type ?? "null");
+}
+
+/**
  * Recursively walk a React element tree and log each node.
  * Useful for diagnosing tree structure changes after Steam updates.
  * Runs once per appId to avoid log spam on re-renders.
@@ -32,15 +43,18 @@ function deepTreeDump(node: any, depth: number, index: number, prefix: string): 
   const typeName =
     node?.type?.name ||
     node?.type?.displayName ||
-    (typeof node?.type === "string" ? node.type : typeof node?.type === "function" ? "(anonymous fn)" : String(node?.type ?? "null"));
+    resolveTypeName(node);
   const key = node?.key ?? "null";
   const className = (node?.props?.className || "").substring(0, 60) || "(none)";
   const childrenRaw = node?.props?.children;
-  const childCount = Array.isArray(childrenRaw)
-    ? childrenRaw.length
-    : childrenRaw != null
-    ? 1
-    : 0;
+  let childCount: number;
+  if (Array.isArray(childrenRaw)) {
+    childCount = childrenRaw.length;
+  } else if (childrenRaw == null) {
+    childCount = 0;
+  } else {
+    childCount = 1;
+  }
 
   debugLog(`${prefix}${indent}[${depth}:${index}] type=${typeName} key=${key} cls=${className} children=${childCount}`);
 


### PR DESCRIPTION
## Summary

- Extract 10 nested ternaries into named consts, helpers, or `if`/`else` chains across 6 files.
- Behaviour-neutral — each site verified for byte-parity in every branch.
- Side-effects: also clears `S7735` (negated condition) on `MainPage:463` and `gameDetailPatch:41`, and `S4624` (nested template literal) on `DownloadQueue:165-166`.

## Per-site changes

| Site | Pattern used |
| --- | --- |
| `CustomPlayButton.tsx:563` (`dlLabel`) | `let` + if/else if/else |
| `CustomPlayButton.tsx:570` (`baseBg`) | `let` + if/else if/else |
| `DangerZone.tsx:224` (PlatformActions JSX) | `let platformsBody: ReactNode` computed above the return |
| `DownloadQueue.tsx:165-166` (finished item description) | `formatFinishedDescription(item)` module-scope helper — also resolves S4624 |
| `MainPage.tsx:463` (Sync panel body) | `let syncBody: ReactNode` + `if (preview) ... else if (syncing) ... else ...` — drops `!syncing` (S7735) |
| `RomMGameInfoPanel.tsx:662` (`biosColor` numeric) | New `pickBiosColor(done, total)` helper |
| `RomMGameInfoPanel.tsx:667` (`biosColor` boolean) | `let` + if/else if/else (boolean input doesn't fit the helper) |
| `gameDetailPatch.tsx:35` (`typeName`) | New `resolveTypeName(node)` helper |
| `gameDetailPatch.tsx:41` (`childCount`) | `let` + if/else if/else with affirmative `x == null` — drops S7735 |

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm exec tsc --noEmit --skipLibCheck` zero errors.
- [x] Diff bounded to exactly 6 files.
- [x] Each site spot-checked for byte-parity branch-by-branch (reviewer agent).

Closes #400