### PR TITLE
chore(adapters): delete unused SteamConfigAdapter app/artwork-id statics

### DIFF
--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -6,11 +6,9 @@ Steam ``userdata`` directory (resolved from ``DECKY_USER_HOME``).
 
 from __future__ import annotations
 
-import binascii
 import contextlib
 import logging
 import os
-import struct
 
 import vdf
 
@@ -58,22 +56,6 @@ class SteamConfigAdapter:
         grid = os.path.join(user_dir, "config", "grid")
         os.makedirs(grid, exist_ok=True)
         return grid
-
-    # -- Shortcut ID generation -----------------------------------------------
-
-    @staticmethod
-    def generate_app_id(exe: str, appname: str) -> int:
-        """Generate Steam shortcut app ID (signed int32). Deprecated."""
-        key = exe + appname
-        crc = binascii.crc32(key.encode("utf-8")) & 0xFFFFFFFF
-        return struct.unpack("i", struct.pack("I", crc | 0x80000000))[0]
-
-    @staticmethod
-    def generate_artwork_id(exe: str, appname: str) -> int:
-        """Generate unsigned artwork ID for grid filenames."""
-        key = exe + appname
-        crc = binascii.crc32(key.encode("utf-8")) & 0xFFFFFFFF
-        return crc | 0x80000000
 
     # -- VDF read/write (deprecated — frontend uses SteamClient API) ----------
 

--- a/tests/adapters/test_steam_config.py
+++ b/tests/adapters/test_steam_config.py
@@ -14,37 +14,6 @@ def adapter(tmp_path):
     return SteamConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
 
 
-# ── App/Artwork ID generation ──────────────────────────────
-
-
-class TestAppIdGeneration:
-    def test_generates_signed_int32(self):
-        app_id = SteamConfigAdapter.generate_app_id("/path/to/exe", "Test Game")
-        assert isinstance(app_id, int)
-        assert app_id < 0  # Should be negative (high bit set)
-
-    def test_deterministic(self):
-        id1 = SteamConfigAdapter.generate_app_id("/path/exe", "Game")
-        id2 = SteamConfigAdapter.generate_app_id("/path/exe", "Game")
-        assert id1 == id2
-
-    def test_different_names_different_ids(self):
-        id1 = SteamConfigAdapter.generate_app_id("/path/exe", "Game A")
-        id2 = SteamConfigAdapter.generate_app_id("/path/exe", "Game B")
-        assert id1 != id2
-
-
-class TestArtworkIdGeneration:
-    def test_generates_unsigned(self):
-        art_id = SteamConfigAdapter.generate_artwork_id("/path/exe", "Game")
-        assert art_id > 0
-
-    def test_matches_app_id_bits(self):
-        # artwork_id and app_id should share the same CRC base
-        art_id = SteamConfigAdapter.generate_artwork_id("/path/exe", "Game")
-        assert art_id & 0x80000000  # High bit set
-
-
 # ── find_steam_user_dir ─────────────────────────────────────
 
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -9,7 +9,6 @@ import pytest
 from adapters.persistence import (
     PersistenceAdapter,
 )
-from adapters.steam_config import SteamConfigAdapter
 from domain.preview_delta import PreviewDelta
 from domain.sync_state import SyncState
 
@@ -53,29 +52,6 @@ class TestShortcutDataFormat:
         start_dir = os.path.join(decky.DECKY_PLUGIN_DIR, "bin")
 
         assert start_dir == os.path.dirname(exe), f"start_dir ({start_dir}) should be parent of exe ({exe})"
-
-    def test_artwork_id_generation_consistency(self, plugin):
-        """Artwork ID must be deterministic for the same exe+name pair."""
-
-        exe = "/home/deck/homebrew/plugins/decky-romm-sync/bin/romm-launcher"
-        name = "Test Game"
-
-        id1 = SteamConfigAdapter.generate_artwork_id(exe, name)
-        id2 = SteamConfigAdapter.generate_artwork_id(exe, name)
-
-        assert id1 == id2, "Artwork ID should be deterministic"
-        assert isinstance(id1, int), "Artwork ID should be an integer"
-        assert id1 > 0, "Artwork ID should be positive (unsigned)"
-
-    def test_artwork_id_differs_per_game(self, plugin):
-        """Different game names should produce different artwork IDs."""
-
-        exe = "/home/deck/homebrew/plugins/decky-romm-sync/bin/romm-launcher"
-
-        id_a = SteamConfigAdapter.generate_artwork_id(exe, "Game A")
-        id_b = SteamConfigAdapter.generate_artwork_id(exe, "Game B")
-
-        assert id_a != id_b, "Different games should have different artwork IDs"
 
 
 class TestSyncPreview:


### PR DESCRIPTION
## Summary

`SteamConfigAdapter.generate_app_id` and `::generate_artwork_id` had zero production callers — only tests exercised them. Their docstrings were already labeled "Deprecated".

## Verified before deletion

- **Python**: zero production call sites; only defs + tests.
- **TS dispatch**: `SteamClient.Apps.AddShortcut` returns the appId from Steam itself. Nothing in `src/` computes a crc32-based appId. No backend callable dispatches through these.
- **Open issues**: no future-feature references.

## Changes

- `py_modules/adapters/steam_config.py`: removed both static methods + now-unused `binascii` and `struct` imports.
- `tests/adapters/test_steam_config.py`: removed `TestAppIdGeneration` + `TestArtworkIdGeneration` classes.
- `tests/services/library/test_sync_orchestrator.py`: removed the 2 artwork-id tests in `TestShortcutDataFormat` (the other 3 tests in the class remain). Removed unused `SteamConfigAdapter` import.

`SteamConfigAdapter` itself stays — it still owns the VDF write path.

## Test plan

- [x] pytest: 2293 passed
- [x] basedpyright: 0 errors / 0 warnings
- [x] ruff: all checks pass
- [x] pnpm build: clean
- [x] tsc --noEmit: clean
- [x] lint-imports: 7 contracts kept
- [x] cosmic-call-bans: OK

Closes #502