### PR TITLE
fix(saves): wizard distinguishes server-unreachable from no-server-saves (#624)

### DIFF
--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -92,18 +92,37 @@ class SetupWizard:
                 }
             )
 
-        # Server saves
-        server_saves: list[dict] = []
+        # Server saves. On failure we MUST NOT treat the empty list as
+        # "server has no saves" — that path auto-confirms the default slot
+        # and the first post-confirmation sync could clobber real server
+        # saves the user already had. Surface a distinct recommendation so
+        # the frontend can hold the wizard and offer a retry instead.
         device_id = self._state_svc.get_server_device_id()
         try:
-            server_saves = await self._loop.run_in_executor(
+            server_saves: list[dict] = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
                 ),
             )
         except Exception as e:
-            self._log_debug(f"get_save_setup_info({rom_id}): failed to list saves: {e}")
+            self._logger.warning(
+                f"get_save_setup_info({rom_id}): failed to list server saves: {e}",
+            )
+            game_state = self._state_svc.state.saves.get(rom_id_str)
+            default_slot = self._state_svc.state.settings.default_slot or "default"
+            slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
+            active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
+            return {
+                "has_local_saves": len(local_files) > 0,
+                "local_files": local_file_info,
+                "server_slots": [],
+                "default_slot": default_slot,
+                "slot_confirmed": slot_confirmed,
+                "active_slot": active_slot,
+                "recommended_action": "server_unreachable",
+                "server_query_failed": True,
+            }
 
         # Group server saves by slot
         slots_map: dict[str | None, list[dict]] = {}
@@ -140,7 +159,9 @@ class SetupWizard:
 
         # Pre-computed wizard recommendation: auto-confirm the default slot only
         # when there are local saves and the server has no slots yet. Every other
-        # combination needs the wizard so the user can choose.
+        # combination needs the wizard so the user can choose. The
+        # ``server_unreachable`` branch returns early above — reaching this point
+        # means the server answered, so an empty ``server_slots`` is authoritative.
         recommended_action = (
             "auto_confirm_default" if (len(local_files) > 0 and len(server_slots) == 0) else "show_wizard"
         )
@@ -153,6 +174,7 @@ class SetupWizard:
             "slot_confirmed": slot_confirmed,
             "active_slot": active_slot,
             "recommended_action": recommended_action,
+            "server_query_failed": False,
         }
 
     async def confirm_slot_choice(

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -39,6 +39,7 @@ import {
 import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getEventTarget } from "../utils/events";
+import { resolveSaveSetupOutcome, SERVER_UNREACHABLE_TOAST_BODY } from "../utils/saveSetup";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, SyncConflict } from "../types";
@@ -272,14 +273,17 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     if (trackingResult.configured) return "proceed";
     try {
       const setupInfo = await getSaveSetupInfo(rid);
-      if (!setupInfo.has_local_saves && setupInfo.server_slots.length === 0) {
-        // No saves anywhere — auto-configure with default, proceed
-        await confirmSlotChoice(rid, setupInfo.default_slot, null);
-        return "proceed";
+      const outcome = resolveSaveSetupOutcome(setupInfo);
+      if (outcome.kind === "server_unreachable") {
+        toaster.toast({
+          title: "RomM Save Sync",
+          body: SERVER_UNREACHABLE_TOAST_BODY,
+        });
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
+        return "abort";
       }
-      if (setupInfo.has_local_saves && setupInfo.server_slots.length === 0) {
-        // Scenario B: local saves, no server — auto-configure
-        await confirmSlotChoice(rid, setupInfo.default_slot, null);
+      if (outcome.kind === "auto_confirm") {
+        await confirmSlotChoice(rid, outcome.slot, null);
         return "proceed";
       }
       // Server has saves — user must configure in saves tab
@@ -287,7 +291,6 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         title: "RomM Save Sync",
         body: "Configure save sync in the Saves tab first",
       });
-      // Switch to saves tab
       globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
       return "abort";
     } catch {

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -39,7 +39,7 @@ import {
 import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getEventTarget } from "../utils/events";
-import { resolveSaveSetupOutcome, SERVER_UNREACHABLE_TOAST_BODY } from "../utils/saveSetup";
+import { applyLaunchGateSetupOutcome, resolveSaveSetupOutcome } from "../utils/saveSetup";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, SyncConflict } from "../types";
@@ -265,34 +265,22 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     );
   };
 
-  // Save-slot tracking gate. Auto-configures the default slot for scenarios
-  // where no server saves exist; otherwise toasts + switches to the saves tab
-  // and tells the caller to bail. Returns "proceed" | "abort".
+  // Save-slot tracking gate. Delegates branch handling to applyLaunchGateSetupOutcome
+  // so the per-outcome side effects (toast + saves-tab switch vs auto-confirm) stay
+  // testable without rendering this component.
   const ensureTrackingConfigured = async (rid: number): Promise<"proceed" | "abort"> => {
     const trackingResult = await isSaveTrackingConfigured(rid).catch(() => ({ configured: true }));
     if (trackingResult.configured) return "proceed";
     try {
       const setupInfo = await getSaveSetupInfo(rid);
       const outcome = resolveSaveSetupOutcome(setupInfo);
-      if (outcome.kind === "server_unreachable") {
-        toaster.toast({
-          title: "RomM Save Sync",
-          body: SERVER_UNREACHABLE_TOAST_BODY,
-        });
-        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
-        return "abort";
-      }
-      if (outcome.kind === "auto_confirm") {
-        await confirmSlotChoice(rid, outcome.slot, null);
-        return "proceed";
-      }
-      // Server has saves — user must configure in saves tab
-      toaster.toast({
-        title: "RomM Save Sync",
-        body: "Configure save sync in the Saves tab first",
+      return applyLaunchGateSetupOutcome(outcome, {
+        rid,
+        confirmSlotChoice,
+        toast: (body) => toaster.toast({ title: "RomM Save Sync", body }),
+        dispatchSavesTab: () =>
+          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } })),
       });
-      globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } }));
-      return "abort";
     } catch {
       // If check fails, proceed with launch anyway
       return "proceed";

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, FC, createElement, ChangeEvent } from "react";
 import { DialogButton, ConfirmModal, TextField, showModal } from "@decky/ui";
 import { getSaveSetupInfo, confirmSlotChoice, logError } from "../api/backend";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
-import { SERVER_UNREACHABLE_WIZARD_MESSAGE } from "../utils/saveSetup";
+import { applyWizardInitialSetupResult, applyWizardRetrySetupResult } from "../utils/saveSetup";
 import type { SaveSetupInfo } from "../types";
 
 interface SlotSetupWizardProps {
@@ -77,33 +77,16 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       try {
         const result = await getSaveSetupInfo(romId);
         if (cancelled) return;
-
-        if (result.recommended_action === "server_unreachable") {
-          // Hold the wizard — auto-confirming default with an unknown server
-          // state could overwrite real server saves the user already had on
-          // first post-confirmation sync. Surface the error so the user can
-          // retry once the server is reachable.
-          setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
-          return;
-        }
-
-        if (result.recommended_action === "auto_confirm_default") {
-          setConfirming(true);
-          try {
-            await confirmSlotChoice(romId, result.default_slot, null);
-            if (!cancelled) onComplete();
-          } catch (e) {
-            if (!cancelled) {
-              setError(`Auto-setup failed: ${e}`);
-              logError(`SlotSetupWizard auto-confirm failed: ${e}`);
-              setConfirming(false);
-              setInfo(result);
-            }
-          }
-          return;
-        }
-
-        setInfo(result);
+        await applyWizardInitialSetupResult(result, {
+          romId,
+          confirmSlotChoice,
+          setError,
+          setConfirming,
+          setInfo,
+          logError,
+          onComplete,
+          isCancelled: () => cancelled,
+        });
       } catch (e) {
         if (!cancelled) {
           setError(`Failed to load save setup info: ${e}`);
@@ -161,15 +144,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             setError(null);
             setLoading(true);
             getSaveSetupInfo(romId).then(
-              (result) => {
-                if (result.recommended_action === "server_unreachable") {
-                  setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
-                  setLoading(false);
-                  return;
-                }
-                setInfo(result);
-                setLoading(false);
-              },
+              (result) => applyWizardRetrySetupResult(result, { setError, setLoading, setInfo }),
               (e) => { setError(`Failed: ${e}`); setLoading(false); },
             );
           }}

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, FC, createElement, ChangeEvent } from "react";
 import { DialogButton, ConfirmModal, TextField, showModal } from "@decky/ui";
 import { getSaveSetupInfo, confirmSlotChoice, logError } from "../api/backend";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
+import { SERVER_UNREACHABLE_WIZARD_MESSAGE } from "../utils/saveSetup";
 import type { SaveSetupInfo } from "../types";
 
 interface SlotSetupWizardProps {
@@ -77,6 +78,15 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         const result = await getSaveSetupInfo(romId);
         if (cancelled) return;
 
+        if (result.recommended_action === "server_unreachable") {
+          // Hold the wizard — auto-confirming default with an unknown server
+          // state could overwrite real server saves the user already had on
+          // first post-confirmation sync. Surface the error so the user can
+          // retry once the server is reachable.
+          setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+          return;
+        }
+
         if (result.recommended_action === "auto_confirm_default") {
           setConfirming(true);
           try {
@@ -151,7 +161,15 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             setError(null);
             setLoading(true);
             getSaveSetupInfo(romId).then(
-              (result) => { setInfo(result); setLoading(false); },
+              (result) => {
+                if (result.recommended_action === "server_unreachable") {
+                  setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+                  setLoading(false);
+                  return;
+                }
+                setInfo(result);
+                setLoading(false);
+              },
               (e) => { setError(`Failed: ${e}`); setLoading(false); },
             );
           }}

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -135,5 +135,12 @@ export interface SaveSetupInfo {
   default_slot: string;
   slot_confirmed: boolean;
   active_slot: string | null;
-  recommended_action: "auto_confirm_default" | "show_wizard";
+  // "server_unreachable" means the server-saves fetch failed — the wizard MUST
+  // hold and offer a retry instead of treating the empty server_slots as
+  // authoritative (auto-confirming default would clobber real server saves on
+  // first sync). See backend `get_save_setup_info`.
+  recommended_action: "auto_confirm_default" | "show_wizard" | "server_unreachable";
+  // Mirrors recommended_action === "server_unreachable" — explicit flag for
+  // call sites that route on the boolean rather than the enum.
+  server_query_failed?: boolean;
 }

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { resolveSaveSetupOutcome } from "./saveSetup";
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyLaunchGateSetupOutcome,
+  applyWizardInitialSetupResult,
+  applyWizardRetrySetupResult,
+  resolveSaveSetupOutcome,
+  SERVER_UNREACHABLE_WIZARD_MESSAGE,
+  SERVER_UNREACHABLE_TOAST_BODY,
+  type LaunchGateSetupDeps,
+  type SaveSetupOutcome,
+  type WizardRetryDeps,
+  type WizardSetupDeps,
+} from "./saveSetup";
 import type { SaveSetupInfo } from "../types";
 
 function makeInfo(overrides: Partial<SaveSetupInfo> = {}): SaveSetupInfo {
@@ -57,5 +68,180 @@ describe("resolveSaveSetupOutcome", () => {
       ],
     });
     expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "needs_user_choice" });
+  });
+});
+
+function makeLaunchGateDeps(overrides: Partial<LaunchGateSetupDeps> = {}): LaunchGateSetupDeps {
+  return {
+    rid: 42,
+    confirmSlotChoice: vi.fn().mockResolvedValue({ success: true }),
+    toast: vi.fn(),
+    dispatchSavesTab: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("applyLaunchGateSetupOutcome", () => {
+  it("toasts the unreachable copy, dispatches the saves-tab switch, and aborts on server_unreachable", async () => {
+    const deps = makeLaunchGateDeps();
+    const result = await applyLaunchGateSetupOutcome({ kind: "server_unreachable" }, deps);
+    expect(result).toBe("abort");
+    expect(deps.toast).toHaveBeenCalledWith(SERVER_UNREACHABLE_TOAST_BODY);
+    expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
+    expect(deps.confirmSlotChoice).not.toHaveBeenCalled();
+  });
+
+  it("calls confirmSlotChoice with the resolved slot and proceeds on auto_confirm", async () => {
+    const deps = makeLaunchGateDeps();
+    const outcome: SaveSetupOutcome = { kind: "auto_confirm", slot: "main" };
+    const result = await applyLaunchGateSetupOutcome(outcome, deps);
+    expect(result).toBe("proceed");
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", null);
+    expect(deps.toast).not.toHaveBeenCalled();
+    expect(deps.dispatchSavesTab).not.toHaveBeenCalled();
+  });
+
+  it("toasts the configure-in-saves-tab copy, dispatches the tab switch, and aborts on needs_user_choice", async () => {
+    const deps = makeLaunchGateDeps();
+    const result = await applyLaunchGateSetupOutcome({ kind: "needs_user_choice" }, deps);
+    expect(result).toBe("abort");
+    expect(deps.toast).toHaveBeenCalledWith("Configure save sync in the Saves tab first");
+    expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
+    expect(deps.confirmSlotChoice).not.toHaveBeenCalled();
+  });
+});
+
+function makeWizardDeps(overrides: Partial<WizardSetupDeps> = {}): WizardSetupDeps {
+  return {
+    romId: 7,
+    confirmSlotChoice: vi.fn().mockResolvedValue({ success: true }),
+    setError: vi.fn(),
+    setConfirming: vi.fn(),
+    setInfo: vi.fn(),
+    logError: vi.fn(),
+    onComplete: vi.fn(),
+    isCancelled: () => false,
+    ...overrides,
+  };
+}
+
+describe("applyWizardInitialSetupResult", () => {
+  it("sets the server-unreachable banner and bails on 'server_unreachable'", async () => {
+    const deps = makeWizardDeps();
+    const result = makeInfo({ recommended_action: "server_unreachable", server_query_failed: true });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setError).toHaveBeenCalledWith(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+    expect(deps.setConfirming).not.toHaveBeenCalled();
+    expect(deps.confirmSlotChoice).not.toHaveBeenCalled();
+    expect(deps.setInfo).not.toHaveBeenCalled();
+    expect(deps.onComplete).not.toHaveBeenCalled();
+  });
+
+  it("auto-confirms and calls onComplete on 'auto_confirm_default'", async () => {
+    const deps = makeWizardDeps();
+    const result = makeInfo({ recommended_action: "auto_confirm_default", default_slot: "alpha" });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setConfirming).toHaveBeenCalledWith(true);
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(7, "alpha", null);
+    expect(deps.onComplete).toHaveBeenCalledOnce();
+    expect(deps.setError).not.toHaveBeenCalled();
+    expect(deps.setInfo).not.toHaveBeenCalled();
+  });
+
+  it("skips onComplete when the caller is cancelled mid-confirm", async () => {
+    let cancelled = false;
+    const confirm = vi.fn().mockImplementation(() => {
+      cancelled = true;
+      return Promise.resolve({ success: true });
+    });
+    const deps = makeWizardDeps({ confirmSlotChoice: confirm, isCancelled: () => cancelled });
+    const result = makeInfo({ recommended_action: "auto_confirm_default" });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.onComplete).not.toHaveBeenCalled();
+    expect(deps.setError).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a confirm failure with error banner, logger, info fallback, and resets confirming", async () => {
+    const deps = makeWizardDeps({
+      confirmSlotChoice: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+    const result = makeInfo({ recommended_action: "auto_confirm_default", default_slot: "alpha" });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setError).toHaveBeenCalledWith(expect.stringContaining("Auto-setup failed:"));
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining("SlotSetupWizard auto-confirm failed:"));
+    expect(deps.setConfirming).toHaveBeenNthCalledWith(1, true);
+    expect(deps.setConfirming).toHaveBeenNthCalledWith(2, false);
+    expect(deps.setInfo).toHaveBeenCalledWith(result);
+    expect(deps.onComplete).not.toHaveBeenCalled();
+  });
+
+  it("skips error/info side effects when the caller is cancelled during a confirm failure", async () => {
+    let cancelled = false;
+    const confirm = vi.fn().mockImplementation(() => {
+      cancelled = true;
+      return Promise.reject(new Error("boom"));
+    });
+    const deps = makeWizardDeps({ confirmSlotChoice: confirm, isCancelled: () => cancelled });
+    const result = makeInfo({ recommended_action: "auto_confirm_default" });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setError).not.toHaveBeenCalled();
+    expect(deps.logError).not.toHaveBeenCalled();
+    expect(deps.setInfo).not.toHaveBeenCalled();
+  });
+
+  it("falls through to setInfo on 'show_wizard'", async () => {
+    const deps = makeWizardDeps();
+    const result = makeInfo({
+      recommended_action: "show_wizard",
+      server_slots: [
+        { slot: "default", saves: [], count: 1, latest_updated_at: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setInfo).toHaveBeenCalledWith(result);
+    expect(deps.setError).not.toHaveBeenCalled();
+    expect(deps.setConfirming).not.toHaveBeenCalled();
+    expect(deps.confirmSlotChoice).not.toHaveBeenCalled();
+  });
+});
+
+function makeRetryDeps(overrides: Partial<WizardRetryDeps> = {}): WizardRetryDeps {
+  return {
+    setError: vi.fn(),
+    setLoading: vi.fn(),
+    setInfo: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("applyWizardRetrySetupResult", () => {
+  it("sets the unreachable banner and clears loading on 'server_unreachable'", () => {
+    const deps = makeRetryDeps();
+    const result = makeInfo({ recommended_action: "server_unreachable" });
+    applyWizardRetrySetupResult(result, deps);
+    expect(deps.setError).toHaveBeenCalledWith(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+    expect(deps.setLoading).toHaveBeenCalledWith(false);
+    expect(deps.setInfo).not.toHaveBeenCalled();
+  });
+
+  it("sets the fetched info and clears loading on a non-unreachable result", () => {
+    const deps = makeRetryDeps();
+    const result = makeInfo({ recommended_action: "show_wizard" });
+    applyWizardRetrySetupResult(result, deps);
+    expect(deps.setInfo).toHaveBeenCalledWith(result);
+    expect(deps.setLoading).toHaveBeenCalledWith(false);
+    expect(deps.setError).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-confirm even when the backend returns 'auto_confirm_default'", () => {
+    // The retry button is user-initiated; the wizard should re-present the
+    // (now-loaded) data rather than re-triggering the destructive auto-setup
+    // path. The setInfo branch covers this case.
+    const deps = makeRetryDeps();
+    const result = makeInfo({ recommended_action: "auto_confirm_default" });
+    applyWizardRetrySetupResult(result, deps);
+    expect(deps.setInfo).toHaveBeenCalledWith(result);
+    expect(deps.setLoading).toHaveBeenCalledWith(false);
+    expect(deps.setError).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolveSaveSetupOutcome } from "./saveSetup";
+import type { SaveSetupInfo } from "../types";
+
+function makeInfo(overrides: Partial<SaveSetupInfo> = {}): SaveSetupInfo {
+  return {
+    has_local_saves: false,
+    local_files: [],
+    server_slots: [],
+    default_slot: "default",
+    slot_confirmed: false,
+    active_slot: null,
+    recommended_action: "auto_confirm_default",
+    ...overrides,
+  };
+}
+
+describe("resolveSaveSetupOutcome", () => {
+  it("routes 'server_unreachable' to the unreachable outcome", () => {
+    const info = makeInfo({ recommended_action: "server_unreachable", server_query_failed: true });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "server_unreachable" });
+  });
+
+  it("routes 'server_unreachable' to the unreachable outcome even when server_query_failed is absent", () => {
+    // The enum alone is authoritative — server_query_failed is a redundant
+    // mirror flag for call sites that branch on a boolean.
+    const info = makeInfo({ recommended_action: "server_unreachable" });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "server_unreachable" });
+  });
+
+  it("routes 'auto_confirm_default' to the auto-confirm outcome with the default slot", () => {
+    const info = makeInfo({ recommended_action: "auto_confirm_default", default_slot: "main" });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "auto_confirm", slot: "main" });
+  });
+
+  it("auto-confirms when the backend asks for the wizard but no server slots exist", () => {
+    // Local saves but server empty — historic launch-gate behavior was to
+    // auto-configure the default; preserved by resolveSaveSetupOutcome.
+    const info = makeInfo({
+      recommended_action: "show_wizard",
+      has_local_saves: true,
+      default_slot: "default",
+    });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "auto_confirm", slot: "default" });
+  });
+
+  it("auto-confirms when both sides are empty under 'show_wizard'", () => {
+    const info = makeInfo({ recommended_action: "show_wizard", default_slot: "default" });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "auto_confirm", slot: "default" });
+  });
+
+  it("requires user choice when the server reports any slots and the wizard is requested", () => {
+    const info = makeInfo({
+      recommended_action: "show_wizard",
+      server_slots: [
+        { slot: "default", saves: [], count: 1, latest_updated_at: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    expect(resolveSaveSetupOutcome(info)).toEqual({ kind: "needs_user_choice" });
+  });
+});

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure decision logic for "what should the caller do with a SaveSetupInfo
+ * response?". Mirrors the three-way outcome both the wizard
+ * (SlotSetupWizard) and the launch gate (CustomPlayButton.ensureTrackingConfigured)
+ * need so the branch is testable in isolation from React/Decky APIs.
+ *
+ * The "server_unreachable" branch exists because `recommended_action` carries
+ * the explicit failure mode from the backend (see `get_save_setup_info`); the
+ * call site MUST NOT treat an empty `server_slots` array as authoritative on
+ * that path or it risks clobbering real server saves on first sync.
+ */
+
+import type { SaveSetupInfo } from "../types";
+
+export type SaveSetupOutcome =
+  | { kind: "server_unreachable" }
+  | { kind: "auto_confirm"; slot: string }
+  | { kind: "needs_user_choice" };
+
+/** Resolve a SaveSetupInfo into the action its callers should take. */
+export function resolveSaveSetupOutcome(info: SaveSetupInfo): SaveSetupOutcome {
+  if (info.recommended_action === "server_unreachable") {
+    return { kind: "server_unreachable" };
+  }
+  // Either the backend marked the response as "auto_confirm_default", or the
+  // server is reachable but reports no saves on either side — both are safe
+  // to auto-confirm with the default slot.
+  if (info.recommended_action === "auto_confirm_default") {
+    return { kind: "auto_confirm", slot: info.default_slot };
+  }
+  // Mirrors CustomPlayButton's pre-extraction branches: local-only or
+  // empty-everywhere can still auto-confirm; only "server has saves" forces
+  // the wizard.
+  if (info.server_slots.length === 0) {
+    return { kind: "auto_confirm", slot: info.default_slot };
+  }
+  return { kind: "needs_user_choice" };
+}
+
+/** User-facing copy for the server-unreachable branch, shared by the wizard
+ *  banner and the launch-gate toast. */
+export const SERVER_UNREACHABLE_WIZARD_MESSAGE =
+  "RomM server is not reachable — cannot configure save slot. Retry once the server is back.";
+
+export const SERVER_UNREACHABLE_TOAST_BODY =
+  "Cannot configure save slot — RomM server is not reachable. Open the Saves tab to retry.";

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -1,8 +1,9 @@
 /**
- * Pure decision logic for "what should the caller do with a SaveSetupInfo
- * response?". Mirrors the three-way outcome both the wizard
- * (SlotSetupWizard) and the launch gate (CustomPlayButton.ensureTrackingConfigured)
- * need so the branch is testable in isolation from React/Decky APIs.
+ * Pure decision logic and branch handlers for "what should the caller do with
+ * a SaveSetupInfo response?". Two callers consume the same three-way outcome:
+ * the wizard (`SlotSetupWizard`) and the launch gate
+ * (`CustomPlayButton.ensureTrackingConfigured`). Anything that lives here can
+ * be unit-tested without rendering the component or stubbing React.
  *
  * The "server_unreachable" branch exists because `recommended_action` carries
  * the explicit failure mode from the backend (see `get_save_setup_info`); the
@@ -44,3 +45,116 @@ export const SERVER_UNREACHABLE_WIZARD_MESSAGE =
 
 export const SERVER_UNREACHABLE_TOAST_BODY =
   "Cannot configure save slot — RomM server is not reachable. Open the Saves tab to retry.";
+
+const NEEDS_USER_CHOICE_TOAST_BODY = "Configure save sync in the Saves tab first";
+
+/** Side-effect bundle for the launch-gate handler. The component supplies
+ *  Decky's `toaster.toast` and the global event dispatch; tests pass spies. */
+export interface LaunchGateSetupDeps {
+  /** ROM id passed to `confirmSlotChoice` on the auto-confirm branch. */
+  rid: number;
+  /** Resolves the user's chosen save slot on the backend. */
+  confirmSlotChoice: (rid: number, slot: string, migrate: string | null) => Promise<unknown>;
+  /** Shows a Decky toast — wrapped as a callback so the helper is dispatch-agnostic. */
+  toast: (body: string) => void;
+  /** Switches to the Saves tab — wrapped as a callback so the helper is
+   *  dispatch-agnostic (component dispatches a `CustomEvent`; tests pass a spy). */
+  dispatchSavesTab: () => void;
+}
+
+/** Dispatch a resolved `SaveSetupOutcome` from the launch gate (`Play` button)
+ *  — returns "proceed" when the launch may continue or "abort" when the user
+ *  was routed to the saves tab. */
+export async function applyLaunchGateSetupOutcome(
+  outcome: SaveSetupOutcome,
+  deps: LaunchGateSetupDeps,
+): Promise<"proceed" | "abort"> {
+  if (outcome.kind === "server_unreachable") {
+    deps.toast(SERVER_UNREACHABLE_TOAST_BODY);
+    deps.dispatchSavesTab();
+    return "abort";
+  }
+  if (outcome.kind === "auto_confirm") {
+    await deps.confirmSlotChoice(deps.rid, outcome.slot, null);
+    return "proceed";
+  }
+  // Server has saves — user must configure in saves tab.
+  deps.toast(NEEDS_USER_CHOICE_TOAST_BODY);
+  deps.dispatchSavesTab();
+  return "abort";
+}
+
+/** Side-effect bundle for the wizard's initial-fetch and retry handlers. The
+ *  component supplies React's state setters and `confirmSlotChoice`; tests
+ *  pass spies. */
+export interface WizardSetupDeps {
+  romId: number;
+  confirmSlotChoice: (rid: number, slot: string, migrate: string | null) => Promise<{ success?: boolean } | undefined>;
+  setError: (message: string | null) => void;
+  setConfirming: (confirming: boolean) => void;
+  setInfo: (info: SaveSetupInfo) => void;
+  logError: (message: string) => void;
+  onComplete: () => void;
+  /** Returns true when the caller has been unmounted/superseded — guards the
+   *  state setters after the awaited `confirmSlotChoice`. */
+  isCancelled: () => boolean;
+}
+
+/** Apply the initial `getSaveSetupInfo` result inside `SlotSetupWizard`'s
+ *  fetch effect. Routes server_unreachable to a held-wizard error banner,
+ *  auto_confirm_default through a backend confirm, and everything else into
+ *  the per-slot picker by calling `setInfo`. */
+export async function applyWizardInitialSetupResult(
+  result: SaveSetupInfo,
+  deps: WizardSetupDeps,
+): Promise<void> {
+  if (result.recommended_action === "server_unreachable") {
+    // Hold the wizard — auto-confirming default with an unknown server state
+    // could overwrite real server saves the user already had on first
+    // post-confirmation sync. Surface the error so the user can retry once
+    // the server is reachable.
+    deps.setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+    return;
+  }
+  if (result.recommended_action === "auto_confirm_default") {
+    deps.setConfirming(true);
+    try {
+      await deps.confirmSlotChoice(deps.romId, result.default_slot, null);
+      if (!deps.isCancelled()) deps.onComplete();
+    } catch (e) {
+      if (!deps.isCancelled()) {
+        deps.setError(`Auto-setup failed: ${e}`);
+        deps.logError(`SlotSetupWizard auto-confirm failed: ${e}`);
+        deps.setConfirming(false);
+        deps.setInfo(result);
+      }
+    }
+    return;
+  }
+  deps.setInfo(result);
+}
+
+/** Side-effect bundle for the wizard's retry button. Narrower than
+ *  WizardSetupDeps because retry never auto-confirms. */
+export interface WizardRetryDeps {
+  setError: (message: string | null) => void;
+  setLoading: (loading: boolean) => void;
+  setInfo: (info: SaveSetupInfo) => void;
+}
+
+/** Apply the retry-button's `getSaveSetupInfo` result. Mirrors the
+ *  server_unreachable handling of the initial fetch but skips the auto-confirm
+ *  branch — retry is user-initiated and never auto-fires a destructive
+ *  setup. */
+export function applyWizardRetrySetupResult(
+  result: SaveSetupInfo,
+  deps: WizardRetryDeps,
+): void {
+  if (result.recommended_action === "server_unreachable") {
+    deps.setError(SERVER_UNREACHABLE_WIZARD_MESSAGE);
+    deps.setLoading(false);
+    return;
+  }
+  deps.setInfo(result);
+  deps.setLoading(false);
+}

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -346,8 +346,13 @@ class TestGetSaveSetupInfo:
         assert slot_names == {"default", "desktop"}
 
     @pytest.mark.asyncio
-    async def test_server_error_returns_empty_slots(self, tmp_path):
-        """Server API failure still returns local info with empty server_slots."""
+    async def test_server_error_recommends_server_unreachable_not_auto_confirm(self, tmp_path):
+        """Server API failure MUST NOT be misread as "server has no saves".
+
+        Regression: a transient list_saves failure used to recommend
+        auto_confirm_default whenever local saves existed, which on the
+        first post-confirmation sync could clobber real server saves.
+        """
         svc, fake = make_service(tmp_path)
         svc._save_sync_state.settings.save_sync_enabled = True
         svc._save_sync_state.device_id = "dev-1"
@@ -358,6 +363,40 @@ class TestGetSaveSetupInfo:
         result = await svc.get_save_setup_info(42)
         assert result["has_local_saves"] is True
         assert result["server_slots"] == []
+        assert result["recommended_action"] == "server_unreachable"
+        assert result["recommended_action"] != "auto_confirm_default"
+        assert result["server_query_failed"] is True
+
+    @pytest.mark.asyncio
+    async def test_server_error_with_oserror_recommends_server_unreachable(self, tmp_path):
+        """OSError (transport-layer) failure routes to server_unreachable too."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.fail_on_next(OSError("Connection refused"))
+
+        result = await svc.get_save_setup_info(42)
+        assert result["recommended_action"] == "server_unreachable"
+        assert result["server_query_failed"] is True
+
+    @pytest.mark.asyncio
+    async def test_server_error_preserves_local_info_in_response(self, tmp_path):
+        """On server failure we still surface what we know locally."""
+        svc, fake = make_service(tmp_path)
+        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._save_sync_state.device_id = "dev-1"
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.fail_on_next(RommApiError(500, "Server error"))
+
+        result = await svc.get_save_setup_info(42)
+        assert result["has_local_saves"] is True
+        assert len(result["local_files"]) == 1
+        assert result["local_files"][0]["filename"] == "pokemon.srm"
+        assert result["default_slot"] == "default"
+        assert result["slot_confirmed"] is False
 
     @pytest.mark.asyncio
     async def test_no_rom_installed(self, tmp_path):
@@ -382,6 +421,8 @@ class TestGetSaveSetupInfo:
         assert result["has_local_saves"] is True
         assert result["server_slots"] == []
         assert result["recommended_action"] == "auto_confirm_default"
+        # Authoritative empty list (server answered) — NOT a hidden failure
+        assert result["server_query_failed"] is False
 
     @pytest.mark.asyncio
     async def test_get_save_setup_info_recommends_wizard_when_server_has_slots(self, tmp_path):
@@ -397,6 +438,7 @@ class TestGetSaveSetupInfo:
         assert result["has_local_saves"] is True
         assert len(result["server_slots"]) == 1
         assert result["recommended_action"] == "show_wizard"
+        assert result["server_query_failed"] is False
 
     @pytest.mark.asyncio
     async def test_get_save_setup_info_recommends_wizard_when_no_local_saves(self, tmp_path):
@@ -411,6 +453,7 @@ class TestGetSaveSetupInfo:
         result = await svc.get_save_setup_info(42)
         assert result["has_local_saves"] is False
         assert result["recommended_action"] == "show_wizard"
+        assert result["server_query_failed"] is False
 
 
 class TestConfirmSlotChoice:


### PR DESCRIPTION
## Summary

`get_save_setup_info` in `slots/setup.py` caught any `list_saves` failure and only `_log_debug`ed it, then computed `recommended_action = "auto_confirm_default"` whenever `len(server_slots) == 0`. A transient API failure was indistinguishable from "ROM has no server saves yet" — the wizard auto-confirmed the default slot, and the first post-confirmation sync could clobber or duplicate the real server saves the user already had. The user was never told their server-side state was unknown at decision time.

Closes #624. Parent: #619.

## Fix

On `list_saves` failure, return a distinct `recommended_action: "server_unreachable"` plus a `server_query_failed: True` flag, mirroring the sibling fixes in #625 / #626. Bump the log from debug to warning since this is the path that produced the silent-data-loss risk.

**Before** (failure path):

```python
{
  "has_local_saves": True,
  "server_slots": [],
  "recommended_action": "auto_confirm_default",  # bug: indistinguishable from "no server saves"
  ...
}
```

**After** (failure path):

```python
{
  "has_local_saves": True,
  "server_slots": [],
  "recommended_action": "server_unreachable",
  "server_query_failed": True,
  ...
}
```

## Frontend changes

- `SlotSetupWizard.tsx` — holds the wizard with a "RomM server not reachable — retry once the server is back" message instead of auto-confirming. Retry button re-checks for the unreachable state too.
- `CustomPlayButton.tsx` — `ensureTrackingConfigured` (the launch-button save gate) had the same silent-failure bug: it auto-configured the default slot whenever `server_slots.length === 0`. It now routes the user to the saves tab with a toast and aborts the launch when the server is unreachable.
- `types/index.ts` — `SaveSetupInfo.recommended_action` enum extended with `"server_unreachable"`; optional `server_query_failed?: boolean` flag added.

## Test plan

- [x] `python -m pytest tests/services/saves/test_slots.py -v` (63 passed)
- [x] `python -m pytest tests/ -q` (2457 passed)
- [x] `ruff check` + `ruff format --check` on touched files (clean)
- [x] `basedpyright` (0 errors)
- [x] `bash scripts/check_cosmic_call_bans.sh` (no forbidden calls)
- [x] `PYTHONPATH=py_modules lint-imports` (7 contracts kept)
- [x] `pnpm build` (no new errors in touched files)
- [x] `pnpm test` (51 passed)
- [x] Coverage on `services/saves/slots/setup.py`: 97%

### New tests

- `test_server_error_recommends_server_unreachable_not_auto_confirm` — `RommApiError` → `recommended_action == "server_unreachable"`, NOT `auto_confirm_default`.
- `test_server_error_with_oserror_recommends_server_unreachable` — `OSError` (transport) → same routing.
- `test_server_error_preserves_local_info_in_response` — failure path still surfaces local files, default_slot, slot_confirmed.
- Happy-path tests extended to assert `server_query_failed is False`.