### PR TITLE
chore: delete 7 orphan Decky callables + matching TS exports (#560)

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,10 +214,6 @@ class Plugin:
     async def test_connection(self):
         return await self._connection_service.test_connection()
 
-    async def get_romm_version(self):
-        """Return cached RomM version (detected on last test_connection or device probe)."""
-        return {"version": self._romm_api.get_version()}
-
     async def save_settings(self, romm_url, romm_user, romm_pass, allow_insecure_ssl=None):
         return self._settings_service.save_settings(romm_url, romm_user, romm_pass, allow_insecure_ssl)
 
@@ -251,9 +247,6 @@ class Plugin:
     async def get_cached_game_detail(self, app_id):
         return self._game_detail_service.get_cached_game_detail(app_id)
 
-    async def get_available_cores(self, platform_slug):
-        return await self._core_service.get_available_cores(platform_slug)
-
     @migration_blocked
     async def set_system_core(self, platform_slug, core_label):
         return await self._core_service.set_system_core(platform_slug, core_label)
@@ -266,10 +259,6 @@ class Plugin:
 
     async def get_firmware_status(self):
         return await self._firmware_service.get_firmware_status()
-
-    @migration_blocked
-    async def download_firmware(self, firmware_id):
-        return await self._firmware_service.download_firmware(firmware_id)
 
     @migration_blocked
     async def download_all_firmware(self, platform_slug):
@@ -370,9 +359,6 @@ class Plugin:
     async def get_sync_stats(self):
         return self._sync_service.get_sync_stats()
 
-    async def get_rom_by_steam_app_id(self, app_id):
-        return self._sync_service.get_rom_by_steam_app_id(app_id)
-
     async def evaluate_launch(self, steam_app_id):
         verdict = await self._launch_gate_service.evaluate(int(steam_app_id))
         return asdict(verdict)
@@ -425,10 +411,6 @@ class Plugin:
     @migration_blocked
     async def pre_launch_sync(self, rom_id):
         return await self._save_sync_service.pre_launch_sync(rom_id)
-
-    @migration_blocked
-    async def post_exit_sync(self, rom_id):
-        return await self._save_sync_service.post_exit_sync(rom_id)
 
     @migration_blocked
     async def sync_rom_saves(self, rom_id):
@@ -494,9 +476,6 @@ class Plugin:
     async def record_session_start(self, rom_id):
         return self._playtime_service.record_session_start(rom_id)
 
-    async def record_session_end(self, rom_id):
-        return await self._playtime_service.record_session_end(rom_id)
-
     async def get_server_playtime(self, rom_id):
         return await self._playtime_service.get_server_playtime(rom_id)
 
@@ -535,6 +514,3 @@ class Plugin:
 
     async def get_achievement_progress(self, rom_id):
         return await self._achievements_service.get_achievement_progress(rom_id)
-
-    async def sync_achievements_after_session(self, rom_id):
-        return await self._achievements_service.sync_achievements_after_session(rom_id)

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,5 @@
 import { callable } from "@decky/api";
-import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, RomLookupResult, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse, LaunchVerdict } from "../types";
+import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse, LaunchVerdict } from "../types";
 
 export interface BackendResult {
   success: boolean;
@@ -59,7 +59,6 @@ export const getWhitelistSettings = callable<[], WhitelistSettings>("get_whiteli
 export const updateWhitelistSettings = callable<[string[], string[]], { success: boolean; message?: string }>("update_whitelist_settings");
 
 export const testConnection = callable<[], BackendResult>("test_connection");
-export const getRommVersion = callable<[], { version: string | null }>("get_romm_version");
 export const startSync = callable<[], BackendResult>("start_sync");
 export const cancelSync = callable<[], BackendResult>("cancel_sync");
 export const syncHeartbeat = callable<[], { success: boolean }>("sync_heartbeat");
@@ -72,7 +71,6 @@ export const startDownload = callable<[number], BackendResult>("start_download")
 export const cancelDownload = callable<[number], BackendResult>("cancel_download");
 export const getDownloadQueue = callable<[], { downloads: DownloadItem[] }>("get_download_queue");
 export const getInstalledRom = callable<[number], InstalledRom | null>("get_installed_rom");
-export const getRomBySteamAppId = callable<[number], RomLookupResult | null>("get_rom_by_steam_app_id");
 export const evaluateLaunch = callable<[number], LaunchVerdict>("evaluate_launch");
 export const removeRom = callable<[number], BackendResult>("remove_rom");
 export const getPlatforms = callable<[], { success: boolean; platforms: PlatformSyncSetting[] }>("get_platforms");
@@ -96,7 +94,6 @@ export const verifySgdbApiKey = callable<[string], { success: boolean; message: 
 export const saveSteamInputSetting = callable<[string], { success: boolean }>("save_steam_input_setting");
 export const applySteamInputSetting = callable<[], { success: boolean; message: string }>("apply_steam_input_setting");
 export const getFirmwareStatus = callable<[], FirmwareStatus>("get_firmware_status");
-export const downloadFirmware = callable<[number], FirmwareDownloadResult>("download_firmware");
 export const downloadAllFirmware = callable<[string], FirmwareDownloadResult>("download_all_firmware");
 export const downloadRequiredFirmware = callable<[string], FirmwareDownloadResult>("download_required_firmware");
 export const checkPlatformBios = callable<[string], BiosStatus>("check_platform_bios");
@@ -108,7 +105,6 @@ export const getBiosStatus = callable<
     bios_label: string | null;
   }
 >("get_bios_status");
-export const getAvailableCores = callable<[string], { cores: AvailableCore[]; active_core: string | null; active_core_label: string | null }>("get_available_cores");
 export const setSystemCore = callable<[string, string], { success: boolean; message?: string; bios_status?: BiosStatus }>("set_system_core");
 export const setGameCore = callable<[string, string, string], { success: boolean; message?: string; bios_status?: BiosStatus }>("set_game_core");
 export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
@@ -156,7 +152,6 @@ export interface ListDevicesResponse {
 export const listDevices = callable<[], ListDevicesResponse>("list_devices");
 export const getSaveStatus = callable<[number], SaveStatus>("get_save_status");
 export const preLaunchSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[] }>("pre_launch_sync");
-export const postExitSync = callable<[number], { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[]; offline?: boolean }>("post_exit_sync");
 export const syncRomSaves = callable<[number], { success: boolean; message: string; synced: number; errors?: string[] }>("sync_rom_saves");
 export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>("sync_all_saves");
 export const resolveSyncConflict = callable<
@@ -164,7 +159,6 @@ export const resolveSyncConflict = callable<
   { success: boolean; message?: string; error_code?: "stale_conflict"; action?: "keep_local" | "use_server" }
 >("resolve_sync_conflict");
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
-export const recordSessionEnd = callable<[number], { success: boolean; duration_sec?: number; total_seconds?: number; session_count?: number; message?: string }>("record_session_end");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");
 export const updateSaveSyncSettings = callable<[SaveSyncSettings], { success: boolean }>("update_save_sync_settings");
 export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSlotSummary[]; active_slot: string }>("get_save_slots");
@@ -311,4 +305,3 @@ export const savesRollbackToVersion = callable<[number, string, number], Rollbac
 // Achievements callables
 export const getAchievements = callable<[number], AchievementList>("get_achievements");
 export const getAchievementProgress = callable<[number], AchievementProgress>("get_achievement_progress");
-export const syncAchievementsAfterSession = callable<[number], AchievementProgress>("sync_achievements_after_session");

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -876,20 +876,6 @@ class TestVersionDetection:
         plugin._romm_api.set_version.assert_called_with(None)
 
     @pytest.mark.asyncio
-    async def test_get_romm_version_returns_cached(self, plugin):
-        """get_romm_version returns the last detected version."""
-        plugin._romm_api.get_version.return_value = "4.8.1"
-        result = await plugin.get_romm_version()
-        assert result == {"version": "4.8.1"}
-
-    @pytest.mark.asyncio
-    async def test_get_romm_version_returns_none_before_connect(self, plugin):
-        """get_romm_version returns None before any connection."""
-        plugin._romm_api.get_version.return_value = None
-        result = await plugin.get_romm_version()
-        assert result == {"version": None}
-
-    @pytest.mark.asyncio
     async def test_timeout_error(self, plugin):
         """Returns timeout_error on request timeout."""
         import asyncio

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -203,7 +203,7 @@ class TestGetRomBySteamAppId:
             "rom_id": 42,
             "file_path": "/roms/n64/zelda.z64",
         }
-        result = await plugin.get_rom_by_steam_app_id(100001)
+        result = plugin._sync_service.get_rom_by_steam_app_id(100001)
         assert result is not None
         assert result["rom_id"] == 42
         assert result["name"] == "Zelda"
@@ -211,7 +211,7 @@ class TestGetRomBySteamAppId:
 
     @pytest.mark.asyncio
     async def test_returns_none_for_unknown(self, plugin):
-        result = await plugin.get_rom_by_steam_app_id(999999)
+        result = plugin._sync_service.get_rom_by_steam_app_id(999999)
         assert result is None
 
 

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -49,7 +49,6 @@ def plugin():
     p._playtime_service = MagicMock()
     p._launch_gate_service = MagicMock()
     p._session_lifecycle_service = MagicMock()
-    p._romm_api = MagicMock()
     return p
 
 
@@ -144,13 +143,6 @@ class TestConnectionCallableDelegation:
         plugin._connection_service.test_connection.assert_awaited_once_with()
         assert result == {"success": True}
 
-    @pytest.mark.asyncio
-    async def test_get_romm_version_delegates(self, plugin):
-        plugin._romm_api.get_version.return_value = "4.8.1"
-        result = await plugin.get_romm_version()
-        plugin._romm_api.get_version.assert_called_once_with()
-        assert result == {"version": "4.8.1"}
-
 
 # ── Migration callables ────────────────────────────────────────────────
 
@@ -204,13 +196,6 @@ class TestMigrationCallableDelegation:
 
 class TestCoreCallableDelegation:
     @pytest.mark.asyncio
-    async def test_get_available_cores_delegates(self, plugin):
-        plugin._core_service.get_available_cores = AsyncMock(return_value=["core_a"])
-        result = await plugin.get_available_cores("snes")
-        plugin._core_service.get_available_cores.assert_awaited_once_with("snes")
-        assert result == ["core_a"]
-
-    @pytest.mark.asyncio
     async def test_set_system_core_delegates(self, plugin):
         plugin._core_service.set_system_core = AsyncMock(return_value={"success": True})
         result = await plugin.set_system_core("snes", "core_a")
@@ -232,13 +217,6 @@ class TestFirmwareCallableDelegation:
         result = await plugin.get_firmware_status()
         plugin._firmware_service.get_firmware_status.assert_awaited_once_with()
         assert result == {"items": []}
-
-    @pytest.mark.asyncio
-    async def test_download_firmware_delegates(self, plugin):
-        plugin._firmware_service.download_firmware = AsyncMock(return_value={"success": True})
-        result = await plugin.download_firmware(42)
-        plugin._firmware_service.download_firmware.assert_awaited_once_with(42)
-        assert result == {"success": True}
 
     @pytest.mark.asyncio
     async def test_download_all_firmware_delegates(self, plugin):
@@ -394,13 +372,6 @@ class TestLibrarySyncCallableDelegation:
         result = await plugin.get_sync_stats()
         plugin._sync_service.get_sync_stats.assert_called_once_with()
         assert result == {"roms": 5}
-
-    @pytest.mark.asyncio
-    async def test_get_rom_by_steam_app_id_delegates(self, plugin):
-        plugin._sync_service.get_rom_by_steam_app_id.return_value = {"id": 42}
-        result = await plugin.get_rom_by_steam_app_id(12345)
-        plugin._sync_service.get_rom_by_steam_app_id.assert_called_once_with(12345)
-        assert result == {"id": 42}
 
 
 class TestShortcutRemovalCallableDelegation:
@@ -684,13 +655,6 @@ class TestAchievementsCallableDelegation:
         plugin._achievements_service.get_achievement_progress.assert_awaited_once_with(42)
         assert result == {"completed": 0}
 
-    @pytest.mark.asyncio
-    async def test_sync_achievements_after_session_delegates(self, plugin):
-        plugin._achievements_service.sync_achievements_after_session = AsyncMock(return_value={"synced": True})
-        result = await plugin.sync_achievements_after_session(42)
-        plugin._achievements_service.sync_achievements_after_session.assert_awaited_once_with(42)
-        assert result == {"synced": True}
-
 
 class TestGameDetailCallableDelegation:
     @pytest.mark.asyncio
@@ -739,12 +703,6 @@ class TestCallableErrorPropagation:
         plugin._migration_service.migrate_retrodeck_files = AsyncMock(side_effect=OSError("io"))
         with pytest.raises(OSError, match="io"):
             await plugin.migrate_retrodeck_files()
-
-    @pytest.mark.asyncio
-    async def test_get_available_cores_propagates(self, plugin):
-        plugin._core_service.get_available_cores = AsyncMock(side_effect=RuntimeError("boom"))
-        with pytest.raises(RuntimeError, match="boom"):
-            await plugin.get_available_cores("snes")
 
     @pytest.mark.asyncio
     async def test_get_firmware_status_propagates(self, plugin):

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -312,7 +312,7 @@ class TestPostExitSync:
         """Returns early when sync_after_exit is false."""
         plugin._save_sync_state.settings.sync_after_exit = False
 
-        result = await plugin.post_exit_sync(42)
+        result = await plugin._save_sync_service.post_exit_sync(42)
 
         assert result["synced"] == 0
         assert "disabled" in result["message"].lower()
@@ -367,7 +367,7 @@ class TestPostExitSync:
         prev_save_path = tmp_path / "retrodeck" / "saves" / "gba" / "pokemon.srm"
         assert not prev_save_path.exists()
 
-        result = await plugin.post_exit_sync(42)
+        result = await plugin._save_sync_service.post_exit_sync(42)
 
         assert result["success"] is True
         # No download happened (Rule 2 skipped server_only).
@@ -467,7 +467,7 @@ class TestPostExitSync:
         prev_save_path = tmp_path / "retrodeck" / "saves" / "gba" / "pokemon.srm"
         assert not prev_save_path.exists()
 
-        result = await plugin.post_exit_sync(42)
+        result = await plugin._save_sync_service.post_exit_sync(42)
 
         assert result["success"] is True
 
@@ -527,7 +527,7 @@ class TestPlaytimeTracking:
             last_session_start=start_time.isoformat(),
         )
 
-        result = await plugin.record_session_end(42)
+        result = await plugin._playtime_service.record_session_end(42)
 
         assert result["success"] is True
         assert result["duration_sec"] >= 590  # ~600s minus execution time
@@ -543,7 +543,7 @@ class TestPlaytimeTracking:
             last_session_start=start_time.isoformat(),
         )
 
-        await plugin.record_session_end(42)
+        await plugin._playtime_service.record_session_end(42)
 
         total = plugin._save_sync_state.playtime["42"].total_seconds
         assert total >= 1290  # 1000 + ~300
@@ -557,14 +557,14 @@ class TestPlaytimeTracking:
             last_session_start=start_time.isoformat(),
         )
 
-        result = await plugin.record_session_end(42)
+        result = await plugin._playtime_service.record_session_end(42)
 
         assert result["session_count"] == 6
 
     @pytest.mark.asyncio
     async def test_end_without_start(self, plugin):
         """record_session_end without active session returns failure."""
-        result = await plugin.record_session_end(42)
+        result = await plugin._playtime_service.record_session_end(42)
 
         assert result["success"] is False
 
@@ -576,7 +576,7 @@ class TestPlaytimeTracking:
             last_session_start=start_time.isoformat(),
         )
 
-        await plugin.record_session_end(42)
+        await plugin._playtime_service.record_session_end(42)
 
         assert plugin._save_sync_state.playtime["42"].last_session_start is None
 
@@ -599,7 +599,7 @@ class TestPlaytimeTracking:
             ).items()
         }
 
-        result = await plugin.record_session_end(42)
+        result = await plugin._playtime_service.record_session_end(42)
 
         assert result["duration_sec"] <= 86400  # 24h max
 
@@ -794,7 +794,7 @@ class TestSaveSyncFeatureFlag:
     async def test_post_exit_sync_disabled(self, plugin):
         """post_exit_sync skips when save sync disabled."""
         plugin._save_sync_state.settings.save_sync_enabled = False
-        result = await plugin.post_exit_sync(42)
+        result = await plugin._save_sync_service.post_exit_sync(42)
         assert result["success"] is True
         assert result["synced"] == 0
         assert "disabled" in result["message"].lower()


### PR DESCRIPTION
## Summary

Seven Decky callables in `main.py` were orphaned when the frontend collapsed session-lifecycle calls into `finalizeGameSession`. Deletes the `@callable` wrappers (underlying service methods stay — `finalize_session` still uses them) and the matching TS `callable<...>(...)` exports.

## Backend deletions (main.py)

`get_romm_version`, `get_available_cores`, `download_firmware`, `get_rom_by_steam_app_id`, `post_exit_sync`, `record_session_end`, `sync_achievements_after_session` — all `@callable` wrappers removed; underlying service methods untouched.

## Frontend deletions (src/api/backend.ts)

`getRommVersion`, `getRomBySteamAppId`, `downloadFirmware`, `getAvailableCores`, `postExitSync`, `recordSessionEnd`, `syncAchievementsAfterSession`. Orphaned `RomLookupResult` import dropped.

## Test impact

Tests that exercised real service behavior through the deleted callable surface were rerouted to call the service directly (10 sites in `test_plugin_saves.py`, 2 in `test_reporter.py`). 7 happy-path delegation tests + 1 error-propagation test + 2 wrapper-only tests deleted.

If a future feature needs one of these, re-add it.

## Test plan

- [x] `pytest`: 2414 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `pnpm build`: clean
- [x] `tsc --noEmit`: clean

Closes #560