### PR TITLE
chore: delete SyncOrchestrator safety-timeout watchdog (#564)

### DIFF
--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -55,10 +55,11 @@ class LibrarySyncStateBox:
     """In-memory state for one library sync run, plus held preview/apply data.
 
     Holds the current ``SyncState`` (idle/running/cancelling), the
-    generation id used by the safety-timeout guard, the heartbeat
-    timestamp, the live progress dict emitted to the frontend, and the
-    apply-staging dicts populated during ``sync_preview`` /
-    ``sync_apply_delta`` and consumed by ``report_sync_results``.
+    generation id used to invalidate stale background work after the
+    run ends, the heartbeat timestamp, the live progress dict emitted
+    to the frontend, and the apply-staging dicts populated during
+    ``sync_preview`` / ``sync_apply_delta`` and consumed by
+    ``report_sync_results``.
     """
 
     sync_state: SyncState = SyncState.IDLE

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -209,8 +209,9 @@ class SyncReporter:
             )
             self._logger.info(f"Sync results reported: {total} games")
         self._sync_state.sync_state = SyncState.IDLE
-        # Invalidate any in-flight safety timeout — sync is over, no
-        # late "done" event should fire on top of the one we just emitted.
+        # Invalidate the run's generation id — any in-flight per-unit
+        # waits that wake after this point see a stale id and exit
+        # without emitting a late "done".
         self._sync_state.current_sync_id = None
         return {"success": True}
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -1,14 +1,15 @@
-"""Preview / apply / per-unit sync lifecycle and the safety heartbeat.
+"""Preview / apply / per-unit sync lifecycle and the heartbeat clock.
 
 Owns every async path the user triggers from the QAM that mutates
 in-flight sync state: starting and cancelling syncs, prefetching
-units for a preview, dispatching the per-unit sync pipeline on apply,
-and the safety-timeout watchdog that closes out stuck "applying"
-phases. Progress emission also lives here — sub-services that need
-to surface progress receive the orchestrator's ``_emit_progress``
-callback through their config. Anything that fetches ROMs belongs in
-:class:`LibraryFetcher`; anything that finalises shortcuts after the
-apply completes belongs in :class:`SyncReporter`.
+units for a preview, and dispatching the per-unit sync pipeline on
+apply. The heartbeat clock — refreshed on every progress emission
+and inspected by per-unit waits — lives here too. Progress emission
+also lives here — sub-services that need to surface progress receive
+the orchestrator's ``_emit_progress`` callback through their config.
+Anything that fetches ROMs belongs in :class:`LibraryFetcher`;
+anything that finalises shortcuts after the apply completes belongs
+in :class:`SyncReporter`.
 """
 
 from __future__ import annotations
@@ -140,7 +141,7 @@ class SyncOrchestrator:
         return {"success": True, "message": "Sync cancelling..."}
 
     def sync_heartbeat(self):
-        """Called by frontend during shortcut application to keep safety timeout alive."""
+        """Called by frontend during shortcut application to refresh the per-unit heartbeat clock."""
         self._sync_state.sync_last_heartbeat = self._clock.monotonic()
         return {"success": True}
 
@@ -265,9 +266,9 @@ class SyncOrchestrator:
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
 
-        # Update sync_stats up-front so the safety-timeout fallback path
-        # surfaces a sensible "X games from Y platforms" message even if
-        # the per-unit dispatch later stalls.
+        # Update sync_stats up-front so ``get_sync_stats`` and any
+        # subsequent shortcut-removal pass see the apply's intended
+        # counts even if the per-unit dispatch later stalls.
         self._state["sync_stats"] = {
             "platforms": delta.platforms_count,
             "roms": delta.total_roms,
@@ -303,49 +304,6 @@ class SyncOrchestrator:
             "totalSteps": total_steps,
         }
         await self._emit("sync_progress", self._sync_state.sync_progress)
-
-    def _start_safety_timeout(self, heartbeat_timeout_sec=30) -> asyncio.Task:
-        """Launch a background task that auto-completes sync if no heartbeat arrives.
-
-        Returns the spawned task so tests can deterministically await its
-        completion; production callers ignore the return value.
-        """
-        box = self._sync_state
-        box.sync_last_heartbeat = self._clock.monotonic()
-        captured_sync_id = box.current_sync_id
-
-        async def _safety_timeout():
-            while box.sync_progress.get("running"):
-                await self._sleeper.sleep(10)
-                # Generation guard: if our sync has ended (cancel, error,
-                # normal completion), current_sync_id was cleared or
-                # replaced. Don't fire stale "done" or overwrite the new
-                # sync state.
-                if box.current_sync_id != captured_sync_id:
-                    return
-                elapsed = self._clock.monotonic() - box.sync_last_heartbeat
-                if elapsed > heartbeat_timeout_sec:
-                    self._logger.warning(f"Sync safety timeout: no heartbeat for {elapsed:.0f}s")
-                    stats = self._state.get("sync_stats", {})
-                    await self._emit_progress(
-                        "done",
-                        current=stats.get("roms", 0),
-                        total=stats.get("roms", 0),
-                        message=(
-                            f"Sync complete: {stats.get('roms', 0)} games from {stats.get('platforms', 0)} platforms"
-                        ),
-                        running=False,
-                    )
-                    # Second generation check: the await above yielded the
-                    # event loop, so a new sync may have started during
-                    # _emit_progress. Don't stomp its state.
-                    if box.current_sync_id != captured_sync_id:
-                        return
-                    box.sync_state = SyncState.IDLE
-                    box.current_sync_id = None
-                    return
-
-        return self._loop.create_task(_safety_timeout())
 
     # ── Sync termination ─────────────────────────────────────────
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -375,7 +375,8 @@ class TestSyncApplyDelta:
 
     @pytest.mark.asyncio
     async def test_apply_persists_sync_stats(self, plugin, tmp_path):
-        """Apply writes the preview's platform/rom counts into ``sync_stats`` for the safety-timeout fallback."""
+        """Apply writes the preview's platform/rom counts into ``sync_stats`` so
+        ``get_sync_stats`` and the shortcut-removal pass see the apply's counts."""
         import decky
 
         plugin.loop = asyncio.get_event_loop()
@@ -548,8 +549,8 @@ class TestFinishSync:
 
     @pytest.mark.asyncio
     async def test_clears_current_sync_id(self, plugin):
-        """_finish_sync invalidates _current_sync_id so any in-flight safety
-        timeout for the cancelled sync sees a stale generation."""
+        """_finish_sync invalidates _current_sync_id so generation-guarded
+        background work (per-unit heartbeat) sees a stale generation."""
         plugin._sync_service._sync_state = SyncState.RUNNING
         plugin._sync_service._sync_progress = {"running": True}
         plugin._sync_service._current_sync_id = "sync-abc"
@@ -557,180 +558,6 @@ class TestFinishSync:
         await plugin._sync_service._orchestrator._finish_sync("Sync cancelled")
 
         assert plugin._sync_service._current_sync_id is None
-
-
-class TestSafetyTimeoutGenerationGuard:
-    """Regression for #351 — safety timeout must not emit a stale "done"
-    after _finish_sync (cancel/error) or report_sync_results (happy end)
-    has already transitioned the sync."""
-
-    @staticmethod
-    def _gated_sleeper(release: "asyncio.Event"):
-        """A sleeper that blocks until ``release`` is set."""
-
-        class _Gated:
-            async def sleep(self, _seconds: float) -> None:
-                await release.wait()
-
-        return _Gated()
-
-    @pytest.mark.asyncio
-    async def test_safety_timeout_silenced_after_finish_sync(self, plugin):
-        """Cancel during sync → safety timeout's late wake-up emits nothing.
-
-        Reproduces the original glitch: UI receiving `cancelled` followed by
-        a phantom `done` because the background timeout fired after
-        ``_finish_sync`` had already transitioned to IDLE.
-        """
-        import decky
-
-        svc = plugin._sync_service
-        loop = asyncio.get_event_loop()
-        plugin.loop = loop
-        svc._loop = loop
-
-        release = asyncio.Event()
-        svc._sleeper = self._gated_sleeper(release)
-        svc._sync_state = SyncState.RUNNING
-        svc._current_sync_id = "sync-abc"
-        svc._sync_progress = {"running": True, "current": 5, "total": 10}
-
-        decky.emit.reset_mock()
-        task = svc._orchestrator._start_safety_timeout(heartbeat_timeout_sec=1)
-        # Advance past the heartbeat timeout so the elapsed check would
-        # otherwise fire — the generation guard must override it.
-        svc._clock.advance(999)
-
-        # Let the safety-timeout task park on the gated sleep.
-        await asyncio.sleep(0)
-        # Cancel completes — clears _current_sync_id while timeout is parked.
-        await svc._orchestrator._finish_sync("Sync cancelled")
-        # Release the timeout; its generation guard should fire and exit.
-        release.set()
-        await task
-
-        progress_phases = [
-            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
-        ]
-        assert "cancelled" in progress_phases
-        # The original glitch: a phantom "done" landing after "cancelled".
-        assert "done" not in progress_phases
-
-    @pytest.mark.asyncio
-    async def test_safety_timeout_fires_when_generation_unchanged(self, plugin):
-        """Sanity check the guard isn't over-eager: same generation → still fires."""
-        import decky
-
-        svc = plugin._sync_service
-        loop = asyncio.get_event_loop()
-        plugin.loop = loop
-        svc._loop = loop
-
-        release = asyncio.Event()
-        svc._sleeper = self._gated_sleeper(release)
-        svc._sync_state = SyncState.RUNNING
-        svc._current_sync_id = "sync-xyz"
-        svc._sync_progress = {"running": True, "current": 5, "total": 10}
-        svc._state["sync_stats"] = {"roms": 5, "platforms": 1}
-
-        decky.emit.reset_mock()
-        task = svc._orchestrator._start_safety_timeout(heartbeat_timeout_sec=1)
-        # Advance the FakeClock past the timeout so elapsed > heartbeat_timeout.
-        svc._clock.advance(999)
-
-        await asyncio.sleep(0)
-        # No cancel — generation id unchanged. Release the sleep; timeout fires.
-        release.set()
-        await task
-
-        progress_phases = [
-            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
-        ]
-        assert "done" in progress_phases
-        assert svc._sync_state == SyncState.IDLE
-        assert svc._current_sync_id is None
-
-    @pytest.mark.asyncio
-    async def test_safety_timeout_silenced_after_report_sync_results(self, plugin, tmp_path):
-        """Happy-end path → safety timeout's late wake-up emits nothing.
-
-        Mirrors the cancel scenario for the report_sync_results clearing
-        path: frontend reports successfully, _current_sync_id is cleared,
-        any in-flight safety timeout sees the stale captured id and exits.
-        """
-        import decky
-
-        from adapters.persistence import PersistenceAdapter
-
-        svc = plugin._sync_service
-        loop = asyncio.get_event_loop()
-        plugin.loop = loop
-        svc._loop = loop
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-        release = asyncio.Event()
-        svc._sleeper = self._gated_sleeper(release)
-        svc._sync_state = SyncState.RUNNING
-        svc._current_sync_id = "sync-happy"
-        svc._sync_progress = {"running": True, "current": 5, "total": 10}
-        svc._pending_sync = {}
-
-        decky.emit.reset_mock()
-        task = svc._orchestrator._start_safety_timeout(heartbeat_timeout_sec=1)
-        svc._clock.advance(999)
-
-        await asyncio.sleep(0)
-        # Happy end: report_sync_results clears the id and transitions to IDLE.
-        await plugin.report_sync_results({}, [])
-        release.set()
-        await task
-
-        progress_phases = [
-            call.args[1]["phase"] for call in decky.emit.call_args_list if call.args and call.args[0] == "sync_progress"
-        ]
-        # report_sync_results emits its own "done"; the safety timeout's
-        # captured id no longer matches, so it does NOT emit a second one.
-        assert progress_phases.count("done") == 1
-        assert svc._current_sync_id is None
-
-    @pytest.mark.asyncio
-    async def test_safety_timeout_does_not_stomp_new_sync_started_during_emit(self, plugin):
-        """Post-emit re-check: a new sync starting between safety timeout's
-        emit and its IDLE/clear must not have its state stomped."""
-        import decky
-
-        svc = plugin._sync_service
-        loop = asyncio.get_event_loop()
-        plugin.loop = loop
-        svc._loop = loop
-
-        release = asyncio.Event()
-        svc._sleeper = self._gated_sleeper(release)
-        svc._sync_state = SyncState.RUNNING
-        svc._current_sync_id = "sync-old"
-        svc._sync_progress = {"running": True, "current": 5, "total": 10}
-        svc._state["sync_stats"] = {"roms": 5, "platforms": 1}
-
-        # Inject a new-sync start during the safety timeout's _emit_progress
-        # await by stubbing _emit_progress to mutate the live state mid-call.
-        async def _emit_progress_mid_start(*_a, **_kw):
-            # Simulate a fresh sync racing in between emit and stomp.
-            svc._sync_state = SyncState.RUNNING
-            svc._current_sync_id = "sync-new"
-
-        svc._orchestrator._emit_progress = _emit_progress_mid_start
-
-        decky.emit.reset_mock()
-        task = svc._orchestrator._start_safety_timeout(heartbeat_timeout_sec=1)
-        svc._clock.advance(999)
-
-        await asyncio.sleep(0)
-        release.set()
-        await task
-
-        # The new sync's state must be intact — safety timeout's second
-        # generation check observed the change and exited.
-        assert svc._sync_state == SyncState.RUNNING
-        assert svc._current_sync_id == "sync-new"
 
 
 class TestSyncPreviewErrorHandling:


### PR DESCRIPTION
## Summary

The watchdog was replaced in #436 by per-unit heartbeat polling (`_unit_wait_with_heartbeat`). Zero production callers; only tests drove the deleted method.

## Removed

- `SyncOrchestrator._start_safety_timeout` + nested `_safety_timeout()` async loop (~42 lines, `sync_orchestrator.py:307-348`)
- 4 tests in `TestSafetyTimeoutGenerationGuard` class + `_gated_sleeper` helper (~172 lines)
- Stale rationale comments in `sync_orchestrator.py`, `reporter.py`, `_state.py` referencing the deleted watchdog

`_unit_wait_with_heartbeat` (live), `sync_last_heartbeat`, and `current_sync_id` are untouched — they back the per-unit polling that replaced the watchdog.

## Test plan

- [x] `pytest`: 2413 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Net: **+25 / -238 lines**

Closes #564