### PR TITLE
chore: delete Plugin._load_metadata_cache (#567)

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,11 +52,6 @@ class Plugin:
         """
         self._debug_logger(msg)
 
-    # -- persistence delegates -------------------------------------------------
-
-    def _load_metadata_cache(self):
-        self._metadata_cache = self._persistence.load_metadata_cache()
-
     async def _main(self):  # Decky lifecycle — must be async
         self.loop = asyncio.get_event_loop()
 

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -317,57 +317,6 @@ class TestGetAllMetadataCache:
         assert result == {}
 
 
-class TestLoadMetadataCache:
-    """Tests for _load_metadata_cache."""
-
-    def test_loads_from_disk(self, plugin, tmp_path):
-        import decky
-
-        from adapters.persistence import _METADATA_CACHE_VERSION, PersistenceAdapter
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        rom_entry = {"summary": "test", "cached_at": 100}
-        cache_data = {"version": _METADATA_CACHE_VERSION, "42": rom_entry}
-        cache_path = os.path.join(str(tmp_path), "metadata_cache.json")
-        with open(cache_path, "w") as f:
-            json.dump(cache_data, f)
-
-        plugin._load_metadata_cache()
-        assert plugin._metadata_cache["42"] == rom_entry
-        assert "version" in plugin._metadata_cache
-
-    def test_empty_when_file_missing(self, plugin, tmp_path):
-        import decky
-
-        from adapters.persistence import PersistenceAdapter
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._metadata_cache = {"old": "data"}
-        plugin._load_metadata_cache()
-        # Only version key should remain (no ROM entries)
-        assert "old" not in plugin._metadata_cache
-        assert plugin._metadata_cache.get("version") == 1
-
-    def test_empty_when_malformed_json(self, plugin, tmp_path):
-        import decky
-
-        from adapters.persistence import PersistenceAdapter
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        cache_path = os.path.join(str(tmp_path), "metadata_cache.json")
-        with open(cache_path, "w") as f:
-            f.write("not valid json{{{")
-
-        plugin._load_metadata_cache()
-        # Only version key should remain (no ROM entries)
-        assert "version" in plugin._metadata_cache
-        rom_keys = [k for k in plugin._metadata_cache if k != "version"]
-        assert rom_keys == []
-
-
 class TestSyncMetadataCapture:
     """Tests for metadata capture during a sync run."""
 

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -759,21 +759,6 @@ class TestCallableErrorPropagation:
             await plugin.evaluate_launch(42)
 
 
-# ── _load_metadata_cache helper ────────────────────────────────────────
-
-
-class TestLoadMetadataCacheHelper:
-    """Cover the ``_load_metadata_cache`` persistence delegate (line 56)."""
-
-    def test_load_metadata_cache_pulls_from_persistence(self, plugin):
-        sentinel = {"42": {"name": "x"}}
-        plugin._persistence = MagicMock()
-        plugin._persistence.load_metadata_cache.return_value = sentinel
-        plugin._load_metadata_cache()
-        plugin._persistence.load_metadata_cache.assert_called_once_with()
-        assert plugin._metadata_cache is sentinel
-
-
 # ── _unload lifecycle hook ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`bootstrap()` loads `metadata_cache` directly via `main.py:76`. The `_load_metadata_cache` method was a persistence helper kept alive only by tests (1 case in `test_plugin_callable_delegation.py` + 3 cases in `test_metadata.py`).

Removes the method + the test cases driving it, plus an orphaned `# -- persistence delegates ---` section header.

## Test plan

- [x] `pytest`: 2437 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass

Closes #567