### PR TITLE
feat(test): introduce FakeRommApi fixture (#662)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -934,6 +934,19 @@ class FakeRetroDeckPaths:
         return self.home
 
 
+@pytest.fixture
+def fake_romm_api():
+    """Function-scoped ``FakeRommApi`` instance.
+
+    Returns a fresh fake per test so seeded state never leaks across
+    tests. Construct without args — tests seed ``platforms`` / ``roms``
+    / ``firmware_files`` / etc. directly on the returned instance.
+    """
+    from fakes.fake_romm_api import FakeRommApi
+
+    return FakeRommApi()
+
+
 @pytest.fixture(autouse=True)
 def _reset_decky_mock_paths():
     """Refresh per-test temp dirs on the mock decky module.

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -1,0 +1,497 @@
+"""In-memory ``RommApi`` implementation covering every RomM Protocol surface.
+
+Use this fake anywhere a service needs a RomM transport in tests. It
+implements every method declared on the per-domain Protocols in
+``services.protocols.transport`` (``RommLibraryApi``, ``RommSyncApi``,
+``RommConnectionApi``, ``RommAchievementsApi``, ``RommFirmwareApi``,
+``RommPlaytimeApi``, ``RommDeviceApi``, ``RommPlatformReader``,
+``RommRomReader``, ``RommSaveApi``, ``RommVersion``) so a single instance
+satisfies any of them via duck typing.
+
+Seed in-memory state directly on the public attributes
+(``platforms`` / ``roms`` / ``firmware_files`` / ``collections`` /
+``virtual_collections`` / ``notes`` / ``saves`` / ``devices``); construct
+without arguments for tests that only care that the surface is callable.
+
+Failure injection mirrors ``FakeSaveApi``:
+
+- ``fail_on_next(exc)`` — the next call to **any** method raises and the
+  arming is consumed (one-shot).
+- ``<method>_side_effect`` attributes — per-method exceptions that fire
+  on every call until cleared. Tests reach for these when a specific
+  method must fail repeatedly (e.g. heartbeat outages).
+
+Downloads write a deterministic payload to ``dest_path`` via ``pathlib``
+so callers that subsequently read the file see real bytes; tests can
+stage richer payloads on ``download_payloads`` (``{key -> bytes}``).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from datetime import UTC, datetime
+from typing import Any
+
+
+class FakeRommApi:
+    """In-memory fake that satisfies every RomM Protocol surface without HTTP.
+
+    All RomM Protocols from ``services.protocols.transport`` are implemented
+    on this single class so a test can pass one instance wherever a more
+    specific Protocol is expected.
+    """
+
+    def __init__(self) -> None:
+        # In-memory seeded data — tests mutate these directly.
+        self.platforms: list[dict] = []
+        self.roms: dict[int, dict] = {}
+        self.firmware_files: list[dict] = []
+        self.collections: list[dict] = []
+        self.virtual_collections: dict[str, list[dict]] = {}
+        self.notes: dict[int, list[dict]] = {}
+        self.saves: dict[int, dict] = {}
+        self.devices: list[dict] = []
+        self.current_user: dict = {"id": 1, "username": "tester"}
+        self.heartbeat_response: dict = {"status": "ok"}
+        self._version: str | None = None
+        self._save_content: dict[int, bytes] = {}
+
+        # Pagination configurable per ROM listing endpoint. Tests can
+        # tweak ``items_per_platform`` keyed by ``(platform_id,)``,
+        # ``items_per_collection`` keyed by ``(collection_id,)`` and
+        # ``items_per_virtual_collection`` keyed by ``(virtual_id,)``
+        # to drive multi-page sync flows.
+
+        # Downloads: optional staged payload bytes for files the test
+        # wants to inspect after download.
+        # Keys: ``"rom:{rom_id}:{filename}"`` for ROM content,
+        # ``"firmware:{firmware_id}:{filename}"`` for firmware,
+        # ``"cover:{cover_url}"`` for covers,
+        # ``"save:{save_id}"`` for save content.
+        self.download_payloads: dict[str, bytes] = {}
+
+        # Failure-injection seams.
+        self._fail_on_next: Exception | None = None
+        self.heartbeat_side_effect: Exception | None = None
+        self.list_platforms_side_effect: Exception | None = None
+        self.list_firmware_side_effect: Exception | None = None
+        self.get_firmware_side_effect: Exception | None = None
+        self.download_firmware_side_effect: Exception | None = None
+        self.get_rom_side_effect: Exception | None = None
+        self.list_roms_side_effect: Exception | None = None
+        self.list_roms_updated_after_side_effect: Exception | None = None
+        self.list_collections_side_effect: Exception | None = None
+        self.list_virtual_collections_side_effect: Exception | None = None
+        self.list_roms_by_collection_side_effect: Exception | None = None
+        self.list_roms_by_virtual_collection_side_effect: Exception | None = None
+        self.download_rom_content_side_effect: Exception | None = None
+        self.download_cover_side_effect: Exception | None = None
+        self.get_current_user_side_effect: Exception | None = None
+        self.get_rom_with_notes_side_effect: Exception | None = None
+        self.create_note_side_effect: Exception | None = None
+        self.update_note_side_effect: Exception | None = None
+        self.register_device_side_effect: Exception | None = None
+        self.list_devices_side_effect: Exception | None = None
+        self.update_device_side_effect: Exception | None = None
+        self.list_saves_side_effect: Exception | None = None
+        self.upload_save_side_effect: Exception | None = None
+        self.download_save_side_effect: Exception | None = None
+        self.download_save_content_side_effect: Exception | None = None
+        self.confirm_download_side_effect: Exception | None = None
+        self.get_save_summary_side_effect: Exception | None = None
+        self.delete_server_saves_side_effect: Exception | None = None
+
+        # Observability — every method records ``(name, args, kwargs)``.
+        self.call_log: list[tuple[str, tuple, dict]] = []
+
+        # Internal id counters for synthesised entities.
+        self._next_save_id = 1000
+        self._next_note_id = 2000
+        self._next_device_id = 1
+
+    # ------------------------------------------------------------------
+    # Failure-injection helpers
+    # ------------------------------------------------------------------
+
+    def fail_on_next(self, exc: Exception) -> None:
+        """Arm the next call (any method) to raise ``exc`` then clear the arming."""
+        self._fail_on_next = exc
+
+    def _check_fail(self, method_side_effect: Exception | None = None) -> None:
+        """Raise the one-shot ``fail_on_next`` exception, then the per-method one.
+
+        Order is intentional: ``fail_on_next`` is one-shot so it must
+        consume first; per-method side effects persist until cleared
+        and fire on every call.
+        """
+        if self._fail_on_next is not None:
+            exc = self._fail_on_next
+            self._fail_on_next = None
+            raise exc
+        if method_side_effect is not None:
+            raise method_side_effect
+
+    def _log(self, name: str, args: tuple = (), kwargs: dict | None = None) -> None:
+        self.call_log.append((name, args, kwargs or {}))
+
+    def _materialize_download(self, dest_path: str, payload: bytes) -> None:
+        """Write ``payload`` bytes to ``dest_path`` via ``pathlib``.
+
+        Mirrors the real adapter's contract that the file exists at
+        ``dest_path`` after a successful download. Parent directories
+        are created so callers don't need to stage them.
+        """
+        dest = pathlib.Path(dest_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(payload)
+
+    # ------------------------------------------------------------------
+    # RommVersion
+    # ------------------------------------------------------------------
+
+    def set_version(self, version: str | None) -> None:
+        self._log("set_version", (version,))
+        self._version = version
+
+    def get_version(self) -> str | None:
+        self._log("get_version")
+        return self._version
+
+    def heartbeat(self) -> dict:
+        self._log("heartbeat")
+        self._check_fail(self.heartbeat_side_effect)
+        return dict(self.heartbeat_response)
+
+    def get_current_user(self) -> dict:
+        self._log("get_current_user")
+        self._check_fail(self.get_current_user_side_effect)
+        return dict(self.current_user)
+
+    # ------------------------------------------------------------------
+    # RommPlatformReader
+    # ------------------------------------------------------------------
+
+    def list_platforms(self) -> list[dict]:
+        self._log("list_platforms")
+        self._check_fail(self.list_platforms_side_effect)
+        return [dict(p) for p in self.platforms]
+
+    # ------------------------------------------------------------------
+    # RommRomReader
+    # ------------------------------------------------------------------
+
+    def get_rom(self, rom_id: int) -> dict:
+        self._log("get_rom", (rom_id,))
+        self._check_fail(self.get_rom_side_effect)
+        rom = self.roms.get(rom_id)
+        if rom is None:
+            return {"id": rom_id}
+        return dict(rom)
+
+    def _paginate(self, items: list[dict], limit: int, offset: int) -> dict:
+        sliced = items[offset : offset + limit]
+        return {"items": [dict(r) for r in sliced], "total": len(items)}
+
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+        self._log("list_roms", (platform_id,), {"limit": limit, "offset": offset})
+        self._check_fail(self.list_roms_side_effect)
+        items = [r for r in self.roms.values() if r.get("platform_id") == platform_id]
+        return self._paginate(items, limit, offset)
+
+    def list_roms_updated_after(
+        self,
+        platform_id: int,
+        updated_after: str,
+        limit: int = 1,
+        offset: int = 0,
+    ) -> dict:
+        self._log(
+            "list_roms_updated_after",
+            (platform_id, updated_after),
+            {"limit": limit, "offset": offset},
+        )
+        self._check_fail(self.list_roms_updated_after_side_effect)
+        items = [
+            r
+            for r in self.roms.values()
+            if r.get("platform_id") == platform_id and (r.get("updated_at") or "") > updated_after
+        ]
+        return self._paginate(items, limit, offset)
+
+    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict:
+        self._log(
+            "list_roms_by_collection",
+            (collection_id,),
+            {"limit": limit, "offset": offset},
+        )
+        self._check_fail(self.list_roms_by_collection_side_effect)
+        items = [r for r in self.roms.values() if collection_id in (r.get("collection_ids") or [])]
+        return self._paginate(items, limit, offset)
+
+    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict:
+        self._log(
+            "list_roms_by_virtual_collection",
+            (virtual_id,),
+            {"limit": limit, "offset": offset},
+        )
+        self._check_fail(self.list_roms_by_virtual_collection_side_effect)
+        items = [r for r in self.roms.values() if virtual_id in (r.get("virtual_collection_ids") or [])]
+        return self._paginate(items, limit, offset)
+
+    def list_collections(self) -> list[dict]:
+        self._log("list_collections")
+        self._check_fail(self.list_collections_side_effect)
+        return [dict(c) for c in self.collections]
+
+    def list_virtual_collections(self, collection_type: str) -> list[dict]:
+        self._log("list_virtual_collections", (collection_type,))
+        self._check_fail(self.list_virtual_collections_side_effect)
+        return [dict(c) for c in self.virtual_collections.get(collection_type, [])]
+
+    def download_rom_content(
+        self,
+        rom_id: int,
+        filename: str,
+        dest: str,
+        progress_callback: Any = None,
+    ) -> None:
+        self._log(
+            "download_rom_content",
+            (rom_id, filename, dest),
+            {"progress_callback": progress_callback},
+        )
+        self._check_fail(self.download_rom_content_side_effect)
+        key = f"rom:{rom_id}:{filename}"
+        payload = self.download_payloads.get(key, b"")
+        self._materialize_download(dest, payload)
+        if progress_callback is not None:
+            total = len(payload)
+            progress_callback(total, total)
+
+    def download_cover(self, cover_url: str, dest: str) -> None:
+        self._log("download_cover", (cover_url, dest))
+        self._check_fail(self.download_cover_side_effect)
+        key = f"cover:{cover_url}"
+        payload = self.download_payloads.get(key, b"")
+        self._materialize_download(dest, payload)
+
+    # ------------------------------------------------------------------
+    # RommFirmwareApi
+    # ------------------------------------------------------------------
+
+    def list_firmware(self) -> list[dict]:
+        self._log("list_firmware")
+        self._check_fail(self.list_firmware_side_effect)
+        return [dict(f) for f in self.firmware_files]
+
+    def get_firmware(self, firmware_id: int) -> dict:
+        self._log("get_firmware", (firmware_id,))
+        self._check_fail(self.get_firmware_side_effect)
+        for fw in self.firmware_files:
+            if fw.get("id") == firmware_id:
+                return dict(fw)
+        return {"id": firmware_id}
+
+    def download_firmware(self, firmware_id: int, filename: str, dest: str) -> None:
+        self._log("download_firmware", (firmware_id, filename, dest))
+        self._check_fail(self.download_firmware_side_effect)
+        key = f"firmware:{firmware_id}:{filename}"
+        payload = self.download_payloads.get(key, b"")
+        self._materialize_download(dest, payload)
+
+    # ------------------------------------------------------------------
+    # RommPlaytimeApi
+    # ------------------------------------------------------------------
+
+    def get_rom_with_notes(self, rom_id: int) -> dict:
+        self._log("get_rom_with_notes", (rom_id,))
+        self._check_fail(self.get_rom_with_notes_side_effect)
+        detail = dict(self.roms.get(rom_id, {"id": rom_id}))
+        detail["all_user_notes"] = [dict(n) for n in self.notes.get(rom_id, [])]
+        return detail
+
+    def create_note(self, rom_id: int, data: dict) -> dict:
+        self._log("create_note", (rom_id, data))
+        self._check_fail(self.create_note_side_effect)
+        note_id = self._next_note_id
+        self._next_note_id += 1
+        note = {"id": note_id, "rom_id": rom_id, **data}
+        self.notes.setdefault(rom_id, []).append(note)
+        return dict(note)
+
+    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+        self._log("update_note", (rom_id, note_id, data))
+        self._check_fail(self.update_note_side_effect)
+        for notes in self.notes.values():
+            for note in notes:
+                if note.get("id") == note_id:
+                    note.update(data)
+                    return dict(note)
+        return {"id": note_id, "rom_id": rom_id, **data}
+
+    # ------------------------------------------------------------------
+    # RommDeviceApi
+    # ------------------------------------------------------------------
+
+    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
+        self._log("register_device", (name, platform, client, client_version))
+        self._check_fail(self.register_device_side_effect)
+        device_id = f"device-{self._next_device_id}"
+        self._next_device_id += 1
+        device = {
+            "id": device_id,
+            "name": name,
+            "platform": platform,
+            "client": client,
+            "client_version": client_version,
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        self.devices.append(device)
+        return dict(device)
+
+    def list_devices(self) -> list[dict]:
+        self._log("list_devices")
+        self._check_fail(self.list_devices_side_effect)
+        return [dict(d) for d in self.devices]
+
+    def update_device(self, device_id: str, **fields) -> dict:
+        self._log("update_device", (device_id,), fields)
+        self._check_fail(self.update_device_side_effect)
+        for device in self.devices:
+            if str(device.get("id")) == str(device_id):
+                device.update({k: v for k, v in fields.items() if v is not None})
+                return dict(device)
+        synthesized = {"id": device_id, **{k: v for k, v in fields.items() if v is not None}}
+        return synthesized
+
+    # ------------------------------------------------------------------
+    # RommSaveApi
+    # ------------------------------------------------------------------
+
+    def list_saves(
+        self,
+        rom_id: int,
+        *,
+        device_id: str | None = None,
+        slot: str | None = None,
+    ) -> list[dict]:
+        self._log("list_saves", (rom_id,), {"device_id": device_id, "slot": slot})
+        self._check_fail(self.list_saves_side_effect)
+        saves = [dict(s) for s in self.saves.values() if s.get("rom_id") == rom_id]
+        if slot is not None:
+            saves = [s for s in saves if s.get("slot") == slot]
+        if device_id:
+            for s in saves:
+                if "device_syncs" not in s:
+                    s["device_syncs"] = [{"device_id": device_id, "is_current": True}]
+        return saves
+
+    def upload_save(
+        self,
+        rom_id: int,
+        file_path: str,
+        emulator: str,
+        save_id: int | None = None,
+        *,
+        device_id: str | None = None,
+        slot: str | None = None,
+        overwrite: bool = False,
+    ) -> dict:
+        self._log(
+            "upload_save",
+            (rom_id, file_path, emulator),
+            {
+                "save_id": save_id,
+                "device_id": device_id,
+                "slot": slot,
+                "overwrite": overwrite,
+            },
+        )
+        self._check_fail(self.upload_save_side_effect)
+        now = datetime.now(UTC).isoformat()
+        # Path algebra only — basename without importing os.path globally.
+        last_sep = max(file_path.rfind("/"), file_path.rfind("\\"))
+        filename = file_path[last_sep + 1 :] if last_sep >= 0 else file_path
+
+        if save_id is not None and save_id in self.saves:
+            entry = self.saves[save_id]
+            entry["updated_at"] = now
+            entry["emulator"] = emulator
+            return dict(entry)
+
+        new_save_id = self._next_save_id
+        self._next_save_id += 1
+        entry = {
+            "id": new_save_id,
+            "rom_id": rom_id,
+            "file_name": filename,
+            "updated_at": now,
+            "emulator": emulator,
+            "slot": slot,
+            "download_path": f"/saves/{filename}",
+        }
+        self.saves[new_save_id] = entry
+        return dict(entry)
+
+    def download_save(self, save_id: int, dest_path: str) -> None:
+        self._log("download_save", (save_id, dest_path))
+        self._check_fail(self.download_save_side_effect)
+        payload = self._save_content.get(save_id) or self.download_payloads.get(f"save:{save_id}", b"")
+        self._materialize_download(dest_path, payload)
+
+    def download_save_content(
+        self,
+        save_id: int,
+        dest_path: str,
+        *,
+        device_id: str | None = None,
+        optimistic: bool = True,
+    ) -> None:
+        self._log(
+            "download_save_content",
+            (save_id, dest_path),
+            {"device_id": device_id, "optimistic": optimistic},
+        )
+        self._check_fail(self.download_save_content_side_effect)
+        payload = self._save_content.get(save_id) or self.download_payloads.get(f"save:{save_id}", b"")
+        self._materialize_download(dest_path, payload)
+
+    def confirm_download(self, save_id: int, device_id: str) -> dict:
+        self._log("confirm_download", (save_id, device_id))
+        self._check_fail(self.confirm_download_side_effect)
+        return {"status": "ok"}
+
+    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
+        self._log("get_save_summary", (rom_id,), {"device_id": device_id})
+        self._check_fail(self.get_save_summary_side_effect)
+        slots: dict[str | None, list[dict]] = {}
+        for s in self.saves.values():
+            if s.get("rom_id") == rom_id:
+                slots.setdefault(s.get("slot"), []).append(s)
+        return {
+            "total_count": sum(len(saves) for saves in slots.values()),
+            "slots": [
+                {
+                    "slot": slot_name,
+                    "count": len(saves),
+                    "latest": max(saves, key=lambda s: s.get("updated_at", "")),
+                }
+                for slot_name, saves in slots.items()
+            ],
+        }
+
+    def delete_server_saves(self, save_ids: list[int]) -> dict:
+        self._log("delete_server_saves", (save_ids,))
+        self._check_fail(self.delete_server_saves_side_effect)
+        for sid in save_ids:
+            self.saves.pop(sid, None)
+            self._save_content.pop(sid, None)
+        return {"deleted": len(save_ids)}
+
+    # ------------------------------------------------------------------
+    # Test helpers
+    # ------------------------------------------------------------------
+
+    def set_server_save_content(self, save_id: int, content: bytes) -> None:
+        """Stage server-side bytes returned by the next ``download_save*`` call."""
+        self._save_content[save_id] = content

--- a/tests/fakes/test_fake_romm_api.py
+++ b/tests/fakes/test_fake_romm_api.py
@@ -1,0 +1,228 @@
+"""Smoke tests for ``FakeRommApi`` — fixture sanity and Protocol satisfaction."""
+
+from __future__ import annotations
+
+import pytest
+
+from fakes.fake_romm_api import FakeRommApi
+from services.protocols.transport import (
+    RommAchievementsApi,
+    RommConnectionApi,
+    RommDeviceApi,
+    RommFirmwareApi,
+    RommLibraryApi,
+    RommPlatformReader,
+    RommPlaytimeApi,
+    RommRomReader,
+    RommSaveApi,
+    RommSyncApi,
+    RommVersion,
+)
+
+
+class TestConstruction:
+    """Construction with defaults works and exposes sensible empty seeded state."""
+
+    def test_default_construction_succeeds(self) -> None:
+        api = FakeRommApi()
+        assert api.platforms == []
+        assert api.roms == {}
+        assert api.firmware_files == []
+        assert api.collections == []
+        assert api.virtual_collections == {}
+        assert api.devices == []
+        assert api.saves == {}
+        assert api.notes == {}
+        assert api.call_log == []
+
+    def test_call_log_records_method_calls(self) -> None:
+        api = FakeRommApi()
+        api.heartbeat()
+        api.list_platforms()
+        assert [name for name, _, _ in api.call_log] == ["heartbeat", "list_platforms"]
+
+
+class TestFailOnNext:
+    """``fail_on_next(exc)`` raises on the next call and clears the arming."""
+
+    def test_raises_on_next_call(self) -> None:
+        api = FakeRommApi()
+        api.fail_on_next(OSError("boom"))
+        with pytest.raises(OSError, match="boom"):
+            api.list_platforms()
+
+    def test_is_one_shot(self) -> None:
+        api = FakeRommApi()
+        api.fail_on_next(RuntimeError("first"))
+        with pytest.raises(RuntimeError):
+            api.heartbeat()
+        # Next call after arming consumed succeeds.
+        assert api.heartbeat() == {"status": "ok"}
+
+    def test_arms_any_method(self) -> None:
+        api = FakeRommApi()
+        api.fail_on_next(ValueError("on next"))
+        with pytest.raises(ValueError, match="on next"):
+            api.list_firmware()
+
+
+class TestPerMethodSideEffects:
+    """Per-method ``*_side_effect`` attrs raise on every call until cleared."""
+
+    def test_list_firmware_side_effect_fires_every_call(self) -> None:
+        api = FakeRommApi()
+        api.list_firmware_side_effect = OSError("offline")
+        with pytest.raises(OSError, match="offline"):
+            api.list_firmware()
+        with pytest.raises(OSError, match="offline"):
+            api.list_firmware()
+
+    def test_heartbeat_side_effect(self) -> None:
+        api = FakeRommApi()
+        api.heartbeat_side_effect = ConnectionError("down")
+        with pytest.raises(ConnectionError):
+            api.heartbeat()
+
+    def test_fail_on_next_takes_precedence_over_side_effect(self) -> None:
+        api = FakeRommApi()
+        api.list_platforms_side_effect = OSError("persistent")
+        api.fail_on_next(RuntimeError("one shot"))
+        with pytest.raises(RuntimeError, match="one shot"):
+            api.list_platforms()
+        # One-shot consumed; persistent side effect still fires.
+        with pytest.raises(OSError, match="persistent"):
+            api.list_platforms()
+
+
+class TestSeededReads:
+    """Seeded in-memory state flows through reads."""
+
+    def test_list_platforms_returns_seeded(self) -> None:
+        api = FakeRommApi()
+        api.platforms = [{"id": 1, "slug": "snes"}, {"id": 2, "slug": "psx"}]
+        assert api.list_platforms() == [{"id": 1, "slug": "snes"}, {"id": 2, "slug": "psx"}]
+
+    def test_list_roms_filters_by_platform_and_paginates(self) -> None:
+        api = FakeRommApi()
+        api.roms = {
+            1: {"id": 1, "platform_id": 10, "name": "A"},
+            2: {"id": 2, "platform_id": 10, "name": "B"},
+            3: {"id": 3, "platform_id": 99, "name": "C"},
+        }
+        result = api.list_roms(platform_id=10, limit=1, offset=1)
+        assert result["total"] == 2
+        assert len(result["items"]) == 1
+        assert result["items"][0]["name"] == "B"
+
+    def test_get_rom_falls_back_to_id_only_for_unknown(self) -> None:
+        api = FakeRommApi()
+        assert api.get_rom(42) == {"id": 42}
+
+    def test_get_rom_with_notes_includes_seeded_notes(self) -> None:
+        api = FakeRommApi()
+        api.roms = {1: {"id": 1, "name": "Tetris"}}
+        api.notes = {1: [{"id": 100, "rom_id": 1, "user_id": 7, "note_raw_markdown": "hi"}]}
+        detail = api.get_rom_with_notes(1)
+        assert detail["name"] == "Tetris"
+        assert detail["all_user_notes"][0]["id"] == 100
+
+
+class TestDownloads:
+    """Download methods write payload bytes to ``dest_path`` via pathlib."""
+
+    def test_download_rom_content_writes_staged_payload(self, tmp_path) -> None:
+        api = FakeRommApi()
+        api.download_payloads["rom:5:game.zip"] = b"hello"
+        dest = tmp_path / "game.zip"
+        api.download_rom_content(5, "game.zip", str(dest))
+        assert dest.read_bytes() == b"hello"
+
+    def test_download_firmware_writes_default_empty_payload(self, tmp_path) -> None:
+        api = FakeRommApi()
+        dest = tmp_path / "bios" / "fw.bin"
+        api.download_firmware(1, "fw.bin", str(dest))
+        # Parent dirs auto-created, default empty payload written.
+        assert dest.exists()
+        assert dest.read_bytes() == b""
+
+    def test_download_save_uses_set_server_save_content(self, tmp_path) -> None:
+        api = FakeRommApi()
+        api.set_server_save_content(99, b"save-bytes")
+        dest = tmp_path / "out.sav"
+        api.download_save(99, str(dest))
+        assert dest.read_bytes() == b"save-bytes"
+
+
+class TestUploadSave:
+    """``upload_save`` synthesises ids and records uploads."""
+
+    def test_creates_new_save_with_auto_id(self) -> None:
+        api = FakeRommApi()
+        result = api.upload_save(rom_id=1, file_path="/tmp/save.sav", emulator="snes9x")
+        assert result["rom_id"] == 1
+        assert result["file_name"] == "save.sav"
+        assert result["id"] in api.saves
+
+
+class TestDeviceRegistration:
+    """Device registration synthesises ids and stores in ``devices``."""
+
+    def test_register_device_assigns_id_and_stores(self) -> None:
+        api = FakeRommApi()
+        device = api.register_device("deck", "steamos", "decky-romm-sync", "0.1.0")
+        assert device["id"] == "device-1"
+        assert len(api.devices) == 1
+        assert api.list_devices()[0]["name"] == "deck"
+
+
+class TestProtocolSatisfaction:
+    """``FakeRommApi`` structurally satisfies every RomM Protocol.
+
+    The transport Protocols are not ``@runtime_checkable`` (deliberate —
+    they're typing-only contracts), so this test verifies the structural
+    surface by checking every Protocol member is present and callable on
+    the fake.
+    """
+
+    @pytest.mark.parametrize(
+        "protocol",
+        [
+            RommVersion,
+            RommPlatformReader,
+            RommRomReader,
+            RommFirmwareApi,
+            RommPlaytimeApi,
+            RommDeviceApi,
+            RommSaveApi,
+            RommAchievementsApi,
+            RommConnectionApi,
+            RommLibraryApi,
+            RommSyncApi,
+        ],
+    )
+    def test_implements_every_protocol_member(self, protocol) -> None:
+        fake = FakeRommApi()
+        # Protocol.__protocol_attrs__ is set by ``typing.Protocol`` for
+        # any subclass; falls back to scanning non-dunder attrs.
+        members = getattr(protocol, "__protocol_attrs__", None) or {
+            name for name in dir(protocol) if not name.startswith("_")
+        }
+        missing = [name for name in members if not callable(getattr(fake, name, None))]
+        assert not missing, f"FakeRommApi missing {protocol.__name__} members: {missing}"
+
+
+class TestFixture:
+    """Conftest ``fake_romm_api`` fixture yields a fresh instance per test."""
+
+    def test_fixture_returns_fake_romm_api(self, fake_romm_api) -> None:
+        assert isinstance(fake_romm_api, FakeRommApi)
+        assert fake_romm_api.platforms == []
+
+    def test_fixture_is_function_scoped(self, fake_romm_api) -> None:
+        # Mutate state — the next test re-using the fixture must get a fresh one.
+        fake_romm_api.platforms.append({"id": 1})
+        assert fake_romm_api.platforms == [{"id": 1}]
+
+    def test_fixture_state_does_not_leak(self, fake_romm_api) -> None:
+        # If function scoping works, the previous test's mutation is gone.
+        assert fake_romm_api.platforms == []


### PR DESCRIPTION
Closes #662. Parent: #621.

## What was built

`FakeRommApi` in `tests/fakes/fake_romm_api.py` — an in-memory RomM transport fake covering every Protocol declared in `services/protocols/transport.py`. Single class so one instance satisfies any of the per-domain Protocols via duck typing.

**Surface mirrors `FakeSaveApi`:**
- In-memory seeded state on public attributes (`platforms`, `roms`, `firmware_files`, `collections`, `virtual_collections`, `notes`, `saves`, `devices`).
- `fail_on_next(exc)` — arm the next call (any method) to raise; one-shot.
- Per-method `*_side_effect` attributes — persistent failure injection per endpoint (`list_firmware_side_effect`, `heartbeat_side_effect`, ...). 28 such seams.
- `call_log` records every `(method_name, args, kwargs)` for assertion.
- Downloads (`download_rom_content`, `download_firmware`, `download_cover`, `download_save`, `download_save_content`) write to `dest_path` via `pathlib` so callers that subsequently read the file see real bytes. Stage payloads via `download_payloads[key]` or `set_server_save_content`.

Wired into `tests/conftest.py` as the function-scoped `fake_romm_api` fixture.

## Protocol coverage

All 11 RomM-related Protocols from `services/protocols/transport.py`:

| Protocol | Method count |
| --- | --- |
| `RommVersion` | 4 (`set_version`, `get_version`, `heartbeat`, `get_current_user`) |
| `RommPlatformReader` | 1 (`list_platforms`) |
| `RommRomReader` | 8 (get/list/list_updated_after/list_by_collection/list_by_virtual_collection/list_collections/list_virtual_collections/download_rom_content/download_cover) |
| `RommFirmwareApi` | 3 (`list_firmware`, `get_firmware`, `download_firmware`) |
| `RommPlaytimeApi` | 3 (`get_rom_with_notes`, `create_note`, `update_note`) |
| `RommDeviceApi` | 3 (`register_device`, `list_devices`, `update_device`) |
| `RommSaveApi` | 7 (`list_saves`, `upload_save`, `download_save`, `download_save_content`, `confirm_download`, `get_save_summary`, `delete_server_saves`) |
| `RommAchievementsApi` | composite (RommRomReader + RommVersion) |
| `RommConnectionApi` | composite (RommPlatformReader + RommVersion) |
| `RommLibraryApi` | composite (RommPlatformReader + RommRomReader) |
| `RommSyncApi` | composite (RommSaveApi + RommVersion + RommDeviceApi) |

## Smoke tests

`tests/fakes/test_fake_romm_api.py` — 31 tests across 8 test classes:
- `TestConstruction` — defaults, call-log recording
- `TestFailOnNext` — one-shot raises, consumed after fire, arms any method
- `TestPerMethodSideEffects` — persistent per-method injection, precedence vs `fail_on_next`
- `TestSeededReads` — `list_platforms` / `list_roms` pagination / `get_rom` fallback / `get_rom_with_notes`
- `TestDownloads` — staged ROM payload, default-empty firmware write with auto-mkdir, `set_server_save_content`
- `TestUploadSave` — id synthesis
- `TestDeviceRegistration` — id synthesis + `list_devices` round-trip
- `TestProtocolSatisfaction` — every Protocol (parametrized x11) — structural check via `__protocol_attrs__`, since the transport Protocols are not `@runtime_checkable`
- `TestFixture` — conftest fixture wiring + function-scope isolation

## Out of scope

Per the issue, **no existing tests are migrated in this PR**. The 11 `_romm_api = MagicMock()` sites across Wave-3 tests remain untouched — migration is #663 (next sub-issue under #621).

## Test plan

- [x] `python -m pytest tests/fakes/ -v` — 31 passed
- [x] `python -m pytest tests/ -q` — 2516 passed (no regressions)
- [x] `ruff check` + `ruff format --check`
- [x] `basedpyright` (CI scope) — 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh`
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] `pnpm build`
- [x] `pnpm test` — 158 passed