### PR TITLE
feat(bootstrap): thread PluginMetadataReader through CallbackBundle

### DIFF
--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -76,6 +76,7 @@ from services.protocols import (
     MetadataCachePersister,
     MigrationFileAdapter,
     PathExistsProbe,
+    PluginMetadataReader,
     RetroArchSaveSortingProvider,
     RetroDeckPaths,
     RomFileAdapter,
@@ -175,6 +176,7 @@ class CallbackBundle:
     firmware_cache_persister: FirmwareCachePersister
     save_sync_state_persister: SaveSyncStatePersister
     log_debug: DebugLogger
+    plugin_metadata: PluginMetadataReader
 
 
 @dataclass(frozen=True)
@@ -322,6 +324,7 @@ def bootstrap(
     sleeper = AsyncioSleeper()
     hostname_provider = HostnameAdapter()
     debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
+    plugin_metadata = PluginMetadataAdapter()
     save_sync_state = SaveService.make_default_state()
 
     adapters = AdapterBundle(
@@ -357,6 +360,7 @@ def bootstrap(
         firmware_cache_persister=firmware_cache_persister,
         save_sync_state_persister=save_sync_state_persister,
         log_debug=debug_logger,
+        plugin_metadata=plugin_metadata,
     )
     runtime_adapters = RuntimeAdaptersBundle(
         clock=clock,
@@ -395,8 +399,6 @@ def wire_services(cfg: WiringConfig) -> dict:
     bios_files_index_binding: LateBinding[dict] = LateBinding("bios_files_index")
     pending_sync_binding: LateBinding[dict] = LateBinding("pending_sync")
 
-    plugin_metadata = PluginMetadataAdapter()
-
     # MigrationService is constructed before SaveService so that
     # save_sync_service can receive a bound reference to
     # ``migration_service.detect_save_sort_change``. SaveService must observe
@@ -433,7 +435,8 @@ def wire_services(cfg: WiringConfig) -> dict:
         hostname_provider=cfg.runtime.hostname_provider,
         log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
-        plugin_version=plugin_metadata.read_version(cfg.runtime.plugin_dir),
+        plugin_metadata=cfg.callbacks.plugin_metadata,
+        plugin_dir=cfg.runtime.plugin_dir,
         emit=cfg.runtime.emit,
         # SaveService must observe fresh sort state before computing saves_dir (#238).
         detect_sort_change=migration_service.detect_save_sort_change,

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         DebugLogger,
         EventEmitter,
         HostnameProvider,
+        PluginMetadataReader,
         RetroDeckPaths,
         RetryStrategy,
         RommSyncApi,
@@ -91,8 +92,13 @@ class SaveServiceConfig:
         resolution fails at runtime, SaveService warns and falls back
         to the parent directory path; see
         ``_resolve_retroarch_corename``.
-    plugin_version:
-        Plugin version string used in user-agent and emitted events.
+    plugin_metadata:
+        ``PluginMetadataReader`` Protocol seam — read once during
+        :meth:`SaveService.__init__` to resolve the declared plugin
+        version forwarded into user-agent strings and emitted events.
+    plugin_dir:
+        Plugin install directory (``decky.DECKY_PLUGIN_DIR``) passed to
+        :meth:`PluginMetadataReader.read_version`.
     emit:
         Optional event emitter for pushing save-sync progress to the
         frontend. ``None`` disables emission (used in unit tests).
@@ -134,7 +140,8 @@ class SaveServiceConfig:
     get_active_core: CoreResolverFn
     hostname_provider: HostnameProvider
     log_debug: DebugLogger
-    plugin_version: str
+    plugin_metadata: PluginMetadataReader
+    plugin_dir: str
     get_core_name: CoreNameProviderFn | None = None
     emit: EventEmitter | None = None
     detect_sort_change: Callable[[], None] | None = None

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -44,6 +44,9 @@ class SaveService:
         self._config = config
         self._state = config.state
         self._save_file = config.save_file
+        # Resolve plugin version once at construction; SyncEngine and any
+        # other consumer receive the resolved string, not the Protocol.
+        plugin_version = config.plugin_metadata.read_version(config.plugin_dir)
 
         self._state_svc = StateService(
             config=StateServiceConfig(
@@ -81,7 +84,7 @@ class SaveService:
                 log_debug=config.log_debug,
                 get_active_core=config.get_active_core,
                 hostname_provider=config.hostname_provider,
-                plugin_version=config.plugin_version,
+                plugin_version=plugin_version,
                 detect_sort_change=config.detect_sort_change,
                 is_retrodeck_migration_pending=config.is_retrodeck_migration_pending,
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,27 @@ class FakeSaveSyncStatePersister:
         return self.canned_load
 
 
+class FakePluginMetadataReader:
+    """In-memory ``PluginMetadataReader`` for tests.
+
+    Returns the version string configured at construction. Tests that
+    don't care about the value can rely on the ``"0.0.0"`` default —
+    matches the production adapter's fallback when ``package.json`` is
+    unreadable. ``read_version`` records the last ``plugin_dir`` it was
+    called with so tests can assert wiring.
+    """
+
+    def __init__(self, version: str = "0.0.0") -> None:
+        self.version = version
+        self.last_plugin_dir: str | None = None
+        self.read_count = 0
+
+    def read_version(self, plugin_dir: str) -> str:
+        self.last_plugin_dir = plugin_dir
+        self.read_count += 1
+        return self.version
+
+
 class FakeFirmwareCachePersister:
     """In-memory ``FirmwareCachePersister`` for tests.
 

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from conftest import FakeHostnameProvider, FakeRetroDeckPaths, _make_retry
+from conftest import FakeHostnameProvider, FakePluginMetadataReader, FakeRetroDeckPaths, _make_retry
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
 
@@ -53,7 +53,8 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         get_active_core=lambda system_name, rom_filename=None: (None, None),
         hostname_provider=FakeHostnameProvider(),
         log_debug=lambda _msg: None,
-        plugin_version="0.14.0",
+        plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
+        plugin_dir=str(tmp_path / "plugin"),
         emit=emit,
     )
     config_kwargs.update(overrides)

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
+from conftest import FakePluginMetadataReader
 from fakes.fake_save_api import FakeSaveApi
 
 from domain.save_state import FileSyncState, RomSaveState
@@ -1102,3 +1103,17 @@ class TestBadPathDeleteSavesPartialFailure:
         # The failing file remains in place; the successful one is gone.
         assert bad_path in fake.files
         assert good_path not in fake.files
+
+
+class TestPluginVersionResolution:
+    """SaveService.__init__ resolves the plugin version exactly once."""
+
+    def test_reads_plugin_version_once_with_injected_plugin_dir(self, tmp_path):
+        """One read at construction, scoped to the injected plugin_dir."""
+        fake_reader = FakePluginMetadataReader(version="0.14.0")
+        plugin_dir = str(tmp_path / "custom-plugin-dir")
+
+        make_service(tmp_path, plugin_metadata=fake_reader, plugin_dir=plugin_dir)
+
+        assert fake_reader.read_count == 1
+        assert fake_reader.last_plugin_dir == plugin_dir

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -10,6 +10,7 @@ from conftest import (
     FakeCoreInfoProvider,
     FakeFirmwareCachePersister,
     FakeHostnameProvider,
+    FakePluginMetadataReader,
     FakeRetroDeckPaths,
     _make_retry,
     _make_testable_plugin,
@@ -105,7 +106,8 @@ def plugin(tmp_path):
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
-            plugin_version="0.14.0",
+            plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
+            plugin_dir=str(tmp_path / "plugin"),
         ),
     )
     p._save_sync_service.init_state()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -24,6 +24,7 @@ from conftest import (
     FakeHostnameProvider,
     FakeMigrationFileAdapter,
     FakePathProbe,
+    FakePluginMetadataReader,
     FakeRetroDeckPaths,
     FakeRomFileAdapter,
     FakeSaveFileAdapter,
@@ -188,6 +189,7 @@ class TestWireServices:
             "core_info_provider": FakeCoreInfoProvider(),
             "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
             "log_debug": MagicMock(),
+            "plugin_metadata": FakePluginMetadataReader(version="0.14.0"),
         }
 
     @staticmethod
@@ -238,6 +240,7 @@ class TestWireServices:
                 firmware_cache_persister=deps["firmware_cache_persister"],
                 save_sync_state_persister=deps["save_sync_state_persister"],
                 log_debug=deps["log_debug"],
+                plugin_metadata=deps["plugin_metadata"],
             ),
             min_required_version=deps["min_required_version"],
         )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -917,6 +917,7 @@ class TestMainStartupOrdering:
                 firmware_cache_persister=MagicMock(),
                 save_sync_state_persister=MagicMock(),
                 log_debug=MagicMock(),
+                plugin_metadata=MagicMock(),
             ),
             runtime_adapters=RuntimeAdaptersBundle(
                 clock=MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock
 import pytest
 
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
-from conftest import FakeHostnameProvider, FakeRetroDeckPaths, _make_retry, _make_testable_plugin
+from conftest import (
+    FakeHostnameProvider,
+    FakePluginMetadataReader,
+    FakeRetroDeckPaths,
+    _make_retry,
+    _make_testable_plugin,
+)
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
@@ -101,7 +107,8 @@ def plugin(tmp_path):
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameProvider(),
             log_debug=p._log_debug,
-            plugin_version="0.14.0",
+            plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
+            plugin_dir=str(tmp_path / "plugin"),
         ),
     )
     p._save_sync_service.init_state()


### PR DESCRIPTION
## Summary

- `PluginMetadataReader` Protocol introduced in #606 was dead end-to-end — bootstrap constructed `PluginMetadataAdapter` inline in `wire_services`, unwrapped `read_version()` to `str` immediately, no service consumed the Protocol.
- Wire it the same way every other adapter Protocol flows: instantiate once in `bootstrap()`, hand to services via `CallbackBundle.plugin_metadata`.
- `SaveService.__init__` now owns the `read_version()` call against the injected Protocol; `SaveServiceConfig.plugin_version: str` is replaced with `plugin_metadata: PluginMetadataReader` + `plugin_dir: str`.
- Inline `PluginMetadataAdapter()` call dropped from `wire_services`.
- `FakePluginMetadataReader` added to `tests/conftest.py`; existing tests that passed `plugin_version="0.14.0"` now pass `plugin_metadata=FakePluginMetadataReader(version="0.14.0")` + `plugin_dir=...` — same intent, new injection path.

## Test plan

- [x] `python -m pytest tests/ -q` — 2506 passed
- [x] `ruff check py_modules/ main.py tests/`
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors / 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh`
- [x] `PYTHONPATH=py_modules lint-imports` — 7/7 contracts kept
- [x] `pnpm build`
- [x] `pnpm test` — 177 passed

Closes #683.