### PR TITLE
ci: bump decky CLI 0.0.7 -> 0.0.8 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Download Decky CLI
         run: |
           mkdir -p /tmp/decky-cli
-          curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/download/0.0.7/decky-linux-x86_64"
+          curl -L -o /tmp/decky-cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/download/0.0.8/decky-linux-x86_64"
           chmod +x /tmp/decky-cli/decky
           echo "/tmp/decky-cli" >> $GITHUB_PATH
 


### PR DESCRIPTION
Latest decky CLI release ([0.0.8](https://github.com/SteamDeckHomebrew/cli/releases/tag/0.0.8), 2025-11-20) adds arm64 linux support. Our x86_64 build is unaffected by the new arch — bump is for hygiene so we don't drift further behind.