### PR TITLE
fix(session): remove dead totalPausedMs writes (#634)

### DIFF
--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -67,7 +67,6 @@ async function handleGameStart(appId: number): Promise<void> {
   logInfo(`Session start: romId=${romId}, appId=${appId}`);
   activeRomId = romId;
   sessionStartTime = Date.now();
-  totalPausedMs = 0;
 
   // Record session start for playtime tracking
   try {
@@ -87,7 +86,6 @@ async function handleGameStop(): Promise<void> {
   // Clear active session immediately to avoid double-processing
   activeRomId = null;
   sessionStartTime = null;
-  totalPausedMs = 0;
 
   try {
     const result = await finalizeGameSession(romId);
@@ -141,7 +139,6 @@ function handleSuspend(): void {
 function handleResume(): void {
   if (activeRomId && suspendedAt) {
     const pauseDuration = Date.now() - suspendedAt;
-    totalPausedMs += pauseDuration;
     logInfo(`Device resumed, paused for ${Math.round(pauseDuration / 1000)}s`);
     suspendedAt = null;
   }
@@ -213,7 +210,6 @@ export function destroySessionManager(): void {
   activeRomId = null;
   sessionStartTime = null;
   suspendedAt = null;
-  totalPausedMs = 0;
   lifecycleChain = Promise.resolve();
 
   logInfo("Session manager destroyed");


### PR DESCRIPTION
Closes #634.

## Summary

\`pnpm build\` was emitting 4 \`TS2304: Cannot find name 'totalPausedMs'\` warnings on \`src/utils/sessionManager.ts\`. The variable was declared in #34 (Phase 5) but never wired into a read site — the planned 'subtract suspended time from final playtime' feature shipped without the subtraction. #618's ESLint cleanup correctly flagged it as unused and removed the declaration, but left the four write sites referencing the now-undeclared name.

This PR removes all four dead assignments. Suspend/resume still logs pause duration via the existing \`logInfo\` call in \`handleResume\` — that's the only observable behavior.

## Expected CI signal

All green. This is purely subtractive; no new code, no test changes.

## Test plan

- [x] \`pnpm build\` — no warnings, \`created dist in 5.3s\`
- [ ] CI green