### PR TITLE
chore(ci): enforce Conventional Commits via PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR title
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+permissions:
+  pull-requests: read
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            chore
+            docs
+            test
+            ci
+            build
+            perf
+            style
+            hardening
+            types
+          requireScope: false
+          subjectPattern: '^[a-z].+[^.]$'
+          subjectPatternError: |
+            The subject "{subject}" in the PR title "{title}" didn't match
+            the pattern. Make sure the subject starts with a lowercase
+            character, doesn't end with a period, and isn't empty.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-title.yml` running `amannn/action-semantic-pull-request@v5` to validate every PR title against Conventional Commits. We squash-merge, so PR title = commit message — this keeps `git log` consistent without manual policing.

## Accepted types

```
feat fix refactor chore docs test ci build perf style hardening types
```

The standard 10 plus `hardening` and `types` — both appear in active PR history (e.g. `hardening(persistence): ...` from #352, `types(persisters): ...`). Tracking those as accepted rather than reformatting old commits.

If we ever decide to fold `hardening` into `fix` and `types` into `refactor`, just drop them from the list — past PRs are squash-merged so the history is fixed.

## Test plan

- [x] `yaml.safe_load` parses cleanly.
- [x] Mental check against 5 recent PR titles — all pass the action's actual parser (`conventional-changelog-conventionalcommits`).
- [x] Existing workflows untouched.

Closes #514