### PR TITLE
refactor(types): type romm_data_changed event union, close #617

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,10 +32,11 @@ export default tseslint.config(
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
       ],
-      // Downgraded to warn — 56 occurrences across the codebase, mostly in
-      // Steam-UI patching code where the upstream API is genuinely untyped.
-      // Cleanup tracked in #617. Promote back to error when zero.
-      "@typescript-eslint/no-explicit-any": "warn",
+      // Promoted back to error in #617 cleanup. Untyped sites that genuinely
+      // need `any` (Steam internal React tree walking in src/patches/) carry
+      // an inline `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
+      // with a documented reason.
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
   {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -37,6 +37,7 @@ import {
 import { SlotSetupWizard } from "./SlotSetupWizard";
 import { SavesTab } from "./SavesTab";
 import type { RomMetadata, InstalledRom, BiosStatus, SaveStatus, SyncConflict, Achievement, AchievementProgress, EarnedAchievement, SaveSlotSummary } from "../types";
+import type { RommDataChangedDetail } from "../types/events";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSaveSortMigrationState, onSaveSortMigrationChange, setSaveSortMigrationStatus } from "../utils/saveSortMigrationStore";
 import { scrollFocusedToCenter } from "../utils/scrollHelpers";
@@ -339,7 +340,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/appId/romIdRef/setState closure.
-    const handleSaveSyncSettingsChange = async (detail: any) => {
+    const handleSaveSyncSettingsChange = async (detail: Extract<RommDataChangedDetail, { type: "save_sync_settings" }>) => {
       const enabled = detail.save_sync_enabled;
       if (!enabled) {
         setState((prev) => ({ ...prev, saveSyncEnabled: false }));
@@ -357,7 +358,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       }));
     };
 
-    const handleSaveSyncChange = async (detail: any) => {
+    const handleSaveSyncChange = async (detail: Extract<RommDataChangedDetail, { type: "save_sync" }>) => {
       if (detail.rom_id && detail.rom_id !== romIdRef.current) return;
       const romId = romIdRef.current;
       if (!romId) return;
@@ -372,7 +373,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       refreshSlotState(romId, setState);
     };
 
-    const handleBiosChange = async (detail: any) => {
+    const handleBiosChange = async (detail: Extract<RommDataChangedDetail, { type: "bios" }>) => {
       if (!detail.platform_slug) return;
       const updated = await checkPlatformBios(detail.platform_slug).catch((): BiosStatus => ({ needs_bios: false }));
       setState((prev) => ({ ...prev, biosStatus: updated.needs_bios ? updated : null }));
@@ -393,7 +394,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       setState((prev) => ({ ...prev, biosStatus }));
     };
 
-    const handleMetadataChange = async (detail: any) => {
+    const handleMetadataChange = async (detail: Extract<RommDataChangedDetail, { type: "metadata" }>) => {
       if (detail.rom_id !== romIdRef.current) return;
       const romId = romIdRef.current;
       if (!romId) return;

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -45,6 +45,7 @@ import {
   debugLog,
 } from "../api/backend";
 import type { AvailableCore, BiosStatus, SaveStatus } from "../types";
+import type { RommDataChangedDetail } from "../types/events";
 import { formatLastPlayed, formatPlaytime } from "../utils/formatters";
 import {
   applySaveSyncDisplay,
@@ -256,8 +257,8 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/romIdRef/setInfo closure.
-    const handleSaveSyncSettingsChange = async (detail: any) => {
-      const enabled = detail.save_sync_enabled as boolean;
+    const handleSaveSyncSettingsChange = async (detail: Extract<RommDataChangedDetail, { type: "save_sync_settings" }>) => {
+      const enabled = detail.save_sync_enabled;
       if (enabled) {
         const rid = romIdRef.current;
         if (rid) {
@@ -293,7 +294,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       }));
     };
 
-    const handleSaveSyncChange = async (detail: any) => {
+    const handleSaveSyncChange = async (detail: Extract<RommDataChangedDetail, { type: "save_sync" }>) => {
       const romId = romIdRef.current ?? detail.rom_id;
       if (!romId) return;
       // If event specifies a rom_id, skip if it's not for this game

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Typed surface for the plugin's custom DOM events. Augments WindowEventMap
+ * so addEventListener/dispatchEvent calls infer the right CustomEvent shape
+ * without per-call `as CustomEvent<X>` casts.
+ *
+ * Add new event names + payloads here; consumers gain typed `detail` access
+ * automatically. The discriminated union for `romm_data_changed` is the
+ * source of truth — dispatch sites must match a variant, and switch-on-type
+ * narrowing in handlers comes for free.
+ */
+
+import type { SaveStatus } from "./saves";
+
+export type RommDataChangedDetail =
+  | { type: "save_sync"; rom_id?: number; save_status?: SaveStatus; has_conflict?: boolean }
+  | { type: "save_sync_settings"; save_sync_enabled: boolean }
+  | { type: "metadata"; rom_id: number }
+  | { type: "bios"; platform_slug: string }
+  | { type: "core_changed"; platform_slug: string };
+
+export interface RommRomUninstalledDetail {
+  rom_id: number;
+}
+
+export interface RommTabSwitchDetail {
+  tab: string;
+}
+
+export interface RommConnectionChangedDetail {
+  state: "checking" | "connected" | "offline";
+}
+
+declare global {
+  interface WindowEventMap {
+    romm_data_changed: CustomEvent<RommDataChangedDetail>;
+    romm_rom_uninstalled: CustomEvent<RommRomUninstalledDetail>;
+    romm_tab_switch: CustomEvent<RommTabSwitchDetail>;
+    romm_connection_changed: CustomEvent<RommConnectionChangedDetail>;
+  }
+}


### PR DESCRIPTION
Closes #617.

Finishes the "zero ESLint warnings" + "promote @typescript-eslint/no-explicit-any → error" acceptance criteria.

## Summary

- New `src/types/events.d.ts` with discriminated union for the `romm_data_changed` CustomEvent payload (5 variants) plus typed sibling events (`romm_rom_uninstalled`, `romm_tab_switch`, `romm_connection_changed`).
- `WindowEventMap` augmentation — `addEventListener`/`dispatchEvent` infer the right `CustomEvent` shape without per-call casts.
- All 6 `(detail: any)` handlers in `RomMGameInfoPanel.tsx` and `RomMPlaySection.tsx` now take their specific `Extract<...>` variant. The switch-on-type narrowing in each `onDataChanged` dispatcher picks the right type for each case automatically.
- `@typescript-eslint/no-explicit-any` promoted from `warn` to `error` in `eslint.config.js`. Sites that genuinely need `any` (Steam internal React tree walking in `src/patches/gameDetailPatch.tsx`) carry inline disables with documented reasons (shipped in #678).

## Stats

| | Before | After |
|---|---|---|
| `no-explicit-any` warnings | 6 | 0 |
| Rule severity | `warn` | `error` |
| Total ESLint warnings | 9 | 3 (react-hooks/exhaustive-deps, not in #617 scope) |

## Expected CI signal

All green. Type-only changes, no runtime behavior changes. Two of the touched files (RomMGameInfoPanel.tsx, RomMPlaySection.tsx) are already in the Sonar coverage exclusion list from previous PRs, so the new-code gate should pass cleanly.

## Test plan

- [x] `pnpm lint` — 0 errors, 3 warnings (all pre-existing exhaustive-deps)
- [x] `pnpm build` — clean, no rollup TS warnings
- [ ] `pnpm test` — could not run locally due to /tmp inode exhaustion (unrelated environment issue); CI will verify
- [ ] CI green

## Heads-up

Local /tmp inode exhaustion blocked the test run on my dev machine — opening this so CI can verify. If tests fail on CI I'll iterate. The changes are type-only (discriminated unions + extracted variant types on handlers), so runtime behavior is unchanged.