### PR TITLE
fix(tests): silence rollup TS warnings on mock setter typing (#643)

### DIFF
--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -113,7 +113,7 @@ describe("extractBiosInfo", () => {
   });
 
   it("marks activeCoreIsDefault=true when no active core is set", () => {
-    const bios = { ...baseBios, active_core_label: null } as BiosStatus;
+    const bios = { ...baseBios, active_core_label: null } as unknown as BiosStatus;
     const result = extractBiosInfo(bios, "ok", "BIOS OK");
     expect(result.activeCoreIsDefault).toBe(true);
     expect(result.activeCoreLabel).toBeNull();

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Dispatch, SetStateAction } from "react";
 import {
   refreshActiveSlotInBackground,
   refreshBiosInBackground,
@@ -38,7 +39,7 @@ describe("refreshActiveSlotInBackground", () => {
     } as unknown as Awaited<ReturnType<typeof backend.getSaveStatus>>);
 
     const setter = vi.fn<(updater: (prev: ActiveSlotState) => ActiveSlotState) => void>();
-    refreshActiveSlotInBackground(1, () => false, setter);
+    refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
@@ -75,7 +76,7 @@ describe("refreshActiveSlotInBackground", () => {
     } as unknown as Awaited<ReturnType<typeof backend.getSaveStatus>>);
 
     const setter = vi.fn<(updater: (prev: ActiveSlotState) => ActiveSlotState) => void>();
-    refreshActiveSlotInBackground(1, () => false, setter);
+    refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
     await flushMicrotasks();
 
     const updater = setter.mock.calls[0][0];
@@ -102,7 +103,7 @@ describe("refreshBiosInBackground", () => {
     } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
 
     const setter = vi.fn<(updater: (prev: BiosState) => BiosState) => void>();
-    refreshBiosInBackground(1, false, setter);
+    refreshBiosInBackground(1, false, setter as unknown as Dispatch<SetStateAction<BiosState>>);
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
@@ -164,7 +165,7 @@ describe("refreshAchievementsInBackground", () => {
     } as unknown as Awaited<ReturnType<typeof backend.getAchievementProgress>>);
 
     const setter = vi.fn<(updater: (prev: AchievementState) => AchievementState) => void>();
-    refreshAchievementsInBackground(1, () => false, setter);
+    refreshAchievementsInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<AchievementState>>);
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();


### PR DESCRIPTION
Closes #643.

## Summary

\`pnpm build\` was emitting 5 \`@rollup/plugin-typescript\` warnings (4× TS2345 in \`sectionRefresh.test.ts\`, 1× TS2352 in \`playSection.test.ts\`). Non-fatal but violated the \"never commit with warnings\" rule.

## Fix

**sectionRefresh.test.ts (4 sites)** — mock setters were typed narrowly as \`(updater: (prev: S) => S) => void\` but the helpers expect React's wider \`Dispatch<SetStateAction<S>>\`. Added a one-line cast at each call site:

\`\`\`ts
refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
\`\`\`

Keeps test ergonomics intact (\`mock.calls[0][0]\` still typed as a directly-callable updater, so existing \`expect(updater({...}))\` assertions work unchanged).

**playSection.test.ts** — \`{ active_core_label: null } as BiosStatus\` failed because \`BiosStatus.active_core_label\` is \`string | undefined\`, not \`null\`. Cast now goes through \`unknown\` to satisfy the conversion check.

## Expected CI signal

All green. Pure test-file changes; no production code touched.

## Test plan

- [x] \`pnpm build\` — clean, no TS warnings
- [x] \`pnpm test\` — 88/88 pass
- [x] \`pnpm lint\` — 0 errors, 59 pre-existing warnings (#617)
- [ ] CI green