### PR TITLE
fix(launch_gate): warn-not-allow when save-status check fails (#629)

### DIFF
--- a/py_modules/services/launch_gate.py
+++ b/py_modules/services/launch_gate.py
@@ -29,6 +29,8 @@ _TOAST_TITLE_NOT_INSTALLED = "RomM Sync"
 _TOAST_BODY_NOT_INSTALLED = "ROM not downloaded. Open the game page to download it first."
 _TOAST_TITLE_SAVE_CONFLICT = "RomM Save Sync"
 _TOAST_BODY_SAVE_CONFLICT = "Save conflict detected — open game page to resolve before playing"
+_TOAST_TITLE_SAVE_STATUS_FAILED = "RomM Save Sync"
+_TOAST_BODY_SAVE_STATUS_FAILED = "Save-status check failed — retry?"
 
 
 @dataclass(frozen=True)
@@ -37,13 +39,17 @@ class LaunchVerdict:
 
     ``action="allow"`` means the launch may proceed (the ROM is either
     not a RomM ROM, is installed with no save conflict, or the save
-    status check failed non-critically). ``action="block"`` carries a
-    machine-readable ``reason`` and the human-readable toast title and
-    body the frontend surfaces to the user.
+    status check failed for a ROM with no tracked saves). ``action="warn"``
+    means the launch may proceed but the frontend should surface a
+    soft toast — used when ``get_save_status`` failed for a ROM that
+    *does* have tracked saves, where silent allow would risk data loss
+    on an unseen conflict. ``action="block"`` carries a machine-readable
+    ``reason`` and the human-readable toast title and body the frontend
+    surfaces to the user.
     """
 
-    action: Literal["allow", "block"]
-    reason: Literal["not_installed", "save_conflict"] | None = None
+    action: Literal["allow", "warn", "block"]
+    reason: Literal["not_installed", "save_conflict", "save_status_failed"] | None = None
     toast_title: str | None = None
     toast_body: str | None = None
 
@@ -103,9 +109,13 @@ class LaunchGateService:
         LaunchVerdict
             ``allow`` when the app is not a RomM ROM, when the ROM is
             installed with no save conflict, or when the save-status
-            read failed non-critically. ``block`` with ``reason``
-            ``not_installed`` or ``save_conflict`` and the matching
-            toast strings otherwise.
+            read failed for a ROM with no tracked saves. ``warn`` with
+            ``reason="save_status_failed"`` when the save-status read
+            failed for a ROM that has tracked saves — the frontend
+            surfaces the warning toast but lets the launch proceed.
+            ``block`` with ``reason="not_installed"`` or
+            ``reason="save_conflict"`` and the matching toast strings
+            otherwise.
         """
         rom = self._rom_lookup.get_rom_by_steam_app_id(steam_app_id)
         if rom is None:
@@ -125,8 +135,18 @@ class LaunchGateService:
         try:
             save_status = await self._save_status_reader.get_save_status(rom_id)
         except Exception as e:
-            # Non-critical: a failed conflict check must not block the launch.
-            self._logger.debug(f"LaunchGate save-status check failed for rom_id={rom_id}: {e}")
+            # A failed conflict check must not silently allow the launch
+            # for ROMs with tracked saves — an unseen conflict would
+            # corrupt the wrong slot. Soft-warn instead so the user can
+            # retry; pure-allow only when nothing is tracked.
+            self._logger.warning(f"LaunchGate save-status check failed for rom_id={rom_id}: {e}")
+            if self._save_status_reader.has_tracked_save(rom_id):
+                return LaunchVerdict(
+                    action="warn",
+                    reason="save_status_failed",
+                    toast_title=_TOAST_TITLE_SAVE_STATUS_FAILED,
+                    toast_body=_TOAST_BODY_SAVE_STATUS_FAILED,
+                )
             return LaunchVerdict(action="allow")
 
         if _has_any_save_conflict(save_status):

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -101,15 +101,20 @@ class LaunchGateInstalledChecker(Protocol):
 
 
 class LaunchGateSaveStatusReader(Protocol):
-    """Save-status read consumed by LaunchGateService.
+    """Save-status surface consumed by LaunchGateService.
 
-    The composition root satisfies this with ``SaveService``'s
-    ``get_save_status``. The gate only consults the returned
-    ``conflicts`` array — any non-empty value blocks the launch with
-    a save-conflict verdict.
+    The composition root satisfies this with ``SaveService``. The gate
+    calls ``get_save_status`` for the canonical conflict signal (a
+    non-empty ``conflicts`` array blocks the launch) and falls back to
+    the synchronous ``has_tracked_save`` in-memory check to decide
+    whether a ``get_save_status`` failure should be soft-warned (ROM has
+    tracked saves — silent allow would risk data loss) or silently
+    allowed (no tracked saves — nothing to corrupt).
     """
 
     async def get_save_status(self, rom_id: int) -> dict: ...
+
+    def has_tracked_save(self, rom_id: int) -> bool: ...
 
 
 class SessionPlaytimeRecorder(Protocol):

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -187,6 +187,20 @@ class SaveService:
         """Check if emulator core changed since last sync for a ROM."""
         return self._status.check_core_change(rom_id)
 
+    def has_tracked_save(self, rom_id: int) -> bool:
+        """Return True when this ROM has at least one tracked save (slot or file).
+
+        Reads in-memory aggregate state only — no I/O, no network. Used by
+        the launch gate to decide whether a ``get_save_status`` failure
+        should surface as a soft ``warn`` verdict (tracked saves exist —
+        silent allow would risk data loss on an unseen conflict) or stay
+        a silent ``allow`` (no tracked saves — nothing to corrupt).
+        """
+        save_entry = self._save_sync_state.saves.get(str(rom_id))
+        if save_entry is None:
+            return False
+        return bool(save_entry.files) or bool(save_entry.slots)
+
     # ------------------------------------------------------------------
     # Sync orchestration (delegated to SyncEngine)
     # ------------------------------------------------------------------

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -71,8 +71,8 @@ export interface RomLookupResult {
 }
 
 export interface LaunchVerdict {
-  action: "allow" | "block";
-  reason: "not_installed" | "save_conflict" | null;
+  action: "allow" | "warn" | "block";
+  reason: "not_installed" | "save_conflict" | "save_status_failed" | null;
   toast_title: string | null;
   toast_body: string | null;
 }

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toaster } from "@decky/api";
+import * as backend from "../api/backend";
+import * as gameDetailPatch from "../patches/gameDetailPatch";
+import * as migrationStore from "./migrationStore";
+import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./launchInterceptor";
+import type { LaunchVerdict } from "../types";
+
+// The interceptor pulls in `../patches/gameDetailPatch` which transitively
+// imports from `@decky/ui` and `react`. The global `@decky/ui` mock in
+// test-setup.ts covers most of it, but `routerHook`/`afterPatch` etc. are
+// pulled by the patch module's top-level imports. To keep this test focused
+// on the interceptor branches, mock the gameDetailPatch surface we touch.
+vi.mock("../patches/gameDetailPatch", () => ({
+  isRomMAppId: vi.fn(),
+}));
+
+vi.mock("../api/backend", () => ({
+  evaluateLaunch: vi.fn(),
+  refreshMigrationState: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock("./migrationStore", () => ({
+  getMigrationState: vi.fn(),
+  setMigrationStatus: vi.fn(),
+}));
+
+vi.mock("./saveSortMigrationStore", () => ({
+  setSaveSortMigrationStatus: vi.fn(),
+}));
+
+type GameActionHandler = (
+  gameActionId: number,
+  appIdStr: string,
+  action: string,
+  launchSource: number,
+) => Promise<void>;
+
+const captureHandler = (): GameActionHandler => {
+  const calls = vi.mocked(SteamClient.Apps.RegisterForGameActionStart).mock.calls;
+  const handler = calls[calls.length - 1]?.[0];
+  if (!handler) throw new Error("RegisterForGameActionStart was not called");
+  return handler as GameActionHandler;
+};
+
+const makeVerdict = (overrides: Partial<LaunchVerdict> = {}): LaunchVerdict => ({
+  action: "allow",
+  reason: null,
+  toast_title: null,
+  toast_body: null,
+  ...overrides,
+});
+
+describe("launchInterceptor", () => {
+  let unregisterMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    unregisterMock = vi.fn();
+    vi.stubGlobal("SteamClient", {
+      Apps: {
+        RegisterForGameActionStart: vi.fn(() => ({ unregister: unregisterMock })),
+        CancelGameAction: vi.fn(),
+      },
+    });
+
+    vi.mocked(gameDetailPatch.isRomMAppId).mockReturnValue(true);
+    vi.mocked(migrationStore.getMigrationState).mockReturnValue({
+      pending: false,
+      reason: null,
+    } as unknown as ReturnType<typeof migrationStore.getMigrationState>);
+    vi.mocked(backend.refreshMigrationState).mockResolvedValue({
+      retrodeck: { pending: false, reason: null },
+      save_sort: { pending: false, reason: null },
+    } as unknown as Awaited<ReturnType<typeof backend.refreshMigrationState>>);
+  });
+
+  afterEach(() => {
+    unregisterLaunchInterceptor();
+  });
+
+  describe("warn action", () => {
+    it("toasts but does NOT cancel the launch when verdict.action is 'warn'", async () => {
+      vi.mocked(backend.evaluateLaunch).mockResolvedValueOnce(
+        makeVerdict({
+          action: "warn",
+          reason: "save_status_failed",
+          toast_title: "Save check failed",
+          toast_body: "Could not verify save state; launching anyway.",
+        }),
+      );
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(42, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+      expect(toaster.toast).toHaveBeenCalledOnce();
+      expect(toaster.toast).toHaveBeenCalledWith({
+        title: "Save check failed",
+        body: "Could not verify save state; launching anyway.",
+      });
+    });
+
+    it("does not toast on 'warn' when toast fields are null", async () => {
+      vi.mocked(backend.evaluateLaunch).mockResolvedValueOnce(
+        makeVerdict({ action: "warn", reason: "save_status_failed" }),
+      );
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(42, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+      expect(toaster.toast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("block action (regression)", () => {
+    it("cancels the game action and toasts when verdict.action is 'block'", async () => {
+      vi.mocked(backend.evaluateLaunch).mockResolvedValueOnce(
+        makeVerdict({
+          action: "block",
+          reason: "not_installed",
+          toast_title: "Not installed",
+          toast_body: "Download the ROM first.",
+        }),
+      );
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(99, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(99);
+      expect(toaster.toast).toHaveBeenCalledWith({
+        title: "Not installed",
+        body: "Download the ROM first.",
+      });
+    });
+
+    it("cancels without toast when 'block' has no toast fields", async () => {
+      vi.mocked(backend.evaluateLaunch).mockResolvedValueOnce(
+        makeVerdict({ action: "block", reason: "save_conflict" }),
+      );
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(7, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(7);
+      expect(toaster.toast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("allow action (regression)", () => {
+    it("neither cancels nor toasts when verdict.action is 'allow'", async () => {
+      vi.mocked(backend.evaluateLaunch).mockResolvedValueOnce(
+        makeVerdict({ action: "allow" }),
+      );
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(1, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+      expect(toaster.toast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("short-circuit guards", () => {
+    it("ignores non-LaunchApp actions", async () => {
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(1, "1234", "QuitApp", 0);
+
+      expect(backend.evaluateLaunch).not.toHaveBeenCalled();
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-RomM app IDs", async () => {
+      vi.mocked(gameDetailPatch.isRomMAppId).mockReturnValue(false);
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(1, "9999", "LaunchApp", 0);
+
+      expect(backend.evaluateLaunch).not.toHaveBeenCalled();
+    });
+
+    it("blocks launch when a RetroDECK migration is pending", async () => {
+      vi.mocked(migrationStore.getMigrationState).mockReturnValue({
+        pending: true,
+        reason: null,
+      } as unknown as ReturnType<typeof migrationStore.getMigrationState>);
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      await handler(55, "1234", "LaunchApp", 0);
+
+      expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(55);
+      expect(toaster.toast).toHaveBeenCalledWith({
+        title: "RomM Sync",
+        body: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      });
+      expect(backend.evaluateLaunch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -55,6 +55,14 @@ export function registerLaunchInterceptor(): void {
           if (verdict.toast_title && verdict.toast_body) {
             toaster.toast({ title: verdict.toast_title, body: verdict.toast_body });
           }
+        } else if (verdict.action === "warn") {
+          // Soft warning — launch proceeds. Surfaced when the backend's
+          // save-status check failed for a ROM with tracked saves; silently
+          // allowing would risk corrupting the wrong slot on an unseen
+          // conflict, so the user gets a toast and can choose to retry.
+          if (verdict.toast_title && verdict.toast_body) {
+            toaster.toast({ title: verdict.toast_title, body: verdict.toast_body });
+          }
         }
       } catch (e) {
         logError(`Launch interceptor error: ${e}`);

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -984,3 +984,44 @@ class TestPerRomLockSerialization:
         enters = [i for i, e in enumerate(order) if e[1] == "enter"]
         exits = [i for i, e in enumerate(order) if e[1] == "exit"]
         assert min(exits) > max(enters), order
+
+
+class TestHasTrackedSave:
+    """Pure in-memory predicate consumed by the launch gate."""
+
+    def test_returns_false_when_no_entry(self, tmp_path):
+        """ROM with no entry in state.saves → False."""
+        svc, _ = make_service(tmp_path)
+        assert svc.has_tracked_save(42) is False
+
+    def test_returns_false_for_empty_entry(self, tmp_path):
+        """ROM with an empty RomSaveState (no files, no slots) → False."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.saves["42"] = RomSaveState()
+        assert svc.has_tracked_save(42) is False
+
+    def test_returns_true_when_files_tracked(self, tmp_path):
+        """ROM with at least one tracked file → True."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.saves["42"] = RomSaveState(
+            files={"pokemon.srm": FileSyncState(tracked_save_id=7, last_sync_hash="abc")},
+        )
+        assert svc.has_tracked_save(42) is True
+
+    def test_returns_true_when_slots_configured(self, tmp_path):
+        """ROM with at least one slot configured (no files yet) → True."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.saves["42"] = RomSaveState(
+            slots={"default": {"label": "Default"}},
+        )
+        assert svc.has_tracked_save(42) is True
+
+    def test_accepts_int_rom_id_casting_to_str_key(self, tmp_path):
+        """``rom_id`` is int on the wire; state keys are str — service stringifies."""
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.saves["99"] = RomSaveState(
+            files={"a.srm": FileSyncState(tracked_save_id=1)},
+        )
+        assert svc.has_tracked_save(99) is True
+        # Wrong rom_id misses cleanly.
+        assert svc.has_tracked_save(100) is False

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -46,16 +46,23 @@ class FakeSaveStatusReader:
         *,
         payload: dict | None = None,
         side_effect: BaseException | None = None,
+        tracked_rom_ids: set[int] | None = None,
     ) -> None:
         self.payload: dict = payload if payload is not None else {"conflicts": []}
         self.side_effect = side_effect
+        self.tracked_rom_ids: set[int] = tracked_rom_ids if tracked_rom_ids is not None else set()
         self.calls: list[int] = []
+        self.tracked_calls: list[int] = []
 
     async def get_save_status(self, rom_id: int) -> dict:
         self.calls.append(rom_id)
         if self.side_effect is not None:
             raise self.side_effect
         return self.payload
+
+    def has_tracked_save(self, rom_id: int) -> bool:
+        self.tracked_calls.append(rom_id)
+        return rom_id in self.tracked_rom_ids
 
 
 @pytest.fixture
@@ -127,11 +134,14 @@ class TestEvaluateAllow:
         assert installed_checker.calls == [99]
         assert save_status_reader.calls == [99]
 
-    def test_save_status_failure_does_not_block(self, event_loop, logger):
-        """ROM installed, save_status raises → allow (non-critical fallback)."""
+    def test_save_status_failure_no_tracked_saves_allows(self, event_loop, logger):
+        """ROM installed, save_status raises, no tracked saves → allow (nothing to corrupt)."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
         installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
-        save_status_reader = FakeSaveStatusReader(side_effect=RuntimeError("boom"))
+        save_status_reader = FakeSaveStatusReader(
+            side_effect=RuntimeError("boom"),
+            tracked_rom_ids=set(),
+        )
         service = _make_service(
             rom_lookup=rom_lookup,
             installed_checker=installed_checker,
@@ -143,6 +153,7 @@ class TestEvaluateAllow:
 
         assert verdict == LaunchVerdict(action="allow")
         assert save_status_reader.calls == [99]
+        assert save_status_reader.tracked_calls == [99]
 
 
 class TestEvaluateBlock:
@@ -196,6 +207,59 @@ class TestEvaluateBlock:
         assert verdict.reason == "save_conflict"
         assert verdict.toast_title == "RomM Save Sync"
         assert verdict.toast_body == "Save conflict detected — open game page to resolve before playing"
+
+
+class TestEvaluateWarn:
+    def test_save_status_failure_with_tracked_saves_warns(self, event_loop, logger, caplog):
+        """ROM installed, save_status raises OSError, tracked saves present → warn."""
+        rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        save_status_reader = FakeSaveStatusReader(
+            side_effect=OSError("network down"),
+            tracked_rom_ids={99},
+        )
+        service = _make_service(
+            rom_lookup=rom_lookup,
+            installed_checker=installed_checker,
+            save_status_reader=save_status_reader,
+            logger=logger,
+        )
+
+        with caplog.at_level("WARNING", logger="test_launch_gate"):
+            verdict = event_loop.run_until_complete(service.evaluate(42))
+
+        assert verdict.action == "warn"
+        assert verdict.reason == "save_status_failed"
+        assert verdict.toast_title == "RomM Save Sync"
+        assert verdict.toast_body == "Save-status check failed — retry?"
+        assert save_status_reader.calls == [99]
+        assert save_status_reader.tracked_calls == [99]
+        # Bumped from DEBUG to WARNING — verify the level and that the
+        # exception detail is included.
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warning_records) == 1
+        assert "rom_id=99" in warning_records[0].getMessage()
+        assert "network down" in warning_records[0].getMessage()
+
+    def test_save_status_failure_warn_when_only_slots_tracked(self, event_loop, logger):
+        """``has_tracked_save`` returning True (e.g. slots-only entry) → warn."""
+        rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        save_status_reader = FakeSaveStatusReader(
+            side_effect=RuntimeError("executor crash"),
+            tracked_rom_ids={99},
+        )
+        service = _make_service(
+            rom_lookup=rom_lookup,
+            installed_checker=installed_checker,
+            save_status_reader=save_status_reader,
+            logger=logger,
+        )
+
+        verdict = event_loop.run_until_complete(service.evaluate(42))
+
+        assert verdict.action == "warn"
+        assert verdict.reason == "save_status_failed"
 
 
 class TestEvaluateEdgeCases:


### PR DESCRIPTION
## Summary

The launch gate currently catches `Exception` from `get_save_status` and returns verdict `allow` with only a DEBUG-level log. If the conflict check itself fails (network, executor bug) for a ROM with tracked saves, the gate silently allows the launch — direct path to save corruption.

Closes #629.

## Changes

- **`action="warn"` added to `LaunchVerdict`** alongside `allow` / `block`. Frontend toasts the warning without cancelling the launch.
- **Failed save-status check + tracked saves → `warn`** verdict with reason `"save_status_failed"`. Log bumped DEBUG → WARNING with exception detail.
- **No tracked saves → `allow` stays.** ROMs with nothing to corrupt keep the existing pure-allow path.
- **`SaveService.has_tracked_save(rom_id)`** added — returns `true` if `RomSaveState.files` OR `slots` is non-empty (covers both file-tracked and slot-configured ROMs).
- **`LaunchGateSaveStatusReader` Protocol widened** with `has_tracked_save` — same cross-service seam, single port for the gate's save-time reads.
- **Frontend `launchInterceptor.ts`** handles the new `warn` branch with a toast (no `CancelGameAction`).

## Design calls (all reviewer-endorsed)

| # | Decision | Rationale |
|---|----------|-----------|
| V1 | Third enum value (`warn`) vs new field on `allow` | Single source of truth on `action`; no hidden state where `action === "allow"` would still need toast handling |
| V2 | "Tracked save" = `files OR slots` non-empty | Slot-only ROMs (user opted into save-sync but no files yet) are still conflict-prone — soft-warn beats silent-allow |
| V3 | Widen existing Protocol vs new single-method Protocol | Both methods are launch-time save reads on one consumer; splitting would force the gate to hold two refs to the same backing service |

## Test plan

- [x] `pytest tests/services/test_launch_gate.py tests/services/saves/test_service.py -v` — 75/75 pass
- [x] `pytest tests/ -q` — full suite (2438 tests) green
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] `basedpyright` scoped + CI scope — 0/0/0
- [x] `scripts/check_cosmic_call_bans.sh` — OK
- [x] `lint-imports` — 7 contracts kept
- [x] `pnpm build` — clean
- [x] Coverage on `services/launch_gate.py` — 100% stmts, 100% branches

Parent: #619