### PR TITLE
chore: set plugin.json author to danielcopper

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "RomM Sync",
   "version": "0.17.1",
-  "author": "Daniel",
+  "author": "danielcopper",
   "flags": [
     "_root"
   ],


### PR DESCRIPTION
Matches the GitHub repo owner / publishing identity. Single-field change in plugin.json.