### PR TITLE
docs(readme): switch coverage badge to shields.io for color thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/danielcopper/decky-romm-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/danielcopper/decky-romm-sync/actions/workflows/ci.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=coverage)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
+[![Coverage](https://img.shields.io/sonar/coverage/danielcopper_decky-romm-sync?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Reliability](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)
 [![Security](https://sonarcloud.io/api/project_badges/measure?project=danielcopper_decky-romm-sync&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=danielcopper_decky-romm-sync)


### PR DESCRIPTION
## Why

The coverage badge in the README renders grey while the other Sonar badges (maintainability, reliability, security) render green. Cosmetic mismatch, looks like CI is "in progress" or something is wrong.

## Cause

Sonar's \`/api/project_badges/measure?metric=X\` endpoint color-codes **letter-grade** metrics (A-E) by their grade. Percentage metrics like \`coverage\` just render the raw number on a neutral grey background — Sonar's badge service has no built-in threshold logic for percentages.

## What

Swaps to shields.io's \`/sonar/coverage/...\` endpoint, which pulls the same value from Sonar but applies shields.io's standard threshold coloring (>80 green, 50-80 yellow, <50 red). Current 96.2% → green.

Single-line README change.