### PR TITLE
refactor(ui): extract getEventTarget helper + early-return narrow for romId (#556)

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -38,6 +38,7 @@ import {
 } from "../api/backend";
 import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { getEventTarget } from "../utils/events";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, SyncConflict } from "../types";
@@ -475,7 +476,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
           Uninstall
         </MenuItem>
       </Menu>,
-      e.currentTarget as EventTarget,
+      getEventTarget(e),
     );
   };
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -349,23 +349,27 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     // Defined inside useEffect to share the cancelled/appId/romIdRef/setState closure.
     const handleSaveSyncSettingsChange = async (detail: any) => {
       const enabled = detail.save_sync_enabled;
-      if (enabled) {
-        const updatedStatus = await getSaveStatus(romIdRef.current!).catch((): SaveStatus | null => null);
-        const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
-        setState((prev) => ({
-          ...prev,
-          saveSyncEnabled: true,
-          saveStatus: updatedStatus,
-          conflicts,
-        }));
-      } else {
+      if (!enabled) {
         setState((prev) => ({ ...prev, saveSyncEnabled: false }));
+        return;
       }
+      const romId = romIdRef.current;
+      if (!romId) return;
+      const updatedStatus = await getSaveStatus(romId).catch((): SaveStatus | null => null);
+      const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
+      setState((prev) => ({
+        ...prev,
+        saveSyncEnabled: true,
+        saveStatus: updatedStatus,
+        conflicts,
+      }));
     };
 
     const handleSaveSyncChange = async (detail: any) => {
       if (detail.rom_id && detail.rom_id !== romIdRef.current) return;
-      const updatedStatus: SaveStatus | null = detail.save_status ?? await getSaveStatus(romIdRef.current!).catch((): SaveStatus | null => null);
+      const romId = romIdRef.current;
+      if (!romId) return;
+      const updatedStatus: SaveStatus | null = detail.save_status ?? await getSaveStatus(romId).catch((): SaveStatus | null => null);
       const conflicts: SyncConflict[] = updatedStatus?.conflicts ?? [];
       setState((prev) => ({
         ...prev,
@@ -373,7 +377,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
         conflicts,
       }));
       // Also re-check slot configuration + refresh slot data
-      refreshSlotState(romIdRef.current!, setState);
+      refreshSlotState(romId, setState);
     };
 
     const handleBiosChange = async (detail: any) => {
@@ -399,7 +403,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
 
     const handleMetadataChange = async (detail: any) => {
       if (detail.rom_id !== romIdRef.current) return;
-      const meta = await getRomMetadata(romIdRef.current!).catch((): RomMetadata | null => null);
+      const romId = romIdRef.current;
+      if (!romId) return;
+      const meta = await getRomMetadata(romId).catch((): RomMetadata | null => null);
       setState((prev) => ({ ...prev, metadata: meta }));
     };
 
@@ -442,14 +448,15 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     if (achievementsLoadedRef.current) return;
     achievementsLoadedRef.current = true;
 
+    const romId: number = state.romId;
     let cancelled = false;
     setState((prev) => ({ ...prev, achievementsLoading: true }));
 
     async function loadAchievements() {
       try {
         const [listResult, progressResult] = await Promise.all([
-          getAchievements(state.romId!),
-          getAchievementProgress(state.romId!),
+          getAchievements(romId),
+          getAchievementProgress(romId),
         ]);
         if (cancelled) return;
         setState((prev) => ({
@@ -573,6 +580,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     return null;
   }
 
+  const romId = state.romId;
   const meta = state.metadata;
 
   // --- Game Info section ---
@@ -1079,7 +1087,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
       } as any);
     } else {
       activeTabContent = createElement(SavesTab, {
-        romId: state.romId!,
+        romId,
         saveStatus: state.saveStatus,
         conflicts: state.conflicts,
         activeSlot: state.activeSlot,

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -27,6 +27,7 @@ import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icon
 import { CustomPlayButton } from "./CustomPlayButton";
 import { hasAnySaveConflict } from "../utils/saveStatus";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { getEventTarget } from "../utils/events";
 import {
   getCachedGameDetail,
   _cachedGameDetailCache,
@@ -723,7 +724,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
           }, `${c.label}${c.is_default ? " (default)" : ""}${info.activeCoreLabel === c.label ? " \u2713" : ""}`);
         }),
       ),
-      (e.currentTarget ?? e.target) as HTMLElement,
+      getEventTarget(e),
     );
   };
 
@@ -738,7 +739,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
         createElement(MenuItem, { key: "delete-saves", tone: "destructive", onClick: handleDeleteSaves }, "Delete Local Saves"),
         createElement(MenuItem, { key: "uninstall", tone: "destructive", onClick: handleUninstall }, "Uninstall"),
       ),
-      (e.currentTarget ?? e.target) as HTMLElement,
+      getEventTarget(e),
     );
   };
 
@@ -749,7 +750,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
           SteamClient.Apps.OpenAppSettingsDialog(appId, "general");
         } }, "Properties"),
       ),
-      (e.currentTarget ?? e.target) as HTMLElement,
+      getEventTarget(e),
     );
   };
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,13 @@
+/**
+ * Event-target helpers for context-menu anchor resolution.
+ *
+ * `getEventTarget` replaces the `(e.currentTarget ?? e.target) as HTMLElement`
+ * cast pattern at context-menu call sites — the cast is required for tsc
+ * but flagged by SonarCloud's S4325 checker, which cannot resolve the same
+ * type narrowing. Returns `HTMLElement | undefined` so callers can pass the
+ * result directly to `showContextMenu`'s optional `EventTarget` parameter.
+ */
+
+export function getEventTarget(e: Event): HTMLElement | undefined {
+  return (e.currentTarget ?? e.target) as HTMLElement | undefined;
+}


### PR DESCRIPTION
## Summary

SonarCloud `typescript:S4325` cleared in Phase 8 (#480) regressed after post-Phase-8 decomposition PRs (#470/#471/#472) lifted closures to module scope — losing the typed flow-narrowing Sonar can resolve. The casts (`romIdRef.current!`, `(e.currentTarget ?? e.target) as HTMLElement`) were tsc-required but Sonar-flagged.

## Approach

- `src/utils/events.ts::getEventTarget(e: Event): HTMLElement | undefined` — narrows `EventTarget | null` for `showContextMenu` consumers. Value-returning helper, no callback.
- For `romIdRef.current!` sites — switched to the standard `const id = romIdRef.current; if (!id) return; ...` early-return narrow pattern inline. (First attempt used a `withRomId(ref, fn)` callback helper, but the extra closure level pushed function-nesting past Sonar's S2004 limit — reverted to the inline pattern that doesn't add nesting.)

## Sites cleared

| File | Sites |
|---|---|
| `RomMGameInfoPanel.tsx` | 6 (3 `romIdRef.current!` handlers + 2 `state.romId!` early-return-lifted + 1 incidental) |
| `RomMPlaySection.tsx` | 3 (event-target casts) |
| `CustomPlayButton.tsx` | 1 (event-target cast) |

`grep -rn 'romIdRef.current!\|as HTMLElement' src/components/RomM*.tsx src/components/CustomPlayButton.tsx` → zero matches.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm exec tsc --noEmit --skipLibCheck` clean

Closes #556