### PR TITLE
chore: trim PreviewDelta to 4 used fields (#562)

### DIFF
--- a/py_modules/domain/preview_delta.py
+++ b/py_modules/domain/preview_delta.py
@@ -17,21 +17,13 @@ class PreviewDelta:
     ``preview_id`` ties the snapshot to the frontend's apply call; mismatched
     ids cause the apply to be rejected as stale. ``created_at`` is the wall
     clock at preview time so apply can reject snapshots older than the TTL.
-    All other fields are the classified-ROM buckets, the full shortcut map
-    (used by downstream artwork and result reporting), the ROM payloads
-    needed for artwork download, and the collection/platform context that
-    feeds the result-aggregation step.
+    ``platforms_count`` and ``total_roms`` are persisted into ``sync_stats``
+    on apply so ``get_sync_stats`` and the stale-removal pass see the
+    apply's intended counts. The per-unit pipeline gets ROM data from
+    :class:`PrefetchedUnit` on the state box, not from this snapshot.
     """
 
     preview_id: str
     created_at: float
-    new: list[dict]
-    changed: list[dict]
-    unchanged_ids: list[int]
-    remove_rom_ids: list[int]
-    all_shortcuts: dict[int, dict]
-    delta_roms: list[dict]
     platforms_count: int
     total_roms: int
-    collection_memberships: dict[str, list[int]]
-    platform_rom_ids: set[int]

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -179,26 +179,13 @@ class SyncOrchestrator:
                 platform_names,
             )
 
-            # Build rom lookup for artwork download during apply
-            roms_by_id = {r["id"]: r for r in all_roms}
-            delta_rom_ids = {sd["rom_id"] for sd in new + changed}
-            delta_roms = [roms_by_id[rid] for rid in delta_rom_ids if rid in roms_by_id]
-
             preview_id = self._uuid_gen.uuid4()
             platforms_count = sum(1 for u in prefetched if u.unit.type == "platform")
             box.pending_delta = PreviewDelta(
                 preview_id=preview_id,
                 created_at=self._clock.time(),
-                new=new,
-                changed=changed,
-                unchanged_ids=unchanged_ids,
-                remove_rom_ids=stale,
-                all_shortcuts={sd["rom_id"]: sd for sd in shortcuts_data},
-                delta_roms=delta_roms,
                 platforms_count=platforms_count,
                 total_roms=len(all_roms),
-                collection_memberships=collection_memberships,
-                platform_rom_ids=platform_rom_ids,
             )
             box.pending_prefetched_units = prefetched
 

--- a/tests/domain/test_preview_delta.py
+++ b/tests/domain/test_preview_delta.py
@@ -1,8 +1,8 @@
 """Unit tests for ``domain.preview_delta.PreviewDelta``.
 
-The dataclass is pure data — its contract is "all 12 fields are required,
+The dataclass is pure data — its contract is "all 4 fields are required,
 immutable, and exposed as typed attributes". Tests cover construction,
-frozen semantics, and the empty-collections boundary case.
+frozen semantics, and the zero-counts boundary case.
 """
 
 from __future__ import annotations
@@ -18,16 +18,8 @@ def _build(**overrides) -> PreviewDelta:
     defaults: dict = {
         "preview_id": "preview-abc",
         "created_at": 1_700_000_000.0,
-        "new": [{"rom_id": 1, "name": "Game A"}],
-        "changed": [{"rom_id": 2, "name": "Game B", "existing_app_id": 1002}],
-        "unchanged_ids": [3],
-        "remove_rom_ids": [4],
-        "all_shortcuts": {1: {"rom_id": 1}, 2: {"rom_id": 2}, 3: {"rom_id": 3}},
-        "delta_roms": [{"id": 1}, {"id": 2}],
         "platforms_count": 2,
         "total_roms": 3,
-        "collection_memberships": {"Favorites": [1, 2]},
-        "platform_rom_ids": {1, 2, 3},
     }
     defaults.update(overrides)
     return PreviewDelta(**defaults)
@@ -37,16 +29,8 @@ def test_construction_exposes_all_fields_as_attributes() -> None:
     delta = _build()
     assert delta.preview_id == "preview-abc"
     assert delta.created_at == 1_700_000_000.0
-    assert delta.new == [{"rom_id": 1, "name": "Game A"}]
-    assert delta.changed == [{"rom_id": 2, "name": "Game B", "existing_app_id": 1002}]
-    assert delta.unchanged_ids == [3]
-    assert delta.remove_rom_ids == [4]
-    assert delta.all_shortcuts == {1: {"rom_id": 1}, 2: {"rom_id": 2}, 3: {"rom_id": 3}}
-    assert delta.delta_roms == [{"id": 1}, {"id": 2}]
     assert delta.platforms_count == 2
     assert delta.total_roms == 3
-    assert delta.collection_memberships == {"Favorites": [1, 2]}
-    assert delta.platform_rom_ids == {1, 2, 3}
 
 
 def test_is_frozen_attribute_rebinding_raises() -> None:
@@ -55,22 +39,10 @@ def test_is_frozen_attribute_rebinding_raises() -> None:
         delta.preview_id = "other"  # type: ignore[misc]
 
 
-def test_empty_collections_are_accepted() -> None:
-    delta = _build(
-        new=[],
-        changed=[],
-        unchanged_ids=[],
-        remove_rom_ids=[],
-        all_shortcuts={},
-        delta_roms=[],
-        platforms_count=0,
-        total_roms=0,
-        collection_memberships={},
-        platform_rom_ids=set(),
-    )
-    assert delta.new == []
-    assert delta.all_shortcuts == {}
-    assert delta.platform_rom_ids == set()
+def test_zero_counts_are_accepted() -> None:
+    delta = _build(platforms_count=0, total_roms=0)
+    assert delta.platforms_count == 0
+    assert delta.total_roms == 0
 
 
 def test_equality_by_field_values() -> None:

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -155,7 +155,6 @@ class TestSyncPreview:
         assert plugin._sync_service._pending_delta is not None
         assert plugin._sync_service._pending_delta.preview_id == result["preview_id"]
         assert plugin._sync_service._pending_delta.created_at == plugin._sync_service._clock.time()
-        assert len(plugin._sync_service._pending_delta.new) == 1
         assert plugin._sync_service._pending_delta.platforms_count == 1
         assert plugin._sync_service._pending_delta.total_roms == 1
         # The unified path caches the prefetched units so apply can
@@ -237,39 +236,8 @@ class TestSyncApplyDelta:
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id=preview_id,
             created_at=plugin._sync_service._clock.time(),
-            new=[
-                {
-                    "rom_id": 3,
-                    "name": "Game C",
-                    "platform_name": "N64",
-                    "platform_slug": "n64",
-                    "fs_name": "c.z64",
-                    "cover_path": "",
-                },
-            ],
-            changed=[
-                {
-                    "rom_id": 2,
-                    "name": "New B",
-                    "existing_app_id": 1002,
-                    "platform_name": "N64",
-                    "platform_slug": "n64",
-                    "fs_name": "b.z64",
-                    "cover_path": "",
-                },
-            ],
-            unchanged_ids=[1],
-            remove_rom_ids=[99],
-            all_shortcuts={
-                1: {"rom_id": 1, "name": "Game A", "platform_name": "N64"},
-                2: {"rom_id": 2, "name": "New B", "platform_name": "N64"},
-                3: {"rom_id": 3, "name": "Game C", "platform_name": "N64"},
-            },
-            delta_roms=[],
             platforms_count=1,
             total_roms=3,
-            collection_memberships={},
-            platform_rom_ids=set(),
         )
         if with_prefetch:
             plugin._sync_service._box.pending_prefetched_units = [
@@ -448,16 +416,8 @@ class TestSyncCancelPreview:
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id="some-id",
             created_at=plugin._sync_service._clock.time(),
-            new=[],
-            changed=[],
-            unchanged_ids=[],
-            remove_rom_ids=[],
-            all_shortcuts={},
-            delta_roms=[],
             platforms_count=0,
             total_roms=0,
-            collection_memberships={},
-            platform_rom_ids=set(),
         )
         plugin._sync_service._box.pending_prefetched_units = [
             _platform_prefetched(name="X", slug="x", roms=[{"id": 1}])
@@ -1127,16 +1087,8 @@ class TestSyncApplyDeltaUnifiedDispatch:
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id="art-preview",
             created_at=plugin._sync_service._clock.time(),
-            new=[{"rom_id": 10, "name": "Game X", "platform_name": "N64"}],
-            changed=[],
-            unchanged_ids=[],
-            remove_rom_ids=[],
-            all_shortcuts={10: {"rom_id": 10, "name": "Game X", "platform_name": "N64"}},
-            delta_roms=roms,
             platforms_count=1,
             total_roms=1,
-            collection_memberships={},
-            platform_rom_ids={10},
         )
         plugin._sync_service._box.pending_prefetched_units = [
             _platform_prefetched(name="N64", slug="n64", roms=roms, skipped=False)
@@ -1177,16 +1129,8 @@ class TestSyncApplyDeltaUnifiedDispatch:
         plugin._sync_service._pending_delta = PreviewDelta(
             preview_id="skip-preview",
             created_at=plugin._sync_service._clock.time(),
-            new=[],
-            changed=[],
-            unchanged_ids=[10],
-            remove_rom_ids=[],
-            all_shortcuts={10: {"rom_id": 10, "name": "A", "platform_name": "N64"}},
-            delta_roms=[],
             platforms_count=1,
             total_roms=1,
-            collection_memberships={},
-            platform_rom_ids={10},
         )
         plugin._sync_service._box.pending_prefetched_units = [
             _platform_prefetched(name="N64", slug="n64", roms=roms, skipped=True)


### PR DESCRIPTION
## Summary

8 of 11 `PreviewDelta` fields were write-only post-#436. The per-unit pipeline gets ROM data via `pending_prefetched_units`, not the delta. The frontend reads counts from `result["summary"]["new_count"]` etc. directly from `classify_roms()`, not from the delta.

## Deleted

- 8 fields from `PreviewDelta`: `new`, `changed`, `unchanged_ids`, `remove_rom_ids`, `all_shortcuts`, `delta_roms`, `collection_memberships`, `platform_rom_ids`
- Upstream compute in `sync_orchestrator.py::sync_preview`: `roms_by_id`, `delta_rom_ids`, `delta_roms` locals — existed only to populate the dead fields
- `pending_delta.new` length assertion in `test_populates_pending_delta`
- Test cases asserting against the 8 deleted fields

## Preserved

- 4 surviving fields: `preview_id`, `created_at`, `platforms_count`, `total_roms`
- `classify_roms()` — still feeds the `summary` dict that the frontend reads

## Test plan

- [x] `pytest`: 2424 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Net: **+10 / -115 lines**

Closes #562