### PR TITLE
chore: delete unused Protocol+adapter+test trios (audit #486 Group D)

### DIFF
--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -168,9 +168,6 @@ class RommApiAdapter:
             {"device_id": device_id},
         )
 
-    def get_save_metadata(self, save_id: int) -> dict:
-        return self._client.request(f"/api/saves/{save_id}")
-
     def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
         query = f"/api/saves/summary?rom_id={rom_id}"
         if device_id is not None:

--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -91,8 +91,3 @@ class SaveFileAdapter:
         """Return the contents of *path* as raw bytes."""
         with open(path, "rb") as f:
             return f.read()
-
-    def write_bytes(self, path: str, data: bytes) -> None:
-        """Write *data* to *path*, overwriting any existing contents."""
-        with open(path, "wb") as f:
-            f.write(data)

--- a/py_modules/adapters/sgdb_artwork_cache.py
+++ b/py_modules/adapters/sgdb_artwork_cache.py
@@ -51,19 +51,3 @@ class SgdbArtworkCacheAdapter:
     def read_bytes(self, path: str) -> bytes:
         """Return the contents of *path* as raw bytes."""
         return pathlib.Path(path).read_bytes()
-
-    def write_bytes_atomic(self, path: str, data: bytes) -> None:
-        """Write *data* to *path* via a temp file + ``os.replace`` swap.
-
-        On failure the temp file is removed and the exception re-raised so
-        callers can decide how to react.
-        """
-        tmp_path = path + ".tmp"
-        try:
-            with open(tmp_path, "wb") as f:
-                f.write(data)
-            os.replace(tmp_path, path)
-        except Exception:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(tmp_path)
-            raise

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -374,10 +374,6 @@ class SaveFileAdapter(Protocol):
         """Return the contents of *path* as raw bytes."""
         ...
 
-    def write_bytes(self, path: str, data: bytes) -> None:
-        """Write *data* to *path*, overwriting any existing contents."""
-        ...
-
 
 class SgdbArtworkCache(Protocol):
     """Filesystem seam for the SteamGridDB artwork cache directory.
@@ -416,12 +412,4 @@ class SgdbArtworkCache(Protocol):
 
     def read_bytes(self, path: str) -> bytes:
         """Return the contents of *path* as raw bytes."""
-        ...
-
-    def write_bytes_atomic(self, path: str, data: bytes) -> None:
-        """Atomically write *data* to *path*.
-
-        Writes to a temp file beside *path* and ``os.replace``s it to the
-        final destination. The temp file is removed on any failure.
-        """
         ...

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -242,10 +242,6 @@ class RommSaveApi(Protocol):
         """Stream a single save file to ``dest_path`` via ``/api/saves/{save_id}/content``."""
         ...
 
-    def get_save_metadata(self, save_id: int) -> dict:
-        """Return save metadata for ``save_id``."""
-        ...
-
     def delete_server_saves(self, save_ids: list[int]) -> dict:
         """Delete the given save ids via ``POST /api/saves/delete``."""
         ...

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -571,15 +571,6 @@ class TestConfirmDownload:
             api.confirm_download(99, "device-abc")
 
 
-class TestGetSaveMetadata:
-    def test_calls_save_by_id(self):
-        api, client = _make_api()
-        client.request.return_value = {"id": 42, "file_name": "save.srm"}
-        result = api.get_save_metadata(42)
-        client.request.assert_called_once_with("/api/saves/42")
-        assert result["file_name"] == "save.srm"
-
-
 class TestGetSaveSummary:
     def test_without_device_id(self):
         api, client = _make_api()

--- a/tests/adapters/test_sgdb_artwork_cache.py
+++ b/tests/adapters/test_sgdb_artwork_cache.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
 
 import pytest
 
@@ -106,47 +105,3 @@ class TestReadBytes:
     def test_missing_raises(self, cache, tmp_path):
         with pytest.raises(FileNotFoundError):
             cache.read_bytes(str(tmp_path / "missing.png"))
-
-
-class TestWriteBytesAtomic:
-    def test_writes_data(self, cache, tmp_path):
-        dest = tmp_path / "icon.png"
-        cache.write_bytes_atomic(str(dest), b"icon-payload")
-        assert dest.read_bytes() == b"icon-payload"
-
-    def test_no_tmp_left_after_success(self, cache, tmp_path):
-        dest = tmp_path / "icon.png"
-        cache.write_bytes_atomic(str(dest), b"data")
-        assert not (tmp_path / "icon.png.tmp").exists()
-
-    def test_overwrites_existing(self, cache, tmp_path):
-        dest = tmp_path / "icon.png"
-        dest.write_bytes(b"old")
-        cache.write_bytes_atomic(str(dest), b"new")
-        assert dest.read_bytes() == b"new"
-
-    def test_cleans_tmp_on_failure(self, cache, tmp_path):
-        dest = tmp_path / "icon.png"
-        # Make os.replace fail; the tmp file should be removed and the
-        # exception propagated to the caller.
-        with (
-            patch("adapters.sgdb_artwork_cache.os.replace", side_effect=OSError("boom")),
-            pytest.raises(OSError, match="boom"),
-        ):
-            cache.write_bytes_atomic(str(dest), b"data")
-        assert not (tmp_path / "icon.png.tmp").exists()
-        assert not dest.exists()
-
-    def test_cleans_tmp_when_open_fails(self, cache, tmp_path):
-        dest = tmp_path / "icon.png"
-        # Simulate write-side failure after tmp was opened — ensure that
-        # if a tmp file lingers, the cleanup still suppresses
-        # FileNotFoundError gracefully.
-        with (
-            patch("builtins.open", side_effect=OSError("disk full")),
-            pytest.raises(OSError, match="disk full"),
-        ):
-            cache.write_bytes_atomic(str(dest), b"data")
-        # tmp may or may not exist depending on how open() failed; what
-        # matters is cleanup didn't itself raise.
-        assert not dest.exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,14 +241,6 @@ class FakeSgdbArtworkCache:
     the loose "directory exists when it contains files" semantics tests
     need.
 
-    ``write_bytes_atomic`` models the real adapter's tmp-file +
-    ``os.replace`` round-trip: the data lands at ``path + ".tmp"``
-    first, then renames to ``path`` on success. Set
-    ``fail_on_atomic_write`` to make the rename step raise — the
-    tmp file is cleaned up before the exception propagates, mirroring
-    the adapter's behaviour. ``tmp_files`` exposes the set of
-    in-flight tmp paths for tests that need to assert on them.
-
     Tests can pre-populate ``files`` directly to stage cached artwork.
     ``isdir_paths`` can be set explicitly when a test needs to model an
     empty cache directory.
@@ -259,8 +251,6 @@ class FakeSgdbArtworkCache:
         self.files: dict[str, bytes] = dict(files) if files else {}
         self.isdir_paths: set[str] | None = None
         self.cache_dir_call_count = 0
-        self.fail_on_atomic_write: bool = False
-        self.tmp_files: set[str] = set()
 
     def cache_dir(self) -> str:
         self.cache_dir_call_count += 1
@@ -290,17 +280,6 @@ class FakeSgdbArtworkCache:
         if path not in self.files:
             raise FileNotFoundError(path)
         return self.files[path]
-
-    def write_bytes_atomic(self, path: str, data: bytes) -> None:
-        tmp_path = path + ".tmp"
-        self.tmp_files.add(tmp_path)
-        self.files[tmp_path] = data
-        if self.fail_on_atomic_write:
-            self.files.pop(tmp_path, None)
-            self.tmp_files.discard(tmp_path)
-            raise OSError("simulated atomic-write failure")
-        self.files[path] = self.files.pop(tmp_path)
-        self.tmp_files.discard(tmp_path)
 
 
 class FakeDownloadFileAdapter:
@@ -835,10 +814,6 @@ class FakeSaveFileAdapter:
         if path not in self.files:
             raise FileNotFoundError(path)
         return self.files[path]
-
-    def write_bytes(self, path: str, data: bytes) -> None:
-        self.files[path] = data
-        self._ensure_mtime(path)
 
 
 class FakePathProbe:

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -81,7 +82,7 @@ class FakeSaveApi:
         return len(data)
 
     def _materialize_download(self, save_id: int, dest_path: str) -> None:
-        """Write the staged bytes for *save_id* to *dest_path* via the adapter.
+        """Write the staged bytes for *save_id* to *dest_path*.
 
         Resolution order:
         1. ``_save_content[save_id]`` — bytes captured at upload or staged
@@ -98,7 +99,7 @@ class FakeSaveApi:
             data = self.save_file.read_bytes(self.uploaded_files[save_id])
         else:
             data = b"\x00" * 1024
-        self.save_file.write_bytes(dest_path, data)
+        pathlib.Path(dest_path).write_bytes(data)
 
     # ------------------------------------------------------------------
     # Unimplemented RomM API methods (use MagicMock for these)
@@ -338,13 +339,6 @@ class FakeSaveApi:
 
         self.downloaded_files[save_id] = dest_path
         self._materialize_download(save_id, dest_path)
-
-    def get_save_metadata(self, save_id: int) -> dict:
-        self.call_log.append(("get_save_metadata", (save_id,), {}))
-        self._check_fail()
-        if save_id in self.saves:
-            return dict(self.saves[save_id])
-        return {"id": save_id, "download_path": f"/saves/unknown_{save_id}"}
 
     def get_rom_with_notes(self, rom_id: int) -> dict:
         self.call_log.append(("get_rom_with_notes", (rom_id,), {}))

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -821,34 +821,3 @@ class TestDebugLoggerProtocolSeam:
             "SGDB debug must NOT leak to logger.info — the injected "
             f"DebugLogger is the only sink. Observed leaks: {sgdb_info_calls}"
         )
-
-
-class TestFakeSgdbArtworkCacheAtomicWrite:
-    """Unit tests for the in-memory fake's ``write_bytes_atomic`` round-trip.
-
-    Verifies the fake models the real adapter's ``path.tmp`` -> ``os.replace``
-    sequence so service-layer tests can exercise atomic-write failure paths
-    through the same Protocol seam.
-    """
-
-    def test_happy_path_writes_final_and_clears_tmp(self):
-        cache = FakeSgdbArtworkCache()
-        dest = os.path.join(cache.cache_dir(), "42_hero.png")
-
-        cache.write_bytes_atomic(dest, b"payload")
-
-        assert cache.files[dest] == b"payload"
-        assert (dest + ".tmp") not in cache.files
-        assert cache.tmp_files == set()
-
-    def test_failure_cleans_tmp_and_raises(self):
-        cache = FakeSgdbArtworkCache()
-        cache.fail_on_atomic_write = True
-        dest = os.path.join(cache.cache_dir(), "42_hero.png")
-
-        with pytest.raises(OSError, match="simulated atomic-write failure"):
-            cache.write_bytes_atomic(dest, b"payload")
-
-        assert dest not in cache.files
-        assert (dest + ".tmp") not in cache.files
-        assert cache.tmp_files == set()


### PR DESCRIPTION
## Summary

Three adapter methods had zero production callers — exercised only by their own unit tests. Removed as closed loops: adapter method + Protocol entry + fake implementation + tests.

| Trio | Adapter | Protocol | Files |
|---|---|---|---|
| A | `SaveFileAdapter.write_bytes` | `services/protocols/files.py:377` | adapter + Protocol + fake + (test-side caller rerouted) |
| B | `SgdbArtworkCache.write_bytes_atomic` | `services/protocols/files.py:421` | adapter + Protocol + fake + tests |
| C | `RommSaveApi.get_save_metadata` | `services/protocols/transport.py:245` | adapter + Protocol + fake + tests |

## Note on Trio A

The audit reported zero callers. There was actually one test-side use: `tests/fakes/fake_save_api.py::FakeSaveApi._materialize_download` called `self.save_file.write_bytes(...)` to materialize downloaded save bytes onto a real `tmp_path`. Rerouted to `pathlib.Path(dest_path).write_bytes(data)` — test infrastructure isn't subject to the no-I/O rule, and the fake's "no `os`/`open`/`shutil`" design is preserved.

## Protocol surface

- `services/protocols/files.py`: 56 → 54 methods
- `services/protocols/transport.py`: 41 → 40 methods

## Test plan

- [x] pytest: 2292 passed (down from 2300, expected with the deleted test classes)
- [x] basedpyright: 0 errors
- [x] ruff: all checks pass
- [x] lint-imports: 7 contracts kept
- [x] cosmic-call-bans: OK

Closes #503