### PR TITLE
fix(saves): split 'not_found' rollback status into ROM-not-installed vs version-deleted (#653)

### DIFF
--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -179,7 +179,7 @@ class VersionsService:
             None,
         )
         if target_save is None:
-            return {"status": "not_found"}
+            return {"status": "version_deleted"}
 
         saves_dir = info["saves_dir"]
         system = info["system"]
@@ -238,14 +238,19 @@ class VersionsService:
 
         Returns a status dict:
         - ``{"status": "ok"}`` on success.
-        - ``{"status": "not_found"}`` if the ROM is not installed or the
-          chosen save id is no longer on the server (genuinely deleted —
-          the ``list_saves`` call succeeded and the id was absent).
+        - ``{"status": "rom_not_installed"}`` if the ROM is not installed
+          locally. The frontend distinguishes this from
+          ``version_deleted`` so it can prompt the user to reinstall the
+          ROM rather than telling them the version is gone from the
+          server.
+        - ``{"status": "version_deleted"}`` if the chosen save id is no
+          longer on the server (genuinely deleted — the ``list_saves``
+          call succeeded and the id was absent).
         - ``{"status": "server_unreachable", "error": ...}`` if the
           post-preflight ``list_saves`` call failed (network, server,
           auth, etc.). The frontend distinguishes this from
-          ``not_found`` so it can show a retry affordance instead of
-          "version no longer on the server".
+          ``version_deleted`` so it can show a retry affordance instead
+          of "version no longer on the server".
         - ``{"status": "conflict_blocked", "conflicts": [...]}`` if the
           pre-flight surfaced a conflict on the currently-tracked save.
           The frontend resolves it via the standard conflict modal.
@@ -265,7 +270,7 @@ class VersionsService:
         async with self._sync_engine._rom_lock(rom_id):
             info = self._rom_info.get_rom_save_info(rom_id)
             if not info:
-                return {"status": "not_found"}
+                return {"status": "rom_not_installed"}
 
             # Matrix pre-flight: get the tracked save in sync first, or surface
             # a conflict that the user must resolve before any switch can run.

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -285,7 +285,8 @@ export interface SaveVersionEntry {
 
 export type RollbackStatus =
   | { status: "ok" }
-  | { status: "not_found" }
+  | { status: "rom_not_installed" }
+  | { status: "version_deleted" }
   | { status: "unsupported" }
   | { status: "server_unreachable"; error: string }
   | { status: "conflict_blocked"; conflicts: SyncConflict[] }

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -95,7 +95,12 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         setVersions(null);
         setExpanded(false);
         onRestored();
-      } else if (result.status === "not_found") {
+      } else if (result.status === "rom_not_installed") {
+        // Distinct from ``version_deleted``: the chosen version may well
+        // still exist on the server; the local ROM install is what's gone
+        // (uninstalled between version-list load and restore tap).
+        toaster.toast({ title: "RomM Sync", body: "ROM is no longer installed locally. Reinstall and try again." });
+      } else if (result.status === "version_deleted") {
         toaster.toast({ title: "RomM Sync", body: "This version no longer exists on the server" });
       } else if (result.status === "server_unreachable") {
         // Distinct from ``not_found``: the version may well still exist;

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -287,17 +287,26 @@ class TestRollbackToVersion:
         )
 
     @pytest.mark.asyncio
-    async def test_returns_not_found_when_rom_not_installed(self, tmp_path):
-        """Returns not_found when the ROM is not in installed_roms."""
+    async def test_returns_rom_not_installed_when_rom_uninstalled(self, tmp_path):
+        """Returns rom_not_installed (NOT version_deleted) when the ROM
+        isn't in ``installed_roms``.
+
+        The two cases used to collide on ``not_found``; the frontend then
+        told the user the version was gone from the server when in fact
+        the local ROM install was what disappeared. This test pins the
+        split so a regression to the conflated status would fail.
+        """
         svc, _fake = make_service(tmp_path)
 
         # rom 999 is not installed
         result = await svc.rollback_to_version(999, "default", 50)
-        assert result == {"status": "not_found"}
+        assert result == {"status": "rom_not_installed"}
+        # Regression guard: must NOT collide with the genuinely-deleted case.
+        assert result["status"] != "version_deleted"
 
     @pytest.mark.asyncio
-    async def test_returns_not_found_when_save_id_missing(self, tmp_path):
-        """Returns not_found when target save_id is not in the server response."""
+    async def test_returns_version_deleted_when_save_id_missing(self, tmp_path):
+        """Returns version_deleted when target save_id is not in the server response."""
         svc, fake = make_service(tmp_path)
 
         _create_save(tmp_path)
@@ -306,7 +315,7 @@ class TestRollbackToVersion:
         fake.saves[100] = self._tracked_save(100)
         # Request save_id=999, which doesn't exist
         result = await svc.rollback_to_version(42, "default", 999)
-        assert result == {"status": "not_found"}
+        assert result == {"status": "version_deleted"}
 
     @pytest.mark.asyncio
     async def test_proceeds_even_with_newer_foreign_save(self, tmp_path):
@@ -521,7 +530,7 @@ class TestRollbackToVersion:
         assert result["status"] == "server_unreachable"
         assert "unreachable" in result.get("error", "").lower()
         # Critical: must NOT collide with the "genuinely deleted" case.
-        assert result["status"] != "not_found"
+        assert result["status"] != "version_deleted"
 
     # ------------------------------------------------------------------
     # Cross-device propagation: rollback re-PUTs target so it becomes


### PR DESCRIPTION
Closes #653. Sub of #619.

## Problem

`VersionsService.rollback_to_version` returned `{"status": "not_found"}` for two distinct failure modes:
1. ROM not installed locally (`info` falsy at the `get_rom_save_info` lookup)
2. Chosen `save_id` absent from a successful `list_saves` response (genuinely deleted server-side)

The frontend rendered both as "This version no longer exists on the server" — wrong for case 1, where the version may well still exist on the server; the local ROM install is what's gone.

Pre-existing — #648 only addressed the `server_unreachable` split.

## Fix

Split the conflated status into two:

- `rom_not_installed` — ROM is not in `installed_roms` (case 1)
- `version_deleted` — `list_saves` succeeded but the target id was absent (case 2)

Chose `version_deleted` over keeping `not_found` for the case-2 rename because it's semantically explicit at the type-union level — `RollbackStatus` now reads as a list of mutually exclusive failure modes (`rom_not_installed`, `version_deleted`, `server_unreachable`, `conflict_blocked`, `preflight_failed`, `put_failed`) with no overlap.

## Frontend

`VersionHistoryPanel.handleRestore` now branches on the two new statuses with distinct toasts:

- `rom_not_installed` → `"ROM is no longer installed locally. Reinstall and try again."`
- `version_deleted` → `"This version no longer exists on the server"` (existing message, preserved)

## Tests

- Renamed `test_returns_not_found_when_rom_not_installed` → `test_returns_rom_not_installed_when_rom_uninstalled`; asserts `rom_not_installed` AND adds a regression guard `result["status"] != "version_deleted"` so any future re-conflation fails the test.
- Renamed `test_returns_not_found_when_save_id_missing` → `test_returns_version_deleted_when_save_id_missing`; asserts `version_deleted`.
- Updated `test_post_preflight_list_saves_failure_returns_server_unreachable` regression guard to compare against `version_deleted` (was `not_found`).

`py_modules/services/saves/versions.py` coverage: 100% (85 stmts, 10 branches, all covered).

## Test plan

- [x] `python -m pytest tests/services/saves/test_versions.py -v` (26 passed)
- [x] `python -m pytest tests/ -q` (2498 passed)
- [x] `ruff check` + `ruff format --check` on touched files
- [x] `basedpyright` scoped + CI scope (0 errors)
- [x] `bash scripts/check_cosmic_call_bans.sh` (OK)
- [x] `PYTHONPATH=py_modules lint-imports` (7 contracts kept)
- [x] `pnpm build` (rollup OK)
- [x] `pnpm test` (177 passed)