### PR TITLE
refactor(arch): guard playtime Protocol imports with TYPE_CHECKING + saves module docstrings (#571)

### DIFF
--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -13,11 +13,18 @@ from typing import TYPE_CHECKING
 
 from domain.save_state import PlaytimeEntry, SaveSyncState
 from lib.iso_time import parse_iso
-from services.protocols import Clock, DebugLogger, RetryStrategy, RommPlaytimeApi, StatePersister
 
 if TYPE_CHECKING:
     import asyncio
     import logging
+
+    from services.protocols import (
+        Clock,
+        DebugLogger,
+        RetryStrategy,
+        RommPlaytimeApi,
+        StatePersister,
+    )
 
 
 @dataclass(frozen=True)

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -1,3 +1,12 @@
+"""Save-sync aggregate root and facade for the Decky callable surface.
+
+Composes the save-sync sub-services (state, sync_engine, status, versions,
+slots, rom_info) over the shared :class:`SaveSyncState` aggregate and
+exposes the public methods the frontend reaches through callables. Most
+methods are thin delegations; orchestration that genuinely spans multiple
+sub-services lives here, single-sub-service logic does not.
+"""
+
 from __future__ import annotations
 
 from domain.save_state import SaveSyncState

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -1,3 +1,11 @@
+"""Slot lifecycle operations for save sync.
+
+Anything that creates, lists, switches, migrates, or deletes slots —
+including the first-sync setup wizard — belongs here. The newest-wins
+matrix executor lives in SyncEngine, status reporting in StatusService,
+and on-disk state persistence in StateService.
+"""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary

Two small consistency drifts surfaced in round-2 audit (#547):

1. **`services/playtime.py`** — Protocol imports moved under `TYPE_CHECKING`. They're type-only (used solely in `PlaytimeServiceConfig` annotations + `self._x = config.x` plumbing). Pattern now matches `services/firmware.py` / `services/migration.py`.

2. **Module docstrings added**:
   - `services/saves/service.py` — facade entry point
   - `services/saves/slots/service.py` — slot lifecycle ops
   
   Both intent-focused (what belongs here), matching the style of `services/saves/state.py` / `versions.py`.

## Test plan

- [x] `pytest`: 2422 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Closes #571