### PR TITLE
refactor(arch): move path_safety from domain/ to lib/ ([CP] purity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pur
 
 - `[CP]` Depend on Protocols (defined in `services/protocols.py`), never on concrete adapter classes. (Canonical dependency inversion.)
 - `[CP]` No raw I/O.
-  - `[ours]` Concrete allow/deny list: forbidden in `services/`: `os.*` (except pure path algebra: `realpath`, `relpath`, `join`, `splitext`, `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`, `subprocess.*`, `hashlib.<x>(open(...))`. (Our enforcement surface; CP says "no I/O" without spelling out the call list.)
+  - `[ours]` Concrete allow/deny list: forbidden in `services/`: `os.*` (except pure path algebra: `relpath`, `join`, `splitext`, `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`, `subprocess.*`, `hashlib.<x>(open(...))`. (Our enforcement surface; CP says "no I/O" without spelling out the call list.)
 - `[CP]` No clocks or randomness — inject side-effecting deps via abstractions.
   - `[ours]` Specific Protocols: `Clock` / `UuidGen` / `Sleeper`. `time.time()` / `time.monotonic()` / `datetime.now()` / `uuid.uuid4()` / `asyncio.sleep()` / `random.*` banned at the call site.
 - `[CP]` No service-to-service concrete imports — services are independent. Cross-service deps are Protocol-typed.

--- a/py_modules/lib/path_safety.py
+++ b/py_modules/lib/path_safety.py
@@ -1,9 +1,11 @@
-"""Pure path containment predicates for guarding destructive filesystem ops.
+"""Path containment predicates for guarding destructive filesystem ops.
 
 Stateless safety checks that answer "is path X safely inside configured
-root Y?" using only path algebra (``realpath``/``relpath``/``split``) —
-no filesystem reads, no clocks, no service collaborators. The source of
-the configured root (e.g. the ``RetroDeckPaths`` Protocol) stays in
+root Y?". Uses ``os.path.realpath`` to resolve symlinks before comparing,
+so callers cannot escape the configured root via a symlink — which means
+this is not pure compute (``realpath`` is an ``lstat`` syscall) and
+belongs in ``lib/`` rather than ``domain/``. The source of the
+configured root (e.g. the ``RetroDeckPaths`` Protocol) stays in
 ``services/``; this module only consumes the resolved string.
 """
 

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -278,8 +278,8 @@ class RomFileAdapter(Protocol):
 
     Owns the raw POSIX calls RomRemovalService uses when physically
     removing an installed ROM (single file or multi-file ROM directory).
-    Path-safety checks remain a domain concern (``domain.path_safety``);
-    this Protocol exposes only the I/O seams.
+    Path-safety checks live in ``lib.path_safety``; this Protocol
+    exposes only the I/O seams.
 
     Implementations are synchronous — services that call from an async
     context offload via ``loop.run_in_executor``.

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -6,8 +6,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from domain.path_safety import is_safe_rom_path
 from domain.save_state import SaveSyncState
+from lib.path_safety import is_safe_rom_path
 
 if TYPE_CHECKING:
     import logging

--- a/tests/lib/test_path_safety.py
+++ b/tests/lib/test_path_safety.py
@@ -1,8 +1,8 @@
-"""Tests for domain.path_safety — pure path containment predicates."""
+"""Tests for lib.path_safety — path containment predicates with realpath resolution."""
 
 import os
 
-from domain.path_safety import is_safe_rom_path
+from lib.path_safety import is_safe_rom_path
 
 
 class TestIsSafeRomPath:


### PR DESCRIPTION
## Summary

`domain/path_safety.py` called `os.path.realpath()` — a filesystem syscall (`lstat`) that resolves symlinks. Domain in our layout must be pure compute (no I/O), so the function was sitting in the wrong place.

Per the audit (#485) finding and the option chosen in #492:

- Moves `path_safety.py` and its test to `lib/` (no logic changes).
- Updates the single production importer (`services/rom_removal.py`).
- Drops `realpath` from the `[ours]` services allow-list in CLAUDE.md (it isn't actually "pure path algebra" — it does a syscall).
- Fixes a stale `protocols/files.py` docstring that still referenced the old `domain.path_safety` location.
- Rewrites `lib/path_safety.py`'s module docstring — the old one claimed "no filesystem reads", which was the misstatement that motivated this move.

## After the rule change

`grep -rn realpath py_modules/services/` returns only one hit — a Protocol docstring describing what the adapter does, not a service-level call. **No new `[CP]` regressions** surfaced by tightening the rule.

## Test plan

- [x] basedpyright: 0 errors / 0 warnings
- [x] ruff: all checks pass
- [x] pytest: 2300 passed
- [x] scripts/check_cosmic_call_bans.sh: OK
- [x] import-linter: 7 contracts kept, 0 broken

Closes #492