### PR TITLE
chore(ui): delete initSyncManager legacy listener (#561)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { SettingsPage } from "./components/SettingsPage";
 import { LibraryPage } from "./components/LibraryPage";
 import { DangerZone } from "./components/DangerZone";
 import { DownloadQueue } from "./components/DownloadQueue";
-import { initSyncManager, initUnitSyncManager } from "./utils/syncManager";
+import { initUnitSyncManager } from "./utils/syncManager";
 import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
@@ -300,7 +300,6 @@ export default definePlugin(() => {
     [{ platform_app_ids: Record<string, number[]>; romm_collection_app_ids?: Record<string, number[]>; total_games: number }]
   >("sync_complete", onSyncComplete);
 
-  const syncApplyListener = initSyncManager();
   const syncApplyUnitListener = initUnitSyncManager();
 
   // Per-unit pipeline: planning + stale + collections events.
@@ -432,7 +431,6 @@ export default definePlugin(() => {
       unregisterGameDetailPatch();
       unregisterMetadataPatches();
       removeEventListener("sync_complete", syncCompleteListener);
-      removeEventListener("sync_apply", syncApplyListener);
       removeEventListener("sync_apply_unit", syncApplyUnitListener);
       removeEventListener("sync_plan", syncPlanListener);
       removeEventListener("sync_stale", syncStaleListener);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,18 +133,6 @@ export interface SyncPreview {
   blocked_by_migration?: boolean;
 }
 
-export interface SyncChangedItem extends SyncAddItem {
-  existing_app_id: number;
-}
-
-export interface SyncApplyData {
-  shortcuts: SyncAddItem[];
-  changed_shortcuts?: SyncChangedItem[];
-  remove_rom_ids: number[];
-  next_step?: number;
-  total_steps?: number;
-}
-
 interface SyncPlanUnit {
   type: "platform" | "collection";
   id: number | string;

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -1,7 +1,7 @@
 import { addEventListener } from "@decky/api";
-import type { SyncAddItem, SyncApplyData, SyncApplyUnitData, SyncChangedItem } from "../types";
-import { getArtworkBase64, reportSyncResults, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
-import { getExistingRomMShortcuts, addShortcut, removeShortcut } from "./steamShortcuts";
+import type { SyncAddItem, SyncApplyUnitData } from "../types";
+import { getArtworkBase64, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
+import { getExistingRomMShortcuts, addShortcut } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -15,7 +15,6 @@ interface ArtworkTarget {
 }
 
 let _cancelRequested = false;
-let _isSyncRunning = false;
 let _isUnitRunning = false;
 
 /** Request cancellation of the frontend shortcut processing loop. */
@@ -158,8 +157,8 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       const existing = await getExistingRomMShortcuts();
       await processUnitShortcuts(data, existing, romIdToAppId, artworkTargets, total);
 
-      // Artwork — keep existing base64 path; this is a per-unit-sized batch
-      // so the giant single sync_apply payload concern doesn't apply.
+      // Artwork — keep existing base64 path; per-unit-sized batch keeps the
+      // payload comfortably under the decky.emit WebSocket size ceiling.
       await processUnitArtwork(artworkTargets);
 
       try {
@@ -170,222 +169,6 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       logInfo(`sync_apply_unit complete: ${data.unit_name} (${Object.keys(romIdToAppId).length}/${total})`);
     } finally {
       _isUnitRunning = false;
-    }
-  });
-}
-
-/**
- * Initialize the sync manager that listens for sync_apply events from the backend.
- * Returns the event listener handle for cleanup.
- */
-export function initSyncManager(): ReturnType<typeof addEventListener> {
-  return addEventListener("sync_apply", async (data: SyncApplyData) => {
-    if (_isSyncRunning) {
-      logInfo("sync_apply: already running, ignoring duplicate event");
-      return;
-    }
-    _isSyncRunning = true;
-    try {
-      // Defensive checks against malformed event data
-      if (!Array.isArray(data.shortcuts)) {
-        logError("sync_apply: data.shortcuts is not an array, aborting");
-        return;
-      }
-      if (!Array.isArray(data.remove_rom_ids)) {
-        logError("sync_apply: data.remove_rom_ids is not an array, aborting");
-        return;
-      }
-      const isDelta = Array.isArray(data.changed_shortcuts);
-      logInfo(`sync_apply received: ${data.shortcuts.length} new, ${isDelta ? data.changed_shortcuts!.length + " changed, " : ""}${data.remove_rom_ids.length} remove${isDelta ? " (delta)" : ""}`);
-  
-      _cancelRequested = false;
-      let cancelled = false;
-      let lastHeartbeat = Date.now();
-
-      const existing = await getExistingRomMShortcuts();
-      const romIdToAppId: Record<string, number> = {};
-      const removedRomIds: number[] = [];
-      const artworkTargets: ArtworkTarget[] = [];
-  
-      // Step plan from backend
-      let currentStep = data.next_step ?? 1;
-      const totalSteps = data.total_steps ?? 3;
-  
-      // --- Step: Apply shortcuts (new + changed) ---
-      const totalNew = data.shortcuts.length;
-      const totalChanged = data.changed_shortcuts?.length ?? 0;
-      const totalShortcuts = totalNew + totalChanged;
-  
-      if (totalShortcuts > 0) {
-        updateSyncProgress({
-          running: true, phase: "applying",
-          current: 0, total: totalShortcuts,
-          message: `Applying shortcuts 0/${totalShortcuts}`,
-          step: currentStep, totalSteps,
-        });
-  
-        for (let i = 0; i < data.shortcuts.length; i++) {
-          const item = data.shortcuts[i];
-          try {
-            updateSyncProgress({
-              current: i + 1,
-              message: `Applying shortcuts ${i + 1}/${totalShortcuts}`,
-            });
-            let appId: number | undefined;
-  
-            if (isDelta) {
-              const newAppId = await addShortcut(item);
-              if (newAppId) {
-                appId = newAppId;
-                romIdToAppId[String(item.rom_id)] = newAppId;
-              }
-            } else {
-              const existingAppId = existing.get(item.rom_id);
-              if (existingAppId) {
-                SteamClient.Apps.SetShortcutName(existingAppId, item.name);
-                SteamClient.Apps.SetShortcutExe(existingAppId, item.exe);
-                SteamClient.Apps.SetShortcutStartDir(existingAppId, item.start_dir);
-                SteamClient.Apps.SetAppLaunchOptions(existingAppId, item.launch_options);
-                appId = existingAppId;
-                romIdToAppId[String(item.rom_id)] = existingAppId;
-              } else {
-                const newAppId = await addShortcut(item);
-                if (newAppId) {
-                  appId = newAppId;
-                  romIdToAppId[String(item.rom_id)] = newAppId;
-                }
-              }
-            }
-  
-            if (appId) {
-              artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
-            }
-          } catch (e) {
-            logError(`Failed to process shortcut for rom ${item.rom_id}: ${e}`);
-          }
-          await delay(50);
-  
-          if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
-            syncHeartbeat().catch(() => {});
-            lastHeartbeat = Date.now();
-          }
-  
-          if (_cancelRequested) {
-            logInfo(`Cancel requested after processing ${i + 1}/${totalShortcuts} shortcuts`);
-            cancelled = true;
-            break;
-          }
-        }
-  
-        // Process changed shortcuts (delta mode only)
-        if (!cancelled && isDelta && data.changed_shortcuts) {
-          for (let i = 0; i < data.changed_shortcuts.length; i++) {
-            const item: SyncChangedItem = data.changed_shortcuts[i];
-            const idx = totalNew + i;
-            try {
-              updateSyncProgress({
-                current: idx + 1,
-                message: `Updating shortcuts ${idx + 1}/${totalShortcuts}`,
-              });
-              const appId = item.existing_app_id;
-  
-              SteamClient.Apps.SetShortcutName(appId, item.name);
-              SteamClient.Apps.SetShortcutExe(appId, item.exe);
-              SteamClient.Apps.SetShortcutStartDir(appId, item.start_dir);
-              SteamClient.Apps.SetAppLaunchOptions(appId, item.launch_options);
-              romIdToAppId[String(item.rom_id)] = appId;
-  
-              artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
-            } catch (e) {
-              logError(`Failed to update shortcut for rom ${item.rom_id}: ${e}`);
-            }
-            await delay(50);
-  
-            if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
-              syncHeartbeat().catch(() => {});
-              lastHeartbeat = Date.now();
-            }
-  
-            if (_cancelRequested) {
-              logInfo(`Cancel requested during changed shortcuts processing`);
-              cancelled = true;
-              break;
-            }
-          }
-        }
-  
-        currentStep++;
-      }
-
-      // --- Batch artwork fetch (parallel, up to 8 at a time) ---
-      if (!cancelled && artworkTargets.length > 0) {
-        for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
-          if (_cancelRequested) {
-            logInfo("Cancel requested during artwork fetching");
-            cancelled = true;
-            break;
-          }
-          const batch = artworkTargets.slice(i, i + ART_CONCURRENCY);
-          await Promise.all(batch.map(async ({ appId, romId, name }) => {
-            try {
-              const artResult = await getArtworkBase64(romId);
-              if (artResult.base64) {
-                await SteamClient.Apps.SetCustomArtworkForApp(appId, artResult.base64, "png", 0);
-                logInfo(`Set cover artwork for ${name} (appId=${appId})`);
-              }
-            } catch (artErr) {
-              logError(`Failed to fetch/set artwork for ${name}: ${artErr}`);
-            }
-          }));
-        }
-      }
-
-      // --- Step: Remove shortcuts ---
-      if (!cancelled && data.remove_rom_ids.length > 0) {
-        const totalRemovals = data.remove_rom_ids.length;
-        updateSyncProgress({
-          phase: "applying", current: 0, total: totalRemovals,
-          message: `Removing shortcuts 0/${totalRemovals}`,
-          step: currentStep, totalSteps,
-        });
-  
-        for (let i = 0; i < data.remove_rom_ids.length; i++) {
-          const romId = data.remove_rom_ids[i];
-          const appId = existing.get(romId);
-          if (appId) {
-            removeShortcut(appId);
-          }
-          removedRomIds.push(romId);
-          updateSyncProgress({
-            current: i + 1,
-            message: `Removing shortcuts ${i + 1}/${totalRemovals}`,
-          });
-          await delay(50);
-  
-          if (_cancelRequested) {
-            logInfo("Cancel requested during removals");
-            cancelled = true;
-            break;
-          }
-        }
-  
-        currentStep++;
-      }
-  
-      // Report results to backend
-      try {
-        await reportSyncResults(romIdToAppId, removedRomIds, cancelled);
-      } catch (e) {
-        logError(`Failed to report sync results: ${e}`);
-      }
-  
-      const doneMsg = cancelled
-        ? `Sync cancelled (${Object.keys(romIdToAppId).length} processed)`
-        : "Sync complete";
-      updateSyncProgress({ running: false, phase: "done", message: doneMsg });
-      logInfo(`sync_apply ${cancelled ? "cancelled" : "complete"}: ${Object.keys(romIdToAppId).length} added/updated, ${removedRomIds.length} removed`);
-    } finally {
-      _isSyncRunning = false;
     }
   });
 }

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -365,8 +365,6 @@ class TestSyncApplyDelta:
             await asyncio.sleep(0)
 
         assert result["success"] is True
-        # No monolithic sync_apply emission — the per-unit pipeline drives apply now.
-        assert not any(c[0][0] == "sync_apply" for c in decky.emit.call_args_list)
         # Per-unit dispatch was kicked off with the prefetched queue.
         do_sync.assert_called_once()
         prefetched_arg = do_sync.call_args.kwargs.get("prefetched") or do_sync.call_args.args[0]
@@ -1319,8 +1317,6 @@ class TestSyncApplyDeltaUnifiedDispatch:
             await asyncio.sleep(0)
 
         assert result["success"] is True
-        # No monolithic sync_apply emission — only the per-unit event.
-        assert not any(c[0][0] == "sync_apply" for c in decky.emit.call_args_list)
         unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
         assert len(unit_events) == 1
         assert unit_events[0]["unit_name"] == "N64"


### PR DESCRIPTION
## Summary

Backend stopped emitting `sync_apply` events in #436 (unified apply path). Frontend `initSyncManager` listener (~211 LOC) sat as dead code awaiting retirement.

Deletes the listener + types-only dependencies, frees the registration site, and drops the matching backend test guards.

## Deleted

| File | Change |
|---|---|
| `src/utils/syncManager.ts` | -222 / +5 — `initSyncManager` function + `_isSyncRunning` flag + `reportSyncResults`/`removeShortcut` imports (only used in the dead block) + stale comment |
| `src/types/index.ts` | -12 — `SyncChangedItem` + `SyncApplyData` interfaces (only consumed by the dead listener) |
| `src/index.tsx` | -3 / +1 — `initSyncManager` import + `syncApplyListener = initSyncManager()` registration + `removeEventListener("sync_apply", …)` cleanup |
| `tests/services/library/test_sync_orchestrator.py` | -4 — two backend assertions guarding the absence of `sync_apply` emissions (now noise) |

`syncApplyDelta` and the per-unit pipeline kick-off paths are untouched.

`grep -rn 'initSyncManager\|sync_apply\b\|SyncApplyData\|SyncChangedItem' src/` → 0 hits.

## Follow-up flagged by agent (not in this PR)

`reportSyncResults` (frontend) + `report_sync_results` (backend) are now technically unused but were not on the deletion list. Consider filing a follow-up.

## Test plan

- [x] `pytest`: 2422 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `pnpm build`: clean
- [x] `tsc --noEmit`: clean

Closes #561