### PR TITLE
test(adapters): cover hostname.py (#574)

### DIFF
--- a/tests/adapters/test_hostname.py
+++ b/tests/adapters/test_hostname.py
@@ -1,0 +1,24 @@
+"""Tests for the HostnameAdapter — wraps socket.gethostname."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from adapters.hostname import HostnameAdapter
+
+
+class TestHostnameAdapter:
+    def test_get_returns_socket_gethostname_value(self):
+        adapter = HostnameAdapter()
+        with patch("adapters.hostname.socket.gethostname", return_value="steamdeck"):
+            assert adapter.get() == "steamdeck"
+
+    def test_get_propagates_oserror_from_socket(self):
+        adapter = HostnameAdapter()
+        with (
+            patch("adapters.hostname.socket.gethostname", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            adapter.get()


### PR DESCRIPTION
## Summary

`adapters/hostname.py` was at 80% — line 16 (`return socket.gethostname()`) wasn't executed in any existing test (no other test instantiates `HostnameAdapter`).

## Note on the audit framing

The audit issue referenced an "OSError fallback at line 16". Inspection shows the file has no fallback — OSError propagates naturally. The 80% gap was simply that line 16 itself wasn't reached anywhere. Added two tests anyway:

- Happy path — returns `socket.gethostname()` value
- Error propagation — `OSError` from `socket.gethostname()` flows up untouched

Both document current behavior. Coverage now at **100%**.

## Test plan

- [x] `pytest`: 2424 passed (was 2422 + 2 new)
- [x] `basedpyright` on the new test file: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] Coverage on `hostname.py`: 80% → **100%**

Closes #574