### PR TITLE
chore: delete confirmed dead code (audit #486 Group A)

### DIFF
--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -86,11 +86,6 @@ class DownloadService:
         self._download_queue: dict = {}
         self._download_tasks: dict = {}
 
-    @property
-    def download_tasks(self) -> dict:
-        """Active download tasks (read-only view)."""
-        return self._download_tasks
-
     def shutdown(self) -> None:
         """Cancel all active downloads and clear task tracking."""
         for task in self._download_tasks.values():

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 
 from domain.save_state import (
     FileSyncState,
-    PlaytimeEntry,
     RomSaveState,
     SaveSyncSettings,
     SaveSyncState,
@@ -81,10 +80,6 @@ class StateService:
     # Typed accessors for the per-ROM substructure
     # ------------------------------------------------------------------
 
-    def get_rom_state(self, rom_id_str: str) -> RomSaveState | None:
-        """Return the typed per-ROM state, or ``None`` if not tracked."""
-        return self._save_sync_state.saves.get(rom_id_str)
-
     def ensure_rom_state(self, rom_id_str: str) -> RomSaveState:
         """Return the per-ROM state, creating an empty one if missing."""
         return self._save_sync_state.saves.setdefault(rom_id_str, RomSaveState())
@@ -99,10 +94,6 @@ class StateService:
     def get_settings(self) -> SaveSyncSettings:
         """Return the live settings dataclass."""
         return self._save_sync_state.settings
-
-    def get_playtime(self, rom_id_str: str) -> PlaytimeEntry | None:
-        """Return the typed playtime entry, or ``None`` if not tracked."""
-        return self._save_sync_state.playtime.get(rom_id_str)
 
     # ------------------------------------------------------------------
     # File tracking mutations

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -13,7 +13,7 @@ import { RomMGameInfoPanel } from "../components/RomMGameInfoPanel";
 import { debugLog } from "../api/backend";
 import type { RoutePatch } from "@decky/api";
 
-// Cached set of RomM app IDs — updated by registerRomMAppId / unregisterRomMAppId
+// Cached set of RomM app IDs — updated by registerRomMAppId
 const rommAppIds = new Set<number>();
 
 // Tracks which appIds have already had their tree dumped (once per page load)
@@ -141,10 +141,6 @@ function dumpTree(container: any, appId: number): void {
 
 export function registerRomMAppId(appId: number) {
   rommAppIds.add(appId);
-}
-
-export function unregisterRomMAppId(appId: number) {
-  rommAppIds.delete(appId);
 }
 
 export function isRomMAppId(appId: number): boolean {

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -182,21 +182,3 @@ export async function applyAllPlaytime(
   }
 }
 
-/**
- * Update metadata cache for a single app and apply direct property mutations.
- * Called after fetching fresh metadata for a ROM.
- */
-export function updateMetadataForApp(appId: number, romId: number, metadata: RomMetadata) {
-  metadataCache[String(romId)] = metadata;
-  appIdToRomId[appId] = romId;
-  registeredAppIds.add(appId);
-  applyDirectMutations(appId, metadata);
-}
-
-/**
- * Update the set of known RomM app IDs (e.g. after sync).
- */
-export function setRegisteredAppIds(appIds: number[]) {
-  registeredAppIds = new Set(appIds);
-}
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,30 +15,6 @@ export type RommErrorCode =
   | "stale_preview"
   | "unknown_error";
 
-export interface RomMPlatform {
-  id: number;
-  slug: string;
-  fs_slug: string;
-  name: string;
-  rom_count: number;
-}
-
-export interface RomMRom {
-  id: number;
-  igdb_id: number | null;
-  platform_id: number;
-  platform_slug: string;
-  platform_name: string;
-  file_name: string;
-  name: string;
-  slug: string;
-  summary: string;
-  path_cover_s: string;
-  path_cover_l: string;
-  has_cover: boolean;
-  revision: string;
-}
-
 export interface InstalledRom {
   rom_id: number;
   file_name: string;


### PR DESCRIPTION
## Summary

Removes 8 symbols with zero call sites verified post-Phase-8:

| Symbol | Location |
|---|---|
| `SaveSyncStateStore.get_rom_state` | `py_modules/services/saves/state.py` |
| `SaveSyncStateStore.get_playtime` | `py_modules/services/saves/state.py` |
| `DownloadService.download_tasks` (`@property`) | `py_modules/services/downloads.py` |
| `updateMetadataForApp` | `src/patches/metadataPatches.ts` |
| `setRegisteredAppIds` | `src/patches/metadataPatches.ts` |
| `unregisterRomMAppId` | `src/patches/gameDetailPatch.tsx` |
| `RomMPlatform` interface | `src/types/index.ts` |
| `RomMRom` interface | `src/types/index.ts` |

Collateral cleanup:
- Removed now-unused `PlaytimeEntry` import in `state.py` (only `get_playtime` used it).
- Updated stale comment in `gameDetailPatch.tsx:16` that named `unregisterRomMAppId`.

## Test plan

- [x] pytest: 2300 passed
- [x] basedpyright: 0 errors
- [x] ruff: all checks pass
- [x] pnpm build: clean
- [x] tsc --noEmit: clean
- [x] Per-symbol grep confirmed zero live references before deletion

Closes #500