### PR TITLE
ci: align pnpm version and stop shipping source maps to users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -51,9 +49,14 @@ jobs:
           chmod +x /tmp/decky-cli/decky
           echo "/tmp/decky-cli" >> $GITHUB_PATH
 
-      - name: Build plugin
+      - name: Build frontend (no source maps in release zip)
         run: |
-          sudo $(which decky) plugin build -b -o /tmp/output -s directory $GITHUB_WORKSPACE
+          pnpm build
+          rm -f dist/*.map
+
+      - name: Package plugin
+        run: |
+          sudo $(which decky) plugin build -o /tmp/output -s directory $GITHUB_WORKSPACE
           sudo chown -R $(whoami) .
 
       - name: Determine tag name

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "rollup -c",
     "size": "size-limit"
   },
+  "packageManager": "pnpm@10.29.3",
   "license": "GPL-3.0",
   "dependencies": {
     "@decky/api": "^1.1.3",


### PR DESCRIPTION
## Source map bloat

Verified by `gh release download` on the latest release zip:

| | size |
|---|---|
| `dist/index.js` | 371 KB |
| `dist/index.js.map` | **2.0 MB** |

That source map ships in every release zip every user downloads, adding ~6× the actual bundle. release.yml now runs `pnpm build` directly, deletes `dist/*.map`, then invokes the decky CLI without `-b` so it just packages what's there. Source maps still exist locally and in CI artifacts — they just don't ship.

## pnpm version alignment

Local dev was on pnpm 10.29.3; CI was pinned to 9 via `pnpm/action-setup with version: 9` in two places. pnpm 9 ↔ 10 lockfile compatibility is currently fine, but worth removing before something subtle breaks.

- Add `packageManager: pnpm@10.29.3` to `package.json` (npm-standard field, honored by pnpm/action-setup@v6)
- Drop explicit `version: 9` from both `pnpm/action-setup@v6` calls (ci.yml + release.yml)

Action picks up the version from `packageManager` automatically. Single source of truth.

## Risk on release.yml change

Dropping `-b` from `decky plugin build` is the only behavioral risk — without it, the CLI is expected to package an existing `dist/` rather than rebuild. If that flag also did something else load-bearing, the next release run will surface it. Worst case: revert this one PR.