### PR TITLE
fix(saves): inject HostnameProvider in SyncEngine ([CP] no-I/O)

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ class Plugin:
                     clock=adapters["clock"],
                     uuid_gen=adapters["uuid_gen"],
                     sleeper=adapters["sleeper"],
+                    hostname_provider=adapters["hostname_provider"],
                 ),
                 callbacks=CallbackBundle(
                     retrodeck_paths=self._retrodeck_paths,

--- a/py_modules/adapters/hostname.py
+++ b/py_modules/adapters/hostname.py
@@ -1,0 +1,16 @@
+"""Hostname adapter — concrete ``HostnameProvider`` Protocol implementation.
+
+Wraps :func:`socket.gethostname` so services can stay free of direct
+``socket`` imports for the sole purpose of reading the local hostname.
+"""
+
+from __future__ import annotations
+
+import socket
+
+
+class HostnameAdapter:
+    """Real ``HostnameProvider`` backed by :func:`socket.gethostname`."""
+
+    def get(self) -> str:
+        return socket.gethostname()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -20,6 +20,7 @@ from adapters.download_file import DownloadFileAdapter as DownloadFileAdapterImp
 from adapters.download_queue import DownloadQueueAdapter as DownloadQueueAdapterImpl
 from adapters.es_de_config import CoreResolver, GamelistXmlEditor
 from adapters.firmware_file import FirmwareFileAdapter as FirmwareFileAdapterImpl
+from adapters.hostname import HostnameAdapter
 from adapters.migration_file import MigrationFileAdapter as MigrationFileAdapterImpl
 from adapters.path_probe import PathProbeAdapter
 from adapters.persistence import (
@@ -69,6 +70,7 @@ from services.protocols import (
     FirmwareCachePersister,
     FirmwareFileAdapter,
     GamelistXmlEditorProtocol,
+    HostnameProvider,
     MetadataCachePersister,
     MigrationFileAdapter,
     PathExistsProbe,
@@ -145,6 +147,7 @@ class RuntimeBundle:
     clock: Clock
     uuid_gen: UuidGen
     sleeper: Sleeper
+    hostname_provider: HostnameProvider
 
 
 @dataclass(frozen=True)
@@ -256,6 +259,7 @@ def bootstrap(
     clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
+    hostname_provider = HostnameAdapter()
     debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
 
     return {
@@ -287,6 +291,7 @@ def bootstrap(
         "clock": clock,
         "uuid_gen": uuid_gen,
         "sleeper": sleeper,
+        "hostname_provider": hostname_provider,
         "debug_logger": debug_logger,
         "core_resolver": core_resolver,
         "gamelist_editor": gamelist_editor,
@@ -359,6 +364,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         clock=cfg.runtime.clock,
         retrodeck_paths=cfg.callbacks.retrodeck_paths,
         get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+        hostname_provider=cfg.runtime.hostname_provider,
         log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
         plugin_version=_read_plugin_version(cfg.runtime.plugin_dir),

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -53,6 +53,7 @@ from services.protocols.infra import (
     DebugLogger,
     DownloadQueueCleanup,
     EventEmitter,
+    HostnameProvider,
     PathExistsProbe,
     PendingSyncReader,
 )
@@ -106,6 +107,7 @@ __all__ = [
     "FirmwareCachePersister",
     "FirmwareFileAdapter",
     "GamelistXmlEditorProtocol",
+    "HostnameProvider",
     "LaunchGateInstalledChecker",
     "LaunchGateRomLookup",
     "LaunchGateSaveStatusReader",

--- a/py_modules/services/protocols/infra.py
+++ b/py_modules/services/protocols/infra.py
@@ -24,6 +24,19 @@ class DebugLogger(Protocol):
     def __call__(self, msg: str) -> None: ...
 
 
+class HostnameProvider(Protocol):
+    """Local device hostname source.
+
+    Services consume this Protocol instead of ``socket.gethostname``
+    directly so device registration stays free of raw syscalls and tests
+    can pin the hostname without monkey-patching :mod:`socket`.
+    """
+
+    def get(self) -> str:
+        """Return the local device hostname."""
+        ...
+
+
 class PathExistsProbe(Protocol):
     """Generic filesystem existence probe.
 

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         CoreResolverFn,
         DebugLogger,
         EventEmitter,
+        HostnameProvider,
         RetroDeckPaths,
         RetryStrategy,
         RommSyncApi,
@@ -78,6 +79,10 @@ class SaveServiceConfig:
         Returns ``(core_so, label)`` tuple; either may be None if
         unresolved. This is an ES-DE question (``which core runs this
         ROM?``).
+    hostname_provider:
+        ``HostnameProvider`` Protocol seam — supplies the local device
+        hostname used as the registered device name during initial
+        server-side device registration.
     get_core_name:
         Callable returning the RetroArch canonical ``corename`` field
         from a core's ``.info`` file for a given ``core_so`` (e.g.
@@ -132,6 +137,7 @@ class SaveServiceConfig:
     clock: Clock
     retrodeck_paths: RetroDeckPaths
     get_active_core: CoreResolverFn
+    hostname_provider: HostnameProvider
     log_debug: DebugLogger
     get_core_name: CoreNameProviderFn | None = None
     plugin_version: str = "0.0.0"

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -66,6 +66,7 @@ class SaveService:
             save_file=config.save_file,
             log_debug=config.log_debug,
             get_active_core=config.get_active_core,
+            hostname_provider=config.hostname_provider,
             plugin_version=config.plugin_version,
             detect_sort_change=config.detect_sort_change,
             is_retrodeck_migration_pending=config.is_retrodeck_migration_pending,

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import socket
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
         Clock,
         CoreResolverFn,
         DebugLogger,
+        HostnameProvider,
         RetryStrategy,
         RommSyncApi,
         SaveFileAdapter,
@@ -80,6 +80,7 @@ class SyncEngine:
         save_file: SaveFileAdapter,
         log_debug: DebugLogger,
         get_active_core: CoreResolverFn,
+        hostname_provider: HostnameProvider,
         plugin_version: str,
         detect_sort_change: Callable[[], None] | None,
         is_retrodeck_migration_pending: Callable[[], bool] | None,
@@ -95,6 +96,7 @@ class SyncEngine:
         self._save_file = save_file
         self._log_debug = log_debug
         self._get_active_core = get_active_core
+        self._hostname_provider = hostname_provider
         self._plugin_version = plugin_version
         self._detect_sort_change = detect_sort_change
         self._is_retrodeck_migration_pending = is_retrodeck_migration_pending
@@ -706,7 +708,7 @@ class SyncEngine:
                 "server_device_id": has_server_id,
             }
 
-        hostname = socket.gethostname()
+        hostname = self._hostname_provider.get()
 
         try:
             result = await self._loop.run_in_executor(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -853,6 +853,21 @@ class FakePathProbe:
         return path in self.paths
 
 
+class FakeHostnameProvider:
+    """In-memory ``HostnameProvider`` for tests.
+
+    Returns the ``hostname`` value configured at construction. Tests
+    that need to assert on the registered device name read the same
+    string back through the service.
+    """
+
+    def __init__(self, hostname: str = "test-host") -> None:
+        self.hostname = hostname
+
+    def get(self) -> str:
+        return self.hostname
+
+
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
 

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from conftest import FakeRetroDeckPaths, _make_retry
+from conftest import FakeHostnameProvider, FakeRetroDeckPaths, _make_retry
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
@@ -52,6 +52,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
             roms=str(tmp_path / "retrodeck" / "roms"),
         ),
         get_active_core=lambda system_name, rom_filename=None: (None, None),
+        hostname_provider=FakeHostnameProvider(),
         log_debug=lambda _msg: None,
         plugin_version="0.14.0",
         emit=emit,

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import (
     FakeCoreInfoProvider,
     FakeFirmwareCachePersister,
+    FakeHostnameProvider,
     FakeRetroDeckPaths,
     _make_retry,
     _make_testable_plugin,
@@ -103,6 +104,7 @@ def plugin(tmp_path):
                 roms=str(tmp_path / "retrodeck" / "roms"),
             ),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
+            hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
         ),
     )

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -20,6 +20,7 @@ from conftest import (
     FakeDownloadQueueAdapter,
     FakeFirmwareCachePersister,
     FakeFirmwareFileAdapter,
+    FakeHostnameProvider,
     FakeMigrationFileAdapter,
     FakePathProbe,
     FakeRetroDeckPaths,
@@ -176,6 +177,7 @@ class TestWireServices:
             "clock": FakeClock(),
             "uuid_gen": FakeUuidGen(),
             "sleeper": FakeSleeper(),
+            "hostname_provider": FakeHostnameProvider(),
             "min_required_version": (4, 8, 1),
             "retrodeck_paths": FakeRetroDeckPaths(
                 saves=str(tmp_path / "saves"),
@@ -229,6 +231,7 @@ class TestWireServices:
                 clock=deps["clock"],
                 uuid_gen=deps["uuid_gen"],
                 sleeper=deps["sleeper"],
+                hostname_provider=deps["hostname_provider"],
             ),
             callbacks=CallbackBundle(
                 retrodeck_paths=deps["retrodeck_paths"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -910,6 +910,7 @@ class TestMainStartupOrdering:
             "clock": MagicMock(),
             "uuid_gen": MagicMock(),
             "sleeper": MagicMock(),
+            "hostname_provider": MagicMock(),
             "debug_logger": MagicMock(),
             "core_resolver": MagicMock(),
             "gamelist_editor": MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -2,12 +2,12 @@ import asyncio
 import json
 import logging
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import FakeRetroDeckPaths, _make_retry, _make_testable_plugin
+from conftest import FakeHostnameProvider, FakeRetroDeckPaths, _make_retry, _make_testable_plugin
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -100,6 +100,7 @@ def plugin(tmp_path):
                 roms=str(tmp_path / "retrodeck" / "roms"),
             ),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
+            hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
         ),
     )
@@ -224,8 +225,9 @@ class TestDeviceRegistration:
     @pytest.mark.asyncio
     async def test_sets_hostname_as_device_name(self, plugin):
         """Device name is set to the local hostname."""
-        with patch("socket.gethostname", return_value="steamdeck"):
-            result = await plugin.ensure_device_registered()
+        plugin._save_sync_service._sync_engine._hostname_provider = FakeHostnameProvider(hostname="steamdeck")
+
+        result = await plugin.ensure_device_registered()
 
         assert result["device_name"] == "steamdeck"
         assert plugin._save_sync_state.device_name == "steamdeck"


### PR DESCRIPTION
## Summary

Drops the direct `socket.gethostname()` call in `services/saves/sync_engine/engine.py` — it was a raw syscall inside a service, a `[CP]` regression on "no raw I/O in services" surfaced by audit #485.

Routes the call through a `HostnameProvider` Protocol wired in `bootstrap.py`, with `HostnameAdapter` as the concrete implementation (`adapters/hostname.py`). `FakeHostnameProvider` in `tests/conftest.py` replaces the old `patch("socket.gethostname")` test hack.

## Changes

- New: `adapters/hostname.py` (`HostnameAdapter`).
- New Protocol: `HostnameProvider` in `services/protocols/infra.py`.
- `SyncEngine` ctor takes `hostname_provider: HostnameProvider`; wired through `SaveServiceConfig` → `RuntimeBundle` → `bootstrap.py`.
- `main.py` instantiates `HostnameAdapter()` into the runtime bundle.
- `import socket` removed from `services/saves/sync_engine/engine.py`.
- Test wiring: `FakeHostnameProvider`, helpers, bootstrap + plugin tests.

## Test plan

- [x] `pytest`: 2300 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `scripts/check_cosmic_call_bans.sh`: OK
- [x] `lint-imports`: 7 contracts kept, 0 broken
- [x] `grep -rn 'import socket' py_modules/services/`: zero matches

Closes #491