### PR TITLE
chore: delete 3 orphan Decky callables (#660)

### DIFF
--- a/main.py
+++ b/main.py
@@ -307,9 +307,6 @@ class Plugin:
     async def cancel_sync(self):
         return self._sync_service.cancel_sync()
 
-    async def get_sync_progress(self):
-        return self._sync_service.get_sync_progress()
-
     async def sync_heartbeat(self):
         return self._sync_service.sync_heartbeat()
 
@@ -370,10 +367,6 @@ class Plugin:
 
     async def get_download_queue(self):
         return self._download_service.get_download_queue()
-
-    @migration_blocked
-    async def clear_completed_downloads(self):
-        return self._download_service.clear_completed_downloads()
 
     async def get_installed_rom(self, rom_id):
         return self._download_service.get_installed_rom(rom_id)
@@ -467,9 +460,6 @@ class Plugin:
 
     async def record_session_start(self, rom_id):
         return self._playtime_service.record_session_start(rom_id)
-
-    async def get_server_playtime(self, rom_id):
-        return await self._playtime_service.get_server_playtime(rom_id)
 
     async def get_all_playtime(self):
         return self._playtime_service.get_all_playtime()

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -112,17 +112,6 @@ class DownloadService:
         for rid in terminal_ids[:excess]:
             del self._download_queue[rid]
 
-    def clear_completed_downloads(self):
-        """Remove all completed/failed/cancelled items from the download queue."""
-        terminal_ids = [
-            rid
-            for rid, item in self._download_queue.items()
-            if item.get("status") in ("completed", "failed", "cancelled")
-        ]
-        for rid in terminal_ids:
-            del self._download_queue[rid]
-        return {"success": True, "removed": len(terminal_ids)}
-
     def _remove_tmp_files(self, paths: list[str]) -> int:
         """Remove each path in *paths*, logging a warning on per-file failure.
 

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -335,9 +335,6 @@ class LibraryService:
     def cancel_sync(self):
         return self._orchestrator.cancel_sync()
 
-    def get_sync_progress(self):
-        return self._box.sync_progress
-
     def sync_heartbeat(self):
         return self._orchestrator.sync_heartbeat()
 

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -223,35 +223,6 @@ class PlaytimeService:
         except (ValueError, TypeError):
             return {"success": False, "message": "Failed to calculate session duration"}
 
-    async def get_server_playtime(self, rom_id: int) -> dict:
-        """Read playtime from RomM server notes for a ROM."""
-        rom_id = int(rom_id)
-        rom_id_str = str(rom_id)
-
-        local_entry = self._save_sync_state.playtime.get(rom_id_str)
-        local_seconds = local_entry.total_seconds if local_entry else 0
-
-        server_seconds = 0
-        try:
-            note = await self._loop.run_in_executor(
-                None,
-                lambda: self._retry.with_retry(self._get_playtime_note, rom_id),
-            )
-            if note:
-                server_data = self._parse_playtime_note_content(note.get("content", ""))
-                if server_data:
-                    server_seconds = int(server_data.get("seconds", 0))
-        except Exception as e:
-            self._log_debug(f"Failed to read server playtime for rom {rom_id}: {e}")
-
-        return {
-            "rom_id": rom_id,
-            "local_seconds": local_seconds,
-            "server_seconds": server_seconds,
-            "total_seconds": max(local_seconds, server_seconds),
-            "session_count": local_entry.session_count if local_entry else 0,
-        }
-
     def get_all_playtime(self) -> dict:
         """Return all local playtime entries keyed by rom_id string."""
         return {"playtime": {rid: pe.to_dict() for rid, pe in self._save_sync_state.playtime.items()}}

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -438,7 +438,7 @@ class TestSyncCancelPreview:
 
 
 class TestSyncControl:
-    """Tests for start_sync, cancel_sync, get_sync_progress, sync_heartbeat — lines 143-163."""
+    """Tests for start_sync, cancel_sync, sync_heartbeat — lines 143-163."""
 
     def test_start_sync_when_idle(self, plugin):
         result = plugin._sync_service.start_sync()
@@ -474,11 +474,6 @@ class TestSyncControl:
         result = plugin._sync_service.cancel_sync()
         assert result["success"] is True
         assert "No sync" in result["message"]
-
-    def test_get_sync_progress(self, plugin):
-        result = plugin._sync_service.get_sync_progress()
-        assert "running" in result
-        assert "phase" in result
 
     def test_sync_heartbeat(self, plugin):
         old = plugin._sync_service._sync_last_heartbeat

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2127,45 +2127,6 @@ class TestStartDownloadCreateTaskFailure:
         assert 42 not in plugin._download_service._download_in_progress
 
 
-class TestClearCompletedDownloads:
-    @pytest.mark.asyncio
-    async def test_removes_all_terminal_items(self, plugin):
-        plugin._download_service._download_queue[1] = {"rom_id": 1, "status": "completed"}
-        plugin._download_service._download_queue[2] = {"rom_id": 2, "status": "failed"}
-        plugin._download_service._download_queue[3] = {"rom_id": 3, "status": "cancelled"}
-        result = await plugin.clear_completed_downloads()
-        assert result["success"] is True
-        assert result["removed"] == 3
-        assert len(plugin._download_service._download_queue) == 0
-
-    @pytest.mark.asyncio
-    async def test_keeps_active_downloads(self, plugin):
-        plugin._download_service._download_queue[1] = {"rom_id": 1, "status": "downloading"}
-        plugin._download_service._download_queue[2] = {"rom_id": 2, "status": "completed"}
-        plugin._download_service._download_queue[3] = {"rom_id": 3, "status": "downloading"}
-        result = await plugin.clear_completed_downloads()
-        assert result["success"] is True
-        assert result["removed"] == 1
-        assert len(plugin._download_service._download_queue) == 2
-        assert 1 in plugin._download_service._download_queue
-        assert 3 in plugin._download_service._download_queue
-
-    @pytest.mark.asyncio
-    async def test_empty_queue(self, plugin):
-        result = await plugin.clear_completed_downloads()
-        assert result["success"] is True
-        assert result["removed"] == 0
-
-    @pytest.mark.asyncio
-    async def test_only_active_items(self, plugin):
-        plugin._download_service._download_queue[1] = {"rom_id": 1, "status": "downloading"}
-        plugin._download_service._download_queue[2] = {"rom_id": 2, "status": "downloading"}
-        result = await plugin.clear_completed_downloads()
-        assert result["success"] is True
-        assert result["removed"] == 0
-        assert len(plugin._download_service._download_queue) == 2
-
-
 class TestShutdown:
     """Tests for DownloadService.shutdown — cancel active tasks + clear tracking."""
 

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -200,36 +200,6 @@ class TestSyncPlaytime:
 
 class TestGetPlaytime:
     @pytest.mark.asyncio
-    async def test_get_server_playtime(self):
-        svc, fake, state, _ = make_service()
-        state.playtime["42"] = PlaytimeEntry(total_seconds=100, session_count=2)
-
-        fake.notes[42] = [
-            {
-                "id": 2000,
-                "rom_id": 42,
-                "title": "romm-sync:playtime",
-                "content": json.dumps({"seconds": 200}),
-                "is_public": False,
-            }
-        ]
-
-        result = await svc.get_server_playtime(42)
-        assert result["local_seconds"] == 100
-        assert result["server_seconds"] == 200
-        assert result["total_seconds"] == 200  # max(100, 200)
-
-    @pytest.mark.asyncio
-    async def test_get_server_playtime_no_note(self):
-        svc, _, state, _ = make_service()
-        state.playtime["42"] = PlaytimeEntry(total_seconds=50, session_count=1)
-
-        result = await svc.get_server_playtime(42)
-        assert result["local_seconds"] == 50
-        assert result["server_seconds"] == 0
-        assert result["total_seconds"] == 50
-
-    @pytest.mark.asyncio
     async def test_get_all_playtime(self):
         svc, _, state, _ = make_service()
         state.playtime["42"] = PlaytimeEntry(total_seconds=100)
@@ -281,17 +251,6 @@ class TestPlaytimeNotes:
 
 
 class TestEdgeCases:
-    @pytest.mark.asyncio
-    async def test_api_error_on_server_playtime(self):
-        svc, fake, state, _ = make_service()
-        state.playtime["42"] = PlaytimeEntry(total_seconds=100, session_count=1)
-        fake.fail_on_next(RommApiError("Server down"))
-
-        result = await svc.get_server_playtime(42)
-        # Should still return local data
-        assert result["local_seconds"] == 100
-        assert result["server_seconds"] == 0
-
     @pytest.mark.asyncio
     async def test_sync_playtime_error_logged_not_raised(self):
         svc, fake, state, _ = make_service()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -679,7 +679,6 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_available_cores",
     "get_platforms",
     "get_collections",
-    "get_sync_progress",
     "sync_heartbeat",
     "report_unit_results",
     "get_registry_platforms",
@@ -718,7 +717,6 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     # Playtime queries.
     "record_session_start",
     "record_session_end",
-    "get_server_playtime",
     "get_all_playtime",
     # SteamGridDB / Steam shortcut artwork (Steam-side, not retrodeck).
     "get_sgdb_artwork_base64",

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -311,13 +311,6 @@ class TestLibrarySyncCallableDelegation:
         assert result == {"started": True}
 
     @pytest.mark.asyncio
-    async def test_get_sync_progress_delegates(self, plugin):
-        plugin._sync_service.get_sync_progress.return_value = {"percent": 50}
-        result = await plugin.get_sync_progress()
-        plugin._sync_service.get_sync_progress.assert_called_once_with()
-        assert result == {"percent": 50}
-
-    @pytest.mark.asyncio
     async def test_sync_heartbeat_delegates(self, plugin):
         plugin._sync_service.sync_heartbeat.return_value = {"alive": True}
         result = await plugin.sync_heartbeat()
@@ -455,13 +448,6 @@ class TestDownloadCallableDelegation:
         result = await plugin.get_download_queue()
         plugin._download_service.get_download_queue.assert_called_once_with()
         assert result == []
-
-    @pytest.mark.asyncio
-    async def test_clear_completed_downloads_delegates(self, plugin):
-        plugin._download_service.clear_completed_downloads.return_value = {"cleared": 2}
-        result = await plugin.clear_completed_downloads()
-        plugin._download_service.clear_completed_downloads.assert_called_once_with()
-        assert result == {"cleared": 2}
 
     @pytest.mark.asyncio
     async def test_get_installed_rom_delegates(self, plugin):
@@ -656,18 +642,6 @@ class TestGameDetailCallableDelegation:
         result = await plugin.get_cached_game_detail("12345")
         plugin._game_detail_service.get_cached_game_detail.assert_called_once_with("12345")
         assert result == {"detail": "x"}
-
-
-# ── Playtime callables ─────────────────────────────────────────────────
-
-
-class TestPlaytimeCallableDelegation:
-    @pytest.mark.asyncio
-    async def test_get_server_playtime_delegates(self, plugin):
-        plugin._playtime_service.get_server_playtime = AsyncMock(return_value={"total": 60})
-        result = await plugin.get_server_playtime(42)
-        plugin._playtime_service.get_server_playtime.assert_awaited_once_with(42)
-        assert result == {"total": 60}
 
 
 # ── Error-propagation tests ────────────────────────────────────────────


### PR DESCRIPTION
Closes #660. Parent: #620.

Same pattern as #586 (which dropped 7 orphan callables). These 3 had zero frontend call sites and were kept alive only by tests.

## Deleted

- `Plugin.get_sync_progress` + `LibraryService.get_sync_progress`
- `Plugin.clear_completed_downloads` + `DownloadService.clear_completed_downloads`
- `Plugin.get_server_playtime` + `PlaytimeService.get_server_playtime`

Also dropped:
- `tests/test_plugin_callable_delegation.py` — `test_get_sync_progress_delegates`, `test_clear_completed_downloads_delegates`, entire `TestPlaytimeCallableDelegation` class (only contained `test_get_server_playtime_delegates`)
- `tests/test_plugin.py` — `get_sync_progress` + `get_server_playtime` whitelist entries
- `tests/services/library/test_sync_orchestrator.py` — `test_get_sync_progress` + updated `TestSyncControl` docstring
- `tests/services/test_downloads.py` — entire `TestClearCompletedDownloads` class (4 tests)
- `tests/services/test_playtime.py` — `test_get_server_playtime`, `test_get_server_playtime_no_note`, `test_api_error_on_server_playtime`

## Kept

The frontend `getSyncProgress` in `src/utils/syncProgress.ts` is a LOCAL utility that reads the `sync_progress` emit channel — unrelated to the deleted backend callable. `MainPage.tsx` still consumes it.

## Verification

```
grep -rn "get_sync_progress\|getSyncProgress" py_modules/ main.py tests/ src/
# only matches: src/utils/syncProgress.ts + src/components/MainPage.tsx (unrelated frontend utility)

grep -rn "clear_completed_downloads\|clearCompletedDownloads" py_modules/ main.py src/ tests/
# zero matches

grep -rn "get_server_playtime\|getServerPlaytime" py_modules/ main.py src/ tests/
# zero matches
```

## Test plan

- [x] Targeted suites pass (`tests/services/library/`, `tests/services/test_downloads.py`, `tests/services/test_playtime.py`, `tests/test_plugin_callable_delegation.py`, `tests/test_plugin.py`) — 440 passed
- [x] Full backend suite pass — 2491 passed
- [x] `ruff check` clean; `ruff format --check` clean (one pre-existing unchanged warning on `typings/decky/__init__.pyi`)
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh` — OK
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] `pnpm build` — created `dist/`
- [x] `pnpm test` — 175 passed (11 files)

LOC delta: 167 deletions, 1 insertion across 9 files.