### PR TITLE
chore(ui): annotate 8 Sonar code-smell sites with NOSONAR (#577)

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -101,7 +101,7 @@ function showLaunchConfirmation(title: string, message: string): Promise<boolean
   });
 }
 
-export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
+export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // NOSONAR(typescript:S3776) — handlePlay gate chain; decomposed into gate-chain helpers in #389. Remaining cc is inherent to gate logic.
   const [state, setState] = useState<PlayButtonState>("loading");
   const [romId, setRomId] = useState<number | null>(null);
   const [romName, setRomName] = useState<string>("");
@@ -366,7 +366,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => {
 
   // Coordinator: runs each pre-launch gate in sequence, bailing on the first
   // cancel. All branch-specific UI lives in the helpers above.
-  const handlePlay = async () => {
+  const handlePlay = async () => { // NOSONAR(typescript:S3776) — gate chain coordinator; decomposed into gate helpers in #389. Remaining cc is inherent to gate logic.
     if (state === "syncing" || state === "launching") return; // debounce
     const overview = appStore.GetAppOverviewByAppID(appId);
     const gameId = overview?.GetGameID?.() ?? String(appId);

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -33,7 +33,7 @@ function formatFinishedDescription(item: DownloadItem): string {
 }
 
 export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
-  const [downloads, setLocalDownloads] = useState<DownloadItem[]>([]);
+  const [downloads, setLocalDownloads] = useState<DownloadItem[]>([]); // NOSONAR(typescript:S6754) — setter intentionally renamed (local wrapper around global download state).
   const [cleared, setCleared] = useState<Set<number>>(new Set());
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -283,7 +283,7 @@ async function loadData(
   }
 }
 
-export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => {
+export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { // NOSONAR(typescript:S3776) — React FC fan-out; decomposed in #387/#391/Phase 7. Further split scatters handlers.
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -105,7 +105,7 @@ interface InfoState {
   saveSyncStatus: "synced" | "conflict" | "none" | null;
   saveSyncLabel: string;
   biosNeeded: boolean;
-  biosStatus: "ok" | "partial" | "missing" | null;
+  biosStatus: "ok" | "partial" | "missing" | null; // NOSONAR(typescript:S4323) — inline union inside InfoState; extracting an alias adds indirection for no reuse benefit.
   biosLabel: string;
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
@@ -330,7 +330,7 @@ async function loadCached(
   }
 }
 
-export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => {
+export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOSONAR(typescript:S3776) — React FC body; decomposed in #392. Holds Steam menu + achievements + save-sync row.
   // Subscribe to version error — re-renders when global state changes
   const versionError = useVersionError();
   const migration = useMigrationStatus();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 }
 
 const QAMPanel: FC = () => {
-  const [page, setPageState] = useState<Page>(currentPage);
+  const [page, setPageState] = useState<Page>(currentPage); // NOSONAR(typescript:S6754) — setter intentionally renamed; setPage wraps it below to provide custom navigation behavior.
   const rootRef = useRef<HTMLDivElement>(null);
   const setPage = (p: Page) => { currentPage = p; setPageState(p); };
 

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -164,7 +164,7 @@ export async function initSessionManager(): Promise<void> {
           if (update.bRunning) {
             // Game started — wait for Router.MainRunningApp to populate
             await delay(500);
-            const running = typeof Router === "undefined" ? null : Router.MainRunningApp;
+            const running = typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
             const appId = running?.appid ?? update.unAppID;
             if (appId) {
               // Refresh map in case a sync happened since init


### PR DESCRIPTION
## Summary

Annotates 8 SonarCloud false positives / rule mismatches with `// NOSONAR(<rule>) — <reason>` so Sonar stops re-flagging them.

## Sites

| File:Line | Rule | Reason |
|---|---|---|
| `RomMGameInfoPanel.tsx:286` | S3776 | React FC fan-out — decomposed in #387/#391/Phase 7; further split scatters handlers |
| `RomMPlaySection.tsx:333` | S3776 | React FC body — decomposed in #392 |
| `CustomPlayButton.tsx:104` | S3776 | `handlePlay` gate chain — decomposed into gate helpers in #389 |
| `CustomPlayButton.tsx:369` | S3776 | Gate chain coordinator — same decomposition lineage |
| `DownloadQueue.tsx:36` | S6754 | `setLocalDownloads` intentionally renamed (local wrapper around global state) |
| `src/index.tsx:46` | S6754 | `setPageState` intentionally renamed; `setPage` wraps it for custom navigation |
| `sessionManager.ts:167` | S7741 | `Router` is an undeclared Steam SP global — `Router === undefined` would `ReferenceError` |
| `RomMPlaySection.tsx:108` | S4323 | Inline union inside `InfoState` — alias extraction adds indirection for no reuse benefit |

## Note

The S3776 default threshold of 15 is unrealistically low for React FCs in this codebase. Phase 7 (#386) was the systematic decomposition pass; further extraction creates artificial seams. This is the well-known Sonar-tax for React presentation roots.

## Test plan

- [x] `pnpm build` clean (Rollup 4.1s)
- [x] `pnpm exec tsc --noEmit --skipLibCheck` clean (one pre-existing deprecation warning about `moduleResolution=node10`, environmental, unrelated)

Closes #577