### PR TITLE
ci: skip sonarcloud job on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     needs: [test]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

All 9 currently-open Dependabot PRs are red on the `sonarcloud` job. Every other check passes. The scan exits with:

> Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' properties, the 'SONAR_TOKEN' environment variable, or contact the project administrator…

Misleading message — it's not a config issue. GitHub puts Dependabot runs in a separate secret scope, so `secrets.SONAR_TOKEN` resolves to empty for those runs and the unauthenticated scan is rejected.

## Why skip (vs. mirror token into Dependabot secrets)

- The Quality Gate is "80% coverage on new code". Dep-bump PRs introduce no new application code — the gate is vacuously satisfied. Running the scan adds no signal.
- Mirroring `SONAR_TOKEN` into Dependabot's secret scope would expose it to a malicious package's `postinstall` / build hook running inside Dependabot CI. Low blast radius for this specific token, but zero gain.

No required-status-check ruleset on `main`, so a skipped job doesn't block merges.

## Resolving the existing red PRs

After this lands, each open Dependabot PR needs to rebase onto the new `main` to pick up the workflow change. Comment `@dependabot rebase` per PR, or close+reopen.