### PR TITLE
chore(test): retain pytest tmp_path only for failed tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 asyncio_mode = auto
 testpaths = tests
 addopts = --import-mode=importlib
+# Only retain tmp_path dirs for failed tests — default "all" leaks one tmpdir per
+# test per session, exhausting /tmp inodes during long-running agent test runs.
+tmp_path_retention_policy = failed


### PR DESCRIPTION
## Summary

- Set `tmp_path_retention_policy = failed` in `pytest.ini` so passing tests' `tmp_path` dirs are cleaned up immediately.
- Default policy is `all`, which keeps one tmpdir per test per session under `/tmp/pytest-of-<user>/` and exhausted `/tmp` inodes (~925k stale dirs) during background agent runs, hitting ENOSPC despite ~7G free.
- Failed tests still keep their tmpdir for post-mortem inspection (within the default 3-session retention count).

## Test plan

- [x] `python -m pytest tests/ -q` — 2506 passed
- [x] `ruff check py_modules/ main.py tests/` — All checks passed
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh` — OK
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken
- [x] `pnpm build` — OK
- [x] `pnpm test` — 177 passed
- [x] Verified `/tmp/pytest-of-deck/` is empty after a fully-passing run

Closes #695