### PR TITLE
chore(ci): add PR + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,67 +1,13 @@
-name: Bug Report
-description: Report a bug or unexpected behavior
+name: Bug report
+description: Report a bug in the plugin
+title: "bug: "
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reporting! Please fill out the details below so we can reproduce and fix the issue.
-
-  - type: input
-    id: version
-    attributes:
-      label: Plugin version
-      description: Which version of decky-romm-sync are you running?
-      placeholder: "e.g. 0.12.0"
-    validations:
-      required: true
-
-  - type: input
-    id: romm-version
-    attributes:
-      label: RomM server version
-      description: Which version of RomM is your server running?
-      placeholder: "e.g. 4.8.1 or 4.9.0"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: device
-    attributes:
-      label: Device
-      options:
-        - Steam Deck (LCD)
-        - Steam Deck (OLED)
-        - Linux Desktop
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: emulator
-    attributes:
-      label: Emulator platform
-      options:
-        - RetroDECK
-        - EmuDeck
-        - Standalone RetroArch
-        - Other / N/A
-    validations:
-      required: true
-
   - type: textarea
-    id: description
+    id: repro
     attributes:
-      label: What happened?
-      description: Describe the bug clearly. What did you expect vs. what actually happened?
-    validations:
-      required: true
-
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to reproduce
-      description: How can we reproduce this?
+      label: Repro steps
+      description: Numbered steps that reproduce the bug from a known-good state.
       placeholder: |
         1. Open QAM > Decky > RomM Sync
         2. Click "Sync Library"
@@ -70,16 +16,54 @@ body:
       required: true
 
   - type: textarea
-    id: logs
+    id: expected
     attributes:
-      label: Logs
-      description: |
-        Paste relevant logs from Decky's log viewer or `~/homebrew/logs/decky-romm-sync/`.
-        Set log level to "debug" in plugin settings to get detailed output.
-      render: text
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
 
   - type: textarea
-    id: context
+    id: actual
     attributes:
-      label: Additional context
-      description: Screenshots, platform details, ROM info, anything else that might help.
+      label: Actual behavior
+      description: What actually happened. Include error messages verbatim.
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: Shown in the QAM panel header, or read from plugin.json.
+      placeholder: "0.5.4"
+    validations:
+      required: true
+
+  - type: input
+    id: retrodeck-version
+    attributes:
+      label: RetroDECK version
+      description: Shown in the RetroDECK Configurator, or read from the Flatpak metadata.
+      placeholder: "0.9.0b"
+    validations:
+      required: true
+
+  - type: input
+    id: decky-version
+    attributes:
+      label: Decky Loader version
+      description: Shown in the Decky settings panel.
+      placeholder: "3.0.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log excerpt
+      description: |
+        Optional. Plugin logs live at `~/homebrew/logs/decky-romm-sync/`. Set log level to "debug" in plugin settings for full output. Decky Loader logs are in `~/homebrew/services/PluginLoader/`.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: RomM Documentation
-    url: https://docs.romm.app
-    about: Check the RomM docs for server setup and API questions
-  - name: Decky Loader
-    url: https://decky.xyz
-    about: For Decky Loader issues (not plugin-specific)
+  - name: Wiki
+    url: https://github.com/danielcopper/decky-romm-sync/wiki
+    about: Architecture, file structure, and feature documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,13 @@
-name: Feature Request
+name: Feature request
 description: Suggest a new feature or improvement
+title: "feat: "
 labels: ["enhancement"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Have an idea for decky-romm-sync? Describe it below!
-
   - type: textarea
     id: problem
     attributes:
-      label: Problem or motivation
-      description: What problem does this solve? Why do you want this?
-      placeholder: "I'm always frustrated when..."
+      label: Problem
+      description: What's missing today? What pain are you running into?
     validations:
       required: true
 
@@ -20,7 +15,7 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: How do you imagine this working?
+      description: How should the plugin behave? Sketch the UX or the API surface.
     validations:
       required: true
 
@@ -28,21 +23,6 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Any workarounds or alternative approaches you've thought of?
-
-  - type: dropdown
-    id: area
-    attributes:
-      label: Area
-      options:
-        - Sync / Library
-        - Downloads
-        - Save Sync
-        - BIOS / Firmware
-        - Artwork
-        - Game Detail Page
-        - Settings / UI
-        - Achievements
-        - Other
+      description: Workarounds you tried, other designs you weighed, or reasons the obvious solution doesn't fit.
     validations:
-      required: true
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- <what changed, 1-3 bullets>
+- <why, if not obvious from the change>
+
+## Test plan
+
+- [ ] `pnpm build` clean
+- [ ] `basedpyright` zero errors
+- [ ] `python -m pytest tests/ -q`
+- [ ] Manual QA on Steam Deck if UI changed
+
+## Notes
+
+<optional — follow-ups, tradeoffs, links to tracking issues, anything that doesn't fit above>
+
+Closes #


### PR DESCRIPTION
## Summary

- `.github/pull_request_template.md` — codifies the Summary + Test plan convention we already write by hand. `Closes #` reminder at the bottom.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — title prefix `bug: `, labels `[bug]`. Required: repro / expected / actual / plugin version / RetroDECK version / Decky Loader version. Optional log textarea with `~/homebrew/logs/decky-romm-sync/` hint.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — title prefix `feat: `, labels `[enhancement]`. Required: problem / proposed solution. Optional: alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`, wiki contact link.

Solo-dev voice across all templates — no "please"/"thanks" boilerplate.

## Test plan

- [x] `yaml.safe_load` parses all 3 `.yml` files.
- [x] Wiki contact link returns HTTP 200.
- [x] Form structure validated against GitHub's [issue-form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema).

Closes #512