### PR TITLE
test(saves): add component tests for saves/*.tsx (#640)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,9 +28,6 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #   - *.config.{js,ts}: build/test/lint config files (rollup, vitest, eslint, size-limit)
 #   - src/test-setup.ts: Vitest setup file, mocks only
 # Temporary exclusions (remove as tests land per #616 Phase 2):
-#   - src/components/saves/*.tsx: relocated from SavesTab.tsx in #613, awaiting
-#     focused component tests (tracked in #640). helpers.ts in the same folder
-#     is tested and stays in scope.
 #   - src/components/settings/*.tsx: relocated from SettingsPage.tsx in #615,
 #     awaiting focused component tests (Phase 2 follow-up). helpers.ts in the
 #     same folder is tested and stays in scope.
@@ -44,7 +41,7 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #     had no tests. Same SettingsPage rationale; remove individually as
 #     focused component tests land (Phase 2 follow-up, tracked alongside
 #     #640/#658).
-sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/components/saves/*.tsx,src/components/settings/*.tsx,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
+sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/components/settings/*.tsx,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
 
 # Suppress false positives
 # S6926: "async without await" — Decky Loader callable framework requires all

--- a/src/components/saves/InactiveSlotBody.test.tsx
+++ b/src/components/saves/InactiveSlotBody.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { InactiveSlotBody, type InactiveSlotBodyProps } from "./InactiveSlotBody";
+import type { SlotSaveFile } from "../../types";
+
+// Override the global @decky/ui DialogButton stub so it forwards `disabled` —
+// the global passthrough <button> only wires `onClick` and silently drops
+// disabled, which masks the prop-driven disable behavior we want to assert.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+vi.mock("@decky/ui", () => {
+  const passthrough = (tag: string) => (props: AnyProps) =>
+    createElement(tag, props, props.children as never);
+  return {
+    DialogButton: ({ children, onClick, disabled }: AnyProps & {
+      onClick?: () => void;
+      disabled?: boolean;
+    }) => createElement("button", { onClick, disabled }, children as never),
+    Focusable: passthrough("div"),
+  };
+});
+
+function makeFile(overrides: Partial<SlotSaveFile> = {}): SlotSaveFile {
+  return {
+    filename: "save.srm",
+    id: 1,
+    size: null,
+    updated_at: "",
+    emulator: "retroarch",
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Partial<InactiveSlotBodyProps> = {}): InactiveSlotBodyProps {
+  return {
+    loadingSlot: false,
+    slotFiles: null,
+    switching: false,
+    switchError: null,
+    isOffline: false,
+    handleActivate: vi.fn(),
+    handleDelete: vi.fn(),
+    deleting: false,
+    ...overrides,
+  };
+}
+
+describe("InactiveSlotBody", () => {
+  it("renders 'Loading...' when loadingSlot is true", () => {
+    const { container } = render(<InactiveSlotBody {...defaultProps({ loadingSlot: true })} />);
+    expect(container.textContent).toContain("Loading...");
+  });
+
+  it("renders no save list rows when slotFiles is null and not loading", () => {
+    const { container } = render(<InactiveSlotBody {...defaultProps()} />);
+    // Neither the loading placeholder nor the empty placeholder
+    expect(container.textContent).not.toContain("Loading...");
+    expect(container.textContent).not.toContain("No saves in this slot");
+  });
+
+  it("renders 'No saves in this slot' when slotFiles is an empty array", () => {
+    const { container } = render(
+      <InactiveSlotBody {...defaultProps({ slotFiles: [] })} />,
+    );
+    expect(container.textContent).toContain("No saves in this slot");
+  });
+
+  it("renders one row per file when slotFiles is populated", () => {
+    const { container } = render(
+      <InactiveSlotBody
+        {...defaultProps({
+          slotFiles: [
+            makeFile({ id: 1, filename: "a.srm" }),
+            makeFile({ id: 2, filename: "b.srm" }),
+          ],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("a.srm");
+    expect(container.textContent).toContain("b.srm");
+  });
+
+  it("button label says 'Activate Slot' by default", () => {
+    const { getByText } = render(<InactiveSlotBody {...defaultProps()} />);
+    expect(getByText("Activate Slot")).toBeInTheDocument();
+  });
+
+  it("button label says 'Switching...' when switching is true", () => {
+    const { getByText, queryByText } = render(
+      <InactiveSlotBody {...defaultProps({ switching: true })} />,
+    );
+    expect(getByText("Switching...")).toBeInTheDocument();
+    expect(queryByText("Activate Slot")).toBeNull();
+  });
+
+  it("button label says 'Delete Slot' by default", () => {
+    const { getByText } = render(<InactiveSlotBody {...defaultProps()} />);
+    expect(getByText("Delete Slot")).toBeInTheDocument();
+  });
+
+  it("button label says 'Deleting...' when deleting is true", () => {
+    const { getByText, queryByText } = render(
+      <InactiveSlotBody {...defaultProps({ deleting: true })} />,
+    );
+    expect(getByText("Deleting...")).toBeInTheDocument();
+    expect(queryByText("Delete Slot")).toBeNull();
+  });
+
+  it("disables Activate when switching is true", () => {
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ switching: true })} />,
+    );
+    expect(getByText("Switching...")).toBeDisabled();
+  });
+
+  it("disables Activate when isOffline is true", () => {
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ isOffline: true })} />,
+    );
+    expect(getByText("Activate Slot")).toBeDisabled();
+  });
+
+  it("enables Activate when neither switching nor offline", () => {
+    const { getByText } = render(<InactiveSlotBody {...defaultProps()} />);
+    expect(getByText("Activate Slot")).not.toBeDisabled();
+  });
+
+  it("disables Delete when deleting is true", () => {
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ deleting: true })} />,
+    );
+    expect(getByText("Deleting...")).toBeDisabled();
+  });
+
+  it("disables Delete when switching is true (in-flight switch blocks delete)", () => {
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ switching: true })} />,
+    );
+    expect(getByText("Delete Slot")).toBeDisabled();
+  });
+
+  it("calls handleActivate when Activate is clicked", () => {
+    const handleActivate = vi.fn();
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ handleActivate })} />,
+    );
+    fireEvent.click(getByText("Activate Slot"));
+    expect(handleActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls handleDelete when Delete is clicked", () => {
+    const handleDelete = vi.fn();
+    const { getByText } = render(
+      <InactiveSlotBody {...defaultProps({ handleDelete })} />,
+    );
+    fireEvent.click(getByText("Delete Slot"));
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows offline hint when isOffline is true", () => {
+    const { container } = render(
+      <InactiveSlotBody {...defaultProps({ isOffline: true })} />,
+    );
+    expect(container.textContent).toContain("Offline — slot switching unavailable");
+  });
+
+  it("hides offline hint when not offline", () => {
+    const { container } = render(<InactiveSlotBody {...defaultProps()} />);
+    expect(container.textContent).not.toContain("Offline — slot switching unavailable");
+  });
+
+  it("shows switchError line when switchError is set", () => {
+    const { container } = render(
+      <InactiveSlotBody {...defaultProps({ switchError: "Something went wrong" })} />,
+    );
+    expect(container.textContent).toContain("Something went wrong");
+  });
+
+  it("hides switchError line when switchError is null", () => {
+    const { container } = render(<InactiveSlotBody {...defaultProps()} />);
+    // No error text — just controls
+    const errorEls = container.querySelectorAll("div");
+    const errorTextNodes = Array.from(errorEls).filter(
+      (el) => el.style.color === "rgb(217, 65, 38)" || el.style.color === "#d94126",
+    );
+    expect(errorTextNodes.length).toBe(0);
+  });
+});

--- a/src/components/saves/NewSlotModal.test.tsx
+++ b/src/components/saves/NewSlotModal.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { NewSlotModal } from "./NewSlotModal";
+
+// Override the global @decky/ui stub so we can capture the ConfirmModal props
+// (onOK, bDisableBackgroundDismiss, closeModal) — the global passthrough <div>
+// silently drops them.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+const captured: {
+  onOK?: () => void;
+  bDisableBackgroundDismiss?: boolean;
+  closeModal?: unknown;
+  strTitle?: string;
+} = {};
+
+vi.mock("@decky/ui", () => ({
+  ConfirmModal: (p: AnyProps & {
+    onOK?: () => void;
+    bDisableBackgroundDismiss?: boolean;
+    closeModal?: unknown;
+    strTitle?: string;
+  }) => {
+    captured.onOK = p.onOK;
+    captured.bDisableBackgroundDismiss = p.bDisableBackgroundDismiss;
+    captured.closeModal = p.closeModal;
+    captured.strTitle = p.strTitle;
+    return createElement("div", { "data-testid": "confirm-modal" }, p.children as never);
+  },
+  TextField: (p: AnyProps & { value?: string; onChange?: (e: unknown) => void }) =>
+    createElement("input", {
+      value: p.value ?? "",
+      onChange: (e: unknown) => p.onChange?.(e),
+    }),
+}));
+
+describe("NewSlotModal", () => {
+  it("renders a ConfirmModal with the slot-name text field", () => {
+    render(<NewSlotModal onSubmit={vi.fn()} />);
+    const input = document.querySelector("input");
+    expect(input).not.toBeNull();
+    expect(input?.value).toBe("");
+    expect(captured.strTitle).toBe("New Save Slot");
+  });
+
+  it("disables background dismiss", () => {
+    render(<NewSlotModal onSubmit={vi.fn()} />);
+    expect(captured.bDisableBackgroundDismiss).toBe(true);
+  });
+
+  it("controls the input value via React state", () => {
+    render(<NewSlotModal onSubmit={vi.fn()} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "speedrun" } });
+    expect(input.value).toBe("speedrun");
+  });
+
+  it("submits the trimmed value when OK is pressed", () => {
+    const onSubmit = vi.fn();
+    render(<NewSlotModal onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  myslot  " } });
+    captured.onOK?.();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("myslot");
+  });
+
+  it("submits an empty string when OK is pressed with empty input", () => {
+    const onSubmit = vi.fn();
+    render(<NewSlotModal onSubmit={onSubmit} />);
+    captured.onOK?.();
+    expect(onSubmit).toHaveBeenCalledWith("");
+  });
+
+  it("submits an empty string when input contains only whitespace (trim collapses)", () => {
+    const onSubmit = vi.fn();
+    render(<NewSlotModal onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "    " } });
+    captured.onOK?.();
+    expect(onSubmit).toHaveBeenCalledWith("");
+  });
+
+  it("forwards closeModal to the underlying ConfirmModal", () => {
+    const closeModal = vi.fn();
+    render(<NewSlotModal closeModal={closeModal} onSubmit={vi.fn()} />);
+    expect(captured.closeModal).toBe(closeModal);
+  });
+
+  it("works without closeModal (optional prop)", () => {
+    render(<NewSlotModal onSubmit={vi.fn()} />);
+    expect(captured.closeModal).toBeUndefined();
+  });
+});

--- a/src/components/saves/SaveFileRow.test.tsx
+++ b/src/components/saves/SaveFileRow.test.tsx
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { renderSaveFileRow, infoRow } from "./SaveFileRow";
+import type { SaveFileStatus, SyncConflict } from "../../types";
+
+function makeFile(overrides: Partial<SaveFileStatus> = {}): SaveFileStatus {
+  return {
+    filename: "save.srm",
+    local_path: null,
+    local_hash: null,
+    local_mtime: null,
+    local_size: null,
+    server_save_id: null,
+    server_file_name: null,
+    server_emulator: null,
+    server_updated_at: null,
+    server_size: null,
+    last_sync_at: null,
+    status: "synced",
+    ...overrides,
+  };
+}
+
+function makeConflict(overrides: Partial<SyncConflict> = {}): SyncConflict {
+  return {
+    type: "sync_conflict",
+    rom_id: 1,
+    filename: "save.srm",
+    server_save_id: 1,
+    server_updated_at: "2025-06-15T10:00:00Z",
+    server_size: 100,
+    local_path: null,
+    local_hash: null,
+    local_mtime: null,
+    local_size: null,
+    created_at: "2025-06-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("infoRow", () => {
+  it("returns null when value is null", () => {
+    expect(infoRow("k", "Label:", null)).toBeNull();
+  });
+
+  it("returns null when value is an empty string", () => {
+    expect(infoRow("k", "Label:", "")).toBeNull();
+  });
+
+  it("renders a row when value is a non-empty string", () => {
+    const el = infoRow("k", "Last:", "hello");
+    expect(el).not.toBeNull();
+    const { container } = render(<div>{el}</div>);
+    expect(container.textContent).toContain("Last:");
+    expect(container.textContent).toContain("hello");
+  });
+});
+
+describe("renderSaveFileRow", () => {
+  // Pin time for deterministic relative formatting
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("renders filename", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile(), undefined, null)}</div>,
+    );
+    expect(container.textContent).toContain("save.srm");
+  });
+
+  it("renders 'Synced' status badge for status 'synced'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "synced" }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe("Synced");
+  });
+
+  it("renders 'Local changes' badge for status 'upload'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "upload" }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe(
+      "Local changes",
+    );
+  });
+
+  it("renders 'Server newer' badge for status 'download'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "download" }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe(
+      "Server newer",
+    );
+  });
+
+  it("renders 'Conflict' badge for status 'conflict'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "conflict" }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe(
+      "Conflict",
+    );
+  });
+
+  it("renders 'Status unknown' badge for status 'unknown'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "unknown" }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe(
+      "Status unknown",
+    );
+  });
+
+  it("renders 'Not synced' badge when status is unrecognized and last_sync_at is null", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "weird" as unknown as SaveFileStatus["status"] }), undefined, null)}</div>,
+    );
+    expect(container.querySelector(".romm-save-status-label")?.textContent).toBe(
+      "Not synced",
+    );
+  });
+
+  it("shows size in the header when local_size is set", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ local_size: 2048 }), undefined, null)}</div>,
+    );
+    expect(container.textContent).toContain("2.0 KB");
+  });
+
+  it("omits size when local_size is null", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ local_size: null }), undefined, null)}</div>,
+    );
+    expect(container.textContent).not.toContain("KB");
+    expect(container.textContent).not.toContain(" B");
+  });
+
+  it("shows the conflict banner when status === 'conflict'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "conflict" }), undefined, null)}</div>,
+    );
+    expect(container.textContent).toContain(
+      "Conflict detected — resolve from the sync action",
+    );
+  });
+
+  it("shows the conflict banner when a conflict arg is passed (even with non-conflict status)", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "synced" }), makeConflict(), null)}</div>,
+    );
+    expect(container.textContent).toContain(
+      "Conflict detected — resolve from the sync action",
+    );
+  });
+
+  it("hides the conflict banner when no conflict and status is not 'conflict'", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ status: "synced" }), undefined, null)}</div>,
+    );
+    expect(container.textContent).not.toContain(
+      "Conflict detected — resolve from the sync action",
+    );
+  });
+
+  it("renders the last-synced info row with 'Never' when neither check nor file timestamp is set", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ last_sync_at: null }), undefined, null)}</div>,
+    );
+    expect(container.textContent).toContain("Last synced:");
+    expect(container.textContent).toContain("Never");
+  });
+
+  it("renders relative time in the last-synced row when last_sync_check_at is set", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ status: "synced", last_sync_at: null }),
+          undefined,
+          "2025-06-15T11:30:00Z",
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("30m ago");
+  });
+
+  it("renders the last-updated info row when server_updated_at is set", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ server_updated_at: "2025-06-15T10:00:00Z" }),
+          undefined,
+          null,
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("Last updated:");
+  });
+
+  it("skips the last-updated row when server_updated_at is null", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ server_updated_at: null }), undefined, null)}</div>,
+    );
+    expect(container.textContent).not.toContain("Last updated:");
+  });
+
+  it("renders the server save sub-block (id-only) when server_save_id is set", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ server_save_id: 42 }),
+          undefined,
+          null,
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("Server save:");
+    expect(container.textContent).toContain("#42");
+  });
+
+  it("renders the server save sub-block (id + emulator) when both are set", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ server_save_id: 42, server_emulator: "retroarch-mgba" }),
+          undefined,
+          null,
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("#42");
+    expect(container.textContent).toContain("retroarch-mgba");
+  });
+
+  it("renders the server filename line when server_file_name is set", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ server_save_id: 42, server_file_name: "remote_save.srm" }),
+          undefined,
+          null,
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("remote_save.srm");
+  });
+
+  it("skips the server save sub-block when server_save_id is null", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ server_save_id: null }), undefined, null)}</div>,
+    );
+    expect(container.textContent).not.toContain("Server save:");
+  });
+
+  it("renders the local-path row when local_path is set", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ local_path: "/data/save.srm" }), undefined, null)}</div>,
+    );
+    expect(container.textContent).toContain("Local path:");
+    expect(container.textContent).toContain("/data/save.srm");
+  });
+
+  it("skips the local-path row when local_path is null", () => {
+    const { container } = render(
+      <div>{renderSaveFileRow(makeFile({ local_path: null }), undefined, null)}</div>,
+    );
+    expect(container.textContent).not.toContain("Local path:");
+  });
+
+  it("appends '(this device) ✓' attribution segment when uploaded_by_us is true", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({
+            status: "synced",
+            uploaded_by_us: true,
+            device_syncs: [
+              { device_id: "d1", device_name: "deck", is_current: true, last_synced_at: "2025-06-15T11:00:00Z" },
+            ],
+          }),
+          undefined,
+          "2025-06-15T11:30:00Z",
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("deck (this device) ✓");
+  });
+
+  it("appends '(not this device) ✓' attribution segment when uploaded_by_us is false", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({
+            status: "synced",
+            uploaded_by_us: false,
+            device_syncs: [
+              { device_id: "d1", device_name: "deck", is_current: true, last_synced_at: "2025-06-15T11:00:00Z" },
+            ],
+          }),
+          undefined,
+          "2025-06-15T11:30:00Z",
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("(not this device) ✓");
+  });
+
+  it("appends 'Newer version available on server' when is_current is false", () => {
+    const { container } = render(
+      <div>
+        {renderSaveFileRow(
+          makeFile({ status: "synced", is_current: false }),
+          undefined,
+          "2025-06-15T11:30:00Z",
+        )}
+      </div>,
+    );
+    expect(container.textContent).toContain("Newer version available on server");
+  });
+});

--- a/src/components/saves/ServerSaveRow.test.tsx
+++ b/src/components/saves/ServerSaveRow.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { renderServerSaveRow } from "./ServerSaveRow";
+import type { SlotSaveFile } from "../../types";
+
+function makeFile(overrides: Partial<SlotSaveFile> = {}): SlotSaveFile {
+  return {
+    filename: "save.srm",
+    id: 1,
+    size: null,
+    updated_at: "",
+    emulator: "retroarch",
+    ...overrides,
+  };
+}
+
+describe("renderServerSaveRow", () => {
+  // Pin time so "Updated <relative>" assertions stay deterministic.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("renders just the filename when size and updated_at are missing", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile({ updated_at: "" }))}</div>);
+    expect(container.textContent).toContain("save.srm");
+    // No second line (size · Updated) when both are absent
+    expect(container.textContent).not.toContain("·");
+    expect(container.textContent).not.toContain("Updated");
+  });
+
+  it("renders filename + formatted size when size is present", () => {
+    const { container } = render(
+      <div>{renderServerSaveRow(makeFile({ size: 2048 }))}</div>,
+    );
+    expect(container.textContent).toContain("save.srm");
+    expect(container.textContent).toContain("2.0 KB");
+  });
+
+  it("renders filename + size + 'Updated <relative>' when both are present", () => {
+    const { container } = render(
+      <div>{renderServerSaveRow(makeFile({
+        size: 1024,
+        updated_at: "2025-06-15T11:30:00Z",
+      }))}</div>,
+    );
+    expect(container.textContent).toContain("save.srm");
+    expect(container.textContent).toContain("1.0 KB");
+    expect(container.textContent).toContain("Updated 30m ago");
+  });
+
+  it("renders only the filename when size is null", () => {
+    const { container } = render(
+      <div>{renderServerSaveRow(makeFile({ size: null, updated_at: "" }))}</div>,
+    );
+    expect(container.textContent).toBe("save.srm");
+  });
+
+  it("renders only filename + Updated when updated_at is set but size is null", () => {
+    const { container } = render(
+      <div>{renderServerSaveRow(makeFile({
+        size: null,
+        updated_at: "2025-06-15T11:30:00Z",
+      }))}</div>,
+    );
+    expect(container.textContent).toContain("save.srm");
+    expect(container.textContent).toContain("Updated 30m ago");
+    expect(container.textContent).not.toContain("KB");
+  });
+
+  it("returns null for the second line when both size and updated_at are missing (no separator)", () => {
+    const { container } = render(<div>{renderServerSaveRow(makeFile())}</div>);
+    // Only the filename div exists — no second line at all
+    const wrapper = container.firstChild as HTMLElement;
+    const rowDiv = wrapper.firstChild as HTMLElement;
+    // First child = filename div; nothing else inside the row
+    expect(rowDiv.children.length).toBe(1);
+  });
+
+  it("uses a unique key per save id so list reconciliation stays stable", () => {
+    const f1 = makeFile({ id: 1, filename: "a.srm" });
+    const f2 = makeFile({ id: 2, filename: "b.srm" });
+    // The key is set on the row's outer div via createElement; we can't read
+    // React keys from the DOM, but we can assert no duplicates by checking
+    // both rows render side-by-side without crashing.
+    const { container } = render(
+      <div>
+        {renderServerSaveRow(f1)}
+        {renderServerSaveRow(f2)}
+      </div>,
+    );
+    expect(container.textContent).toContain("a.srm");
+    expect(container.textContent).toContain("b.srm");
+    // Both rows are direct children of the wrapper
+    expect((container.firstChild as HTMLElement).children.length).toBe(2);
+  });
+});

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -5,8 +5,7 @@ import { SlotPanel } from "./SlotPanel";
 import * as backend from "../../api/backend";
 import { toaster } from "@decky/api";
 import { showModal } from "@decky/ui";
-import type { SaveStatus, SaveSlotSummary, SlotSaveFile, SwitchSlotResponse } from "../../types";
-import type { SlotDeleteInfo, DeleteSlotResult } from "../../api/backend";
+import type { SaveStatus, SaveSlotSummary, SlotSaveFile } from "../../types";
 
 // showModal in the @decky/ui mock receives a React element created by
 // createElement(ConfirmModal, props). We capture that element so tests can
@@ -29,6 +28,7 @@ vi.mock("@decky/ui", () => {
       onClick?: () => void;
       disabled?: boolean;
     }) => createElement("button", { onClick, disabled }, children as never),
+    // Used transitively by InactiveSlotBody, which SlotPanel renders.
     Focusable: (p: AnyProps) => createElement("div", {}, p.children as never),
     showModal: vi.fn(),
   };
@@ -278,7 +278,7 @@ describe("SlotPanel", () => {
       vi.mocked(backend.switchSlot).mockResolvedValue({
         success: true,
         save_status: newStatus,
-      } as SwitchSlotResponse);
+      });
 
       const onSlotSwitched = vi.fn();
       const { container, getByText } = render(
@@ -294,25 +294,34 @@ describe("SlotPanel", () => {
     });
 
     it("shows the 'pending_uploads' error", async () => {
-      vi.mocked(backend.getSlotSaves).mockResolvedValue({
-        success: true,
-        slot: "default",
-        saves: [],
-      });
-      vi.mocked(backend.switchSlot).mockResolvedValue({
-        success: false,
-        reason: "pending_uploads",
-      });
+      vi.useFakeTimers();
+      try {
+        vi.mocked(backend.getSlotSaves).mockResolvedValue({
+          success: true,
+          slot: "default",
+          saves: [],
+        });
+        vi.mocked(backend.switchSlot).mockResolvedValue({
+          success: false,
+          reason: "pending_uploads",
+        });
 
-      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
-      fireEvent.click(container.querySelector("button")!);
-      await flushAsync();
-      fireEvent.click(getByText("Activate Slot"));
-      await flushAsync();
-      await flushAsync();
-      expect(container.textContent).toContain(
-        "Sync your saves first — local changes haven't been uploaded",
-      );
+        const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+        fireEvent.click(container.querySelector("button")!);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        fireEvent.click(getByText("Activate Slot"));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(container.textContent).toContain(
+          "Sync your saves first — local changes haven't been uploaded",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("auto-clears the switchError after 5 seconds", async () => {
@@ -353,57 +362,84 @@ describe("SlotPanel", () => {
     });
 
     it("shows the 'server_unreachable' error", async () => {
-      vi.mocked(backend.getSlotSaves).mockResolvedValue({
-        success: true,
-        slot: "default",
-        saves: [],
-      });
-      vi.mocked(backend.switchSlot).mockResolvedValue({
-        success: false,
-        reason: "server_unreachable",
-      });
-      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
-      fireEvent.click(container.querySelector("button")!);
-      await flushAsync();
-      fireEvent.click(getByText("Activate Slot"));
-      await flushAsync();
-      await flushAsync();
-      expect(container.textContent).toContain("Can't switch — RomM server is not reachable");
+      vi.useFakeTimers();
+      try {
+        vi.mocked(backend.getSlotSaves).mockResolvedValue({
+          success: true,
+          slot: "default",
+          saves: [],
+        });
+        vi.mocked(backend.switchSlot).mockResolvedValue({
+          success: false,
+          reason: "server_unreachable",
+        });
+        const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+        fireEvent.click(container.querySelector("button")!);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        fireEvent.click(getByText("Activate Slot"));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(container.textContent).toContain("Can't switch — RomM server is not reachable");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("shows the generic error on unknown reason", async () => {
-      vi.mocked(backend.getSlotSaves).mockResolvedValue({
-        success: true,
-        slot: "default",
-        saves: [],
-      });
-      vi.mocked(backend.switchSlot).mockResolvedValue({
-        success: false,
-        reason: "sync_disabled",
-      });
-      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
-      fireEvent.click(container.querySelector("button")!);
-      await flushAsync();
-      fireEvent.click(getByText("Activate Slot"));
-      await flushAsync();
-      await flushAsync();
-      expect(container.textContent).toContain("Failed to switch slot");
+      vi.useFakeTimers();
+      try {
+        vi.mocked(backend.getSlotSaves).mockResolvedValue({
+          success: true,
+          slot: "default",
+          saves: [],
+        });
+        vi.mocked(backend.switchSlot).mockResolvedValue({
+          success: false,
+          reason: "sync_disabled",
+        });
+        const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+        fireEvent.click(container.querySelector("button")!);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        fireEvent.click(getByText("Activate Slot"));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(container.textContent).toContain("Failed to switch slot");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("catches thrown errors and surfaces an error line", async () => {
-      vi.mocked(backend.getSlotSaves).mockResolvedValue({
-        success: true,
-        slot: "default",
-        saves: [],
-      });
-      vi.mocked(backend.switchSlot).mockRejectedValue(new Error("boom"));
-      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
-      fireEvent.click(container.querySelector("button")!);
-      await flushAsync();
-      fireEvent.click(getByText("Activate Slot"));
-      await flushAsync();
-      await flushAsync();
-      expect(container.textContent).toContain("An error occurred while switching slots");
+      vi.useFakeTimers();
+      try {
+        vi.mocked(backend.getSlotSaves).mockResolvedValue({
+          success: true,
+          slot: "default",
+          saves: [],
+        });
+        vi.mocked(backend.switchSlot).mockRejectedValue(new Error("boom"));
+        const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+        fireEvent.click(container.querySelector("button")!);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        fireEvent.click(getByText("Activate Slot"));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(container.textContent).toContain("An error occurred while switching slots");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -417,7 +453,7 @@ describe("SlotPanel", () => {
       vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
         success: false,
         reason: "active_slot",
-      } as SlotDeleteInfo);
+      });
       const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
       fireEvent.click(container.querySelector("button")!);
       await flushAsync();
@@ -444,10 +480,10 @@ describe("SlotPanel", () => {
         source: "server",
         server_save_count: 3,
         local_file_count: 2,
-      } as SlotDeleteInfo);
+      });
       vi.mocked(backend.deleteSlot).mockResolvedValue({
         success: true,
-      } as DeleteSlotResult);
+      });
 
       const onSlotDeleted = vi.fn();
       const { container, getByText } = render(<SlotPanel {...defaultProps({ onSlotDeleted })} />);
@@ -487,7 +523,7 @@ describe("SlotPanel", () => {
         source: "local",
         server_save_count: 0,
         local_file_count: 1,
-      } as SlotDeleteInfo);
+      });
 
       const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
       fireEvent.click(container.querySelector("button")!);
@@ -512,11 +548,11 @@ describe("SlotPanel", () => {
         success: true,
         slot: "default",
         source: "local",
-      } as SlotDeleteInfo);
+      });
       vi.mocked(backend.deleteSlot).mockResolvedValue({
         success: false,
         message: "couldn't reach server",
-      } as DeleteSlotResult);
+      });
 
       const onSlotDeleted = vi.fn();
       const { container, getByText } = render(<SlotPanel {...defaultProps({ onSlotDeleted })} />);
@@ -544,7 +580,7 @@ describe("SlotPanel", () => {
         success: true,
         slot: "default",
         source: "local",
-      } as SlotDeleteInfo);
+      });
       vi.mocked(backend.deleteSlot).mockRejectedValue(new Error("network"));
 
       const { container, getByText } = render(<SlotPanel {...defaultProps()} />);

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -1,0 +1,662 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import { createElement } from "react";
+import { SlotPanel } from "./SlotPanel";
+import * as backend from "../../api/backend";
+import { toaster } from "@decky/api";
+import { showModal } from "@decky/ui";
+import type { SaveStatus, SaveSlotSummary, SlotSaveFile, SwitchSlotResponse } from "../../types";
+import type { SlotDeleteInfo, DeleteSlotResult } from "../../api/backend";
+
+// showModal in the @decky/ui mock receives a React element created by
+// createElement(ConfirmModal, props). We capture that element so tests can
+// read `.props.onOK`, `.props.strDescription`, etc.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface ConfirmModalProps {
+  onOK?: () => void | Promise<void>;
+  strDescription?: string;
+  strTitle?: string;
+  strOKButtonText?: string;
+}
+
+vi.mock("@decky/ui", () => {
+  // ConfirmModal is just a marker component — never actually rendered in tests.
+  // showModal captures the element and tests pull props off it directly.
+  const ConfirmModal = (p: AnyProps) => createElement("div", {}, p.children as never);
+  return {
+    ConfirmModal,
+    DialogButton: ({ children, onClick, disabled }: AnyProps & {
+      onClick?: () => void;
+      disabled?: boolean;
+    }) => createElement("button", { onClick, disabled }, children as never),
+    Focusable: (p: AnyProps) => createElement("div", {}, p.children as never),
+    showModal: vi.fn(),
+  };
+});
+
+function lastConfirmModalProps(): ConfirmModalProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as { props?: ConfirmModalProps } | undefined;
+  return el?.props ?? null;
+}
+
+// Stub VersionHistoryPanel so we don't need to wire its own callable mocks.
+// We render a tiny marker so tests can assert it appeared per file.
+vi.mock("./VersionHistoryPanel", () => ({
+  VersionHistoryPanel: (p: { filename: string; isOffline: boolean }) =>
+    createElement("div", { "data-testid": `vhp-${p.filename}`, "data-offline": String(p.isOffline) }),
+}));
+
+function makeSummary(overrides: Partial<SaveSlotSummary> = {}): SaveSlotSummary {
+  return {
+    slot: "default",
+    source: "local",
+    count: 0,
+    latest_updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeStatus(overrides: Partial<SaveStatus> = {}): SaveStatus {
+  return {
+    rom_id: 1,
+    files: [],
+    playtime: {
+      total_seconds: 0,
+      session_count: 0,
+      last_session_start: null,
+      last_session_duration_sec: null,
+    },
+    device_id: "dev",
+    last_sync_check_at: null,
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof SlotPanel>> = {}) {
+  return {
+    romId: 1,
+    slot: makeSummary(),
+    isActive: false,
+    defaultExpanded: false,
+    saveStatus: null,
+    conflicts: [],
+    isOffline: false,
+    onSlotSwitched: vi.fn(),
+    onVersionRestored: vi.fn(),
+    onSlotDeleted: vi.fn(),
+    ...overrides,
+  };
+}
+
+const flushAsync = () => new Promise((r) => setTimeout(r, 0));
+
+describe("SlotPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("expand/collapse", () => {
+    it("renders collapsed by default", () => {
+      const { container } = render(<SlotPanel {...defaultProps()} />);
+      expect(container.textContent).toContain("▸");
+      expect(container.textContent).not.toContain("▾");
+    });
+
+    it("renders expanded when defaultExpanded is true", () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ defaultExpanded: true })} />,
+      );
+      expect(container.textContent).toContain("▾");
+    });
+
+    it("toggles expanded state when the header is clicked", async () => {
+      const { container } = render(<SlotPanel {...defaultProps()} />);
+      const header = container.querySelector("button");
+      if (!header) throw new Error("no header button");
+      fireEvent.click(header);
+      await flushAsync();
+      expect(container.textContent).toContain("▾");
+      fireEvent.click(header);
+      await flushAsync();
+      expect(container.textContent).toContain("▸");
+    });
+
+    it("calls getSlotSaves exactly once on first expand for an inactive slot (caches)", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      const { container } = render(<SlotPanel {...defaultProps()} />);
+      const header = container.querySelector("button");
+      if (!header) throw new Error("no header");
+      fireEvent.click(header);
+      await flushAsync();
+      fireEvent.click(header); // collapse
+      fireEvent.click(header); // expand again — should NOT refetch (cached)
+      await flushAsync();
+      expect(vi.mocked(backend.getSlotSaves)).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call getSlotSaves when expanding an active slot", async () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ isActive: true, saveStatus: makeStatus() })} />,
+      );
+      const header = container.querySelector("button");
+      if (!header) throw new Error("no header");
+      fireEvent.click(header);
+      await flushAsync();
+      expect(vi.mocked(backend.getSlotSaves)).not.toHaveBeenCalled();
+    });
+
+    it("falls back to an empty list when getSlotSaves returns success=false", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: false,
+        slot: "default",
+        saves: [],
+      });
+      const { container } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      expect(container.textContent).toContain("No saves in this slot");
+    });
+
+    it("falls back to an empty list when getSlotSaves throws", async () => {
+      vi.mocked(backend.getSlotSaves).mockRejectedValue(new Error("network"));
+      const { container } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      expect(container.textContent).toContain("No saves in this slot");
+    });
+  });
+
+  describe("active slot body", () => {
+    it("renders one SaveFileRow + VersionHistoryPanel per file", () => {
+      const status = makeStatus({
+        files: [
+          {
+            filename: "a.srm",
+            local_path: "/data/a.srm",
+            local_hash: "h",
+            local_mtime: "2025-06-15T10:00:00Z",
+            local_size: 100,
+            server_save_id: 1,
+            server_file_name: null,
+            server_emulator: null,
+            server_updated_at: null,
+            server_size: null,
+            last_sync_at: null,
+            status: "synced",
+          },
+          {
+            filename: "b.srm",
+            local_path: "/data/b.srm",
+            local_hash: "h",
+            local_mtime: "2025-06-15T10:00:00Z",
+            local_size: 100,
+            server_save_id: 2,
+            server_file_name: null,
+            server_emulator: null,
+            server_updated_at: null,
+            server_size: null,
+            last_sync_at: null,
+            status: "synced",
+          },
+        ],
+      });
+      const { container, queryByTestId } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            defaultExpanded: true,
+            saveStatus: status,
+          })}
+        />,
+      );
+      expect(container.textContent).toContain("a.srm");
+      expect(container.textContent).toContain("b.srm");
+      expect(queryByTestId("vhp-a.srm")).not.toBeNull();
+      expect(queryByTestId("vhp-b.srm")).not.toBeNull();
+    });
+
+    it("shows 'No save files tracked yet' when active slot has no files", () => {
+      const { container } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            defaultExpanded: true,
+            saveStatus: makeStatus({ files: [] }),
+          })}
+        />,
+      );
+      expect(container.textContent).toContain("No save files tracked yet");
+    });
+
+    it("forwards isOffline to VersionHistoryPanel for each file", () => {
+      const status = makeStatus({
+        files: [
+          {
+            filename: "a.srm",
+            local_path: "/data/a.srm",
+            local_hash: "h",
+            local_mtime: "2025-06-15T10:00:00Z",
+            local_size: 100,
+            server_save_id: 1,
+            server_file_name: null,
+            server_emulator: null,
+            server_updated_at: null,
+            server_size: null,
+            last_sync_at: null,
+            status: "synced",
+          },
+        ],
+      });
+      const { getByTestId } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            defaultExpanded: true,
+            saveStatus: status,
+            isOffline: true,
+          })}
+        />,
+      );
+      expect(getByTestId("vhp-a.srm").getAttribute("data-offline")).toBe("true");
+    });
+  });
+
+  describe("handleActivate", () => {
+    it("calls onSlotSwitched on a successful switch", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      const newStatus = makeStatus({ active_slot: "default" });
+      vi.mocked(backend.switchSlot).mockResolvedValue({
+        success: true,
+        save_status: newStatus,
+      } as SwitchSlotResponse);
+
+      const onSlotSwitched = vi.fn();
+      const { container, getByText } = render(
+        <SlotPanel {...defaultProps({ onSlotSwitched })} />,
+      );
+      fireEvent.click(container.querySelector("button")!); // expand
+      await flushAsync();
+      fireEvent.click(getByText("Activate Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(onSlotSwitched).toHaveBeenCalledTimes(1);
+      expect(onSlotSwitched).toHaveBeenCalledWith("default", newStatus);
+    });
+
+    it("shows the 'pending_uploads' error", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.switchSlot).mockResolvedValue({
+        success: false,
+        reason: "pending_uploads",
+      });
+
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Activate Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(container.textContent).toContain(
+        "Sync your saves first — local changes haven't been uploaded",
+      );
+    });
+
+    it("auto-clears the switchError after 5 seconds", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(backend.getSlotSaves).mockResolvedValue({
+          success: true,
+          slot: "default",
+          saves: [],
+        });
+        vi.mocked(backend.switchSlot).mockResolvedValue({
+          success: false,
+          reason: "pending_uploads",
+        });
+
+        const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+        fireEvent.click(container.querySelector("button")!);
+        await vi.advanceTimersByTimeAsync(0);
+        fireEvent.click(getByText("Activate Slot"));
+        // Flush the awaited switchSlot promise + the setSwitchError state
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(container.textContent).toContain(
+          "Sync your saves first — local changes haven't been uploaded",
+        );
+        // The 5s clear timer fires
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5001);
+        });
+        expect(container.textContent).not.toContain(
+          "Sync your saves first — local changes haven't been uploaded",
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("shows the 'server_unreachable' error", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.switchSlot).mockResolvedValue({
+        success: false,
+        reason: "server_unreachable",
+      });
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Activate Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(container.textContent).toContain("Can't switch — RomM server is not reachable");
+    });
+
+    it("shows the generic error on unknown reason", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.switchSlot).mockResolvedValue({
+        success: false,
+        reason: "sync_disabled",
+      });
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Activate Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(container.textContent).toContain("Failed to switch slot");
+    });
+
+    it("catches thrown errors and surfaces an error line", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.switchSlot).mockRejectedValue(new Error("boom"));
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Activate Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(container.textContent).toContain("An error occurred while switching slots");
+    });
+  });
+
+  describe("handleDelete", () => {
+    it("toasts the failure reason and skips the confirm modal when getSlotDeleteInfo returns !success", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
+        success: false,
+        reason: "active_slot",
+      } as SlotDeleteInfo);
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: "Cannot delete the active slot. Switch to a different slot first.",
+        }),
+      );
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+    });
+
+    it("opens the ConfirmModal with a server-delete message when source=server and saves > 0", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
+        success: true,
+        slot: "default",
+        source: "server",
+        server_save_count: 3,
+        local_file_count: 2,
+      } as SlotDeleteInfo);
+      vi.mocked(backend.deleteSlot).mockResolvedValue({
+        success: true,
+      } as DeleteSlotResult);
+
+      const onSlotDeleted = vi.fn();
+      const { container, getByText } = render(<SlotPanel {...defaultProps({ onSlotDeleted })} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+
+      expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
+      const modalProps = lastConfirmModalProps();
+      expect(modalProps).not.toBeNull();
+      expect(modalProps?.strTitle).toBe("Delete Slot");
+      expect(modalProps?.strDescription).toContain("3 saves from slot 'default'");
+      expect(modalProps?.strDescription).toContain("2 tracked files will be unlinked");
+      expect(modalProps?.strDescription).toContain("This cannot be undone.");
+
+      // Run the OK callback
+      await modalProps?.onOK?.();
+      await flushAsync();
+      expect(vi.mocked(backend.deleteSlot)).toHaveBeenCalledWith(1, "default");
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Slot 'default' deleted" }),
+      );
+      expect(onSlotDeleted).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses 'remove from local config' wording when source=local", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
+        success: true,
+        slot: "default",
+        source: "local",
+        server_save_count: 0,
+        local_file_count: 1,
+      } as SlotDeleteInfo);
+
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+      const modalProps = lastConfirmModalProps();
+      expect(modalProps?.strDescription).toContain(
+        "remove slot 'default' from your local configuration",
+      );
+      expect(modalProps?.strDescription).toContain("1 tracked file will be unlinked");
+    });
+
+    it("toasts the failure message when deleteSlot returns success=false", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
+        success: true,
+        slot: "default",
+        source: "local",
+      } as SlotDeleteInfo);
+      vi.mocked(backend.deleteSlot).mockResolvedValue({
+        success: false,
+        message: "couldn't reach server",
+      } as DeleteSlotResult);
+
+      const onSlotDeleted = vi.fn();
+      const { container, getByText } = render(<SlotPanel {...defaultProps({ onSlotDeleted })} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+
+      await lastConfirmModalProps()?.onOK?.();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "couldn't reach server" }),
+      );
+      expect(onSlotDeleted).not.toHaveBeenCalled();
+    });
+
+    it("toasts a generic message when deleteSlot throws", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockResolvedValue({
+        success: true,
+        slot: "default",
+        source: "local",
+      } as SlotDeleteInfo);
+      vi.mocked(backend.deleteSlot).mockRejectedValue(new Error("network"));
+
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+
+      await lastConfirmModalProps()?.onOK?.();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "An error occurred while deleting the slot" }),
+      );
+    });
+
+    it("toasts a generic 'Failed to load slot info' when getSlotDeleteInfo throws", async () => {
+      vi.mocked(backend.getSlotSaves).mockResolvedValue({
+        success: true,
+        slot: "default",
+        saves: [],
+      });
+      vi.mocked(backend.getSlotDeleteInfo).mockRejectedValue(new Error("network"));
+
+      const { container, getByText } = render(<SlotPanel {...defaultProps()} />);
+      fireEvent.click(container.querySelector("button")!);
+      await flushAsync();
+      fireEvent.click(getByText("Delete Slot"));
+      await flushAsync();
+      await flushAsync();
+
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Failed to load slot info" }),
+      );
+      expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("badges and summary line", () => {
+    it("renders the 'local' source badge for source=local", () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ slot: makeSummary({ source: "local" }) })} />,
+      );
+      const badge = container.querySelector(".romm-slot-badge-local");
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toBe("local");
+    });
+
+    it("renders the 'server' source badge for source=server", () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ slot: makeSummary({ source: "server" }) })} />,
+      );
+      const badge = container.querySelector(".romm-slot-badge-server");
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toBe("server");
+    });
+
+    it("shows the 'active' badge only when isActive is true", () => {
+      const { container, rerender } = render(<SlotPanel {...defaultProps()} />);
+      expect(container.querySelector(".romm-slot-badge-active")).toBeNull();
+      rerender(<SlotPanel {...defaultProps({ isActive: true, saveStatus: makeStatus() })} />);
+      expect(container.querySelector(".romm-slot-badge-active")).not.toBeNull();
+    });
+
+    it("shows the sync summary line only when active AND syncSummaryText is non-null", () => {
+      // Inactive: no summary line
+      const { container, rerender } = render(<SlotPanel {...defaultProps()} />);
+      expect(container.querySelector(".romm-slot-sync-summary")).toBeNull();
+      // Active with empty files: "No saves found" text appears
+      rerender(
+        <SlotPanel {...defaultProps({ isActive: true, saveStatus: makeStatus() })} />,
+      );
+      const summary = container.querySelector(".romm-slot-sync-summary");
+      expect(summary).not.toBeNull();
+      expect(summary?.textContent).toBe("No saves found");
+    });
+
+    it("renders the slot count using slot.count when inactive and no slot files loaded", () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ slot: makeSummary({ count: 5 }) })} />,
+      );
+      expect(container.textContent).toContain("5 saves");
+    });
+
+    it("uses singular 'save' wording for count === 1", () => {
+      const { container } = render(
+        <SlotPanel {...defaultProps({ slot: makeSummary({ count: 1 }) })} />,
+      );
+      expect(container.textContent).toContain("1 save");
+      expect(container.textContent).not.toContain("1 saves");
+    });
+  });
+
+  it("renders '(no slot)' for an empty slot name", () => {
+    const { container } = render(
+      <SlotPanel {...defaultProps({ slot: makeSummary({ slot: "" }) })} />,
+    );
+    expect(container.textContent).toContain("(no slot)");
+  });
+
+  it("loads and renders inactive slot files when expanded", async () => {
+    const files: SlotSaveFile[] = [
+      { id: 1, filename: "remote-a.srm", size: 1024, updated_at: "", emulator: "mgba" },
+    ];
+    vi.mocked(backend.getSlotSaves).mockResolvedValue({
+      success: true,
+      slot: "default",
+      saves: files,
+    });
+    const { container } = render(<SlotPanel {...defaultProps()} />);
+    fireEvent.click(container.querySelector("button")!);
+    await flushAsync();
+    expect(container.textContent).toContain("remote-a.srm");
+  });
+});

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -4,7 +4,7 @@
  * flows; the parent SavesTab handles slot creation and the offline banner.
  */
 
-import { useState, useRef, createElement, FC } from "react";
+import { useState, useRef, useEffect, createElement, FC } from "react";
 import { ConfirmModal, DialogButton, showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
 import { getSlotSaves, switchSlot, debugLog, getSlotDeleteInfo, deleteSlot } from "../../api/backend";
@@ -80,6 +80,12 @@ export const SlotPanel: FC<SlotPanelProps> = ({
   const [switchError, setSwitchError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const switchErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (switchErrorTimerRef.current) clearTimeout(switchErrorTimerRef.current);
+    };
+  }, []);
 
   const slotName = slot.slot;
 

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -1,0 +1,417 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { VersionHistoryPanel } from "./VersionHistoryPanel";
+import * as backend from "../../api/backend";
+import { toaster } from "@decky/api";
+import { showSyncConflictModal } from "../SyncConflictModal";
+import type { SaveVersionEntry, RollbackStatus } from "../../api/backend";
+
+// Override the global DialogButton stub so it forwards `disabled` and we can
+// assert it. The global stub only wires onClick.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+vi.mock("@decky/ui", () => ({
+  DialogButton: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled }, children as never),
+}));
+
+vi.mock("../SyncConflictModal", () => ({
+  showSyncConflictModal: vi.fn(),
+}));
+
+function makeVersion(overrides: Partial<SaveVersionEntry> = {}): SaveVersionEntry {
+  return {
+    id: 11,
+    file_name: "save-v1.srm",
+    emulator: "mgba",
+    updated_at: "2025-06-14T10:00:00Z",
+    file_size_bytes: 1024,
+    device_syncs: [
+      { device_id: "d1", device_name: "deck", is_current: true, last_synced_at: "2025-06-14T10:00:00Z" },
+    ],
+    uploaded_by_us: true,
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof VersionHistoryPanel>> = {}) {
+  return {
+    romId: 1,
+    slot: "default",
+    filename: "save.srm",
+    isOffline: false,
+    onRestored: vi.fn(),
+    ...overrides,
+  };
+}
+
+const flushAsync = () => new Promise((r) => setTimeout(r, 0));
+
+describe("VersionHistoryPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders collapsed by default with 'Previous Versions' label", () => {
+    const { container, getByText } = render(<VersionHistoryPanel {...defaultProps()} />);
+    expect(getByText("Previous Versions")).toBeInTheDocument();
+    // ▸ collapsed chevron
+    expect(container.textContent).toContain("▸");
+    expect(vi.mocked(backend.savesListFileVersions)).not.toHaveBeenCalled();
+  });
+
+  it("expands on first click and triggers savesListFileVersions exactly once", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [makeVersion({ id: 1 })],
+    });
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledWith(
+      1,
+      "default",
+      "save.srm",
+    );
+    // After load, list count appears in label
+    expect(container.textContent).toContain("Previous Versions (1)");
+    // ▾ expanded chevron
+    expect(container.textContent).toContain("▾");
+  });
+
+  it("does not refetch when toggled a second time after a successful load", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [makeVersion()],
+    });
+    const { container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    const button = container.querySelector("button");
+    if (!button) throw new Error("no toggle button");
+    fireEvent.click(button);
+    await flushAsync();
+    fireEvent.click(button); // collapse
+    fireEvent.click(button); // expand again
+    await flushAsync();
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the fetch when isOffline is true and shows offline body", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [],
+    });
+    const { getByText, container } = render(
+      <VersionHistoryPanel {...defaultProps({ isOffline: true })} />,
+    );
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(vi.mocked(backend.savesListFileVersions)).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Offline — versions unavailable");
+  });
+
+  it("shows a loading body while the fetch is in flight", async () => {
+    let resolveFetch: (v: { status: "ok"; versions: SaveVersionEntry[] }) => void = () => undefined;
+    vi.mocked(backend.savesListFileVersions).mockImplementation(
+      () => new Promise((res) => { resolveFetch = res; }),
+    );
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(container.textContent).toContain("Loading...");
+    resolveFetch({ status: "ok", versions: [] });
+    await flushAsync();
+  });
+
+  it("shows 'No older versions available' when the list is empty", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [],
+    });
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(container.textContent).toContain("No older versions available");
+  });
+
+  it("shows error body + Retry button when server is unreachable on load", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "server_unreachable",
+      error: "ECONNREFUSED",
+    });
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(container.textContent).toContain("Couldn't reach RomM. Tap retry.");
+    expect(getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("Retry button retriggers loadVersions", async () => {
+    vi.mocked(backend.savesListFileVersions)
+      .mockResolvedValueOnce({ status: "server_unreachable", error: "boom" })
+      .mockResolvedValueOnce({ status: "ok", versions: [makeVersion({ id: 7 })] });
+
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+
+    fireEvent.click(getByText("Retry"));
+    await flushAsync();
+    expect(vi.mocked(backend.savesListFileVersions)).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Previous Versions (1)");
+  });
+
+  it("shows error body when the fetch throws", async () => {
+    vi.mocked(backend.savesListFileVersions).mockRejectedValue(new Error("network"));
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(container.textContent).toContain("Couldn't reach RomM. Tap retry.");
+  });
+
+  it("renders version rows with #id · emulator · size and attribution", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [
+        makeVersion({
+          id: 42,
+          emulator: "mgba",
+          file_size_bytes: 2048,
+          file_name: "save-42.srm",
+          uploaded_by_us: true,
+          device_syncs: [
+            { device_id: "d1", device_name: "deck", is_current: true, last_synced_at: "2025-06-14T10:00:00Z" },
+          ],
+        }),
+      ],
+    });
+    const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+
+    expect(container.textContent).toContain("#42");
+    expect(container.textContent).toContain("mgba");
+    expect(container.textContent).toContain("2.0 KB");
+    expect(container.textContent).toContain("save-42.srm");
+    expect(container.textContent).toContain("deck (this device) ✓");
+    expect(getByText("Restore")).toBeInTheDocument();
+  });
+
+  it("disables Restore when offline", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [makeVersion()],
+    });
+    // Re-render with offline=false to load versions, then switch to offline.
+    // Simpler: load and then assert directly that with isOffline=true, the
+    // body is the offline notice, not the version list. So this test is
+    // covered by "skips fetch when offline". Here we cover the disabled
+    // flag in the restoring path:
+    const { getByText } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    expect(getByText("Restore")).not.toBeDisabled();
+  });
+
+  describe("handleRestore status branches", () => {
+    async function expand(props: Partial<React.ComponentProps<typeof VersionHistoryPanel>> = {}) {
+      vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+        status: "ok",
+        versions: [makeVersion({ id: 11 })],
+      });
+      const onRestored = vi.fn();
+      const utils = render(
+        <VersionHistoryPanel {...defaultProps({ ...props, onRestored })} />,
+      );
+      fireEvent.click(utils.getByText("Previous Versions"));
+      await flushAsync();
+      return { ...utils, onRestored };
+    }
+
+    it("status 'ok' toasts, calls onRestored, and collapses", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({ status: "ok" });
+      const { getByText, onRestored, container } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "RomM Sync", body: expect.stringContaining("Save restored") }),
+      );
+      expect(onRestored).toHaveBeenCalledTimes(1);
+      // Collapsed again — chevron is ▸
+      await waitFor(() => expect(container.textContent).toContain("▸"));
+    });
+
+    it("status 'conflict_blocked' opens the sync conflict modal with the first conflict", async () => {
+      const conflict = {
+        type: "sync_conflict" as const,
+        rom_id: 1,
+        filename: "save.srm",
+        server_save_id: 1,
+        server_updated_at: "2025-06-15T10:00:00Z",
+        server_size: 100,
+        local_path: null,
+        local_hash: null,
+        local_mtime: null,
+        local_size: null,
+        created_at: "2025-06-15T10:00:00Z",
+      };
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "conflict_blocked",
+        conflicts: [conflict],
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(showSyncConflictModal)).toHaveBeenCalledWith(conflict);
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Resolve the conflict, then try again" }),
+      );
+    });
+
+    it("status 'conflict_blocked' with empty conflicts skips the modal but still toasts", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "conflict_blocked",
+        conflicts: [],
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(showSyncConflictModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Resolve the conflict, then try again" }),
+      );
+    });
+
+    it("status 'preflight_failed' toasts the first error detail", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "preflight_failed",
+        errors: ["upload failed: timeout"],
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Sync failed before restore: upload failed: timeout" }),
+      );
+    });
+
+    it("status 'preflight_failed' with empty errors falls back to 'preflight error'", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "preflight_failed",
+        errors: [],
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Sync failed before restore: preflight error" }),
+      );
+    });
+
+    it("status 'put_failed' toasts the local-success warning, collapses, and calls onRestored", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "put_failed",
+        error: "503",
+      });
+      const { getByText, onRestored } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining("Restored locally") }),
+      );
+      expect(onRestored).toHaveBeenCalledTimes(1);
+    });
+
+    it("status 'rom_not_installed' toasts the reinstall prompt", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "rom_not_installed",
+      });
+      const { getByText, onRestored } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "ROM is no longer installed locally. Reinstall and try again." }),
+      );
+      expect(onRestored).not.toHaveBeenCalled();
+    });
+
+    it("status 'version_deleted' toasts the version-gone message", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "version_deleted",
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "This version no longer exists on the server" }),
+      );
+    });
+
+    it("status 'server_unreachable' toasts the connection-prompt message", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "server_unreachable",
+        error: "ECONNREFUSED",
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Couldn't reach RomM. Check your connection and try again." }),
+      );
+    });
+
+    it("status 'unsupported' toasts the version requirement", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
+        status: "unsupported",
+      });
+      const { getByText } = await expand();
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Version history requires RomM 4.7+" }),
+      );
+    });
+
+    it("swallows thrown errors from the rollback call (logged via debugLog, no toast)", async () => {
+      vi.mocked(backend.savesRollbackToVersion).mockRejectedValue(new Error("boom"));
+      const { getByText } = await expand();
+      const initialToasts = vi.mocked(toaster.toast).mock.calls.length;
+      fireEvent.click(getByText("Restore"));
+      await flushAsync();
+      await flushAsync();
+      // No new toaster call from the rollback path itself (debugLog only)
+      expect(vi.mocked(toaster.toast).mock.calls.length).toBe(initialToasts);
+    });
+  });
+
+  it("Restore button is disabled while a restore is in flight", async () => {
+    vi.mocked(backend.savesListFileVersions).mockResolvedValue({
+      status: "ok",
+      versions: [makeVersion()],
+    });
+    let resolveRestore: (v: RollbackStatus) => void = () => undefined;
+    vi.mocked(backend.savesRollbackToVersion).mockImplementation(
+      () => new Promise((res) => { resolveRestore = res; }),
+    );
+    const { getByText } = render(<VersionHistoryPanel {...defaultProps()} />);
+    fireEvent.click(getByText("Previous Versions"));
+    await flushAsync();
+    fireEvent.click(getByText("Restore"));
+    await flushAsync();
+    expect(getByText("Restoring...")).toBeDisabled();
+    resolveRestore({ status: "ok" });
+    await flushAsync();
+  });
+});

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -199,7 +199,7 @@ describe("VersionHistoryPanel", () => {
     expect(getByText("Restore")).toBeInTheDocument();
   });
 
-  it("disables Restore when offline", async () => {
+  it("Restore is enabled when not restoring and not offline", async () => {
     vi.mocked(backend.savesListFileVersions).mockResolvedValue({
       status: "ok",
       versions: [makeVersion()],


### PR DESCRIPTION
Closes #640.

## Summary

Adds Vitest + React Testing Library tests for all 6 components in `src/components/saves/`:

- `NewSlotModal.tsx` (8 tests) — controlled input, trim-on-submit, dismiss guard, optional `closeModal`
- `ServerSaveRow.tsx` (7 tests) — filename-only, size-only, size + relative-updated, null fields, unique keys
- `SaveFileRow.tsx` (28 tests) — `infoRow` null/empty guard, every status badge (`synced`/`upload`/`download`/`conflict`/`unknown`/missing), conflict banner via status OR conflict arg, attribution segments (this device / not this device), info rows skipped when value null, server save sub-block id-only / id+emulator / with filename
- `InactiveSlotBody.tsx` (19 tests) — every loading/null/empty/populated state, switching + deleting labels, disabled when switching/offline/deleting, click handlers, offline hint, switchError line
- `VersionHistoryPanel.tsx` (23 tests) — lazy-load once + cache on second toggle, offline skip, loading/empty/error bodies, Retry retriggers, every `RollbackStatus` branch (`ok`, `conflict_blocked` with + without first conflict, `preflight_failed` with + without errors, `put_failed`, `rom_not_installed`, `version_deleted`, `server_unreachable`, `unsupported`), Restore disabled while in flight
- `SlotPanel.tsx` (30 tests) — collapsed/expanded by default, getSlotSaves cached (no refetch), no fetch for active slot, active body renders SaveFileRow + VersionHistoryPanel per file with isOffline forwarded, every handleActivate reason (`pending_uploads`, `server_unreachable`, generic, throw), auto-clear timer (`vi.useFakeTimers`), full handleDelete flow (failure toast, success modal with onOK callback, source=server / source=local wording, deleteSlot failure + throw paths, getSlotDeleteInfo throw), source / active badges, sync summary line

Total: 115 new tests, all passing (full suite: 292 passed).

## Sonar exclusion

Removed `src/components/saves/*.tsx` from `sonar.coverage.exclusions` and its explanatory comment paragraph (keeping the unchanged `settings/*.tsx` and SettingsPage/RomMGameInfoPanel/etc. entries intact).

## Coverage (v8, from lcov)

| File | Lines | Branches |
|------|-------|----------|
| InactiveSlotBody.tsx | 14/14 (100%) | 20/20 (100%) |
| NewSlotModal.tsx | 5/5 (100%) | 0/0 (n/a) |
| SaveFileRow.tsx | 25/25 (100%) | 31/33 (94%) |
| ServerSaveRow.tsx | 4/4 (100%) | 6/6 (100%) |
| SlotPanel.tsx | 84/84 (100%) | 63/71 (89%) |
| VersionHistoryPanel.tsx | 82/82 (100%) | 56/63 (89%) |

All 6 files exceed the 80% line-coverage target on every measure.

## Test plan

- [x] `pnpm test` — 292 passed
- [x] `pnpm lint` — 0 errors (3 pre-existing warnings in unrelated files: `DownloadQueue.tsx`, `MainPage.tsx`, `SlotSetupWizard.tsx`)
- [x] `pnpm build` — rollup OK
- [x] `pnpm test:coverage` — all 6 files at 100% lines, >=88% branches