### PR TITLE
feat(lib): introduce ListResult typed-subtype union (#623)

### DIFF
--- a/py_modules/lib/list_result.py
+++ b/py_modules/lib/list_result.py
@@ -1,0 +1,84 @@
+"""Discriminated result for list-returning calls that can fail.
+
+Anything that fetches a collection from a remote (RomM, SteamGridDB, …) and
+must distinguish "the server answered and the list is empty" from "the call
+failed and we have no information" returns a :class:`ListResult` instead of
+a bare ``list``. The discriminator is ``error``: when it is ``None`` the
+call succeeded and ``items`` is the (possibly empty) list; when it is set
+the call failed and ``items`` is ``None``. The runtime invariant (exactly
+one set) is enforced in :meth:`ListResult.__post_init__`; consumers branch
+on ``error is None`` before reading ``items``. basedpyright does not
+co-narrow two independent ``Optional`` fields in basic mode, so the
+recommended consumer pattern adds one explicit assertion::
+
+    if result.error is None:
+        assert result.items is not None
+        for item in result.items:
+            ...
+
+The assertion is a static-typing concession, not a runtime guard against
+the invariant — the dataclass already prevents both fields being ``None``.
+
+Lives in ``lib/`` rather than ``models/`` because it is a cross-cutting
+control-flow primitive: services, adapters, and domain logic may all
+construct or consume it, and it has no place in the persisted-data layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ErrorCode(StrEnum):
+    """Coarse failure categories for list-returning calls.
+
+    Kept deliberately small — consumers route on these codes (retry vs.
+    surface auth prompt vs. show "unknown error"), so each addition is a
+    new branch downstream. Free-form detail goes in
+    :attr:`ListResult.error_message`, not here.
+    """
+
+    SERVER_UNREACHABLE = "server_unreachable"
+    AUTH_FAILED = "auth_failed"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ListResult(Generic[T]):
+    """Success-or-failure envelope for a list fetch.
+
+    Exactly one of ``items`` / ``error`` is set; the invariant is enforced
+    in :meth:`__post_init__`. Construct via :meth:`ok` or :meth:`failed`
+    rather than the default constructor — direct construction is supported
+    for dataclass parity but does not buy you anything over the helpers.
+    """
+
+    items: list[T] | None = None
+    error: ErrorCode | None = None
+    error_message: str | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce the exactly-one-of-items-or-error discriminator."""
+        items_set = self.items is not None
+        error_set = self.error is not None
+        if items_set == error_set:
+            raise ValueError(
+                "ListResult requires exactly one of `items` or `error` to be set "
+                f"(items_set={items_set}, error_set={error_set})"
+            )
+        if not error_set and self.error_message is not None:
+            raise ValueError("ListResult.error_message must be None when `error` is None")
+
+    @classmethod
+    def ok(cls, items: list[T]) -> ListResult[T]:
+        """Build a success result wrapping ``items`` (may be an empty list)."""
+        return cls(items=items, error=None, error_message=None)
+
+    @classmethod
+    def failed(cls, code: ErrorCode, message: str | None = None) -> ListResult[T]:
+        """Build a failure result with the given ``code`` and optional ``message``."""
+        return cls(items=None, error=code, error_message=message)

--- a/py_modules/lib/list_result.py
+++ b/py_modules/lib/list_result.py
@@ -1,23 +1,22 @@
-"""Discriminated result for list-returning calls that can fail.
+"""Typed-subtype union for list-returning calls that can fail.
 
 Anything that fetches a collection from a remote (RomM, SteamGridDB, …) and
 must distinguish "the server answered and the list is empty" from "the call
-failed and we have no information" returns a :class:`ListResult` instead of
-a bare ``list``. The discriminator is ``error``: when it is ``None`` the
-call succeeded and ``items`` is the (possibly empty) list; when it is set
-the call failed and ``items`` is ``None``. The runtime invariant (exactly
-one set) is enforced in :meth:`ListResult.__post_init__`; consumers branch
-on ``error is None`` before reading ``items``. basedpyright does not
-co-narrow two independent ``Optional`` fields in basic mode, so the
-recommended consumer pattern adds one explicit assertion::
+failed and we have no information" returns a :data:`ListResult` instead of
+a bare ``list``. ``ListResult[T]`` is the union ``OkListResult[T] |
+FailedListResult``; consumers narrow via ``isinstance`` or ``match``::
 
-    if result.error is None:
-        assert result.items is not None
-        for item in result.items:
-            ...
+    if isinstance(result, FailedListResult):
+        log.warning("fetch failed: %s", result.error)
+        return
+    for item in result.items:
+        ...
 
-The assertion is a static-typing concession, not a runtime guard against
-the invariant — the dataclass already prevents both fields being ``None``.
+Both branches narrow cleanly under basedpyright basic mode — the success
+branch (``else``) infers ``OkListResult[T]`` and exposes ``items`` without
+an extra assertion. Do not introduce a ``TypeGuard``-based predicate
+(e.g. ``is_ok``): ``TypeGuard`` only narrows the positive branch, leaving
+the ``else`` untyped under basic mode.
 
 Lives in ``lib/`` rather than ``models/`` because it is a cross-cutting
 control-flow primitive: services, adapters, and domain logic may all
@@ -28,7 +27,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Generic, TypeVar
+from typing import Generic, TypeAlias, TypeVar
 
 T = TypeVar("T")
 
@@ -39,7 +38,7 @@ class ErrorCode(StrEnum):
     Kept deliberately small — consumers route on these codes (retry vs.
     surface auth prompt vs. show "unknown error"), so each addition is a
     new branch downstream. Free-form detail goes in
-    :attr:`ListResult.error_message`, not here.
+    :attr:`FailedListResult.error_message`, not here.
     """
 
     SERVER_UNREACHABLE = "server_unreachable"
@@ -48,37 +47,26 @@ class ErrorCode(StrEnum):
 
 
 @dataclass(frozen=True)
-class ListResult(Generic[T]):
-    """Success-or-failure envelope for a list fetch.
+class OkListResult(Generic[T]):
+    """Success branch of :data:`ListResult` — wraps the fetched list.
 
-    Exactly one of ``items`` / ``error`` is set; the invariant is enforced
-    in :meth:`__post_init__`. Construct via :meth:`ok` or :meth:`failed`
-    rather than the default constructor — direct construction is supported
-    for dataclass parity but does not buy you anything over the helpers.
+    ``items`` may be empty (the server answered, nothing matched) — that is
+    still a successful call, distinct from the failure branch.
     """
 
-    items: list[T] | None = None
-    error: ErrorCode | None = None
+    items: list[T]
+
+
+@dataclass(frozen=True)
+class FailedListResult:
+    """Failure branch of :data:`ListResult` — carries the routing code.
+
+    ``error_message`` is free-form detail for logs and UI; routing logic
+    must branch on :attr:`error` (the :class:`ErrorCode`) instead.
+    """
+
+    error: ErrorCode
     error_message: str | None = None
 
-    def __post_init__(self) -> None:
-        """Enforce the exactly-one-of-items-or-error discriminator."""
-        items_set = self.items is not None
-        error_set = self.error is not None
-        if items_set == error_set:
-            raise ValueError(
-                "ListResult requires exactly one of `items` or `error` to be set "
-                f"(items_set={items_set}, error_set={error_set})"
-            )
-        if not error_set and self.error_message is not None:
-            raise ValueError("ListResult.error_message must be None when `error` is None")
 
-    @classmethod
-    def ok(cls, items: list[T]) -> ListResult[T]:
-        """Build a success result wrapping ``items`` (may be an empty list)."""
-        return cls(items=items, error=None, error_message=None)
-
-    @classmethod
-    def failed(cls, code: ErrorCode, message: str | None = None) -> ListResult[T]:
-        """Build a failure result with the given ``code`` and optional ``message``."""
-        return cls(items=None, error=code, error_message=message)
+ListResult: TypeAlias = "OkListResult[T] | FailedListResult"

--- a/tests/lib/test_list_result.py
+++ b/tests/lib/test_list_result.py
@@ -1,0 +1,148 @@
+"""Tests for the ListResult discriminated helper."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from lib.list_result import ErrorCode, ListResult
+
+
+class TestErrorCode:
+    """ErrorCode is a str-enum with the documented members."""
+
+    def test_is_str_subclass(self):
+        # str-enum members compare equal to their string value, which lets
+        # callers serialize/transport the code without an explicit .value.
+        assert isinstance(ErrorCode.SERVER_UNREACHABLE, str)
+        assert ErrorCode.SERVER_UNREACHABLE == "server_unreachable"
+
+    def test_required_members_present(self):
+        assert ErrorCode.SERVER_UNREACHABLE.value == "server_unreachable"
+        assert ErrorCode.AUTH_FAILED.value == "auth_failed"
+        assert ErrorCode.UNKNOWN.value == "unknown"
+
+
+class TestListResultOk:
+    """ListResult.ok wraps a list and signals success."""
+
+    def test_with_populated_list(self):
+        result: ListResult[int] = ListResult.ok([1, 2, 3])
+        assert result.items == [1, 2, 3]
+        assert result.error is None
+        assert result.error_message is None
+
+    def test_with_empty_list_is_success_not_failure(self):
+        """Empty list is "server answered, nothing matched" — still success."""
+        result: ListResult[str] = ListResult.ok([])
+        assert result.items == []
+        assert result.error is None
+        assert result.error_message is None
+
+    def test_with_dict_items(self):
+        items = [{"id": 1, "name": "Mario"}, {"id": 2, "name": "Luigi"}]
+        result: ListResult[dict[str, object]] = ListResult.ok(items)
+        assert result.items == items
+        assert result.error is None
+
+
+class TestListResultFailed:
+    """ListResult.failed wraps an error code and optional message."""
+
+    def test_with_code_and_message(self):
+        result: ListResult[int] = ListResult.failed(ErrorCode.SERVER_UNREACHABLE, "connection refused")
+        assert result.items is None
+        assert result.error is ErrorCode.SERVER_UNREACHABLE
+        assert result.error_message == "connection refused"
+
+    def test_with_code_only(self):
+        result: ListResult[int] = ListResult.failed(ErrorCode.AUTH_FAILED)
+        assert result.items is None
+        assert result.error is ErrorCode.AUTH_FAILED
+        assert result.error_message is None
+
+    @pytest.mark.parametrize(
+        "code",
+        [ErrorCode.SERVER_UNREACHABLE, ErrorCode.AUTH_FAILED, ErrorCode.UNKNOWN],
+    )
+    def test_each_error_code(self, code):
+        result: ListResult[int] = ListResult.failed(code, "boom")
+        assert result.error is code
+        assert result.error_message == "boom"
+
+
+class TestDiscriminatorInvariant:
+    """Exactly one of items/error must be set — both or neither is a bug."""
+
+    def test_both_none_raises(self):
+        with pytest.raises(ValueError, match="exactly one of"):
+            ListResult[int]()
+
+    def test_both_set_raises(self):
+        with pytest.raises(ValueError, match="exactly one of"):
+            ListResult[int](items=[1], error=ErrorCode.UNKNOWN)
+
+    def test_both_set_with_empty_list_still_raises(self):
+        """Empty list is still "items is set"; it should not be treated as missing."""
+        with pytest.raises(ValueError, match="exactly one of"):
+            ListResult[int](items=[], error=ErrorCode.UNKNOWN)
+
+    def test_error_message_without_error_raises(self):
+        with pytest.raises(ValueError, match="error_message must be None"):
+            ListResult[int](items=[1], error=None, error_message="should not be set")
+
+
+class TestImmutability:
+    """frozen=True locks fields after construction."""
+
+    def test_cannot_reassign_items(self):
+        result: ListResult[int] = ListResult.ok([1])
+        with pytest.raises(FrozenInstanceError):
+            result.items = [2]  # type: ignore[misc]
+
+    def test_cannot_reassign_error(self):
+        result: ListResult[int] = ListResult.failed(ErrorCode.UNKNOWN)
+        with pytest.raises(FrozenInstanceError):
+            result.error = ErrorCode.AUTH_FAILED  # type: ignore[misc]
+
+
+class TestConsumerPattern:
+    """The documented `error is None` + `assert items is not None` flow.
+
+    basedpyright in basic mode does not co-narrow two independent
+    ``Optional`` fields, so the project consumer pattern pairs the
+    discriminator check with one explicit assertion before reading items.
+    These tests exercise that exact shape so any future refactor that
+    breaks it (e.g. splitting into typed subtypes) is forced to update the
+    consumer expectations here too.
+    """
+
+    def test_success_branch_can_iterate_items(self):
+        result: ListResult[int] = ListResult.ok([10, 20, 30])
+        if result.error is None:
+            assert result.items is not None
+            total = sum(result.items)
+        else:
+            total = -1
+        assert total == 60
+
+    def test_failure_branch_routes_on_code(self):
+        result: ListResult[int] = ListResult.failed(ErrorCode.AUTH_FAILED, "bad password")
+        if result.error is None:
+            outcome = "ok"
+        elif result.error is ErrorCode.AUTH_FAILED:
+            outcome = "reauth"
+        else:
+            outcome = "other"
+        assert outcome == "reauth"
+
+    def test_consumer_transforming_items(self):
+        """Realistic consumer pattern — read items only on success."""
+        result: ListResult[str] = ListResult.ok(["a", "b", "c"])
+        collected: list[str] = []
+        if result.error is None:
+            assert result.items is not None
+            for item in result.items:
+                collected.append(item.upper())
+        assert collected == ["A", "B", "C"]

--- a/tests/lib/test_list_result.py
+++ b/tests/lib/test_list_result.py
@@ -1,4 +1,4 @@
-"""Tests for the ListResult discriminated helper."""
+"""Tests for the ListResult typed-subtype union helper."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from lib.list_result import ErrorCode, ListResult
+from lib.list_result import ErrorCode, FailedListResult, ListResult, OkListResult
 
 
 class TestErrorCode:
@@ -24,41 +24,34 @@ class TestErrorCode:
         assert ErrorCode.UNKNOWN.value == "unknown"
 
 
-class TestListResultOk:
-    """ListResult.ok wraps a list and signals success."""
+class TestOkListResult:
+    """OkListResult wraps the fetched list — success branch of the union."""
 
     def test_with_populated_list(self):
-        result: ListResult[int] = ListResult.ok([1, 2, 3])
+        result = OkListResult(items=[1, 2, 3])
         assert result.items == [1, 2, 3]
-        assert result.error is None
-        assert result.error_message is None
 
     def test_with_empty_list_is_success_not_failure(self):
         """Empty list is "server answered, nothing matched" — still success."""
-        result: ListResult[str] = ListResult.ok([])
+        result: OkListResult[str] = OkListResult(items=[])
         assert result.items == []
-        assert result.error is None
-        assert result.error_message is None
 
     def test_with_dict_items(self):
         items = [{"id": 1, "name": "Mario"}, {"id": 2, "name": "Luigi"}]
-        result: ListResult[dict[str, object]] = ListResult.ok(items)
+        result = OkListResult(items=items)
         assert result.items == items
-        assert result.error is None
 
 
-class TestListResultFailed:
-    """ListResult.failed wraps an error code and optional message."""
+class TestFailedListResult:
+    """FailedListResult carries an error code and optional message."""
 
     def test_with_code_and_message(self):
-        result: ListResult[int] = ListResult.failed(ErrorCode.SERVER_UNREACHABLE, "connection refused")
-        assert result.items is None
+        result = FailedListResult(error=ErrorCode.SERVER_UNREACHABLE, error_message="connection refused")
         assert result.error is ErrorCode.SERVER_UNREACHABLE
         assert result.error_message == "connection refused"
 
     def test_with_code_only(self):
-        result: ListResult[int] = ListResult.failed(ErrorCode.AUTH_FAILED)
-        assert result.items is None
+        result = FailedListResult(error=ErrorCode.AUTH_FAILED)
         assert result.error is ErrorCode.AUTH_FAILED
         assert result.error_message is None
 
@@ -67,82 +60,118 @@ class TestListResultFailed:
         [ErrorCode.SERVER_UNREACHABLE, ErrorCode.AUTH_FAILED, ErrorCode.UNKNOWN],
     )
     def test_each_error_code(self, code):
-        result: ListResult[int] = ListResult.failed(code, "boom")
+        result = FailedListResult(error=code, error_message="boom")
         assert result.error is code
         assert result.error_message == "boom"
 
 
-class TestDiscriminatorInvariant:
-    """Exactly one of items/error must be set — both or neither is a bug."""
+class TestEquality:
+    """Frozen dataclasses get value-based equality for free."""
 
-    def test_both_none_raises(self):
-        with pytest.raises(ValueError, match="exactly one of"):
-            ListResult[int]()
+    def test_two_ok_with_same_items_are_equal(self):
+        assert OkListResult(items=[1, 2]) == OkListResult(items=[1, 2])
 
-    def test_both_set_raises(self):
-        with pytest.raises(ValueError, match="exactly one of"):
-            ListResult[int](items=[1], error=ErrorCode.UNKNOWN)
+    def test_two_ok_with_different_items_are_not_equal(self):
+        assert OkListResult(items=[1, 2]) != OkListResult(items=[1, 3])
 
-    def test_both_set_with_empty_list_still_raises(self):
-        """Empty list is still "items is set"; it should not be treated as missing."""
-        with pytest.raises(ValueError, match="exactly one of"):
-            ListResult[int](items=[], error=ErrorCode.UNKNOWN)
+    def test_two_failed_with_same_code_are_equal(self):
+        assert FailedListResult(error=ErrorCode.UNKNOWN) == FailedListResult(error=ErrorCode.UNKNOWN)
 
-    def test_error_message_without_error_raises(self):
-        with pytest.raises(ValueError, match="error_message must be None"):
-            ListResult[int](items=[1], error=None, error_message="should not be set")
+    def test_two_failed_with_same_code_and_message_are_equal(self):
+        left = FailedListResult(error=ErrorCode.AUTH_FAILED, error_message="bad password")
+        right = FailedListResult(error=ErrorCode.AUTH_FAILED, error_message="bad password")
+        assert left == right
+
+    def test_failed_and_ok_are_never_equal(self):
+        assert OkListResult(items=[]) != FailedListResult(error=ErrorCode.UNKNOWN)
 
 
 class TestImmutability:
     """frozen=True locks fields after construction."""
 
-    def test_cannot_reassign_items(self):
-        result: ListResult[int] = ListResult.ok([1])
+    def test_cannot_reassign_ok_items(self):
+        result = OkListResult(items=[1])
         with pytest.raises(FrozenInstanceError):
             result.items = [2]  # type: ignore[misc]
 
-    def test_cannot_reassign_error(self):
-        result: ListResult[int] = ListResult.failed(ErrorCode.UNKNOWN)
+    def test_cannot_reassign_failed_error(self):
+        result = FailedListResult(error=ErrorCode.UNKNOWN)
         with pytest.raises(FrozenInstanceError):
             result.error = ErrorCode.AUTH_FAILED  # type: ignore[misc]
 
+    def test_cannot_reassign_failed_message(self):
+        result = FailedListResult(error=ErrorCode.UNKNOWN, error_message="x")
+        with pytest.raises(FrozenInstanceError):
+            result.error_message = "y"  # type: ignore[misc]
 
-class TestConsumerPattern:
-    """The documented `error is None` + `assert items is not None` flow.
 
-    basedpyright in basic mode does not co-narrow two independent
-    ``Optional`` fields, so the project consumer pattern pairs the
-    discriminator check with one explicit assertion before reading items.
-    These tests exercise that exact shape so any future refactor that
-    breaks it (e.g. splitting into typed subtypes) is forced to update the
-    consumer expectations here too.
+class TestIsinstanceNarrowing:
+    """isinstance(r, FailedListResult) narrows BOTH branches under basic mode.
+
+    The success branch must reach ``.items`` without an extra assertion —
+    that is the contract that motivates the typed-subtype shape over a
+    single dataclass with two Optional fields.
     """
 
-    def test_success_branch_can_iterate_items(self):
-        result: ListResult[int] = ListResult.ok([10, 20, 30])
-        if result.error is None:
-            assert result.items is not None
-            total = sum(result.items)
-        else:
+    def test_success_branch_iterates_items_without_assert(self):
+        result: ListResult[int] = OkListResult(items=[10, 20, 30])
+        # SIM108: deliberately block-style — the point of this test is that
+        # the `else` branch narrows to OkListResult and `result.items` is
+        # reachable without an assert. A ternary would hide the narrowing.
+        if isinstance(result, FailedListResult):  # noqa: SIM108
             total = -1
+        else:
+            total = sum(result.items)
         assert total == 60
 
     def test_failure_branch_routes_on_code(self):
-        result: ListResult[int] = ListResult.failed(ErrorCode.AUTH_FAILED, "bad password")
-        if result.error is None:
-            outcome = "ok"
-        elif result.error is ErrorCode.AUTH_FAILED:
-            outcome = "reauth"
+        result: ListResult[int] = FailedListResult(error=ErrorCode.AUTH_FAILED, error_message="bad password")
+        if isinstance(result, FailedListResult):
+            outcome = "reauth" if result.error is ErrorCode.AUTH_FAILED else "other"
         else:
-            outcome = "other"
+            outcome = "ok"
         assert outcome == "reauth"
 
     def test_consumer_transforming_items(self):
-        """Realistic consumer pattern — read items only on success."""
-        result: ListResult[str] = ListResult.ok(["a", "b", "c"])
+        """Realistic consumer pattern — read items only on success, no assert."""
+        result: ListResult[str] = OkListResult(items=["a", "b", "c"])
         collected: list[str] = []
-        if result.error is None:
-            assert result.items is not None
+        if isinstance(result, FailedListResult):
+            pass
+        else:
             for item in result.items:
                 collected.append(item.upper())
         assert collected == ["A", "B", "C"]
+
+
+class TestMatchNarrowing:
+    """``match`` statement narrows the union cleanly too."""
+
+    def test_match_success_branch(self):
+        result: ListResult[int] = OkListResult(items=[1, 2, 3])
+        match result:
+            case OkListResult(items=items):
+                total = sum(items)
+            case FailedListResult():
+                total = -1
+        assert total == 6
+
+    def test_match_failure_branch(self):
+        result: ListResult[int] = FailedListResult(error=ErrorCode.SERVER_UNREACHABLE)
+        match result:
+            case OkListResult():
+                outcome = "ok"
+            case FailedListResult(error=ErrorCode.SERVER_UNREACHABLE):
+                outcome = "retry"
+            case FailedListResult():
+                outcome = "other"
+        assert outcome == "retry"
+
+    def test_match_empty_ok(self):
+        result: ListResult[str] = OkListResult(items=[])
+        match result:
+            case OkListResult(items=items):
+                count = len(items)
+            case FailedListResult():
+                count = -1
+        assert count == 0


### PR DESCRIPTION
## Summary

Foundation for #619 (silent-failure hardening epic) — a typed-subtype union returned by list-fetching calls that can fail. Closes #623.

- `ListResult[T] = OkListResult[T] | FailedListResult` as a `TypeAlias`
- `ErrorCode` `StrEnum` with `SERVER_UNREACHABLE` / `AUTH_FAILED` / `UNKNOWN`
- Both subtypes are frozen dataclasses; structurally impossible to construct an invalid result
- 24 tests, 100% line + branch coverage on the new module
- No service consumers in this PR — 5 saves subs (#624-#628) and 1 library sub (#630) adopt it next

## Why typed union vs single dataclass

basedpyright `basic` mode (project setting) does not co-narrow two independent `Optional` fields. A single `ListResult` with `items: list[T] | None` + `error: ErrorCode | None` would force consumers to write `assert result.items is not None` on every success branch — six future consumers × multiple branches each.

The typed-union design gets clean narrowing in BOTH branches under basic mode:

\`\`\`python
if isinstance(result, FailedListResult):
    return error_response(result.error, result.error_message)
return sum(result.items)   # narrowed automatically, zero asserts
\`\`\`

Empirically verified by the review pass before merge. Also documented in the module docstring so future readers don't reach for the \`TypeGuard\` pitfall (only narrows the positive branch).

## Commit history

Two commits — first lands the original single-dataclass spec, second redesigns to the typed union after review pushback. PR can be squash-merged; both messages are conventional and stand alone.

## Test plan

- [x] \`python -m pytest tests/lib/test_list_result.py -v\` — 24/24 pass
- [x] \`python -m pytest tests/ -q\` — full suite (2455 tests) green
- [x] \`ruff check\` + \`ruff format --check\` on changed files — clean
- [x] \`basedpyright\` scoped + CI scope — 0/0/0
- [x] \`scripts/check_cosmic_call_bans.sh\` — OK
- [x] \`lint-imports\` — 7 contracts kept

One scoped \`# noqa: SIM108\` on \`tests/lib/test_list_result.py:121\` — the test deliberately uses a block-style \`if/else\` to demonstrate that the success branch narrows without an assert. A ternary would hide the load-bearing narrowing behavior being verified. Justified inline.