### PR TITLE
chore(githooks): run basedpyright + pytest on feature branches

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Pre-commit hook: format and lint staged Python files with ruff
+# Pre-commit hook: format and lint staged Python files with ruff.
+# On feature branches, also run basedpyright + pytest before allowing the commit.
+# Heavy checks are skipped when committing directly to main.
 
 # Find ruff — prefer Mason binary, fall back to PATH
 RUFF="${HOME}/.local/share/nvim/mason/bin/ruff"
@@ -11,7 +13,8 @@ if [ -z "$RUFF" ]; then
     exit 0
 fi
 
-# Get staged Python files
+# Get staged Python files. Hook exits early if no Python changed —
+# heavy checks below also skip in that case.
 STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.py')
 if [ -z "$STAGED" ]; then
     exit 0
@@ -28,9 +31,36 @@ for file in $STAGED; do
     fi
 done
 
-# Final check — abort on unfixable errors (e.g. line too long)
-$RUFF check $STAGED
-if [ $? -ne 0 ]; then
+# Final ruff check — abort on unfixable errors (e.g. line too long)
+if ! $RUFF check $STAGED; then
     echo "pre-commit: ruff found unfixable errors, aborting commit"
     exit 1
+fi
+
+# Heavy checks only on feature branches — skip when on main
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ]; then
+    exit 0
+fi
+
+# basedpyright (full repo scan, ~10-20s)
+if command -v basedpyright >/dev/null 2>&1; then
+    echo "pre-commit: running basedpyright..."
+    if ! basedpyright; then
+        echo "pre-commit: basedpyright found errors, aborting commit"
+        exit 1
+    fi
+else
+    echo "pre-commit: basedpyright not in PATH, skipping type check"
+fi
+
+# pytest (full suite, ~1m)
+if command -v pytest >/dev/null 2>&1; then
+    echo "pre-commit: running pytest..."
+    if ! python -m pytest tests/ -q; then
+        echo "pre-commit: pytest failed, aborting commit"
+        exit 1
+    fi
+else
+    echo "pre-commit: pytest not in PATH, skipping tests"
 fi


### PR DESCRIPTION
Beef up the existing pre-commit hook so feature-branch commits get the same checks CI runs — without slowing down direct main commits.

## What

Existing hook (unchanged): run \`ruff format\` and \`ruff check --fix\` on staged Python files. Early-exit if no Python staged.

New tail end (only when \`git rev-parse --abbrev-ref HEAD\` is not \`main\`):

1. \`basedpyright\` (full repo scan, ~10-20s)
2. \`python -m pytest tests/ -q\` (~1m)

Either tool missing from PATH is a no-op (graceful for contributors who haven't run \`mise run setup\`).

## Why this split

You don't commit directly to main (worktree convention enforces feature branches). The \`if BRANCH = main\` gate is defensive: if you ever do commit to main, the slow checks don't fire — but on the normal feature-branch path you can't accidentally land a typecheck or test failure that CI would catch a few minutes later.

## Cost

Adds ~1-1.5 min per commit on feature branches **only when Python files are staged**. Pure-frontend commits skip the whole hook (the existing early-exit), pure-doc commits same. The tradeoff is wasted commit-cycle time versus catching breakage locally — you have the call.

## Easy revert

If the cost is too high, drop the bottom half of the script or guard pytest behind another \`if\`.