### PR TITLE
chore: delete unused domain helpers and models (audit #486 Group B)

### DIFF
--- a/py_modules/domain/save_extensions.py
+++ b/py_modules/domain/save_extensions.py
@@ -39,22 +39,3 @@ def get_save_extensions(platform_slug: str | None = None) -> tuple[str, ...]:
     if platform_slug is not None and platform_slug in _PLATFORM_OVERRIDES:
         return _PLATFORM_OVERRIDES[platform_slug]
     return _DEFAULT_EXTENSIONS
-
-
-def get_all_known_extensions() -> tuple[str, ...]:
-    """Return all unique extensions across defaults and all platform overrides.
-
-    Useful for broad file discovery or migration tooling.
-    """
-    seen: set[str] = set()
-    result: list[str] = []
-    for ext in _DEFAULT_EXTENSIONS:
-        if ext not in seen:
-            seen.add(ext)
-            result.append(ext)
-    for exts in _PLATFORM_OVERRIDES.values():
-        for ext in exts:
-            if ext not in seen:
-                seen.add(ext)
-                result.append(ext)
-    return tuple(result)

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -78,17 +78,6 @@ def resolve_save_dir(
     return os.path.join(*parts)
 
 
-def resolve_save_filename(rom_path: str, ext: str = ".srm") -> str:
-    """Derive the save filename from a ROM path.
-
-    Takes the ROM's basename, strips extension, appends save extension.
-    E.g. "gba/Pokemon.gba" -> "Pokemon.srm"
-    """
-    basename = os.path.basename(rom_path)
-    name, _ = os.path.splitext(basename)
-    return name + ext
-
-
 def sanitize_save_filename(name: str) -> str:
     """Reduce *name* to a safe filename component for joining onto ``saves_dir``.
 
@@ -158,16 +147,3 @@ def compute_local_save_target(server_save: dict, rom_name: str) -> LocalSaveTarg
     if sanitized != target:
         return LocalSaveTarget(sanitized, sanitized_from=target)
     return LocalSaveTarget(sanitized)
-
-
-def detect_path_change(stored_path: str | None, resolved_path: str) -> bool:
-    """Detect if the save path has changed since last sync.
-
-    Useful for warning users when RetroArch settings change (e.g.
-    sort_by_content toggled) which would move where saves are expected.
-
-    Returns True if paths differ (or stored_path is None -- first sync).
-    """
-    if stored_path is None:
-        return True
-    return stored_path != resolved_path

--- a/py_modules/models/saves.py
+++ b/py_modules/models/saves.py
@@ -22,37 +22,9 @@ class SaveConflict:
 
 
 @dataclass(frozen=True)
-class SaveFileStatus:
-    """Status of a single save file for display."""
-
-    filename: str
-    status: str
-    last_sync_at: str | None
-    local_path: str | None = None
-    local_hash: str | None = None
-    local_mtime: str | None = None
-    local_size: int | None = None
-    server_save_id: int | None = None
-    server_updated_at: str | None = None
-    server_size: int | None = None
-
-
-@dataclass(frozen=True)
 class SaveSyncSettings:
     """User-facing save sync configuration."""
 
     save_sync_enabled: bool
     sync_before_launch: bool
     sync_after_exit: bool
-
-
-@dataclass(frozen=True)
-class SyncResult:
-    """Result of a sync operation."""
-
-    success: bool
-    message: str
-    synced: int = 0
-    errors: tuple[str, ...] = ()
-    conflicts: tuple[SaveConflict, ...] = ()
-    offline: bool = False

--- a/tests/domain/test_save_extensions.py
+++ b/tests/domain/test_save_extensions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from domain.save_extensions import get_all_known_extensions, get_save_extensions
+from domain.save_extensions import get_save_extensions
 
 _DEFAULTS = (".srm", ".rtc", ".sav")
 
@@ -59,29 +59,3 @@ class TestGetSaveExtensionsWithOverride:
         with patch("domain.save_extensions._PLATFORM_OVERRIDES", {"test": custom}):
             result = get_save_extensions("test")
             assert result == custom
-
-
-class TestGetAllKnownExtensions:
-    """get_all_known_extensions covers defaults and all override extensions."""
-
-    def test_contains_default_extensions(self):
-        result = get_all_known_extensions()
-        assert ".srm" in result
-        assert ".rtc" in result
-        assert ".sav" in result
-
-    def test_contains_override_extensions(self):
-        """Real overrides (nds, segacd) are included."""
-        result = get_all_known_extensions()
-        assert ".dsv" in result
-        assert ".brm" in result
-
-    def test_returns_tuple(self):
-        assert isinstance(get_all_known_extensions(), tuple)
-
-    def test_no_duplicates(self):
-        """Extensions shared between defaults and overrides appear only once."""
-        result = get_all_known_extensions()
-        assert result.count(".srm") == 1
-        assert result.count(".rtc") == 1
-        assert result.count(".sav") == 1

--- a/tests/domain/test_save_path.py
+++ b/tests/domain/test_save_path.py
@@ -9,9 +9,7 @@ import pytest
 from domain.save_path import (
     LocalSaveTarget,
     compute_local_save_target,
-    detect_path_change,
     resolve_save_dir,
-    resolve_save_filename,
     sanitize_save_filename,
 )
 
@@ -155,55 +153,6 @@ class TestResolveSaveDir:
         )
         # dirname of the full path is /other/location/roms/gba → basename is gba
         assert result == "/saves/gba"
-
-
-# ---------------------------------------------------------------------------
-# resolve_save_filename
-# ---------------------------------------------------------------------------
-
-
-class TestResolveSaveFilename:
-    def test_basic_rom_path(self) -> None:
-        """gba/Pokemon.gba → Pokemon.srm"""
-        assert resolve_save_filename("gba/Pokemon.gba") == "Pokemon.srm"
-
-    def test_default_extension_is_srm(self) -> None:
-        assert resolve_save_filename("snes/Zelda.sfc") == "Zelda.srm"
-
-    def test_custom_extension(self) -> None:
-        assert resolve_save_filename("gba/Game.gba", ext=".sav") == "Game.sav"
-
-    def test_spaces_in_name(self) -> None:
-        assert resolve_save_filename("psx/Crash Bandicoot (USA).bin") == "Crash Bandicoot (USA).srm"
-
-    def test_m3u_strips_m3u_extension(self) -> None:
-        """m3u playlists: strip .m3u, keep base name"""
-        assert resolve_save_filename("psx/Game (USA)/Game (USA).m3u") == "Game (USA).srm"
-
-    def test_rom_without_subdir(self) -> None:
-        """ROM path with no directory component"""
-        assert resolve_save_filename("Game.gba") == "Game.srm"
-
-
-# ---------------------------------------------------------------------------
-# detect_path_change
-# ---------------------------------------------------------------------------
-
-
-class TestDetectPathChange:
-    def test_same_path_returns_false(self) -> None:
-        assert detect_path_change("/saves/gba", "/saves/gba") is False
-
-    def test_different_path_returns_true(self) -> None:
-        assert detect_path_change("/saves/gba", "/saves/Game (USA)") is True
-
-    def test_none_stored_returns_true(self) -> None:
-        """First sync — no stored path yet → treat as changed."""
-        assert detect_path_change(None, "/saves/gba") is True
-
-    def test_trailing_slash_difference(self) -> None:
-        """Paths with vs without trailing slash are different strings."""
-        assert detect_path_change("/saves/gba/", "/saves/gba") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_saves.py
+++ b/tests/models/test_saves.py
@@ -2,7 +2,7 @@
 
 from dataclasses import asdict
 
-from models.saves import SaveConflict, SaveFileStatus, SaveSyncSettings, SyncResult
+from models.saves import SaveConflict, SaveSyncSettings
 
 
 class TestSaveConflict:
@@ -55,29 +55,6 @@ class TestSaveConflict:
         assert d["server_save_id"] == 10
 
 
-class TestSaveFileStatus:
-    def test_construction_minimal(self):
-        s = SaveFileStatus(filename="pokemon.srm", status="synced", last_sync_at="2026-01-01T00:00:00Z")
-        assert s.filename == "pokemon.srm"
-        assert s.local_path is None
-
-    def test_construction_full(self):
-        s = SaveFileStatus(
-            filename="pokemon.srm",
-            status="conflict",
-            last_sync_at=None,
-            local_path="/saves/pokemon.srm",
-            local_hash="abc",
-            local_mtime="2026-01-01T00:00:00Z",
-            local_size=1024,
-            server_save_id=100,
-            server_updated_at="2026-01-02T00:00:00Z",
-            server_size=2048,
-        )
-        assert s.status == "conflict"
-        assert s.server_save_id == 100
-
-
 class TestSaveSyncSettings:
     def test_construction(self):
         s = SaveSyncSettings(
@@ -97,45 +74,3 @@ class TestSaveSyncSettings:
         assert d["save_sync_enabled"] is False
         assert d["sync_before_launch"] is False
         assert d["sync_after_exit"] is False
-
-
-class TestSyncResult:
-    def test_defaults(self):
-        r = SyncResult(success=True, message="OK")
-        assert r.synced == 0
-        assert r.errors == ()
-        assert r.conflicts == ()
-        assert r.offline is False
-
-    def test_with_conflicts(self):
-        c = SaveConflict(
-            rom_id=1,
-            filename="f.srm",
-            local_path=None,
-            local_hash=None,
-            local_mtime=None,
-            local_size=None,
-            server_save_id=10,
-            server_updated_at="",
-            server_size=None,
-            created_at="",
-        )
-        r = SyncResult(success=False, message="conflict", conflicts=(c,))
-        assert len(r.conflicts) == 1
-
-    def test_asdict_nested_conflicts(self):
-        c = SaveConflict(
-            rom_id=1,
-            filename="f.srm",
-            local_path=None,
-            local_hash=None,
-            local_mtime=None,
-            local_size=None,
-            server_save_id=10,
-            server_updated_at="",
-            server_size=None,
-            created_at="",
-        )
-        r = SyncResult(success=False, message="err", conflicts=(c,))
-        d = asdict(r)
-        assert d["conflicts"][0]["rom_id"] == 1


### PR DESCRIPTION
## Summary

Removes 5 symbols (plus their dedicated test cases) — zero production callers, only their own tests kept them alive:

| Symbol | Location |
|---|---|
| `resolve_save_filename` | `py_modules/domain/save_path.py` |
| `detect_path_change` | `py_modules/domain/save_path.py` |
| `get_all_known_extensions` | `py_modules/domain/save_extensions.py` |
| `SaveFileStatus` | `py_modules/models/saves.py` |
| `SyncResult` | `py_modules/models/saves.py` |

Confirmed NOT affected: `SessionFinalizeSyncResult` (live, distinct type) and `TestReportSyncResults*` (live tests, distinct symbols).

## Test count

2300 → 2281 (19 tests removed — exactly matches the deleted test cases for the 5 symbols).

## Test plan

- [x] pytest: 2281 passed (down from 2300, expected)
- [x] basedpyright: 0 errors
- [x] ruff: all checks pass

Closes #501