### PR TITLE
chore: auto-assign new issues to @danielcopper

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug report
 description: Report a bug in the plugin
 title: "bug: "
 labels: ["bug"]
+assignees: ["danielcopper"]
 body:
   - type: textarea
     id: repro

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: Suggest a new feature or improvement
 title: "feat: "
 labels: ["enhancement"]
+assignees: ["danielcopper"]
 body:
   - type: textarea
     id: problem

--- a/.github/workflows/issue-assign.yml
+++ b/.github/workflows/issue-assign.yml
@@ -1,0 +1,20 @@
+name: Auto-assign issues
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: toJson(github.event.issue.assignees) == '[]'
+    steps:
+      - name: Assign to repo owner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE" --repo "$REPO" --add-assignee danielcopper


### PR DESCRIPTION
Two-layer auto-assign:

## 1. Issue templates (UI pre-fill)

Adds \`assignees: [\"danielcopper\"]\` to both \`.github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml\`. The assignee field is pre-populated when filing via the web UI.

## 2. Workflow catch-all

New \`.github/workflows/issue-assign.yml\` listens on \`issues: opened\` and \`issues: reopened\`, assigns @danielcopper iff the assignees array is empty.

This catches:

- Issues filed without a template (\`blank_issues_enabled: false\` today, but defensive)
- Issues created via \`gh issue create\` without \`--assignee\` (e.g. #608, #609)
- Issues opened by Dependabot security advisories
- Anything else that ever opens an issue here

## Preserves manual override

The \`if: toJson(github.event.issue.assignees) == '[]'\` guard means if you (or anyone) explicitly assigns someone else when filing, the workflow leaves it alone.

## Permissions

\`permissions: issues: write\` only — minimum surface. Uses the default \`GITHUB_TOKEN\`, no PAT needed.