### PR TITLE
test(settings): add component tests for settings/*.tsx (#658)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,9 +30,6 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #   - src/test-utils/**: shared mock harnesses (e.g. @decky/api event bus),
 #     consumed only by tests
 # Temporary exclusions (remove as tests land per #616 Phase 2):
-#   - src/components/settings/*.tsx: relocated from SettingsPage.tsx in #615,
-#     awaiting focused component tests (Phase 2 follow-up). helpers.ts in the
-#     same folder is tested and stays in scope.
 #   - src/components/SettingsPage.tsx: orchestration shell after #615 decomp;
 #     handler wiring + section instantiation, no testable logic of its own
 #     (tracked alongside settings/ Phase 2 in #658).
@@ -43,7 +40,7 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #     had no tests. Same SettingsPage rationale; remove individually as
 #     focused component tests land (Phase 2 follow-up, tracked alongside
 #     #640/#658).
-sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/test-utils/**,src/components/settings/*.tsx,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
+sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/test-utils/**,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
 
 # Suppress false positives
 # S6926: "async without await" — Decky Loader callable framework requires all

--- a/src/components/settings/AdvancedSection.test.tsx
+++ b/src/components/settings/AdvancedSection.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { AdvancedSection } from "./AdvancedSection";
+
+// DropdownItem isn't in the global @decky/ui stub. Capture rgOptions +
+// selectedOption + onChange so we can drive the onChange callback and assert
+// the wiring without rendering a real Steam Dropdown.
+interface DropdownOption { data: unknown; label: string }
+interface DropdownItemProps {
+  label?: string;
+  rgOptions?: DropdownOption[];
+  selectedOption?: unknown;
+  onChange?: (option: DropdownOption) => void;
+}
+const captured: { items: DropdownItemProps[] } = { items: [] };
+
+vi.mock("@decky/ui", () => {
+  type AnyProps = Record<string, unknown> & { children?: unknown };
+  const passthrough = (tag: string) => (p: AnyProps) =>
+    createElement(tag, {}, p.children as never);
+  return {
+    PanelSection: passthrough("section"),
+    PanelSectionRow: passthrough("div"),
+    DropdownItem: (p: DropdownItemProps) => {
+      captured.items.push(p);
+      return createElement("div", { "data-testid": "dropdown" }, p.label as never);
+    },
+  };
+});
+
+describe("AdvancedSection", () => {
+  beforeEach(() => {
+    captured.items = [];
+  });
+
+  it("renders the log-level dropdown with the four canonical options", () => {
+    render(<AdvancedSection logLevel="info" onLogLevelChange={vi.fn()} />);
+    expect(captured.items).toHaveLength(1);
+    const item = captured.items[0];
+    expect(item?.label).toBe("Log Level");
+    expect(item?.rgOptions?.map((o) => o.data)).toEqual([
+      "error",
+      "warn",
+      "info",
+      "debug",
+    ]);
+  });
+
+  it("forwards the current logLevel as selectedOption", () => {
+    render(<AdvancedSection logLevel="debug" onLogLevelChange={vi.fn()} />);
+    expect(captured.items[0]?.selectedOption).toBe("debug");
+  });
+
+  it("dispatches onLogLevelChange with option.data when the dropdown fires", () => {
+    const onChange = vi.fn();
+    render(<AdvancedSection logLevel="info" onLogLevelChange={onChange} />);
+    captured.items[0]?.onChange?.({ data: "warn", label: "Warn" });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("warn");
+  });
+
+  it("passes string values straight through (no transformation)", () => {
+    const onChange = vi.fn();
+    render(<AdvancedSection logLevel="error" onLogLevelChange={onChange} />);
+    captured.items[0]?.onChange?.({ data: "error", label: "Error" });
+    expect(onChange).toHaveBeenCalledWith("error");
+  });
+});

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { ConnectionSection } from "./ConnectionSection";
+import { showModal } from "@decky/ui";
+
+// Local re-mock: ButtonItem must forward `disabled`; ToggleField must
+// forward `checked` + a usable onChange that mirrors the global stub's
+// (boolean) signature; Field renders both label + description so we can
+// assert masked-password / "(not set)" copy.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface ToggleFieldProps {
+  label?: unknown;
+  description?: unknown;
+  checked?: boolean;
+  onChange?: (value: boolean) => void;
+}
+const toggleCaptured: { items: ToggleFieldProps[] } = { items: [] };
+
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", {}, p.children as never),
+  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "field" },
+      createElement("span", { "data-testid": "field-label" }, p.label as never),
+      createElement("span", { "data-testid": "field-desc" }, p.description as never),
+      p.children as never,
+    ),
+  DialogButton: ({ children, onClick }: AnyProps & { onClick?: () => void }) =>
+    createElement("button", { onClick }, children as never),
+  ButtonItem: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled }, children as never),
+  ToggleField: (p: ToggleFieldProps) => {
+    toggleCaptured.items.push(p);
+    return createElement("input", {
+      type: "checkbox",
+      checked: p.checked ?? false,
+      "data-testid": "toggle",
+      onChange: (e: { target: { checked: boolean } }) => p.onChange?.(e.target.checked),
+    });
+  },
+  showModal: vi.fn(),
+}));
+
+interface TextInputProps {
+  label: string;
+  value: string;
+  field?: string;
+  bIsPassword?: boolean;
+  onSubmit: (value: string) => void;
+}
+
+function lastShownModalProps(): TextInputProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<TextInputProps> | undefined;
+  return el?.props ?? null;
+}
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof ConnectionSection>> = {}) {
+  return {
+    url: "",
+    username: "",
+    password: "",
+    allowInsecureSsl: false,
+    status: "",
+    loading: false,
+    onUrlSubmit: vi.fn(),
+    onUsernameSubmit: vi.fn(),
+    onPasswordSubmit: vi.fn(),
+    onAllowInsecureSslChange: vi.fn(),
+    onTestConnection: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ConnectionSection", () => {
+  beforeEach(() => {
+    toggleCaptured.items = [];
+    vi.clearAllMocks();
+  });
+
+  describe("URL field", () => {
+    it("shows '(not set)' description when url is empty", () => {
+      const { getAllByTestId } = render(<ConnectionSection {...defaultProps()} />);
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("(not set)");
+    });
+
+    it("shows the configured URL in the description", () => {
+      const { getAllByTestId } = render(
+        <ConnectionSection {...defaultProps({ url: "http://romm.local" })} />,
+      );
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("http://romm.local");
+    });
+
+    it("opens a TextInputModal with field='url' when Edit is clicked", () => {
+      const onUrlSubmit = vi.fn();
+      const { getAllByText } = render(
+        <ConnectionSection {...defaultProps({ url: "http://romm.local", onUrlSubmit })} />,
+      );
+      // Three Edit buttons (URL, username, password). URL is first.
+      fireEvent.click(getAllByText("Edit")[0]!);
+      const props = lastShownModalProps();
+      expect(props?.label).toBe("RomM URL");
+      expect(props?.value).toBe("http://romm.local");
+      expect(props?.field).toBe("url");
+      expect(props?.bIsPassword).toBeUndefined();
+      expect(props?.onSubmit).toBe(onUrlSubmit);
+    });
+  });
+
+  describe("username field", () => {
+    it("shows '(not set)' when username is empty", () => {
+      const { getAllByTestId } = render(<ConnectionSection {...defaultProps()} />);
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs.filter((d) => d === "(not set)").length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("shows the username when set", () => {
+      const { getAllByTestId } = render(
+        <ConnectionSection {...defaultProps({ username: "daniel" })} />,
+      );
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("daniel");
+    });
+
+    it("opens a TextInputModal with field='username' on Edit", () => {
+      const onUsernameSubmit = vi.fn();
+      const { getAllByText } = render(
+        <ConnectionSection {...defaultProps({ username: "daniel", onUsernameSubmit })} />,
+      );
+      fireEvent.click(getAllByText("Edit")[1]!);
+      const props = lastShownModalProps();
+      expect(props?.label).toBe("Username");
+      expect(props?.value).toBe("daniel");
+      expect(props?.field).toBe("username");
+      expect(props?.onSubmit).toBe(onUsernameSubmit);
+    });
+  });
+
+  describe("shared-account warning", () => {
+    it("is hidden for a personal username", () => {
+      const { container } = render(
+        <ConnectionSection {...defaultProps({ username: "daniel" })} />,
+      );
+      expect(container.textContent).not.toContain("Shared account detected");
+    });
+
+    it("renders for a known shared-account username", () => {
+      const { container } = render(
+        <ConnectionSection {...defaultProps({ username: "admin" })} />,
+      );
+      expect(container.textContent).toContain("Shared account detected");
+      expect(container.textContent).toContain('"admin"');
+    });
+  });
+
+  describe("password field", () => {
+    it("shows '(not set)' when password is empty", () => {
+      const { getAllByTestId } = render(<ConnectionSection {...defaultProps()} />);
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs.filter((d) => d === "(not set)").length).toBe(3);
+    });
+
+    it("shows '••••' when a password is set", () => {
+      const { getAllByTestId } = render(
+        <ConnectionSection {...defaultProps({ password: "stored" })} />,
+      );
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("••••");
+    });
+
+    it("opens a TextInputModal with field='password' and bIsPassword=true on Edit", () => {
+      const onPasswordSubmit = vi.fn();
+      const { getAllByText } = render(
+        <ConnectionSection {...defaultProps({ password: "stored", onPasswordSubmit })} />,
+      );
+      fireEvent.click(getAllByText("Edit")[2]!);
+      const props = lastShownModalProps();
+      expect(props?.label).toBe("Password");
+      expect(props?.value).toBe("");
+      expect(props?.field).toBe("password");
+      expect(props?.bIsPassword).toBe(true);
+      expect(props?.onSubmit).toBe(onPasswordSubmit);
+    });
+  });
+
+  describe("HTTPS SSL toggle", () => {
+    it("is hidden when url is http://...", () => {
+      render(<ConnectionSection {...defaultProps({ url: "http://romm.local" })} />);
+      expect(toggleCaptured.items).toHaveLength(0);
+    });
+
+    it("is hidden when url is empty", () => {
+      render(<ConnectionSection {...defaultProps()} />);
+      expect(toggleCaptured.items).toHaveLength(0);
+    });
+
+    it("is visible when url is https://...", () => {
+      render(<ConnectionSection {...defaultProps({ url: "https://romm.local" })} />);
+      expect(toggleCaptured.items).toHaveLength(1);
+      expect(toggleCaptured.items[0]?.label).toBe("Allow Insecure SSL");
+    });
+
+    it("treats case-insensitive https prefix", () => {
+      render(<ConnectionSection {...defaultProps({ url: "HTTPS://romm.local" })} />);
+      expect(toggleCaptured.items).toHaveLength(1);
+    });
+
+    it("reflects allowInsecureSsl in checked state", () => {
+      render(
+        <ConnectionSection
+          {...defaultProps({ url: "https://romm.local", allowInsecureSsl: true })}
+        />,
+      );
+      expect(toggleCaptured.items[0]?.checked).toBe(true);
+    });
+
+    it("dispatches onAllowInsecureSslChange when toggled", () => {
+      const onAllowInsecureSslChange = vi.fn();
+      render(
+        <ConnectionSection
+          {...defaultProps({ url: "https://romm.local", onAllowInsecureSslChange })}
+        />,
+      );
+      toggleCaptured.items[0]?.onChange?.(true);
+      expect(onAllowInsecureSslChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("Test Connection button", () => {
+    it("fires onTestConnection when clicked", () => {
+      const onTestConnection = vi.fn();
+      const { getByText } = render(
+        <ConnectionSection {...defaultProps({ onTestConnection })} />,
+      );
+      fireEvent.click(getByText("Test Connection"));
+      expect(onTestConnection).toHaveBeenCalledTimes(1);
+    });
+
+    it("is disabled while loading", () => {
+      const { getByText } = render(<ConnectionSection {...defaultProps({ loading: true })} />);
+      expect(getByText("Test Connection")).toBeDisabled();
+    });
+  });
+
+  describe("status row", () => {
+    it("renders the status Field when non-empty", () => {
+      const { getAllByTestId } = render(
+        <ConnectionSection {...defaultProps({ status: "Connected ✓" })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Connected ✓");
+    });
+
+    it("omits the status Field when empty", () => {
+      const { getAllByTestId } = render(<ConnectionSection {...defaultProps()} />);
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      // No status label among the field labels (3 base fields: URL, Username, Password).
+      expect(labels).toEqual(["RomM URL", "Username", "Password"]);
+    });
+  });
+});

--- a/src/components/settings/ControllerSection.test.tsx
+++ b/src/components/settings/ControllerSection.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { ControllerSection } from "./ControllerSection";
+import type { RetroArchInputCheck } from "../../types";
+
+// Local re-mock: ButtonItem must forward `disabled`, DropdownItem must
+// capture rgOptions + onChange so we can drive the dropdown without a real
+// Steam UI.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface DropdownOption { data: unknown; label: string }
+interface DropdownItemProps {
+  label?: string;
+  rgOptions?: DropdownOption[];
+  selectedOption?: unknown;
+  onChange?: (option: DropdownOption) => void;
+}
+const dropdownCaptured: { items: DropdownItemProps[] } = { items: [] };
+
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", {}, p.children as never),
+  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "field" },
+      createElement("span", { "data-testid": "field-label" }, p.label as never),
+      createElement("span", { "data-testid": "field-desc" }, p.description as never),
+    ),
+  ButtonItem: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled }, children as never),
+  DropdownItem: (p: DropdownItemProps) => {
+    dropdownCaptured.items.push(p);
+    return createElement("div", { "data-testid": "dropdown" }, p.label as never);
+  },
+}));
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof ControllerSection>> = {}) {
+  return {
+    steamInputMode: "default",
+    steamInputStatus: "",
+    retroarchWarning: null,
+    retroarchFixStatus: "",
+    loading: false,
+    onModeChange: vi.fn(),
+    onApplyMode: vi.fn(),
+    onFixInputDriver: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ControllerSection", () => {
+  beforeEach(() => {
+    dropdownCaptured.items = [];
+    vi.clearAllMocks();
+  });
+
+  describe("mode dropdown", () => {
+    it("renders the three Steam Input mode options", () => {
+      render(<ControllerSection {...defaultProps()} />);
+      expect(dropdownCaptured.items).toHaveLength(1);
+      const opts = dropdownCaptured.items[0]?.rgOptions ?? [];
+      expect(opts.map((o) => o.data)).toEqual(["default", "force_on", "force_off"]);
+    });
+
+    it("forwards steamInputMode as selectedOption", () => {
+      render(<ControllerSection {...defaultProps({ steamInputMode: "force_on" })} />);
+      expect(dropdownCaptured.items[0]?.selectedOption).toBe("force_on");
+    });
+
+    it("dispatches onModeChange with option.data on dropdown change", () => {
+      const onModeChange = vi.fn();
+      render(<ControllerSection {...defaultProps({ onModeChange })} />);
+      dropdownCaptured.items[0]?.onChange?.({ data: "force_off", label: "Force Off" });
+      expect(onModeChange).toHaveBeenCalledWith("force_off");
+    });
+  });
+
+  describe("apply button", () => {
+    it("fires onApplyMode when clicked", () => {
+      const onApplyMode = vi.fn();
+      const { getByText } = render(
+        <ControllerSection {...defaultProps({ onApplyMode })} />,
+      );
+      fireEvent.click(getByText("Apply to All Shortcuts"));
+      expect(onApplyMode).toHaveBeenCalledTimes(1);
+    });
+
+    it("is disabled while loading=true", () => {
+      const { getByText } = render(<ControllerSection {...defaultProps({ loading: true })} />);
+      expect(getByText("Apply to All Shortcuts")).toBeDisabled();
+    });
+
+    it("is enabled when loading=false", () => {
+      const { getByText } = render(<ControllerSection {...defaultProps()} />);
+      expect(getByText("Apply to All Shortcuts")).not.toBeDisabled();
+    });
+  });
+
+  describe("steamInputStatus field", () => {
+    it("renders the status Field when non-empty", () => {
+      const { getAllByTestId } = render(
+        <ControllerSection {...defaultProps({ steamInputStatus: "Applied to 12 shortcuts" })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Applied to 12 shortcuts");
+    });
+
+    it("omits the status Field when empty", () => {
+      const { queryAllByTestId } = render(<ControllerSection {...defaultProps()} />);
+      expect(queryAllByTestId("field")).toHaveLength(0);
+    });
+  });
+
+  describe("RetroArch warning block", () => {
+    function warning(overrides: Partial<RetroArchInputCheck> = {}): RetroArchInputCheck {
+      return {
+        warning: true,
+        current: "udev",
+        config_path: "/home/deck/.config/retroarch/retroarch.cfg",
+        ...overrides,
+      };
+    }
+
+    it("is hidden when retroarchWarning is null", () => {
+      const { container } = render(<ControllerSection {...defaultProps()} />);
+      expect(container.textContent).not.toContain("RetroArch input_driver");
+      expect(container.textContent).not.toContain("Fix input_driver");
+    });
+
+    it("is hidden when retroarchWarning.warning is false", () => {
+      const { container } = render(
+        <ControllerSection
+          {...defaultProps({ retroarchWarning: warning({ warning: false }) })}
+        />,
+      );
+      expect(container.textContent).not.toContain("RetroArch input_driver");
+    });
+
+    it("renders the current input_driver in the warning label", () => {
+      const { container } = render(
+        <ControllerSection
+          {...defaultProps({ retroarchWarning: warning({ current: "udev" }) })}
+        />,
+      );
+      expect(container.textContent).toContain('RetroArch input_driver: "udev"');
+    });
+
+    it("fires onFixInputDriver when the fix button is clicked", () => {
+      const onFixInputDriver = vi.fn();
+      const { getByText } = render(
+        <ControllerSection
+          {...defaultProps({ retroarchWarning: warning(), onFixInputDriver })}
+        />,
+      );
+      fireEvent.click(getByText("Fix input_driver to sdl2"));
+      expect(onFixInputDriver).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the fix-status Field when retroarchFixStatus is non-empty", () => {
+      const { getAllByTestId } = render(
+        <ControllerSection
+          {...defaultProps({
+            retroarchWarning: warning(),
+            retroarchFixStatus: "Updated retroarch.cfg",
+          })}
+        />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Updated retroarch.cfg");
+    });
+
+    it("omits the fix-status Field when retroarchFixStatus is empty", () => {
+      const { getAllByTestId } = render(
+        <ControllerSection {...defaultProps({ retroarchWarning: warning() })} />,
+      );
+      // Only the warning-label Field, no fix-status Field.
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toHaveLength(1);
+      expect(labels[0]).toContain("RetroArch input_driver");
+    });
+  });
+});

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { RegisteredDevicesSection } from "./RegisteredDevicesSection";
+import type { RegisteredDevice } from "../../api/backend";
+
+// Local re-mock: Field renders both label+description so we can assert the
+// pipe-separated parts string. PanelSection/PanelSectionRow are pass-through.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", { "data-testid": "row" }, p.children as never),
+  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "field" },
+      createElement("span", { "data-testid": "field-label" }, p.label as never),
+      createElement("span", { "data-testid": "field-desc" }, p.description as never),
+    ),
+}));
+
+function makeDevice(overrides: Partial<RegisteredDevice> = {}): RegisteredDevice {
+  return {
+    id: "d1abc12345678",
+    name: "Steam Deck",
+    platform: "linux",
+    client: "decky-romm-sync",
+    client_version: "0.17.1",
+    last_seen: "2025-06-15T11:55:00Z",
+    created_at: "2025-06-01T10:00:00Z",
+    is_current_device: false,
+    ...overrides,
+  };
+}
+
+function defaultProps(
+  overrides: Partial<React.ComponentProps<typeof RegisteredDevicesSection>> = {},
+) {
+  return {
+    devicesLoading: false,
+    devicesError: null,
+    registeredDevices: null,
+    ...overrides,
+  };
+}
+
+describe("RegisteredDevicesSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z"));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  describe("loading state", () => {
+    it("renders 'Loading...' when devicesLoading is true", () => {
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ devicesLoading: true })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Loading...");
+    });
+
+    it("hides loading even if devicesError is also set (loading takes precedence)", () => {
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ devicesLoading: true, devicesError: "boom" })}
+        />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Loading...");
+      expect(labels).not.toContain("Could not load devices");
+    });
+  });
+
+  describe("error state", () => {
+    it("renders 'Could not load devices' with the error in the description", () => {
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ devicesError: "Network unreachable" })}
+        />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(labels).toContain("Could not load devices");
+      expect(descs).toContain("Network unreachable");
+    });
+  });
+
+  describe("empty state", () => {
+    it("renders 'No devices registered' when the list is empty", () => {
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [] })}
+        />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("No devices registered");
+    });
+
+    it("renders nothing meaningful when registeredDevices is null and no loading/error", () => {
+      const { queryAllByTestId } = render(<RegisteredDevicesSection {...defaultProps()} />);
+      expect(queryAllByTestId("field")).toHaveLength(0);
+    });
+  });
+
+  describe("populated list", () => {
+    it("renders one row per device", () => {
+      const devices = [
+        makeDevice({ id: "device-aaaaaaaa", name: "Steam Deck" }),
+        makeDevice({ id: "device-bbbbbbbb", name: "Desktop" }),
+      ];
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />,
+      );
+      // 2 device rows; no loading/error/empty rows are rendered.
+      expect(getAllByTestId("field")).toHaveLength(2);
+    });
+
+    it("formats the description as 'client vX · platform · last seen Xm ago · ID 8chars'", () => {
+      const device = makeDevice({
+        id: "device-aaaaaaaa-rest-of-uuid",
+        client: "decky-romm-sync",
+        client_version: "0.17.1",
+        platform: "linux",
+        last_seen: "2025-06-15T11:55:00Z", // 5 minutes ago
+      });
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [device] })}
+        />,
+      );
+      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
+      expect(desc).toContain("decky-romm-sync v0.17.1");
+      expect(desc).toContain("linux");
+      expect(desc).toContain("last seen 5m ago");
+      expect(desc).toContain("ID device-a"); // first 8 chars of id
+    });
+
+    it("omits the platform segment when device.platform is null", () => {
+      const device = makeDevice({ platform: null });
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [device] })}
+        />,
+      );
+      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
+      // No "linux" or platform string — segments are: client, last seen, ID.
+      const segments = desc.split(" · ");
+      expect(segments).toHaveLength(3);
+    });
+
+    it("falls back to 'unknown client v?' when client/client_version are null", () => {
+      const device = makeDevice({ client: null, client_version: null });
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [device] })}
+        />,
+      );
+      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
+      expect(desc).toContain("unknown client v?");
+    });
+
+    it("renders '(unnamed)' when device.name is null", () => {
+      const device = makeDevice({ name: null });
+      const { container } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [device] })}
+        />,
+      );
+      expect(container.textContent).toContain("(unnamed)");
+    });
+
+    it("renders the '(this device)' badge only on the current device", () => {
+      const devices = [
+        makeDevice({ id: "device-aaaa1111", name: "Steam Deck", is_current_device: true }),
+        makeDevice({ id: "device-bbbb2222", name: "Desktop", is_current_device: false }),
+      ];
+      const { container } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />,
+      );
+      const matches = container.textContent?.match(/\(this device\)/g) ?? [];
+      expect(matches).toHaveLength(1);
+    });
+
+    it("renders 'ID —' when the id is empty string", () => {
+      const device = makeDevice({ id: "" });
+      const { getAllByTestId } = render(
+        <RegisteredDevicesSection
+          {...defaultProps({ registeredDevices: [device] })}
+        />,
+      );
+      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
+      expect(desc).toContain("ID —");
+    });
+  });
+});

--- a/src/components/settings/SaveSortMigrationSection.test.tsx
+++ b/src/components/settings/SaveSortMigrationSection.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { SaveSortMigrationSection } from "./SaveSortMigrationSection";
+import type { SaveSortMigrationStatus } from "../../api/backend";
+
+// Local re-mock: ButtonItem must forward `disabled` so we can assert the
+// disabled state while migrating.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", {}, p.children as never),
+  Field: (p: AnyProps & { label?: unknown }) =>
+    createElement("div", { "data-testid": "field" }, p.label as never),
+  ButtonItem: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled }, children as never),
+}));
+
+function makeMigration(overrides: Partial<SaveSortMigrationStatus> = {}): SaveSortMigrationStatus {
+  return {
+    pending: true,
+    old_settings: { sort_by_content: false, sort_by_core: false },
+    new_settings: { sort_by_content: true, sort_by_core: false },
+    saves_count: 12,
+    ...overrides,
+  };
+}
+
+function defaultProps(
+  overrides: Partial<React.ComponentProps<typeof SaveSortMigrationSection>> = {},
+) {
+  return {
+    migration: makeMigration(),
+    migrating: false,
+    result: "",
+    onMigrate: vi.fn(),
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("SaveSortMigrationSection", () => {
+  describe("banner content", () => {
+    it("renders the warning headline", () => {
+      const { container } = render(<SaveSortMigrationSection {...defaultProps()} />);
+      expect(container.textContent).toContain("RetroArch save sorting changed");
+    });
+
+    it("renders the 'From:' line when old_settings is present", () => {
+      const { container } = render(<SaveSortMigrationSection {...defaultProps()} />);
+      expect(container.textContent).toContain(
+        "From: Sort by content: OFF, Sort by core: OFF",
+      );
+    });
+
+    it("renders the 'To:' line when new_settings is present", () => {
+      const { container } = render(<SaveSortMigrationSection {...defaultProps()} />);
+      expect(container.textContent).toContain(
+        "To: Sort by content: ON, Sort by core: OFF",
+      );
+    });
+
+    it("omits the 'From:' line when old_settings is missing", () => {
+      const { container } = render(
+        <SaveSortMigrationSection
+          {...defaultProps({ migration: makeMigration({ old_settings: undefined }) })}
+        />,
+      );
+      expect(container.textContent).not.toContain("From:");
+    });
+
+    it("omits the 'To:' line when new_settings is missing", () => {
+      const { container } = render(
+        <SaveSortMigrationSection
+          {...defaultProps({ migration: makeMigration({ new_settings: undefined }) })}
+        />,
+      );
+      expect(container.textContent).not.toContain("To:");
+    });
+
+    it("renders the saves_count line", () => {
+      const { container } = render(
+        <SaveSortMigrationSection
+          {...defaultProps({ migration: makeMigration({ saves_count: 7 }) })}
+        />,
+      );
+      expect(container.textContent).toContain("7 save file(s) to migrate");
+    });
+
+    it("falls back to '0 save file(s) to migrate' when saves_count is missing", () => {
+      const { container } = render(
+        <SaveSortMigrationSection
+          {...defaultProps({ migration: makeMigration({ saves_count: undefined }) })}
+        />,
+      );
+      expect(container.textContent).toContain("0 save file(s) to migrate");
+    });
+  });
+
+  describe("buttons", () => {
+    it("calls onMigrate when 'Migrate Save Files' is clicked", () => {
+      const onMigrate = vi.fn();
+      const { getByText } = render(
+        <SaveSortMigrationSection {...defaultProps({ onMigrate })} />,
+      );
+      fireEvent.click(getByText("Migrate Save Files"));
+      expect(onMigrate).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onDismiss when 'Dismiss (I migrated manually)' is clicked", () => {
+      const onDismiss = vi.fn();
+      const { getByText } = render(
+        <SaveSortMigrationSection {...defaultProps({ onDismiss })} />,
+      );
+      fireEvent.click(getByText("Dismiss (I migrated manually)"));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders 'Migrating...' label and disables both buttons while migrating=true", () => {
+      const { getByText } = render(
+        <SaveSortMigrationSection {...defaultProps({ migrating: true })} />,
+      );
+      const migrateBtn = getByText("Migrating...");
+      const dismissBtn = getByText("Dismiss (I migrated manually)");
+      expect(migrateBtn).toBeDisabled();
+      expect(dismissBtn).toBeDisabled();
+    });
+
+    it("renders 'Migrate Save Files' label and enables both buttons when migrating=false", () => {
+      const { getByText } = render(<SaveSortMigrationSection {...defaultProps()} />);
+      const migrateBtn = getByText("Migrate Save Files");
+      const dismissBtn = getByText("Dismiss (I migrated manually)");
+      expect(migrateBtn).not.toBeDisabled();
+      expect(dismissBtn).not.toBeDisabled();
+    });
+  });
+
+  describe("result row", () => {
+    it("renders the result Field when result is non-empty", () => {
+      const { getAllByTestId } = render(
+        <SaveSortMigrationSection {...defaultProps({ result: "Migrated 12 files" })} />,
+      );
+      const labels = getAllByTestId("field").map((el) => el.textContent);
+      expect(labels).toContain("Migrated 12 files");
+    });
+
+    it("omits the result Field when result is empty", () => {
+      const { queryAllByTestId } = render(<SaveSortMigrationSection {...defaultProps()} />);
+      expect(queryAllByTestId("field")).toHaveLength(0);
+    });
+  });
+});

--- a/src/components/settings/SaveSyncSection.test.tsx
+++ b/src/components/settings/SaveSyncSection.test.tsx
@@ -386,8 +386,9 @@ describe("SaveSyncSection", () => {
     it("omits the status Field when empty", () => {
       const { getAllByTestId } = render(<SaveSyncSection {...defaultProps()} />);
       const labels = getAllByTestId("field-label").map((el) => el.textContent);
-      // No syncStatus label among the rendered fields.
-      expect(labels).not.toContain("Synced");
+      // Catches the regression where the `{syncStatus && ...}` guard is
+      // dropped and the Field renders with an empty label.
+      expect(labels.filter((l) => l === "")).toHaveLength(0);
     });
   });
 });

--- a/src/components/settings/SaveSyncSection.test.tsx
+++ b/src/components/settings/SaveSyncSection.test.tsx
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { SaveSyncSection } from "./SaveSyncSection";
+import { showModal } from "@decky/ui";
+import type { SaveSyncSettings } from "../../types";
+
+// Local re-mock: ButtonItem must forward `disabled`; ToggleField + DropdownItem
+// expose their props so we can drive their controlled behavior without a real
+// Steam UI; Field renders both label + description for assertions.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface ToggleFieldProps {
+  label?: unknown;
+  description?: unknown;
+  checked?: boolean;
+  onChange?: (value: boolean) => void;
+}
+interface DropdownOption { data: unknown; label: string }
+interface DropdownItemProps {
+  label?: string;
+  rgOptions?: DropdownOption[];
+  selectedOption?: unknown;
+  onChange?: (option: DropdownOption) => void;
+}
+const toggleCaptured: { items: ToggleFieldProps[] } = { items: [] };
+const dropdownCaptured: { items: DropdownItemProps[] } = { items: [] };
+
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", {}, p.children as never),
+  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "field" },
+      createElement("span", { "data-testid": "field-label" }, p.label as never),
+      createElement("span", { "data-testid": "field-desc" }, p.description as never),
+      p.children as never,
+    ),
+  DialogButton: ({ children, onClick }: AnyProps & { onClick?: () => void }) =>
+    createElement("button", { onClick }, children as never),
+  ButtonItem: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled }, children as never),
+  ToggleField: (p: ToggleFieldProps) => {
+    toggleCaptured.items.push(p);
+    return createElement("input", {
+      type: "checkbox",
+      checked: p.checked ?? false,
+      "data-testid": "toggle",
+      onChange: (e: { target: { checked: boolean } }) => p.onChange?.(e.target.checked),
+    });
+  },
+  DropdownItem: (p: DropdownItemProps) => {
+    dropdownCaptured.items.push(p);
+    return createElement("div", { "data-testid": "dropdown" }, p.label as never);
+  },
+  showModal: vi.fn(),
+}));
+
+interface TextInputProps {
+  label: string;
+  value: string;
+  onSubmit: (value: string) => void;
+}
+
+function lastShownModalProps(): TextInputProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<TextInputProps> | undefined;
+  return el?.props ?? null;
+}
+
+function makeSettings(overrides: Partial<SaveSyncSettings> = {}): SaveSyncSettings {
+  return {
+    save_sync_enabled: true,
+    sync_before_launch: false,
+    sync_after_exit: false,
+    default_slot: "default",
+    autocleanup_limit: 10,
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof SaveSyncSection>> = {}) {
+  return {
+    saveSyncSettings: makeSettings(),
+    saveSyncToggleKey: 0,
+    deviceInfo: null,
+    syncing: false,
+    syncStatus: "",
+    onToggleSaveSync: vi.fn(),
+    onSettingChange: vi.fn(),
+    onDefaultSlotSubmit: vi.fn(),
+    onResetDefaultSlot: vi.fn(),
+    onSyncAll: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("SaveSyncSection", () => {
+  beforeEach(() => {
+    toggleCaptured.items = [];
+    dropdownCaptured.items = [];
+    vi.clearAllMocks();
+  });
+
+  describe("loading state", () => {
+    it("renders 'Loading...' when saveSyncSettings is null", () => {
+      const { getAllByTestId } = render(
+        <SaveSyncSection {...defaultProps({ saveSyncSettings: null })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Loading...");
+      // No toggle when loading.
+      expect(toggleCaptured.items).toHaveLength(0);
+    });
+  });
+
+  describe("master toggle", () => {
+    it("renders the Enable Save Sync toggle reflecting saveSyncSettings.save_sync_enabled", () => {
+      render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ save_sync_enabled: false }) })}
+        />,
+      );
+      const masterToggle = toggleCaptured.items.find((t) => t.label === "Enable Save Sync");
+      expect(masterToggle?.checked).toBe(false);
+    });
+
+    it("dispatches onToggleSaveSync when toggled", () => {
+      const onToggleSaveSync = vi.fn();
+      render(<SaveSyncSection {...defaultProps({ onToggleSaveSync })} />);
+      const masterToggle = toggleCaptured.items.find((t) => t.label === "Enable Save Sync");
+      masterToggle?.onChange?.(true);
+      expect(onToggleSaveSync).toHaveBeenCalledWith(true);
+    });
+
+    it("renders the 'Save sync is disabled' field when disabled", () => {
+      const { getAllByTestId } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ save_sync_enabled: false }) })}
+        />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Save sync is disabled");
+    });
+
+    it("hides sub-controls when save_sync_enabled is false", () => {
+      render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ save_sync_enabled: false }) })}
+        />,
+      );
+      // Only the master toggle present.
+      expect(toggleCaptured.items).toHaveLength(1);
+      // No dropdown, no Sync All button.
+      expect(dropdownCaptured.items).toHaveLength(0);
+    });
+
+    it("treats save_sync_enabled defaulting to false when missing (?? false)", () => {
+      // Cast through Partial to drop the required field intentionally.
+      const partial = makeSettings();
+      delete (partial as { save_sync_enabled?: boolean }).save_sync_enabled;
+      render(<SaveSyncSection {...defaultProps({ saveSyncSettings: partial })} />);
+      const masterToggle = toggleCaptured.items.find((t) => t.label === "Enable Save Sync");
+      expect(masterToggle?.checked).toBe(false);
+    });
+  });
+
+  describe("device info field", () => {
+    it("is hidden when deviceInfo is null", () => {
+      const { container } = render(<SaveSyncSection {...defaultProps()} />);
+      expect(container.textContent).not.toContain("Registered as");
+    });
+
+    it("renders the device name when deviceInfo is provided", () => {
+      const { container } = render(
+        <SaveSyncSection
+          {...defaultProps({ deviceInfo: { device_id: "d1", device_name: "Steam Deck" } })}
+        />,
+      );
+      expect(container.textContent).toContain('Registered as "Steam Deck"');
+    });
+  });
+
+  describe("sync_before_launch / sync_after_exit toggles", () => {
+    it("reflect their values from saveSyncSettings", () => {
+      render(
+        <SaveSyncSection
+          {...defaultProps({
+            saveSyncSettings: makeSettings({
+              sync_before_launch: true,
+              sync_after_exit: false,
+            }),
+          })}
+        />,
+      );
+      const before = toggleCaptured.items.find((t) => t.label === "Sync before launch");
+      const after = toggleCaptured.items.find((t) => t.label === "Sync after exit");
+      expect(before?.checked).toBe(true);
+      expect(after?.checked).toBe(false);
+    });
+
+    it("dispatches partial settings on sync_before_launch change", () => {
+      const onSettingChange = vi.fn();
+      render(<SaveSyncSection {...defaultProps({ onSettingChange })} />);
+      const before = toggleCaptured.items.find((t) => t.label === "Sync before launch");
+      before?.onChange?.(true);
+      expect(onSettingChange).toHaveBeenCalledWith({ sync_before_launch: true });
+    });
+
+    it("dispatches partial settings on sync_after_exit change", () => {
+      const onSettingChange = vi.fn();
+      render(<SaveSyncSection {...defaultProps({ onSettingChange })} />);
+      const after = toggleCaptured.items.find((t) => t.label === "Sync after exit");
+      after?.onChange?.(true);
+      expect(onSettingChange).toHaveBeenCalledWith({ sync_after_exit: true });
+    });
+  });
+
+  describe("default slot field", () => {
+    it("shows the current default_slot value in the description", () => {
+      const { container } = render(
+        <SaveSyncSection
+          {...defaultProps({
+            saveSyncSettings: makeSettings({ default_slot: "speedrun" }),
+          })}
+        />,
+      );
+      expect(container.textContent).toContain("speedrun");
+    });
+
+    it("shows '(no slot)' when default_slot is empty", () => {
+      const { container } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: "" }) })}
+        />,
+      );
+      expect(container.textContent).toContain("(no slot)");
+    });
+
+    it("opens a TextInputModal on Edit with the current default_slot", () => {
+      const onDefaultSlotSubmit = vi.fn();
+      const { getByText } = render(
+        <SaveSyncSection
+          {...defaultProps({
+            saveSyncSettings: makeSettings({ default_slot: "main" }),
+            onDefaultSlotSubmit,
+          })}
+        />,
+      );
+      fireEvent.click(getByText("Edit"));
+      const props = lastShownModalProps();
+      expect(props?.label).toBe("Default Save Slot");
+      expect(props?.value).toBe("main");
+      expect(props?.onSubmit).toBe(onDefaultSlotSubmit);
+    });
+
+    it("passes an empty string to the modal when default_slot is null", () => {
+      const { getByText } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: null }) })}
+        />,
+      );
+      fireEvent.click(getByText("Edit"));
+      expect(lastShownModalProps()?.value).toBe("");
+    });
+  });
+
+  describe("Reset to default button", () => {
+    it("is hidden when default_slot === 'default'", () => {
+      const { container } = render(<SaveSyncSection {...defaultProps()} />);
+      expect(container.textContent).not.toContain("Reset to default");
+    });
+
+    it("is rendered and fires onResetDefaultSlot when default_slot differs", () => {
+      const onResetDefaultSlot = vi.fn();
+      const { getByText } = render(
+        <SaveSyncSection
+          {...defaultProps({
+            saveSyncSettings: makeSettings({ default_slot: "speedrun" }),
+            onResetDefaultSlot,
+          })}
+        />,
+      );
+      fireEvent.click(getByText("Reset to default"));
+      expect(onResetDefaultSlot).toHaveBeenCalledTimes(1);
+    });
+
+    it("is rendered when default_slot is null (null !== 'default')", () => {
+      const { getByText } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: null }) })}
+        />,
+      );
+      expect(getByText("Reset to default")).toBeInTheDocument();
+    });
+  });
+
+  describe("legacy-mode warning", () => {
+    it("is hidden for a normal slot like 'default'", () => {
+      const { container } = render(<SaveSyncSection {...defaultProps()} />);
+      expect(container.textContent).not.toContain("Legacy mode");
+    });
+
+    it("renders when default_slot is null", () => {
+      const { container } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: null }) })}
+        />,
+      );
+      expect(container.textContent).toContain("Legacy mode (no slot)");
+    });
+
+    it("renders when default_slot is the empty string", () => {
+      const { container } = render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ default_slot: "" }) })}
+        />,
+      );
+      expect(container.textContent).toContain("Legacy mode (no slot)");
+    });
+  });
+
+  describe("history limit dropdown", () => {
+    it("renders the four canonical limit options", () => {
+      render(<SaveSyncSection {...defaultProps()} />);
+      const dd = dropdownCaptured.items.find((d) => d.label === "Save History Limit");
+      expect(dd?.rgOptions?.map((o) => o.data)).toEqual([5, 10, 20, 50]);
+    });
+
+    it("reflects autocleanup_limit as selectedOption", () => {
+      render(
+        <SaveSyncSection
+          {...defaultProps({ saveSyncSettings: makeSettings({ autocleanup_limit: 20 }) })}
+        />,
+      );
+      const dd = dropdownCaptured.items.find((d) => d.label === "Save History Limit");
+      expect(dd?.selectedOption).toBe(20);
+    });
+
+    it("defaults selectedOption to 10 when autocleanup_limit is missing", () => {
+      const partial = makeSettings();
+      delete (partial as { autocleanup_limit?: number }).autocleanup_limit;
+      render(<SaveSyncSection {...defaultProps({ saveSyncSettings: partial })} />);
+      const dd = dropdownCaptured.items.find((d) => d.label === "Save History Limit");
+      expect(dd?.selectedOption).toBe(10);
+    });
+
+    it("dispatches partial settings with autocleanup_limit on change", () => {
+      const onSettingChange = vi.fn();
+      render(<SaveSyncSection {...defaultProps({ onSettingChange })} />);
+      const dd = dropdownCaptured.items.find((d) => d.label === "Save History Limit");
+      dd?.onChange?.({ data: 50, label: "50" });
+      expect(onSettingChange).toHaveBeenCalledWith({ autocleanup_limit: 50 });
+    });
+  });
+
+  describe("Sync All button", () => {
+    it("fires onSyncAll when clicked", () => {
+      const onSyncAll = vi.fn();
+      const { getByText } = render(<SaveSyncSection {...defaultProps({ onSyncAll })} />);
+      fireEvent.click(getByText("Sync All Saves Now"));
+      expect(onSyncAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders 'Syncing...' and is disabled while syncing=true", () => {
+      const { getByText } = render(<SaveSyncSection {...defaultProps({ syncing: true })} />);
+      const btn = getByText("Syncing...");
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  describe("syncStatus row", () => {
+    it("renders the status Field when non-empty", () => {
+      const { getAllByTestId } = render(
+        <SaveSyncSection {...defaultProps({ syncStatus: "Synced 3 files ✓" })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Synced 3 files ✓");
+    });
+
+    it("omits the status Field when empty", () => {
+      const { getAllByTestId } = render(<SaveSyncSection {...defaultProps()} />);
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      // No syncStatus label among the rendered fields.
+      expect(labels).not.toContain("Synced");
+    });
+  });
+});

--- a/src/components/settings/SteamGridDBSection.test.tsx
+++ b/src/components/settings/SteamGridDBSection.test.tsx
@@ -145,8 +145,8 @@ describe("SteamGridDBSection", () => {
 
     it("omits the status row when sgdbStatus is empty", () => {
       const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps()} />);
-      // Only 2 Fields when no status row: API Key + (no status). Confirm no
-      // accidental status leak.
+      // Only the "API Key" Field renders when sgdbStatus is empty (Verify is
+      // a ButtonItem, not a Field). Confirm no accidental empty-label leak.
       const labels = getAllByTestId("field-label").map((el) => el.textContent);
       expect(labels.filter((l) => l === "")).toHaveLength(0);
     });

--- a/src/components/settings/SteamGridDBSection.test.tsx
+++ b/src/components/settings/SteamGridDBSection.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement, type ReactElement } from "react";
+import { SteamGridDBSection } from "./SteamGridDBSection";
+import { showModal } from "@decky/ui";
+
+// Local re-mock — we need:
+//  - DialogButton to forward `disabled` so we can assert the Verify state.
+//  - ButtonItem to forward `onClick` + `disabled` (not in global stub).
+//  - Field to render the `description` text so masked-key vs. "Not configured"
+//    can be asserted via container.textContent.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+vi.mock("@decky/ui", () => ({
+  PanelSection: (p: AnyProps) =>
+    createElement("section", {}, p.children as never),
+  PanelSectionRow: (p: AnyProps) =>
+    createElement("div", {}, p.children as never),
+  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "field" },
+      createElement("span", { "data-testid": "field-label" }, p.label as never),
+      createElement("span", { "data-testid": "field-desc" }, p.description as never),
+      p.children as never,
+    ),
+  DialogButton: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled, "data-role": "dialog" }, children as never),
+  ButtonItem: ({ children, onClick, disabled }: AnyProps & {
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => createElement("button", { onClick, disabled, "data-role": "item" }, children as never),
+  showModal: vi.fn(),
+}));
+
+interface TextInputProps {
+  label: string;
+  value: string;
+  bIsPassword?: boolean;
+  onSubmit: (value: string) => void;
+}
+
+function lastShownModalProps(): TextInputProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<TextInputProps> | undefined;
+  return el?.props ?? null;
+}
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof SteamGridDBSection>> = {}) {
+  return {
+    sgdbApiKey: "",
+    sgdbStatus: "",
+    sgdbVerifying: false,
+    onSubmitKey: vi.fn(),
+    onVerifyKey: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("SteamGridDBSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("api key field", () => {
+    it("renders masked '••••' description when a key is set", () => {
+      const { getAllByTestId } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />,
+      );
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("••••");
+    });
+
+    it("renders 'Not configured' description when the key is empty", () => {
+      const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps()} />);
+      const descs = getAllByTestId("field-desc").map((el) => el.textContent);
+      expect(descs).toContain("Not configured");
+    });
+
+    it("opens a TextInputModal when Edit is clicked, prefilled empty and password-typed", () => {
+      const onSubmitKey = vi.fn();
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", onSubmitKey })} />,
+      );
+      fireEvent.click(getByText("Edit"));
+      const props = lastShownModalProps();
+      expect(props).not.toBeNull();
+      expect(props?.label).toBe("SteamGridDB API Key");
+      expect(props?.value).toBe("");
+      expect(props?.bIsPassword).toBe(true);
+      expect(props?.onSubmit).toBe(onSubmitKey);
+    });
+  });
+
+  describe("verify button", () => {
+    it("is disabled while verifying", () => {
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", sgdbVerifying: true })} />,
+      );
+      const btn = getByText("Verifying...");
+      expect(btn).toBeDisabled();
+    });
+
+    it("is disabled when no key is configured (even if not verifying)", () => {
+      const { getByText } = render(<SteamGridDBSection {...defaultProps()} />);
+      const btn = getByText("Verify Key");
+      expect(btn).toBeDisabled();
+    });
+
+    it("is enabled when a key is set and not verifying", () => {
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored" })} />,
+      );
+      const btn = getByText("Verify Key");
+      expect(btn).not.toBeDisabled();
+    });
+
+    it("fires onVerifyKey when clicked", () => {
+      const onVerifyKey = vi.fn();
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", onVerifyKey })} />,
+      );
+      fireEvent.click(getByText("Verify Key"));
+      expect(onVerifyKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders 'Verifying...' label while sgdbVerifying is true", () => {
+      const { getByText } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbApiKey: "stored", sgdbVerifying: true })} />,
+      );
+      expect(getByText("Verifying...")).toBeInTheDocument();
+    });
+  });
+
+  describe("status row", () => {
+    it("renders a status Field when sgdbStatus is non-empty", () => {
+      const { getAllByTestId } = render(
+        <SteamGridDBSection {...defaultProps({ sgdbStatus: "Valid key ✓" })} />,
+      );
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels).toContain("Valid key ✓");
+    });
+
+    it("omits the status row when sgdbStatus is empty", () => {
+      const { getAllByTestId } = render(<SteamGridDBSection {...defaultProps()} />);
+      // Only 2 Fields when no status row: API Key + (no status). Confirm no
+      // accidental status leak.
+      const labels = getAllByTestId("field-label").map((el) => el.textContent);
+      expect(labels.filter((l) => l === "")).toHaveLength(0);
+    });
+  });
+});

--- a/src/components/settings/TextInputModal.test.tsx
+++ b/src/components/settings/TextInputModal.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { TextInputModal, pendingEdits } from "./TextInputModal";
+
+// Override the global @decky/ui stub: capture ConfirmModal props (onOK,
+// bDisableBackgroundDismiss, closeModal, strTitle) — the global passthrough
+// <div> drops them. Mirrors the NewSlotModal test pattern.
+type AnyProps = Record<string, unknown> & { children?: unknown };
+interface CapturedConfirm {
+  onOK?: () => void;
+  bDisableBackgroundDismiss?: boolean;
+  closeModal?: unknown;
+  strTitle?: string;
+}
+const captured: CapturedConfirm & { textFieldPassword?: boolean } = {};
+
+vi.mock("@decky/ui", () => ({
+  ConfirmModal: (p: AnyProps & CapturedConfirm) => {
+    captured.onOK = p.onOK;
+    captured.bDisableBackgroundDismiss = p.bDisableBackgroundDismiss;
+    captured.closeModal = p.closeModal;
+    captured.strTitle = p.strTitle;
+    return createElement("div", { "data-testid": "confirm-modal" }, p.children as never);
+  },
+  TextField: (p: AnyProps & {
+    value?: string;
+    bIsPassword?: boolean;
+    onChange?: (e: { target: { value: string } }) => void;
+  }) => {
+    captured.textFieldPassword = p.bIsPassword;
+    return createElement("input", {
+      value: p.value ?? "",
+      type: p.bIsPassword ? "password" : "text",
+      onChange: (e: unknown) => p.onChange?.(e as { target: { value: string } }),
+    });
+  },
+}));
+
+function reset() {
+  for (const k of Object.keys(captured) as Array<keyof typeof captured>) {
+    delete captured[k];
+  }
+  delete pendingEdits.url;
+  delete pendingEdits.username;
+  delete pendingEdits.password;
+}
+
+describe("TextInputModal", () => {
+  beforeEach(reset);
+
+  it("renders the ConfirmModal with the provided label as title", () => {
+    render(<TextInputModal label="RomM URL" value="" onSubmit={vi.fn()} />);
+    expect(captured.strTitle).toBe("RomM URL");
+  });
+
+  it("disables background dismiss", () => {
+    render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+    expect(captured.bDisableBackgroundDismiss).toBe(true);
+  });
+
+  it("seeds the input with the initial value", () => {
+    render(<TextInputModal label="x" value="http://romm.local" onSubmit={vi.fn()} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("http://romm.local");
+  });
+
+  it("updates the input value when the user types", () => {
+    render(<TextInputModal label="x" value="old" onSubmit={vi.fn()} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "new" } });
+    expect(input.value).toBe("new");
+  });
+
+  it("invokes onSubmit with the current value when OK is pressed", () => {
+    const onSubmit = vi.fn();
+    render(<TextInputModal label="x" value="initial" onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "edited" } });
+    captured.onOK?.();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("edited");
+  });
+
+  it("does NOT trim — submits whitespace as-is (parent is responsible)", () => {
+    const onSubmit = vi.fn();
+    render(<TextInputModal label="x" value="" onSubmit={onSubmit} />);
+    const input = document.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "  spaced  " } });
+    captured.onOK?.();
+    expect(onSubmit).toHaveBeenCalledWith("  spaced  ");
+  });
+
+  it("forwards bIsPassword=true to the TextField as a password input", () => {
+    render(<TextInputModal label="Password" value="" bIsPassword onSubmit={vi.fn()} />);
+    expect(captured.textFieldPassword).toBe(true);
+    const input = document.querySelector("input");
+    expect(input?.getAttribute("type")).toBe("password");
+  });
+
+  it("renders a non-password TextField when bIsPassword is omitted", () => {
+    render(<TextInputModal label="URL" value="" onSubmit={vi.fn()} />);
+    expect(captured.textFieldPassword).toBeUndefined();
+    const input = document.querySelector("input");
+    expect(input?.getAttribute("type")).toBe("text");
+  });
+
+  it("forwards closeModal to ConfirmModal", () => {
+    const closeModal = vi.fn();
+    render(<TextInputModal label="x" value="" closeModal={closeModal} onSubmit={vi.fn()} />);
+    expect(captured.closeModal).toBe(closeModal);
+  });
+
+  it("works without closeModal", () => {
+    render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+    expect(captured.closeModal).toBeUndefined();
+  });
+
+  describe("pendingEdits persistence", () => {
+    it("writes the current value to pendingEdits[field] when field='url'", () => {
+      render(<TextInputModal label="URL" value="" field="url" onSubmit={vi.fn()} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "http://romm.local" } });
+      captured.onOK?.();
+      expect(pendingEdits.url).toBe("http://romm.local");
+      expect(pendingEdits.username).toBeUndefined();
+      expect(pendingEdits.password).toBeUndefined();
+    });
+
+    it("writes pendingEdits.username when field='username'", () => {
+      render(<TextInputModal label="User" value="" field="username" onSubmit={vi.fn()} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "daniel" } });
+      captured.onOK?.();
+      expect(pendingEdits.username).toBe("daniel");
+    });
+
+    it("writes pendingEdits.password when field='password'", () => {
+      render(
+        <TextInputModal label="Pwd" value="" field="password" bIsPassword onSubmit={vi.fn()} />,
+      );
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "s3cret" } });
+      captured.onOK?.();
+      expect(pendingEdits.password).toBe("s3cret");
+    });
+
+    it("does NOT touch pendingEdits when field is omitted", () => {
+      render(<TextInputModal label="x" value="" onSubmit={vi.fn()} />);
+      const input = document.querySelector("input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "nope" } });
+      captured.onOK?.();
+      expect(pendingEdits.url).toBeUndefined();
+      expect(pendingEdits.username).toBeUndefined();
+      expect(pendingEdits.password).toBeUndefined();
+    });
+
+    it("still calls onSubmit when field is set (pendingEdits write does not short-circuit)", () => {
+      const onSubmit = vi.fn();
+      render(<TextInputModal label="x" value="" field="url" onSubmit={onSubmit} />);
+      captured.onOK?.();
+      expect(onSubmit).toHaveBeenCalledWith("");
+    });
+  });
+});


### PR DESCRIPTION
Closes #658

## Summary

Phase 2 component tests for the 8 `.tsx` files in `src/components/settings/`. Mirrors the saves vertical landed in #696. Frontend tests only — no source `.tsx` changes.

## Components covered

| Component | New tests | Lines | Branches |
|---|---|---|---|
| `AdvancedSection.tsx` | 4 | 100% | 100% (no branches) |
| `TextInputModal.tsx` | 15 | 100% | 100% |
| `SteamGridDBSection.tsx` | 10 | 100% | 100% |
| `RegisteredDevicesSection.tsx` | 12 | 100% | 96.66% |
| `SaveSortMigrationSection.tsx` | 13 | 100% | 100% |
| `ControllerSection.tsx` | 14 | 100% | 100% |
| `ConnectionSection.tsx` | 21 | 100% | 100% |
| `SaveSyncSection.tsx` | 29 | 100% | 100% |

Coverage parsed from `coverage/lcov.info` (v8 provider, branch coverage enabled). Total suite: 410 tests (was 292), 25 files (was 17). All green locally.

## sonar-project.properties

- Removed `src/components/settings/*.tsx` from `sonar.coverage.exclusions`.
- Removed the now-stale temp-exclusion paragraph for it. Other temp exclusions (SettingsPage, RomMGameInfoPanel, RomMPlaySection, DangerZone, SavesTab, SlotSetupWizard) left intact.

## Test patterns reused

- `lastShownModalProps()` helper (from `SlotPanel.test.tsx`) for asserting `showModal(<X ... />)` props by reading `mock.calls.at(-1)[0].props`.
- `captured` capture object (from `NewSlotModal.test.tsx`) for pulling `ConfirmModal.onOK`/`bDisableBackgroundDismiss`/`closeModal` off the mock.
- Local `vi.mock("@decky/ui", ...)` re-mocks in every file. Reason: the global stub in `test-setup.ts` only knows the components the saves vertical needed (`ConfirmModal`, `DialogButton`, `TextField`, `ToggleField`, `Dropdown`, `showModal`, etc.). Settings components additionally use `PanelSection`, `PanelSectionRow`, `Field`, `ButtonItem`, `DropdownItem`, and need `disabled` forwarding on `DialogButton`/`ButtonItem` + a way to capture `DropdownItem.rgOptions`/`onChange`. Each test file overrides the global mock with what it needs, scoped to that file.

## Test plan

- [x] `pnpm test` — 410 pass (was 292)
- [x] `pnpm test:coverage` — 100% lines on all 8 source files
- [x] `pnpm lint` — 0 new errors/warnings (3 pre-existing warnings in `DownloadQueue.tsx`, `MainPage.tsx`, `SlotSetupWizard.tsx` unchanged)
- [x] `pnpm build` — clean