### PR TITLE
chore: delete SaveServiceConfig.runtime_dir phantom field (#566)

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -356,7 +356,6 @@ def wire_services(cfg: WiringConfig) -> dict:
         settings=cfg.stores.settings,
         state=cfg.stores.state,
         save_sync_state=cfg.stores.save_sync_state,
-        runtime_dir=cfg.runtime.runtime_dir,
         save_sync_state_persister=cfg.callbacks.save_sync_state_persister,
         save_file=cfg.adapters.save_file,
         loop=cfg.runtime.loop,

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -52,10 +52,6 @@ class SaveServiceConfig:
         Caller should pre-populate via :meth:`SaveService.load_state`
         after construction; the aggregate ships with defaults out of
         the box.
-    runtime_dir:
-        Absolute path to the plugin runtime directory. Consumed by
-        SaveService for ad-hoc runtime files; ``save_sync_state.json``
-        persistence routes through ``save_sync_state_persister``.
     save_sync_state_persister:
         Protocol-typed I/O wrapper for ``save_sync_state.json``. The
         ``StateService`` uses ``.save(data)`` / ``.load() -> dict | None``
@@ -129,7 +125,6 @@ class SaveServiceConfig:
     settings: dict
     state: dict
     save_sync_state: SaveSyncState
-    runtime_dir: str
     save_sync_state_persister: SaveSyncStatePersister
     save_file: SaveFileAdapter
     loop: asyncio.AbstractEventLoop

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -41,7 +41,6 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         settings={"log_level": "debug"},
         state={"shortcut_registry": {}, "installed_roms": {}},
         save_sync_state=SaveService.make_default_state(),
-        runtime_dir=str(tmp_path),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
         save_file=save_file,
         loop=asyncio.get_event_loop(),

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -90,7 +90,6 @@ def plugin(tmp_path):
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-            runtime_dir=str(tmp_path),
             save_sync_state_persister=SaveSyncStatePersisterAdapter(
                 PersistenceAdapter(
                     settings_dir=str(tmp_path),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -86,7 +86,6 @@ def plugin(tmp_path):
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-            runtime_dir=str(tmp_path),
             save_sync_state_persister=SaveSyncStatePersisterAdapter(
                 PersistenceAdapter(
                     settings_dir=str(tmp_path),


### PR DESCRIPTION
## Summary

`SaveServiceConfig.runtime_dir` was a phantom field — passed by bootstrap and three test fixtures, but never read by `SaveService` or any of its 6 sub-services. Docstring claimed "Consumed by SaveService for ad-hoc runtime files" — no such consumption existed.

## Deleted

- Field + docstring entry in `services/saves/_config.py`
- `runtime_dir=cfg.runtime.runtime_dir` kwarg in `bootstrap.py`
- `runtime_dir=` kwarg in 3 test fixtures (`tests/services/saves/_helpers.py`, `tests/services/test_game_detail.py`, `tests/test_plugin_saves.py`)

Other `runtime_dir` occurrences (`WiringConfig.runtime.runtime_dir`, `PersistenceAdapter`, `DownloadService`, `SgdbArtworkCacheAdapter`) are unrelated and untouched.

## Test plan

- [x] `pytest`: 2441 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept

Closes #566