### PR TITLE
fix(library): handle pagination failure without wiping shortcuts (#630)

### DIFF
--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -316,9 +316,13 @@ class LibraryFetcher:
                     limit,
                     offset,
                 )
-            except Exception as e:
-                self._logger.error(f"Failed to fetch ROMs for platform {platform_name}: {e}")
-                break
+            except Exception:
+                # Re-raise so the orchestrator aborts before the stale-cleanup
+                # pass runs against a partial list. Swallowing here would
+                # cause every ROM not yet paginated to be classified as
+                # "stale" and removed from Steam.
+                self._logger.exception(f"Failed to fetch ROMs for platform {platform_name}")
+                raise
 
             rom_list = roms.get("items", []) if isinstance(roms, dict) else roms
             for rom in rom_list:
@@ -498,9 +502,13 @@ class LibraryFetcher:
                     limit,
                     offset,
                 )
-            except Exception as e:
-                self._logger.error(f"Failed to fetch ROMs for platform {platform_name}: {e}")
-                break
+            except Exception:
+                # Re-raise so the orchestrator aborts before the stale-cleanup
+                # pass runs against a partial list. Swallowing here would
+                # cause every ROM not yet paginated to be classified as
+                # "stale" and removed from Steam.
+                self._logger.exception(f"Failed to fetch ROMs for platform {platform_name}")
+                raise
 
             rom_list = page.get("items", []) if isinstance(page, dict) else page
             for rom in rom_list:

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -281,17 +281,35 @@ class TestFullFetchPlatformRoms:
         assert len(all_roms) == 51
 
     @pytest.mark.asyncio
-    async def test_handles_api_error(self, plugin):
+    async def test_raises_on_api_error_to_protect_stale_cleanup(self, plugin):
+        """Pagination failure must propagate — silently returning a partial list
+        would cause the orchestrator's stale-cleanup pass to wipe every ROM the
+        truncated fetch missed. See #630."""
         from unittest.mock import AsyncMock, MagicMock
 
         mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Server error"))
+        mock_loop.run_in_executor = AsyncMock(side_effect=RuntimeError("Server error"))
         plugin._sync_service._loop = mock_loop
         plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
         all_roms = []
-        await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
-        assert len(all_roms) == 0  # gracefully handles error
+        with pytest.raises(RuntimeError, match="Server error"):
+            await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_second_page_failure(self, plugin):
+        """Page 1 OK + page 2 raises must propagate — partial accumulation is unsafe."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, RuntimeError("page 2 boom")])
+        plugin._sync_service._loop = mock_loop
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+
+        all_roms = []
+        with pytest.raises(RuntimeError, match="page 2 boom"):
+            await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
 
     @pytest.mark.asyncio
     async def test_cancelling_during_fetch(self, plugin):
@@ -601,8 +619,13 @@ class TestFetchPlatformUnit:
             await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
     @pytest.mark.asyncio
-    async def test_breaks_pagination_on_page_exception(self, plugin):
-        """Lines 501-503: per-page exception logs error and breaks the pagination loop."""
+    async def test_first_page_exception_propagates(self, plugin):
+        """A page-fetch failure must raise so the orchestrator aborts before stale-cleanup.
+
+        Previous behaviour swallowed the exception and returned ``([], False)``
+        — which classified every existing ROM as stale and wiped the Steam
+        shortcut library. See #630.
+        """
         from domain.work_unit import WorkUnit
 
         # No prior sync => incremental skip returns None and we fall through to pagination.
@@ -614,10 +637,26 @@ class TestFetchPlatformUnit:
         plugin._sync_service._loop = mock_loop
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=10)
-        unit_roms, skipped = await plugin._sync_service._fetcher.fetch_platform_unit(unit)
+        with pytest.raises(RuntimeError, match="page boom"):
+            await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
-        assert unit_roms == []
-        assert skipped is False
+    @pytest.mark.asyncio
+    async def test_second_page_exception_propagates(self, plugin):
+        """Page 1 OK + page 2 raises must propagate so partial accumulation never
+        reaches the stale-cleanup pass. See #630."""
+        from domain.work_unit import WorkUnit
+
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
+
+        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, RuntimeError("page 2 boom")])
+        plugin._sync_service._loop = mock_loop
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=200)
+        with pytest.raises(RuntimeError, match="page 2 boom"):
+            await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
     @pytest.mark.asyncio
     async def test_paginates_across_multiple_pages(self, plugin):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1231,6 +1231,66 @@ class TestDoSyncPerUnitErrors:
         assert plugin._sync_service._sync_state == SyncState.IDLE
 
     @pytest.mark.asyncio
+    async def test_pagination_failure_does_not_emit_partial_stale_removal(self, plugin):
+        """#630 safety invariant: a fetch_platform_unit failure must NOT trigger
+        the stale-cleanup pass with a partial ROM set.
+
+        Before the fix, ``fetch_platform_unit`` swallowed pagination exceptions
+        and returned ``([], False)``. The orchestrator then ran ``_finalize_per_unit``
+        with ``synced_rom_ids == set()`` and the registry's full ROM list was
+        emitted via ``sync_stale``, which the frontend turned into a wholesale
+        Steam shortcut deletion.
+
+        Now that the fetcher re-raises, the exception hits the outer ``except``
+        in ``_do_sync_per_unit`` BEFORE ``_finalize_per_unit`` runs, so no
+        ``sync_stale`` event is ever emitted.
+        """
+        import decky
+
+        from domain.work_unit import WorkUnit
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+
+        # Existing registry the frontend would happily delete from if the
+        # orchestrator ever emitted a partial sync_stale.
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "Game A", "platform_name": "N64", "app_id": 1000},
+            "20": {"name": "Game B", "platform_name": "N64", "app_id": 2000},
+            "30": {"name": "Game C", "platform_name": "N64", "app_id": 3000},
+        }
+
+        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)]
+        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
+        # Mid-pagination failure — the bug scenario from #630.
+        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(side_effect=RuntimeError("HTTP 500 on page 2"))
+        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+        # Drain any pending tasks scheduled by the outer handler.
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # The load-bearing assertion: sync_stale must never have been emitted.
+        stale_events = [c for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert stale_events == [], (
+            f"Pagination failure leaked a partial sync_stale event: {stale_events}. "
+            "This is the #630 wipe-the-library bug."
+        )
+        # And the registry is untouched — the orchestrator never reaches the
+        # reporter's finalize path when the fetcher raises.
+        assert set(plugin._state["shortcut_registry"].keys()) == {"10", "20", "30"}
+        # The error path was taken instead.
+        error_events = [
+            c
+            for c in decky.emit.call_args_list
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("phase") == "error"
+        ]
+        assert len(error_events) >= 1
+        assert plugin._sync_service._sync_state == SyncState.IDLE
+
+    @pytest.mark.asyncio
     async def test_cancelling_state_before_first_unit_skips_processing(self, plugin):
         """If state is CANCELLING when the unit loop starts, no units run (lines 462-464)."""
         import decky


### PR DESCRIPTION
## Summary

Pagination loops in `_full_fetch_platform_roms` and `fetch_platform_unit` wrapped each page in `try/except Exception: break` and returned partial results. The orchestrator could not distinguish "platform has 42 ROMs" from "platform has 200 but page 2 failed" — and stale-cleanup then deleted Steam shortcuts for every ROM that didn't make it into the partial fetch. Single bad HTTP response mid-pagination = library wipe.

Closes #630.

## Fix — option (a): raise on pagination failure

`_do_sync_per_unit` already has a single-point exception handler (`sync_orchestrator.py:410-423`) that classifies, emits an `error`-phase `sync_progress` event, resets state to `IDLE`, and exits. Critically, **the error handler never reaches `_finalize_per_unit`** — the only path that emits `sync_stale`. Raising from the fetcher buys the safety invariant for free, no return-shape changes, no partial-aware aggregator, no conditional downstream wiring.

Option (b) (`(roms, partial: bool)` tuple) was the alternative — preserves partial-progress UX at the cost of plumbing through downstream callers. Punted; partial-fetch UX is a separate concern that can be solved at a different layer if anyone misses it.

## Changes

- `fetcher.py:_full_fetch_platform_roms` + `fetch_platform_unit` — `try/except: break` → `try/except: raise` on per-page failure (preserves chained context).
- `logger.error(f"... {e}")` → `logger.exception(...)` so the stack trace is captured.

## Test plan

- [x] **Safety invariant test** (`test_sync_orchestrator.py::TestDoSyncPerUnitErrors::test_pagination_failure_does_not_emit_partial_stale_removal`) — seeds shortcut_registry with 3 ROMs, makes `fetch_platform_unit` raise on page 2, asserts **zero `sync_stale` events emitted**, registry intact, error-phase progress event emitted, state returned to IDLE. **Before this fix the old code would have emitted `sync_stale` with `remove_rom_ids=[10, 20, 30]` → 3 frontend `RemoveShortcut` calls.**
- [x] `pytest tests/services/library/test_fetcher.py tests/services/library/test_sync_orchestrator.py -v` — 106/106 pass
- [x] `pytest tests/ -q` — full suite (2458) green
- [x] `ruff check` + `ruff format --check` — clean
- [x] `basedpyright` scoped + CI scope — 0/0/0
- [x] `scripts/check_cosmic_call_bans.sh` — OK
- [x] `lint-imports` — 7 contracts kept

## Notes

- `_full_fetch_platform_roms` is dead production code (only test callers); per-unit pipeline replaced it. Fixed anyway to prevent future re-use of the broken pattern. Deletion is a follow-up under #620.
- `fetch_collection_unit` had no try/except wrapping pagination — already propagated naturally. Symmetry restored.

Parent: #619