### PR TITLE
refactor(saves): decompose slots/service into sub-modules (#558)

### DIFF
--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -1,0 +1,194 @@
+"""Slot deletion: local state cleanup + server-side save removal.
+
+Anything that tears down an existing slot — surfacing what the delete
+will do to the confirmation modal, deleting the slot's server-side
+saves, and cleaning the local file-tracking entries that point at them
+— lives here. Slot listing, active-slot switching, and the first-sync
+setup wizard belong in their own sub-modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from domain.save_state import RomSaveState
+
+if TYPE_CHECKING:
+    import asyncio
+    import logging
+
+    from services.protocols import (
+        DebugLogger,
+        RetryStrategy,
+        RommSaveApi,
+    )
+    from services.saves.rom_info import RomInfoService
+    from services.saves.state import StateService
+
+
+class SlotDeleter:
+    """Slot deletion: validates the request, deletes server saves, cleans local state."""
+
+    def __init__(
+        self,
+        *,
+        state_svc: StateService,
+        rom_info: RomInfoService,
+        romm_api: RommSaveApi,
+        retry: RetryStrategy,
+        loop: asyncio.AbstractEventLoop,
+        logger: logging.Logger,
+        log_debug: DebugLogger,
+    ) -> None:
+        self._state_svc = state_svc
+        self._rom_info = rom_info
+        self._romm_api = romm_api
+        self._retry = retry
+        self._loop = loop
+        self._logger = logger
+        self._log_debug = log_debug
+
+    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[str, RomSaveState, dict[str, dict]]:
+        """Shared validation for slot delete operations.
+
+        Returns an error dict on failure, or a (rom_id_str, rom_state, slots_dict)
+        tuple on success.
+        """
+        if not self._state_svc.is_save_sync_enabled():
+            return {"success": False, "reason": "disabled"}
+        if not self._rom_info.get_rom_save_info(rom_id):
+            return {"success": False, "reason": "not_installed"}
+        rom_id_str = str(rom_id)
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        if save_state is None:
+            return {"success": False, "reason": "not_found"}
+        slots_dict: dict[str, dict] = save_state.slots
+        if slot not in slots_dict:
+            return {"success": False, "reason": "not_found"}
+        return rom_id_str, save_state, slots_dict
+
+    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
+        """Return info about what deleting a slot would do, for the confirmation modal."""
+        rom_id = int(rom_id)
+        slot = str(slot).strip() if slot else ""
+
+        result = self._validate_slot_operation(rom_id, slot)
+        if isinstance(result, dict):
+            return result
+        _rom_id_str, save_state, slots_dict = result
+
+        slot_info = slots_dict[slot]
+        source = slot_info.get("source", "server")
+        active_slot = save_state.active_slot
+        is_active = slot == (active_slot or "")
+
+        # Server save count
+        server_save_ids: list[int] = []
+        if source == "server":
+            device_id = self._state_svc.get_server_device_id()
+            try:
+                server_saves: list[dict] = await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(
+                        lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                    ),
+                )
+                server_save_ids = [s["id"] for s in server_saves]
+            except Exception as e:
+                self._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
+
+        # Local tracked files pointing to server saves in this slot
+        files_state = save_state.files
+        local_filenames: list[str] = []
+        if server_save_ids:
+            id_set = set(server_save_ids)
+            for filename, fstate in files_state.items():
+                if fstate.tracked_save_id in id_set:
+                    local_filenames.append(filename)
+
+        return {
+            "success": True,
+            "slot": slot,
+            "source": source,
+            "server_save_count": len(server_save_ids),
+            "server_save_ids": server_save_ids,
+            "local_file_count": len(local_filenames),
+            "local_filenames": local_filenames,
+            "is_active": is_active,
+        }
+
+    async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict:
+        """Delete all server saves in a slot. Returns result dict with count and IDs."""
+        device_id = self._state_svc.get_server_device_id()
+        try:
+            server_saves: list[dict] = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                ),
+            )
+            save_ids = [s["id"] for s in server_saves]
+            if save_ids:
+                await self._loop.run_in_executor(
+                    None,
+                    lambda: self._retry.with_retry(
+                        lambda: self._romm_api.delete_server_saves(save_ids),
+                    ),
+                )
+            return {"success": True, "count": len(save_ids), "ids": set(save_ids)}
+        except Exception as e:
+            self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
+            return {
+                "success": False,
+                "reason": "server_error",
+                "message": f"Failed to delete server saves: {e}",
+            }
+
+    async def delete_slot(self, rom_id: int, slot: str) -> dict:
+        """Delete a save slot and all its saves (local state + server if applicable)."""
+        rom_id = int(rom_id)
+        slot = str(slot).strip() if slot else ""
+
+        result = self._validate_slot_operation(rom_id, slot)
+        if isinstance(result, dict):
+            return result
+        _rom_id_str, save_state, slots_dict = result
+
+        effective_active = save_state.active_slot or ""
+        if slot == effective_active:
+            return {
+                "success": False,
+                "reason": "active_slot",
+                "message": "Cannot delete the active slot. Switch to a different slot first.",
+            }
+
+        slot_info = slots_dict[slot]
+        source = slot_info.get("source", "server")
+
+        deleted_server_saves = 0
+        cleaned_files = 0
+        deleted_ids: set[int] = set()
+
+        if source == "server":
+            result = await self._delete_server_slot_saves(rom_id, slot)
+            if not result["success"]:
+                return result
+            deleted_server_saves = result["count"]
+            deleted_ids = result["ids"]
+
+        # Clean up tracked file entries pointing to deleted saves
+        files_state = save_state.files
+        if deleted_ids:
+            to_remove = [fn for fn, fs in files_state.items() if fs.tracked_save_id in deleted_ids]
+            for fn in to_remove:
+                del files_state[fn]
+                cleaned_files += 1
+
+        del slots_dict[slot]
+        self._state_svc.save_state()
+
+        return {
+            "success": True,
+            "deleted_server_saves": deleted_server_saves,
+            "cleaned_files": cleaned_files,
+        }

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -1,0 +1,168 @@
+"""Slot listing reads against the live server + persisted state.
+
+Anything that reads slot inventory for the QAM (merging persisted local
+slots with the server view and projecting the result back to disk) lives
+here. Mutating writes for the active slot, the setup wizard, and slot
+deletion belong in their own sub-modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from services.saves._messages import SAVE_SYNC_DISABLED
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from services.protocols import (
+        DebugLogger,
+        RetryStrategy,
+        RommSaveApi,
+    )
+    from services.saves.state import StateService
+
+
+class SlotListing:
+    """Slot inventory reader: merges server slot summaries with persisted local slots."""
+
+    def __init__(
+        self,
+        *,
+        state_svc: StateService,
+        romm_api: RommSaveApi,
+        retry: RetryStrategy,
+        loop: asyncio.AbstractEventLoop,
+        log_debug: DebugLogger,
+    ) -> None:
+        self._state_svc = state_svc
+        self._romm_api = romm_api
+        self._retry = retry
+        self._loop = loop
+        self._log_debug = log_debug
+
+    async def get_save_slots(self, rom_id: int) -> dict:
+        """List available save slots for a ROM.
+
+        Merges server slots with locally-created slots. Persists the merged
+        result so local slots survive restarts. Promotes local slots to server
+        when they appear on the server. Removes server slots that no longer
+        exist on the server (unless they are the active_slot).
+        """
+        rom_id = int(rom_id)
+        if not self._state_svc.is_save_sync_enabled():
+            return {"success": False, "slots": [], "active_slot": "default"}
+
+        rom_id_str = str(rom_id)
+        device_id = self._state_svc.get_server_device_id()
+        rom_state = self._state_svc.state.saves.get(rom_id_str)
+        default_slot = self._state_svc.state.settings.default_slot or "default"
+        # ROM not tracked → fall back to the global default slot. ROM
+        # tracked with ``active_slot=None`` → preserve legacy mode (None
+        # means "no slots"; the persisted slots dict will contain ``""``).
+        if rom_state is None:
+            active_slot: str | None = default_slot
+            persisted_slots: dict[str, dict] = {}
+        else:
+            active_slot = rom_state.active_slot
+            persisted_slots = rom_state.slots
+
+        # Fetch server slots
+        server_slots_list: list[dict] = []
+        try:
+            summary = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.get_save_summary(rom_id, device_id=device_id),
+                ),
+            )
+            server_slots_list = summary.get("slots", [])
+        except Exception as e:
+            self._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
+
+        # Merge: update persisted slots with server data, promote local→server
+        merged: dict[str, dict] = {}
+        for s in server_slots_list:
+            raw = s.get("slot") or s.get("slot_name")
+            name = raw if raw else ""
+            merged[name] = {
+                "source": "server",
+                "count": s.get("count", 0),
+                "latest_updated_at": (s.get("latest") or {}).get("updated_at"),
+            }
+
+        self._merge_persisted_slots(persisted_slots, merged, active_slot)
+
+        # Persist merged slots in state
+        game_entry = self._state_svc.ensure_rom_state(rom_id_str)
+        game_entry.slots = merged
+        self._state_svc.save_state()
+
+        # Build response list
+        result_slots = [
+            {
+                "slot": name,
+                "source": info.get("source", "server"),
+                "count": info.get("count", 0),
+                "latest_updated_at": info.get("latest_updated_at"),
+            }
+            for name, info in sorted(merged.items())
+        ]
+
+        return {"success": True, "slots": result_slots, "active_slot": active_slot}
+
+    @staticmethod
+    def _merge_persisted_slots(
+        persisted: dict[str, dict],
+        merged: dict[str, dict],
+        active_slot: str | None,
+    ) -> None:
+        """Add persisted local slots (or the active slot) that aren't on the server.
+
+        Mutates ``merged`` in place. Local slots are always kept. A persisted
+        server slot that's gone from the server is dropped unless it's the
+        active slot — we want to keep the UI functional until the user
+        explicitly switches away.
+        """
+        for name, info in persisted.items():
+            if name in merged:
+                continue
+            if info.get("source") == "local":
+                merged[name] = {"source": "local", "count": 0, "latest_updated_at": None}
+            elif info.get("source") == "server" and name == (active_slot or ""):
+                merged[name] = {"source": "server", "count": 0, "latest_updated_at": None}
+
+    async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
+        """Fetch server save files for a specific slot.
+
+        Used by the frontend to show save files when expanding an inactive slot panel.
+        Lightweight — no local file scanning or conflict detection.
+        """
+        rom_id = int(rom_id)
+        slot = str(slot).strip() if slot else ""
+
+        if not self._state_svc.is_save_sync_enabled():
+            return {"success": False, "slot": slot, "saves": [], "error": SAVE_SYNC_DISABLED}
+
+        device_id = self._state_svc.get_server_device_id()
+
+        try:
+            server_saves: list[dict] = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
+                ),
+            )
+            saves = [
+                {
+                    "filename": s["file_name"],
+                    "id": s["id"],
+                    "size": s.get("file_size_bytes"),
+                    "updated_at": s.get("updated_at", ""),
+                    "emulator": s.get("emulator", ""),
+                }
+                for s in server_saves
+            ]
+            return {"success": True, "slot": slot, "saves": saves}
+        except Exception as e:
+            return {"success": False, "slot": slot, "saves": [], "error": str(e)}

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -1,21 +1,26 @@
-"""Slot lifecycle operations for save sync.
+"""Slots facade and config: the public entry point for slot lifecycle.
 
 Anything that creates, lists, switches, migrates, or deletes slots —
-including the first-sync setup wizard — belongs here. The newest-wins
-matrix executor lives in SyncEngine, status reporting in StatusService,
-and on-disk state persistence in StateService.
+including the first-sync setup wizard — is exposed by ``SlotsService``.
+The implementations live in the sibling sub-modules
+(:mod:`services.saves.slots.listing`,
+:mod:`services.saves.slots.switching`,
+:mod:`services.saves.slots.setup`,
+:mod:`services.saves.slots.deletion`); ``SlotsService`` wires them
+from the config and delegates. The newest-wins matrix executor lives in
+SyncEngine, status reporting in StatusService, on-disk state
+persistence in StateService.
 """
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from domain.emulator_tag import build_emulator_tag
-from domain.save_state import RomSaveState
-from services.saves._helpers import _local_save_target
-from services.saves._messages import SAVE_SYNC_DISABLED
+from services.saves.slots.deletion import SlotDeleter
+from services.saves.slots.listing import SlotListing
+from services.saves.slots.setup import _NO_MIGRATION, SetupWizard
+from services.saves.slots.switching import SlotSwitcher
 
 if TYPE_CHECKING:
     import asyncio
@@ -35,7 +40,7 @@ if TYPE_CHECKING:
     from services.saves.sync_engine import SyncEngine
 
 
-_NO_MIGRATION = object()  # sentinel: no slot migration requested
+__all__ = ["_NO_MIGRATION", "SlotsService", "SlotsServiceConfig"]
 
 
 @dataclass(frozen=True)
@@ -66,447 +71,89 @@ class SlotsServiceConfig:
 
 
 class SlotsService:
-    """Slot lifecycle: list, set-active, switch, migrate, delete, first-sync wizard."""
+    """Slot lifecycle entry point — composes the listing, switching, setup, and deletion sub-modules."""
 
     def __init__(self, *, config: SlotsServiceConfig) -> None:
         self._config = config
-        self._state = config.state
-        self._state_svc = config.state_svc
-        self._sync_engine = config.sync_engine
-        self._status_service = config.status_service
-        self._rom_info = config.rom_info
-        self._romm_api = config.romm_api
-        self._retry = config.retry
-        self._loop = config.loop
-        self._logger = config.logger
-        self._clock = config.clock
-        self._save_file = config.save_file
-        self._log_debug = config.log_debug
-        self._get_active_core = config.get_active_core
+
+        self._listing = SlotListing(
+            state_svc=config.state_svc,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            loop=config.loop,
+            log_debug=config.log_debug,
+        )
+        self._switcher = SlotSwitcher(
+            state_svc=config.state_svc,
+            sync_engine=config.sync_engine,
+            status_service=config.status_service,
+            rom_info=config.rom_info,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            loop=config.loop,
+            clock=config.clock,
+            save_file=config.save_file,
+            log_debug=config.log_debug,
+        )
+        self._setup = SetupWizard(
+            state=config.state,
+            state_svc=config.state_svc,
+            rom_info=config.rom_info,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            loop=config.loop,
+            logger=config.logger,
+            save_file=config.save_file,
+            log_debug=config.log_debug,
+            get_active_core=config.get_active_core,
+        )
+        self._deleter = SlotDeleter(
+            state_svc=config.state_svc,
+            rom_info=config.rom_info,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            loop=config.loop,
+            logger=config.logger,
+            log_debug=config.log_debug,
+        )
 
     # ------------------------------------------------------------------
-    # Slot listing
+    # Slot listing — delegates to :class:`SlotListing`.
     # ------------------------------------------------------------------
 
     async def get_save_slots(self, rom_id: int) -> dict:
-        """List available save slots for a ROM.
-
-        Merges server slots with locally-created slots. Persists the merged
-        result so local slots survive restarts. Promotes local slots to server
-        when they appear on the server. Removes server slots that no longer
-        exist on the server (unless they are the active_slot).
-        """
-        rom_id = int(rom_id)
-        if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "slots": [], "active_slot": "default"}
-
-        rom_id_str = str(rom_id)
-        device_id = self._state_svc.get_server_device_id()
-        rom_state = self._state_svc.state.saves.get(rom_id_str)
-        default_slot = self._state_svc.state.settings.default_slot or "default"
-        # ROM not tracked → fall back to the global default slot. ROM
-        # tracked with ``active_slot=None`` → preserve legacy mode (None
-        # means "no slots"; the persisted slots dict will contain ``""``).
-        if rom_state is None:
-            active_slot: str | None = default_slot
-            persisted_slots: dict[str, dict] = {}
-        else:
-            active_slot = rom_state.active_slot
-            persisted_slots = rom_state.slots
-
-        # Fetch server slots
-        server_slots_list: list[dict] = []
-        try:
-            summary = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.get_save_summary(rom_id, device_id=device_id),
-                ),
-            )
-            server_slots_list = summary.get("slots", [])
-        except Exception as e:
-            self._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
-
-        # Merge: update persisted slots with server data, promote local→server
-        merged: dict[str, dict] = {}
-        for s in server_slots_list:
-            raw = s.get("slot") or s.get("slot_name")
-            name = raw if raw else ""
-            merged[name] = {
-                "source": "server",
-                "count": s.get("count", 0),
-                "latest_updated_at": (s.get("latest") or {}).get("updated_at"),
-            }
-
-        self._merge_persisted_slots(persisted_slots, merged, active_slot)
-
-        # Persist merged slots in state
-        game_entry = self._state_svc.ensure_rom_state(rom_id_str)
-        game_entry.slots = merged
-        self._state_svc.save_state()
-
-        # Build response list
-        result_slots = [
-            {
-                "slot": name,
-                "source": info.get("source", "server"),
-                "count": info.get("count", 0),
-                "latest_updated_at": info.get("latest_updated_at"),
-            }
-            for name, info in sorted(merged.items())
-        ]
-
-        return {"success": True, "slots": result_slots, "active_slot": active_slot}
-
-    @staticmethod
-    def _merge_persisted_slots(
-        persisted: dict[str, dict],
-        merged: dict[str, dict],
-        active_slot: str | None,
-    ) -> None:
-        """Add persisted local slots (or the active slot) that aren't on the server.
-
-        Mutates ``merged`` in place. Local slots are always kept. A persisted
-        server slot that's gone from the server is dropped unless it's the
-        active slot — we want to keep the UI functional until the user
-        explicitly switches away.
-        """
-        for name, info in persisted.items():
-            if name in merged:
-                continue
-            if info.get("source") == "local":
-                merged[name] = {"source": "local", "count": 0, "latest_updated_at": None}
-            elif info.get("source") == "server" and name == (active_slot or ""):
-                merged[name] = {"source": "server", "count": 0, "latest_updated_at": None}
+        """List available save slots for a ROM."""
+        return await self._listing.get_save_slots(rom_id)
 
     async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
-        """Fetch server save files for a specific slot.
-
-        Used by the frontend to show save files when expanding an inactive slot panel.
-        Lightweight — no local file scanning or conflict detection.
-        """
-        rom_id = int(rom_id)
-        slot = str(slot).strip() if slot else ""
-
-        if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "slot": slot, "saves": [], "error": SAVE_SYNC_DISABLED}
-
-        device_id = self._state_svc.get_server_device_id()
-
-        try:
-            server_saves: list[dict] = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
-                ),
-            )
-            saves = [
-                {
-                    "filename": s["file_name"],
-                    "id": s["id"],
-                    "size": s.get("file_size_bytes"),
-                    "updated_at": s.get("updated_at", ""),
-                    "emulator": s.get("emulator", ""),
-                }
-                for s in server_saves
-            ]
-            return {"success": True, "slot": slot, "saves": saves}
-        except Exception as e:
-            return {"success": False, "slot": slot, "saves": [], "error": str(e)}
+        """Fetch server save files for a specific slot."""
+        return await self._listing.get_slot_saves(rom_id, slot)
 
     # ------------------------------------------------------------------
-    # Active slot mutation
+    # Active slot mutation + slot switching — delegate to :class:`SlotSwitcher`.
+    # Kept on the facade so tests that reach for ``svc._slots._set_active_slot``
+    # continue to drive the same code path.
     # ------------------------------------------------------------------
 
     def _set_active_slot(self, rom_id: int, slot: str) -> dict:
-        """Set the active save slot for a specific game.
-
-        If the slot doesn't exist yet (not on server), it is persisted
-        as a local slot. It will be promoted to server once a save is
-        uploaded to it.
-        """
-        rom_id = int(rom_id)
-        slot_str = str(slot).strip() if slot else ""
-        # Empty string = legacy mode (None slot)
-        resolved_slot: str | None = slot_str if slot_str else None
-
-        rom_id_str = str(rom_id)
-        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
-        rom_state.active_slot = resolved_slot
-
-        # Ensure slot is in the persisted slots dict (use "" as key for legacy/None)
-        slot_key = resolved_slot if resolved_slot is not None else ""
-        if slot_key not in rom_state.slots:
-            rom_state.slots[slot_key] = {"source": "local", "count": 0, "latest_updated_at": None}
-
-        self._state_svc.save_state()
-        self._loop.create_task(self._status_service.check_save_status_background(rom_id))
-        return {"success": True, "active_slot": resolved_slot}
-
-    # ------------------------------------------------------------------
-    # Slot switching
-    # ------------------------------------------------------------------
-
-    def _check_slot_switch_readiness(self, rom_id: int) -> dict:
-        """Check whether it is safe to switch slots for this ROM.
-
-        A switch is unsafe if local files have changed since the last sync
-        to the current slot — those changes would be lost.
-        Files that were never synced do not block (they'll be deleted on switch).
-
-        Returns ``{"ready": True}`` or
-        ``{"ready": False, "reason": str, "files": list[str]}``.
-        """
-        rom_id_str = str(rom_id)
-        save_state = self._state_svc.state.saves.get(rom_id_str)
-        files_state = save_state.files if save_state else {}
-
-        pending: list[str] = []
-        local_files = self._rom_info.find_save_files(rom_id)
-        for lf in local_files:
-            filename = lf["filename"]
-            file_state = files_state.get(filename)
-            last_sync_hash = file_state.last_sync_hash if file_state else None
-            if last_sync_hash:
-                current_hash = self._save_file.checksum_md5(lf["path"])
-                if current_hash != last_sync_hash:
-                    pending.append(filename)
-
-        if pending:
-            return {"ready": False, "reason": "pending_uploads", "files": pending}
-
-        return {"ready": True}
+        """Set the active save slot for a specific game."""
+        return self._switcher._set_active_slot(rom_id, slot)
 
     async def switch_slot(self, rom_id: int, new_slot: str) -> dict:
-        """Switch the active save slot with immediate state sync.
-
-        Pre-checks (all must pass):
-        1. Save sync must be enabled.
-        2. ROM must be installed.
-        3. No local files with pending changes (changed since last sync to current slot).
-        4. Server must be reachable.
-
-        On success:
-        - If the new slot has server saves: downloads them, replacing local files.
-        - If the new slot is empty: deletes local save files (fresh start).
-        - Never uploads — saves are not carried between slots.
-        """
-        rom_id = int(rom_id)
-        rom_id_str = str(rom_id)
-
-        # 1. Save sync must be enabled
-        if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "reason": "sync_disabled"}
-
-        # 2. Slot normalisation (empty → None for legacy mode)
-        slot_str = str(new_slot).strip() if new_slot else ""
-        resolved_slot: str | None = slot_str if slot_str else None
-
-        # 3. ROM must be installed
-        info = self._rom_info.get_rom_save_info(rom_id)
-        if not info:
-            return {"success": False, "reason": "not_installed"}
-
-        saves_dir = info["saves_dir"]
-        system = info["system"]
-
-        # 4. Check for pending local changes (hashing — run in executor)
-        readiness = await self._loop.run_in_executor(
-            None,
-            self._check_slot_switch_readiness,
-            rom_id,
-        )
-        if not readiness.get("ready"):
-            return {
-                "success": False,
-                "reason": readiness.get("reason", "pending_uploads"),
-                "files": readiness.get("files", []),
-            }
-
-        # 5. Fetch server saves for the new slot (also proves server is reachable)
-        device_id = self._state_svc.get_server_device_id()
-        try:
-            all_server_saves: list[dict] = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
-                ),
-            )
-        except Exception:
-            return {"success": False, "reason": "server_unreachable"}
-
-        # Filter to the target slot (FakeSaveApi doesn't filter, real API may not either)
-        # Normalize "" and None both to None before comparing (legacy saves may use either)
-        slot_saves = [s for s in all_server_saves if (s.get("slot") or None) == resolved_slot]
-
-        # 6. Update active slot in state
-        self._set_active_slot(rom_id, new_slot)
-
-        # 7. Sync local state to match the new slot
-        if slot_saves:
-            # New slot has server saves — download them, replacing local files.
-            # rom_name is guaranteed by the earlier ``info`` check (line 1642).
-            await self._loop.run_in_executor(
-                None,
-                self._do_switch_downloads,
-                slot_saves,
-                saves_dir,
-                rom_id_str,
-                system,
-                info["rom_name"],
-            )
-        else:
-            # New slot is empty — delete local save files for a fresh start
-            await self._loop.run_in_executor(
-                None,
-                self._delete_local_saves_for_switch,
-                rom_id,
-                rom_id_str,
-            )
-
-        # 8. Update last_sync_check_at
-        save_entry = self._state_svc.ensure_rom_state(rom_id_str)
-        save_entry.last_sync_check_at = self._clock.now().isoformat()
-        self._state_svc.save_state()
-
-        # 9. Return fresh status
-        save_status = await self._status_service.get_save_status(rom_id)
-        return {"success": True, "save_status": save_status}
-
-    def _do_switch_downloads(
-        self,
-        slot_saves: list[dict],
-        saves_dir: str,
-        rom_id_str: str,
-        system: str,
-        rom_name: str,
-    ) -> None:
-        """Download all saves from *slot_saves* into *saves_dir*.
-
-        Each save lands at ``<saves_dir>/<rom_name>.<server.file_extension>`` —
-        the canonical RetroArch path. Runs synchronously; call via
-        ``run_in_executor``.
-        """
-        for server_save in slot_saves:
-            target = _local_save_target(server_save, rom_name)
-            self._sync_engine._do_download_save(server_save, saves_dir, target, rom_id_str, system)
-
-    def _delete_local_saves_for_switch(self, rom_id: int, rom_id_str: str) -> None:
-        """Delete local save files and clear file tracking state for a slot switch.
-
-        Unlike delete_local_saves (the callable), this preserves slot config
-        (active_slot, slot_confirmed, slots dict) and only clears files + tracking.
-        Runs synchronously — call via run_in_executor.
-        """
-        local_files = self._rom_info.find_save_files(rom_id)
-        for lf in local_files:
-            try:
-                self._save_file.remove(lf["path"])
-                self._log_debug(f"Deleted local save for switch: {lf['filename']}")
-            except Exception as e:
-                self._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
-
-        # Clear file tracking state (but keep slot config)
-        self._state_svc.clear_files_state(rom_id_str)
+        """Switch the active save slot with immediate state sync."""
+        return await self._switcher.switch_slot(rom_id, new_slot)
 
     # ------------------------------------------------------------------
-    # Save Setup Wizard
+    # Save setup wizard — delegates to :class:`SetupWizard`.
     # ------------------------------------------------------------------
 
     def is_save_tracking_configured(self, rom_id: int) -> dict:
-        """Check if save slot tracking is configured for a game.
-
-        Fast, synchronous check — reads only from local state.
-        Returns {"configured": bool, "active_slot": str|None}
-        """
-        rom_id_str = str(int(rom_id))
-        game_state = self._state_svc.state.saves.get(rom_id_str)
-        configured = bool(game_state.slot_confirmed) if game_state else False
-        active_slot = game_state.active_slot if (game_state and configured) else None
-        return {"configured": configured, "active_slot": active_slot}
+        """Check if save slot tracking is configured for a game."""
+        return self._setup.is_save_tracking_configured(rom_id)
 
     async def get_save_setup_info(self, rom_id: int) -> dict:
-        """Get info needed for the first-sync setup wizard.
-
-        Fetches server saves, checks local files, determines which
-        scenario (A-E) applies so the frontend can display the right UI.
-        """
-        rom_id = int(rom_id)
-        rom_id_str = str(rom_id)
-
-        # Local saves
-        local_files = self._rom_info.find_save_files(rom_id)
-        local_file_info = []
-        for lf in local_files:
-            local_file_info.append(
-                {
-                    "filename": lf["filename"],
-                    "size": self._save_file.get_size(lf["path"]) if self._save_file.is_file(lf["path"]) else 0,
-                }
-            )
-
-        # Server saves
-        server_saves: list[dict] = []
-        device_id = self._state_svc.get_server_device_id()
-        try:
-            server_saves = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
-                ),
-            )
-        except Exception as e:
-            self._log_debug(f"get_save_setup_info({rom_id}): failed to list saves: {e}")
-
-        # Group server saves by slot
-        slots_map: dict[str | None, list[dict]] = {}
-        for ss in server_saves:
-            slot_key = ss.get("slot")
-            slots_map.setdefault(slot_key, []).append(ss)
-
-        server_slots = []
-        for slot_key, saves in slots_map.items():
-            latest = max((s.get("updated_at", "") for s in saves), default=None)
-            server_slots.append(
-                {
-                    "slot": slot_key,
-                    "saves": [
-                        {
-                            "id": s.get("id"),
-                            "file_name": s.get("file_name", ""),
-                            "emulator": s.get("emulator", ""),
-                            "updated_at": s.get("updated_at", ""),
-                            "file_size_bytes": s.get("file_size_bytes", 0),
-                        }
-                        for s in saves
-                    ],
-                    "count": len(saves),
-                    "latest_updated_at": latest,
-                }
-            )
-
-        # State info
-        game_state = self._state_svc.state.saves.get(rom_id_str)
-        default_slot = self._state_svc.state.settings.default_slot or "default"
-        slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
-        active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
-
-        # Pre-computed wizard recommendation: auto-confirm the default slot only
-        # when there are local saves and the server has no slots yet. Every other
-        # combination needs the wizard so the user can choose.
-        recommended_action = (
-            "auto_confirm_default" if (len(local_files) > 0 and len(server_slots) == 0) else "show_wizard"
-        )
-
-        return {
-            "has_local_saves": len(local_files) > 0,
-            "local_files": local_file_info,
-            "server_slots": server_slots,
-            "default_slot": default_slot,
-            "slot_confirmed": slot_confirmed,
-            "active_slot": active_slot,
-            "recommended_action": recommended_action,
-        }
+        """Get info needed for the first-sync setup wizard."""
+        return await self._setup.get_save_setup_info(rom_id)
 
     async def confirm_slot_choice(
         self,
@@ -514,257 +161,17 @@ class SlotsService:
         chosen_slot: str,
         migrate_from_slot: str | None | object = _NO_MIGRATION,
     ) -> dict:
-        """Confirm which slot to use for a game's save sync.
-
-        Sets slot_confirmed=true and active_slot in state.
-
-        If migrate_from_slot is provided (can be None for legacy no-slot saves),
-        migrates saves: upload local files to chosen_slot, then delete old server saves.
-        Pass _NO_MIGRATION sentinel (the default) to skip migration.
-        """
-        rom_id = int(rom_id)
-        rom_id_str = str(rom_id)
-        chosen_slot = str(chosen_slot).strip()
-        if not chosen_slot:
-            return {"success": False, "needs_conflict_resolution": False, "message": "Slot name cannot be empty"}
-
-        # Update state
-        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
-        rom_state.active_slot = chosen_slot
-        rom_state.slot_confirmed = True
-
-        # Migration: re-upload local files to new slot, delete old server saves
-        if migrate_from_slot is not _NO_MIGRATION:
-            # migrate_from_slot can be None (legacy no-slot) or a string slot name
-            from_slot: str | None = migrate_from_slot if isinstance(migrate_from_slot, str) else None
-            try:
-                await self._migrate_slot_saves(rom_id, rom_id_str, chosen_slot, from_slot)
-            except Exception as e:
-                self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed: {e}")
-                self._state_svc.save_state()
-                return {
-                    "success": True,
-                    "needs_conflict_resolution": False,
-                    "message": f"Slot confirmed but migration failed: {e}",
-                }
-
-        self._state_svc.save_state()
-        return {"success": True, "needs_conflict_resolution": False, "message": "Slot confirmed"}
-
-    async def _migrate_slot_saves(
-        self,
-        rom_id: int,
-        rom_id_str: str,
-        chosen_slot: str,
-        migrate_from_slot: str | None,
-    ) -> None:
-        """Migrate server saves from one slot to another.
-
-        For each local file: upload with new slot, then delete old server save.
-        Safe order: POST first, DELETE after.
-        """
-        device_id = self._state_svc.get_server_device_id()
-
-        # Find server saves in the old slot
-        all_saves = await self._loop.run_in_executor(
-            None,
-            lambda: self._retry.with_retry(
-                lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
-            ),
-        )
-        old_slot_saves = [s for s in all_saves if s.get("slot") == migrate_from_slot]
-        if not old_slot_saves:
-            return
-
-        # Get local files for re-upload
-        local_files = self._rom_info.find_save_files(rom_id)
-        local_by_name = {lf["filename"]: lf for lf in local_files}
-
-        # Resolve emulator tag
-        info = self._rom_info.get_rom_save_info(rom_id)
-        system = info["system"] if info else ""
-        installed = self._state["installed_roms"].get(rom_id_str, {})
-        rom_filename = os.path.basename(installed.get("file_path", "")) or None
-        core_so, _label = self._get_active_core(system, rom_filename)
-        emulator = build_emulator_tag(core_so)
-
-        ids_to_delete: list[int] = []
-
-        for old_save in old_slot_saves:
-            fname = old_save.get("file_name", "")
-            local_file = local_by_name.get(fname)
-            if local_file and self._save_file.is_file(local_file["path"]):
-                # Upload to new slot
-                await self._loop.run_in_executor(
-                    None,
-                    lambda lf=local_file, em=emulator: self._retry.with_retry(
-                        lambda: self._romm_api.upload_save(
-                            rom_id,
-                            lf["path"],
-                            em,
-                            device_id=device_id,
-                            slot=chosen_slot,
-                        ),
-                    ),
-                )
-            old_id = old_save.get("id")
-            if old_id is not None:
-                ids_to_delete.append(old_id)
-
-        # Delete old saves
-        if ids_to_delete:
-            await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.delete_server_saves(ids_to_delete),
-                ),
-            )
+        """Confirm which slot to use for a game's save sync."""
+        return await self._setup.confirm_slot_choice(rom_id, chosen_slot, migrate_from_slot)
 
     # ------------------------------------------------------------------
-    # Slot deletion
+    # Slot deletion — delegates to :class:`SlotDeleter`.
     # ------------------------------------------------------------------
-
-    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[str, RomSaveState, dict[str, dict]]:
-        """Shared validation for slot delete operations.
-
-        Returns an error dict on failure, or a (rom_id_str, rom_state, slots_dict)
-        tuple on success.
-        """
-        if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "reason": "disabled"}
-        if not self._rom_info.get_rom_save_info(rom_id):
-            return {"success": False, "reason": "not_installed"}
-        rom_id_str = str(rom_id)
-        save_state = self._state_svc.state.saves.get(rom_id_str)
-        if save_state is None:
-            return {"success": False, "reason": "not_found"}
-        slots_dict: dict[str, dict] = save_state.slots
-        if slot not in slots_dict:
-            return {"success": False, "reason": "not_found"}
-        return rom_id_str, save_state, slots_dict
 
     async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
-        """Return info about what deleting a slot would do, for the confirmation modal."""
-        rom_id = int(rom_id)
-        slot = str(slot).strip() if slot else ""
-
-        result = self._validate_slot_operation(rom_id, slot)
-        if isinstance(result, dict):
-            return result
-        _rom_id_str, save_state, slots_dict = result
-
-        slot_info = slots_dict[slot]
-        source = slot_info.get("source", "server")
-        active_slot = save_state.active_slot
-        is_active = slot == (active_slot or "")
-
-        # Server save count
-        server_save_ids: list[int] = []
-        if source == "server":
-            device_id = self._state_svc.get_server_device_id()
-            try:
-                server_saves: list[dict] = await self._loop.run_in_executor(
-                    None,
-                    lambda: self._retry.with_retry(
-                        lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
-                    ),
-                )
-                server_save_ids = [s["id"] for s in server_saves]
-            except Exception as e:
-                self._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
-
-        # Local tracked files pointing to server saves in this slot
-        files_state = save_state.files
-        local_filenames: list[str] = []
-        if server_save_ids:
-            id_set = set(server_save_ids)
-            for filename, fstate in files_state.items():
-                if fstate.tracked_save_id in id_set:
-                    local_filenames.append(filename)
-
-        return {
-            "success": True,
-            "slot": slot,
-            "source": source,
-            "server_save_count": len(server_save_ids),
-            "server_save_ids": server_save_ids,
-            "local_file_count": len(local_filenames),
-            "local_filenames": local_filenames,
-            "is_active": is_active,
-        }
-
-    async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict:
-        """Delete all server saves in a slot. Returns result dict with count and IDs."""
-        device_id = self._state_svc.get_server_device_id()
-        try:
-            server_saves: list[dict] = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(
-                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
-                ),
-            )
-            save_ids = [s["id"] for s in server_saves]
-            if save_ids:
-                await self._loop.run_in_executor(
-                    None,
-                    lambda: self._retry.with_retry(
-                        lambda: self._romm_api.delete_server_saves(save_ids),
-                    ),
-                )
-            return {"success": True, "count": len(save_ids), "ids": set(save_ids)}
-        except Exception as e:
-            self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
-            return {
-                "success": False,
-                "reason": "server_error",
-                "message": f"Failed to delete server saves: {e}",
-            }
+        """Return info about what deleting a slot would do."""
+        return await self._deleter.get_slot_delete_info(rom_id, slot)
 
     async def delete_slot(self, rom_id: int, slot: str) -> dict:
         """Delete a save slot and all its saves (local state + server if applicable)."""
-        rom_id = int(rom_id)
-        slot = str(slot).strip() if slot else ""
-
-        result = self._validate_slot_operation(rom_id, slot)
-        if isinstance(result, dict):
-            return result
-        _rom_id_str, save_state, slots_dict = result
-
-        effective_active = save_state.active_slot or ""
-        if slot == effective_active:
-            return {
-                "success": False,
-                "reason": "active_slot",
-                "message": "Cannot delete the active slot. Switch to a different slot first.",
-            }
-
-        slot_info = slots_dict[slot]
-        source = slot_info.get("source", "server")
-
-        deleted_server_saves = 0
-        cleaned_files = 0
-        deleted_ids: set[int] = set()
-
-        if source == "server":
-            result = await self._delete_server_slot_saves(rom_id, slot)
-            if not result["success"]:
-                return result
-            deleted_server_saves = result["count"]
-            deleted_ids = result["ids"]
-
-        # Clean up tracked file entries pointing to deleted saves
-        files_state = save_state.files
-        if deleted_ids:
-            to_remove = [fn for fn, fs in files_state.items() if fs.tracked_save_id in deleted_ids]
-            for fn in to_remove:
-                del files_state[fn]
-                cleaned_files += 1
-
-        del slots_dict[slot]
-        self._state_svc.save_state()
-
-        return {
-            "success": True,
-            "deleted_server_saves": deleted_server_saves,
-            "cleaned_files": cleaned_files,
-        }
+        return await self._deleter.delete_slot(rom_id, slot)

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -1,0 +1,268 @@
+"""First-sync setup wizard and slot migration.
+
+Anything that drives the user-facing wizard for the very first time a
+ROM is opened — surfacing the scenario the frontend renders, recording
+the user's slot choice, and migrating server-side saves between slots
+when requested — lives here. Slot listing, active-slot switching, and
+slot deletion belong in their own sub-modules.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from domain.emulator_tag import build_emulator_tag
+
+if TYPE_CHECKING:
+    import asyncio
+    import logging
+
+    from services.protocols import (
+        CoreResolverFn,
+        DebugLogger,
+        RetryStrategy,
+        RommSaveApi,
+        SaveFileAdapter,
+    )
+    from services.saves.rom_info import RomInfoService
+    from services.saves.state import StateService
+
+
+_NO_MIGRATION = object()  # sentinel: no slot migration requested
+
+
+class SetupWizard:
+    """First-sync slot configuration: setup-info fetch, confirm-choice, slot-migration."""
+
+    def __init__(
+        self,
+        *,
+        state: dict,
+        state_svc: StateService,
+        rom_info: RomInfoService,
+        romm_api: RommSaveApi,
+        retry: RetryStrategy,
+        loop: asyncio.AbstractEventLoop,
+        logger: logging.Logger,
+        save_file: SaveFileAdapter,
+        log_debug: DebugLogger,
+        get_active_core: CoreResolverFn,
+    ) -> None:
+        self._state = state
+        self._state_svc = state_svc
+        self._rom_info = rom_info
+        self._romm_api = romm_api
+        self._retry = retry
+        self._loop = loop
+        self._logger = logger
+        self._save_file = save_file
+        self._log_debug = log_debug
+        self._get_active_core = get_active_core
+
+    def is_save_tracking_configured(self, rom_id: int) -> dict:
+        """Check if save slot tracking is configured for a game.
+
+        Fast, synchronous check — reads only from local state.
+        Returns {"configured": bool, "active_slot": str|None}
+        """
+        rom_id_str = str(int(rom_id))
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        configured = bool(game_state.slot_confirmed) if game_state else False
+        active_slot = game_state.active_slot if (game_state and configured) else None
+        return {"configured": configured, "active_slot": active_slot}
+
+    async def get_save_setup_info(self, rom_id: int) -> dict:
+        """Get info needed for the first-sync setup wizard.
+
+        Fetches server saves, checks local files, determines which
+        scenario (A-E) applies so the frontend can display the right UI.
+        """
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+
+        # Local saves
+        local_files = self._rom_info.find_save_files(rom_id)
+        local_file_info = []
+        for lf in local_files:
+            local_file_info.append(
+                {
+                    "filename": lf["filename"],
+                    "size": self._save_file.get_size(lf["path"]) if self._save_file.is_file(lf["path"]) else 0,
+                }
+            )
+
+        # Server saves
+        server_saves: list[dict] = []
+        device_id = self._state_svc.get_server_device_id()
+        try:
+            server_saves = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
+                ),
+            )
+        except Exception as e:
+            self._log_debug(f"get_save_setup_info({rom_id}): failed to list saves: {e}")
+
+        # Group server saves by slot
+        slots_map: dict[str | None, list[dict]] = {}
+        for ss in server_saves:
+            slot_key = ss.get("slot")
+            slots_map.setdefault(slot_key, []).append(ss)
+
+        server_slots = []
+        for slot_key, saves in slots_map.items():
+            latest = max((s.get("updated_at", "") for s in saves), default=None)
+            server_slots.append(
+                {
+                    "slot": slot_key,
+                    "saves": [
+                        {
+                            "id": s.get("id"),
+                            "file_name": s.get("file_name", ""),
+                            "emulator": s.get("emulator", ""),
+                            "updated_at": s.get("updated_at", ""),
+                            "file_size_bytes": s.get("file_size_bytes", 0),
+                        }
+                        for s in saves
+                    ],
+                    "count": len(saves),
+                    "latest_updated_at": latest,
+                }
+            )
+
+        # State info
+        game_state = self._state_svc.state.saves.get(rom_id_str)
+        default_slot = self._state_svc.state.settings.default_slot or "default"
+        slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
+        active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
+
+        # Pre-computed wizard recommendation: auto-confirm the default slot only
+        # when there are local saves and the server has no slots yet. Every other
+        # combination needs the wizard so the user can choose.
+        recommended_action = (
+            "auto_confirm_default" if (len(local_files) > 0 and len(server_slots) == 0) else "show_wizard"
+        )
+
+        return {
+            "has_local_saves": len(local_files) > 0,
+            "local_files": local_file_info,
+            "server_slots": server_slots,
+            "default_slot": default_slot,
+            "slot_confirmed": slot_confirmed,
+            "active_slot": active_slot,
+            "recommended_action": recommended_action,
+        }
+
+    async def confirm_slot_choice(
+        self,
+        rom_id: int,
+        chosen_slot: str,
+        migrate_from_slot: str | None | object = _NO_MIGRATION,
+    ) -> dict:
+        """Confirm which slot to use for a game's save sync.
+
+        Sets slot_confirmed=true and active_slot in state.
+
+        If migrate_from_slot is provided (can be None for legacy no-slot saves),
+        migrates saves: upload local files to chosen_slot, then delete old server saves.
+        Pass _NO_MIGRATION sentinel (the default) to skip migration.
+        """
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+        chosen_slot = str(chosen_slot).strip()
+        if not chosen_slot:
+            return {"success": False, "needs_conflict_resolution": False, "message": "Slot name cannot be empty"}
+
+        # Update state
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        rom_state.active_slot = chosen_slot
+        rom_state.slot_confirmed = True
+
+        # Migration: re-upload local files to new slot, delete old server saves
+        if migrate_from_slot is not _NO_MIGRATION:
+            # migrate_from_slot can be None (legacy no-slot) or a string slot name
+            from_slot: str | None = migrate_from_slot if isinstance(migrate_from_slot, str) else None
+            try:
+                await self._migrate_slot_saves(rom_id, rom_id_str, chosen_slot, from_slot)
+            except Exception as e:
+                self._logger.warning(f"confirm_slot_choice({rom_id}): migration failed: {e}")
+                self._state_svc.save_state()
+                return {
+                    "success": True,
+                    "needs_conflict_resolution": False,
+                    "message": f"Slot confirmed but migration failed: {e}",
+                }
+
+        self._state_svc.save_state()
+        return {"success": True, "needs_conflict_resolution": False, "message": "Slot confirmed"}
+
+    async def _migrate_slot_saves(
+        self,
+        rom_id: int,
+        rom_id_str: str,
+        chosen_slot: str,
+        migrate_from_slot: str | None,
+    ) -> None:
+        """Migrate server saves from one slot to another.
+
+        For each local file: upload with new slot, then delete old server save.
+        Safe order: POST first, DELETE after.
+        """
+        device_id = self._state_svc.get_server_device_id()
+
+        # Find server saves in the old slot
+        all_saves = await self._loop.run_in_executor(
+            None,
+            lambda: self._retry.with_retry(
+                lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
+            ),
+        )
+        old_slot_saves = [s for s in all_saves if s.get("slot") == migrate_from_slot]
+        if not old_slot_saves:
+            return
+
+        # Get local files for re-upload
+        local_files = self._rom_info.find_save_files(rom_id)
+        local_by_name = {lf["filename"]: lf for lf in local_files}
+
+        # Resolve emulator tag
+        info = self._rom_info.get_rom_save_info(rom_id)
+        system = info["system"] if info else ""
+        installed = self._state["installed_roms"].get(rom_id_str, {})
+        rom_filename = os.path.basename(installed.get("file_path", "")) or None
+        core_so, _label = self._get_active_core(system, rom_filename)
+        emulator = build_emulator_tag(core_so)
+
+        ids_to_delete: list[int] = []
+
+        for old_save in old_slot_saves:
+            fname = old_save.get("file_name", "")
+            local_file = local_by_name.get(fname)
+            if local_file and self._save_file.is_file(local_file["path"]):
+                # Upload to new slot
+                await self._loop.run_in_executor(
+                    None,
+                    lambda lf=local_file, em=emulator: self._retry.with_retry(
+                        lambda: self._romm_api.upload_save(
+                            rom_id,
+                            lf["path"],
+                            em,
+                            device_id=device_id,
+                            slot=chosen_slot,
+                        ),
+                    ),
+                )
+            old_id = old_save.get("id")
+            if old_id is not None:
+                ids_to_delete.append(old_id)
+
+        # Delete old saves
+        if ids_to_delete:
+            await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.delete_server_saves(ids_to_delete),
+                ),
+            )

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -1,0 +1,251 @@
+"""Active-slot mutation and the destructive slot-switch flow.
+
+Anything that flips the active slot on a ROM lives here — the simple
+state-only ``_set_active_slot`` flip and the full ``switch_slot`` flow
+that synchronises the local saves directory to the new slot's contents.
+Slot listing, the setup wizard, and slot deletion belong in their own
+sub-modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from services.saves._helpers import _local_save_target
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from services.protocols import (
+        Clock,
+        DebugLogger,
+        RetryStrategy,
+        RommSaveApi,
+        SaveFileAdapter,
+    )
+    from services.saves.rom_info import RomInfoService
+    from services.saves.state import StateService
+    from services.saves.status import StatusService
+    from services.saves.sync_engine import SyncEngine
+
+
+class SlotSwitcher:
+    """Active-slot setter + the destructive slot-switch flow.
+
+    Owns ``_set_active_slot`` (the lightweight active-slot flip used
+    elsewhere in the slots package and by the setup wizard) and
+    ``switch_slot`` (the full pre-check + state-sync flow surfaced as a
+    public callable).
+    """
+
+    def __init__(
+        self,
+        *,
+        state_svc: StateService,
+        sync_engine: SyncEngine,
+        status_service: StatusService,
+        rom_info: RomInfoService,
+        romm_api: RommSaveApi,
+        retry: RetryStrategy,
+        loop: asyncio.AbstractEventLoop,
+        clock: Clock,
+        save_file: SaveFileAdapter,
+        log_debug: DebugLogger,
+    ) -> None:
+        self._state_svc = state_svc
+        self._sync_engine = sync_engine
+        self._status_service = status_service
+        self._rom_info = rom_info
+        self._romm_api = romm_api
+        self._retry = retry
+        self._loop = loop
+        self._clock = clock
+        self._save_file = save_file
+        self._log_debug = log_debug
+
+    def _set_active_slot(self, rom_id: int, slot: str) -> dict:
+        """Set the active save slot for a specific game.
+
+        If the slot doesn't exist yet (not on server), it is persisted
+        as a local slot. It will be promoted to server once a save is
+        uploaded to it.
+        """
+        rom_id = int(rom_id)
+        slot_str = str(slot).strip() if slot else ""
+        # Empty string = legacy mode (None slot)
+        resolved_slot: str | None = slot_str if slot_str else None
+
+        rom_id_str = str(rom_id)
+        rom_state = self._state_svc.ensure_rom_state(rom_id_str)
+        rom_state.active_slot = resolved_slot
+
+        # Ensure slot is in the persisted slots dict (use "" as key for legacy/None)
+        slot_key = resolved_slot if resolved_slot is not None else ""
+        if slot_key not in rom_state.slots:
+            rom_state.slots[slot_key] = {"source": "local", "count": 0, "latest_updated_at": None}
+
+        self._state_svc.save_state()
+        self._loop.create_task(self._status_service.check_save_status_background(rom_id))
+        return {"success": True, "active_slot": resolved_slot}
+
+    def _check_slot_switch_readiness(self, rom_id: int) -> dict:
+        """Check whether it is safe to switch slots for this ROM.
+
+        A switch is unsafe if local files have changed since the last sync
+        to the current slot — those changes would be lost.
+        Files that were never synced do not block (they'll be deleted on switch).
+
+        Returns ``{"ready": True}`` or
+        ``{"ready": False, "reason": str, "files": list[str]}``.
+        """
+        rom_id_str = str(rom_id)
+        save_state = self._state_svc.state.saves.get(rom_id_str)
+        files_state = save_state.files if save_state else {}
+
+        pending: list[str] = []
+        local_files = self._rom_info.find_save_files(rom_id)
+        for lf in local_files:
+            filename = lf["filename"]
+            file_state = files_state.get(filename)
+            last_sync_hash = file_state.last_sync_hash if file_state else None
+            if last_sync_hash:
+                current_hash = self._save_file.checksum_md5(lf["path"])
+                if current_hash != last_sync_hash:
+                    pending.append(filename)
+
+        if pending:
+            return {"ready": False, "reason": "pending_uploads", "files": pending}
+
+        return {"ready": True}
+
+    async def switch_slot(self, rom_id: int, new_slot: str) -> dict:
+        """Switch the active save slot with immediate state sync.
+
+        Pre-checks (all must pass):
+        1. Save sync must be enabled.
+        2. ROM must be installed.
+        3. No local files with pending changes (changed since last sync to current slot).
+        4. Server must be reachable.
+
+        On success:
+        - If the new slot has server saves: downloads them, replacing local files.
+        - If the new slot is empty: deletes local save files (fresh start).
+        - Never uploads — saves are not carried between slots.
+        """
+        rom_id = int(rom_id)
+        rom_id_str = str(rom_id)
+
+        # 1. Save sync must be enabled
+        if not self._state_svc.is_save_sync_enabled():
+            return {"success": False, "reason": "sync_disabled"}
+
+        # 2. Slot normalisation (empty → None for legacy mode)
+        slot_str = str(new_slot).strip() if new_slot else ""
+        resolved_slot: str | None = slot_str if slot_str else None
+
+        # 3. ROM must be installed
+        info = self._rom_info.get_rom_save_info(rom_id)
+        if not info:
+            return {"success": False, "reason": "not_installed"}
+
+        saves_dir = info["saves_dir"]
+        system = info["system"]
+
+        # 4. Check for pending local changes (hashing — run in executor)
+        readiness = await self._loop.run_in_executor(
+            None,
+            self._check_slot_switch_readiness,
+            rom_id,
+        )
+        if not readiness.get("ready"):
+            return {
+                "success": False,
+                "reason": readiness.get("reason", "pending_uploads"),
+                "files": readiness.get("files", []),
+            }
+
+        # 5. Fetch server saves for the new slot (also proves server is reachable)
+        device_id = self._state_svc.get_server_device_id()
+        try:
+            all_server_saves: list[dict] = await self._loop.run_in_executor(
+                None,
+                lambda: self._retry.with_retry(
+                    lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
+                ),
+            )
+        except Exception:
+            return {"success": False, "reason": "server_unreachable"}
+
+        # Filter to the target slot (FakeSaveApi doesn't filter, real API may not either)
+        # Normalize "" and None both to None before comparing (legacy saves may use either)
+        slot_saves = [s for s in all_server_saves if (s.get("slot") or None) == resolved_slot]
+
+        # 6. Update active slot in state
+        self._set_active_slot(rom_id, new_slot)
+
+        # 7. Sync local state to match the new slot
+        if slot_saves:
+            # New slot has server saves — download them, replacing local files.
+            # rom_name is guaranteed by the earlier ``info`` check.
+            await self._loop.run_in_executor(
+                None,
+                self._do_switch_downloads,
+                slot_saves,
+                saves_dir,
+                rom_id_str,
+                system,
+                info["rom_name"],
+            )
+        else:
+            # New slot is empty — delete local save files for a fresh start
+            await self._loop.run_in_executor(
+                None,
+                self._delete_local_saves_for_switch,
+                rom_id,
+                rom_id_str,
+            )
+
+        # 8. Update last_sync_check_at
+        save_entry = self._state_svc.ensure_rom_state(rom_id_str)
+        save_entry.last_sync_check_at = self._clock.now().isoformat()
+        self._state_svc.save_state()
+
+        # 9. Return fresh status
+        save_status = await self._status_service.get_save_status(rom_id)
+        return {"success": True, "save_status": save_status}
+
+    def _do_switch_downloads(
+        self,
+        slot_saves: list[dict],
+        saves_dir: str,
+        rom_id_str: str,
+        system: str,
+        rom_name: str,
+    ) -> None:
+        """Download all saves from *slot_saves* into *saves_dir*.
+
+        Each save lands at ``<saves_dir>/<rom_name>.<server.file_extension>`` —
+        the canonical RetroArch path. Runs synchronously; call via
+        ``run_in_executor``.
+        """
+        for server_save in slot_saves:
+            target = _local_save_target(server_save, rom_name)
+            self._sync_engine._do_download_save(server_save, saves_dir, target, rom_id_str, system)
+
+    def _delete_local_saves_for_switch(self, rom_id: int, rom_id_str: str) -> None:
+        """Delete local save files and clear file tracking state for a slot switch.
+
+        Unlike delete_local_saves (the callable), this preserves slot config
+        (active_slot, slot_confirmed, slots dict) and only clears files + tracking.
+        Runs synchronously — call via run_in_executor.
+        """
+        local_files = self._rom_info.find_save_files(rom_id)
+        for lf in local_files:
+            try:
+                self._save_file.remove(lf["path"])
+                self._log_debug(f"Deleted local save for switch: {lf['filename']}")
+            except Exception as e:
+                self._log_debug(f"Failed to delete {lf['filename']} during switch: {e}")
+
+        # Clear file tracking state (but keep slot config)
+        self._state_svc.clear_files_state(rom_id_str)


### PR DESCRIPTION
## Summary

`services/saves/slots/service.py` was 762 LOC over the `[ours]` 700 threshold. Decomposed into focused sub-modules within `services/saves/slots/`, mirroring the `services/saves/sync_engine/` pattern from #495.

## LOC after

| File | LOC |
|---|---|
| `service.py` | 177 (was 770) |
| `setup.py` | 268 |
| `switching.py` | 251 |
| `deletion.py` | 194 |
| `listing.py` | 168 |
| `__init__.py` | 11 |

All sub-modules ≤500 LOC.

## Sub-module mapping

| Sub-module | Class | Responsibility |
|---|---|---|
| `listing.py` | `SlotListing` | `get_save_slots`, `_merge_persisted_slots`, `get_slot_saves` |
| `switching.py` | `SlotSwitcher` | `_set_active_slot`, `_check_slot_switch_readiness`, `switch_slot`, downloads + delete-for-switch |
| `setup.py` | `SetupWizard` | Setup-wizard flow: `is_save_tracking_configured`, `get_save_setup_info`, `confirm_slot_choice`, `_migrate_slot_saves` |
| `deletion.py` | `SlotDeleter` | `_validate_slot_operation`, `get_slot_delete_info`, `delete_slot`, server-saves cleanup |

`SlotsService` (facade in `service.py`) instantiates the four sub-modules from `SlotsServiceConfig` and delegates public methods. Internal delegate methods (`_set_active_slot`, `confirm_slot_choice`) kept on the facade because tests access them.

## Constraints preserved

- `SlotsService.__init__(*, config: SlotsServiceConfig)` signature unchanged
- `SlotsServiceConfig` fields unchanged
- `_NO_MIGRATION` sentinel still importable from `services.saves.slots.service`
- All public method signatures unchanged

## Test plan

- [x] `pytest`: 2441 passed (unchanged — tests untouched)
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Closes #558