### PR TITLE
chore(types): demote internal TS exports (audit #486 Group E)

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -213,7 +213,7 @@ export interface MigrationStatus {
   saves_count?: number;
 }
 
-export interface ConflictDetail {
+interface ConflictDetail {
   filename: string;
   old_path: string;
   old_size: number;
@@ -254,7 +254,7 @@ export const refreshMigrationState = callable<[], { retrodeck: MigrationStatus; 
 // End-of-session orchestration — collapses recordSessionEnd + syncAchievementsAfterSession
 // + postExitSync + refreshMigrationState into a single backend round-trip.
 // See SessionLifecycleService in py_modules/services/session_lifecycle.py.
-export interface SessionFinalizeSyncResult {
+interface SessionFinalizeSyncResult {
   offline: boolean;
   success: boolean;
   synced: number | null;
@@ -264,7 +264,7 @@ export interface SessionFinalizeSyncResult {
   conflicts_toast: string | null;
 }
 
-export interface SessionFinalizeMigration {
+interface SessionFinalizeMigration {
   retrodeck: MigrationStatus;
   save_sort: SaveSortMigrationStatus;
 }

--- a/src/components/SyncConflictModal.tsx
+++ b/src/components/SyncConflictModal.tsx
@@ -4,7 +4,7 @@ import { resolveSyncConflict, logError } from "../api/backend";
 import type { SyncConflict } from "../types";
 import { formatTimestamp } from "../utils/formatters";
 
-export type SyncConflictAction = "keep_local" | "use_server";
+type SyncConflictAction = "keep_local" | "use_server";
 export type SyncConflictResolution = SyncConflictAction | "cancel";
 
 interface SyncConflictModalProps {
@@ -33,7 +33,7 @@ function formatBytes(bytes: number | null): string {
  * If `onResolve` throws, the parent should set `errorMessage` and keep the modal
  * mounted so the user can retry. Buttons are disabled while `isLoading` is true.
  */
-export const SyncConflictModal: FC<SyncConflictModalProps> = ({
+const SyncConflictModal: FC<SyncConflictModalProps> = ({
   conflict,
   onResolve,
   onCancel,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,7 +145,7 @@ export interface SyncApplyData {
   total_steps?: number;
 }
 
-export interface SyncPlanUnit {
+interface SyncPlanUnit {
   type: "platform" | "collection";
   id: number | string;
   name: string;
@@ -177,7 +177,7 @@ export interface SyncCollectionsData {
   romm_collection_app_ids: Record<string, number[]>;
 }
 
-export interface FirmwareFile {
+interface FirmwareFile {
   id: number;
   file_name: string;
   size: number;
@@ -189,7 +189,7 @@ export interface FirmwareFile {
   classification: "required" | "optional" | "unknown";
 }
 
-export interface FirmwarePlatform {
+interface FirmwarePlatform {
   platform_slug: string;
   files: FirmwareFile[];
 }
@@ -308,7 +308,7 @@ export interface SaveFileStatus {
   uploaded_by_us?: boolean | null;
 }
 
-export interface PlaytimeEntry {
+interface PlaytimeEntry {
   total_seconds: number;
   session_count: number;
   last_session_start: string | null;
@@ -366,7 +366,7 @@ export interface SwitchSlotResponse {
   save_status?: SaveStatus;
 }
 
-export interface SaveSetupSlotInfo {
+interface SaveSetupSlotInfo {
   slot: string | null;
   saves: Array<{
     id: number;


### PR DESCRIPTION
## Summary

10 TypeScript types/components were `export`-ed but referenced only inside their own file. Drops the `export` keyword on each — definitions stay intact, internal usage unaffected. Cleaner public surface, no behaviour change.

| Symbol | File |
|---|---|
| `SyncPlanUnit` | `src/types/index.ts` |
| `FirmwareFile` | `src/types/index.ts` |
| `FirmwarePlatform` | `src/types/index.ts` |
| `PlaytimeEntry` | `src/types/index.ts` |
| `SaveSetupSlotInfo` | `src/types/index.ts` |
| `ConflictDetail` | `src/api/backend.ts` |
| `SessionFinalizeSyncResult` | `src/api/backend.ts` |
| `SessionFinalizeMigration` | `src/api/backend.ts` |
| `SyncConflictAction` | `src/components/SyncConflictModal.tsx` |
| `SyncConflictModal` (FC) | `src/components/SyncConflictModal.tsx` |

`SyncConflictModal` is consumed via the `showSyncConflictModal` helper (same file) — never imported directly.

## Test plan

- [x] Per-symbol grep confirmed zero external references before demoting
- [x] `pnpm build`: clean
- [x] `pnpm exec tsc --noEmit --skipLibCheck`: 0 errors

Closes #504