### PR TITLE
fix(saves): block destructive delete-slot confirm when fetch failed (#626)

### DIFF
--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -95,7 +95,19 @@ class SlotDeleter:
                 )
                 server_save_ids = [s["id"] for s in server_saves]
             except Exception as e:
-                self._log_debug(f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}")
+                # Don't return a fake "0 server saves" — the confirmation modal
+                # would render "delete 0 saves" and the user would confirm a
+                # destructive wipe of a slot we never actually inspected. Surface
+                # the failure so the frontend can refuse to open the confirm.
+                self._logger.warning(
+                    f"get_slot_delete_info: failed to list saves for slot '{slot}': {e}",
+                )
+                return {
+                    "success": False,
+                    "reason": "server_unreachable",
+                    "error": "server_unreachable",
+                    "message": "Cannot inspect slot — server unreachable",
+                }
 
         # Local tracked files pointing to server saves in this slot
         files_state = save_state.files

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -175,6 +175,9 @@ export interface SlotDeleteInfo {
   local_filenames?: string[];
   is_active?: boolean;
   reason?: string;
+  // Coarse failure category for routing (e.g. "server_unreachable").
+  // Mirrors `reason` for the cases the modal needs to handle differently.
+  error?: string;
   message?: string;
 }
 

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -11,7 +11,7 @@ import { getSlotSaves, switchSlot, debugLog, getSlotDeleteInfo, deleteSlot } fro
 import type { SlotDeleteInfo } from "../../api/backend";
 import type { SaveStatus, SyncConflict, SaveSlotSummary, SlotSaveFile, SwitchSlotResponse } from "../../types";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
-import { displaySlot, formatRelativeTime } from "./helpers";
+import { displaySlot, formatRelativeTime, slotDeleteFailureToast } from "./helpers";
 import { renderSaveFileRow } from "./SaveFileRow";
 import { renderServerSaveRow } from "./ServerSaveRow";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
@@ -223,11 +223,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
     try {
       const info: SlotDeleteInfo = await getSlotDeleteInfo(romId, slotName);
       if (!info.success) {
-        if (info.reason === "active_slot" || info.is_active) {
-          toaster.toast({ title: "RomM Sync", body: "Cannot delete the active slot. Switch to a different slot first." });
-        } else {
-          toaster.toast({ title: "RomM Sync", body: info.message ?? "Cannot delete this slot" });
-        }
+        toaster.toast({ title: "RomM Sync", body: slotDeleteFailureToast(info) });
         return;
       }
 

--- a/src/components/saves/helpers.test.ts
+++ b/src/components/saves/helpers.test.ts
@@ -6,9 +6,11 @@ import {
   pickLastSyncer,
   attributionLabel,
   formatAttributionSegment,
+  slotDeleteFailureToast,
   statusLabel,
 } from "./helpers";
 import type { DeviceSyncInfo } from "../../types";
+import type { SlotDeleteInfo } from "../../api/backend";
 
 describe("displaySlot", () => {
   it("returns '(no slot)' for null", () => {
@@ -199,5 +201,60 @@ describe("statusLabel", () => {
 
   it("defaults to grey 'Not synced' when status is unknown and lastSyncAt is null", () => {
     expect(statusLabel("weird", null)).toEqual({ color: "#8f98a0", label: "Not synced" });
+  });
+});
+
+describe("slotDeleteFailureToast", () => {
+  it("explains the active-slot guard when reason='active_slot'", () => {
+    const info: SlotDeleteInfo = { success: false, reason: "active_slot" };
+    expect(slotDeleteFailureToast(info)).toBe(
+      "Cannot delete the active slot. Switch to a different slot first.",
+    );
+  });
+
+  it("explains the active-slot guard when is_active flag is set", () => {
+    const info: SlotDeleteInfo = { success: false, is_active: true };
+    expect(slotDeleteFailureToast(info)).toBe(
+      "Cannot delete the active slot. Switch to a different slot first.",
+    );
+  });
+
+  it("surfaces the server-unreachable warning when reason='server_unreachable'", () => {
+    // Regression for #626: without this branch the modal opens and the user
+    // confirms a destructive delete based on stale/empty data.
+    const info: SlotDeleteInfo = {
+      success: false,
+      reason: "server_unreachable",
+      message: "Cannot inspect slot — server unreachable",
+    };
+    expect(slotDeleteFailureToast(info)).toBe(
+      "Cannot inspect slot — server unreachable",
+    );
+  });
+
+  it("surfaces the server-unreachable warning when only error='server_unreachable'", () => {
+    const info: SlotDeleteInfo = {
+      success: false,
+      error: "server_unreachable",
+      message: "boom",
+    };
+    expect(slotDeleteFailureToast(info)).toBe("boom");
+  });
+
+  it("falls back to a generic server-unreachable message when no message is provided", () => {
+    const info: SlotDeleteInfo = { success: false, reason: "server_unreachable" };
+    expect(slotDeleteFailureToast(info)).toBe(
+      "Cannot inspect slot — RomM server is not reachable",
+    );
+  });
+
+  it("surfaces the backend message for unrecognised failure reasons", () => {
+    const info: SlotDeleteInfo = { success: false, reason: "weird", message: "Custom failure" };
+    expect(slotDeleteFailureToast(info)).toBe("Custom failure");
+  });
+
+  it("falls back to a generic message when no message and no special reason", () => {
+    const info: SlotDeleteInfo = { success: false };
+    expect(slotDeleteFailureToast(info)).toBe("Cannot delete this slot");
   });
 });

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -5,6 +5,7 @@
  */
 
 import type { DeviceSyncInfo } from "../../types";
+import type { SlotDeleteInfo } from "../../api/backend";
 
 /** Display a slot name, using "(no slot)" for null/empty values */
 export function displaySlot(slot: string | null | undefined): string {
@@ -80,6 +81,22 @@ export function formatAttributionSegment(
     return deviceName ? `${deviceName} ✓` : `✓`;
   }
   return null;
+}
+
+/**
+ * Pick the toast body to surface when `get_slot_delete_info` returned
+ * success=false. The frontend uses this to refuse the destructive confirm
+ * modal and explain why — most importantly the `server_unreachable` branch,
+ * which guards against confirming a wipe of a slot we never inspected.
+ */
+export function slotDeleteFailureToast(info: SlotDeleteInfo): string {
+  if (info.reason === "active_slot" || info.is_active) {
+    return "Cannot delete the active slot. Switch to a different slot first.";
+  }
+  if (info.reason === "server_unreachable" || info.error === "server_unreachable") {
+    return info.message ?? "Cannot inspect slot — RomM server is not reachable";
+  }
+  return info.message ?? "Cannot delete this slot";
 }
 
 /** Map a save file status to color and label */

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -1030,6 +1030,76 @@ class TestDeleteSlot:
         assert result["reason"] == "not_found"
 
     @pytest.mark.asyncio
+    async def test_get_slot_delete_info_server_unreachable(self, tmp_path):
+        """list_saves failure surfaces as success=False, not a fake 0-count.
+
+        Regression for #626: silently returning ``server_save_count: 0`` made
+        the confirmation modal claim the slot was empty, so the user could
+        confirm a destructive delete of a slot we never actually inspected.
+        """
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"save1": {"source": "server", "count": 3, "latest_updated_at": None}},
+            files_state={
+                "pokemon.srm": {"tracked_save_id": 10, "last_sync_hash": "abc"},
+            },
+        )
+        fake.fail_on_next(OSError("connection refused"))
+
+        result = await svc.get_slot_delete_info(42, "save1")
+
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        assert result["error"] == "server_unreachable"
+        assert "message" in result
+        # Critically: no fake "0 saves" count that would let the confirm modal
+        # render "delete 0 saves".
+        assert "server_save_count" not in result
+        assert "server_save_ids" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_local_slot_unaffected_by_server_failure(self, tmp_path):
+        """Local-source slots skip the API call and still succeed when the server is down."""
+        svc, fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"local1": {"source": "local", "count": 0, "latest_updated_at": None}},
+        )
+        # Even if the API were down, a local-only slot must not be blocked.
+        fake.fail_on_next(OSError("connection refused"))
+
+        result = await svc.get_slot_delete_info(42, "local1")
+
+        assert result["success"] is True
+        assert result["source"] == "local"
+        assert result["server_save_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_slot_delete_info_empty_server_slot_still_success(self, tmp_path):
+        """Server fetch succeeds with zero saves → success=True, count=0.
+
+        Confirms the new failure path doesn't swallow the legitimate "the
+        server answered and the list was empty" case.
+        """
+        svc, _fake = make_service(tmp_path)
+        self._setup_state_with_slots(
+            svc,
+            tmp_path,
+            extra_slots={"empty": {"source": "server", "count": 0, "latest_updated_at": None}},
+        )
+        # No saves added to fake — list_saves returns an empty list cleanly.
+
+        result = await svc.get_slot_delete_info(42, "empty")
+
+        assert result["success"] is True
+        assert result["server_save_count"] == 0
+        assert result["server_save_ids"] == []
+        assert result["local_file_count"] == 0
+
+    @pytest.mark.asyncio
     async def test_delete_slot_server_saves_success(self, tmp_path):
         """Deleting a server slot removes server saves and cleans up state."""
         svc, fake = make_service(tmp_path)


### PR DESCRIPTION
## Summary
`get_slot_delete_info` swallowed `list_saves` failures and returned `server_save_count: 0, server_save_ids: []` as though the slot were genuinely empty. The confirmation modal then offered to delete "0 saves" from a slot we never actually inspected — confirming was a direct path to silently wiping a populated slot.

Closes #626.

## Fix

**Backend (`py_modules/services/saves/slots/deletion.py`)** — on `list_saves` failure, return a failure response instead of pretending the slot is empty.

Before:
```python
except Exception as e:
    self._log_debug(f"... failed to list saves for slot '{slot}': {e}")
# falls through and returns success=True with server_save_count=0
```

After:
```python
except Exception as e:
    self._logger.warning(f"... failed to list saves for slot '{slot}': {e}")
    return {
        "success": False,
        "reason": "server_unreachable",
        "error": "server_unreachable",
        "message": "Cannot inspect slot — server unreachable",
    }
```

Both `reason` and `error` are populated so the frontend can route on either (consistent with how `switch_slot` already uses `reason`).

**Frontend (`src/api/backend.ts`, `src/components/SavesTab.tsx`)** — added `error?: string` to `SlotDeleteInfo` and a dedicated `server_unreachable` branch in `handleDelete` so the confirm modal is never opened when we couldn't inspect the slot. Existing `info.message` fallback already covered the generic case, but the explicit branch yields a clearer toast ("Cannot inspect slot — RomM server is not reachable").

Local-source slots skip the API call and are unaffected.

## Test plan

New tests in `tests/services/saves/test_slots.py::TestDeleteSlot`:
- `test_get_slot_delete_info_server_unreachable` — `fail_on_next(OSError(...))` -> response carries `success: False`, `reason: "server_unreachable"`, `error: "server_unreachable"`, `message`, and explicitly does NOT carry `server_save_count` / `server_save_ids` (no fake-zero leak).
- `test_get_slot_delete_info_local_slot_unaffected_by_server_failure` — local-source slot must not be blocked when the server is down (no API call to fail).
- `test_get_slot_delete_info_empty_server_slot_still_success` — genuine "server answered, empty list" remains `success: True, server_save_count: 0`.

Gates (all green from worktree root):
- [x] `python -m pytest tests/services/saves/test_slots.py -v` — 64 passed (3 new).
- [x] `python -m pytest tests/ -q` — 2458 passed.
- [x] `ruff check` + `ruff format --check` on touched files.
- [x] `basedpyright` scoped (touched files) + CI scope (`py_modules tests`) — 0 errors / 0 warnings.
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean.
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken.
- [x] `pnpm build` — succeeds (pre-existing unrelated TS warnings in `sectionRefresh.test.ts`).
- [x] `pnpm test` — 51 passed.

Coverage on `py_modules/services/saves/slots/deletion.py`: 98% (the new failure branch is exercised).

Parent: #619