### PR TITLE
fix(saves): surface server-query-failed flag in get_save_status (#628)

### DIFF
--- a/py_modules/domain/save_status.py
+++ b/py_modules/domain/save_status.py
@@ -32,6 +32,8 @@ class SaveSyncDisplay:
 def compute_save_sync_display(
     files: list[dict] | None,
     last_sync_check_at: str | None,
+    *,
+    server_query_failed: bool = False,
 ) -> SaveSyncDisplay:
     """Compute save sync display status and label.
 
@@ -39,7 +41,16 @@ def compute_save_sync_display(
     'none'), ``label`` (static text or ``None`` when the frontend formats
     a time-ago label), and ``last_sync_check_at`` (passthrough for the
     time-ago case).
+
+    When *server_query_failed* is True the server's save list could not
+    be fetched, so the matrix verdict on each file is unreliable. The
+    display collapses to ``status="none"`` with a "Server unreachable"
+    label rather than reporting the false "synced" / "ready to upload"
+    state a stale-but-empty file list would produce.
     """
+    if server_query_failed:
+        return SaveSyncDisplay(status="none", label="Server unreachable", last_sync_check_at=None)
+
     if not files:
         return SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)
 

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -140,7 +140,13 @@ class StatusService:
                 local_outcome = outcome
         return local_outcome, server_only_outcomes
 
-    def _get_save_status_io(self, rom_id: int, server_saves: list[dict]) -> dict:
+    def _get_save_status_io(
+        self,
+        rom_id: int,
+        server_saves: list[dict],
+        *,
+        server_query_failed: bool = False,
+    ) -> dict:
         """Sync helper for get_save_status — runs in executor.
 
         Builds the saves-tab status for one ROM as a single-entry view of
@@ -163,6 +169,15 @@ class StatusService:
         The one allowed mutation is recording an adopted baseline hash when
         the action requests it (``Skip(adopt_baseline=True)``) — pure state
         hygiene, no network traffic.
+
+        When *server_query_failed* is True the caller's ``list_saves`` call
+        raised before *server_saves* was populated. Matrix evaluation runs
+        as usual against the empty list (so local-file rows still appear
+        with paths/sizes/hashes), but each resulting status is rewritten
+        to ``"unknown"`` and server-side fields are nulled out — the empty
+        list classifies every local save as Upload, which would surface a
+        misleading "ready to upload" indicator on what is in fact a
+        connectivity blip.
         """
         rom_id_str = str(rom_id)
         info = self._rom_info.get_rom_save_info(rom_id)
@@ -191,6 +206,9 @@ class StatusService:
                     server_device_id=server_device_id,
                     own_upload_ids=own_upload_ids,
                 )
+                if server_query_failed:
+                    status_entry = _redact_server_fields(status_entry)
+                    conflict_entry = None
                 file_statuses.append(status_entry)
                 if conflict_entry is not None:
                     conflicts.append(conflict_entry)
@@ -208,7 +226,14 @@ class StatusService:
             "last_sync_check_at": last_sync_check_at,
             "conflicts": conflicts,
             "save_sort_changed": self._rom_info.is_save_sort_changed(),
-            "save_sync_display": asdict(compute_save_sync_display(file_statuses, last_sync_check_at)),
+            "save_sync_display": asdict(
+                compute_save_sync_display(
+                    file_statuses,
+                    last_sync_check_at,
+                    server_query_failed=server_query_failed,
+                )
+            ),
+            "server_query_failed": server_query_failed,
         }
 
     # ------------------------------------------------------------------
@@ -216,10 +241,18 @@ class StatusService:
     # ------------------------------------------------------------------
 
     async def get_save_status(self, rom_id: int) -> dict:
-        """Get save sync status for a ROM (local files, server saves, conflict state)."""
+        """Get save sync status for a ROM (local files, server saves, conflict state).
+
+        When the ``list_saves`` call raises (transient network blip, server
+        offline, …) the returned dict carries ``server_query_failed: True``
+        and each surfaced file is marked ``status="unknown"`` instead of
+        the matrix-derived "ready to upload" label that an empty server
+        list would otherwise produce — see ``_get_save_status_io``.
+        """
         rom_id = int(rom_id)
 
         server_saves: list[dict] = []
+        server_query_failed = False
         try:
             device_id = self._state_svc.get_server_device_id()
             server_saves = await self._loop.run_in_executor(
@@ -228,8 +261,16 @@ class StatusService:
             )
         except Exception as e:
             self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
+            server_query_failed = True
 
-        return await self._loop.run_in_executor(None, self._get_save_status_io, rom_id, server_saves)
+        return await self._loop.run_in_executor(
+            None,
+            lambda: self._get_save_status_io(
+                rom_id,
+                server_saves,
+                server_query_failed=server_query_failed,
+            ),
+        )
 
     async def check_save_status_background(self, rom_id: int) -> None:
         """Run full save status check in background and emit result to frontend."""
@@ -295,3 +336,27 @@ def _outcome_server_sort_key(outcome: MatrixOutcome) -> float:
         return 0.0
     newest = max(candidates, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
     return parse_iso_to_epoch(newest.get("updated_at")) or 0.0
+
+
+def _redact_server_fields(entry: dict) -> dict:
+    """Return a copy of *entry* with status="unknown" and server fields nulled out.
+
+    Used when the ``list_saves`` query failed: the matrix ran against an
+    empty server list, so any "synced"/"upload"/"download"/"conflict" verdict
+    and any server-side attribution (id, file_name, emulator, updated_at,
+    size, device_syncs, is_current, uploaded_by_us) reflects "we have no
+    server information", not the actual state of the server. The local-file
+    fields (filename, local_path, local_hash, local_mtime, local_size,
+    last_sync_at) come from local state and stay intact.
+    """
+    redacted = dict(entry)
+    redacted["status"] = "unknown"
+    redacted["server_save_id"] = None
+    redacted["server_file_name"] = None
+    redacted["server_emulator"] = None
+    redacted["server_updated_at"] = None
+    redacted["server_size"] = None
+    redacted["device_syncs"] = []
+    redacted["is_current"] = True
+    redacted["uploaded_by_us"] = None
+    return redacted

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -25,6 +25,13 @@ function computeSyncSummary(
 ): { syncSummaryText: string | null; syncSummaryColor: string } {
   if (!isActive || !saveStatus) return { syncSummaryText: null, syncSummaryColor: MUTED_COLOR };
 
+  // Backend signals it could not reach the server — suppress the matrix-derived
+  // "Synced" / "Not synced" labels (they would reflect an empty server list, not
+  // reality) and render a neutral "Server unreachable" instead.
+  if (saveStatus.server_query_failed) {
+    return { syncSummaryText: "Server unreachable", syncSummaryColor: MUTED_COLOR };
+  }
+
   const hasConflict = conflicts.length > 0;
   const fileCount = saveStatus.files?.length ?? 0;
 

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -11,38 +11,12 @@ import { getSlotSaves, switchSlot, debugLog, getSlotDeleteInfo, deleteSlot } fro
 import type { SlotDeleteInfo } from "../../api/backend";
 import type { SaveStatus, SyncConflict, SaveSlotSummary, SlotSaveFile, SwitchSlotResponse } from "../../types";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
-import { displaySlot, formatRelativeTime, slotDeleteFailureToast } from "./helpers";
+import { computeSyncSummary, displaySlot, slotDeleteFailureToast } from "./helpers";
 import { renderSaveFileRow } from "./SaveFileRow";
 import { renderServerSaveRow } from "./ServerSaveRow";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 
 const MUTED_COLOR = "#8f98a0";
-
-function computeSyncSummary(
-  isActive: boolean,
-  saveStatus: SaveStatus | null,
-  conflicts: SyncConflict[],
-): { syncSummaryText: string | null; syncSummaryColor: string } {
-  if (!isActive || !saveStatus) return { syncSummaryText: null, syncSummaryColor: MUTED_COLOR };
-
-  // Backend signals it could not reach the server — suppress the matrix-derived
-  // "Synced" / "Not synced" labels (they would reflect an empty server list, not
-  // reality) and render a neutral "Server unreachable" instead.
-  if (saveStatus.server_query_failed) {
-    return { syncSummaryText: "Server unreachable", syncSummaryColor: MUTED_COLOR };
-  }
-
-  const hasConflict = conflicts.length > 0;
-  const fileCount = saveStatus.files?.length ?? 0;
-
-  if (hasConflict) return { syncSummaryText: "Conflict detected", syncSummaryColor: "#d94126" };
-  if (fileCount > 0 && saveStatus.last_sync_check_at) {
-    const rel = formatRelativeTime(saveStatus.last_sync_check_at);
-    return { syncSummaryText: rel === "just now" ? "Synced just now" : `Synced ${rel}`, syncSummaryColor: "#5ba32b" };
-  }
-  if (fileCount > 0) return { syncSummaryText: "Not synced", syncSummaryColor: MUTED_COLOR };
-  return { syncSummaryText: "No saves found", syncSummaryColor: MUTED_COLOR };
-}
 
 function renderActiveSlotBody(
   saveStatus: SaveStatus | null,

--- a/src/components/saves/helpers.test.ts
+++ b/src/components/saves/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  computeSyncSummary,
   displaySlot,
   formatBytes,
   formatRelativeTime,
@@ -9,7 +10,7 @@ import {
   slotDeleteFailureToast,
   statusLabel,
 } from "./helpers";
-import type { DeviceSyncInfo } from "../../types";
+import type { DeviceSyncInfo, SaveStatus, SyncConflict } from "../../types";
 import type { SlotDeleteInfo } from "../../api/backend";
 
 describe("displaySlot", () => {
@@ -195,6 +196,14 @@ describe("statusLabel", () => {
     expect(statusLabel("conflict", null)).toEqual({ color: "#d94126", label: "Conflict" });
   });
 
+  it("returns grey 'Status unknown' for status 'unknown'", () => {
+    expect(statusLabel("unknown", null)).toEqual({ color: "#8f98a0", label: "Status unknown" });
+  });
+
+  it("returns grey 'Status unknown' for status 'unknown' even when lastSyncAt is set", () => {
+    expect(statusLabel("unknown", "2025-06-15T10:00:00Z")).toEqual({ color: "#8f98a0", label: "Status unknown" });
+  });
+
   it("defaults to green 'Synced' when status is unknown but lastSyncAt is set", () => {
     expect(statusLabel("weird", "2025-06-15T10:00:00Z")).toEqual({ color: "#5ba32b", label: "Synced" });
   });
@@ -256,5 +265,192 @@ describe("slotDeleteFailureToast", () => {
   it("falls back to a generic message when no message and no special reason", () => {
     const info: SlotDeleteInfo = { success: false };
     expect(slotDeleteFailureToast(info)).toBe("Cannot delete this slot");
+  });
+});
+
+describe("computeSyncSummary", () => {
+  const makeStatus = (overrides: Partial<SaveStatus> = {}): SaveStatus => ({
+    rom_id: 1,
+    files: [],
+    playtime: {
+      total_seconds: 0,
+      session_count: 0,
+      last_session_start: null,
+      last_session_duration_sec: null,
+    },
+    device_id: "dev",
+    last_sync_check_at: null,
+    ...overrides,
+  });
+
+  it("returns null text for inactive slot", () => {
+    expect(computeSyncSummary(false, makeStatus(), [])).toEqual({
+      syncSummaryText: null,
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("returns null text when saveStatus is null", () => {
+    expect(computeSyncSummary(true, null, [])).toEqual({
+      syncSummaryText: null,
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("short-circuits to 'Server unreachable' when server_query_failed is true", () => {
+    const status = makeStatus({
+      server_query_failed: true,
+      files: [
+        {
+          filename: "save.srm",
+          local_path: "/local/save.srm",
+          local_hash: "abc",
+          local_mtime: "2025-06-15T10:00:00Z",
+          local_size: 100,
+          server_save_id: null,
+          server_file_name: null,
+          server_emulator: null,
+          server_updated_at: null,
+          server_size: null,
+          last_sync_at: null,
+          status: "unknown",
+        },
+      ],
+    });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Server unreachable",
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("server_query_failed wins over conflicts", () => {
+    const status = makeStatus({ server_query_failed: true });
+    const conflicts: SyncConflict[] = [
+      {
+        type: "sync_conflict",
+        rom_id: 1,
+        filename: "save.srm",
+        server_save_id: 1,
+        server_updated_at: "2025-06-15T10:00:00Z",
+        server_size: 100,
+        local_path: null,
+        local_hash: null,
+        local_mtime: null,
+        local_size: null,
+        created_at: "2025-06-15T10:00:00Z",
+      },
+    ];
+    expect(computeSyncSummary(true, status, conflicts)).toEqual({
+      syncSummaryText: "Server unreachable",
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("returns 'Conflict detected' (red) when conflicts present", () => {
+    const status = makeStatus({ files: [] });
+    const conflicts: SyncConflict[] = [
+      {
+        type: "sync_conflict",
+        rom_id: 1,
+        filename: "save.srm",
+        server_save_id: 1,
+        server_updated_at: "2025-06-15T10:00:00Z",
+        server_size: 100,
+        local_path: null,
+        local_hash: null,
+        local_mtime: null,
+        local_size: null,
+        created_at: "2025-06-15T10:00:00Z",
+      },
+    ];
+    expect(computeSyncSummary(true, status, conflicts)).toEqual({
+      syncSummaryText: "Conflict detected",
+      syncSummaryColor: "#d94126",
+    });
+  });
+
+  it("returns 'No saves found' when fileCount is 0 and no conflicts", () => {
+    expect(computeSyncSummary(true, makeStatus(), [])).toEqual({
+      syncSummaryText: "No saves found",
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("returns 'Not synced' when files exist but last_sync_check_at is null", () => {
+    const status = makeStatus({
+      files: [
+        {
+          filename: "save.srm",
+          local_path: "/local/save.srm",
+          local_hash: "abc",
+          local_mtime: "2025-06-15T10:00:00Z",
+          local_size: 100,
+          server_save_id: null,
+          server_file_name: null,
+          server_emulator: null,
+          server_updated_at: null,
+          server_size: null,
+          last_sync_at: null,
+          status: "upload",
+        },
+      ],
+    });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Not synced",
+      syncSummaryColor: "#8f98a0",
+    });
+  });
+
+  it("returns 'Synced just now' when relative time is 'just now'", () => {
+    const nowIso = new Date().toISOString();
+    const status = makeStatus({
+      last_sync_check_at: nowIso,
+      files: [
+        {
+          filename: "save.srm",
+          local_path: "/local/save.srm",
+          local_hash: "abc",
+          local_mtime: nowIso,
+          local_size: 100,
+          server_save_id: null,
+          server_file_name: null,
+          server_emulator: null,
+          server_updated_at: null,
+          server_size: null,
+          last_sync_at: null,
+          status: "synced",
+        },
+      ],
+    });
+    expect(computeSyncSummary(true, status, [])).toEqual({
+      syncSummaryText: "Synced just now",
+      syncSummaryColor: "#5ba32b",
+    });
+  });
+
+  it("returns 'Synced <rel>' with relative time when last_sync_check_at is older", () => {
+    const oldIso = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30 min ago
+    const status = makeStatus({
+      last_sync_check_at: oldIso,
+      files: [
+        {
+          filename: "save.srm",
+          local_path: "/local/save.srm",
+          local_hash: "abc",
+          local_mtime: oldIso,
+          local_size: 100,
+          server_save_id: null,
+          server_file_name: null,
+          server_emulator: null,
+          server_updated_at: null,
+          server_size: null,
+          last_sync_at: null,
+          status: "synced",
+        },
+      ],
+    });
+    const result = computeSyncSummary(true, status, []);
+    expect(result.syncSummaryColor).toBe("#5ba32b");
+    expect(result.syncSummaryText).toMatch(/^Synced \d+m ago$/);
   });
 });

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -111,6 +111,8 @@ export function statusLabel(status: string, lastSyncAt: string | null): { color:
       return { color: "#1a9fff", label: "Server newer" };
     case "conflict":
       return { color: "#d94126", label: "Conflict" };
+    case "unknown":
+      return { color: "#8f98a0", label: "Status unknown" };
     default:
       if (lastSyncAt) return { color: "#5ba32b", label: "Synced" };
       return { color: "#8f98a0", label: "Not synced" };

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -4,8 +4,10 @@
  * belongs here; rendering helpers live alongside their components.
  */
 
-import type { DeviceSyncInfo } from "../../types";
+import type { DeviceSyncInfo, SaveStatus, SyncConflict } from "../../types";
 import type { SlotDeleteInfo } from "../../api/backend";
+
+const MUTED_COLOR = "#8f98a0";
 
 /** Display a slot name, using "(no slot)" for null/empty values */
 export function displaySlot(slot: string | null | undefined): string {
@@ -117,4 +119,35 @@ export function statusLabel(status: string, lastSyncAt: string | null): { color:
       if (lastSyncAt) return { color: "#5ba32b", label: "Synced" };
       return { color: "#8f98a0", label: "Not synced" };
   }
+}
+
+/**
+ * Build the active slot's sync-summary header line.
+ *
+ * Returns the empty (null) state for inactive slots or missing status. When
+ * the backend signals `server_query_failed`, short-circuits with a neutral
+ * "Server unreachable" instead of running the matrix-derived classification
+ * (which would otherwise read an empty server list as "ready to upload").
+ */
+export function computeSyncSummary(
+  isActive: boolean,
+  saveStatus: SaveStatus | null,
+  conflicts: SyncConflict[],
+): { syncSummaryText: string | null; syncSummaryColor: string } {
+  if (!isActive || !saveStatus) return { syncSummaryText: null, syncSummaryColor: MUTED_COLOR };
+
+  if (saveStatus.server_query_failed) {
+    return { syncSummaryText: "Server unreachable", syncSummaryColor: MUTED_COLOR };
+  }
+
+  const hasConflict = conflicts.length > 0;
+  const fileCount = saveStatus.files?.length ?? 0;
+
+  if (hasConflict) return { syncSummaryText: "Conflict detected", syncSummaryColor: "#d94126" };
+  if (fileCount > 0 && saveStatus.last_sync_check_at) {
+    const rel = formatRelativeTime(saveStatus.last_sync_check_at);
+    return { syncSummaryText: rel === "just now" ? "Synced just now" : `Synced ${rel}`, syncSummaryColor: "#5ba32b" };
+  }
+  if (fileCount > 0) return { syncSummaryText: "Not synced", syncSummaryColor: MUTED_COLOR };
+  return { syncSummaryText: "No saves found", syncSummaryColor: MUTED_COLOR };
 }

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -78,6 +78,12 @@ export interface SaveStatus {
   conflicts?: SyncConflict[];
   active_slot?: string | null;
   save_sync_display?: SaveSyncDisplay;
+  /** True when the backend's ``list_saves`` call raised before the matrix
+   *  ran. Every file row carries ``status: "unknown"`` in that case — the
+   *  empty server list would otherwise be classified as "ready to upload"
+   *  and surface a misleading uploads-pending indicator on what is in
+   *  fact a connectivity blip. */
+  server_query_failed?: boolean;
 }
 
 export interface SaveSlotSummary {

--- a/tests/domain/test_save_status.py
+++ b/tests/domain/test_save_status.py
@@ -59,3 +59,19 @@ class TestComputeSaveSyncDisplay:
         files = [{"status": "synced", "local_path": "/saves/test.srm"}]
         result = compute_save_sync_display(files, "not-a-date")
         assert result == SaveSyncDisplay(status="synced", label=None, last_sync_check_at="not-a-date")
+
+    def test_server_query_failed_overrides_everything(self):
+        """server_query_failed=True collapses to 'Server unreachable' regardless of files."""
+        files = [{"status": "synced", "local_path": "/saves/test.srm"}]
+        result = compute_save_sync_display(files, "2026-01-01T00:00:00Z", server_query_failed=True)
+        assert result == SaveSyncDisplay(status="none", label="Server unreachable", last_sync_check_at=None)
+
+    def test_server_query_failed_with_empty_files(self):
+        """server_query_failed=True also wins over the empty-files branch."""
+        result = compute_save_sync_display([], None, server_query_failed=True)
+        assert result == SaveSyncDisplay(status="none", label="Server unreachable", last_sync_check_at=None)
+
+    def test_server_query_failed_default_false_preserves_legacy(self):
+        """Default value (False) preserves the pre-fix behavior."""
+        result = compute_save_sync_display(None, None)
+        assert result == SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -338,3 +338,148 @@ class TestBuildersDefensiveBranches:
         # A bare object is not Download/Conflict/Upload, so the function falls
         # through to the candidates check; an empty list returns None.
         assert _resolve_chosen_server(object(), []) is None
+
+
+class TestServerQueryFailed:
+    """``get_save_status`` must surface a connectivity-failure flag and
+    suppress the misleading "ready to upload" indicators an empty server
+    list would otherwise produce against local-only saves."""
+
+    @pytest.mark.asyncio
+    async def test_list_saves_failure_sets_flag_and_marks_status_unknown(self, tmp_path):
+        """OSError from list_saves → server_query_failed=True, file status=unknown."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.fail_on_next(OSError("connection reset"))
+
+        result = await svc.get_save_status(42)
+
+        assert result["server_query_failed"] is True
+        # A local save exists, so a row still appears — but the misleading
+        # matrix-derived "upload" verdict against an empty server list is
+        # replaced with the neutral "unknown" status.
+        assert len(result["files"]) == 1
+        file_row = result["files"][0]
+        assert file_row["status"] == "unknown"
+        assert file_row["filename"] == "pokemon.srm"
+        # Local-side fields stay intact (they come from local state, not
+        # from the failed list_saves call).
+        assert file_row["local_path"] is not None
+        assert file_row["local_hash"] is not None
+        assert file_row["local_size"] is not None
+        # Server-side attribution is nulled out — we have no server info.
+        assert file_row["server_save_id"] is None
+        assert file_row["server_file_name"] is None
+        assert file_row["server_emulator"] is None
+        assert file_row["server_updated_at"] is None
+        assert file_row["server_size"] is None
+        assert file_row["device_syncs"] == []
+        assert file_row["uploaded_by_us"] is None
+        # No conflicts can be reported when we don't actually know the
+        # server state.
+        assert result["conflicts"] == []
+        # The aggregate display collapses to a neutral "Server unreachable"
+        # label rather than the misleading "Not synced" / "Synced".
+        assert result["save_sync_display"] == {
+            "status": "none",
+            "label": "Server unreachable",
+            "last_sync_check_at": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_happy_path_flag_is_false(self, tmp_path):
+        """Successful list_saves preserves the normal flow with the flag set False."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+
+        ss = _server_save()
+        fake.saves[100] = ss
+
+        result = await svc.get_save_status(42)
+
+        assert result["server_query_failed"] is False
+        assert len(result["files"]) >= 1
+        # Real matrix verdict surfaced (not redacted).
+        assert result["files"][0]["status"] != "unknown"
+
+    @pytest.mark.asyncio
+    async def test_empty_server_response_is_not_failure(self, tmp_path):
+        """Genuine empty list (no saves on server) ≠ server_query_failed.
+
+        list_saves returns ``[]`` legitimately (no saves uploaded for this
+        ROM yet). The matrix correctly classifies the local-only file as
+        "upload" — that's the truth of the situation, not a misleading
+        artifact. The flag stays False and the display does NOT collapse
+        to "Server unreachable".
+        """
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        # No fail_on_next, no fake.saves entry → list_saves returns [].
+
+        result = await svc.get_save_status(42)
+
+        assert result["server_query_failed"] is False
+        # The matrix's "upload" verdict on a local-only file with a truly
+        # empty server is the correct answer, not a stale-cache artifact.
+        assert len(result["files"]) == 1
+        assert result["files"][0]["status"] == "upload"
+        # save_sync_display is NOT the "Server unreachable" fallback.
+        assert result["save_sync_display"]["label"] != "Server unreachable"
+
+    def test_redacted_entry_preserves_local_metadata(self, tmp_path):
+        """The bad-path redaction must not strip local-side metadata —
+        users still need to see *which* file is in the unknown state."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        ss = _server_save()
+        fake.saves[100] = ss
+
+        # Drive the IO helper directly with the failure flag so we exercise
+        # the redaction path against a "successful" matrix result.
+        result = svc._status._get_save_status_io(42, [ss], server_query_failed=True)
+
+        assert result["server_query_failed"] is True
+        assert len(result["files"]) == 1
+        row = result["files"][0]
+        assert row["status"] == "unknown"
+        assert row["filename"] == "pokemon.srm"
+        assert row["local_path"] is not None
+        assert row["local_size"] == 1024
+        assert row["server_save_id"] is None
+        assert result["conflicts"] == []
+
+
+class TestCompositeServerQueryFailedDomain:
+    """compute_save_sync_display short-circuits on server_query_failed."""
+
+    def test_failure_flag_overrides_files_and_check_timestamp(self):
+        """Even with files and a recent check, the failure flag wins."""
+        from domain.save_status import compute_save_sync_display
+
+        files = [{"filename": "pokemon.srm", "status": "synced", "local_path": "/x/pokemon.srm"}]
+        display = compute_save_sync_display(
+            files,
+            "2026-04-01T08:00:00+00:00",
+            server_query_failed=True,
+        )
+        assert display.status == "none"
+        assert display.label == "Server unreachable"
+        assert display.last_sync_check_at is None
+
+    def test_happy_path_default_kw_unchanged(self):
+        """Omitting the kw argument keeps the legacy behavior intact."""
+        from domain.save_status import compute_save_sync_display
+
+        files = [{"filename": "pokemon.srm", "status": "synced", "local_path": "/x/pokemon.srm"}]
+        display = compute_save_sync_display(files, "2026-04-01T08:00:00+00:00")
+        assert display.status == "synced"
+        assert display.label is None
+        assert display.last_sync_check_at == "2026-04-01T08:00:00+00:00"


### PR DESCRIPTION
## Summary

Closes #628. Parent: #619.

`status/service.py:get_save_status` previously caught the `list_saves` exception, logged a debug line, and proceeded to feed `server_saves=[]` into the matrix evaluator. Every local-only save then got classified as `Upload`, the file-status DTO advertised "ready to upload", and `save_sync_display` reported the synced/upload state of a server we never actually talked to. A single network blip flipped the SAVES tab from "synced" to "uploads pending".

## Fix

Backend now tracks whether `list_saves` raised and propagates that as a `server_query_failed` flag through the IO helper into the response dict. When the flag is `True`:

- The single file row is rewritten via `_redact_server_fields`: `status="unknown"`, server-side fields (`server_save_id`, `server_file_name`, `server_emulator`, `server_updated_at`, `server_size`, `device_syncs`, `uploaded_by_us`) nulled out. Local-side fields (`filename`, `local_path`, `local_hash`, `local_mtime`, `local_size`, `last_sync_at`) stay intact so the SavesTab can still show *which* file is in the unknown state.
- `conflicts` is suppressed (we cannot diagnose a conflict against an empty/missing server list).
- `compute_save_sync_display` short-circuits to `status="none"`, `label="Server unreachable"`, regardless of files/last_sync_check_at.

### DTO shape before/after

**Before** (network blip on a synced game):
```jsonc
{
  "files": [{ "filename": "pokemon.srm", "status": "upload", ... }],
  "save_sync_display": { "status": "synced", "label": "Not synced", ... },
  "conflicts": []
}
```

**After**:
```jsonc
{
  "files": [{ "filename": "pokemon.srm", "status": "unknown",
              "server_save_id": null, "device_syncs": [], ... }],
  "save_sync_display": { "status": "none", "label": "Server unreachable", "last_sync_check_at": null },
  "conflicts": [],
  "server_query_failed": true
}
```

### Frontend handling

- `SaveStatus` interface gains `server_query_failed?: boolean`.
- `SavesTab.computeSyncSummary` short-circuits to `"Server unreachable"` when the flag is set (suppresses the misleading "Synced X ago" / "Not synced" header on the active slot).
- `SavesTab.statusLabel` gains an `unknown` case rendering `"Status unknown"` in muted color — replaces the silent fall-through that previously rendered "Synced" when `lastSyncAt` was set.
- `RomMPlaySection`'s play-section row consumes the backend-computed `save_sync_display` verbatim via `applySaveSyncDisplay`, which now ships the `"Server unreachable"` label automatically (no FE logic change).

## Test plan

- [x] `python -m pytest tests/services/saves/test_status.py -v` — 20 passed including 4 new in `TestServerQueryFailed` + 2 new in `TestCompositeServerQueryFailedDomain`
- [x] `python -m pytest tests/ -q` — 2464 passed
- [x] `python -m pytest tests/domain/test_save_status.py -v` — covers the 3 new flag-handling branches
- [x] `ruff check` + `ruff format --check`
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh` — no forbidden calls
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept
- [x] `pnpm build` — built dist/index.js
- [x] `pnpm test` — 51 vitest tests passed
- [x] Coverage on touched modules: `domain/save_status.py` 100%, `services/saves/status/builders.py` 100%, `services/saves/status/service.py` 96% (new lines fully covered; missed lines are pre-existing in `check_save_status_background`, `check_core_change`, `_outcome_server_sort_key`).