### PR TITLE
chore(library): delete dead monolithic report_sync_results chain (#659)

### DIFF
--- a/main.py
+++ b/main.py
@@ -324,9 +324,6 @@ class Plugin:
     async def sync_cancel_preview(self):
         return self._sync_service.sync_cancel_preview()
 
-    async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
-        return await self._sync_service.report_sync_results(rom_id_to_app_id, removed_rom_ids, cancelled)
-
     async def report_unit_results(self, rom_id_to_app_id):
         return await self._sync_service.report_unit_results(rom_id_to_app_id)
 

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -58,8 +58,8 @@ class LibrarySyncStateBox:
     generation id used to invalidate stale background work after the
     run ends, the heartbeat timestamp, the live progress dict emitted
     to the frontend, and the apply-staging dicts populated during
-    ``sync_preview`` / ``sync_apply_delta`` and consumed by
-    ``report_sync_results``.
+    ``sync_preview`` / ``sync_apply_delta`` and consumed by the
+    per-unit pipeline.
     """
 
     sync_state: SyncState = SyncState.IDLE

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -1,9 +1,10 @@
 """Sync result reporter and registry-query sub-service.
 
-Owns the post-apply path: the frontend-driven ``report_sync_results``
-callback that finalises artwork file names, updates the shortcut
-registry, persists last-sync metadata, and emits the
-``sync_complete`` event. Also owns the registry-derived query
+Owns the post-apply path: the per-unit ``report_unit_results`` callback
+that finalises artwork file names and appends per-ROM registry entries,
+and the terminal ``finalize_per_unit_run`` step that builds the
+cross-unit collection mappings, persists last-sync metadata, and emits
+the ``sync_complete`` event. Also owns the registry-derived query
 methods (``get_registry_platforms``, ``get_sync_stats``,
 ``get_rom_by_steam_app_id``) and the ``clear_sync_cache`` reset.
 Anything that mutates the registry as a side-effect of a finished
@@ -119,102 +120,6 @@ class SyncReporter:
 
         return platform_app_ids, romm_collection_app_ids
 
-    def _report_sync_results_io(self, rom_id_to_app_id, removed_rom_ids):
-        """Sync helper for report_sync_results — artwork renames, state save in executor."""
-        grid = self._steam_config.grid_dir()
-        box = self._sync_state
-
-        for rom_id_str, app_id in rom_id_to_app_id.items():
-            pending = box.pending_sync.get(int(rom_id_str), {})
-            cover_path = self._finalize_cover_path(grid, pending.get("cover_path", ""), app_id, rom_id_str)
-            self._state["shortcut_registry"][rom_id_str] = self._build_registry_entry(pending, app_id, cover_path)
-
-        for rom_id in removed_rom_ids:
-            self._state["shortcut_registry"].pop(str(rom_id), None)
-
-        # Apply Steam Input mode for new shortcuts
-        steam_input_mode = self._settings.get("steam_input_mode", "default")
-        if steam_input_mode != "default" and rom_id_to_app_id:
-            try:
-                self._steam_config.set_steam_input_config(
-                    [int(aid) for aid in rom_id_to_app_id.values()], mode=steam_input_mode
-                )
-            except Exception as e:
-                self._logger.error(f"Failed to set Steam Input config: {e}")
-
-        # Capture pending state before clearing
-        pending_collection_memberships = box.pending_collection_memberships
-        pending_platform_rom_ids = box.pending_platform_rom_ids
-        box.pending_collection_memberships = {}
-        box.pending_platform_rom_ids = None
-        box.pending_sync = {}
-
-        # Build final collection mappings
-        platform_app_ids, romm_collection_app_ids = self._build_collection_app_ids(
-            self._state["shortcut_registry"],
-            pending_platform_rom_ids,
-            pending_collection_memberships,
-        )
-
-        # Save state with the actual synced platforms/collections
-        self._state["last_sync"] = self._clock.now().isoformat()
-        self._state["last_synced_collections"] = list(pending_collection_memberships.keys())
-        self._state["last_synced_platforms"] = list(platform_app_ids.keys())
-        self._state_persister.save_state()
-
-        return platform_app_ids, romm_collection_app_ids
-
-    async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
-        """Called by frontend after applying shortcuts via SteamClient."""
-        platform_app_ids, romm_collection_app_ids = await self._loop.run_in_executor(
-            None, self._report_sync_results_io, rom_id_to_app_id, removed_rom_ids
-        )
-
-        total = len(self._state["shortcut_registry"])
-        processed = len(rom_id_to_app_id)
-
-        if cancelled:
-            await self._emit(
-                "sync_complete",
-                {
-                    "platform_app_ids": platform_app_ids,
-                    "romm_collection_app_ids": romm_collection_app_ids,
-                    "total_games": processed,
-                    "cancelled": True,
-                },
-            )
-            await self._emit_progress(
-                "done",
-                current=processed,
-                total=total,
-                message=f"Sync cancelled: {processed} of {total} games processed",
-                running=False,
-            )
-            self._logger.info(f"Sync cancelled: {processed}/{total} games processed")
-        else:
-            await self._emit(
-                "sync_complete",
-                {
-                    "platform_app_ids": platform_app_ids,
-                    "romm_collection_app_ids": romm_collection_app_ids,
-                    "total_games": processed,
-                },
-            )
-            await self._emit_progress(
-                "done",
-                current=total,
-                total=total,
-                message=f"Sync complete: {total} games from {len(platform_app_ids)} platforms",
-                running=False,
-            )
-            self._logger.info(f"Sync results reported: {total} games")
-        self._sync_state.sync_state = SyncState.IDLE
-        # Invalidate the run's generation id — any in-flight per-unit
-        # waits that wake after this point see a stale id and exit
-        # without emitting a late "done".
-        self._sync_state.current_sync_id = None
-        return {"success": True}
-
     # ── Finalise per-unit run ────────────────────────────────────
 
     def _finalize_per_unit_run_io(
@@ -224,8 +129,7 @@ class SyncReporter:
     ) -> tuple[dict, dict[str, list]]:
         """Build collection app-id maps and persist last_sync metadata.
 
-        Mirrors the tail of ``_report_sync_results_io`` for the per-unit
-        path: by the time this runs, every per-unit ``report_unit_results``
+        By the time this runs, every per-unit ``report_unit_results``
         has already updated the registry, so we only need to build the
         cross-unit collection mappings and write the final
         ``last_sync`` / ``last_synced_*`` fields.

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -352,9 +352,6 @@ class LibraryService:
         return self._orchestrator.sync_cancel_preview()
 
     # Reporting
-    async def report_sync_results(self, rom_id_to_app_id, removed_rom_ids, cancelled=False):
-        return await self._reporter.report_sync_results(rom_id_to_app_id, removed_rom_ids, cancelled)
-
     async def report_unit_results(self, rom_id_to_app_id):
         return await self._reporter.report_unit_results(rom_id_to_app_id)
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -85,7 +85,6 @@ export const removePlatformShortcuts = callable<[string], { success: boolean; ap
 export const removeAllShortcuts = callable<[], { success: boolean; message: string; removed_count: number; app_ids: number[]; rom_ids: (string | number)[] }>("remove_all_shortcuts");
 export const getArtworkBase64 = callable<[number], { base64: string | null }>("get_artwork_base64");
 export const getSgdbArtworkBase64 = callable<[number, number], { base64: string | null; no_api_key?: boolean }>("get_sgdb_artwork_base64");
-export const reportSyncResults = callable<[Record<string, number>, number[], boolean], { success: boolean }>("report_sync_results");
 export const reportUnitResults = callable<[Record<string, number>], { success: boolean; count: number }>("report_unit_results");
 export const reportRemovalResults = callable<[(string | number)[]], { success: boolean; message: string }>("report_removal_results");
 export const uninstallAllRoms = callable<[], { success: boolean; removed_count: number; errors: { rom_id: string; error: string }[] }>("uninstall_all_roms");

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -12,85 +12,6 @@ from adapters.persistence import (
 # conftest.py patches decky before this import
 
 
-class TestReportSyncResults:
-    @pytest.mark.asyncio
-    async def test_updates_registry(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": "/grid/abc.png"},
-            2: {"name": "Game B", "platform_name": "SNES", "cover_path": "/grid/def.png"},
-        }
-
-        result = await plugin.report_sync_results(
-            {"1": 100001, "2": 100002},
-            [],
-        )
-        assert result["success"] is True
-        assert "1" in plugin._state["shortcut_registry"]
-        assert plugin._state["shortcut_registry"]["1"]["app_id"] == 100001
-        assert plugin._state["shortcut_registry"]["1"]["name"] == "Game A"
-        assert plugin._state["shortcut_registry"]["1"]["platform_name"] == "N64"
-        assert "2" in plugin._state["shortcut_registry"]
-
-    @pytest.mark.asyncio
-    async def test_removes_stale_entries(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._state["shortcut_registry"]["99"] = {
-            "app_id": 99999,
-            "name": "Old Game",
-            "platform_name": "NES",
-        }
-        plugin._sync_service._pending_sync = {}
-
-        result = await plugin.report_sync_results({}, [99])
-        assert result["success"] is True
-        assert "99" not in plugin._state["shortcut_registry"]
-
-    @pytest.mark.asyncio
-    async def test_emits_sync_complete(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-        decky.emit.reset_mock()
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": ""},
-        }
-
-        await plugin.report_sync_results({"1": 100001}, [])
-        # emit called twice: sync_complete then sync_progress (done)
-        assert decky.emit.call_count == 2
-        sync_complete_call = decky.emit.call_args_list[0]
-        assert sync_complete_call[0][0] == "sync_complete"
-        assert sync_complete_call[0][1]["total_games"] == 1
-
-    @pytest.mark.asyncio
-    async def test_updates_last_sync(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._sync_service._pending_sync = {}
-        await plugin.report_sync_results({}, [])
-        assert plugin._state["last_sync"] is not None
-
-    @pytest.mark.asyncio
-    async def test_clears_pending_sync(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        plugin._sync_service._pending_sync = {1: {"name": "X", "platform_name": "Y", "cover_path": ""}}
-        await plugin.report_sync_results({"1": 1}, [])
-        assert plugin._sync_service._pending_sync == {}
-
-
 class TestGetSyncStats:
     @pytest.mark.asyncio
     async def test_computes_from_registry(self, plugin):
@@ -318,47 +239,6 @@ class TestClearSyncCache:
         result = plugin._sync_service.clear_sync_cache()
         assert result["success"] is True
         assert plugin._state["last_sync"] is None
-
-
-class TestReportSyncResultsCancelled:
-    """Tests for report_sync_results with cancelled=True — lines 773-788."""
-
-    @pytest.mark.asyncio
-    async def test_emits_cancelled_progress(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-        decky.emit.reset_mock()
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": ""},
-        }
-
-        await plugin.report_sync_results({"1": 100001}, [], cancelled=True)
-
-        # Find the sync_progress done emission
-        progress_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_progress"]
-        assert len(progress_calls) >= 1
-        last_progress = progress_calls[-1][0][1]
-        assert last_progress["running"] is False
-        assert "cancelled" in last_progress["message"].lower()
-
-    @pytest.mark.asyncio
-    async def test_emits_sync_complete_with_cancelled_flag(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-        decky.emit.reset_mock()
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": ""},
-        }
-
-        await plugin.report_sync_results({"1": 100001}, [], cancelled=True)
-
-        complete_calls = [c for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
-        assert len(complete_calls) == 1
-        assert complete_calls[0][0][1]["cancelled"] is True
 
 
 class TestFinalizePerUnitRun:

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -781,64 +781,6 @@ class TestRemovePlatformShortcuts:
         assert result["platform_name"] == "Nintendo 64"
 
 
-class TestArtworkRenameOnSync:
-    """Tests for artwork rename in report_sync_results."""
-
-    @pytest.mark.asyncio
-    async def test_renames_staged_to_app_id(self, plugin, tmp_path):
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-
-        # Create staged artwork
-        staging = grid_dir / "romm_1_cover.png"
-        staging.write_text("cover data")
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": str(staging)},
-        }
-
-        await plugin.report_sync_results({"1": 100001}, [])
-
-        # Staging file should be gone, final file should exist
-        assert not staging.exists()
-        final = grid_dir / "100001p.png"
-        assert final.exists()
-        assert final.read_text() == "cover data"
-
-        # Registry should store the final path
-        entry = plugin._state["shortcut_registry"]["1"]
-        assert entry["cover_path"] == str(final)
-
-    @pytest.mark.asyncio
-    async def test_handles_already_final_artwork(self, plugin, tmp_path):
-        """If cover_path already points to the final file, don't error."""
-        import decky
-
-        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
-
-        grid_dir = tmp_path / "grid"
-        grid_dir.mkdir()
-        plugin._steam_config.grid_dir = lambda: str(grid_dir)
-
-        final = grid_dir / "100001p.png"
-        final.write_text("cover data")
-
-        plugin._sync_service._pending_sync = {
-            1: {"name": "Game A", "platform_name": "N64", "cover_path": str(final)},
-        }
-
-        await plugin.report_sync_results({"1": 100001}, [])
-
-        assert final.exists()
-        entry = plugin._state["shortcut_registry"]["1"]
-        assert entry["cover_path"] == str(final)
-
-
 class TestRemovalCleansUpAppIdArtwork:
     """Tests for app_id-based artwork cleanup in report_removal_results."""
 
@@ -924,7 +866,7 @@ class TestReportRemovalSteamInputCleanup:
 class TestCollectionSyncEdgeCases:
     """Edge-case tests for the merged platform + collection sync engine.
 
-    Tests exercise classify_roms() and _report_sync_results_io() directly.
+    Tests exercise classify_roms() and _build_collection_app_ids() directly.
     """
 
     # ------------------------------------------------------------------
@@ -1043,89 +985,16 @@ class TestCollectionSyncEdgeCases:
         assert len(stale) == 0
 
     # ------------------------------------------------------------------
-    # Scenario 5: collection_create_platform_groups = False (default)
+    # Scenario 5/6: collection_create_platform_groups toggle via
+    # _build_collection_app_ids (kept helper used by per-unit path)
     # ------------------------------------------------------------------
-
-    def test_sc5_collection_rom_excluded_from_platform_groups_by_default(self, plugin):
-        """With toggle OFF, collection-only ROM B (PSX) is not included in platform_app_ids for PSX."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = False
-
-        # ROM A (id=1) came via GBA platform; ROM B (id=2) came via collection only (PSX)
-        svc._state["shortcut_registry"] = {
-            "1": _make_registry_entry("ROM A", "Game Boy Advance", app_id=1001, platform_slug="gba"),
-            "2": _make_registry_entry("ROM B", "PlayStation", app_id=1002, platform_slug="psx"),
-        }
-
-        # platform_rom_ids only contains ROM A (from platform fetch)
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {"Favorites": [1, 2]}
-        svc._pending_sync = {
-            1: {
-                "name": "ROM A",
-                "platform_name": "Game Boy Advance",
-                "platform_slug": "gba",
-                "cover_path": "",
-            },
-            2: {
-                "name": "ROM B",
-                "platform_name": "PlayStation",
-                "platform_slug": "psx",
-                "cover_path": "",
-            },
-        }
-
-        platform_app_ids, _romm_collection_app_ids = svc._reporter._report_sync_results_io({}, [])
-
-        assert "Game Boy Advance" in platform_app_ids
-        assert 1001 in platform_app_ids["Game Boy Advance"]
-        # PSX platform group should NOT be created because ROM B is collection-only
-        assert "PlayStation" not in platform_app_ids
-
-    # ------------------------------------------------------------------
-    # Scenario 6: collection_create_platform_groups = True
-    # ------------------------------------------------------------------
-
-    def test_sc6_collection_rom_included_in_platform_groups_when_toggle_on(self, plugin):
-        """With toggle ON, collection-only ROM B (PSX) IS included in platform_app_ids for PSX."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = True
-
-        svc._state["shortcut_registry"] = {
-            "1": _make_registry_entry("ROM A", "Game Boy Advance", app_id=1001, platform_slug="gba"),
-            "2": _make_registry_entry("ROM B", "PlayStation", app_id=1002, platform_slug="psx"),
-        }
-
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {"Favorites": [1, 2]}
-        svc._pending_sync = {
-            1: {
-                "name": "ROM A",
-                "platform_name": "Game Boy Advance",
-                "platform_slug": "gba",
-                "cover_path": "",
-            },
-            2: {
-                "name": "ROM B",
-                "platform_name": "PlayStation",
-                "platform_slug": "psx",
-                "cover_path": "",
-            },
-        }
-
-        platform_app_ids, _romm_collection_app_ids = svc._reporter._report_sync_results_io({}, [])
-
-        assert "Game Boy Advance" in platform_app_ids
-        assert 1001 in platform_app_ids["Game Boy Advance"]
-        # PSX platform group SHOULD exist because toggle is on
-        assert "PlayStation" in platform_app_ids
-        assert 1002 in platform_app_ids["PlayStation"]
 
     def test_sc5c_build_collection_app_ids_excludes_collection_only_roms(self, plugin):
         """_build_collection_app_ids respects the toggle.
 
-        Platform collection mapping is built from the full registry in report_sync_results.
-        collection-only ROMs must be excluded when the toggle is OFF.
+        Platform collection mapping is built from the full registry by
+        the per-unit finalisation path. Collection-only ROMs must be
+        excluded when the toggle is OFF.
         """
         svc = plugin._sync_service
         svc._settings["collection_create_platform_groups"] = False
@@ -1165,21 +1034,21 @@ class TestCollectionSyncEdgeCases:
     # ------------------------------------------------------------------
 
     def test_sc7_rom_appears_in_both_platform_and_collection_app_ids(self, plugin):
-        """ROM A (in both GBA platform and Favorites collection) appears in both platform_app_ids
-        and romm_collection_app_ids after _report_sync_results_io."""
+        """ROM A (in both GBA platform and Favorites collection) appears in both
+        platform_app_ids and romm_collection_app_ids when built via
+        _build_collection_app_ids."""
         svc = plugin._sync_service
         svc._settings["collection_create_platform_groups"] = False
 
-        svc._state["shortcut_registry"] = {
+        registry = {
             "1": _make_registry_entry("ROM A", "Game Boy Advance", app_id=1001, platform_slug="gba"),
         }
+        platform_rom_ids = {1}
+        collection_memberships = {"Favorites": [1]}
 
-        # ROM A came from platform
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {"Favorites": [1]}
-        svc._pending_sync = {}
-
-        platform_app_ids, romm_collection_app_ids = svc._reporter._report_sync_results_io({}, [])
+        platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
+            registry, platform_rom_ids, collection_memberships
+        )
 
         # Platform group for GBA exists (ROM A is a platform ROM)
         assert "Game Boy Advance" in platform_app_ids
@@ -1215,82 +1084,38 @@ class TestCollectionSyncEdgeCases:
         assert len(unchanged_ids) == 0
 
     # ------------------------------------------------------------------
-    # Additional edge cases for _report_sync_results_io
+    # Additional edge cases for _build_collection_app_ids
     # ------------------------------------------------------------------
 
-    def test_report_sync_clears_pending_state(self, plugin):
-        """_report_sync_results_io clears pending_sync, pending_collection_memberships,
-        and pending_platform_rom_ids after completion."""
-        svc = plugin._sync_service
-
-        svc._state["shortcut_registry"] = {}
-        svc._pending_sync = {1: {"name": "ROM A", "platform_name": "GBA", "cover_path": ""}}
-        svc._pending_collection_memberships = {"Favorites": [1]}
-        svc._pending_platform_rom_ids = {1}
-
-        svc._reporter._report_sync_results_io({}, [])
-
-        assert svc._pending_sync == {}
-        assert svc._pending_collection_memberships == {}
-        assert svc._pending_platform_rom_ids is None
-
-    def test_report_sync_collection_app_ids_empty_when_no_memberships(self, plugin):
+    def test_build_collection_app_ids_empty_when_no_memberships(self, plugin):
         """romm_collection_app_ids is empty when no collection memberships are set."""
         svc = plugin._sync_service
 
-        svc._state["shortcut_registry"] = {
+        registry = {
             "1": _make_registry_entry("ROM A", "GBA", app_id=1001),
         }
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {}
-        svc._pending_sync = {}
 
-        _platform_app_ids, romm_collection_app_ids = svc._reporter._report_sync_results_io({}, [])
+        _platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(registry, {1}, {})
 
         assert romm_collection_app_ids == {}
 
-    def test_report_sync_collection_app_ids_excludes_missing_registry_entries(self, plugin):
+    def test_build_collection_app_ids_excludes_missing_registry_entries(self, plugin):
         """romm_collection_app_ids skips rom_ids that have no registry entry."""
         svc = plugin._sync_service
 
         # Only ROM id=1 is in the registry; ROM id=99 is referenced in memberships but missing
-        svc._state["shortcut_registry"] = {
+        registry = {
             "1": _make_registry_entry("ROM A", "GBA", app_id=1001),
         }
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {"Favorites": [1, 99]}
-        svc._pending_sync = {}
 
-        _platform_app_ids, romm_collection_app_ids = svc._reporter._report_sync_results_io({}, [])
+        _platform_app_ids, romm_collection_app_ids = svc._reporter._build_collection_app_ids(
+            registry, {1}, {"Favorites": [1, 99]}
+        )
 
         assert "Favorites" in romm_collection_app_ids
         assert 1001 in romm_collection_app_ids["Favorites"]
         # ROM 99 has no registry entry, so its app_id is not included
         assert len(romm_collection_app_ids["Favorites"]) == 1
-
-    def test_report_sync_platform_groups_include_newly_added_roms(self, plugin):
-        """ROMs added in this sync (via rom_id_to_app_id) appear in platform_app_ids."""
-        svc = plugin._sync_service
-        svc._settings["collection_create_platform_groups"] = False
-
-        # Registry is initially empty; the sync adds ROM A
-        svc._state["shortcut_registry"] = {}
-        svc._pending_platform_rom_ids = {1}
-        svc._pending_collection_memberships = {}
-        svc._pending_sync = {
-            1: {
-                "name": "ROM A",
-                "platform_name": "Game Boy Advance",
-                "platform_slug": "gba",
-                "cover_path": "",
-                "fs_name": "ROM A.zip",
-            }
-        }
-
-        platform_app_ids, _romm = svc._reporter._report_sync_results_io({"1": 1001}, [])
-
-        assert "Game Boy Advance" in platform_app_ids
-        assert 1001 in platform_app_ids["Game Boy Advance"]
 
     def test_classify_roms_new_when_not_in_registry(self, plugin):
         """ROMs not present in the registry at all are classified as new."""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -681,7 +681,6 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_collections",
     "get_sync_progress",
     "sync_heartbeat",
-    "report_sync_results",
     "report_unit_results",
     "get_registry_platforms",
     "report_removal_results",

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -339,13 +339,6 @@ class TestLibrarySyncCallableDelegation:
         assert result == {"applied": True}
 
     @pytest.mark.asyncio
-    async def test_report_sync_results_delegates(self, plugin):
-        plugin._sync_service.report_sync_results = AsyncMock(return_value={"ok": True})
-        result = await plugin.report_sync_results({"1": 100}, [2], cancelled=True)
-        plugin._sync_service.report_sync_results.assert_awaited_once_with({"1": 100}, [2], True)
-        assert result == {"ok": True}
-
-    @pytest.mark.asyncio
     async def test_report_unit_results_delegates(self, plugin):
         plugin._sync_service.report_unit_results = AsyncMock(return_value={"ok": True})
         result = await plugin.report_unit_results({"1": 100})


### PR DESCRIPTION
Closes #659. Parent: #620.

## Summary

End-to-end dead path after #436/#544 cut the apply pipeline over to per-unit. Frontend uses ``reportUnitResults`` exclusively (``src/utils/syncManager.ts``). Removing the monolithic ``report_sync_results`` chain drops ~400 LOC of dead callable wiring + tests with zero behaviour change.

## Deleted (verified dead via grep)

- ``src/api/backend.ts:88`` — ``reportSyncResults`` callable export (zero importers)
- ``main.py:327-328`` — ``Plugin.report_sync_results`` callable method
- ``py_modules/services/library/service.py:355-356`` — ``LibraryService.report_sync_results`` delegate
- ``py_modules/services/library/reporter.py:122-216`` — ``SyncReporter.report_sync_results`` + ``_report_sync_results_io`` helper
- Stale docstring references in ``services/library/_state.py`` (``LibrarySyncStateBox``) and ``reporter.py`` (module + ``_finalize_per_unit_run_io``)
- ``tests/test_plugin.py`` — ``report_sync_results`` from the callable whitelist
- ``tests/test_plugin_callable_delegation.py`` — ``test_report_sync_results_delegates``
- ``tests/services/library/test_reporter.py`` — ``TestReportSyncResults`` (5 tests) and ``TestReportSyncResultsCancelled`` (2 tests)
- ``tests/services/library/test_service.py`` — ``TestArtworkRenameOnSync`` (2 tests), ``test_sc5``/``test_sc6`` (replaced by surviving ``_sc5c``/``_sc6c``), and 4 ``_report_sync_results_io`` edge-case exercises (3 ported to the kept ``_build_collection_app_ids`` helper, 1 dropped as duplicate)

## Kept (still used by per-unit pipeline + ``finalize_per_unit_run``)

- ``SyncReporter._finalize_cover_path`` — called by ``_report_unit_results_io``
- ``SyncReporter._build_registry_entry`` — called by ``_report_unit_results_io``
- ``SyncReporter._build_collection_app_ids`` — called by ``_finalize_per_unit_run_io``

## Verification

- ``grep -rn 'report_sync_results\|reportSyncResults' py_modules/ main.py src/ tests/`` → 0 hits
- ``grep -rn '_report_sync_results_io' py_modules/ main.py tests/`` → 0 hits
- Coverage on remaining ``reporter.py``: **95%** (123 stmts, 26 branches; misses are unrelated ``_finalize_per_unit_run`` cancel-branch and one ``_finalize_cover_path`` no-grid guard)

## Test plan

- [x] ``python -m pytest tests/services/library/ tests/test_plugin_callable_delegation.py`` (284 passed)
- [x] ``python -m pytest tests/`` (2471 passed)
- [x] ``ruff check`` + ``ruff format --check`` on touched files
- [x] ``basedpyright`` scoped + CI scope (0 errors)
- [x] ``bash scripts/check_cosmic_call_bans.sh`` (OK)
- [x] ``PYTHONPATH=py_modules lint-imports`` (7 contracts kept, 0 broken)
- [x] ``pnpm build`` (clean) + ``pnpm test`` (158 passed)