### PR TITLE
refactor(ui): clear misc Sonar minors (#402)

### DIFF
--- a/src/components/CoreChangeModal.tsx
+++ b/src/components/CoreChangeModal.tsx
@@ -66,9 +66,6 @@ const CoreChangeModalContent: FC<CoreChangeModalProps> = ({ oldLabel, newLabel, 
           </div>
         </div>
 
-        {/* TODO: Add wiki link for known incompatibilities once wiki is updated */}
-        {/* TODO: Remove per-game warning when RetroDECK fixes awk regex matching (#210) */}
-
         <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
           <DialogButton onClick={() => handleChoice(true)}>
             Continue

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -145,10 +145,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
         romIdRef.current = rid;
         if (cached.rom_name) setRomName(cached.rom_name);
 
-        if (!cached.installed) {
-          debugLog(`CustomPlayButton: -> download`);
-          setState("download");
-        } else {
+        if (cached.installed) {
           // Check for conflicts from cached save status
           const hasConflict = hasAnySaveConflict(cached.save_status);
           if (hasConflict) {
@@ -158,6 +155,9 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
             debugLog(`CustomPlayButton: -> play`);
             setState("play");
           }
+        } else {
+          debugLog(`CustomPlayButton: -> download`);
+          setState("download");
         }
       } catch (e) {
         logError(`CustomPlayButton init error: ${e}`);
@@ -658,7 +658,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           disabled
         >
           <span className={`${appActionButtonClasses?.Throbber || ""} romm-throbber`.trim()} />
-          Launching...
+          <span>Launching...</span>
         </DialogButton>
       </Focusable>
     );
@@ -686,7 +686,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           disabled
         >
           <span className={`${appActionButtonClasses?.Throbber || ""} romm-throbber`.trim()} />
-          Syncing saves...
+          <span>Syncing saves...</span>
         </DialogButton>
       </Focusable>
     );

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -68,7 +68,7 @@ const PlatformActionModal: FC<{
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
         <DialogButton onClick={() => { closeModal?.(); onRemoveShortcuts(); }}>
-          Remove Shortcuts ({platform.count} game{platform.count !== 1 ? "s" : ""})
+          Remove Shortcuts ({platform.count} game{platform.count === 1 ? "" : "s"})
         </DialogButton>
         <DialogButton onClick={() => { closeModal?.(); onDeleteSaves(); }}>
           Delete Save Files
@@ -119,7 +119,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         await reportRemovalResults(result.rom_ids);
       }
       await clearPlatformCollection(result.platform_name || p.name);
-      setActionStatus(`Removed ${p.count} ${p.name} game${p.count !== 1 ? "s" : ""}`);
+      setActionStatus(`Removed ${p.count} ${p.name} game${p.count === 1 ? "" : "s"}`);
       await refreshPlatforms();
       loadNonSteamApps();
     } catch {
@@ -439,7 +439,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
     for (const app of toRemove) {
       SteamClient.Apps.RemoveShortcut(app.appId);
     }
-    setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length !== 1 ? "s" : ""}`);
+    setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
     setConfirmRemoveAll(false);
     setConfirmRetrodeck(false);
     loadNonSteamApps();
@@ -456,7 +456,9 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
       }
       return `Are you sure? Remove ${nonSteamApps.length - whitelistedIds.size} games (${whitelistedIds.size} whitelisted)?`;
     }
-    return `Remove ${nonSteamApps.length - whitelistedIds.size} Non-Steam Games${whitelistedIds.size > 0 ? ` (${whitelistedIds.size} excluded)` : ""}`;
+    const remaining = nonSteamApps.length - whitelistedIds.size;
+    const excluded = whitelistedIds.size > 0 ? ` (${whitelistedIds.size} excluded)` : "";
+    return `Remove ${remaining} Non-Steam Games${excluded}`;
   };
 
   return (

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -371,7 +371,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   } else if (syncing) {
     syncBody = (
       <>
-        {syncProgress && syncProgress.step && syncProgress.totalSteps ? (
+        {syncProgress?.step && syncProgress?.totalSteps ? (
           <PanelSectionRow>
             <ProgressBarWithInfo
               indeterminate={progressFraction === undefined}
@@ -479,7 +479,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             )}
           </>
         )}
-        {retroarchWarning && retroarchWarning.warning && (
+        {retroarchWarning?.warning && (
           <PanelSectionRow>
             <Field
               label="RetroArch: input_driver issue"

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -158,7 +158,7 @@ function biosStatusFromCache(cachedBios: Record<string, unknown> | null | undefi
   return {
     needs_bios: true,
     ...cachedBios,
-  } as BiosStatus;
+  };
 }
 
 /** Build a `SaveStatus` from a cached game detail's `save_status` field. */
@@ -242,7 +242,7 @@ async function loadData(
     const biosStatus = biosStatusFromCache(cached.bios_status);
     const saveStatus = saveStatusFromCache(romId, cached.save_status);
     const conflicts: SyncConflict[] = cached.save_status?.conflicts ?? [];
-    const raId = (cached as any).ra_id ?? null;
+    const raId = cached.ra_id ?? null;
 
     // Render immediately with cached data (metadata may be null — that's OK)
     setter({
@@ -348,7 +348,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/appId/romIdRef/setState closure.
     const handleSaveSyncSettingsChange = async (detail: any) => {
-      const enabled = detail.save_sync_enabled as boolean;
+      const enabled = detail.save_sync_enabled;
       if (enabled) {
         const updatedStatus = await getSaveStatus(romIdRef.current!).catch((): SaveStatus | null => null);
         const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
@@ -384,7 +384,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
 
     const handleCoreChange = async () => {
       // Re-fetch cached game detail to pick up new core info
-      delete (_cachedGameDetailCache as Record<number, unknown>)[appId];
+      delete _cachedGameDetailCache[appId];
       const cached = await getCachedGameDetail(appId);
       if (cancelled || !cached.found) return;
       let biosStatus: BiosStatus | null = null;
@@ -691,9 +691,6 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
 
     biosColumn.push(
       createElement("div", { key: "bios-title", className: "romm-panel-section-title", style: { marginBottom: "8px" } }, "BIOS"),
-    );
-
-    biosColumn.push(
       createElement("div", {
         key: "bios-row",
         className: "romm-panel-status-inline",
@@ -777,7 +774,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
             key: "unknown-note",
             className: "romm-panel-file-row",
             style: { color: "rgba(255, 255, 255, 0.4)", fontSize: "12px", marginTop: "8px" },
-          }, `+ ${unknownCount} other file${unknownCount !== 1 ? "s" : ""} on server (not required by any known core)`),
+          }, `+ ${unknownCount} other file${unknownCount === 1 ? "" : "s"} on server (not required by any known core)`),
         );
       }
 
@@ -889,7 +886,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
           top: `${Math.round(rng(i * 3) * 100)}%`,
           left: `${Math.round(rng(i * 3 + 1) * 100)}%`,
           dur: 2.2 + rng(i * 3 + 2) * 1.8, // 2.2–4.0s
-          delay: rng(i * 7 + 5) * 2.0,      // 0–2.0s
+          delay: rng(i * 7 + 5) * 2,      // 0–2.0s
         }));
       };
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -748,7 +748,6 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         createElement(MenuItem, { key: "properties", onClick: () => {
           SteamClient.Apps.OpenAppSettingsDialog(appId, "general");
         } }, "Properties"),
-        // TODO: Add to/Remove from Collection and Favorites when APIs are explored
       ),
       (e.currentTarget ?? e.target) as HTMLElement,
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,15 @@ type Page = "main" | "settings" | "library" | "data" | "downloads";
 // Module-level page state survives QAM remounts (e.g. after modal close)
 let currentPage: Page = "main";
 
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
 const QAMPanel: FC = () => {
   const [page, setPageState] = useState<Page>(currentPage);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -96,15 +105,6 @@ export default definePlugin(() => {
   const CALLABLE_TIMEOUT = 5000;
   let initAttempt = 0;
   let initDone = false;
-
-  function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-    return Promise.race([
-      promise,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms),
-      ),
-    ]);
-  }
 
   async function loadAppIdsAndMetadata() {
     const [cache, appIdMap] = await withTimeout(

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -164,7 +164,7 @@ export async function initSessionManager(): Promise<void> {
           if (update.bRunning) {
             // Game started — wait for Router.MainRunningApp to populate
             await delay(500);
-            const running = typeof Router !== "undefined" ? Router.MainRunningApp : null;
+            const running = typeof Router === "undefined" ? null : Router.MainRunningApp;
             const appId = running?.appid ?? update.unAppID;
             if (appId) {
               // Refresh map in case a sync happened since init

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -26,7 +26,7 @@ export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
       )
     );
     for (const { appId, launchOptions } of entries) {
-      if (launchOptions && launchOptions.includes(ROMM_MARKER)) {
+      if (launchOptions?.includes(ROMM_MARKER)) {
         const match = launchOptions.match(/romm:(\d+)/);
         if (match) {
           result.set(Number(match[1]), appId);


### PR DESCRIPTION
## Summary

Sweep the remaining frontend Sonar MAJOR/MINOR findings not covered by #399 / #400 / #401.

| Rule | Sites cleared | Notes |
| --- | --- | --- |
| S7735 negated conditions | 6/6 | Flipped to affirmative form (e.g. `count !== 1 ? "s" : ""` → `count === 1 ? "" : "s"`). |
| S4325 unnecessary type assertions | **4 of 10** | 6 retained as load-bearing — see below. |
| S6582 prefer optional chain | 3/3 | `x && x.y` → `x?.y`. |
| S7748 zero fraction | 1/1 | `* 2.0` → `* 2`. |
| S7778 Array.push multiple | 1 merge | Merged 2 consecutive `biosColumn.push()` calls; the 3rd is separated by intervening logic. |
| S4624 nested template literal | 1/1 | Pre-computed `remaining` + `excluded` locals in `DangerZone.removeButtonLabel`. |
| S7721 nested function | 1/1 | Hoisted `withTimeout` from the `definePlugin` callback to module scope in `src/index.tsx`. |
| S6772 ambiguous spacing | 2/2 | Wrapped `Launching...` / `Syncing saves...` text in `<span>`. |
| S1135 TODO comments | 3/3 | Deleted source TODOs — tracked in #478, #479, #210. |

## S4325 — retained casts

For each, removing the cast caused `pnpm exec tsc --noEmit --skipLibCheck` to error. They're flagged by Sonar but actually load-bearing under our tsconfig (`strict: true`):

- `RomMGameInfoPanel.tsx:174` — `f.status as "skip"|...` (string → literal union)
- `RomMGameInfoPanel.tsx:256` — `cached.metadata as RomMetadata | null` (drops `undefined`)
- `RomMGameInfoPanel.tsx:823, 1111` — `Focusable as any` (data-attrs / variadic children not in `FocusableProps`)
- `RomMPlaySection.tsx:726, 741, 753` — `(e.currentTarget ?? e.target) as HTMLElement` (bridges `EventTarget | null` → `EventTarget | undefined`)

These can be revisited later — either by improving the surrounding types or by adding NOSONAR with explicit justification. Out of scope for this polish PR.

## Tracking issues opened

- #478 — wiki link for CoreChangeModal known incompatibilities
- #479 — Collection / Favorites actions in game detail context menu

## Test plan

- [x] `pnpm build` clean.
- [x] `pnpm exec tsc --noEmit --skipLibCheck` zero errors.
- [x] `grep -rnE 'TODO' src/` returns zero matches in the 3 deleted-comment files.
- [x] Each fix manually verified for behavior parity (reviewer agent + targeted spot-checks).

Closes #402