### PR TITLE
chore: clean docstring rot — 8 sites across 7 files (#672)

### DIFF
--- a/py_modules/adapters/plugin_metadata.py
+++ b/py_modules/adapters/plugin_metadata.py
@@ -1,9 +1,10 @@
 """Concrete ``PluginMetadataReader`` adapter — reads ``package.json``.
 
-Owns the raw ``open()`` + ``json.load()`` round-trip bootstrap formerly
-performed inline. A missing or malformed ``package.json`` is not a
-hard failure — bootstrap must keep wiring services even when the
-metadata read fails, so the adapter returns the documented fallback.
+Owns the raw ``open()`` + ``json.load()`` round-trip behind the
+``PluginMetadataReader`` Protocol. A missing or malformed
+``package.json`` is not a hard failure — bootstrap must keep wiring
+services even when the metadata read fails, so the adapter returns the
+documented fallback.
 """
 
 from __future__ import annotations

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -2,9 +2,10 @@
 
 Adapter construction lives here so ``main.py`` only deals with the
 Decky lifecycle and the callable surface. ``bootstrap()`` also loads
-and migrates settings as part of adapter wiring so ``RommHttpAdapter``
-binds the live, migrated dict in a single pass; that same dict is
-returned for the caller to keep as its source of truth.
+and migrates settings as part of adapter wiring so adapters that bind
+a live mutable settings dict (such as ``RommHttpAdapter``) bind the
+migrated dict in a single pass; that same dict is returned for the
+caller to keep as its source of truth.
 """
 
 from __future__ import annotations

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -4,8 +4,8 @@ Owned by :class:`LibraryService`; each sub-service receives a reference
 so they can coordinate without back-refs to the façade. The contract:
 sub-services mutate the box's fields directly (it is the single source
 of truth for in-flight sync run state); the façade exposes property
-accessors over the box so external callers see the same shape that
-preceded the decomposition.
+accessors over the box so external callers see a flat shape rather
+than reaching through ``service._state.x``.
 """
 
 from __future__ import annotations

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -23,11 +23,10 @@ class SystemResolver(Protocol):
 class RetroDeckPaths(Protocol):
     """Bundled accessor for the four RetroDECK runtime directory paths.
 
-    Replaces the four single-method ``*Provider`` Protocols, each of
-    which had the same ``def __call__(self) -> str`` shape — making
-    them structurally interchangeable and silently swappable at the
-    call site. Distinct method names give the type checker enough
-    information to flag a saves-for-bios mix-up.
+    Distinct method names per path are deliberate: a single
+    ``def __call__(self) -> str`` shape would make a saves-for-bios
+    mix-up silently type-check at the call site. Separate names give
+    the type checker enough information to flag it.
     """
 
     def saves_path(self) -> str: ...

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -7,7 +7,7 @@ filesystem + path-algebra responsibility — no RomM I/O, no state
 mutation. Shared by SlotsService, SyncEngine, and StatusService; reads
 about whether a save-sort migration is pending live here too because
 they share ``_get_rom_save_info``'s decision to honour the previous
-layout while a migration is in flight (#238).
+layout while a migration is in flight.
 """
 
 from __future__ import annotations

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -48,10 +48,11 @@ class VersionsServiceConfig:
 
 
 class VersionsService:
-    """Save version history reads and rollback orchestration.
+    """Aggregate root for the module's contract.
 
-    Coordinates the rollback flow but does not perform file or server
-    writes — those go through SyncEngine / LocalSavesAdapter.
+    Per-ROM lock acquisition and atomic save-state persistence are
+    delegated to the injected ``SyncEngine`` / ``StateService``; this
+    class owns the rollback orchestration on top of them.
     """
 
     def __init__(self, *, config: VersionsServiceConfig) -> None:

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -44,8 +44,8 @@ class SessionFinalizeSyncResult:
     scenario" — for example a successful sync that uploaded nothing.
     ``conflicts_toast`` is the second, additive toast fired when the
     sync surfaces unresolved conflicts; ``None`` when there are no
-    conflicts. Pre-rendering the conflict string here matches the
-    previous frontend ``notifyConflicts`` output byte-for-byte.
+    conflicts. Conflict-string rendering lives here so the frontend
+    receives a ready-to-display body.
     """
 
     offline: bool
@@ -79,11 +79,11 @@ class SessionFinalizeResult:
     leaves Steam's playtime display untouched. ``sync`` is always
     present; its fields encode whatever action the frontend still
     needs to take (toast, event dispatch). ``migration`` is ``None``
-    when the migration-state refresh raised — matching the pre-PR
-    frontend behavior where a refresh failure logged a warning and
-    left the migration stores untouched (any stale ``pending`` badge
-    keeps showing). When the refresh succeeds, ``migration`` carries
-    the two typed status payloads the frontend feeds into its stores.
+    when the migration-state refresh raised — the frontend then leaves
+    the migration stores untouched (any stale ``pending`` badge keeps
+    showing) and logs the failure backend-side. When the refresh
+    succeeds, ``migration`` carries the two typed status payloads the
+    frontend feeds into its stores.
     """
 
     total_seconds: int | None
@@ -112,10 +112,10 @@ class SessionLifecycleServiceConfig:
 def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> tuple[str | None, str | None]:
     """Map the raw post-exit-sync flags onto the (title, body) toast pair.
 
-    Mirrors the pre-PR frontend branching exactly: offline wins over
-    success, success-with-uploads renders the synced toast, a successful
-    no-op produces no toast at all, and any non-success/non-offline
-    state falls through to the failure toast.
+    Branching: offline wins over success, success-with-uploads renders
+    the synced toast, a successful no-op produces no toast at all, and
+    any non-success/non-offline state falls through to the failure
+    toast.
     """
     if offline:
         return _TOAST_TITLE, _TOAST_BODY_OFFLINE
@@ -129,8 +129,7 @@ def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> t
 def _render_conflicts_toast(conflicts: list[dict]) -> str | None:
     """Render the additive "N save conflict(s) need resolution" body.
 
-    Matches the pre-PR frontend ``notifyConflicts`` output byte-for-byte:
-    singular when ``count == 1``, plural otherwise. Returns ``None``
+    Singular when ``count == 1``, plural otherwise. Returns ``None``
     when there are no conflicts so the frontend skips the second toast.
     """
     count = len(conflicts)
@@ -227,11 +226,10 @@ class SessionLifecycleService:
     async def _build_sync_result(self, rom_id: int) -> SessionFinalizeSyncResult:
         """Run post-exit sync and render the resulting toast strings.
 
-        Mirrors the ``@migration_blocked`` decorator's gate: when a
-        RetroDECK migration is pending the destructive post-exit sync is
-        skipped and rendered as the standard "failed to sync saves
-        after exit" toast — the same outcome the pre-PR flow produced
-        when the decorator returned ``blocked_by_migration``.
+        Honours the ``@migration_blocked`` gate: when a RetroDECK
+        migration is pending the destructive post-exit sync is skipped
+        and rendered as the standard "failed to sync saves after exit"
+        toast.
         """
         if self._migration_reader.is_retrodeck_migration_pending():
             return SessionFinalizeSyncResult(
@@ -283,9 +281,8 @@ class SessionLifecycleService:
 
         Returns ``None`` on refresh failure (exception or non-dict
         payload) — the frontend then leaves the migration stores
-        untouched, matching the pre-PR ``refreshMigrationState().catch``
-        behavior where a failure logged a warning without clearing any
-        stale ``pending`` badge.
+        untouched (any stale ``pending`` badge keeps showing) and the
+        failure is logged backend-side.
         """
         try:
             payload = await self._migration_reader.refresh_state()


### PR DESCRIPTION
Closes #672. Parent: #622.

Mechanical edits — docstrings only, no behavior change. Each site violated CLAUDE.md's "intent over behavior" rule by leaking refactor history ("formerly performed inline", "pre-PR", "byte-for-byte", "see PR #N", "preceded the decomposition", etc.) into source.

## Sites

1. **`py_modules/services/protocols/paths.py`** — `RetroDeckPaths` class docstring
   - Before: "Replaces the four single-method `*Provider` Protocols, each of which had the same `def __call__(self) -> str` shape..."
   - After: "Distinct method names per path are deliberate: a single `def __call__(self) -> str` shape would make a saves-for-bios mix-up silently type-check..."

2. **`py_modules/adapters/plugin_metadata.py`** — module docstring
   - Before: "...the raw `open()` + `json.load()` round-trip bootstrap formerly performed inline."
   - After: "...the raw `open()` + `json.load()` round-trip behind the `PluginMetadataReader` Protocol."

3. **`py_modules/services/library/_state.py`** — module docstring
   - Before: "...external callers see the same shape that preceded the decomposition."
   - After: "...external callers see a flat shape rather than reaching through `service._state.x`."

4. **`py_modules/services/saves/rom_info.py`** — module docstring
   - Before: "...while a migration is in flight (#238)."
   - After: "...while a migration is in flight." (trailing PR reference dropped)

5. **`py_modules/services/saves/versions.py`** — `VersionsService` class docstring
   - Before: strict subset of the module docstring ("Save version history reads and rollback orchestration. Coordinates...")
   - After: instance-specific contract — "Aggregate root for the module's contract. Per-ROM lock acquisition and atomic save-state persistence are delegated to the injected `SyncEngine` / `StateService`..."

6. **`py_modules/services/session_lifecycle.py`** — two class docstrings + four method docstrings
   - `SessionFinalizeSyncResult`: dropped "matches the previous frontend `notifyConflicts` output byte-for-byte" → "Conflict-string rendering lives here so the frontend receives a ready-to-display body."
   - `SessionFinalizeResult`: dropped "matching the pre-PR frontend behavior where a refresh failure logged a warning..." → "the frontend then leaves the migration stores untouched (any stale `pending` badge keeps showing) and logs the failure backend-side."
   - `_render_sync_toast` (method): dropped "Mirrors the pre-PR frontend branching exactly"
   - `_render_conflicts_toast` (method): dropped "Matches the pre-PR frontend `notifyConflicts` output byte-for-byte"
   - `_build_sync_result` (method): dropped "Mirrors the `@migration_blocked` decorator's gate... the same outcome the pre-PR flow produced when the decorator returned `blocked_by_migration`" → "Honours the `@migration_blocked` gate..."
   - `_refresh_migration` (method): dropped "matching the pre-PR `refreshMigrationState().catch` behavior..."

7. **`py_modules/bootstrap.py`** — module docstring
   - Before: "...so `RommHttpAdapter` binds the live, migrated dict in a single pass..."
   - After: "...so adapters that bind a live mutable settings dict (such as `RommHttpAdapter`) bind the migrated dict in a single pass..."

## Method-level cleanups (vs strict module/class scope)

The issue flagged the recurring "pre-PR" / "byte-for-byte" pattern at lines 115, 132, 233, 286 in `session_lifecycle.py` as out-of-scope for the strict module/class rule but worth a focused pass. All four cleaned in this PR — they were genuine refactor-history leaks (rendering logic mirrors something that no longer exists in the codebase), not real method contracts.

## Test plan

- [x] `python -m pytest tests/ -q` — 2498 passed
- [x] `ruff check` + `ruff format --check` — clean (one pre-existing format violation in `typings/decky/__init__.pyi` untouched)
- [x] `basedpyright` (scoped + CI scope) — 0 errors
- [x] `bash scripts/check_cosmic_call_bans.sh` — OK
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] `pnpm build` — clean
- [x] `pnpm test` — 177 passed