### PR TITLE
chore: delete dead RomLookupResult type + server_saves param (#661)

### DIFF
--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -69,7 +69,7 @@ class VersionsService:
     # Version History API
     # ------------------------------------------------------------------
 
-    def _find_file_state(self, rom_id_str: str, filename: str, server_saves: list[dict]) -> FileSyncState | None:  # noqa: ARG002 — server_saves kept for callable signature stability
+    def _find_file_state(self, rom_id_str: str, filename: str) -> FileSyncState | None:
         """Look up the per-file sync state for *filename* (canonical local name).
 
         State keys are always ``<rom_name>.<ext>`` — the same canonical
@@ -117,7 +117,7 @@ class VersionsService:
             self._log_debug(f"list_file_versions: failed to list saves: {e}")
             return {"status": "server_unreachable", "error": str(e)}
 
-        file_state = self._find_file_state(rom_id_str, filename, server_saves)
+        file_state = self._find_file_state(rom_id_str, filename)
         tracked_id = file_state.tracked_save_id if file_state else None
 
         rom_state = self._state_svc.state.saves.get(rom_id_str)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -62,14 +62,6 @@ export interface RomMetadata {
   steam_categories?: number[];
 }
 
-export interface RomLookupResult {
-  rom_id: number;
-  name: string;
-  platform_name: string;
-  platform_slug: string;
-  installed: InstalledRom | null;
-}
-
 export interface LaunchVerdict {
   action: "allow" | "warn" | "block";
   reason: "not_installed" | "save_conflict" | "save_status_failed" | null;


### PR DESCRIPTION
Closes #661. Parent: #620.

## What was deleted

- **`src/types/api.ts`** — `RomLookupResult` interface (8 LOC). Zero references in `src/`.
- **`py_modules/services/saves/versions.py`** — unread `server_saves` parameter on `VersionsService._find_file_state` plus its stale `# noqa: ARG002` justification. `_find_file_state` is a private one-call-site instance method; the single caller at `versions.py:120` (`list_file_versions`) was updated to drop the arg.

## Verification

- `grep -rn "RomLookupResult" src/` -> zero hits.
- `grep -rn "_find_file_state" py_modules/ tests/` -> only the def + single caller, both updated. No tests referenced the removed param.

## Test plan

- [x] `python -m pytest tests/services/saves/test_versions.py -v` (26 passed)
- [x] `python -m pytest tests/ -q` (2485 passed)
- [x] `ruff check` clean; `ruff format --check` clean for changed files (pre-existing `typings/decky/__init__.pyi` reformat noise unrelated to this PR)
- [x] `basedpyright` scoped + CI scope: 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh` clean
- [x] `PYTHONPATH=py_modules lint-imports`: 7 kept, 0 broken
- [x] `pnpm build` succeeds
- [x] `pnpm test` (158 passed)

LOC delta: `2 files changed, 2 insertions(+), 10 deletions(-)`.