### PR TITLE
fix(library): hoist refreshBios to function declaration (#617)

### DIFF
--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -145,16 +145,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     }
   }, [activeTab]);
 
-  // Load BIOS data lazily on first switch to BIOS tab
-  useEffect(() => {
-    if (activeTab === "bios" && !biosLoaded.current) {
-      biosLoaded.current = true;
-      // eslint-disable-next-line react-hooks/immutability -- TODO(#617): hoist refreshBios as function decl or move call after definition
-      refreshBios();
-    }
-  }, [activeTab]);
-
-  const refreshBios = async () => {
+  async function refreshBios() {
     setBiosLoading(true);
     setBiosError("");
     try {
@@ -169,7 +160,15 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
       setBiosError(`Failed to fetch firmware status: ${e}`);
     }
     setBiosLoading(false);
-  };
+  }
+
+  // Load BIOS data lazily on first switch to BIOS tab
+  useEffect(() => {
+    if (activeTab === "bios" && !biosLoaded.current) {
+      biosLoaded.current = true;
+      refreshBios();
+    }
+  }, [activeTab]);
 
   // --- Platforms tab handlers ---
   const handleToggle = async (id: number, enabled: boolean) => {


### PR DESCRIPTION
Closes 1 of 7 \`TODO(#617)\` markers in [#617](https://github.com/danielcopper/decky-romm-sync/issues/617).

## Summary

\`refreshBios\` was declared as a const-arrow-function after the \`useEffect\` that called it, requiring an \`eslint-disable-next-line react-hooks/immutability\` to silence the rule. Hoisting it to a function declaration eliminates the violation — function declarations are hoisted to the top of their enclosing scope so forward references are safe.

No behavioral change.

## Expected CI signal

All green. Net-neutral on warning count (the inline disable was suppressing a warning that no longer fires after the hoist).

## Test plan

- [x] \`pnpm lint\` — 60 warnings (unchanged from main; my change removed one disable comment and one suppressed warning, net zero)
- [x] \`pnpm build\` — clean
- [x] \`pnpm test\` — 148/148 pass
- [ ] CI green

## Remaining #617 work

Six TODO(#617) markers + 60 \`any\` warnings still tracked under the issue. Most require design decisions (replace mutable cache with setState, debounce, etc.) or are intentional Steam-UI internals (\`gameDetailPatch.tsx\`).