### PR TITLE
test(library): inject OSError via FakeCoverArtFileStore (#576c)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,10 @@ class FakeCoverArtFileStore:
     Tests can pre-populate ``files`` directly to stage fixtures, and
     inspect it after the act to assert removals/renames. ``isdir_paths``
     can be set explicitly when a test needs to model an empty directory
-    or override the path-based default.
+    or override the path-based default. ``rename_failures`` injects
+    ``OSError`` on ``rename`` for the listed source paths so tests can
+    exercise the production error-handling branches without patching
+    stdlib.
     """
 
     def __init__(self, files: dict[str, bytes] | None = None) -> None:
@@ -200,6 +203,12 @@ class FakeCoverArtFileStore:
         # Explicit directory whitelist; when None, isdir is inferred from
         # parent-of-files membership.
         self.isdir_paths: set[str] | None = None
+        # Source paths that should raise OSError on rename. Mirrors the
+        # Wave 3 fake-adapter failure-injection pattern (e.g.
+        # FakeDownloadFileAdapter / FakeFirmwareFileAdapter) so tests
+        # drive error paths through the Protocol instead of patching
+        # ``os.replace`` globally.
+        self.rename_failures: set[str] = set()
 
     def exists(self, path: str) -> bool:
         return path in self.files or self.isdir(path)
@@ -208,6 +217,8 @@ class FakeCoverArtFileStore:
         self.files.pop(path, None)
 
     def rename(self, src: str, dst: str) -> None:
+        if src in self.rename_failures:
+            raise OSError(f"rename failed for {src}")
         if src not in self.files:
             raise FileNotFoundError(src)
         self.files[dst] = self.files.pop(src)

--- a/tests/services/library/conftest.py
+++ b/tests/services/library/conftest.py
@@ -35,14 +35,16 @@ from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalSer
 if TYPE_CHECKING:
     # basedpyright resolves ``conftest`` to the nearest local file. The
     # actual fakes live in the parent ``tests/conftest.py``; declare the
-    # symbol for typing purposes here and let runtime resolve through
+    # symbols for typing purposes here and let runtime resolve through
     # ``importlib`` below.
-    from conftest import FakeSettingsPersister
+    from conftest import FakeCoverArtFileStore, FakeSettingsPersister
 
 # Runtime: pytest ensures the root ``tests/conftest.py`` is loaded under
 # the module name ``conftest`` before this local conftest is imported,
-# so the symbol is already on the loaded module.
-FakeSettingsPersister = importlib.import_module("conftest").FakeSettingsPersister
+# so the symbols are already on the loaded module.
+_root_conftest = importlib.import_module("conftest")
+FakeSettingsPersister = _root_conftest.FakeSettingsPersister
+FakeCoverArtFileStore = _root_conftest.FakeCoverArtFileStore
 
 
 @pytest.fixture

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+from conftest import FakeCoverArtFileStore
 
 from adapters.persistence import (
     PersistenceAdapter,
@@ -246,16 +247,19 @@ class TestFinalizeCoverPath:
         assert result == ""
 
     def test_handles_rename_os_error(self, plugin, tmp_path):
-        from unittest.mock import patch
-
         grid = str(tmp_path)
-        staging = tmp_path / "romm_1_cover.png"
-        staging.write_text("data")
+        staging_path = os.path.join(grid, "romm_1_cover.png")
 
-        with patch("os.replace", side_effect=OSError("perm denied")):
-            result = plugin._sync_service._reporter._finalize_cover_path(grid, str(staging), 100001, "1")
+        # Inject OSError on rename through the CoverArtFileStore Protocol —
+        # mirrors the Wave 3 fake-adapter failure-injection pattern instead
+        # of patching ``os.replace`` globally.
+        fake_store = FakeCoverArtFileStore(files={staging_path: b"data"})
+        fake_store.rename_failures.add(staging_path)
+        plugin._artwork_service._cover_art_file_store = fake_store
+
+        result = plugin._sync_service._reporter._finalize_cover_path(grid, staging_path, 100001, "1")
         # Should return original path on error
-        assert result == str(staging)
+        assert result == staging_path
 
 
 class TestBuildRegistryEntry:


### PR DESCRIPTION
## Summary

`tests/services/library/test_reporter.py::test_handles_rename_os_error` was using `patch("os.replace", side_effect=OSError(...))` to inject the failure — globally patching stdlib instead of going through the `CoverArtFileStore` Protocol that production code uses.

Replaces with fake-adapter failure injection (Wave 3 pattern). Test exercises the same error path through the proper seam.

## Changes

- `tests/conftest.py` — extended `FakeCoverArtFileStore` with `rename_failures: set[str]`. `rename()` raises `OSError` when src is in the set.
- `tests/services/library/conftest.py` — re-export shim for `FakeCoverArtFileStore` (basedpyright resolves to the nearest local conftest).
- `tests/services/library/test_reporter.py` — rewrote `test_handles_rename_os_error` to use the fake with `rename_failures.add(staging_path)`. Same assertion.

## Sanity check

Removed the `try/except OSError` in `services/artwork.py::ArtworkService.finalize_cover_path`. Test failed with `OSError` propagating out as expected. Restored production code; test passes again. Confirms the rewritten test exercises the real error path.

## Test plan

- [x] `pytest`: 2424 passed
- [x] `basedpyright`: 0 errors / 0 warnings
- [x] `ruff`: all checks pass
- [x] Sanity check confirmed the test catches a real regression

Part of #576.