### PR TITLE
test(saves): cover status/builders.py defensive branches (#575)

### DIFF
--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -3,6 +3,7 @@
 import pytest
 
 from domain.save_state import RomSaveState
+from services.saves.status.builders import _resolve_chosen_server, _status_from_action
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
@@ -323,3 +324,17 @@ class TestSaveSyncDisplayEnrichment:
         assert result["save_sync_display"]["status"] == "conflict"
         assert result["save_sync_display"]["label"] == "Conflict"
         assert result["save_sync_display"]["last_sync_check_at"] is None
+
+
+class TestBuildersDefensiveBranches:
+    """Direct coverage of the defensive fallbacks in builders.py."""
+
+    def test_status_from_action_unknown_type_defaults_to_synced(self):
+        """An action that matches none of Skip/Upload/Download/Conflict falls back to "synced"."""
+        assert _status_from_action(object()) == "synced"
+
+    def test_resolve_chosen_server_empty_candidates_returns_none(self):
+        """Skip-branch with no server candidates yields no chosen server save."""
+        # A bare object is not Download/Conflict/Upload, so the function falls
+        # through to the candidates check; an empty list returns None.
+        assert _resolve_chosen_server(object(), []) is None


### PR DESCRIPTION
## Summary

`services/saves/status/builders.py` was at 90% — two defensive branches untested:

- Line 76: `_status_from_action` default `"synced"` fallback
- Line 98: `_resolve_chosen_server` empty-candidates None case

Adds two unit tests targeting both branches. Coverage now at **100%**.

Tests landed in `tests/services/saves/test_status.py` (the existing status-tests home — the project layout doesn't have a separate `status/test_builders.py`).

## Test plan

- [x] `pytest tests/services/saves/test_status.py`: 14 passed
- [x] `pytest`: 2424 passed
- [x] `ruff`: all checks pass
- [x] Coverage on `builders.py`: 90% → **100%**

Closes #575