### PR TITLE
chore(ci): add dependabot.yml for npm + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Frontend (npm via pnpm)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "area:ci"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "area:ci"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` opening auto-PRs for:
- **npm** (weekly, `chore(deps)` prefix, `area:ci` label, limit 5)
- **github-actions** (monthly, `chore(ci)` prefix, `area:ci` label)

## Why no pip ecosystem

`pyproject.toml` contains only tooling config (`[tool.basedpyright]`, `[tool.ruff]`, `[tool.pytest.ini_options]`) — no `[project]` table, no `dependencies`. Python dev tools are installed via `pip install pytest pytest-asyncio …` inside `mise.toml`'s `setup` task; Dependabot can't parse mise tasks. The pip block is intentionally absent until we add a real `[project]` table (or pull deps from `requirements.txt`).

## Test plan

- [x] `yaml.safe_load` OK
- [x] Verified against [GitHub's dependabot.yml schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [x] Commit-message prefixes match our PR-title check (#514) — `chore(deps)` and `chore(ci)` are both accepted types

Closes #509