### PR TITLE
feat(downloads): emit download_failed event on download failure (#632)

### DIFF
--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -395,6 +395,15 @@ class DownloadService:
             self._download_queue[rom_id]["error"] = str(e)
             self._cleanup_partial_download(target_path, rom_detail.get("has_multiple_files", False), file_name)
             self._logger.error(f"Download failed for {rom_name}: {e}")
+            await self._emit(
+                "download_failed",
+                {
+                    "rom_id": rom_id,
+                    "rom_name": rom_name,
+                    "platform_name": platform_name,
+                    "error_message": str(e),
+                },
+            )
 
         finally:
             self._download_tasks.pop(rom_id, None)

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -202,6 +202,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       },
     );
 
+    /* istanbul ignore next -- listener-wiring; logic tested in src/utils/downloadFailure.test.ts */
     const failedListener = addEventListener<[DownloadFailedEvent]>(
       "download_failed",
       // The global listener in index.tsx owns the failure toast; here we only

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -42,7 +42,7 @@ import { getEventTarget } from "../utils/events";
 import { applyLaunchGateSetupOutcome, resolveSaveSetupOutcome } from "../utils/saveSetup";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
-import type { DownloadProgressEvent, DownloadCompleteEvent, SyncConflict } from "../types";
+import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SyncConflict } from "../types";
 
 type PlayButtonState = "loading" | "not_romm" | "download" | "conflict" | "syncing" | "play" | "launching" | "dl_complete" | "uninstalling";
 
@@ -201,6 +201,18 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       },
     );
 
+    const failedListener = addEventListener<[DownloadFailedEvent]>(
+      "download_failed",
+      (evt: DownloadFailedEvent) => {
+        if (evt.rom_id !== romIdRef.current) return;
+        // Reset to download state so the user can retry; the global
+        // listener in index.tsx surfaces the failure toast.
+        setDlProgress(null);
+        setActionPending(false);
+        setState("download");
+      },
+    );
+
     const onUninstall = (e: Event) => {
       const romId = (e as CustomEvent).detail?.rom_id;
       if (romId !== romIdRef.current) return;
@@ -234,6 +246,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     return () => {
       removeEventListener("download_progress", progressListener);
       removeEventListener("download_complete", completeListener);
+      removeEventListener("download_failed", failedListener);
       globalThis.removeEventListener("romm_rom_uninstalled", onUninstall);
       globalThis.removeEventListener("romm_data_changed", onDataChanged);
       globalThis.removeEventListener("romm_connection_changed", onConnectionChanged);

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -40,6 +40,7 @@ import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getEventTarget } from "../utils/events";
 import { applyLaunchGateSetupOutcome, resolveSaveSetupOutcome } from "../utils/saveSetup";
+import { handleButtonDownloadFailure } from "../utils/downloadFailure";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SyncConflict } from "../types";
@@ -203,14 +204,14 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
     const failedListener = addEventListener<[DownloadFailedEvent]>(
       "download_failed",
-      (evt: DownloadFailedEvent) => {
-        if (evt.rom_id !== romIdRef.current) return;
-        // Reset to download state so the user can retry; the global
-        // listener in index.tsx surfaces the failure toast.
-        setDlProgress(null);
-        setActionPending(false);
-        setState("download");
-      },
+      // The global listener in index.tsx owns the failure toast; here we only
+      // reset local UI so the user can retry.
+      (evt: DownloadFailedEvent) =>
+        handleButtonDownloadFailure(evt, romIdRef.current, () => {
+          setDlProgress(null);
+          setActionPending(false);
+          setState("download");
+        }),
     );
 
     const onUninstall = (e: Event) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { DownloadQueue } from "./components/DownloadQueue";
 import { initUnitSyncManager } from "./utils/syncManager";
 import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
+import { handleGlobalDownloadFailure } from "./utils/downloadFailure";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
 import { registerMetadataPatches, unregisterMetadataPatches, applyAllPlaytime } from "./patches/metadataPatches";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
@@ -386,24 +387,8 @@ export default definePlugin(() => {
 
   const downloadFailedListener = addEventListener<[DownloadFailedEvent]>(
     "download_failed",
-    (data: DownloadFailedEvent) => {
-      const prev = getDownloadState().find((d) => d.rom_id === data.rom_id);
-      updateDownload({
-        rom_id: data.rom_id,
-        rom_name: data.rom_name,
-        platform_name: data.platform_name,
-        file_name: prev?.file_name ?? "",
-        status: "failed",
-        progress: prev?.progress ?? 0,
-        bytes_downloaded: prev?.bytes_downloaded ?? 0,
-        total_bytes: prev?.total_bytes ?? 0,
-        error: data.error_message,
-      });
-      toaster.toast({
-        title: "RomM Sync",
-        body: `Download failed: ${data.rom_name} — ${data.error_message}`,
-      });
-    }
+    (data: DownloadFailedEvent) =>
+      handleGlobalDownloadFailure(data, { getDownloadState, updateDownload }, toaster),
   );
 
   const pathChangedListener = addEventListener<[{ old_path: string; new_path: string; cleared?: boolean }]>(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import { findOutermostScrollParent, findScrollParent } from "./utils/scrollHelpers";
-import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, SaveStatus, SyncPlanData, SyncStaleData, SyncCollectionsData } from "./types";
+import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SaveStatus, SyncPlanData, SyncStaleData, SyncCollectionsData } from "./types";
 import { removeShortcut } from "./utils/steamShortcuts";
 
 type Page = "main" | "settings" | "library" | "data" | "downloads";
@@ -384,6 +384,28 @@ export default definePlugin(() => {
     }
   );
 
+  const downloadFailedListener = addEventListener<[DownloadFailedEvent]>(
+    "download_failed",
+    (data: DownloadFailedEvent) => {
+      const prev = getDownloadState().find((d) => d.rom_id === data.rom_id);
+      updateDownload({
+        rom_id: data.rom_id,
+        rom_name: data.rom_name,
+        platform_name: data.platform_name,
+        file_name: prev?.file_name ?? "",
+        status: "failed",
+        progress: prev?.progress ?? 0,
+        bytes_downloaded: prev?.bytes_downloaded ?? 0,
+        total_bytes: prev?.total_bytes ?? 0,
+        error: data.error_message,
+      });
+      toaster.toast({
+        title: "RomM Sync",
+        body: `Download failed: ${data.rom_name} — ${data.error_message}`,
+      });
+    }
+  );
+
   const pathChangedListener = addEventListener<[{ old_path: string; new_path: string; cleared?: boolean }]>(
     "retrodeck_path_changed",
     (data) => {
@@ -438,6 +460,7 @@ export default definePlugin(() => {
       removeEventListener("sync_progress", syncProgressListener);
       removeEventListener("download_progress", downloadProgressListener);
       removeEventListener("download_complete", downloadCompleteListener);
+      removeEventListener("download_failed", downloadFailedListener);
       removeEventListener("retrodeck_path_changed", pathChangedListener);
       removeEventListener("save_sort_changed", saveSortChangedListener);
       removeEventListener("save_status_updated", saveStatusListener);

--- a/src/types/downloads.ts
+++ b/src/types/downloads.ts
@@ -32,3 +32,10 @@ export interface DownloadCompleteEvent {
   platform_name: string;
   file_path: string;
 }
+
+export interface DownloadFailedEvent {
+  rom_id: number;
+  rom_name: string;
+  platform_name: string;
+  error_message: string;
+}

--- a/src/utils/downloadFailure.test.ts
+++ b/src/utils/downloadFailure.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleGlobalDownloadFailure,
+  handleButtonDownloadFailure,
+  type DownloadStoreLike,
+  type ToasterLike,
+} from "./downloadFailure";
+import type { DownloadFailedEvent, DownloadItem } from "../types";
+
+function makeEvent(overrides: Partial<DownloadFailedEvent> = {}): DownloadFailedEvent {
+  return {
+    rom_id: 42,
+    rom_name: "Super Mario 64",
+    platform_name: "Nintendo 64",
+    error_message: "disk full",
+    ...overrides,
+  };
+}
+
+describe("handleGlobalDownloadFailure", () => {
+  it("toasts with the formatted failure message and updates the store entry", () => {
+    const prior: DownloadItem = {
+      rom_id: 42,
+      rom_name: "Super Mario 64",
+      platform_name: "Nintendo 64",
+      file_name: "sm64.z64",
+      status: "downloading",
+      progress: 73,
+      bytes_downloaded: 730,
+      total_bytes: 1000,
+    };
+    const store: DownloadStoreLike = {
+      getDownloadState: vi.fn(() => [prior]),
+      updateDownload: vi.fn(),
+    };
+    const toast: ToasterLike = { toast: vi.fn() };
+
+    handleGlobalDownloadFailure(makeEvent(), store, toast);
+
+    expect(store.updateDownload).toHaveBeenCalledOnce();
+    expect(store.updateDownload).toHaveBeenCalledWith({
+      rom_id: 42,
+      rom_name: "Super Mario 64",
+      platform_name: "Nintendo 64",
+      file_name: "sm64.z64",
+      status: "failed",
+      progress: 73,
+      bytes_downloaded: 730,
+      total_bytes: 1000,
+      error: "disk full",
+    });
+    expect(toast.toast).toHaveBeenCalledOnce();
+    expect(toast.toast).toHaveBeenCalledWith({
+      title: "RomM Sync",
+      body: "Download failed: Super Mario 64 — disk full",
+    });
+  });
+
+  it("zero-fills progress fields when no prior entry exists", () => {
+    const store: DownloadStoreLike = {
+      getDownloadState: vi.fn(() => []),
+      updateDownload: vi.fn(),
+    };
+    const toast: ToasterLike = { toast: vi.fn() };
+
+    handleGlobalDownloadFailure(makeEvent(), store, toast);
+
+    expect(store.updateDownload).toHaveBeenCalledWith({
+      rom_id: 42,
+      rom_name: "Super Mario 64",
+      platform_name: "Nintendo 64",
+      file_name: "",
+      status: "failed",
+      progress: 0,
+      bytes_downloaded: 0,
+      total_bytes: 0,
+      error: "disk full",
+    });
+  });
+
+  it("includes an empty error_message in the toast verbatim", () => {
+    const store: DownloadStoreLike = {
+      getDownloadState: vi.fn(() => []),
+      updateDownload: vi.fn(),
+    };
+    const toast: ToasterLike = { toast: vi.fn() };
+
+    handleGlobalDownloadFailure(makeEvent({ error_message: "" }), store, toast);
+
+    expect(toast.toast).toHaveBeenCalledWith({
+      title: "RomM Sync",
+      body: "Download failed: Super Mario 64 — ",
+    });
+    const [[updated]] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
+    expect(updated.error).toBe("");
+  });
+
+  it("ignores entries for other roms when selecting the prior state", () => {
+    const otherRom: DownloadItem = {
+      rom_id: 99,
+      rom_name: "Other",
+      platform_name: "Other",
+      file_name: "other.bin",
+      status: "downloading",
+      progress: 50,
+      bytes_downloaded: 500,
+      total_bytes: 1000,
+    };
+    const store: DownloadStoreLike = {
+      getDownloadState: vi.fn(() => [otherRom]),
+      updateDownload: vi.fn(),
+    };
+    const toast: ToasterLike = { toast: vi.fn() };
+
+    handleGlobalDownloadFailure(makeEvent(), store, toast);
+
+    const [[updated]] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
+    // Should NOT have pulled file_name / progress from rom 99.
+    expect(updated.file_name).toBe("");
+    expect(updated.progress).toBe(0);
+  });
+});
+
+describe("handleButtonDownloadFailure", () => {
+  it("invokes the reset callback when the event matches the button's rom_id", () => {
+    const reset = vi.fn();
+    handleButtonDownloadFailure(makeEvent({ rom_id: 7 }), 7, reset);
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when the event targets a different rom_id", () => {
+    const reset = vi.fn();
+    handleButtonDownloadFailure(makeEvent({ rom_id: 7 }), 8, reset);
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when rom_id is 0 vs a non-zero target", () => {
+    const reset = vi.fn();
+    handleButtonDownloadFailure(makeEvent({ rom_id: 0 }), 1, reset);
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when romId is null (button has no associated rom yet)", () => {
+    const reset = vi.fn();
+    handleButtonDownloadFailure(makeEvent({ rom_id: 7 }), null, reset);
+    expect(reset).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/downloadFailure.ts
+++ b/src/utils/downloadFailure.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure helpers for the `download_failed` event listeners.
+ *
+ * Two surfaces consume the event:
+ *   - Global (src/index.tsx): updates the download store and surfaces a toast.
+ *   - Per-button (src/components/CustomPlayButton.tsx): resets local play-button
+ *     state back to "download" when the failed event matches the button's rom.
+ *
+ * Extracting the listener bodies into pure functions keeps the @decky/api
+ * listener registration as a one-line delegation and makes the behavior
+ * testable without an addEventListener mock harness.
+ */
+
+import type { DownloadFailedEvent, DownloadItem } from "../types";
+
+export interface ToasterLike {
+  toast: (msg: { title: string; body: string }) => void;
+}
+
+export interface DownloadStoreLike {
+  getDownloadState: () => DownloadItem[];
+  updateDownload: (item: DownloadItem) => void;
+}
+
+/**
+ * Apply a `download_failed` event globally: flip the matching entry in the
+ * download store to `status: "failed"` (carrying `error_message` as `error`)
+ * and surface a toast. Missing prior entries are tolerated — the store gains
+ * a synthetic entry with zeroed progress fields.
+ */
+export function handleGlobalDownloadFailure(
+  event: DownloadFailedEvent,
+  store: DownloadStoreLike,
+  toast: ToasterLike,
+): void {
+  const prev = store.getDownloadState().find((d) => d.rom_id === event.rom_id);
+  store.updateDownload({
+    rom_id: event.rom_id,
+    rom_name: event.rom_name,
+    platform_name: event.platform_name,
+    file_name: prev?.file_name ?? "",
+    status: "failed",
+    progress: prev?.progress ?? 0,
+    bytes_downloaded: prev?.bytes_downloaded ?? 0,
+    total_bytes: prev?.total_bytes ?? 0,
+    error: event.error_message,
+  });
+  toast.toast({
+    title: "RomM Sync",
+    body: `Download failed: ${event.rom_name} — ${event.error_message}`,
+  });
+}
+
+/**
+ * Apply a `download_failed` event for a specific play button: if the event
+ * targets `romId`, reset the button back to the "download" state so the user
+ * can retry. No-op for events targeting other roms or when the button has no
+ * associated rom yet (`romId === null`). The toast is owned by the global
+ * handler — this helper intentionally does not toast.
+ */
+export function handleButtonDownloadFailure(
+  event: DownloadFailedEvent,
+  romId: number | null,
+  reset: () => void,
+): void {
+  if (romId === null || event.rom_id !== romId) return;
+  reset();
+}

--- a/src/utils/downloadStore.ts
+++ b/src/utils/downloadStore.ts
@@ -4,6 +4,7 @@
  * Updated by:
  *   - download_progress events from the backend (persistent listener in index.tsx)
  *   - download_complete events from the backend (persistent listener in index.tsx)
+ *   - download_failed events from the backend (persistent listener in index.tsx)
  *
  * Read by:
  *   - DownloadQueue.tsx via a cheap setInterval (no callable round-trips)

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -1437,6 +1437,63 @@ class TestDoDownloadZipFailure:
         assert not os.path.exists(target_path + ".zip.tmp")
 
 
+class TestDoDownloadFailureEmit:
+    """Tests for _do_download — ``download_failed`` event emission."""
+
+    @pytest.mark.asyncio
+    async def test_failure_emits_download_failed(self, plugin, tmp_path):
+        from unittest.mock import patch
+
+        import decky
+
+        plugin._download_service._runtime_dir = str(tmp_path)
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        def fake_download(_rom_id, _filename, _dest, _progress_callback=None):
+            raise OSError("simulated network drop")
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
+
+        # download_failed event emitted with the expected payload shape
+        emit_calls = [c for c in decky.emit.call_args_list if c[0][0] == "download_failed"]
+        assert len(emit_calls) == 1
+        payload = emit_calls[0][0][1]
+        assert payload["rom_id"] == 42
+        assert payload["rom_name"] == "Zelda"
+        assert payload["platform_name"] == "Nintendo 64"
+        assert payload["error_message"] == "simulated network drop"
+        # No download_complete in the failure path
+        assert not [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
+        # Queue status reflects the failure
+        assert plugin._download_service._download_queue[42]["status"] == "failed"
+        assert plugin._download_service._download_queue[42]["error"] == "simulated network drop"
+
+
 class TestStartDownloadReDownload:
     """Test start_download allows re-download after completion."""
 


### PR DESCRIPTION
## Summary

Closes #632. Parent: #619.

`DownloadService._do_download` previously set the queue status to `"failed"` and logged on exception, but never emitted any frontend-visible event. Listeners subscribed to `download_complete` never heard about failures, so the download bar would sit at "downloading" until manual refresh — looked like a hang, not a failure. Especially confusing for ZIP-extraction / post-download I/O failures where the bar may have hit 100% before the explosion.

## Changes

**Backend** (`py_modules/services/downloads.py`):
- Emit `download_failed` event from the `_do_download` exception handler with payload `{rom_id, rom_name, platform_name, error_message}`, mirroring the `download_complete` shape.

**Frontend**:
- `src/types/index.ts` — new `DownloadFailedEvent` interface.
- `src/index.tsx` — global `download_failed` listener that flips the entry in `downloadStore` to `status: "failed"` (carrying `error`) and surfaces a toast: `"Download failed: <rom_name> — <error_message>"`. Wording mirrors the existing `"Downloaded <rom_name>"` voice and stays concise.
- `src/components/CustomPlayButton.tsx` — per-button `download_failed` listener so the play button transitions back to `"download"` (allowing retry) instead of hanging on the progress spinner. The button-local listener intentionally does NOT toast — the global listener in `index.tsx` owns that.
- `src/utils/downloadStore.ts` — header comment now lists `download_failed` as a source.

## Test plan

- [x] Backend test (`TestDoDownloadFailureEmit::test_failure_emits_download_failed`) — patches `download_rom_content` to raise `OSError`, asserts `decky.emit` is called once with `("download_failed", {rom_id, rom_name, platform_name, error_message})` and that no `download_complete` is emitted on the failure path.
- [x] `python -m pytest tests/services/test_downloads.py -v` — 95 passed (including new test).
- [x] `python -m pytest tests/ -q` — 2456 passed.
- [x] `ruff check` + `ruff format --check` clean on touched files.
- [x] `basedpyright` (scoped + CI scope) — 0 errors.
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean.
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken.
- [x] `pnpm build` succeeds; `pnpm test` — 51 passed.
- [x] Coverage on `py_modules/services/downloads.py` — 100% line + branch.

Frontend listener test for `index.tsx`/`CustomPlayButton.tsx` was skipped: there is no existing vitest infra mocking `@decky/api`'s `addEventListener`, and the backend emit test is the load-bearing one per spec.