### PR TITLE
fix(library): clear pending_prefetched_units on start_sync (#555)

### DIFF
--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -125,6 +125,10 @@ class SyncOrchestrator:
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
+        # Skip Preview ON path: any cache left from a prior preview is
+        # stale by definition — start_sync refetches from scratch via
+        # _do_sync_per_unit's no-prefetched branch.
+        box.pending_prefetched_units = None
         self._loop.create_task(self._do_sync_per_unit())
         return {"success": True, "message": "Sync started"}
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -492,6 +492,19 @@ class TestSyncControl:
         assert result["success"] is False
         assert "already in progress" in result["message"]
 
+    def test_start_sync_clears_prior_prefetch_cache(self, plugin):
+        """Skip Preview ON path: any cache left from a prior preview is
+        stale and must be cleared at entry so _do_sync_per_unit refetches.
+        """
+        plugin._sync_service._box.pending_prefetched_units = [
+            _platform_prefetched(name="OLD", slug="old", roms=[{"id": 99}])
+        ]
+
+        result = plugin._sync_service.start_sync()
+
+        assert result["success"] is True
+        assert plugin._sync_service._box.pending_prefetched_units is None
+
     def test_cancel_sync_when_running(self, plugin):
         plugin._sync_service._sync_state = SyncState.RUNNING
         result = plugin._sync_service.cancel_sync()


### PR DESCRIPTION
## Summary

`SyncOrchestrator.start_sync()` did not clear `pending_prefetched_units` at entry. The #436 cache had 6 clear sites in the preview/apply flow but missed this one. If a user previewed then immediately ran a Skip Preview ON sync, the cached units lingered stale until next preview/cancel.

Adds the entry-clear mirroring `sync_preview` line 161.

## Test plan

- [x] `pytest`: 2423 passed
- [x] `basedpyright`: 0 errors
- [x] `ruff`: all checks pass
- [x] New test `TestSyncControl::test_start_sync_clears_prior_prefetch_cache` verifies the fix

Closes #555