### PR TITLE
ci(dependabot): group minor/patch bumps and auto-merge on green CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - "area:ci"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -20,3 +25,23 @@ updates:
       - "area:ci"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Python (test/lint deps pinned in requirements-dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area:ci"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Why

Today's 9 simultaneous Dependabot PRs were partly noise that grouping would have collapsed and partly patch/minor bumps that don't need a human in the loop.

## What

**Grouping (`.github/dependabot.yml`)**
- npm: all minor + patch bumps land in **one** PR per week
- github-actions: all minor + patch bumps land in **one** PR per month
- pip: new ecosystem so Dependabot bumps `requirements-dev.txt` too; minor + patch grouped
- Majors stay individual on purpose — they need review

**Auto-merge workflow (`.github/workflows/dependabot-auto-merge.yml`)**
- On any Dependabot PR, fetches metadata via `dependabot/fetch-metadata`
- If `update-type` is `version-update:semver-patch` or `semver-minor`, runs `gh pr merge --auto --squash`
- Majors are ignored — manual review path

## Prerequisite — required status checks

`gh pr merge --auto` waits for **branch protection / ruleset required status checks** to pass before merging. With no required checks configured, it merges instantly — defeating the purpose.

The repo ruleset (`main-ruleset`, id 12787616) currently has no `required_status_checks` rule. After this lands, I'll add one referencing `test`, `build`, `lint`, `commitlint` via `gh api` (excluding `sonarcloud` since it's skipped on Dependabot PRs per #545).

This means **all** PRs will need those 4 checks green before merge after the ruleset update — not just Dependabot ones. That's the intended effect.

## Effect on today's open PRs

- npm: 4 individual PRs would have been 1 group PR + 1 typescript major. After this lands and re-runs, future weekly batches collapse.
- github-actions: 5 individual majors → still 5 (because they're all majors today). Future minor/patch waves will group.