### PR TITLE
ci: pin python dev deps and enable pip/pnpm caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install Python test dependencies
-        run: pip install pytest pytest-asyncio pytest-cov
+        run: pip install -r requirements-dev.txt
 
       - name: Run tests with coverage
         run: python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=xml --cov-branch
@@ -36,13 +38,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -58,9 +62,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install lint dependencies
-        run: pip install import-linter ruff basedpyright
+        run: pip install -r requirements-dev.txt
 
       - name: Ruff check
         run: ruff check .

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ _.python.venv = { path = ".venv", create = true }
 
 [tasks.setup]
 description = "Install JS and Python dependencies"
-run = ["pnpm install", "pip install pytest pytest-asyncio pytest-cov import-linter ruff basedpyright", "git config core.hooksPath .githooks"]
+run = ["pnpm install", "pip install -r requirements-dev.txt", "git config core.hooksPath .githooks"]
 
 [tasks.build]
 description = "Build frontend"

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -138,9 +138,9 @@ class RommHttpAdapter:
         """Translate non-HTTP exceptions (ssl, timeout, connection) to typed errors."""
         if isinstance(exc, ssl.SSLError):
             return RommSSLError(str(exc), url=url, method=method)
-        if isinstance(exc, (socket.timeout, TimeoutError)):
+        if isinstance(exc, socket.timeout | TimeoutError):
             return RommTimeoutError(str(exc), url=url, method=method)
-        if isinstance(exc, (ConnectionError, OSError)):
+        if isinstance(exc, ConnectionError | OSError):
             return RommConnectionError(str(exc), url=url, method=method)
         return RommApiError(f"Unexpected error: {exc}", url=url, method=method)
 
@@ -152,7 +152,7 @@ class RommHttpAdapter:
         if isinstance(exc, urllib.error.URLError):
             return (
                 self._translate_unwrapped(exc.reason, url, method)
-                if isinstance(exc.reason, (ssl.SSLError, socket.timeout, TimeoutError))
+                if isinstance(exc.reason, ssl.SSLError | socket.timeout | TimeoutError)
                 else RommConnectionError(str(exc), url=url, method=method)
             )
         return self._translate_unwrapped(exc, url, method)
@@ -160,12 +160,12 @@ class RommHttpAdapter:
     @staticmethod
     def is_retryable(exc: Exception) -> bool:
         """Check if an exception is a transient error worth retrying."""
-        if isinstance(exc, (RommServerError, RommConnectionError, RommTimeoutError)):
+        if isinstance(exc, RommServerError | RommConnectionError | RommTimeoutError):
             return True
         # Backward compat for non-RomM exceptions
         if isinstance(exc, urllib.error.HTTPError):
             return exc.code >= 500
-        return isinstance(exc, (urllib.error.URLError, ConnectionError, TimeoutError, OSError))
+        return isinstance(exc, urllib.error.URLError | ConnectionError | TimeoutError | OSError)
 
     def with_retry(self, fn, *args, max_attempts: int = 3, base_delay: int = 1, **kwargs):
         """Call fn(*args, **kwargs) with exponential backoff retry.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest>=8.0,<9.0
+pytest-asyncio>=0.23,<1.0
+pytest-cov>=5.0,<7.0
+ruff>=0.7,<0.8
+basedpyright>=1.21,<2.0
+import-linter>=2.0,<3.0


### PR DESCRIPTION
## Why

Two papercuts in the current CI:

1. **Unpinned dev deps.** `pip install pytest pytest-asyncio pytest-cov` and `pip install import-linter ruff basedpyright` resolve to whatever PyPI ships at run-time. A 0-day breakage on any of those takes CI down with no warning.
2. **No dep caches.** `setup-python` and `setup-node` ran without `cache:`, so every job reinstalled from scratch (~30s wasted per run × 3 jobs × every push/PR).

## What

- New `requirements-dev.txt` with bounded versions (block majors, allow minor/patch through Dependabot's new pip ecosystem from the sister PR)
- `setup-python` gets `cache: pip` + `cache-dependency-path: requirements-dev.txt` (test + lint jobs)
- `setup-node` gets `cache: pnpm` + `cache-dependency-path: pnpm-lock.yaml`. `pnpm/action-setup` moves above `setup-node` in the build job because the cache resolver needs pnpm on PATH
- `mise.toml`'s `[tasks.setup]` switches to `pip install -r requirements-dev.txt` so local dev and CI install the same versions

## Notes

Ranges are deliberately loose (`>=8.0,<9.0` etc.) — block majors, let Dependabot land minor/patch automatically once auto-merge is in place. Tighten to exact `==` later if a specific bug bites.