### PR TITLE
chore(bootstrap): polish — typed BootstrapResult, default-state factory, core_info_provider move, plugin_version required (#671)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import sys
 from dataclasses import asdict
+from typing import Any
 
 plugin_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(plugin_dir, "py_modules"))
@@ -9,26 +10,38 @@ sys.path.insert(0, plugin_dir)
 
 import decky
 from bootstrap import (
-    AdapterBundle,
-    CallbackBundle,
     RuntimeBundle,
-    StateBundle,
     WiringConfig,
     bootstrap,
     wire_services,
 )
 
 from lib.migration_gate import migration_blocked
-from services.protocols import (
-    RetroArchConfigReader,
-    RetroArchCoreInfoReader,
-    RetroDeckPaths,
-)
 
 
 class Plugin:
     settings: dict
     loop: asyncio.AbstractEventLoop
+
+    # Test-only attribute slots — production ``Plugin`` does not read
+    # these after ``_main`` (the wired services own them), but the
+    # test suite constructs ``Plugin()`` bare and pokes the same handles
+    # the production wiring would set. Annotated as ``Any`` because
+    # tests pass real adapters, ``MagicMock``s, or fakes interchangeably.
+    # Annotations alone do not create the attribute, so bare access still
+    # raises ``AttributeError`` (the ``TestPersistenceAttributeIsLoud``
+    # regression remains green).
+    _persistence: Any
+    _state: Any
+    _metadata_cache: Any
+    _state_persister: Any
+    _settings_persister: Any
+    _metadata_cache_persister: Any
+    _http_adapter: Any
+    _romm_api: Any
+    _steam_config: Any
+    _retrodeck_paths: Any
+    _save_sync_state: Any
 
     _MIN_REQUIRED_VERSION = (4, 8, 1)
 
@@ -58,80 +71,33 @@ class Plugin:
         # ── 1. Wire adapters ────────────────────────────────────────────────
         # Bootstrap loads + migrates settings as part of adapter construction
         # so RommHttpAdapter binds the live, migrated dict in one pass.
-        adapters = bootstrap(
+        result = bootstrap(
             settings_dir=decky.DECKY_PLUGIN_SETTINGS_DIR,
             runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             user_home=decky.DECKY_USER_HOME,
             logger=decky.logger,
         )
-        self._persistence = adapters["persistence"]
-        self.settings = adapters["settings"]
-        self._state = adapters["state"]
-        self._metadata_cache = adapters["metadata_cache"]
-        self._state_persister = adapters["state_persister"]
-        self._settings_persister = adapters["settings_persister"]
-        self._metadata_cache_persister = adapters["metadata_cache_persister"]
-        self._http_adapter = adapters["http_adapter"]
-        self._romm_api = adapters["romm_api"]
-        self._steam_config = adapters["steam_config"]
-        self._sgdb_adapter = adapters["sgdb_adapter"]
-        self._retrodeck_paths: RetroDeckPaths = adapters["retrodeck_paths"]
-        self._retroarch_config: RetroArchConfigReader = adapters["retroarch_config"]
-        self._retroarch_core_info: RetroArchCoreInfoReader = adapters["retroarch_core_info"]
-        self._debug_logger = adapters["debug_logger"]
+        self.settings = result.stores.settings
+        self._debug_logger = result.handles.debug_logger
 
         # ── 4. Wire services ────────────────────────────────────────────────
-        from services.saves import SaveService
-
-        self._save_sync_state = SaveService.make_default_state()
         services = wire_services(
             WiringConfig(
-                adapters=AdapterBundle(
-                    http_adapter=self._http_adapter,
-                    romm_api=self._romm_api,
-                    steam_config=self._steam_config,
-                    sgdb_adapter=self._sgdb_adapter,
-                    cover_art_file_store=adapters["cover_art_file_store"],
-                    sgdb_artwork_cache=adapters["sgdb_artwork_cache"],
-                    download_files=adapters["download_files"],
-                    download_queue=adapters["download_queue"],
-                    firmware_files=adapters["firmware_files"],
-                    migration_files=adapters["migration_files"],
-                    rom_files=adapters["rom_files"],
-                    save_file=adapters["save_file"],
-                    gamelist_editor=adapters["gamelist_editor"],
-                    path_probe=adapters["path_probe"],
-                ),
-                stores=StateBundle(
-                    state=self._state,
-                    settings=self.settings,
-                    metadata_cache=self._metadata_cache,
-                    save_sync_state=self._save_sync_state,
-                ),
+                adapters=result.adapters,
+                stores=result.stores,
                 runtime=RuntimeBundle(
                     loop=self.loop,
                     logger=decky.logger,
                     plugin_dir=decky.DECKY_PLUGIN_DIR,
                     runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
                     emit=decky.emit,
-                    clock=adapters["clock"],
-                    uuid_gen=adapters["uuid_gen"],
-                    sleeper=adapters["sleeper"],
-                    hostname_provider=adapters["hostname_provider"],
+                    clock=result.runtime_adapters.clock,
+                    uuid_gen=result.runtime_adapters.uuid_gen,
+                    sleeper=result.runtime_adapters.sleeper,
+                    hostname_provider=result.runtime_adapters.hostname_provider,
                 ),
-                callbacks=CallbackBundle(
-                    retrodeck_paths=self._retrodeck_paths,
-                    get_retroarch_save_sorting=self._retroarch_config.get_retroarch_save_sorting,
-                    get_core_name=self._retroarch_core_info.get_corename,
-                    state_persister=self._state_persister,
-                    settings_persister=self._settings_persister,
-                    metadata_cache_persister=self._metadata_cache_persister,
-                    firmware_cache_persister=adapters["firmware_cache_persister"],
-                    core_info_provider=adapters["core_resolver"],
-                    save_sync_state_persister=adapters["save_sync_state_persister"],
-                    log_debug=self._debug_logger,
-                ),
+                callbacks=result.callbacks,
                 min_required_version=self._MIN_REQUIRED_VERSION,
             )
         )

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -96,15 +96,24 @@ from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalSer
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridService, SteamGridServiceConfig
 
-_DEFAULT_STATE: dict = {
-    "shortcut_registry": {},
-    "installed_roms": {},
-    "last_sync": None,
-    "sync_stats": {"platforms": 0, "roms": 0},
-    "downloaded_bios": {},
-    "retrodeck_home_path": "",
-    "save_sort_settings": None,
-}
+
+def _default_state() -> dict:
+    """Fresh default ``state`` dict for first-run persistence.
+
+    A factory (not a module-level constant) so that callers always receive
+    independent inner containers — services may mutate ``state`` in place,
+    and a shared module-level default would silently corrupt subsequent
+    loads.
+    """
+    return {
+        "shortcut_registry": {},
+        "installed_roms": {},
+        "last_sync": None,
+        "sync_stats": {"platforms": 0, "roms": 0},
+        "downloaded_bios": {},
+        "retrodeck_home_path": "",
+        "save_sort_settings": None,
+    }
 
 
 @dataclass(frozen=True)
@@ -125,6 +134,7 @@ class AdapterBundle:
     save_file: SaveFileAdapter
     gamelist_editor: GamelistXmlEditorProtocol
     path_probe: PathExistsProbe
+    core_info_provider: CoreInfoProvider
 
 
 @dataclass(frozen=True)
@@ -163,9 +173,58 @@ class CallbackBundle:
     settings_persister: SettingsPersister
     metadata_cache_persister: MetadataCachePersister
     firmware_cache_persister: FirmwareCachePersister
-    core_info_provider: CoreInfoProvider
     save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
+
+
+@dataclass(frozen=True)
+class RuntimeAdaptersBundle:
+    """Concrete adapters for the Clock/UuidGen/Sleeper/HostnameProvider seams.
+
+    Bootstrap owns adapter instantiation, but the ``RuntimeBundle``
+    handed to ``wire_services`` also needs runtime-only state ``main.py``
+    introduces (the ``asyncio`` loop, ``decky.emit``). This sub-bundle
+    carries the seams bootstrap builds so ``main.py`` can compose the
+    final ``RuntimeBundle`` without instantiating any adapters itself.
+    """
+
+    clock: Clock
+    uuid_gen: UuidGen
+    sleeper: Sleeper
+    hostname_provider: HostnameProvider
+
+
+@dataclass(frozen=True)
+class BootstrapHandles:
+    """Bootstrap outputs ``main.py`` needs that don't fit the wiring bundles.
+
+    Anything ``Plugin`` itself binds (not the services) lives here:
+    the debug logger forwarded by ``Plugin._log_debug``. The bundles
+    already cover everything passed to ``wire_services``; this struct
+    keeps those Plugin-only handles typed instead of returning them
+    via the untyped dict shape of yore.
+    """
+
+    debug_logger: DebugLogger
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Typed return shape for :func:`bootstrap`.
+
+    The four bundles carry every Protocol-typed seam and live state
+    dict that services need; :attr:`handles` carries the small set of
+    raw outputs only ``main.py`` itself binds (debug logger). Together
+    they replace the historical untyped ``dict`` return so every
+    consumer is caught by basedpyright instead of failing silently at
+    runtime on a typo.
+    """
+
+    adapters: AdapterBundle
+    stores: StateBundle
+    callbacks: CallbackBundle
+    runtime_adapters: RuntimeAdaptersBundle
+    handles: BootstrapHandles
 
 
 @dataclass(frozen=True)
@@ -191,8 +250,8 @@ def bootstrap(
     plugin_dir: str,
     user_home: str,
     logger: logging.Logger,
-) -> dict:
-    """Create and return all adapters and on-disk state dicts.
+) -> BootstrapResult:
+    """Build every adapter and bundle the composition root hands to ``main.py``.
 
     Bootstrap owns adapter instantiation and is the only path that
     constructs ``PersistenceAdapter``. Settings, plugin state, and the
@@ -218,10 +277,10 @@ def bootstrap(
 
     Returns
     -------
-    Mapping of adapter name to instance, plus ``"settings"`` / ``"state"``
-    / ``"metadata_cache"`` — the live migrated dicts shared with the
-    persister adapters and any other consumer that binds the same
-    reference.
+    :class:`BootstrapResult`
+        Typed bundles consumed by ``wire_services`` (``adapters``,
+        ``stores``, ``callbacks``) plus the small set of Plugin-only
+        handles ``main.py`` itself binds (``handles.debug_logger``).
     """
     retrodeck_paths = RetroDeckPathsAdapter(user_home=user_home, logger=logger)
     retroarch_config = RetroArchConfigAdapter(user_home=user_home, logger=logger)
@@ -239,7 +298,7 @@ def bootstrap(
     settings = persistence.load_settings()
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
-    state = persistence.load_state(dict(_DEFAULT_STATE))
+    state = persistence.load_state(_default_state())
     state = migrate_state(state)
     metadata_cache = persistence.load_metadata_cache()
     state_persister = StatePersisterAdapter(persistence, state)
@@ -263,41 +322,57 @@ def bootstrap(
     sleeper = AsyncioSleeper()
     hostname_provider = HostnameAdapter()
     debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
+    save_sync_state = SaveService.make_default_state()
 
-    return {
-        "persistence": persistence,
-        "firmware_cache_persister": firmware_cache_persister,
-        "save_sync_state_persister": save_sync_state_persister,
-        "state_persister": state_persister,
-        "settings_persister": settings_persister,
-        "metadata_cache_persister": metadata_cache_persister,
-        "settings": settings,
-        "state": state,
-        "metadata_cache": metadata_cache,
-        "http_adapter": http_adapter,
-        "romm_api": romm_api,
-        "steam_config": steam_config,
-        "sgdb_adapter": sgdb_adapter,
-        "cover_art_file_store": cover_art_file_store,
-        "sgdb_artwork_cache": sgdb_artwork_cache,
-        "download_files": download_files,
-        "download_queue": download_queue,
-        "firmware_files": firmware_files,
-        "migration_files": migration_files,
-        "rom_files": rom_files,
-        "save_file": save_file,
-        "path_probe": path_probe,
-        "retrodeck_paths": retrodeck_paths,
-        "retroarch_config": retroarch_config,
-        "retroarch_core_info": retroarch_core_info,
-        "clock": clock,
-        "uuid_gen": uuid_gen,
-        "sleeper": sleeper,
-        "hostname_provider": hostname_provider,
-        "debug_logger": debug_logger,
-        "core_resolver": core_resolver,
-        "gamelist_editor": gamelist_editor,
-    }
+    adapters = AdapterBundle(
+        http_adapter=http_adapter,
+        romm_api=romm_api,
+        steam_config=steam_config,
+        sgdb_adapter=sgdb_adapter,
+        cover_art_file_store=cover_art_file_store,
+        sgdb_artwork_cache=sgdb_artwork_cache,
+        download_files=download_files,
+        download_queue=download_queue,
+        firmware_files=firmware_files,
+        migration_files=migration_files,
+        rom_files=rom_files,
+        save_file=save_file,
+        gamelist_editor=gamelist_editor,
+        path_probe=path_probe,
+        core_info_provider=core_resolver,
+    )
+    stores = StateBundle(
+        state=state,
+        settings=settings,
+        metadata_cache=metadata_cache,
+        save_sync_state=save_sync_state,
+    )
+    callbacks = CallbackBundle(
+        retrodeck_paths=retrodeck_paths,
+        get_retroarch_save_sorting=retroarch_config.get_retroarch_save_sorting,
+        get_core_name=retroarch_core_info.get_corename,
+        state_persister=state_persister,
+        settings_persister=settings_persister,
+        metadata_cache_persister=metadata_cache_persister,
+        firmware_cache_persister=firmware_cache_persister,
+        save_sync_state_persister=save_sync_state_persister,
+        log_debug=debug_logger,
+    )
+    runtime_adapters = RuntimeAdaptersBundle(
+        clock=clock,
+        uuid_gen=uuid_gen,
+        sleeper=sleeper,
+        hostname_provider=hostname_provider,
+    )
+    handles = BootstrapHandles(debug_logger=debug_logger)
+
+    return BootstrapResult(
+        adapters=adapters,
+        stores=stores,
+        callbacks=callbacks,
+        runtime_adapters=runtime_adapters,
+        handles=handles,
+    )
 
 
 def wire_services(cfg: WiringConfig) -> dict:
@@ -337,7 +412,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             get_bios_files_index=bios_files_index_binding.get,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             get_retroarch_save_sorting=cfg.callbacks.get_retroarch_save_sorting,
-            get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+            get_active_core=cfg.adapters.core_info_provider.get_active_core,
             get_core_name=cfg.callbacks.get_core_name,
         ),
     )
@@ -354,7 +429,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         logger=cfg.runtime.logger,
         clock=cfg.runtime.clock,
         retrodeck_paths=cfg.callbacks.retrodeck_paths,
-        get_active_core=cfg.callbacks.core_info_provider.get_active_core,
+        get_active_core=cfg.adapters.core_info_provider.get_active_core,
         hostname_provider=cfg.runtime.hostname_provider,
         log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
@@ -484,7 +559,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             firmware_cache_persister=cfg.callbacks.firmware_cache_persister,
             firmware_files=cfg.adapters.firmware_files,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
-            core_info=cfg.callbacks.core_info_provider,
+            core_info=cfg.adapters.core_info_provider,
         ),
     )
     # Load the BIOS registry from disk now so the property does not raise
@@ -546,7 +621,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         config=CoreServiceConfig(
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
-            core_info=cfg.callbacks.core_info_provider,
+            core_info=cfg.adapters.core_info_provider,
             gamelist_editor=cfg.adapters.gamelist_editor,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             bios_checker=firmware_service,

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -134,8 +134,8 @@ class SaveServiceConfig:
     get_active_core: CoreResolverFn
     hostname_provider: HostnameProvider
     log_debug: DebugLogger
+    plugin_version: str
     get_core_name: CoreNameProviderFn | None = None
-    plugin_version: str = "0.0.0"
     emit: EventEmitter | None = None
     detect_sort_change: Callable[[], None] | None = None
     is_retrodeck_migration_pending: Callable[[], bool] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,14 @@ def _make_testable_plugin():
     from main import Plugin
 
     class TestablePlugin(Plugin):
-        """Plugin subclass that declares test-only attributes for type safety."""
+        """Plugin subclass that declares test-only attributes for type safety.
+
+        Only the genuinely test-fixture-only attributes (``_fake_api``,
+        ``_resolve_system``) live here. Test-fixture handles shared with
+        production wiring (``_state``, ``_http_adapter``, ...) are
+        declared on ``Plugin`` itself as ``Any``-typed annotation slots
+        so test-only construction paths type-check uniformly.
+        """
 
         _fake_api: Any
         _resolve_system: Any
@@ -69,7 +76,7 @@ def _make_testable_plugin():
     instance = TestablePlugin()
     instance._migration_service = MagicMock()
     instance._migration_service.is_retrodeck_migration_pending.return_value = False
-    instance._debug_logger = lambda _msg: None
+    instance._debug_logger = lambda msg: None
     return instance
 
 

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -105,6 +105,7 @@ def plugin(tmp_path):
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
+            plugin_version="0.14.0",
         ),
     )
     p._save_sync_service.init_state()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from bootstrap import (
     AdapterBundle,
+    BootstrapResult,
     CallbackBundle,
     RuntimeBundle,
     StateBundle,
@@ -30,9 +31,6 @@ from conftest import (
 )
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
-from adapters.persistence import PersistenceAdapter
-from adapters.retroarch_config import RetroArchConfigAdapter
-from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApiAdapter
@@ -48,92 +46,88 @@ from services.saves import SaveService
 from services.steamgrid import SteamGridService
 
 
-class TestBootstrap:
-    def test_returns_persistence_adapter(self, tmp_path):
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert "persistence" in result
-        assert isinstance(result["persistence"], PersistenceAdapter)
+def _bootstrap_for(tmp_path) -> BootstrapResult:
+    return bootstrap(
+        settings_dir=str(tmp_path / "settings"),
+        runtime_dir=str(tmp_path / "runtime"),
+        plugin_dir=str(tmp_path / "plugin"),
+        user_home=str(tmp_path / "home"),
+        logger=logging.getLogger("test"),
+    )
 
-    def test_returns_http_adapter(self, tmp_path):
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert "http_adapter" in result
-        assert isinstance(result["http_adapter"], RommHttpAdapter)
+
+class TestBootstrap:
+    def test_returns_typed_bootstrap_result(self, tmp_path):
+        result = _bootstrap_for(tmp_path)
+        assert isinstance(result, BootstrapResult)
 
     def test_http_adapter_shares_settings_reference(self, tmp_path):
-        """RommHttpAdapter binds the same dict bootstrap returns under "settings"."""
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        # Mutate the dict bootstrap returned — http_adapter holds the same ref.
-        result["settings"]["romm_url"] = "http://changed.com"
-        assert result["http_adapter"]._settings["romm_url"] == "http://changed.com"
-        assert result["http_adapter"]._settings is result["settings"]
+        """RommHttpAdapter binds the same dict the StateBundle exposes."""
+        result = _bootstrap_for(tmp_path)
+        # Mutate the live settings dict — http_adapter holds the same ref.
+        result.stores.settings["romm_url"] = "http://changed.com"
+        assert result.adapters.http_adapter._settings["romm_url"] == "http://changed.com"
+        assert result.adapters.http_adapter._settings is result.stores.settings
 
-    def test_persistence_has_correct_paths(self, tmp_path):
-        settings_dir = str(tmp_path / "s")
-        runtime_dir = str(tmp_path / "r")
-        result = bootstrap(
-            settings_dir=settings_dir,
-            runtime_dir=runtime_dir,
-            plugin_dir=str(tmp_path / "p"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert result["persistence"]._settings_dir == settings_dir
-        assert result["persistence"]._runtime_dir == runtime_dir
+    def test_returns_http_adapter(self, tmp_path):
+        result = _bootstrap_for(tmp_path)
+        assert isinstance(result.adapters.http_adapter, RommHttpAdapter)
 
     def test_returns_steam_config(self, tmp_path):
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert "steam_config" in result
-        assert isinstance(result["steam_config"], SteamConfigAdapter)
+        result = _bootstrap_for(tmp_path)
+        assert isinstance(result.adapters.steam_config, SteamConfigAdapter)
 
     def test_returns_romm_api(self, tmp_path):
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert "romm_api" in result
-        assert isinstance(result["romm_api"], RommApiAdapter)
+        result = _bootstrap_for(tmp_path)
+        assert isinstance(result.adapters.romm_api, RommApiAdapter)
 
-    def test_returns_split_retrodeck_adapters(self, tmp_path):
-        """Bootstrap instantiates all three split adapters (paths, cfg, core_info)."""
-        result = bootstrap(
-            settings_dir=str(tmp_path / "settings"),
-            runtime_dir=str(tmp_path / "runtime"),
-            plugin_dir=str(tmp_path / "plugin"),
-            user_home=str(tmp_path / "home"),
-            logger=logging.getLogger("test"),
-        )
-        assert isinstance(result["retrodeck_paths"], RetroDeckPathsAdapter)
-        assert isinstance(result["retroarch_config"], RetroArchConfigAdapter)
-        assert isinstance(result["retroarch_core_info"], RetroArchCoreInfoAdapter)
-        # Old bundled key must no longer be present.
-        assert "retrodeck_config" not in result
+    def test_returns_retrodeck_paths_adapter(self, tmp_path):
+        """Bootstrap instantiates the RetroDECK paths adapter for the callbacks bundle."""
+        result = _bootstrap_for(tmp_path)
+        assert isinstance(result.callbacks.retrodeck_paths, RetroDeckPathsAdapter)
+
+    def test_returns_core_info_provider_on_adapters(self, tmp_path):
+        """``core_info_provider`` (CoreResolver) is bundled with adapters, not callbacks.
+
+        Lock-in for #671 — stateful adapter sits next to ``gamelist_editor``
+        in :class:`AdapterBundle`. :class:`CallbackBundle` carries only
+        provider callables and persisters.
+        """
+        result = _bootstrap_for(tmp_path)
+        # AdapterBundle exposes the stateful CoreResolver.
+        assert result.adapters.core_info_provider is not None
+        # CallbackBundle no longer carries it.
+        assert not hasattr(result.callbacks, "core_info_provider")
+
+    def test_persistence_loaded_with_default_state_factory(self, tmp_path):
+        """First-run state contains the keys ``_default_state()`` ships.
+
+        Regression for #671: ``_default_state`` must be a factory, not a
+        shared module-level dict — services mutate ``state`` in place.
+        """
+        result = _bootstrap_for(tmp_path)
+        state = result.stores.state
+        # Inner containers were independently constructed; mutating them
+        # does not bleed into a future bootstrap call's state.
+        state["shortcut_registry"]["sentinel"] = {"app_id": 1}
+        state["sync_stats"]["platforms"] = 42
+
+        second = _bootstrap_for(tmp_path)
+        assert second.stores.state["shortcut_registry"] == {}
+        assert second.stores.state["sync_stats"] == {"platforms": 0, "roms": 0}
+
+    def test_handles_debug_logger_exposed(self, tmp_path):
+        """``BootstrapHandles.debug_logger`` is the same instance the CallbackBundle wires."""
+        result = _bootstrap_for(tmp_path)
+        assert result.handles.debug_logger is result.callbacks.log_debug
+
+    def test_runtime_adapters_bundle_populated(self, tmp_path):
+        """Bootstrap owns instantiation of clock/uuid/sleeper/hostname for ``main.py`` to compose RuntimeBundle."""
+        result = _bootstrap_for(tmp_path)
+        assert result.runtime_adapters.clock is not None
+        assert result.runtime_adapters.uuid_gen is not None
+        assert result.runtime_adapters.sleeper is not None
+        assert result.runtime_adapters.hostname_provider is not None
 
 
 class TestWireServices:
@@ -215,6 +209,7 @@ class TestWireServices:
                 save_file=deps["save_file"],
                 gamelist_editor=deps["gamelist_editor"],
                 path_probe=deps["path_probe"],
+                core_info_provider=deps["core_info_provider"],
             ),
             stores=StateBundle(
                 state=deps["state"],
@@ -241,7 +236,6 @@ class TestWireServices:
                 settings_persister=deps["settings_persister"],
                 metadata_cache_persister=deps["metadata_cache_persister"],
                 firmware_cache_persister=deps["firmware_cache_persister"],
-                core_info_provider=deps["core_info_provider"],
                 save_sync_state_persister=deps["save_sync_state_persister"],
                 log_debug=deps["log_debug"],
             ),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -807,13 +807,18 @@ class TestMainStartupOrdering:
     async def test_main_calls_detect_path_change_before_prune(self):
         from unittest.mock import AsyncMock, patch
 
+        from bootstrap import (
+            AdapterBundle,
+            BootstrapHandles,
+            BootstrapResult,
+            CallbackBundle,
+            RuntimeAdaptersBundle,
+            StateBundle,
+        )
+
         from main import Plugin
 
         plugin = Plugin()
-        plugin._persistence = MagicMock()
-        plugin._persistence.load_settings.return_value = {}
-        plugin._persistence.load_state.side_effect = lambda x: x
-        plugin._persistence.load_metadata_cache.return_value = {}
 
         call_order: list[str] = []
 
@@ -870,51 +875,60 @@ class TestMainStartupOrdering:
             "session_lifecycle_service": MagicMock(),
         }
 
-        bootstrapped_adapters = {
-            "persistence": plugin._persistence,
-            "firmware_cache_persister": MagicMock(),
-            "save_sync_state_persister": MagicMock(),
-            "state_persister": MagicMock(),
-            "settings_persister": MagicMock(),
-            "metadata_cache_persister": MagicMock(),
-            "settings": {},
-            "state": {
-                "shortcut_registry": {},
-                "installed_roms": {},
-                "last_sync": None,
-                "sync_stats": {"platforms": 0, "roms": 0},
-                "downloaded_bios": {},
-                "retrodeck_home_path": "",
-                "save_sort_settings": None,
-            },
-            "metadata_cache": {},
-            "http_adapter": MagicMock(),
-            "romm_api": MagicMock(),
-            "steam_config": MagicMock(),
-            "sgdb_adapter": MagicMock(),
-            "cover_art_file_store": MagicMock(),
-            "sgdb_artwork_cache": MagicMock(),
-            "download_files": MagicMock(),
-            "firmware_files": MagicMock(),
-            "download_queue": MagicMock(),
-            "migration_files": MagicMock(),
-            "rom_files": MagicMock(),
-            "save_file": MagicMock(),
-            "path_probe": MagicMock(),
-            "retrodeck_paths": MagicMock(),
-            "retroarch_config": MagicMock(),
-            "retroarch_core_info": MagicMock(),
-            "clock": MagicMock(),
-            "uuid_gen": MagicMock(),
-            "sleeper": MagicMock(),
-            "hostname_provider": MagicMock(),
-            "debug_logger": MagicMock(),
-            "core_resolver": MagicMock(),
-            "gamelist_editor": MagicMock(),
-        }
+        bootstrap_result = BootstrapResult(
+            adapters=AdapterBundle(
+                http_adapter=MagicMock(),
+                romm_api=MagicMock(),
+                steam_config=MagicMock(),
+                sgdb_adapter=MagicMock(),
+                cover_art_file_store=MagicMock(),
+                sgdb_artwork_cache=MagicMock(),
+                download_files=MagicMock(),
+                download_queue=MagicMock(),
+                firmware_files=MagicMock(),
+                migration_files=MagicMock(),
+                rom_files=MagicMock(),
+                save_file=MagicMock(),
+                gamelist_editor=MagicMock(),
+                path_probe=MagicMock(),
+                core_info_provider=MagicMock(),
+            ),
+            stores=StateBundle(
+                state={
+                    "shortcut_registry": {},
+                    "installed_roms": {},
+                    "last_sync": None,
+                    "sync_stats": {"platforms": 0, "roms": 0},
+                    "downloaded_bios": {},
+                    "retrodeck_home_path": "",
+                    "save_sort_settings": None,
+                },
+                settings={},
+                metadata_cache={},
+                save_sync_state=MagicMock(),
+            ),
+            callbacks=CallbackBundle(
+                retrodeck_paths=MagicMock(),
+                get_retroarch_save_sorting=MagicMock(),
+                get_core_name=MagicMock(),
+                state_persister=MagicMock(),
+                settings_persister=MagicMock(),
+                metadata_cache_persister=MagicMock(),
+                firmware_cache_persister=MagicMock(),
+                save_sync_state_persister=MagicMock(),
+                log_debug=MagicMock(),
+            ),
+            runtime_adapters=RuntimeAdaptersBundle(
+                clock=MagicMock(),
+                uuid_gen=MagicMock(),
+                sleeper=MagicMock(),
+                hostname_provider=MagicMock(),
+            ),
+            handles=BootstrapHandles(debug_logger=MagicMock()),
+        )
 
         with (
-            patch("main.bootstrap", return_value=bootstrapped_adapters),
+            patch("main.bootstrap", return_value=bootstrap_result),
             patch("main.wire_services", return_value=wired_services),
         ):
             await plugin._main()

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -101,6 +101,7 @@ def plugin(tmp_path):
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
+            plugin_version="0.14.0",
         ),
     )
     p._save_sync_service.init_state()


### PR DESCRIPTION
## Summary

Four bootstrap-layer hygiene fixes bundled in one diff (they all touch `bootstrap.py` — landing them together avoids per-PR conflicts).

### 1. `_DEFAULT_STATE` → `_default_state()` factory

**Before:** module-level `_DEFAULT_STATE: dict` whose inner dicts were shared into the live `state` on first run via `dict(_DEFAULT_STATE)` (shallow copy). Any in-place mutation by a service silently corrupted the module-level default.

**After:** `_default_state() -> dict` factory returning fresh containers each call. No risk of forgetting `deepcopy` at a future call site.

### 2. `core_info_provider` moved from `CallbackBundle` to `AdapterBundle`

**Before:** `CoreResolver` (stateful adapter with mutable caches) was routed through `CallbackBundle.core_info_provider`, contradicting `CallbackBundle`'s docstring ("Provider callables and persister Protocols").

**After:** lives next to `gamelist_editor` in `AdapterBundle` — structurally identical (both stateful adapters around RetroDECK config files). `CallbackBundle` now only carries true callables + persisters, matching its docstring.

### 3. `SaveServiceConfig.plugin_version = "0.0.0"` default dropped

**Before:** a forgotten wiring would ship a fake `"0.0.0"` user-agent to the RomM server.

**After:** `plugin_version: str` is required. Bootstrap already passes the real version (after #606's `PluginMetadataReader`); the two stand-alone test callsites (`test_plugin_saves.py`, `test_game_detail.py`) now pass `plugin_version="0.14.0"` explicitly.

### 4. Typed `BootstrapResult` dataclass

**Before:** `bootstrap()` returned an untyped 33-key `dict`. `main.py` re-keyed 15 of those into `self._*` attributes that nothing else on `Plugin` reads. Each typo silently failed at runtime.

**After:** `bootstrap()` returns a `@dataclass(frozen=True) class BootstrapResult` with five fields:
- `adapters: AdapterBundle` — all Protocol-typed I/O adapters
- `stores: StateBundle` — live state/settings/metadata_cache/save_sync_state dicts
- `callbacks: CallbackBundle` — provider callables + persisters (now minus `core_info_provider`)
- `runtime_adapters: RuntimeAdaptersBundle` — clock/uuid_gen/sleeper/hostname_provider (composed into the final `RuntimeBundle` in `main.py` together with the loop + emit it owns)
- `handles: BootstrapHandles` — debug_logger only (the one thing `Plugin` itself reads after wiring)

`_main()` shrinks from 100 LOC to ~50; 14 unused `self._*` adapter assignments removed from `Plugin`. basedpyright catches typos against the typed shape that the dict version silently swallowed.

## Test plan

- [x] `python -m pytest tests/test_plugin.py tests/test_plugin_callable_delegation.py tests/test_bootstrap.py tests/services/ -v` — 1343 passed
- [x] `python -m pytest tests/ -q` — 2506 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `basedpyright` (CI scope) — 0 errors
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept
- [x] `pnpm build` — clean (no frontend changes)
- [x] Coverage: `py_modules/bootstrap.py` 100%

## Notes for review

- `Plugin` now declares the test-fixture-only adapter slots (`_persistence`, `_state`, `_metadata_cache`, `_state_persister`, `_settings_persister`, `_metadata_cache_persister`, `_http_adapter`, `_romm_api`, `_steam_config`, `_retrodeck_paths`, `_save_sync_state`) as `Any`-typed annotation slots. Production wiring no longer sets them — only tests do, via fixture poking. **Annotations alone don't create attributes**, so `TestPersistenceAttributeIsLoud` (the bare-`Plugin()` regression) remains green.
- `TestMainStartupOrdering` was migrated from patching `bootstrap` with a dict to passing a fully-typed `BootstrapResult`. The bundle construction is verbose but the diff is mechanical.
- The `core_info_provider` move forced `cfg.callbacks.core_info_provider.*` → `cfg.adapters.core_info_provider.*` at four `wire_services` callsites.

Closes #671.
Parent epic: #622.