### PR TITLE
test: cover 4 untested error paths (dismiss_save_sort, firmware, rom_removal, saves) (#663)

### DIFF
--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -1025,3 +1025,80 @@ class TestHasTrackedSave:
         assert svc.has_tracked_save(99) is True
         # Wrong rom_id misses cleanly.
         assert svc.has_tracked_save(100) is False
+
+
+class TestBadPathDeleteSavesPartialFailure:
+    """Coverage for the per-file ``except`` arm in ``_delete_saves_for_roms``.
+
+    Wires a ``FakeSaveFileAdapter`` into the service post-construction so
+    one targeted ``remove`` call raises ``OSError`` while the rest succeed.
+    """
+
+    @staticmethod
+    def _install_fake_save_file(svc, files: dict[str, bytes], remove_failures: set[str]):
+        """Replace the real ``SaveFileAdapter`` with a fake on both consumers.
+
+        The aggregate root and ``RomInfoService`` both hold the adapter
+        reference — both must point at the same fake so file discovery
+        and deletion run through the failure-injecting instance.
+        """
+        from conftest import FakeSaveFileAdapter
+
+        fake = FakeSaveFileAdapter(files=files)
+        # Mark each saves-dir as present so ``find_save_files`` walks them.
+        for path in files:
+            fake.dirs.add(os.path.dirname(path))
+        fake.remove_failures = set(remove_failures)
+        svc._save_file = fake
+        svc._rom_info._save_file = fake
+        return fake
+
+    @pytest.mark.asyncio
+    async def test_delete_local_saves_partial_failure_returns_error_response(self, tmp_path):
+        """One ``remove`` failure flips success=False but counts the rest."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+
+        saves_dir = str(tmp_path / "saves" / "gba")
+        good_path = os.path.join(saves_dir, "pokemon.srm")
+        bad_path = os.path.join(saves_dir, "pokemon.rtc")
+        fake = self._install_fake_save_file(
+            svc,
+            files={good_path: b"\x00" * 16, bad_path: b"\x01" * 16},
+            remove_failures={bad_path},
+        )
+
+        result = svc.delete_local_saves(42)
+
+        assert result["success"] is False
+        # The successful remove still counts.
+        assert result["deleted_count"] == 1
+        assert "1 error(s)" in result["message"]
+        # The failing path remains; the successful one is gone.
+        assert bad_path in fake.files
+        assert good_path not in fake.files
+
+    @pytest.mark.asyncio
+    async def test_delete_platform_saves_partial_failure_returns_error_response(self, tmp_path):
+        """One ``remove`` failure across the platform flips success=False."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _install_rom(svc, tmp_path, rom_id=2, system="gba", file_name="game2.gba")
+
+        saves_dir = str(tmp_path / "saves" / "gba")
+        good_path = os.path.join(saves_dir, "game1.srm")
+        bad_path = os.path.join(saves_dir, "game2.srm")
+        fake = self._install_fake_save_file(
+            svc,
+            files={good_path: b"\x00" * 16, bad_path: b"\x01" * 16},
+            remove_failures={bad_path},
+        )
+
+        result = svc.delete_platform_saves("gba")
+
+        assert result["success"] is False
+        assert result["deleted_count"] == 1
+        assert "1 error(s)" in result["message"]
+        # The failing file remains in place; the successful one is gone.
+        assert bad_path in fake.files
+        assert good_path not in fake.files

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -2068,3 +2068,100 @@ class TestDeletePlatformBiosIOLogsWarnings:
         assert "scph5501.bin" in plugin._state["downloaded_bios"]
         # The successful file's state entry is cleared.
         assert "scph5502.bin" not in plugin._state["downloaded_bios"]
+
+
+class TestBadPathFirmwareCallables:
+    """Coverage for the three previously-untested firmware-callable error paths.
+
+    Each test wires a fresh ``FirmwareService`` against the seeded
+    ``FakeRommApi`` fixture instead of the plugin's ``MagicMock`` so the
+    failure injection runs through the real Protocol surface.
+    """
+
+    def _build_service(self, fake_romm_api, *, firmware_cache_persister=None):
+        """Build a fresh ``FirmwareService`` wired against the supplied fake API."""
+        import decky
+
+        if firmware_cache_persister is None:
+            firmware_cache_persister = FakeFirmwareCachePersister()
+        state = {
+            "shortcut_registry": {},
+            "installed_roms": {},
+            "downloaded_bios": {},
+            "retrodeck_home_path": "",
+        }
+        svc = FirmwareService(
+            config=FirmwareServiceConfig(
+                romm_api=fake_romm_api,
+                state=state,
+                loop=asyncio.get_event_loop(),
+                logger=decky.logger,
+                plugin_dir=decky.DECKY_PLUGIN_DIR,
+                clock=_make_clock(),
+                state_persister=MagicMock(),
+                firmware_cache_persister=firmware_cache_persister,
+                firmware_files=FakeFirmwareFileAdapter(),
+                retrodeck_paths=FakeRetroDeckPaths(),
+                core_info=FakeCoreInfoProvider(),
+            ),
+        )
+        svc.load_bios_registry()
+        return svc
+
+    def test_invalidate_cache_logs_warning_when_persist_fails(self, fake_romm_api, caplog):
+        """Persister raising ``OSError`` is swallowed with a warning log."""
+        import logging
+
+        persister = FakeFirmwareCachePersister()
+        persister.save_side_effect = OSError("disk full")
+        fw = self._build_service(fake_romm_api, firmware_cache_persister=persister)
+        fw._firmware_cache = [{"id": 1, "file_name": "bios.bin"}]
+        fw._firmware_cache_epoch = 1.0
+
+        with caplog.at_level(logging.WARNING):
+            fw.invalidate_firmware_cache()  # must not raise
+
+        # In-memory cache cleared regardless of persister failure.
+        assert fw._firmware_cache is None
+        assert fw._firmware_cache_epoch == 0
+        # The persister was attempted and produced a warning.
+        assert persister.save_count == 1
+        assert any("disk full" in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_download_all_firmware_returns_error_with_zero_when_list_fetch_fails(self, fake_romm_api, caplog):
+        """Initial ``list_firmware`` failure short-circuits with ``downloaded=0``."""
+        import logging
+
+        fw = self._build_service(fake_romm_api)
+        fw._loop = asyncio.get_event_loop()
+        fake_romm_api.fail_on_next(OSError("connection reset"))
+
+        with caplog.at_level(logging.ERROR):
+            result = await fw.download_all_firmware("dc")
+
+        assert result["success"] is False
+        assert result["downloaded"] == 0
+        assert "message" in result
+        # The cache was not populated by the failed fetch.
+        assert fw._firmware_cache is None
+
+    @pytest.mark.asyncio
+    async def test_download_required_firmware_returns_error_with_zero_when_list_fetch_fails(
+        self, fake_romm_api, caplog
+    ):
+        """Initial ``list_firmware`` failure short-circuits with ``downloaded=0``."""
+        import logging
+
+        fw = self._build_service(fake_romm_api)
+        fw._loop = asyncio.get_event_loop()
+        fake_romm_api.fail_on_next(OSError("connection reset"))
+
+        with caplog.at_level(logging.ERROR):
+            result = await fw.download_required_firmware("dc")
+
+        assert result["success"] is False
+        assert result["downloaded"] == 0
+        assert "message" in result
+        # The cache was not populated by the failed fetch.
+        assert fw._firmware_cache is None

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -1035,3 +1035,22 @@ class TestRefreshState:
         mig.detect_save_sort_change.assert_not_called()
         mig.get_migration_status.assert_not_called()
         mig.get_save_sort_migration_status.assert_not_called()
+
+
+class TestBadPathDismissSaveSortMigration:
+    """Coverage for the previously-untested ``dismiss_save_sort_migration`` callable."""
+
+    def test_dismiss_save_sort_migration_clears_state_and_persists(self, plugin):
+        """User dismissing the warning pops the marker and persists state once."""
+        plugin._state["save_sort_settings_previous"] = {
+            "sort_by_content": True,
+            "sort_by_core": False,
+        }
+        persister = plugin._migration_service._state_persister
+        saves_before = persister.save_count
+
+        result = plugin._migration_service.dismiss_save_sort_migration()
+
+        assert result == {"success": True}
+        assert "save_sort_settings_previous" not in plugin._state
+        assert persister.save_count == saves_before + 1

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -493,3 +493,30 @@ class TestDownloadQueueCleanup:
 
         result2 = await svc.uninstall_all_roms()
         assert result2["success"] is True
+
+
+class TestBadPathRemoveRom:
+    """Coverage for the previously-untested ``remove_rom`` exception handler."""
+
+    @pytest.mark.asyncio
+    async def test_remove_rom_handles_filesystem_failure(self, service, state, queue_cleanup, rom_files):
+        """``remove_tree`` OSError surfaces as a failure response with no eviction."""
+        rom_dir = f"{_ROMS_BASE}/psx/FF7"
+        rom_files.files[f"{rom_dir}/disc1.bin"] = b"\x00" * 100
+        rom_files.remove_tree_failures.add(rom_dir)
+
+        state["installed_roms"]["42"] = {
+            "rom_id": 42,
+            "file_path": f"{rom_dir}/FF7.m3u",
+            "rom_dir": rom_dir,
+            "system": "psx",
+        }
+
+        result = await service.remove_rom(42)
+
+        assert result["success"] is False
+        assert "Failed to delete ROM files" in result["message"]
+        # State entry remains because the IO helper raised before state mutation.
+        assert "42" in state["installed_roms"]
+        # No queue eviction on failure.
+        assert queue_cleanup.evicted == []


### PR DESCRIPTION
Closes #663.
Parent epic: #621.

## Summary

Adds bad-path coverage for four previously-untested error sites discovered in the post-refactor review. Each lives in its own focused `TestBadPath*` class to keep the new surface visible.

## New tests

- `tests/services/test_migration.py` — `TestBadPathDismissSaveSortMigration` (1 test)
  - `test_dismiss_save_sort_migration_clears_state_and_persists` covers `migration.py:592-594` (the only fully-untested callable).

- `tests/services/test_firmware.py` — `TestBadPathFirmwareCallables` (3 tests, wired against the new `FakeRommApi`)
  - `test_invalidate_cache_logs_warning_when_persist_fails` covers `firmware.py:213-214`.
  - `test_download_all_firmware_returns_error_with_zero_when_list_fetch_fails` covers `firmware.py:403-407`.
  - `test_download_required_firmware_returns_error_with_zero_when_list_fetch_fails` covers `firmware.py:462-466`.

- `tests/services/test_rom_removal.py` — `TestBadPathRemoveRom` (1 test)
  - `test_remove_rom_handles_filesystem_failure` covers `rom_removal.py:102-104` via `FakeRomFileAdapter.remove_tree_failures`; also asserts the download queue is NOT evicted on failure.

- `tests/services/saves/test_service.py` — `TestBadPathDeleteSavesPartialFailure` (2 tests, wired against `FakeSaveFileAdapter`)
  - `test_delete_local_saves_partial_failure_returns_error_response` covers `saves/service.py:318-319, 335`.
  - `test_delete_platform_saves_partial_failure_returns_error_response` covers `saves/service.py:358`.

## Coverage delta (branch coverage)

| Module | Before | After |
|---|---|---|
| `services/firmware.py` | 93% (20 miss) | 96% (8 miss) |
| `services/migration.py` | 94% (17 miss) | 94% (14 miss) |
| `services/rom_removal.py` | 96% (4 miss) | 99% (1 miss) |
| `services/saves/service.py` | 96% (4 miss) | 100% (0 miss) |

## Scope notes

- Existing `MagicMock(romm_api)` setups in `test_firmware.py` were not migrated to `FakeRommApi` — only the three new bad-path tests use it. Broader migration is the deferred test-brittleness cleanup.
- Uses existing fakes throughout (`FakeRommApi`, `FakeRomFileAdapter`, `FakeSaveFileAdapter`, `FakeFirmwareCachePersister`).
- LF line endings, no AI attribution, conventional-commit subject.

## Test plan

- [x] `python -m pytest tests/services/test_migration.py tests/services/test_firmware.py tests/services/test_rom_removal.py tests/services/saves/test_service.py -v` (205 passed)
- [x] `python -m pytest tests/ -q` (2523 passed)
- [x] `ruff check` + `ruff format --check` on touched files
- [x] `basedpyright` scoped + CI scope (0 errors)
- [x] `bash scripts/check_cosmic_call_bans.sh`
- [x] `PYTHONPATH=py_modules lint-imports` (7 contracts kept)