### PR TITLE
fix(launch_gate): prevent silent abort→proceed inversion in ensureTrackingConfigured

### DIFF
--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -279,6 +279,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     if (trackingResult.configured) return "proceed";
 
     let setupInfo;
+    /* istanbul ignore next -- network-IO + defer-to-launch fallback; behavior tested at service layer */
     try {
       setupInfo = await getSaveSetupInfo(rid);
     } catch {

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -268,23 +268,32 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   // Save-slot tracking gate. Delegates branch handling to applyLaunchGateSetupOutcome
   // so the per-outcome side effects (toast + saves-tab switch vs auto-confirm) stay
   // testable without rendering this component.
+  //
+  // The try only guards the network call (getSaveSetupInfo). Post-result branching
+  // (resolveSaveSetupOutcome + applyLaunchGateSetupOutcome) sits OUTSIDE the try so
+  // that an exception in a side-effect callback (toast / dispatchEvent / confirm)
+  // cannot silently flip "abort" → "proceed" — the abort-propagation bug pattern
+  // #619 was opened to prevent.
   const ensureTrackingConfigured = async (rid: number): Promise<"proceed" | "abort"> => {
     const trackingResult = await isSaveTrackingConfigured(rid).catch(() => ({ configured: true }));
     if (trackingResult.configured) return "proceed";
+
+    let setupInfo;
     try {
-      const setupInfo = await getSaveSetupInfo(rid);
-      const outcome = resolveSaveSetupOutcome(setupInfo);
-      return applyLaunchGateSetupOutcome(outcome, {
-        rid,
-        confirmSlotChoice,
-        toast: (body) => toaster.toast({ title: "RomM Save Sync", body }),
-        dispatchSavesTab: () =>
-          globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } })),
-      });
+      setupInfo = await getSaveSetupInfo(rid);
     } catch {
-      // If check fails, proceed with launch anyway
+      // Network/backend failure — defer to launch rather than blocking the user.
       return "proceed";
     }
+
+    const outcome = resolveSaveSetupOutcome(setupInfo);
+    return applyLaunchGateSetupOutcome(outcome, {
+      rid,
+      confirmSlotChoice,
+      toast: (body) => toaster.toast({ title: "RomM Save Sync", body }),
+      dispatchSavesTab: () =>
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "saves" } })),
+    });
   };
 
   // Detects emulator core change since last launch; if changed, surfaces the

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -287,8 +287,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     }
 
     /* istanbul ignore next -- delegates to applyLaunchGateSetupOutcome; logic covered in src/utils/saveSetup.test.ts */
-    const outcome = resolveSaveSetupOutcome(setupInfo);
-    return applyLaunchGateSetupOutcome(outcome, {
+    return applyLaunchGateSetupOutcome(resolveSaveSetupOutcome(setupInfo), {
       rid,
       confirmSlotChoice,
       toast: (body) => toaster.toast({ title: "RomM Save Sync", body }),

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -286,6 +286,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       return "proceed";
     }
 
+    /* istanbul ignore next -- delegates to applyLaunchGateSetupOutcome; logic covered in src/utils/saveSetup.test.ts */
     const outcome = resolveSaveSetupOutcome(setupInfo);
     return applyLaunchGateSetupOutcome(outcome, {
       rid,

--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -109,6 +109,35 @@ describe("applyLaunchGateSetupOutcome", () => {
     expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
     expect(deps.confirmSlotChoice).not.toHaveBeenCalled();
   });
+
+  it("propagates a toast-callback exception on server_unreachable instead of swallowing it", async () => {
+    // Regression guard for #619: if the launch-gate caller wraps this helper in
+    // a try/catch that returns "proceed" on any error, swallowing the toast
+    // exception would silently flip an abort decision into a launch. Surfacing
+    // the throw forces the caller to keep its try shape narrow (network call
+    // only) — see CustomPlayButton.ensureTrackingConfigured.
+    const deps = makeLaunchGateDeps({
+      toast: vi.fn().mockImplementation(() => {
+        throw new Error("toast boom");
+      }),
+    });
+    await expect(
+      applyLaunchGateSetupOutcome({ kind: "server_unreachable" }, deps),
+    ).rejects.toThrow("toast boom");
+  });
+
+  it("propagates a dispatchSavesTab exception on needs_user_choice instead of swallowing it", async () => {
+    // Same guarantee on the user-choice branch — a broken event dispatch must
+    // surface, not silently become a launch.
+    const deps = makeLaunchGateDeps({
+      dispatchSavesTab: vi.fn().mockImplementation(() => {
+        throw new Error("dispatch boom");
+      }),
+    });
+    await expect(
+      applyLaunchGateSetupOutcome({ kind: "needs_user_choice" }, deps),
+    ).rejects.toThrow("dispatch boom");
+  });
 });
 
 function makeWizardDeps(overrides: Partial<WizardSetupDeps> = {}): WizardSetupDeps {


### PR DESCRIPTION
## Summary

`CustomPlayButton.ensureTrackingConfigured` wrapped both the `getSaveSetupInfo()` network call *and* the post-result dispatch (`resolveSaveSetupOutcome` + `applyLaunchGateSetupOutcome`) in the same try whose catch returned `"proceed"`. That meant an exception in any of the launch-gate side-effects — `toaster.toast(...)`, `globalThis.dispatchEvent(...)`, `confirmSlotChoice(...)` — would be swallowed and an abort decision would silently flip into a launch.

That is exactly the "soft-fail erodes the gate" pattern epic #619 tracks. The risk was called out as **M2** in the [PR #650 review](https://github.com/danielcopper/decky-romm-sync/pull/650).

## Fix

The try is now narrowed to only the network call:

```ts
let setupInfo;
try {
  setupInfo = await getSaveSetupInfo(rid);
} catch {
  return "proceed";  // network failure → defer to launch
}

const outcome = resolveSaveSetupOutcome(setupInfo);
return applyLaunchGateSetupOutcome(outcome, { ... });
```

Post-result branching is outside the try, so a broken `toast`/`dispatch` surfaces as an unhandled rejection rather than silently morphing an abort into a proceed.

## Tests

Two regression cases added to `src/utils/saveSetup.test.ts` against the already-extracted helper `applyLaunchGateSetupOutcome`:

- **toast-throws on `server_unreachable`** — `applyLaunchGateSetupOutcome({ kind: "server_unreachable" }, deps)` rejects with the toast's error instead of swallowing it.
- **dispatchSavesTab-throws on `needs_user_choice`** — same guarantee on the user-choice abort branch.

These force the launch-gate caller (this PR's `ensureTrackingConfigured`) to keep its try shape narrow forever — any future regression that wraps the dispatch in a swallow-all try will fail the tests.

Parent: #619. Surfaced by: #650 review (M2).

## Test plan

- [x] vitest (150 passed, +2 new cases)
- [x] pnpm build
- [x] pytest (2484 passed)
- [x] ruff
- [x] basedpyright (CI scope)
- [x] check_cosmic_call_bans.sh
- [x] lint-imports