### PR TITLE
refactor(ui): clear S7773 + S6594 + S6660 mechanical lints (#573)

### DIFF
--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -631,11 +631,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
     if (meta.average_rating != null && meta.average_rating > 0) {
       gameInfoChildren.push(infoRow("rating", "Rating", `${Math.round(meta.average_rating)}%`));
     }
-  } else {
+  } else if (state.platformName) {
     // No metadata — still show platform
-    if (state.platformName) {
-      gameInfoChildren.push(infoRow("platform", "Platform", state.platformName));
-    }
+    gameInfoChildren.push(infoRow("platform", "Platform", state.platformName));
   }
 
   const gameInfoContent = gameInfoChildren.length > 0

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,8 +114,8 @@ export default definePlugin(() => {
     registerMetadataPatches(cache, appIdMap);
 
     for (const appIdStr of Object.keys(appIdMap)) {
-      const appId = parseInt(appIdStr, 10);
-      if (!isNaN(appId)) {
+      const appId = Number.parseInt(appIdStr, 10);
+      if (!Number.isNaN(appId)) {
         registerRomMAppId(appId);
       }
     }

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -18,8 +18,8 @@ export function registerLaunchInterceptor(): void {
     async (gameActionId: number, appIdStr: string, action: string, _launchSource: number) => {
       if (action !== "LaunchApp") return;
 
-      const appId = parseInt(appIdStr, 10);
-      if (isNaN(appId) || !isRomMAppId(appId)) return;
+      const appId = Number.parseInt(appIdStr, 10);
+      if (Number.isNaN(appId) || !isRomMAppId(appId)) return;
 
       // Block launch if a RetroDECK migration is pending. Backend also blocks
       // via @migration_blocked, but cancelling the Steam action here prevents

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -27,7 +27,7 @@ export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
     );
     for (const { appId, launchOptions } of entries) {
       if (launchOptions?.includes(ROMM_MARKER)) {
-        const match = launchOptions.match(/romm:(\d+)/);
+        const match = /romm:(\d+)/.exec(launchOptions);
         if (match) {
           result.set(Number(match[1]), appId);
         }


### PR DESCRIPTION
## Summary

Six SonarCloud quick wins:

- **4× S7773** prefer `Number.parseInt` / `Number.isNaN`: `src/index.tsx:117-118`, `src/utils/launchInterceptor.ts:21-22`
- **1× S6594** prefer `RegExp.exec()` over `.match()`: `src/utils/steamShortcuts.ts:30`
- **1× S6660** `if`-only-statement-in-`else`: `src/components/RomMGameInfoPanel.tsx`

Pure mechanical replacements. No behavior change.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm exec tsc --noEmit --skipLibCheck` clean

Closes #573