### PR TITLE
fix(saves): preserve slot map on list-saves API failure (#625)

### DIFF
--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -67,8 +67,10 @@ class SlotListing:
             active_slot = rom_state.active_slot
             persisted_slots = rom_state.slots
 
-        # Fetch server slots
-        server_slots_list: list[dict] = []
+        # Fetch server slots. On failure we MUST NOT persist a merged map —
+        # an empty server_slots_list would drop every persisted server slot
+        # except the active one and the user would see their slot inventory
+        # vanish on a transient network blip.
         try:
             summary = await self._loop.run_in_executor(
                 None,
@@ -76,9 +78,15 @@ class SlotListing:
                     lambda: self._romm_api.get_save_summary(rom_id, device_id=device_id),
                 ),
             )
-            server_slots_list = summary.get("slots", [])
         except Exception as e:
             self._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
+            return {
+                "success": False,
+                "slots": [],
+                "active_slot": active_slot,
+                "error": str(e),
+            }
+        server_slots_list: list[dict] = summary.get("slots", [])
 
         # Merge: update persisted slots with server data, promote local→server
         merged: dict[str, dict] = {}

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -161,7 +161,7 @@ export const resolveSyncConflict = callable<
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");
 export const updateSaveSyncSettings = callable<[SaveSyncSettings], { success: boolean }>("update_save_sync_settings");
-export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSlotSummary[]; active_slot: string }>("get_save_slots");
+export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSlotSummary[]; active_slot: string; error?: string }>("get_save_slots");
 export const getSlotSaves = callable<[number, string], SlotSavesResponse>("get_slot_saves");
 export const switchSlot = callable<[number, string], SwitchSlotResponse>("switch_slot");
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -101,6 +101,10 @@ function refreshSlotState(
     .catch(() => {});
   getSaveSlots(romId)
     .then((slotResult) => {
+      // On API failure the backend returns success:false with empty slots so it
+      // doesn't clobber persisted state — skip the UI update to preserve the
+      // last-known good slot list rather than blank it on a transient blip.
+      if (!slotResult.success) return;
       setter((prev) => {
         const newSlot = slotResult.active_slot === undefined ? prev.activeSlot : slotResult.active_slot;
         return {
@@ -492,6 +496,15 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         if (!state.romId) return;
         const result = await getSaveSlots(state.romId);
         if (cancelled) return;
+        // On API failure the backend returns success:false with empty slots so
+        // it doesn't clobber persisted state — keep the previous UI list and
+        // allow another load attempt rather than wiping the panel.
+        if (!result.success) {
+          debugLog(`Failed to load save slots: ${result.error ?? "unknown"}`);
+          slotsLoadedRef.current = false;
+          setState((prev) => ({ ...prev, slotsLoading: false }));
+          return;
+        }
         setState((prev) => ({
           ...prev,
           activeSlot: result.active_slot === undefined ? prev.activeSlot : result.active_slot,

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -40,6 +40,7 @@ import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, SyncConflict, A
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
+import { applyLoadSlotsResult, applyRefreshSlotResult } from "../utils/slotState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedCard } from "./MigrationBlockedCard";
 
@@ -100,20 +101,7 @@ function refreshSlotState(
     .then((result) => setter((prev) => ({ ...prev, slotConfirmed: result.configured })))
     .catch(() => {});
   getSaveSlots(romId)
-    .then((slotResult) => {
-      // On API failure the backend returns success:false with empty slots so it
-      // doesn't clobber persisted state — skip the UI update to preserve the
-      // last-known good slot list rather than blank it on a transient blip.
-      if (!slotResult.success) return;
-      setter((prev) => {
-        const newSlot = slotResult.active_slot === undefined ? prev.activeSlot : slotResult.active_slot;
-        return {
-          ...prev,
-          availableSlots: slotResult.slots || [],
-          activeSlot: newSlot,
-        };
-      });
-    })
+    .then((slotResult) => applyRefreshSlotResult<PanelState>(slotResult, setter))
     .catch(() => {});
 }
 
@@ -496,21 +484,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         if (!state.romId) return;
         const result = await getSaveSlots(state.romId);
         if (cancelled) return;
-        // On API failure the backend returns success:false with empty slots so
-        // it doesn't clobber persisted state — keep the previous UI list and
-        // allow another load attempt rather than wiping the panel.
-        if (!result.success) {
-          debugLog(`Failed to load save slots: ${result.error ?? "unknown"}`);
-          slotsLoadedRef.current = false;
-          setState((prev) => ({ ...prev, slotsLoading: false }));
-          return;
-        }
-        setState((prev) => ({
-          ...prev,
-          activeSlot: result.active_slot === undefined ? prev.activeSlot : result.active_slot,
-          availableSlots: result.slots || [],
-          slotsLoading: false,
-        }));
+        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, debugLog);
       } catch (e) {
         debugLog(`Failed to load save slots: ${e}`);
         if (!cancelled) {

--- a/src/utils/slotState.test.ts
+++ b/src/utils/slotState.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import {
+  applyLoadSlotsResult,
+  applyRefreshSlotResult,
+  type LoadSlotsFields,
+  type RefreshSlotFields,
+  type SlotsResponse,
+} from "./slotState";
+import type { SaveSlotSummary } from "../types";
+
+const slot = (name: string): SaveSlotSummary => ({
+  slot: name,
+  source: "server",
+  count: 1,
+  latest_updated_at: null,
+});
+
+interface RefreshState extends RefreshSlotFields {
+  unrelated: number;
+}
+
+interface LoadState extends LoadSlotsFields {
+  unrelated: string;
+}
+
+const refreshState = (overrides: Partial<RefreshState> = {}): RefreshState => ({
+  activeSlot: null,
+  availableSlots: [],
+  unrelated: 0,
+  ...overrides,
+});
+
+const loadState = (overrides: Partial<LoadState> = {}): LoadState => ({
+  activeSlot: null,
+  availableSlots: [],
+  slotsLoading: false,
+  unrelated: "",
+  ...overrides,
+});
+
+/** Build a typed setState mock that matches `Dispatch<SetStateAction<S>>` —
+ *  vi.fn's default mock type narrows to the first invocation and trips TS
+ *  when the helper accepts `S | (prev: S) => S`. */
+const makeSetter = <S>() => vi.fn() as unknown as Dispatch<SetStateAction<S>>;
+
+/** Read the updater function passed to a `makeSetter` mock — typed to keep
+ *  the test assertions clean even though the underlying mock is `unknown`. */
+const lastUpdater = <S>(setter: Dispatch<SetStateAction<S>>): (prev: S) => S => {
+  const calls = (setter as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  return calls[calls.length - 1][0] as (prev: S) => S;
+};
+
+const callCount = <S>(setter: Dispatch<SetStateAction<S>>): number =>
+  (setter as unknown as { mock: { calls: unknown[][] } }).mock.calls.length;
+
+describe("applyRefreshSlotResult", () => {
+  it("skips the setter when success=false (preserves persisted state)", () => {
+    const setter = makeSetter<RefreshState>();
+    const result: SlotsResponse = { success: false, slots: [], error: "boom" };
+    applyRefreshSlotResult<RefreshState>(result, setter);
+    expect(callCount(setter)).toBe(0);
+  });
+
+  it("merges slots and active_slot on success", () => {
+    const setter = makeSetter<RefreshState>();
+    const result: SlotsResponse = {
+      success: true,
+      slots: [slot("a"), slot("b")],
+      active_slot: "a",
+    };
+    applyRefreshSlotResult<RefreshState>(result, setter);
+    expect(callCount(setter)).toBe(1);
+    const next = lastUpdater(setter)(refreshState({ unrelated: 7 }));
+    expect(next).toEqual({
+      activeSlot: "a",
+      availableSlots: [slot("a"), slot("b")],
+      unrelated: 7,
+    });
+  });
+
+  it("preserves prev.activeSlot when active_slot is undefined", () => {
+    const setter = makeSetter<RefreshState>();
+    applyRefreshSlotResult<RefreshState>({ success: true, slots: [slot("x")] }, setter);
+    const next = lastUpdater(setter)(refreshState({ activeSlot: "previous" }));
+    expect(next.activeSlot).toBe("previous");
+    expect(next.availableSlots).toEqual([slot("x")]);
+  });
+
+  it("treats explicit null active_slot as the new value (does not preserve prev)", () => {
+    const setter = makeSetter<RefreshState>();
+    applyRefreshSlotResult<RefreshState>({ success: true, slots: [], active_slot: null }, setter);
+    const next = lastUpdater(setter)(refreshState({ activeSlot: "previous" }));
+    expect(next.activeSlot).toBeNull();
+  });
+
+  it("defaults a missing slots field to []", () => {
+    const setter = makeSetter<RefreshState>();
+    applyRefreshSlotResult<RefreshState>({ success: true } as unknown as SlotsResponse, setter);
+    const next = lastUpdater(setter)(refreshState({ availableSlots: [slot("stale")] }));
+    expect(next.availableSlots).toEqual([]);
+  });
+});
+
+describe("applyLoadSlotsResult", () => {
+  it("on failure: logs the error, resets the loaded-once ref, clears spinner only", () => {
+    const setter = makeSetter<LoadState>();
+    const loadedRef: MutableRefObject<boolean> = { current: true };
+    const logError = vi.fn();
+    const result: SlotsResponse = { success: false, slots: [], error: "boom" };
+    applyLoadSlotsResult<LoadState>(result, setter, loadedRef, logError);
+
+    expect(logError).toHaveBeenCalledWith("Failed to load save slots: boom");
+    expect(loadedRef.current).toBe(false);
+    expect(callCount(setter)).toBe(1);
+    const prev = loadState({
+      activeSlot: "keep",
+      availableSlots: [slot("keep")],
+      slotsLoading: true,
+      unrelated: "keep",
+    });
+    const next = lastUpdater(setter)(prev);
+    expect(next).toEqual({
+      activeSlot: "keep",
+      availableSlots: [slot("keep")],
+      slotsLoading: false,
+      unrelated: "keep",
+    });
+  });
+
+  it("on failure with no error field: logs 'unknown'", () => {
+    const logError = vi.fn();
+    applyLoadSlotsResult<LoadState>(
+      { success: false, slots: [] },
+      makeSetter<LoadState>(),
+      { current: true },
+      logError,
+    );
+    expect(logError).toHaveBeenCalledWith("Failed to load save slots: unknown");
+  });
+
+  it("on success: merges slots + active_slot, clears spinner, does not log or touch ref", () => {
+    const setter = makeSetter<LoadState>();
+    const loadedRef: MutableRefObject<boolean> = { current: true };
+    const logError = vi.fn();
+    const result: SlotsResponse = {
+      success: true,
+      slots: [slot("a")],
+      active_slot: "a",
+    };
+    applyLoadSlotsResult<LoadState>(result, setter, loadedRef, logError);
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(loadedRef.current).toBe(true);
+    const next = lastUpdater(setter)(loadState({ slotsLoading: true, unrelated: "x" }));
+    expect(next).toEqual({
+      activeSlot: "a",
+      availableSlots: [slot("a")],
+      slotsLoading: false,
+      unrelated: "x",
+    });
+  });
+
+  it("on success: preserves prev.activeSlot when active_slot is undefined", () => {
+    const setter = makeSetter<LoadState>();
+    applyLoadSlotsResult<LoadState>(
+      { success: true, slots: [slot("x")] },
+      setter,
+      { current: true },
+      vi.fn(),
+    );
+    const next = lastUpdater(setter)(loadState({ activeSlot: "previous" }));
+    expect(next.activeSlot).toBe("previous");
+  });
+
+  it("on success: treats explicit null active_slot as the new value", () => {
+    const setter = makeSetter<LoadState>();
+    applyLoadSlotsResult<LoadState>(
+      { success: true, slots: [], active_slot: null },
+      setter,
+      { current: true },
+      vi.fn(),
+    );
+    const next = lastUpdater(setter)(loadState({ activeSlot: "previous" }));
+    expect(next.activeSlot).toBeNull();
+  });
+
+  it("on success: defaults a missing slots field to []", () => {
+    const setter = makeSetter<LoadState>();
+    applyLoadSlotsResult<LoadState>(
+      { success: true } as unknown as SlotsResponse,
+      setter,
+      { current: true },
+      vi.fn(),
+    );
+    const next = lastUpdater(setter)(loadState({ availableSlots: [slot("stale")] }));
+    expect(next.availableSlots).toEqual([]);
+  });
+});

--- a/src/utils/slotState.ts
+++ b/src/utils/slotState.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers that translate a `get_save_slots` callable response into the
+ * side-effects the panel component needs to apply. Centralises the
+ * "success:false means keep existing UI state" guard so it can be unit-tested
+ * without rendering the panel component.
+ *
+ * Backend contract: on API failure the callable returns `success:false` with
+ * an empty `slots` array so it doesn't clobber persisted state — the UI must
+ * preserve the last-known good slot list rather than blank it on a transient
+ * blip.
+ */
+
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { SaveSlotSummary } from "../types";
+
+export interface SlotsResponse {
+  success: boolean;
+  slots: SaveSlotSummary[];
+  active_slot?: string | null;
+  error?: string;
+}
+
+export interface RefreshSlotFields {
+  activeSlot: string | null;
+  availableSlots: SaveSlotSummary[];
+}
+
+export interface LoadSlotsFields {
+  activeSlot: string | null;
+  availableSlots: SaveSlotSummary[];
+  slotsLoading: boolean;
+}
+
+/** Apply a `refreshSlotState` response: on success merge slots+active_slot,
+ *  on failure leave UI untouched. */
+export function applyRefreshSlotResult<S extends RefreshSlotFields>(
+  slotResult: SlotsResponse,
+  setter: Dispatch<SetStateAction<S>>,
+): void {
+  if (!slotResult.success) return;
+  setter((prev) => ({
+    ...prev,
+    availableSlots: slotResult.slots || [],
+    activeSlot: slotResult.active_slot === undefined ? prev.activeSlot : slotResult.active_slot,
+  }));
+}
+
+/** Apply a `loadSlots` response: on success merge slots+active_slot and clear
+ *  the loading spinner; on failure clear the spinner, log, and reset the
+ *  loaded-once ref so a subsequent tab visit retries. */
+export function applyLoadSlotsResult<S extends LoadSlotsFields>(
+  result: SlotsResponse,
+  setter: Dispatch<SetStateAction<S>>,
+  loadedRef: MutableRefObject<boolean>,
+  logError: (msg: string) => void,
+): void {
+  if (!result.success) {
+    logError(`Failed to load save slots: ${result.error ?? "unknown"}`);
+    loadedRef.current = false;
+    setter((prev) => ({ ...prev, slotsLoading: false }));
+    return;
+  }
+  setter((prev) => ({
+    ...prev,
+    activeSlot: result.active_slot === undefined ? prev.activeSlot : result.active_slot,
+    availableSlots: result.slots || [],
+    slotsLoading: false,
+  }));
+}

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -86,6 +86,81 @@ class TestSaveSlots:
         result = await svc.get_save_slots(123)
         assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_get_save_slots_preserves_map_on_api_failure(self, tmp_path):
+        """API failure must NOT rewrite the persisted slot map.
+
+        Regression for #625: a single transient ``get_save_summary`` error used
+        to drop every persisted server slot except the active one, then persist
+        the depleted map. The user would see slots vanish from the UI even
+        though they were still on the server.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
+
+        # Seed persisted state with the active slot + two more server slots
+        # that would be dropped by the merge if the failure path persisted.
+        original_slots = {
+            "default": {"source": "server", "count": 1, "latest_updated_at": "2026-04-17T10:00:00"},
+            "save1": {"source": "server", "count": 3, "latest_updated_at": "2026-04-16T09:00:00"},
+            "save2": {"source": "server", "count": 2, "latest_updated_at": "2026-04-15T08:00:00"},
+        }
+        svc._save_sync_state.saves["123"] = RomSaveState(
+            active_slot="default",
+            slot_confirmed=True,
+            slots=dict(original_slots),
+        )
+        svc.save_state()  # baseline the on-disk state for the post-call check
+        state_path = tmp_path / "save_sync_state.json"
+        baseline = state_path.read_text()
+
+        fake.fail_on_next(OSError("connection refused"))
+
+        result = await svc.get_save_slots(123)
+
+        # Response indicates failure with the carried-over active slot.
+        assert result["success"] is False
+        assert result["slots"] == []
+        assert result["active_slot"] == "default"
+        assert "connection refused" in result["error"]
+        # In-memory slot map is untouched (no merge / overwrite happened).
+        assert svc._save_sync_state.saves["123"].slots == original_slots
+        # On-disk state is unchanged — no save_state() call after the failure.
+        assert state_path.read_text() == baseline
+
+    @pytest.mark.asyncio
+    async def test_get_save_slots_empty_server_response_persists(self, tmp_path):
+        """A genuine empty server response is success and persists correctly.
+
+        Distinguishes the new failure path from the case where the server
+        legitimately returns no slots — that's still ``success: True`` and the
+        merged map (which keeps the active slot) is written back to disk.
+        """
+        svc, _ = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        svc._save_sync_state.server_device_id = "dev-1"
+        # Active slot persists through the merge (kept even when server is empty).
+        svc._save_sync_state.saves["123"] = RomSaveState(
+            active_slot="default",
+            slot_confirmed=True,
+            slots={"default": {"source": "server", "count": 1, "latest_updated_at": None}},
+        )
+
+        # No fake.saves entries → genuine empty server response.
+        result = await svc.get_save_slots(123)
+
+        assert result["success"] is True
+        # Active slot retained by the merge even though server returned nothing.
+        slot_names = [s["slot"] for s in result["slots"]]
+        assert slot_names == ["default"]
+        # State persisted: reload from disk and confirm the slots map matches.
+        state_path = tmp_path / "save_sync_state.json"
+        persisted = json.loads(state_path.read_text())
+        assert "default" in persisted["saves"]["123"]["slots"]
+
     def test_set_active_slot(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._save_sync_state.settings.save_sync_enabled = True


### PR DESCRIPTION
## Summary

`get_save_slots` used to swallow `get_save_summary` failures, proceed with an empty `server_slots_list`, and persist the resulting depleted merge. A single transient network blip rewrote the on-disk slot inventory so every non-active server slot vanished from the QAM; the user thought the slots had been deleted server-side and only a successful re-sync could restore them.

Closes #625.

## Fix

- `services/saves/slots/listing.py`: on `get_save_summary` exception, early-return `{"success": False, "slots": [], "active_slot": active_slot, "error": ...}` before any merge/persist runs. The merge-and-persist path now only executes when the server list was actually fetched (including legitimately empty responses, which still persist as before).
- `src/api/backend.ts`: extend the `getSaveSlots` callable type with the optional `error` field.
- `src/components/RomMGameInfoPanel.tsx`: gate both `refreshSlotState` and `loadSlots` on `result.success` so a failed call no longer clobbers the rendered slot list with the empty failure payload. Last-known-good slots stay on screen until the next successful fetch.

### ListResult decision

Chose the early-return `{success, slots, active_slot, error}` shape over `ListResult[T]`. `ListResult` is positioned as a callable-facing primitive; this is an internal try/except inside a single service method that already returns a dict-shaped response. Introducing the typed-subtype union here would force a translation back to the dict shape at the callable boundary for no narrowing benefit, and the shape now matches the sibling `get_slot_saves` failure response (`{"success": False, "slot": ..., "saves": [], "error": ...}`).

## Test plan

- [x] `python -m pytest tests/services/saves/test_slots.py -v` -> 63 passed (2 new bad-path + 1 new edge-case tests).
- [x] `python -m pytest tests/ -q` -> 2457 passed.
- [x] `ruff check` + `ruff format --check` on touched files -> clean.
- [x] `basedpyright` scoped + CI scope -> 0 errors / 0 warnings.
- [x] `bash scripts/check_cosmic_call_bans.sh` -> no forbidden calls.
- [x] `PYTHONPATH=py_modules lint-imports` -> 7 kept, 0 broken.
- [x] `pnpm build` -> bundle created (the 4 pre-existing TS2345 errors in `src/utils/sectionRefresh.test.ts` are on `main` and unrelated to this PR).
- [x] `pnpm test` (vitest) -> 51 passed.
- [x] Coverage on `services/saves/slots/listing.py`: 96% (61 stmts, 16 branches; remaining miss is on the unrelated `get_slot_saves` branch).

Parent: #619