### PR TITLE
refactor(saves): adopt XxxServiceConfig ctor pattern across sub-services (#494)

### DIFF
--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -13,6 +13,7 @@ layout while a migration is in flight (#238).
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.save_extensions import get_save_extensions
@@ -29,25 +30,36 @@ if TYPE_CHECKING:
     )
 
 
+@dataclass(frozen=True)
+class RomInfoServiceConfig:
+    """Frozen wiring bundle handed to ``RomInfoService.__init__``.
+
+    Holds the main plugin state dict (for ``installed_roms`` reads and
+    save-sort state), the Protocol-typed filesystem adapter, the
+    RetroDECK runtime-path accessor, the ES-DE core resolver, the
+    optional RetroArch core-name provider, and the standard-library
+    logger.
+    """
+
+    state: dict
+    save_file: SaveFileAdapter
+    retrodeck_paths: RetroDeckPaths
+    get_active_core: CoreResolverFn
+    get_core_name: CoreNameProviderFn | None
+    logger: logging.Logger
+
+
 class RomInfoService:
     """Resolves per-ROM save paths and discovers local save files on disk."""
 
-    def __init__(
-        self,
-        *,
-        state: dict,
-        save_file: SaveFileAdapter,
-        retrodeck_paths: RetroDeckPaths,
-        get_active_core: CoreResolverFn,
-        get_core_name: CoreNameProviderFn | None,
-        logger: logging.Logger,
-    ) -> None:
-        self._state = state
-        self._save_file = save_file
-        self._retrodeck_paths = retrodeck_paths
-        self._get_active_core = get_active_core
-        self._get_core_name = get_core_name
-        self._logger = logger
+    def __init__(self, *, config: RomInfoServiceConfig) -> None:
+        self._config = config
+        self._state = config.state
+        self._save_file = config.save_file
+        self._retrodeck_paths = config.retrodeck_paths
+        self._get_active_core = config.get_active_core
+        self._get_core_name = config.get_core_name
+        self._logger = config.logger
 
     def get_rom_save_info(self, rom_id: int) -> dict | None:
         """Get save-related info for an installed ROM.

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from domain.save_state import SaveSyncState
 from services.saves._config import SaveServiceConfig
-from services.saves.rom_info import RomInfoService
-from services.saves.slots import SlotsService
+from services.saves.rom_info import RomInfoService, RomInfoServiceConfig
+from services.saves.slots import SlotsService, SlotsServiceConfig
 from services.saves.slots.service import _NO_MIGRATION
-from services.saves.state import StateService
-from services.saves.status import StatusService
-from services.saves.sync_engine import SyncEngine
-from services.saves.versions import VersionsService
+from services.saves.state import StateService, StateServiceConfig
+from services.saves.status import StatusService, StatusServiceConfig
+from services.saves.sync_engine import SyncEngine, SyncEngineConfig
+from services.saves.versions import VersionsService, VersionsServiceConfig
 
 
 class SaveService:
@@ -37,80 +37,92 @@ class SaveService:
         self._save_file = config.save_file
 
         self._state_svc = StateService(
-            save_sync_state=config.save_sync_state,
-            state=config.state,
-            persister=config.save_sync_state_persister,
-            logger=config.logger,
+            config=StateServiceConfig(
+                save_sync_state=config.save_sync_state,
+                state=config.state,
+                persister=config.save_sync_state_persister,
+                logger=config.logger,
+            ),
         )
         # Convenience alias — both names reference the same aggregate.
         self._save_sync_state = self._state_svc.state
 
         self._rom_info = RomInfoService(
-            state=config.state,
-            save_file=config.save_file,
-            retrodeck_paths=config.retrodeck_paths,
-            get_active_core=config.get_active_core,
-            get_core_name=config.get_core_name,
-            logger=config.logger,
+            config=RomInfoServiceConfig(
+                state=config.state,
+                save_file=config.save_file,
+                retrodeck_paths=config.retrodeck_paths,
+                get_active_core=config.get_active_core,
+                get_core_name=config.get_core_name,
+                logger=config.logger,
+            ),
         )
 
         self._sync_engine = SyncEngine(
-            state=config.state,
-            state_svc=self._state_svc,
-            rom_info=self._rom_info,
-            romm_api=config.romm_api,
-            retry=config.retry,
-            loop=config.loop,
-            logger=config.logger,
-            clock=config.clock,
-            save_file=config.save_file,
-            log_debug=config.log_debug,
-            get_active_core=config.get_active_core,
-            hostname_provider=config.hostname_provider,
-            plugin_version=config.plugin_version,
-            detect_sort_change=config.detect_sort_change,
-            is_retrodeck_migration_pending=config.is_retrodeck_migration_pending,
+            config=SyncEngineConfig(
+                state=config.state,
+                state_svc=self._state_svc,
+                rom_info=self._rom_info,
+                romm_api=config.romm_api,
+                retry=config.retry,
+                loop=config.loop,
+                logger=config.logger,
+                clock=config.clock,
+                save_file=config.save_file,
+                log_debug=config.log_debug,
+                get_active_core=config.get_active_core,
+                hostname_provider=config.hostname_provider,
+                plugin_version=config.plugin_version,
+                detect_sort_change=config.detect_sort_change,
+                is_retrodeck_migration_pending=config.is_retrodeck_migration_pending,
+            ),
         )
 
         self._status = StatusService(
-            state=config.state,
-            state_svc=self._state_svc,
-            sync_engine=self._sync_engine,
-            rom_info=self._rom_info,
-            romm_api=config.romm_api,
-            retry=config.retry,
-            loop=config.loop,
-            logger=config.logger,
-            log_debug=config.log_debug,
-            get_active_core=config.get_active_core,
-            emit=config.emit,
+            config=StatusServiceConfig(
+                state=config.state,
+                state_svc=self._state_svc,
+                sync_engine=self._sync_engine,
+                rom_info=self._rom_info,
+                romm_api=config.romm_api,
+                retry=config.retry,
+                loop=config.loop,
+                logger=config.logger,
+                log_debug=config.log_debug,
+                get_active_core=config.get_active_core,
+                emit=config.emit,
+            ),
         )
 
         self._versions = VersionsService(
-            state_svc=self._state_svc,
-            sync_engine=self._sync_engine,
-            rom_info=self._rom_info,
-            romm_api=config.romm_api,
-            retry=config.retry,
-            loop=config.loop,
-            logger=config.logger,
-            log_debug=config.log_debug,
+            config=VersionsServiceConfig(
+                state_svc=self._state_svc,
+                sync_engine=self._sync_engine,
+                rom_info=self._rom_info,
+                romm_api=config.romm_api,
+                retry=config.retry,
+                loop=config.loop,
+                logger=config.logger,
+                log_debug=config.log_debug,
+            ),
         )
 
         self._slots = SlotsService(
-            state=config.state,
-            state_svc=self._state_svc,
-            sync_engine=self._sync_engine,
-            status_service=self._status,
-            rom_info=self._rom_info,
-            romm_api=config.romm_api,
-            retry=config.retry,
-            loop=config.loop,
-            logger=config.logger,
-            clock=config.clock,
-            save_file=config.save_file,
-            log_debug=config.log_debug,
-            get_active_core=config.get_active_core,
+            config=SlotsServiceConfig(
+                state=config.state,
+                state_svc=self._state_svc,
+                sync_engine=self._sync_engine,
+                status_service=self._status,
+                rom_info=self._rom_info,
+                romm_api=config.romm_api,
+                retry=config.retry,
+                loop=config.loop,
+                logger=config.logger,
+                clock=config.clock,
+                save_file=config.save_file,
+                log_debug=config.log_debug,
+                get_active_core=config.get_active_core,
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/py_modules/services/saves/slots/__init__.py
+++ b/py_modules/services/saves/slots/__init__.py
@@ -6,6 +6,6 @@ executor and I/O orchestrators belong in SyncEngine; status
 reporting in StatusService; persistence in StateService.
 """
 
-from services.saves.slots.service import SlotsService
+from services.saves.slots.service import SlotsService, SlotsServiceConfig
 
-__all__ = ["SlotsService"]
+__all__ = ["SlotsService", "SlotsServiceConfig"]

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.emulator_tag import build_emulator_tag
@@ -29,39 +30,51 @@ if TYPE_CHECKING:
 _NO_MIGRATION = object()  # sentinel: no slot migration requested
 
 
+@dataclass(frozen=True)
+class SlotsServiceConfig:
+    """Frozen wiring bundle handed to ``SlotsService.__init__``.
+
+    Holds the main plugin state dict, the peer save sub-services
+    (state, sync_engine, status, rom_info), the Protocol-typed RomM
+    adapter and retry strategy, runtime infrastructure (loop, logger,
+    clock), the Protocol-typed filesystem adapter, the ``DebugLogger``
+    seam, and the ES-DE core resolver used during slot migration to
+    build the emulator tag for re-upload.
+    """
+
+    state: dict
+    state_svc: StateService
+    sync_engine: SyncEngine
+    status_service: StatusService
+    rom_info: RomInfoService
+    romm_api: RommSaveApi
+    retry: RetryStrategy
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    clock: Clock
+    save_file: SaveFileAdapter
+    log_debug: DebugLogger
+    get_active_core: CoreResolverFn
+
+
 class SlotsService:
     """Slot lifecycle: list, set-active, switch, migrate, delete, first-sync wizard."""
 
-    def __init__(
-        self,
-        *,
-        state: dict,
-        state_svc: StateService,
-        sync_engine: SyncEngine,
-        status_service: StatusService,
-        rom_info: RomInfoService,
-        romm_api: RommSaveApi,
-        retry: RetryStrategy,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        clock: Clock,
-        save_file: SaveFileAdapter,
-        log_debug: DebugLogger,
-        get_active_core: CoreResolverFn,
-    ) -> None:
-        self._state = state
-        self._state_svc = state_svc
-        self._sync_engine = sync_engine
-        self._status_service = status_service
-        self._rom_info = rom_info
-        self._romm_api = romm_api
-        self._retry = retry
-        self._loop = loop
-        self._logger = logger
-        self._clock = clock
-        self._save_file = save_file
-        self._log_debug = log_debug
-        self._get_active_core = get_active_core
+    def __init__(self, *, config: SlotsServiceConfig) -> None:
+        self._config = config
+        self._state = config.state
+        self._state_svc = config.state_svc
+        self._sync_engine = config.sync_engine
+        self._status_service = config.status_service
+        self._rom_info = config.rom_info
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._loop = config.loop
+        self._logger = config.logger
+        self._clock = config.clock
+        self._save_file = config.save_file
+        self._log_debug = config.log_debug
+        self._get_active_core = config.get_active_core
 
     # ------------------------------------------------------------------
     # Slot listing

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -10,6 +10,7 @@ never opens the JSON file directly.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.save_state import (
@@ -25,21 +26,30 @@ if TYPE_CHECKING:
     from services.protocols import SaveSyncStatePersister
 
 
+@dataclass(frozen=True)
+class StateServiceConfig:
+    """Frozen wiring bundle handed to ``StateService.__init__``.
+
+    Holds the live :class:`SaveSyncState` aggregate, the main plugin
+    state dict (used for orphan-pruning against the shortcut registry),
+    the Protocol-typed persister, and the standard-library logger.
+    """
+
+    save_sync_state: SaveSyncState
+    state: dict
+    persister: SaveSyncStatePersister
+    logger: logging.Logger
+
+
 class StateService:
     """Owns the live ``SaveSyncState`` aggregate and its persistence."""
 
-    def __init__(
-        self,
-        *,
-        save_sync_state: SaveSyncState,
-        state: dict,
-        persister: SaveSyncStatePersister,
-        logger: logging.Logger,
-    ) -> None:
-        self._save_sync_state = save_sync_state
-        self._state = state
-        self._persister = persister
-        self._logger = logger
+    def __init__(self, *, config: StateServiceConfig) -> None:
+        self._config = config
+        self._save_sync_state = config.save_sync_state
+        self._state = config.state
+        self._persister = config.persister
+        self._logger = config.logger
 
     @property
     def state(self) -> SaveSyncState:

--- a/py_modules/services/saves/status/__init__.py
+++ b/py_modules/services/saves/status/__init__.py
@@ -5,6 +5,6 @@ one or more ROMs lives here. Mutations belong in SyncEngine; storage
 in StateService.
 """
 
-from services.saves.status.service import StatusService
+from services.saves.status.service import StatusService, StatusServiceConfig
 
-__all__ = ["StatusService"]
+__all__ = ["StatusService", "StatusServiceConfig"]

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from models.saves import SaveConflict
@@ -33,35 +33,47 @@ if TYPE_CHECKING:
     from services.saves.sync_engine import MatrixOutcome, SyncEngine
 
 
+@dataclass(frozen=True)
+class StatusServiceConfig:
+    """Frozen wiring bundle handed to ``StatusService.__init__``.
+
+    Holds the main plugin state dict, the peer save sub-services
+    (state, sync_engine, rom_info), the Protocol-typed RomM adapter
+    and retry strategy, the plugin event loop, the standard-library
+    logger, the ``DebugLogger`` seam, the ES-DE core resolver, and
+    the optional event emitter used to push background status updates
+    to the frontend.
+    """
+
+    state: dict
+    state_svc: StateService
+    sync_engine: SyncEngine
+    rom_info: RomInfoService
+    romm_api: RommSaveApi
+    retry: RetryStrategy
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    log_debug: DebugLogger
+    get_active_core: CoreResolverFn
+    emit: EventEmitter | None
+
+
 class StatusService:
     """Read-only matrix-driven status reporting for the SAVES tab."""
 
-    def __init__(
-        self,
-        *,
-        state: dict,
-        state_svc: StateService,
-        sync_engine: SyncEngine,
-        rom_info: RomInfoService,
-        romm_api: RommSaveApi,
-        retry: RetryStrategy,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        log_debug: DebugLogger,
-        get_active_core: CoreResolverFn,
-        emit: EventEmitter | None,
-    ) -> None:
-        self._state = state
-        self._state_svc = state_svc
-        self._sync_engine = sync_engine
-        self._rom_info = rom_info
-        self._romm_api = romm_api
-        self._retry = retry
-        self._loop = loop
-        self._logger = logger
-        self._log_debug = log_debug
-        self._get_active_core = get_active_core
-        self._emit = emit
+    def __init__(self, *, config: StatusServiceConfig) -> None:
+        self._config = config
+        self._state = config.state
+        self._state_svc = config.state_svc
+        self._sync_engine = config.sync_engine
+        self._rom_info = config.rom_info
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._loop = config.loop
+        self._logger = config.logger
+        self._log_debug = config.log_debug
+        self._get_active_core = config.get_active_core
+        self._emit = config.emit
 
     def _status_entry_from_outcome(
         self,

--- a/py_modules/services/saves/sync_engine/__init__.py
+++ b/py_modules/services/saves/sync_engine/__init__.py
@@ -7,6 +7,6 @@ Read-only matrix consumption (status reporting) belongs in
 StatusService; persistence belongs in StateService.
 """
 
-from services.saves.sync_engine.engine import MatrixOutcome, SyncEngine
+from services.saves.sync_engine.engine import MatrixOutcome, SyncEngine, SyncEngineConfig
 
-__all__ = ["MatrixOutcome", "SyncEngine"]
+__all__ = ["MatrixOutcome", "SyncEngine", "SyncEngineConfig"]

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from models.saves import SaveConflict
@@ -43,80 +43,94 @@ if TYPE_CHECKING:
     from services.saves.state import StateService
 
 
-__all__ = ["MatrixOutcome", "SyncEngine"]
+__all__ = ["MatrixOutcome", "SyncEngine", "SyncEngineConfig"]
+
+
+@dataclass(frozen=True)
+class SyncEngineConfig:
+    """Frozen wiring bundle handed to ``SyncEngine.__init__``.
+
+    Holds the main plugin state dict, the peer save sub-services
+    (state, rom_info), the Protocol-typed RomM adapter and retry
+    strategy, runtime infrastructure (loop, logger, clock), the
+    Protocol-typed filesystem adapter, the ``DebugLogger`` seam, the
+    ES-DE core resolver, the hostname provider used for device
+    registration, the plugin version string passed to the server on
+    register/update, and the optional sort-change and migration-pending
+    callbacks SyncEngine consults at the entry of every public flow.
+    """
+
+    state: dict
+    state_svc: StateService
+    rom_info: RomInfoService
+    romm_api: RommSyncApi
+    retry: RetryStrategy
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    clock: Clock
+    save_file: SaveFileAdapter
+    log_debug: DebugLogger
+    get_active_core: CoreResolverFn
+    hostname_provider: HostnameProvider
+    plugin_version: str
+    detect_sort_change: Callable[[], None] | None
+    is_retrodeck_migration_pending: Callable[[], bool] | None
 
 
 class SyncEngine:
     """Newest-wins matrix executor, sync orchestration callables, and rom-level lock dispatch."""
 
-    def __init__(
-        self,
-        *,
-        state: dict,
-        state_svc: StateService,
-        rom_info: RomInfoService,
-        romm_api: RommSyncApi,
-        retry: RetryStrategy,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        clock: Clock,
-        save_file: SaveFileAdapter,
-        log_debug: DebugLogger,
-        get_active_core: CoreResolverFn,
-        hostname_provider: HostnameProvider,
-        plugin_version: str,
-        detect_sort_change: Callable[[], None] | None,
-        is_retrodeck_migration_pending: Callable[[], bool] | None,
-    ) -> None:
-        self._state = state
-        self._state_svc = state_svc
-        self._rom_info = rom_info
-        self._romm_api = romm_api
-        self._retry = retry
-        self._loop = loop
-        self._logger = logger
-        self._clock = clock
-        self._save_file = save_file
-        self._log_debug = log_debug
-        self._get_active_core = get_active_core
-        self._hostname_provider = hostname_provider
-        self._plugin_version = plugin_version
-        self._detect_sort_change = detect_sort_change
-        self._is_retrodeck_migration_pending = is_retrodeck_migration_pending
+    def __init__(self, *, config: SyncEngineConfig) -> None:
+        self._config = config
+        self._state = config.state
+        self._state_svc = config.state_svc
+        self._rom_info = config.rom_info
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._loop = config.loop
+        self._logger = config.logger
+        self._clock = config.clock
+        self._save_file = config.save_file
+        self._log_debug = config.log_debug
+        self._get_active_core = config.get_active_core
+        self._hostname_provider = config.hostname_provider
+        self._plugin_version = config.plugin_version
+        self._detect_sort_change = config.detect_sort_change
+        self._is_retrodeck_migration_pending = config.is_retrodeck_migration_pending
         # Per-rom lock dict — serializes concurrent sync operations on the
         # same rom_id (pre_launch_sync, post_exit_sync, manual sync, resolve).
         self._rom_sync_locks: dict[int, asyncio.Lock] = {}
 
         self._matrix = MatrixExecutor(
-            state=state,
-            state_svc=state_svc,
-            rom_info=rom_info,
-            romm_api=romm_api,
-            retry=retry,
-            logger=logger,
-            clock=clock,
-            save_file=save_file,
-            log_debug=log_debug,
-            get_active_core=get_active_core,
+            state=config.state,
+            state_svc=config.state_svc,
+            rom_info=config.rom_info,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            logger=config.logger,
+            clock=config.clock,
+            save_file=config.save_file,
+            log_debug=config.log_debug,
+            get_active_core=config.get_active_core,
         )
         self._devices = DeviceRegistry(
-            state_svc=state_svc,
-            romm_api=romm_api,
-            retry=retry,
-            logger=logger,
-            log_debug=log_debug,
-            plugin_version=plugin_version,
+            state_svc=config.state_svc,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            logger=config.logger,
+            log_debug=config.log_debug,
+            plugin_version=config.plugin_version,
         )
         self._rollback = RollbackOrchestrator(
-            state_svc=state_svc,
-            rom_info=rom_info,
-            romm_api=romm_api,
+            state_svc=config.state_svc,
+            rom_info=config.rom_info,
+            romm_api=config.romm_api,
             matrix=self._matrix,
-            retry=retry,
-            clock=clock,
-            save_file=save_file,
-            logger=logger,
-            log_debug=log_debug,
+            retry=config.retry,
+            clock=config.clock,
+            save_file=config.save_file,
+            logger=config.logger,
+            log_debug=config.log_debug,
         )
 
     def _rom_lock(self, rom_id: int) -> asyncio.Lock:

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -11,7 +11,7 @@ resolution, status reporting) belong in SyncEngine or StatusService.
 from __future__ import annotations
 
 import os
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from services.saves._helpers import _local_save_target
@@ -27,6 +27,26 @@ if TYPE_CHECKING:
     from services.saves.sync_engine import SyncEngine
 
 
+@dataclass(frozen=True)
+class VersionsServiceConfig:
+    """Frozen wiring bundle handed to ``VersionsService.__init__``.
+
+    Holds the peer save sub-services consumed during rollback
+    orchestration (state, sync_engine, rom_info), the Protocol-typed
+    RomM adapter and retry strategy, the plugin event loop, the
+    standard-library logger, and the ``DebugLogger`` seam.
+    """
+
+    state_svc: StateService
+    sync_engine: SyncEngine
+    rom_info: RomInfoService
+    romm_api: RommSaveApi
+    retry: RetryStrategy
+    loop: asyncio.AbstractEventLoop
+    logger: logging.Logger
+    log_debug: DebugLogger
+
+
 class VersionsService:
     """Save version history reads and rollback orchestration.
 
@@ -34,26 +54,16 @@ class VersionsService:
     writes — those go through SyncEngine / LocalSavesAdapter.
     """
 
-    def __init__(
-        self,
-        *,
-        state_svc: StateService,
-        sync_engine: SyncEngine,
-        rom_info: RomInfoService,
-        romm_api: RommSaveApi,
-        retry: RetryStrategy,
-        loop: asyncio.AbstractEventLoop,
-        logger: logging.Logger,
-        log_debug: DebugLogger,
-    ) -> None:
-        self._state_svc = state_svc
-        self._sync_engine = sync_engine
-        self._rom_info = rom_info
-        self._romm_api = romm_api
-        self._retry = retry
-        self._loop = loop
-        self._logger = logger
-        self._log_debug = log_debug
+    def __init__(self, *, config: VersionsServiceConfig) -> None:
+        self._config = config
+        self._state_svc = config.state_svc
+        self._sync_engine = config.sync_engine
+        self._rom_info = config.rom_info
+        self._romm_api = config.romm_api
+        self._retry = config.retry
+        self._loop = config.loop
+        self._logger = config.logger
+        self._log_debug = config.log_debug
 
     # ------------------------------------------------------------------
     # Version History API

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -5,7 +5,7 @@ import logging
 from conftest import FakeSaveSyncStatePersister
 
 from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
-from services.saves.state import StateService
+from services.saves.state import StateService, StateServiceConfig
 
 
 def _make_state_svc(
@@ -16,10 +16,12 @@ def _make_state_svc(
     p = persister or FakeSaveSyncStatePersister()
     return (
         StateService(
-            save_sync_state=save_sync_state,
-            state=state,
-            persister=p,
-            logger=logging.getLogger("test"),
+            config=StateServiceConfig(
+                save_sync_state=save_sync_state,
+                state=state,
+                persister=p,
+                logger=logging.getLogger("test"),
+            ),
         ),
         p,
     )


### PR DESCRIPTION
## Summary

Six saves sub-services took bare kwargs (4–15 each) instead of the single-config frozen-dataclass pattern documented in CLAUDE.md `[ours]` rules and used by Library sub-services + top-level services. This PR brings them to parity.

**Behavior unchanged. Ctor-shape only.**

## Ctor migration

| Service | Before | After |
|---|---|---|
| `SyncEngine` | 15 kwargs | `def __init__(self, *, config: SyncEngineConfig)` |
| `SlotsService` | 13 kwargs | `def __init__(self, *, config: SlotsServiceConfig)` |
| `StatusService` | 11 kwargs | `def __init__(self, *, config: StatusServiceConfig)` |
| `VersionsService` | 8 kwargs | `def __init__(self, *, config: VersionsServiceConfig)` |
| `RomInfoService` | 6 kwargs | `def __init__(self, *, config: RomInfoServiceConfig)` |
| `StateService` | 4 kwargs | `def __init__(self, *, config: StateServiceConfig)` |

All configs are `@dataclass(frozen=True)`. Sub-services unpack `self._foo = config.foo` at the top of `__init__` so internal attribute references and existing tests that touch `_detect_sort_change` / `_retry` etc. continue to work unchanged.

## Config home

Each config lives inline with its sub-service module — matches the Library pattern (`LibraryFetcherConfig` is in `fetcher.py`, etc.). Re-exported from the sub-package `__init__.py` for `slots/`, `status/`, `sync_engine/`. The pre-existing top-level `services/saves/_config.py` (which holds `SaveServiceConfig`) is left untouched.

## Test impact

- `tests/services/saves/_helpers.py::make_service`: **untouched** — it builds `SaveService` via `SaveServiceConfig`; the facade constructs sub-services internally.
- `tests/services/test_state.py::_make_state_svc`: only direct sub-service construction site in tests — updated to wrap params in `StateServiceConfig(...)`.

## Test plan

- [x] `pytest`: 2413 passed (unchanged)
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Closes #494