### PR TITLE
feat(bootstrap): add PluginMetadataReader Protocol + adapter (#576b)

### DIFF
--- a/py_modules/adapters/plugin_metadata.py
+++ b/py_modules/adapters/plugin_metadata.py
@@ -1,0 +1,23 @@
+"""Concrete ``PluginMetadataReader`` adapter — reads ``package.json``.
+
+Owns the raw ``open()`` + ``json.load()`` round-trip bootstrap formerly
+performed inline. A missing or malformed ``package.json`` is not a
+hard failure — bootstrap must keep wiring services even when the
+metadata read fails, so the adapter returns the documented fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+
+class PluginMetadataAdapter:
+    """Real ``PluginMetadataReader`` backed by the on-disk ``package.json``."""
+
+    def read_version(self, plugin_dir: str) -> str:
+        try:
+            with open(os.path.join(plugin_dir, "package.json")) as f:
+                return json.load(f).get("version", "0.0.0")
+        except (OSError, json.JSONDecodeError):
+            return "0.0.0"

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -31,6 +31,7 @@ from adapters.persistence import (
     SettingsPersisterAdapter,
     StatePersisterAdapter,
 )
+from adapters.plugin_metadata import PluginMetadataAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -298,18 +299,6 @@ def bootstrap(
     }
 
 
-def _read_plugin_version(plugin_dir: str) -> str:
-    """Read plugin version from package.json."""
-    import json
-    import os
-
-    try:
-        with open(os.path.join(plugin_dir, "package.json")) as f:
-            return json.load(f).get("version", "0.0.0")
-    except (OSError, json.JSONDecodeError):
-        return "0.0.0"
-
-
 def wire_services(cfg: WiringConfig) -> dict:
     """Create service instances after plugin state is initialised.
 
@@ -329,6 +318,8 @@ def wire_services(cfg: WiringConfig) -> dict:
     # the NameError a bare forward-ref lambda would produce.
     bios_files_index_binding: LateBinding[dict] = LateBinding("bios_files_index")
     pending_sync_binding: LateBinding[dict] = LateBinding("pending_sync")
+
+    plugin_metadata = PluginMetadataAdapter()
 
     # MigrationService is constructed before SaveService so that
     # save_sync_service can receive a bound reference to
@@ -366,7 +357,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         hostname_provider=cfg.runtime.hostname_provider,
         log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
-        plugin_version=_read_plugin_version(cfg.runtime.plugin_dir),
+        plugin_version=plugin_metadata.read_version(cfg.runtime.plugin_dir),
         emit=cfg.runtime.emit,
         # SaveService must observe fresh sort state before computing saves_dir (#238).
         detect_sort_change=migration_service.detect_save_sort_change,

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -71,6 +71,7 @@ from services.protocols.paths import (
 from services.protocols.persistence import (
     FirmwareCachePersister,
     MetadataCachePersister,
+    PluginMetadataReader,
     SaveSyncStatePersister,
     SettingsPersister,
     StatePersister,
@@ -118,6 +119,7 @@ __all__ = [
     "MigrationFileAdapter",
     "PathExistsProbe",
     "PendingSyncReader",
+    "PluginMetadataReader",
     "RetroArchConfigReader",
     "RetroArchCoreInfoReader",
     "RetroArchSaveSortingProvider",

--- a/py_modules/services/protocols/persistence.py
+++ b/py_modules/services/protocols/persistence.py
@@ -61,3 +61,24 @@ class FirmwareCachePersister(Protocol):
     def save(self, data: dict) -> None: ...
 
     def load(self) -> dict: ...
+
+
+class PluginMetadataReader(Protocol):
+    """Read plugin install metadata from ``package.json``.
+
+    Owns the one-shot read of the plugin's ``package.json`` at startup
+    so ``bootstrap`` does not perform raw ``open()`` calls. The plugin
+    directory is supplied by the caller — implementations resolve the
+    ``package.json`` path and parse the JSON payload. A missing or
+    malformed file must not abort bootstrap; implementations return the
+    documented fallback (``"0.0.0"`` for ``read_version``).
+    """
+
+    def read_version(self, plugin_dir: str) -> str:
+        """Return the plugin's declared semantic version.
+
+        Falls back to ``"0.0.0"`` when the file is missing, unreadable,
+        malformed, or has no ``version`` field — bootstrap must not
+        abort on a metadata read.
+        """
+        ...

--- a/tests/adapters/test_plugin_metadata.py
+++ b/tests/adapters/test_plugin_metadata.py
@@ -1,0 +1,63 @@
+"""Tests for the PluginMetadataAdapter — reads plugin package.json."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from adapters.plugin_metadata import PluginMetadataAdapter
+
+
+class TestPluginMetadataAdapter:
+    def test_read_version_returns_declared_version(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text(json.dumps({"version": "1.2.3"}))
+
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(plugin_dir)) == "1.2.3"
+
+    def test_read_version_missing_file_returns_fallback(self, tmp_path):
+        """A missing package.json must not abort bootstrap."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(plugin_dir)) == "0.0.0"
+
+    def test_read_version_missing_directory_returns_fallback(self, tmp_path):
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(tmp_path / "does-not-exist")) == "0.0.0"
+
+    def test_read_version_malformed_json_returns_fallback(self, tmp_path):
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text("{not valid json")
+
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(plugin_dir)) == "0.0.0"
+
+    def test_read_version_missing_version_field_returns_fallback(self, tmp_path):
+        """A package.json without a ``version`` key falls back to ``0.0.0``."""
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text(json.dumps({"name": "decky-romm-sync"}))
+
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(plugin_dir)) == "0.0.0"
+
+    @pytest.mark.parametrize("empty_value", ["", None])
+    def test_read_version_empty_version_returned_as_is(self, tmp_path, empty_value):
+        """The adapter does not validate the version string — empty/None pass through.
+
+        The fallback is only applied when the field is missing entirely; an
+        empty string or ``None`` reflects what the file actually contained
+        and surfaces upstream so a malformed publish can be diagnosed.
+        """
+        plugin_dir = tmp_path / "plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text(json.dumps({"version": empty_value}))
+
+        adapter = PluginMetadataAdapter()
+        assert adapter.read_version(str(plugin_dir)) == empty_value


### PR DESCRIPTION
## Summary

`bootstrap.py` was opening `package.json` directly via `with open(...)` to read the plugin version. Routes through a `PluginMetadataReader` Protocol (`services/protocols/persistence.py`) implemented by `PluginMetadataAdapter` (`adapters/plugin_metadata.py`).

## Why `persistence.py` (not `paths.py`)

It's a file-read seam for a plugin data file — semantic match with the other `*Persister` Protocols. `paths.py` is reserved for runtime path/system/core resolution.

## Changes

- `services/protocols/persistence.py` — added `PluginMetadataReader` Protocol with `read_version(plugin_dir: str) -> str`. Re-exported via `services/protocols/__init__.py`.
- `adapters/plugin_metadata.py` — new adapter lifting the `open()` + `json.load()` block verbatim, including the `(OSError, json.JSONDecodeError)` fallback to `"0.0.0"`.
- `bootstrap.py` — removed `_read_plugin_version` helper + inline `import json/os`; instantiates `PluginMetadataAdapter()` near `LateBinding` setup; calls `plugin_metadata.read_version(...)` at the version site.
- `tests/adapters/test_plugin_metadata.py` — happy path + bad paths (missing file/dir, malformed JSON, missing version field) + edge cases.

## Test plan

- [x] `pytest`: 2431 passed (was 2424 + 7 new tests)
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] `lint-imports`: 7 contracts kept
- [x] `cosmic-call-bans`: OK

Part of #576.