### PR TITLE
fix(saves): distinct server-unreachable status for rollback_to_version + list_file_versions (#627)

### DIFF
--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -269,7 +269,7 @@ class SaveService:
     # Versions (delegated to VersionsService)
     # ------------------------------------------------------------------
 
-    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> list[dict]:
+    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict:
         """List server-side versions of *filename* in the active slot."""
         return await self._versions.list_file_versions(rom_id, slot, filename)
 

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -79,7 +79,7 @@ class VersionsService:
         """
         return self._state_svc.get_file_state(rom_id_str, filename)
 
-    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> list[dict]:
+    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict:
         """List server-side saves in the active slot, excluding the currently-tracked one.
 
         The slot is the unit, not the filename. Saves uploaded by other
@@ -88,12 +88,19 @@ class VersionsService:
         slot, so no filename filter is applied — every save in the slot
         except the one we're currently tracking shows up here.
 
-        Sorted by ``updated_at`` descending (newest first). Each entry
-        contains: id, file_name, emulator, updated_at, file_size_bytes,
-        device_syncs, uploaded_by_us.
-
         ``filename`` is kept in the signature for compatibility with the
         callable wiring but no longer affects which versions are returned.
+
+        Returns a status dict:
+        - ``{"status": "ok", "versions": [...]}`` on success. ``versions``
+          is sorted by ``updated_at`` descending (newest first); each entry
+          contains: id, file_name, emulator, updated_at, file_size_bytes,
+          device_syncs, uploaded_by_us. ``versions`` may be empty — the
+          server answered, nothing matched.
+        - ``{"status": "server_unreachable", "error": ...}`` if the
+          ``list_saves`` call failed (network, server, auth, etc.). The
+          frontend distinguishes this from an empty list so it can show a
+          retry affordance instead of "no versions available".
         """
         rom_id = int(rom_id)
         rom_id_str = str(rom_id)
@@ -106,8 +113,9 @@ class VersionsService:
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot if slot else None)
                 ),
             )
-        except Exception:
-            return []
+        except Exception as e:
+            self._log_debug(f"list_file_versions: failed to list saves: {e}")
+            return {"status": "server_unreachable", "error": str(e)}
 
         file_state = self._find_file_state(rom_id_str, filename, server_saves)
         tracked_id = file_state.tracked_save_id if file_state else None
@@ -130,7 +138,7 @@ class VersionsService:
         ]
 
         versions.sort(key=lambda v: v["updated_at"], reverse=True)
-        return versions
+        return {"status": "ok", "versions": versions}
 
     def _rollback_to_version_io(
         self,
@@ -231,7 +239,13 @@ class VersionsService:
         Returns a status dict:
         - ``{"status": "ok"}`` on success.
         - ``{"status": "not_found"}`` if the ROM is not installed or the
-          chosen save id is no longer on the server.
+          chosen save id is no longer on the server (genuinely deleted —
+          the ``list_saves`` call succeeded and the id was absent).
+        - ``{"status": "server_unreachable", "error": ...}`` if the
+          post-preflight ``list_saves`` call failed (network, server,
+          auth, etc.). The frontend distinguishes this from
+          ``not_found`` so it can show a retry affordance instead of
+          "version no longer on the server".
         - ``{"status": "conflict_blocked", "conflicts": [...]}`` if the
           pre-flight surfaced a conflict on the currently-tracked save.
           The frontend resolves it via the standard conflict modal.
@@ -280,7 +294,7 @@ class VersionsService:
                 )
             except Exception as e:
                 self._log_debug(f"rollback_to_version: failed to list saves: {e}")
-                return {"status": "not_found"}
+                return {"status": "server_unreachable", "error": str(e)}
 
             result = await self._loop.run_in_executor(
                 None,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -295,11 +295,16 @@ export type RollbackStatus =
   | { status: "ok" }
   | { status: "not_found" }
   | { status: "unsupported" }
+  | { status: "server_unreachable"; error: string }
   | { status: "conflict_blocked"; conflicts: SyncConflict[] }
   | { status: "preflight_failed"; errors: string[] }
   | { status: "put_failed"; error: string };
 
-export const savesListFileVersions = callable<[number, string, string], SaveVersionEntry[]>("saves_list_file_versions");
+export type ListFileVersionsResult =
+  | { status: "ok"; versions: SaveVersionEntry[] }
+  | { status: "server_unreachable"; error: string };
+
+export const savesListFileVersions = callable<[number, string, string], ListFileVersionsResult>("saves_list_file_versions");
 export const savesRollbackToVersion = callable<[number, string, number], RollbackStatus>("saves_rollback_to_version");
 
 // Achievements callables

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -8,7 +8,7 @@ import { useState, createElement, FC } from "react";
 import { DialogButton } from "@decky/ui";
 import { toaster } from "@decky/api";
 import { debugLog, savesListFileVersions, savesRollbackToVersion } from "../../api/backend";
-import type { SaveVersionEntry, RollbackStatus } from "../../api/backend";
+import type { SaveVersionEntry, RollbackStatus, ListFileVersionsResult } from "../../api/backend";
 import { showSyncConflictModal } from "../SyncConflictModal";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
 import { formatTimestamp } from "../../utils/formatters";
@@ -33,21 +33,34 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
   const [versions, setVersions] = useState<SaveVersionEntry[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [restoring, setRestoring] = useState<number | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const loadVersions = async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result: ListFileVersionsResult = await savesListFileVersions(romId, slot, filename);
+      if (result.status === "ok") {
+        setVersions(result.versions);
+      } else if (result.status === "server_unreachable") {
+        debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.error}`);
+        setVersions(null);
+        setLoadError("Couldn't reach RomM. Tap retry.");
+      }
+    } catch (e) {
+      debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`);
+      setVersions(null);
+      setLoadError("Couldn't reach RomM. Tap retry.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleToggle = async () => {
     const willExpand = !expanded;
     setExpanded(willExpand);
-    if (willExpand && versions === null && !isOffline) {
-      setLoading(true);
-      try {
-        const result = await savesListFileVersions(romId, slot, filename);
-        setVersions(result);
-      } catch (e) {
-        debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`);
-        setVersions([]);
-      } finally {
-        setLoading(false);
-      }
+    if (willExpand && versions === null && loadError === null && !isOffline) {
+      await loadVersions();
     }
   };
 
@@ -84,6 +97,11 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         onRestored();
       } else if (result.status === "not_found") {
         toaster.toast({ title: "RomM Sync", body: "This version no longer exists on the server" });
+      } else if (result.status === "server_unreachable") {
+        // Distinct from ``not_found``: the version may well still exist;
+        // we just couldn't reach the server to confirm. Prompt for retry
+        // instead of telling the user the version is gone.
+        toaster.toast({ title: "RomM Sync", body: "Couldn't reach RomM. Check your connection and try again." });
       } else if (result.status === "unsupported") {
         toaster.toast({ title: "RomM Sync", body: "Version history requires RomM 4.7+" });
       }
@@ -174,6 +192,24 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
     }
     if (loading) {
       return createElement("div", { style: { fontSize: "11px", color: "#8f98a0" } }, "Loading...");
+    }
+    if (loadError !== null) {
+      // Distinct from the empty-list case: surface a retry affordance so
+      // the user isn't misled into thinking there are no versions when
+      // the server was actually unreachable.
+      return createElement("div", {
+        style: { display: "flex", alignItems: "center", gap: "8px" },
+      },
+        createElement("span", {
+          style: { fontSize: "11px", color: "#c46161", fontStyle: "italic" as const },
+        }, loadError),
+        createElement(DialogButton as any, {
+          style: { padding: "2px 8px", minWidth: "auto", fontSize: "11px", width: "auto", flexShrink: 0 },
+          noFocusRing: false,
+          onFocus: scrollFocusedToCenter,
+          onClick: () => { void loadVersions(); },
+        }, "Retry"),
+      );
     }
     if (versionCount === 0) {
       return createElement("div", {

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -59,7 +59,8 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        ids_in_order = [v["id"] for v in result]
+        assert result["status"] == "ok"
+        ids_in_order = [v["id"] for v in result["versions"]]
         assert ids_in_order == [60, 50]  # newest first; tracked id=100 excluded
 
     @pytest.mark.asyncio
@@ -92,8 +93,9 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 1
-        assert result[0]["id"] == 50
+        assert result["status"] == "ok"
+        assert len(result["versions"]) == 1
+        assert result["versions"][0]["id"] == 50
 
     @pytest.mark.asyncio
     async def test_sorted_newest_first(self, tmp_path):
@@ -107,9 +109,11 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 2
-        assert result[0]["id"] == 50  # newer of the two old versions first
-        assert result[1]["id"] == 30
+        assert result["status"] == "ok"
+        versions = result["versions"]
+        assert len(versions) == 2
+        assert versions[0]["id"] == 50  # newer of the two old versions first
+        assert versions[1]["id"] == 30
 
     @pytest.mark.asyncio
     async def test_empty_when_no_older_versions(self, tmp_path):
@@ -121,7 +125,7 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert result == []
+        assert result == {"status": "ok", "versions": []}
 
     @pytest.mark.asyncio
     async def test_no_tracked_save_returns_every_save_in_slot(self, tmp_path):
@@ -135,18 +139,28 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert {v["id"] for v in result} == {100, 50}
+        assert result["status"] == "ok"
+        assert {v["id"] for v in result["versions"]} == {100, 50}
 
     @pytest.mark.asyncio
-    async def test_api_error_returns_empty(self, tmp_path):
-        """Returns empty list when the server call fails."""
+    async def test_api_error_returns_server_unreachable(self, tmp_path):
+        """Server failure returns a distinct ``server_unreachable`` status.
+
+        Critical: do NOT return a bare empty list — the frontend would
+        render that as "no older versions" when actually the server is
+        unreachable. The discriminated status lets the UI show a retry
+        affordance instead.
+        """
         svc, fake = make_service(tmp_path)
 
-        fake.fail_on_next(Exception("network error"))
+        fake.fail_on_next(OSError("network error"))
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert result == []
+        assert result["status"] == "server_unreachable"
+        assert "network" in result["error"].lower()
+        # Must NOT be the same shape as the happy-path empty case.
+        assert result != {"status": "ok", "versions": []}
 
     @pytest.mark.asyncio
     async def test_result_shape(self, tmp_path):
@@ -172,8 +186,10 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 1
-        entry = result[0]
+        assert result["status"] == "ok"
+        versions = result["versions"]
+        assert len(versions) == 1
+        entry = versions[0]
         assert entry["id"] == 50
         assert entry["file_name"] == "pokemon [2026-03-01_10-00-00].srm"
         assert entry["emulator"] == "retroarch-mgba"
@@ -204,8 +220,10 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 2
-        by_id = {v["id"]: v for v in result}
+        assert result["status"] == "ok"
+        versions = result["versions"]
+        assert len(versions) == 2
+        by_id = {v["id"]: v for v in versions}
         assert by_id[50]["uploaded_by_us"] is True
         assert by_id[30]["uploaded_by_us"] is False
 
@@ -230,8 +248,10 @@ class TestListFileVersions:
 
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 1
-        assert result[0]["uploaded_by_us"] is None
+        assert result["status"] == "ok"
+        versions = result["versions"]
+        assert len(versions) == 1
+        assert versions[0]["uploaded_by_us"] is None
 
 
 class TestRollbackToVersion:
@@ -460,6 +480,48 @@ class TestRollbackToVersion:
 
         assert result["status"] == "preflight_failed"
         assert any("network" in err.lower() for err in result.get("errors", []))
+
+    @pytest.mark.asyncio
+    async def test_post_preflight_list_saves_failure_returns_server_unreachable(self, tmp_path):
+        """A ``list_saves`` failure AFTER a clean pre-flight returns the
+        distinct ``server_unreachable`` status, not ``not_found``.
+
+        Before #627 this case returned ``{"status": "not_found"}`` —
+        identical to the "save_id genuinely deleted" case — so the user
+        was told "this version is no longer on the server" when in fact
+        the server was unreachable. The distinct status lets the
+        frontend surface a retry affordance.
+        """
+        svc, fake = make_service(tmp_path)
+
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        self._setup_state(svc, tmp_path, tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = self._tracked_save(100)
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-02-01T10:00:00Z")
+
+        # Let the pre-flight ``list_saves`` succeed, then fail on the next
+        # ``list_saves`` call — the one the post-preflight switch makes.
+        original_list = fake.list_saves
+        call_count = {"n": 0}
+
+        def fail_second_list(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:
+                raise OSError("server unreachable after preflight")
+            return original_list(*args, **kwargs)
+
+        fake.list_saves = fail_second_list  # type: ignore[method-assign]
+
+        try:
+            result = await svc.rollback_to_version(42, "default", 50)
+        finally:
+            fake.list_saves = original_list  # type: ignore[method-assign]
+
+        assert result["status"] == "server_unreachable"
+        assert "unreachable" in result.get("error", "").lower()
+        # Critical: must NOT collide with the "genuinely deleted" case.
+        assert result["status"] != "not_found"
 
     # ------------------------------------------------------------------
     # Cross-device propagation: rollback re-PUTs target so it becomes

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -1062,8 +1062,9 @@ class TestSavesVersionHistoryCallables:
 
         result = await plugin.saves_list_file_versions(42, "default", "pokemon.srm")
 
-        assert len(result) == 1
-        assert result[0]["id"] == 50
+        assert result["status"] == "ok"
+        assert len(result["versions"]) == 1
+        assert result["versions"][0]["id"] == 50
 
     @pytest.mark.asyncio
     async def test_saves_rollback_to_version_happy_path(self, plugin, tmp_path):


### PR DESCRIPTION
## Summary

Closes #627. Parent: #619.

`rollback_to_version` returned `{"status": "not_found"}` for two unrelated cases: (a) the chosen `save_id` is genuinely deleted on the server, and (b) the post-preflight `list_saves` call failed (network, server). The user was told "this version is no longer on the server" when actually the server was unreachable — they might re-pick a different version and rollback into stale local state, or assume their save was deleted by another device.

`list_file_versions` had the same bug pattern: any API failure returned a bare `[]`, indistinguishable from "the slot really has no older versions". Folded into the same PR (issue called this out as a secondary fix).

## Fix

Both functions now return a distinct `server_unreachable` status with an `error` field carrying the underlying message.

### Before / after — `rollback_to_version`

```diff
- # any list_saves failure
- return {"status": "not_found"}
+ return {"status": "server_unreachable", "error": str(e)}
```

`"not_found"` is now reserved for the genuine-deletion cases (ROM not installed, `save_id` absent from a successful list response).

### Before / after — `list_file_versions`

```diff
- async def list_file_versions(...) -> list[dict]:
-     try:
-         server_saves = ...
-     except Exception:
-         return []
-     ...
-     return versions
+ async def list_file_versions(...) -> dict:
+     try:
+         server_saves = ...
+     except Exception as e:
+         return {"status": "server_unreachable", "error": str(e)}
+     ...
+     return {"status": "ok", "versions": versions}
```

This is a wire-shape change; the frontend `ListFileVersionsResult` type was added and the consumer updated.

## `ListResult` adoption — decision

Considered using `ListResult[dict]` from `lib/list_result.py` (the codebase's typed-union primitive for fail-or-list calls) but stuck with a dict-discriminated shape because:

1. Decky callable returns serialize over JSON-RPC — a `ListResult` dataclass would need `asdict()` conversion at the callable boundary anyway, flattening to the same dict shape at the wire layer.
2. The dict-discriminated pattern already matches `RollbackStatus` (the sister callable in this file), so we keep wire conventions uniform across saves callables.
3. `ListResult` remains the right pick for pure-Python internal call sites; it's just not load-bearing through Decky's callable boundary.

## Frontend impact

- `RollbackStatus` gains `{ status: "server_unreachable"; error: string }`.
- New `ListFileVersionsResult` discriminated type added.
- `VersionHistoryPanel` tracks a separate `loadError` state and surfaces a **Retry** button instead of the misleading "No older versions available" message when the load failed.
- `handleRestore` adds a `server_unreachable` toast: "Couldn't reach RomM. Check your connection and try again."

## Test plan

- [x] `python -m pytest tests/services/saves/test_versions.py -v` — 26/26 pass
- [x] `python -m pytest tests/ -q` — 2456/2456 pass
- [x] `ruff check` clean; `ruff format --check` (the one pre-existing unformatted file in `typings/` is unrelated)
- [x] `basedpyright` (scoped + CI scope) — 0 errors
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7/7 contracts kept
- [x] `pnpm build` succeeded (pre-existing test-file TS warnings unrelated to this PR)
- [x] `pnpm test` — 51/51 pass
- [x] 100% line + branch coverage on `services/saves/versions.py`

### New / updated tests

- `test_post_preflight_list_saves_failure_returns_server_unreachable` — wraps `fake.list_saves` to succeed on the first call (pre-flight) and fail with `OSError` on the second (post-preflight), asserts the distinct `server_unreachable` status.
- `test_api_error_returns_server_unreachable` — replaces the old `test_api_error_returns_empty`; asserts `{"status": "server_unreachable", "error": ...}` and explicitly that the response does NOT equal `{"status": "ok", "versions": []}`.
- All happy-path `list_file_versions` tests updated to unwrap `result["versions"]`.