### PR TITLE
refactor(library): unify apply path — sync_preview caches per-unit queue (#436)

### DIFF
--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -18,6 +18,7 @@ from domain.sync_state import SyncState
 
 if TYPE_CHECKING:
     from domain.preview_delta import PreviewDelta
+    from domain.work_unit import WorkUnit
 
 
 def _default_progress() -> dict:
@@ -28,6 +29,25 @@ def _default_progress() -> dict:
         "total": 0,
         "message": "",
     }
+
+
+@dataclass(frozen=True)
+class PrefetchedUnit:
+    """One work unit with its ROMs already fetched.
+
+    Cached on :class:`LibrarySyncStateBox` between ``sync_preview`` and
+    ``sync_apply_delta`` so the apply phase can dispatch the per-unit
+    pipeline without re-fetching ROMs from RomM. ``skipped`` mirrors the
+    second return of :meth:`LibraryFetcher.fetch_platform_unit` — when
+    True, the artwork-download step is bypassed because cover paths are
+    already populated from the registry. ``all_collection_rom_ids`` is
+    only set for collection units; platform units leave it ``None``.
+    """
+
+    unit: WorkUnit
+    roms: list[dict]
+    skipped: bool
+    all_collection_rom_ids: list[int] | None = None
 
 
 @dataclass
@@ -59,3 +79,9 @@ class LibrarySyncStateBox:
     # for the active unit. Surfaces the result so the orchestrator can
     # accumulate the per-unit registry into the cross-run accumulators.
     last_unit_results: dict[str, int] | None = None
+    # Skip Preview OFF apply cache: ``sync_preview`` builds the work
+    # queue + prefetches each unit's ROMs upfront so the user-confirmed
+    # ``sync_apply_delta`` dispatches the per-unit pipeline without
+    # re-fetching from RomM. Cleared on apply success, apply error,
+    # cancel, and on every new ``sync_preview`` call.
+    pending_prefetched_units: list[PrefetchedUnit] | None = None

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -20,7 +20,7 @@ from domain.shortcut_data import build_shortcuts_data
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 from lib.errors import classify_error
-from services.library._state import LibrarySyncStateBox
+from services.library._state import LibrarySyncStateBox, PrefetchedUnit
 
 if TYPE_CHECKING:
     import logging
@@ -669,6 +669,76 @@ class LibraryFetcher:
             offset += limit
 
         return new_roms, all_collection_rom_ids
+
+    async def prefetch_all_units(
+        self,
+    ) -> tuple[list[PrefetchedUnit], list[dict], list[dict], dict[str, list[int]], set[int]]:
+        """Build the work queue and fetch every unit's ROMs upfront.
+
+        Used by the unified preview path so ``sync_apply_delta`` can
+        dispatch the per-unit pipeline against cached unit data without
+        re-fetching from RomM on the apply step. Mirrors the data shape
+        the legacy ``_fetch_and_prepare`` produced for the monolithic
+        preview path: the aggregated ROM list, shortcut data, full
+        platform list (kept for downstream callers that count
+        platforms), per-collection memberships, and the set of rom_ids
+        seen via platform units (used for the platform-collection diff
+        gate in the summary). Caches metadata at the end through the
+        injected ``MetadataExtractor`` so a mid-flight crash leaves the
+        ROM metadata stamped on disk.
+        """
+        await self._emit_progress("platforms", message="Fetching platforms...")
+        work_queue = await self.build_work_queue()
+        self._check_cancelling()
+
+        prefetched: list[PrefetchedUnit] = []
+        all_roms: list[dict] = []
+        platform_rom_ids: set[int] = set()
+        collection_memberships: dict[str, list[int]] = {}
+        synced_rom_ids: set[int] = set()
+
+        total_units = len(work_queue)
+        for unit_index, unit in enumerate(work_queue, 1):
+            self._check_cancelling()
+            await self._emit_progress(
+                "roms",
+                current=len(all_roms),
+                message=f"Fetching {unit.name}... ({unit_index}/{total_units})",
+            )
+
+            if unit.type == "platform":
+                unit_roms, skipped = await self.fetch_platform_unit(unit)
+                for rom in unit_roms:
+                    platform_rom_ids.add(rom["id"])
+                    synced_rom_ids.add(rom["id"])
+                all_roms.extend(unit_roms)
+                prefetched.append(PrefetchedUnit(unit=unit, roms=unit_roms, skipped=skipped))
+            else:
+                unit_roms, all_collection_rom_ids = await self.fetch_collection_unit(unit, synced_rom_ids)
+                if all_collection_rom_ids:
+                    collection_memberships[unit.name] = all_collection_rom_ids
+                all_roms.extend(unit_roms)
+                prefetched.append(
+                    PrefetchedUnit(
+                        unit=unit,
+                        roms=unit_roms,
+                        skipped=False,
+                        all_collection_rom_ids=all_collection_rom_ids,
+                    )
+                )
+
+        shortcuts_data = build_shortcuts_data(all_roms, self._plugin_dir)
+        self._check_cancelling()
+
+        if self._metadata_service is not None:
+            for rom in all_roms:
+                rom_id_str = str(rom["id"])
+                self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
+                self._metadata_service.mark_metadata_dirty()
+            self._metadata_service.flush_metadata_if_dirty()
+        self._log_debug(f"Metadata cached for {len(all_roms)} ROMs (prefetch)")
+
+        return prefetched, all_roms, shortcuts_data, collection_memberships, platform_rom_ids
 
     def cache_metadata_for_unit(self, unit_roms: list[dict]) -> None:
         """Stamp the metadata cache for one unit's ROMs and flush.

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1,12 +1,11 @@
 """Preview / apply / per-unit sync lifecycle and the safety heartbeat.
 
 Owns every async path the user triggers from the QAM that mutates
-in-flight sync state: starting and cancelling syncs, building a
-preview delta from a fetch result, applying that delta back via the
-``sync_apply`` event, driving the per-unit sync pipeline, and the
-safety-timeout watchdog that closes out stuck "applying" phases.
-Progress emission also lives here — sub-services that need to
-surface progress receive the orchestrator's ``_emit_progress``
+in-flight sync state: starting and cancelling syncs, prefetching
+units for a preview, dispatching the per-unit sync pipeline on apply,
+and the safety-timeout watchdog that closes out stuck "applying"
+phases. Progress emission also lives here — sub-services that need
+to surface progress receive the orchestrator's ``_emit_progress``
 callback through their config. Anything that fetches ROMs belongs in
 :class:`LibraryFetcher`; anything that finalises shortcuts after the
 apply completes belongs in :class:`SyncReporter`.
@@ -28,7 +27,7 @@ from domain.sync_diff import (
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 from lib.errors import classify_error
-from services.library._state import LibrarySyncStateBox
+from services.library._state import LibrarySyncStateBox, PrefetchedUnit
 
 if TYPE_CHECKING:
     import logging
@@ -69,8 +68,8 @@ class SyncOrchestratorConfig:
     diff), runtime infrastructure (loop, logger), event emitter, the
     Clock/UuidGen/Sleeper test seams, state-persistence callback, the
     shared :class:`LibrarySyncStateBox`, and three peer references the
-    orchestrator drives at runtime: the :class:`LibraryFetcher` whose
-    ``_fetch_and_prepare`` it consumes, an optional
+    orchestrator drives at runtime: the :class:`LibraryFetcher` it
+    delegates prefetching and per-unit fetches to, an optional
     :class:`ArtworkManager` for the apply-phase artwork download, and
     an optional :class:`MetadataExtractor` it asks to flush its dirty
     metadata cache during the sync ``finally``.
@@ -156,10 +155,19 @@ class SyncOrchestrator:
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
+        # New preview always invalidates a prior cache — the user may
+        # have changed enabled platforms/collections or the RomM library
+        # may have shifted underneath them.
+        box.pending_prefetched_units = None
         try:
-            fetch_result = await self._fetcher._fetch_and_prepare()
-            all_roms, shortcuts_data, platforms, collection_memberships, platform_rom_ids = fetch_result
-            platform_names = {p["name"] for p in platforms if p.get("name")}
+            (
+                prefetched,
+                all_roms,
+                shortcuts_data,
+                collection_memberships,
+                platform_rom_ids,
+            ) = await self._fetcher.prefetch_all_units()
+            platform_names = {u.unit.name for u in prefetched if u.unit.type == "platform"}
             new, changed, unchanged_ids, stale, disabled_count = classify_roms(
                 shortcuts_data,
                 self._state["shortcut_registry"],
@@ -172,6 +180,7 @@ class SyncOrchestrator:
             delta_roms = [roms_by_id[rid] for rid in delta_rom_ids if rid in roms_by_id]
 
             preview_id = self._uuid_gen.uuid4()
+            platforms_count = sum(1 for u in prefetched if u.unit.type == "platform")
             box.pending_delta = PreviewDelta(
                 preview_id=preview_id,
                 created_at=self._clock.time(),
@@ -181,11 +190,12 @@ class SyncOrchestrator:
                 remove_rom_ids=stale,
                 all_shortcuts={sd["rom_id"]: sd for sd in shortcuts_data},
                 delta_roms=delta_roms,
-                platforms_count=len(platforms),
+                platforms_count=platforms_count,
                 total_roms=len(all_roms),
                 collection_memberships=collection_memberships,
                 platform_rom_ids=platform_rom_ids,
             )
+            box.pending_prefetched_units = prefetched
 
             await self._emit_progress("done", message="Preview ready", running=False)
 
@@ -213,12 +223,14 @@ class SyncOrchestrator:
                 "preview_id": preview_id,
             }
         except asyncio.CancelledError:
+            box.pending_prefetched_units = None
             await self._finish_sync(_SYNC_CANCELLED)
             raise
         except Exception as e:
             import traceback
 
             self._logger.error(f"Sync preview failed: {e}\n{traceback.format_exc()}")
+            box.pending_prefetched_units = None
             _code, _msg = classify_error(e)
             await self._emit_progress("error", message=_msg, running=False)
             return {"success": False, "message": _msg, "error_code": _code}
@@ -232,97 +244,45 @@ class SyncOrchestrator:
         age = self._clock.time() - box.pending_delta.created_at
         if age > _PREVIEW_MAX_AGE_SECONDS:
             box.pending_delta = None
+            box.pending_prefetched_units = None
             return {
                 "success": False,
                 "message": "Preview is older than 30 minutes, please re-run sync",
                 "error_code": "stale_preview",
             }
         delta = box.pending_delta
+        prefetched = box.pending_prefetched_units
         box.pending_delta = None
+        # Take the cache out of the box before dispatch so a concurrent
+        # cancel/error path can't double-consume it; the per-unit driver
+        # owns the list for the lifetime of this apply.
+        box.pending_prefetched_units = None
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
 
-        # Calculate apply step plan
-        delta_roms = delta.delta_roms
-        has_artwork = len(delta_roms) > 0
-        has_shortcuts = len(delta.new) + len(delta.changed) > 0
-        has_removals = len(delta.remove_rom_ids) > 0
-
-        apply_steps = []
-        if has_artwork:
-            apply_steps.append("artwork")
-        if has_shortcuts:
-            apply_steps.append("shortcuts")
-        if has_removals:
-            apply_steps.append("removals")
-        total_steps = len(apply_steps)
-        current_step = 0
-
-        # Step: Download artwork
-        if has_artwork:
-            current_step += 1
-            await self._emit_progress(
-                "applying",
-                total=len(delta_roms),
-                message=f"Downloading artwork 0/{len(delta_roms)}",
-                step=current_step,
-                total_steps=total_steps,
-            )
-            cover_paths = await self._download_artwork(
-                delta_roms, progress_step=current_step, progress_total_steps=total_steps
-            )
-            for sd in delta.new + delta.changed:
-                sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
-
-        # Populate _pending_sync for report_sync_results and get_artwork_base64
-        box.pending_sync = delta.all_shortcuts
-        box.pending_collection_memberships = delta.collection_memberships
-        box.pending_platform_rom_ids = delta.platform_rom_ids
-
-        # Update sync_stats
+        # Update sync_stats up-front so the safety-timeout fallback path
+        # surfaces a sensible "X games from Y platforms" message even if
+        # the per-unit dispatch later stalls.
         self._state["sync_stats"] = {
             "platforms": delta.platforms_count,
             "roms": delta.total_roms,
         }
         self._state_persister.save_state()
 
-        # Figure out which step the frontend starts at
-        next_step = current_step + 1
+        if prefetched is None:
+            # Cache was lost (server restart, race, etc.) — log a warning
+            # and let _do_sync_per_unit refetch from scratch so the user
+            # still gets a successful sync rather than a hard failure.
+            self._logger.warning("sync_apply_delta: prefetch cache empty, falling back to fresh fetch")
 
-        total_changes = len(delta.new) + len(delta.changed)
-        await self._emit_progress(
-            "applying",
-            total=total_changes,
-            message=f"Applying shortcuts 0/{total_changes}",
-            step=next_step,
-            total_steps=total_steps,
-        )
-
-        # Emit delta with step plan for frontend
-        await self._emit(
-            "sync_apply",
-            {
-                "shortcuts": delta.new,
-                "changed_shortcuts": delta.changed,
-                "remove_rom_ids": delta.remove_rom_ids,
-                "next_step": next_step,
-                "total_steps": total_steps,
-            },
-        )
-
-        self._logger.info(
-            f"Delta sync emitted: {len(delta.new)} new, {len(delta.changed)} changed, "
-            f"{len(delta.remove_rom_ids)} removed"
-        )
-
-        # Heartbeat safety timeout
-        self._start_safety_timeout()
+        self._loop.create_task(self._do_sync_per_unit(prefetched=prefetched))
 
         return {"success": True, "message": "Applying changes"}
 
     def sync_cancel_preview(self):
         self._sync_state.pending_delta = None
+        self._sync_state.pending_prefetched_units = None
         return {"success": True}
 
     # ── Progress & safety ────────────────────────────────────────
@@ -401,7 +361,7 @@ class SyncOrchestrator:
 
     # ── Per-unit pipeline ────────────────────────────────────────
 
-    async def _do_sync_per_unit(self):
+    async def _do_sync_per_unit(self, prefetched: list[PrefetchedUnit] | None = None):
         """Per-unit sync pipeline (Phase 0 + per-unit dispatch + finalize).
 
         Replaces the monolithic all-platforms-then-all-shortcuts flow:
@@ -411,6 +371,11 @@ class SyncOrchestrator:
         Steam-collection mappings + ``sync_complete`` at the end. Each
         completed unit is a crash-safe checkpoint in the on-disk
         registry.
+
+        When ``prefetched`` is supplied, the work queue is taken from
+        the cached units and each unit's ROMs come from the cache —
+        used by the Skip Preview OFF path so apply does not refetch the
+        library after preview has already paginated it.
         """
         box = self._sync_state
         # Cross-unit accumulators — built up unit-by-unit, consumed by the
@@ -428,17 +393,23 @@ class SyncOrchestrator:
         cancelled = False
 
         try:
-            try:
-                work_queue = await self._fetcher.build_work_queue()
-            except asyncio.CancelledError:
-                await self._finish_sync(_SYNC_CANCELLED)
-                raise
-            except Exception as e:
-                self._logger.error(f"Failed to build work queue: {e}")
-                _code, _msg = classify_error(e)
-                await self._emit_progress("error", message=_msg, running=False)
-                box.sync_state = SyncState.IDLE
-                return
+            work_queue: list[WorkUnit]
+            prefetched_by_unit: dict[WorkUnit, PrefetchedUnit] = {}
+            if prefetched is not None:
+                work_queue = [pu.unit for pu in prefetched]
+                prefetched_by_unit = {pu.unit: pu for pu in prefetched}
+            else:
+                try:
+                    work_queue = await self._fetcher.build_work_queue()
+                except asyncio.CancelledError:
+                    await self._finish_sync(_SYNC_CANCELLED)
+                    raise
+                except Exception as e:
+                    self._logger.error(f"Failed to build work queue: {e}")
+                    _code, _msg = classify_error(e)
+                    await self._emit_progress("error", message=_msg, running=False)
+                    box.sync_state = SyncState.IDLE
+                    return
 
             total_units = len(work_queue)
             total_roms_planned = sum(u.rom_count for u in work_queue)
@@ -471,6 +442,7 @@ class SyncOrchestrator:
                     collection_memberships=collection_memberships,
                     platform_rom_ids=platform_rom_ids,
                     all_rom_id_to_app_id=all_rom_id_to_app_id,
+                    prefetched=prefetched_by_unit.get(unit),
                 )
                 total_games_applied += applied
 
@@ -514,8 +486,16 @@ class SyncOrchestrator:
         collection_memberships: dict[str, list[int]],
         platform_rom_ids: set[int],
         all_rom_id_to_app_id: dict[str, int],
+        prefetched: PrefetchedUnit | None = None,
     ) -> int:
-        """Process one work unit start-to-finish; return shortcuts applied."""
+        """Process one work unit start-to-finish; return shortcuts applied.
+
+        When ``prefetched`` is supplied (Skip Preview OFF path), this
+        unit's ROMs come from the cached preview result and no extra
+        RomM round trip happens. When ``prefetched`` is ``None`` (Skip
+        Preview ON or cache-fallback path), the unit's ROMs are fetched
+        on demand via the per-unit fetcher.
+        """
         box = self._sync_state
         await self._emit_progress(
             "unit",
@@ -524,16 +504,26 @@ class SyncOrchestrator:
             message=f"{unit.name} ({unit_index + 1}/{total_units})",
         )
 
-        # Fetch this unit's ROMs. Platform units may incremental-skip;
-        # collection units always paginate (collection membership is the
-        # source of truth, no per-collection "last_sync" gate today).
+        # Fetch (or replay) this unit's ROMs. Platform units may
+        # incremental-skip; collection units always paginate (collection
+        # membership is the source of truth, no per-collection
+        # "last_sync" gate today).
         if unit.type == "platform":
-            unit_roms, skipped = await self._fetcher.fetch_platform_unit(unit)
+            if prefetched is not None:
+                unit_roms = prefetched.roms
+                skipped = prefetched.skipped
+            else:
+                unit_roms, skipped = await self._fetcher.fetch_platform_unit(unit)
             platform_rom_ids.update(r["id"] for r in unit_roms)
             synced_rom_ids.update(r["id"] for r in unit_roms)
         else:
             skipped = False
-            unit_roms, all_collection_rom_ids = await self._fetcher.fetch_collection_unit(unit, synced_rom_ids)
+            if prefetched is not None:
+                unit_roms = prefetched.roms
+                all_collection_rom_ids = prefetched.all_collection_rom_ids or []
+                synced_rom_ids.update(r["id"] for r in unit_roms)
+            else:
+                unit_roms, all_collection_rom_ids = await self._fetcher.fetch_collection_unit(unit, synced_rom_ids)
             if all_collection_rom_ids:
                 collection_memberships[unit.name] = all_collection_rom_ids
 
@@ -541,8 +531,12 @@ class SyncOrchestrator:
             return 0
 
         # Build shortcut data + cache metadata for this unit only.
+        # When ``prefetched`` is set the preview path already stamped
+        # the metadata cache for every ROM in the run; skip the
+        # redundant re-stamp.
         shortcuts_data = build_shortcuts_data(unit_roms, self._fetcher._plugin_dir)
-        self._fetcher.cache_metadata_for_unit(unit_roms)
+        if prefetched is None:
+            self._fetcher.cache_metadata_for_unit(unit_roms)
 
         # Download artwork for this unit (skipped if the incremental
         # path already populated cover_path from the registry).

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -497,6 +497,136 @@ class TestFetchCollectionRoms:
         assert roms[0]["id"] == 42
 
 
+class TestPrefetchAllUnits:
+    """Tests for prefetch_all_units — the Skip Preview OFF upfront fetch."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_units(self, plugin):
+        """No enabled platforms + no enabled collections → empty prefetch + empty aggregates."""
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=[])
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        (
+            prefetched,
+            all_roms,
+            shortcuts_data,
+            memberships,
+            platform_rom_ids,
+        ) = await plugin._sync_service._fetcher.prefetch_all_units()
+
+        assert prefetched == []
+        assert all_roms == []
+        assert shortcuts_data == []
+        assert memberships == {}
+        assert platform_rom_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_fetches_each_platform_unit(self, plugin):
+        """Each platform unit goes through fetch_platform_unit and aggregates into all_roms."""
+        from domain.work_unit import WorkUnit
+
+        queue = [
+            WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1),
+            WorkUnit(type="platform", id=2, name="GBA", slug="gba", rom_count=1),
+        ]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+
+        async def fake_platform(unit):
+            return [
+                {
+                    "id": int(unit.id) * 10,
+                    "name": f"Game {unit.name}",
+                    "platform_name": unit.name,
+                    "platform_slug": unit.slug,
+                }
+            ], False
+
+        plugin._sync_service._fetcher.fetch_platform_unit = fake_platform
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        (
+            prefetched,
+            all_roms,
+            _shortcuts,
+            memberships,
+            platform_rom_ids,
+        ) = await plugin._sync_service._fetcher.prefetch_all_units()
+
+        assert [pu.unit.name for pu in prefetched] == ["N64", "GBA"]
+        assert {r["id"] for r in all_roms} == {10, 20}
+        assert platform_rom_ids == {10, 20}
+        assert memberships == {}
+
+    @pytest.mark.asyncio
+    async def test_fetches_collection_unit_records_membership(self, plugin):
+        """Collection units populate collection_memberships with their member ids."""
+        from domain.work_unit import WorkUnit
+
+        queue = [WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=2)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+
+        async def fake_collection(_unit, synced):
+            synced.add(101)
+            return [
+                {"id": 101, "name": "C101", "platform_name": "N64", "platform_slug": "n64"},
+            ], [101, 102]
+
+        plugin._sync_service._fetcher.fetch_collection_unit = fake_collection
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        (
+            prefetched,
+            _all,
+            _shortcuts,
+            memberships,
+            platform_rom_ids,
+        ) = await plugin._sync_service._fetcher.prefetch_all_units()
+
+        assert memberships == {"Faves": [101, 102]}
+        # Collection-only ROMs do not land in platform_rom_ids.
+        assert platform_rom_ids == set()
+        # PrefetchedUnit retains the full membership list for finalize.
+        assert prefetched[0].all_collection_rom_ids == [101, 102]
+
+    @pytest.mark.asyncio
+    async def test_preserves_skipped_flag_on_platform_unit(self, plugin):
+        """``skipped=True`` from fetch_platform_unit flows into the PrefetchedUnit."""
+        from domain.work_unit import WorkUnit
+
+        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
+            return_value=([{"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"}], True)
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        prefetched, *_ = await plugin._sync_service._fetcher.prefetch_all_units()
+
+        assert prefetched[0].skipped is True
+
+    @pytest.mark.asyncio
+    async def test_caches_metadata_for_every_rom(self, plugin):
+        """Aggregated ROMs run through metadata_service for the dirty-flush before returning."""
+        from domain.work_unit import WorkUnit
+
+        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
+            return_value=([{"id": 10, "name": "A", "platform_name": "N64"}], True)
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        metadata_service = MagicMock()
+        metadata_service.extract_metadata = MagicMock(return_value={"name": "A"})
+        plugin._sync_service._fetcher._metadata_service = metadata_service
+
+        await plugin._sync_service._fetcher.prefetch_all_units()
+
+        metadata_service.extract_metadata.assert_called_once()
+        metadata_service.mark_metadata_dirty.assert_called_once()
+        metadata_service.flush_metadata_if_dirty.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # TestCollectionSyncEdgeCases
 # ---------------------------------------------------------------------------

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -11,8 +11,38 @@ from adapters.persistence import (
 )
 from domain.preview_delta import PreviewDelta
 from domain.sync_state import SyncState
+from domain.work_unit import WorkUnit
+from services.library._state import PrefetchedUnit
 
 # conftest.py patches decky before this import
+
+
+def _prefetch_result(
+    *,
+    prefetched=None,
+    all_roms=None,
+    shortcuts_data=None,
+    collection_memberships=None,
+    platform_rom_ids=None,
+):
+    """Build the 5-tuple returned by ``LibraryFetcher.prefetch_all_units``."""
+    return (
+        prefetched or [],
+        all_roms or [],
+        shortcuts_data or [],
+        collection_memberships or {},
+        platform_rom_ids if platform_rom_ids is not None else set(),
+    )
+
+
+def _platform_prefetched(name="N64", slug="n64", roms=None, skipped=True):
+    """Helper to build a single platform PrefetchedUnit for preview tests."""
+    roms = roms or []
+    return PrefetchedUnit(
+        unit=WorkUnit(type="platform", id=1, name=name, slug=slug, rom_count=len(roms)),
+        roms=roms,
+        skipped=skipped,
+    )
 
 
 class TestShortcutDataFormat:
@@ -65,16 +95,21 @@ class TestSyncPreview:
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
 
-        # Mock _fetch_and_prepare to return known data
-        platforms = [{"name": "N64", "slug": "n64"}]
+        # Mock prefetch_all_units to return known data
         all_roms = [{"id": 1}, {"id": 2}, {"id": 3}]
         shortcuts_data = [
             {"rom_id": 1, "name": "Game A", "platform_name": "N64", "platform_slug": "n64", "fs_name": "a.z64"},
             {"rom_id": 2, "name": "Game B", "platform_name": "N64", "platform_slug": "n64", "fs_name": "b.z64"},
             {"rom_id": 3, "name": "Game C", "platform_name": "N64", "platform_slug": "n64", "fs_name": "c.z64"},
         ]
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(
-            return_value=(all_roms, shortcuts_data, platforms, {}, set())
+        prefetched = [_platform_prefetched(name="N64", slug="n64", roms=all_roms)]
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(
+            return_value=_prefetch_result(
+                prefetched=prefetched,
+                all_roms=all_roms,
+                shortcuts_data=shortcuts_data,
+                platform_rom_ids={1, 2, 3},
+            )
         )
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
@@ -101,13 +136,18 @@ class TestSyncPreview:
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
 
-        platforms = [{"name": "N64", "slug": "n64"}]
         all_roms = [{"id": 1}]
         shortcuts_data = [
             {"rom_id": 1, "name": "Game A", "platform_name": "N64", "platform_slug": "n64", "fs_name": "a.z64"},
         ]
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(
-            return_value=(all_roms, shortcuts_data, platforms, {}, set())
+        prefetched = [_platform_prefetched(name="N64", slug="n64", roms=all_roms)]
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(
+            return_value=_prefetch_result(
+                prefetched=prefetched,
+                all_roms=all_roms,
+                shortcuts_data=shortcuts_data,
+                platform_rom_ids={1},
+            )
         )
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
@@ -118,6 +158,10 @@ class TestSyncPreview:
         assert len(plugin._sync_service._pending_delta.new) == 1
         assert plugin._sync_service._pending_delta.platforms_count == 1
         assert plugin._sync_service._pending_delta.total_roms == 1
+        # The unified path caches the prefetched units so apply can
+        # dispatch the per-unit pipeline without refetching.
+        assert plugin._sync_service._box.pending_prefetched_units is not None
+        assert len(plugin._sync_service._box.pending_prefetched_units) == 1
 
     @pytest.mark.asyncio
     async def test_returns_error_when_sync_running(self, plugin):
@@ -134,24 +178,61 @@ class TestSyncPreview:
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
 
-        platforms = [{"name": "N64"}]
         all_roms = [{"id": 1}]
         shortcuts_data = [
             {"rom_id": 1, "name": "Game A", "platform_name": "N64", "platform_slug": "n64", "fs_name": "a.z64"},
         ]
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(
-            return_value=(all_roms, shortcuts_data, platforms, {}, set())
+        prefetched = [_platform_prefetched(name="N64", slug="n64", roms=all_roms)]
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(
+            return_value=_prefetch_result(
+                prefetched=prefetched,
+                all_roms=all_roms,
+                shortcuts_data=shortcuts_data,
+                platform_rom_ids={1},
+            )
         )
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
         await plugin.sync_preview()
         assert plugin._sync_service._sync_state == SyncState.IDLE
 
+    @pytest.mark.asyncio
+    async def test_new_preview_clears_prior_prefetch_cache(self, plugin):
+        """A fresh ``sync_preview`` invalidates any cached prefetched units."""
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+
+        # Seed a stale cache as if a previous preview ran.
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="OLD", slug="old", roms=[{"id": 99}])
+        ]
+
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(
+            return_value=_prefetch_result(
+                prefetched=[_platform_prefetched(name="N64", slug="n64", roms=[{"id": 1}])],
+                all_roms=[{"id": 1}],
+                shortcuts_data=[
+                    {"rom_id": 1, "name": "A", "platform_name": "N64", "platform_slug": "n64", "fs_name": "a.z64"},
+                ],
+                platform_rom_ids={1},
+            )
+        )
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        await plugin.sync_preview()
+
+        # New preview replaced the stale cache.
+        units = plugin._sync_service._box.pending_prefetched_units
+        assert units is not None
+        assert [u.unit.name for u in units] == ["N64"]
+
 
 class TestSyncApplyDelta:
     """Tests for sync_apply_delta()."""
 
-    def _setup_pending_delta(self, plugin, preview_id="test-preview-123"):
+    def _setup_pending_delta(self, plugin, preview_id="test-preview-123", *, with_prefetch=True):
         """Helper to populate _pending_delta with valid data."""
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id=preview_id,
@@ -190,6 +271,19 @@ class TestSyncApplyDelta:
             collection_memberships={},
             platform_rom_ids=set(),
         )
+        if with_prefetch:
+            plugin._sync_service._box.pending_prefetched_units = [
+                _platform_prefetched(
+                    name="N64",
+                    slug="n64",
+                    roms=[
+                        {"id": 1, "name": "Game A", "platform_name": "N64", "platform_slug": "n64"},
+                        {"id": 2, "name": "New B", "platform_name": "N64", "platform_slug": "n64"},
+                        {"id": 3, "name": "Game C", "platform_name": "N64", "platform_slug": "n64"},
+                    ],
+                    skipped=True,
+                )
+            ]
 
     @pytest.mark.asyncio
     async def test_rejects_wrong_preview_id(self, plugin):
@@ -222,8 +316,10 @@ class TestSyncApplyDelta:
         assert result["success"] is False
         assert result["error_code"] == "stale_preview"
         assert "30 minutes" in result["message"]
-        # Stale delta is cleared so a repeat apply can't pick it up.
+        # Stale delta + prefetch cache are cleared so a repeat apply
+        # can't pick them up.
         assert plugin._sync_service._pending_delta is None
+        assert plugin._sync_service._box.pending_prefetched_units is None
 
     @pytest.mark.asyncio
     async def test_accepts_when_preview_just_under_max_age(self, plugin, tmp_path):
@@ -239,6 +335,7 @@ class TestSyncApplyDelta:
         }
         self._setup_pending_delta(plugin, "preview-xyz")
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._do_sync_per_unit = AsyncMock()
         # Just under the 30-minute window.
         plugin._sync_service._clock.advance(1799)
 
@@ -247,51 +344,56 @@ class TestSyncApplyDelta:
         assert result["success"] is True
 
     @pytest.mark.asyncio
-    async def test_emits_sync_apply_with_delta(self, plugin, tmp_path):
-
+    async def test_dispatches_per_unit_with_cached_queue(self, plugin, tmp_path):
+        """Apply hands the prefetched cache to ``_do_sync_per_unit`` and clears the box cache."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        # Set up registry for unchanged rom
         plugin._state["shortcut_registry"] = {
             "1": {"app_id": 1001, "name": "Game A", "platform_name": "N64"},
         }
         self._setup_pending_delta(plugin)
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        do_sync = AsyncMock()
+        plugin._sync_service._orchestrator._do_sync_per_unit = do_sync
 
         result = await plugin.sync_apply_delta("test-preview-123")
-        assert result["success"] is True
+        # Drain the create_task'd dispatch.
+        for _ in range(3):
+            await asyncio.sleep(0)
 
-        # Check decky.emit was called with sync_apply
-        emit_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_apply"]
-        assert len(emit_calls) == 1
-        payload = emit_calls[0][0][1]
-        assert len(payload["shortcuts"]) == 1  # new
-        assert len(payload["changed_shortcuts"]) == 1  # changed
-        assert payload["remove_rom_ids"] == [99]
+        assert result["success"] is True
+        # No monolithic sync_apply emission — the per-unit pipeline drives apply now.
+        assert not any(c[0][0] == "sync_apply" for c in decky.emit.call_args_list)
+        # Per-unit dispatch was kicked off with the prefetched queue.
+        do_sync.assert_called_once()
+        prefetched_arg = do_sync.call_args.kwargs.get("prefetched") or do_sync.call_args.args[0]
+        assert prefetched_arg is not None
+        assert [pu.unit.name for pu in prefetched_arg] == ["N64"]
+        # Apply takes the cache out of the box so a concurrent error path can't double-consume.
+        assert plugin._sync_service._box.pending_prefetched_units is None
 
     @pytest.mark.asyncio
-    async def test_populates_pending_sync(self, plugin, tmp_path):
-
+    async def test_apply_persists_sync_stats(self, plugin, tmp_path):
+        """Apply writes the preview's platform/rom counts into ``sync_stats`` for the safety-timeout fallback."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
         plugin._state["shortcut_registry"] = {
             "1": {"app_id": 1001, "name": "Game A", "platform_name": "N64"},
         }
         self._setup_pending_delta(plugin)
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._do_sync_per_unit = AsyncMock()
 
         await plugin.sync_apply_delta("test-preview-123")
-        assert 1 in plugin._sync_service._pending_sync
-        assert 2 in plugin._sync_service._pending_sync
-        assert 3 in plugin._sync_service._pending_sync
+
+        assert plugin._state["sync_stats"]["platforms"] == 1
+        assert plugin._state["sync_stats"]["roms"] == 3
 
     @pytest.mark.asyncio
     async def test_clears_pending_delta(self, plugin, tmp_path):
@@ -307,51 +409,36 @@ class TestSyncApplyDelta:
         }
         self._setup_pending_delta(plugin)
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._do_sync_per_unit = AsyncMock()
 
         await plugin.sync_apply_delta("test-preview-123")
         assert plugin._sync_service._pending_delta is None
 
     @pytest.mark.asyncio
-    async def test_sync_apply_does_not_include_collection_data(self, plugin, tmp_path):
-
+    async def test_apply_without_prefetch_logs_warning_and_falls_back(self, plugin, tmp_path):
+        """Cache missing at apply (e.g. server restart) → log warning + dispatch without cache."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"] = {
-            "1": {"app_id": 1001, "name": "Game A", "platform_name": "N64"},
-            "5": {"app_id": 1005, "name": "Game E", "platform_name": "SNES"},
-        }
-        # Include both rom 1 and 5 as unchanged
-        plugin._sync_service._pending_delta = PreviewDelta(
-            preview_id="test-preview-123",
-            created_at=plugin._sync_service._clock.time(),
-            new=[],
-            changed=[],
-            unchanged_ids=[1, 5],
-            remove_rom_ids=[],
-            all_shortcuts={
-                1: {"rom_id": 1, "name": "Game A", "platform_name": "N64"},
-                5: {"rom_id": 5, "name": "Game E", "platform_name": "SNES"},
-            },
-            delta_roms=[],
-            platforms_count=2,
-            total_roms=2,
-            collection_memberships={},
-            platform_rom_ids=set(),
-        )
+        self._setup_pending_delta(plugin, with_prefetch=False)
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        do_sync = AsyncMock()
+        plugin._sync_service._orchestrator._do_sync_per_unit = do_sync
 
-        await plugin.sync_apply_delta("test-preview-123")
+        result = await plugin.sync_apply_delta("test-preview-123")
+        for _ in range(3):
+            await asyncio.sleep(0)
 
-        emit_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_apply"]
-        assert len(emit_calls) == 1
-        # Platform collection data is no longer in sync_apply — it's built in report_sync_results
-        # and sent via sync_complete instead.
-        assert "collection_platform_app_ids" not in emit_calls[0][0][1]
-        assert "platform_eligible_rom_ids" not in emit_calls[0][0][1]
+        assert result["success"] is True
+        do_sync.assert_called_once()
+        if do_sync.call_args.kwargs:
+            prefetched_arg = do_sync.call_args.kwargs.get("prefetched")
+        else:
+            prefetched_arg = do_sync.call_args.args[0] if do_sync.call_args.args else None
+        # Fallback path: per-unit pipeline runs without cached units (does a fresh fetch).
+        assert prefetched_arg is None
 
 
 class TestSyncCancelPreview:
@@ -373,8 +460,13 @@ class TestSyncCancelPreview:
             collection_memberships={},
             platform_rom_ids=set(),
         )
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="X", slug="x", roms=[{"id": 1}])
+        ]
         result = await plugin.sync_cancel_preview()
         assert plugin._sync_service._pending_delta is None
+        # Cancelling the preview also evicts the prefetched-units cache.
+        assert plugin._sync_service._box.pending_prefetched_units is None
         assert result["success"] is True
 
     @pytest.mark.asyncio
@@ -631,18 +723,23 @@ class TestSafetyTimeoutGenerationGuard:
 
 
 class TestSyncPreviewErrorHandling:
-    """Tests for sync_preview error paths — lines 210-219."""
+    """Tests for sync_preview error paths."""
 
     @pytest.mark.asyncio
     async def test_general_exception_returns_error(self, plugin):
-
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(side_effect=RuntimeError("Something broke"))
+        # Seed a cache so we can verify it's cleared on error.
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="STALE", slug="stale", roms=[{"id": 1}])
+        ]
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(side_effect=RuntimeError("Something broke"))
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
         result = await plugin._sync_service.sync_preview()
         assert result["success"] is False
         assert "error_code" in result
         assert plugin._sync_service._sync_state == SyncState.IDLE
+        # Error path evicts the prefetch cache so apply can't pick up a half-built one.
+        assert plugin._sync_service._box.pending_prefetched_units is None
 
     @pytest.mark.asyncio
     async def test_cancelled_error_reraises(self, plugin):
@@ -651,12 +748,16 @@ class TestSyncPreviewErrorHandling:
 
         decky.emit.reset_mock()
 
-        plugin._sync_service._fetcher._fetch_and_prepare = AsyncMock(side_effect=asyncio.CancelledError("cancelled"))
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="STALE", slug="stale", roms=[{"id": 1}])
+        ]
+        plugin._sync_service._fetcher.prefetch_all_units = AsyncMock(side_effect=asyncio.CancelledError("cancelled"))
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
         with pytest.raises(asyncio.CancelledError):
             await plugin._sync_service.sync_preview()
         assert plugin._sync_service._sync_state == SyncState.IDLE
+        assert plugin._sync_service._box.pending_prefetched_units is None
 
 
 # ──────────────────────────────────────────────────────────────
@@ -1163,137 +1264,112 @@ class TestShutdown:
         assert plugin._sync_service._sync_state == SyncState.CANCELLING
 
 
-class TestSyncApplyDeltaArtworkStep:
-    """Tests for the artwork step in sync_apply_delta() — lines 254, 264-276.
+class TestSyncApplyDeltaUnifiedDispatch:
+    """The unified apply path drives the per-unit pipeline through ``_do_sync_per_unit``.
 
-    When delta_roms is non-empty, the orchestrator must:
-    - Include "artwork" in the step plan
-    - Emit an "applying" progress event for the artwork phase
-    - Delegate to _download_artwork and stamp cover_path on each shortcut
+    Artwork download moves into the per-unit loop (``_sync_one_unit``)
+    rather than a single bulk pre-step — verified by end-to-end tests in
+    :class:`TestDoSyncPerUnit` that follow the cached-prefetch path
+    through to ``sync_apply_unit`` emission.
     """
 
     @pytest.mark.asyncio
-    async def test_artwork_step_downloads_and_stamps_cover_paths(self, plugin, tmp_path):
+    async def test_apply_dispatches_per_unit_with_artwork_for_non_skipped_units(self, plugin, tmp_path):
+        """End-to-end: prefetched non-skipped unit triggers per-unit artwork + sync_apply_unit."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
         plugin._state["shortcut_registry"] = {}
 
+        roms = [
+            {"id": 10, "name": "Game X", "platform_name": "N64", "platform_slug": "n64", "fs_name": "x.z64"},
+        ]
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id="art-preview",
             created_at=plugin._sync_service._clock.time(),
-            new=[
-                {
-                    "rom_id": 10,
-                    "name": "Game X",
-                    "platform_name": "N64",
-                    "platform_slug": "n64",
-                    "fs_name": "x.z64",
-                    "cover_path": "",
-                },
-            ],
-            changed=[
-                {
-                    "rom_id": 11,
-                    "name": "Game Y",
-                    "existing_app_id": 2002,
-                    "platform_name": "N64",
-                    "platform_slug": "n64",
-                    "fs_name": "y.z64",
-                    "cover_path": "",
-                },
-            ],
+            new=[{"rom_id": 10, "name": "Game X", "platform_name": "N64"}],
+            changed=[],
             unchanged_ids=[],
             remove_rom_ids=[],
-            all_shortcuts={
-                10: {"rom_id": 10, "name": "Game X", "platform_name": "N64"},
-                11: {"rom_id": 11, "name": "Game Y", "platform_name": "N64"},
-            },
-            # Non-empty delta_roms triggers the artwork step (line 253-254 + 263-276).
-            delta_roms=[{"id": 10, "name": "Game X"}, {"id": 11, "name": "Game Y"}],
+            all_shortcuts={10: {"rom_id": 10, "name": "Game X", "platform_name": "N64"}},
+            delta_roms=roms,
             platforms_count=1,
-            total_roms=2,
+            total_roms=1,
             collection_memberships={},
-            platform_rom_ids=set(),
+            platform_rom_ids={10},
         )
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="N64", slug="n64", roms=roms, skipped=False)
+        ]
 
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(
-            return_value={10: "/grid/x.png", 11: "/grid/y.png"}
-        )
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={10: "/grid/x.png"})
+
+        async def fake_wait(_unit, event):
+            event.set()
+            return {"10": 5000}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
 
         result = await plugin.sync_apply_delta("art-preview")
+        # Drain background dispatch.
+        for _ in range(10):
+            await asyncio.sleep(0)
+
         assert result["success"] is True
-
-        # _download_artwork was invoked with the delta_roms list.
+        # No monolithic sync_apply emission — only the per-unit event.
+        assert not any(c[0][0] == "sync_apply" for c in decky.emit.call_args_list)
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        assert unit_events[0]["unit_name"] == "N64"
+        # Cover path was downloaded per-unit (not skipped) and stamped onto the unit's shortcut.
         plugin._sync_service._orchestrator._download_artwork.assert_called_once()
-        call_args = plugin._sync_service._orchestrator._download_artwork.call_args
-        assert call_args.args[0] == [{"id": 10, "name": "Game X"}, {"id": 11, "name": "Game Y"}]
-
-        # The artwork step bumped current_step to 1, so total_steps reflects artwork + shortcuts.
-        emit_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_apply"]
-        payload = emit_calls[0][0][1]
-        # apply_steps == ["artwork", "shortcuts"] → total_steps=2, next_step=2
-        assert payload["total_steps"] == 2
-        assert payload["next_step"] == 2
-
-        # cover_path was stamped on every new/changed shortcut via the
-        # sync_apply payload (the in-memory PreviewDelta lists are mutated
-        # in place before being emitted on line 275-276).
-        sync_apply_payload = emit_calls[0][0][1]
-        new_by_id = {sd["rom_id"]: sd for sd in sync_apply_payload["shortcuts"]}
-        changed_by_id = {sd["rom_id"]: sd for sd in sync_apply_payload["changed_shortcuts"]}
-        assert new_by_id[10]["cover_path"] == "/grid/x.png"
-        assert changed_by_id[11]["cover_path"] == "/grid/y.png"
+        assert unit_events[0]["shortcuts"][0]["cover_path"] == "/grid/x.png"
 
     @pytest.mark.asyncio
-    async def test_artwork_step_emits_applying_progress_with_step_plan(self, plugin, tmp_path):
-        """Artwork phase emits an 'applying' progress event with step=1."""
+    async def test_apply_skips_artwork_for_incremental_units(self, plugin, tmp_path):
+        """Prefetched unit marked ``skipped=True`` bypasses artwork download in the per-unit loop."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
 
+        roms = [{"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"}]
         plugin._sync_service._pending_delta = PreviewDelta(
-            preview_id="art-progress",
+            preview_id="skip-preview",
             created_at=plugin._sync_service._clock.time(),
-            new=[
-                {
-                    "rom_id": 20,
-                    "name": "G",
-                    "platform_name": "N64",
-                    "platform_slug": "n64",
-                    "fs_name": "g.z64",
-                    "cover_path": "",
-                },
-            ],
+            new=[],
             changed=[],
-            unchanged_ids=[],
+            unchanged_ids=[10],
             remove_rom_ids=[],
-            all_shortcuts={20: {"rom_id": 20, "name": "G", "platform_name": "N64"}},
-            delta_roms=[{"id": 20, "name": "G"}],
+            all_shortcuts={10: {"rom_id": 10, "name": "A", "platform_name": "N64"}},
+            delta_roms=[],
             platforms_count=1,
             total_roms=1,
             collection_memberships={},
-            platform_rom_ids=set(),
+            platform_rom_ids={10},
         )
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="N64", slug="n64", roms=roms, skipped=True)
+        ]
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
 
-        emit_progress = AsyncMock()
-        plugin._sync_service._orchestrator._emit_progress = emit_progress
-        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={20: "/g.png"})
+        async def fake_wait(_unit, event):
+            event.set()
+            return {}
 
-        result = await plugin.sync_apply_delta("art-progress")
-        assert result["success"] is True
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
 
-        # First _emit_progress call is the artwork "applying" message (line 265-271).
-        first_call = emit_progress.call_args_list[0]
-        assert first_call.args[0] == "applying"
-        assert first_call.kwargs["step"] == 1
-        assert "Downloading artwork" in first_call.kwargs["message"]
+        await plugin.sync_apply_delta("skip-preview")
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        # Skipped=True → artwork download was not called for the unit.
+        plugin._sync_service._orchestrator._download_artwork.assert_not_called()
 
 
 class TestDoSyncPerUnitErrors:
@@ -1535,6 +1611,136 @@ class TestSyncOneUnitCollectionAndCancel:
         assert plugin._sync_service._pending_sync == {}
         assert plugin._sync_service._box.unit_complete_event is None
         assert plugin._sync_service._sync_state == SyncState.CANCELLING
+
+
+class TestSyncOneUnitWithPrefetched:
+    """``_sync_one_unit`` consumes pre-fetched ROMs when handed a ``PrefetchedUnit``.
+
+    The unified Skip Preview OFF apply path passes the preview's
+    cached unit data down so the per-unit driver does not call back into
+    the fetcher for the same ROMs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_platform_unit_uses_cached_roms_no_refetch(self, plugin):
+        plugin.loop = asyncio.get_event_loop()
+
+        cached_roms = [
+            {"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            {"id": 11, "name": "B", "platform_name": "N64", "platform_slug": "n64"},
+        ]
+        prefetched = _platform_prefetched(name="N64", slug="n64", roms=cached_roms, skipped=True)
+        # If anything calls the fetcher, the test fails — there is no live mock.
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(side_effect=AssertionError("must not refetch"))
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            return {"10": 5001, "11": 5002}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        platform_rom_ids: set[int] = set()
+        synced_rom_ids: set[int] = set()
+        applied = await plugin._sync_service._orchestrator._sync_one_unit(
+            prefetched.unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=synced_rom_ids,
+            collection_memberships={},
+            platform_rom_ids=platform_rom_ids,
+            all_rom_id_to_app_id={},
+            prefetched=prefetched,
+        )
+
+        assert applied == 2
+        # platform_rom_ids and synced_rom_ids reflect the cached ROMs even though no fetch happened.
+        assert platform_rom_ids == {10, 11}
+        assert synced_rom_ids == {10, 11}
+        plugin._sync_service._fetcher.fetch_platform_unit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collection_unit_uses_cached_membership_no_refetch(self, plugin):
+        """Cached collection units replay their membership without refetching."""
+        from domain.work_unit import WorkUnit
+        from services.library._state import PrefetchedUnit
+
+        plugin.loop = asyncio.get_event_loop()
+        unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=2)
+        cached_roms = [{"id": 30, "name": "X", "platform_name": "N64", "platform_slug": "n64"}]
+        prefetched = PrefetchedUnit(
+            unit=unit,
+            roms=cached_roms,
+            skipped=False,
+            all_collection_rom_ids=[30, 31],
+        )
+        plugin._sync_service._fetcher.fetch_collection_unit = AsyncMock(side_effect=AssertionError("must not refetch"))
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            return {"30": 9001}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        memberships: dict[str, list[int]] = {}
+        synced_rom_ids: set[int] = set()
+        applied = await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=synced_rom_ids,
+            collection_memberships=memberships,
+            platform_rom_ids=set(),
+            all_rom_id_to_app_id={},
+            prefetched=prefetched,
+        )
+
+        assert applied == 1
+        # Cached membership flows through as if fetch_collection_unit had returned it.
+        assert memberships == {"Faves": [30, 31]}
+        # ROMs marked as synced so subsequent collection units can dedup.
+        assert synced_rom_ids == {30}
+        plugin._sync_service._fetcher.fetch_collection_unit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prefetched_unit_skips_metadata_re_stamp(self, plugin):
+        """``cache_metadata_for_unit`` is not invoked when ROMs come from prefetch (already stamped)."""
+        plugin.loop = asyncio.get_event_loop()
+        prefetched = _platform_prefetched(
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"}],
+            skipped=True,
+        )
+        cache_meta = MagicMock()
+        plugin._sync_service._fetcher.cache_metadata_for_unit = cache_meta
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            return {"10": 5001}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._sync_one_unit(
+            prefetched.unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+            all_rom_id_to_app_id={},
+            prefetched=prefetched,
+        )
+
+        cache_meta.assert_not_called()
 
 
 class TestWaitForUnitCompleteCancelled:


### PR DESCRIPTION
## Summary

Skip Preview OFF was still routing through the legacy `sync_preview → sync_apply_delta` monolithic-delta path while Skip Preview ON used the per-unit pipeline shipped in #433. Same machinery now drives both — preview/apply users get the same incremental delivery.

## What changes

- **`_state.py`** — new `PrefetchedUnit` frozen dataclass + `pending_prefetched_units: list[PrefetchedUnit] | None` on `LibrarySyncStateBox`.
- **`fetcher.py`** — new `prefetch_all_units()` runs the work queue upfront, fetches each unit's ROMs, aggregates summary inputs, stamps metadata cache once.
- **`sync_orchestrator.py`**:
  - `sync_preview()` calls `prefetch_all_units()`, caches result on the box.
  - `sync_apply_delta()` dispatches the cached queue through `_do_sync_per_unit(prefetched=...)`. **No longer emits the monolithic `sync_apply` event.** No re-fetch.
  - `_do_sync_per_unit` / `_sync_one_unit` accept optional `prefetched` data and skip the fetcher round-trip when supplied.
  - Cache cleared on fresh preview entry, preview CancelledError, preview general-exception, stale-preview rejection (>30 min), happy-path apply, and `sync_cancel_preview()`.
  - Stale-cache fallback: missing cache logs a warning and falls back to fresh per-unit fetch.

Frontend untouched — `sync_apply_unit` handler from #433 already in place. Frontend `initSyncManager` legacy `sync_apply` listener stays as dead code until a follow-up retires it (out of scope per issue body).

## Out of scope (follow-ups)

- Removing `initSyncManager` legacy `sync_apply` handler in the frontend.
- Deleting `LibraryFetcher._fetch_and_prepare` — kept because three integration tests in `test_service.py` still exercise it for end-to-end fetch + collection-dedup coverage. Removing means rewriting those tests; not blocking this PR.

## Test plan

- [x] `pytest`: 2422 passed (+9 new tests)
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK
- [x] `pnpm build`: clean
- [x] `tsc --noEmit`: clean
- [x] Coverage on `sync_orchestrator.py`: **99%**
- [x] Skip Preview ON path verified unchanged (reviewer agent)
- [x] All 6 cache-clear sites verified present (reviewer agent)
- [x] Stale-cache fallback exercises a fresh-fetch with warning

Closes #436