### PR TITLE
chore(main): polish main.py — debug_log delegation, migration banner, poll lifecycle (#670)

### DIFF
--- a/main.py
+++ b/main.py
@@ -170,35 +170,12 @@ class Plugin:
 
         # ── 6. Background tasks ─────────────────────────────────────────────
         self._migration_service.detect_save_sort_change()
-        self.loop.create_task(self._download_service.poll_download_requests())
+        self._download_service.start()
         decky.logger.info("RomM Sync plugin loaded")
-
-    async def migrate_retrodeck_files(self, conflict_strategy=None):
-        """Delegate to MigrationService."""
-        return await self._migration_service.migrate_retrodeck_files(conflict_strategy)
-
-    async def get_migration_status(self):
-        """Delegate to MigrationService."""
-        return await self._migration_service.get_migration_status()
-
-    async def get_save_sort_migration_status(self):
-        return await self._migration_service.get_save_sort_migration_status()
-
-    async def migrate_save_sort_files(self, conflict_strategy=None):
-        return await self._migration_service.migrate_save_sort_files(conflict_strategy)
-
-    async def dismiss_save_sort_migration(self):
-        return self._migration_service.dismiss_save_sort_migration()
-
-    async def dismiss_retrodeck_migration(self):
-        return self._migration_service.dismiss_retrodeck_migration()
-
-    async def refresh_migration_state(self):
-        return await self._migration_service.refresh_state()
 
     async def _unload(self):  # Decky lifecycle — must be async
         self._sync_service.shutdown()
-        self._download_service.shutdown()
+        await self._download_service.shutdown()
         decky.logger.info("RomM Sync plugin unloaded")
 
     # ── Callables ──────────────────────────────────────────────────────
@@ -216,7 +193,7 @@ class Plugin:
         self._settings_service.frontend_log(level, message)
 
     async def debug_log(self, message):
-        await self.frontend_log("debug", message)
+        self._settings_service.frontend_log("debug", message)
 
     async def save_log_level(self, level):
         return self._settings_service.save_log_level(level)
@@ -496,3 +473,26 @@ class Plugin:
 
     async def get_achievement_progress(self, rom_id):
         return await self._achievements_service.get_achievement_progress(rom_id)
+
+    # ── Migration delegation to MigrationService ──────────────
+
+    async def migrate_retrodeck_files(self, conflict_strategy=None):
+        return await self._migration_service.migrate_retrodeck_files(conflict_strategy)
+
+    async def get_migration_status(self):
+        return await self._migration_service.get_migration_status()
+
+    async def get_save_sort_migration_status(self):
+        return await self._migration_service.get_save_sort_migration_status()
+
+    async def migrate_save_sort_files(self, conflict_strategy=None):
+        return await self._migration_service.migrate_save_sort_files(conflict_strategy)
+
+    async def dismiss_save_sort_migration(self):
+        return self._migration_service.dismiss_save_sort_migration()
+
+    async def dismiss_retrodeck_migration(self):
+        return self._migration_service.dismiss_retrodeck_migration()
+
+    async def refresh_migration_state(self):
+        return await self._migration_service.refresh_state()

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -86,7 +86,7 @@ class DownloadService:
         self._download_in_progress: set = set()
         self._download_queue: dict = {}
         self._download_tasks: dict = {}
-        self._poll_task: asyncio.Task | None = None
+        self._poll_task: asyncio.Task[None] | None = None
 
     def start(self) -> None:
         """Spawn the background ``poll_download_requests`` task.

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -9,6 +9,7 @@ filesystem I/O is delegated to the ``DownloadFileAdapter`` and
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -85,9 +86,32 @@ class DownloadService:
         self._download_in_progress: set = set()
         self._download_queue: dict = {}
         self._download_tasks: dict = {}
+        self._poll_task: asyncio.Task | None = None
 
-    def shutdown(self) -> None:
-        """Cancel all active downloads and clear task tracking."""
+    def start(self) -> None:
+        """Spawn the background ``poll_download_requests`` task.
+
+        Owns the task handle so :meth:`shutdown` can cancel it on
+        unload. Idempotent: a second call while a poll task is already
+        running is a no-op.
+        """
+        if self._poll_task is not None and not self._poll_task.done():
+            return
+        self._poll_task = self._loop.create_task(self.poll_download_requests())
+
+    async def shutdown(self) -> None:
+        """Cancel the background poll task and all active downloads.
+
+        Awaits the poll task so the loop fully exits before unload
+        returns; per-ROM download tasks are cancelled fire-and-forget
+        (their ``finally`` clauses run on the event loop after this
+        method returns, which is acceptable on plugin unload).
+        """
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
+            self._poll_task = None
         for task in self._download_tasks.values():
             task.cancel()
         self._download_tasks.clear()

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2130,22 +2130,127 @@ class TestStartDownloadCreateTaskFailure:
 class TestShutdown:
     """Tests for DownloadService.shutdown — cancel active tasks + clear tracking."""
 
-    def test_shutdown_cancels_active_tasks_and_clears(self, plugin):
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_active_tasks_and_clears(self, plugin):
         task_a = MagicMock()
         task_b = MagicMock()
         plugin._download_service._download_tasks[1] = task_a
         plugin._download_service._download_tasks[2] = task_b
 
-        plugin._download_service.shutdown()
+        await plugin._download_service.shutdown()
 
         task_a.cancel.assert_called_once_with()
         task_b.cancel.assert_called_once_with()
         assert plugin._download_service._download_tasks == {}
 
-    def test_shutdown_no_tasks_is_noop(self, plugin):
+    @pytest.mark.asyncio
+    async def test_shutdown_no_tasks_is_noop(self, plugin):
         # No tasks registered — must not raise.
-        plugin._download_service.shutdown()
+        await plugin._download_service.shutdown()
         assert plugin._download_service._download_tasks == {}
+
+
+class TestStartShutdownLifecycle:
+    """Tests for DownloadService.start / shutdown — poll-task ownership.
+
+    The service owns its background ``poll_download_requests`` task so
+    ``main._unload`` can cancel it via ``await shutdown()``. Covers the
+    spawn, idempotent re-spawn, await-cancellation, and combined
+    shutdown-with-active-downloads paths.
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_spawns_poll_task(self, plugin):
+        plugin._download_service._loop = asyncio.get_event_loop()
+        # Stub the poll coroutine so we don't run the real polling
+        # loop — we only care that start() owns the task handle.
+
+        async def _noop_poll():
+            await asyncio.sleep(0.01)
+
+        plugin._download_service.poll_download_requests = _noop_poll  # type: ignore[method-assign]
+
+        assert plugin._download_service._poll_task is None
+        plugin._download_service.start()
+        assert plugin._download_service._poll_task is not None
+        assert isinstance(plugin._download_service._poll_task, asyncio.Task)
+
+        # Let the stub task finish so the loop has nothing pending.
+        await plugin._download_service._poll_task
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent_when_task_running(self, plugin):
+        plugin._download_service._loop = asyncio.get_event_loop()
+
+        async def _long_poll():
+            await asyncio.sleep(5)
+
+        plugin._download_service.poll_download_requests = _long_poll  # type: ignore[method-assign]
+
+        plugin._download_service.start()
+        first_task = plugin._download_service._poll_task
+        plugin._download_service.start()
+        second_task = plugin._download_service._poll_task
+
+        assert first_task is second_task
+
+        # Clean up — cancel + await to let the loop tear down without
+        # an unawaited-task warning.
+        await plugin._download_service.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_start_after_previous_task_done_spawns_new(self, plugin):
+        plugin._download_service._loop = asyncio.get_event_loop()
+
+        async def _quick_poll():
+            return None
+
+        plugin._download_service.poll_download_requests = _quick_poll  # type: ignore[method-assign]
+
+        plugin._download_service.start()
+        first_task = plugin._download_service._poll_task
+        assert first_task is not None
+        await first_task
+
+        plugin._download_service.start()
+        second_task = plugin._download_service._poll_task
+        assert second_task is not None
+        assert second_task is not first_task
+
+        await second_task
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_poll_task_and_awaits_exit(self, plugin):
+        plugin._download_service._loop = asyncio.get_event_loop()
+
+        async def _long_poll():
+            await asyncio.sleep(30)
+
+        plugin._download_service.poll_download_requests = _long_poll  # type: ignore[method-assign]
+
+        plugin._download_service.start()
+        poll_task = plugin._download_service._poll_task
+        assert poll_task is not None
+        assert not poll_task.done()
+
+        await plugin._download_service.shutdown()
+
+        assert poll_task.done()
+        assert poll_task.cancelled()
+        assert plugin._download_service._poll_task is None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_handles_missing_poll_task(self, plugin):
+        # Never called start() — shutdown must still tear down per-ROM
+        # tasks without touching the missing poll handle.
+        task_a = MagicMock()
+        plugin._download_service._download_tasks[7] = task_a
+
+        await plugin._download_service.shutdown()
+
+        task_a.cancel.assert_called_once_with()
+        assert plugin._download_service._download_tasks == {}
+        assert plugin._download_service._poll_task is None
 
 
 class TestCleanupLeftoverTmpFilesNoRetrodeckPaths:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2170,7 +2170,6 @@ class TestStartShutdownLifecycle:
 
         plugin._download_service.poll_download_requests = _noop_poll  # type: ignore[method-assign]
 
-        assert plugin._download_service._poll_task is None
         plugin._download_service.start()
         poll_task = plugin._download_service._poll_task
         assert isinstance(poll_task, asyncio.Task)

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2172,11 +2172,11 @@ class TestStartShutdownLifecycle:
 
         assert plugin._download_service._poll_task is None
         plugin._download_service.start()
-        assert plugin._download_service._poll_task is not None
-        assert isinstance(plugin._download_service._poll_task, asyncio.Task)
+        poll_task = plugin._download_service._poll_task
+        assert isinstance(poll_task, asyncio.Task)
 
         # Let the stub task finish so the loop has nothing pending.
-        await plugin._download_service._poll_task
+        await poll_task
 
     @pytest.mark.asyncio
     async def test_start_is_idempotent_when_task_running(self, plugin):

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -730,10 +730,13 @@ class TestCallableErrorPropagation:
 
 
 class TestUnloadHook:
-    """Cover the ``_unload`` shutdown sequence (lines 203-205)."""
+    """Cover the ``_unload`` shutdown sequence."""
 
     @pytest.mark.asyncio
     async def test_unload_calls_shutdown_on_sync_and_download(self, plugin):
+        # DownloadService.shutdown is async (it awaits the poll task);
+        # the bare-MagicMock default returns a non-awaitable.
+        plugin._download_service.shutdown = AsyncMock()
         await plugin._unload()
         plugin._sync_service.shutdown.assert_called_once_with()
-        plugin._download_service.shutdown.assert_called_once_with()
+        plugin._download_service.shutdown.assert_awaited_once_with()


### PR DESCRIPTION
Closes #670. Parent: #622.

## Summary

Three small post-#277 polish items in one PR.

### 1. `debug_log` peer-call fix

`Plugin.debug_log` was calling `self.frontend_log(\"debug\", message)` (another `@callable`) instead of the service. Two-character fix: call `self._settings_service.frontend_log(\"debug\", message)` directly so the method matches the rest of the file's \"delegate to service\" pattern.

### 2. Migration callables banner move

The seven migration callables were sandwiched between `_main()` and the `# ── Callables ──` banner, physically separated from the rest of the callable surface. They are real frontend callables (`src/api/backend.ts`), not lifecycle helpers. Moved them below the banner under a new `## Migration delegation to MigrationService` sub-banner that matches the existing per-service banner style. The obsolete one-line `\"Delegate to MigrationService.\"` docstrings are dropped — the call line `return await self._migration_service.method(...)` is self-explanatory.

### 3. `poll_download_requests` cancellation (lifecycle leak)

`main.py` was spawning the background poll task via `self.loop.create_task(...)` and never keeping the handle; `_unload()` only cancelled per-ROM `_download_tasks`, so the poll task ran forever (real lifecycle leak, masked by plugin-process restart).

Fixed using approach (b) from the issue: `DownloadService` now owns its own background task.

- New `start()`: spawns `poll_download_requests()` and stores the `asyncio.Task` handle. Idempotent — a second call while the task is still running is a no-op.
- `shutdown()` is now `async`: cancels the poll task, awaits its exit (suppressing `CancelledError`), then cancels the per-ROM download tasks. `main._unload` `await`s it so the loop fully exits before unload returns.
- `main._main` calls `self._download_service.start()` instead of the inline `create_task`.

## Test plan

- [x] `python -m pytest tests/services/test_downloads.py tests/test_plugin.py -v` (149 passing)
- [x] `python -m pytest tests/ -q` (2503 passing)
- [x] `ruff check` + `ruff format --check` (touched files)
- [x] `basedpyright` (0 errors, 0 warnings — touched files + full scope)
- [x] `bash scripts/check_cosmic_call_bans.sh` (no forbidden calls)
- [x] `PYTHONPATH=py_modules lint-imports` (7 contracts kept, 0 broken)
- [x] `pnpm build` (rollup ok)
- [x] `pnpm test` (177 frontend tests passing)
- [x] Coverage on touched modules: `services/downloads.py` 100%, `main.py` 95%

## Notes

- New tests in `TestStartShutdownLifecycle` cover start (spawn + idempotent re-spawn + respawn-after-done) and shutdown (cancels + awaits + cleans up; no-op when never started).
- Existing `TestShutdown` tests updated for the `async` signature.
- `TestUnloadHook::test_unload_calls_shutdown_on_sync_and_download` updated to use `AsyncMock` for `_download_service.shutdown` so `await` works on the bare MagicMock fixture.