### PR TITLE
feat(test): add @decky/api event-listener mock harness for component tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,23 @@ Every backend feature or callable where testing makes sense MUST have unit tests
 
 Tests mirror the source structure: `tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`. Each test file maps 1:1 to a source module. Shared mocks live in `tests/conftest.py`.
 
+### Frontend component tests — `@decky/api` event harness
+
+`src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route through (wired in `src/test-setup.ts`). Tests dispatch backend events via `emitDeckyEvent` instead of mocking `@decky/api` per-file. `src/components/CustomPlayButton.test.tsx` is the reference shape:
+
+```tsx
+import { emitDeckyEvent } from "../test-utils/decky-api-mock";
+
+act(() => {
+  emitDeckyEvent<[DownloadFailedEvent]>("download_failed", { rom_id: 42, ... });
+});
+await findByText("Download"); // assert visible side effect
+```
+
+The bus is reset between tests by `afterEach` in `test-setup.ts`. Use `deckyEventListenerCount(name)` to assert that `useEffect` cleanup ran on unmount. DOM-level `globalThis.dispatchEvent(new CustomEvent(...))` flows (e.g. `romm_data_changed`) bypass the harness — happy-dom handles them natively.
+
+Prefer the harness over extracting listener bodies into `src/utils/*.ts` purely for testability. Helper extraction stays valid for genuinely-reusable logic.
+
 ## Security
 
 - NEVER read or use credentials from settings files (`~/homebrew/settings/`) without explicit user permission

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ export default tseslint.config(
   {
     // Vitest globals (describe/it/expect/vi/...) are injected at runtime via
     // vitest.config.ts `globals: true` + tsconfig "types": ["vitest/globals"].
-    files: ["src/**/*.{test,spec}.{ts,tsx}", "src/test-setup.ts"],
+    files: ["src/**/*.{test,spec}.{ts,tsx}", "src/test-setup.ts", "src/test-utils/**/*.ts"],
     languageOptions: {
       globals: { ...globals.vitest },
     },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,6 +27,8 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #   - src/index.tsx: thin plugin-entry shim wired via decky-loader
 #   - *.config.{js,ts}: build/test/lint config files (rollup, vitest, eslint, size-limit)
 #   - src/test-setup.ts: Vitest setup file, mocks only
+#   - src/test-utils/**: shared mock harnesses (e.g. @decky/api event bus),
+#     consumed only by tests
 # Temporary exclusions (remove as tests land per #616 Phase 2):
 #   - src/components/settings/*.tsx: relocated from SettingsPage.tsx in #615,
 #     awaiting focused component tests (Phase 2 follow-up). helpers.ts in the
@@ -41,7 +43,7 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/defaults/**,**/bin/**,**/__pyc
 #     had no tests. Same SettingsPage rationale; remove individually as
 #     focused component tests land (Phase 2 follow-up, tracked alongside
 #     #640/#658).
-sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/components/settings/*.tsx,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
+sonar.coverage.exclusions=**/tests/**,**/conftest.py,src/patches/**,src/types/**,src/index.tsx,src/utils/styleInjector.ts,src/utils/steamShortcuts.ts,*.config.js,*.config.ts,src/test-setup.ts,src/test-utils/**,src/components/settings/*.tsx,src/components/SettingsPage.tsx,src/components/RomMGameInfoPanel.tsx,src/components/RomMPlaySection.tsx,src/components/DangerZone.tsx,src/components/SavesTab.tsx,src/components/SlotSetupWizard.tsx,py_modules/vdf/**
 
 # Suppress false positives
 # S6926: "async without await" — Decky Loader callable framework requires all

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Reference test for the `src/test-utils/decky-api-mock.ts` event-bus harness.
+ *
+ * Exercises CustomPlayButton's per-button `download_failed` listener — the
+ * exact case #654 was opened to unblock. The test:
+ *
+ * 1. Mocks `getCachedGameDetail` so the button reaches `state === "play"`.
+ * 2. Dispatches a `download_failed` event matching the button's `romId` via
+ *    `emitDeckyEvent` from the harness.
+ * 3. Asserts the button transitioned back to "Download" — the visible
+ *    side-effect of `handleButtonDownloadFailure(...) -> reset()`.
+ *
+ * Future component tests that consume `@decky/api` events should follow this
+ * shape. The bus is reset between tests by `src/test-setup.ts`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, waitFor, act } from "@testing-library/react";
+import { CustomPlayButton } from "./CustomPlayButton";
+import {
+  emitDeckyEvent,
+  deckyEventListenerCount,
+} from "../test-utils/decky-api-mock";
+import type { CachedGameDetail } from "../api/backend";
+import type { DownloadFailedEvent } from "../types";
+
+// Stub the cached-detail store: synchronous Promise.resolve so the initial
+// useEffect settles within a single waitFor tick. The default test-setup
+// `callable()` stub would otherwise leave the button stuck in "loading".
+vi.mock("../utils/cachedGameDetailStore", () => ({
+  getCachedGameDetail: vi.fn<(appId: number) => Promise<CachedGameDetail>>(),
+  invalidateCachedGameDetail: vi.fn(),
+}));
+
+// Connection state defaults to "connected" — the offline branch is exercised
+// elsewhere; here we want the simplest path into the "play"/"download" render.
+vi.mock("../utils/connectionState", () => ({
+  getRommConnectionState: () => "connected",
+}));
+
+import { getCachedGameDetail } from "../utils/cachedGameDetailStore";
+
+function mockCachedDetail(overrides: Partial<CachedGameDetail> = {}): void {
+  vi.mocked(getCachedGameDetail).mockResolvedValue({
+    found: true,
+    rom_id: 42,
+    rom_name: "Test ROM",
+    installed: true,
+    ...overrides,
+  });
+}
+
+describe("CustomPlayButton — download_failed listener", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+  });
+
+  it("registers a download_failed listener on mount", async () => {
+    mockCachedDetail();
+    expect(deckyEventListenerCount("download_failed")).toBe(0);
+
+    render(<CustomPlayButton appId={100} />);
+
+    await waitFor(() => {
+      expect(deckyEventListenerCount("download_failed")).toBe(1);
+    });
+  });
+
+  it("transitions back to Download when a matching download_failed event arrives", async () => {
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+
+    // Initial state lands on "play" once getCachedGameDetail resolves.
+    await findByText("Play");
+
+    // Dispatch the Decky-loader event the listener subscribes to. The
+    // listener calls setState — wrap in act() so the resulting render flushes.
+    act(() => {
+      const event: DownloadFailedEvent = {
+        rom_id: 42,
+        rom_name: "Test ROM",
+        platform_name: "PSX",
+        error_message: "disk full",
+      };
+      emitDeckyEvent<[DownloadFailedEvent]>("download_failed", event);
+    });
+
+    // Reset path: setState("download"), so the Download label appears and
+    // the Play label is gone.
+    await findByText("Download");
+    expect(queryByText("Play")).toBeNull();
+  });
+
+  it("ignores download_failed for a different rom_id", async () => {
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    act(() => {
+      emitDeckyEvent<[DownloadFailedEvent]>("download_failed", {
+        rom_id: 999, // mismatched — listener no-ops
+        rom_name: "Other",
+        platform_name: "PSX",
+        error_message: "boom",
+      });
+    });
+
+    // Button stays in "play" state — Play label persists, Download absent.
+    expect(await findByText("Play")).toBeInTheDocument();
+    expect(queryByText("Download")).toBeNull();
+  });
+
+  it("removes the download_failed listener on unmount", async () => {
+    mockCachedDetail();
+    const { unmount } = render(<CustomPlayButton appId={100} />);
+
+    await waitFor(() => {
+      expect(deckyEventListenerCount("download_failed")).toBe(1);
+    });
+
+    unmount();
+    expect(deckyEventListenerCount("download_failed")).toBe(0);
+  });
+});

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -202,7 +202,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       },
     );
 
-    /* istanbul ignore next -- listener-wiring; logic tested in src/utils/downloadFailure.test.ts */
+    /* istanbul ignore next -- delegation line; end-to-end wiring tested in CustomPlayButton.test.tsx */
     const failedListener = addEventListener<[DownloadFailedEvent]>(
       "download_failed",
       // The global listener in index.tsx owns the failure toast; here we only

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -2,10 +2,12 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import { createElement } from "react";
+import { resetDeckyEventBus } from "./test-utils/decky-api-mock";
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  resetDeckyEventBus();
 });
 
 // Steam Deck ambient globals — minimal stubs; individual tests refine via vi.mocked.
@@ -34,11 +36,20 @@ vi.stubGlobal("collectionStore", { userCollections: [] });
 
 // @decky/api — callable returns a vi.fn that resolves to undefined by default.
 // Tests opt into specific behavior via vi.mocked(<callable>).mockResolvedValue(...).
-vi.mock("@decky/api", () => ({
-  callable: <T,>(_name: string) => vi.fn().mockResolvedValue(undefined) as unknown as T,
-  toaster: { toast: vi.fn() },
-  definePlugin: (fn: unknown) => fn,
-}));
+// addEventListener / removeEventListener route through the in-memory event bus
+// in src/test-utils/decky-api-mock.ts so tests can drive Decky-loader events
+// via emitDeckyEvent(). Async factory + dynamic import is required because
+// vi.mock factories are hoisted above top-level imports.
+vi.mock("@decky/api", async () => {
+  const bus = await import("./test-utils/decky-api-mock");
+  return {
+    callable: <T,>(_name: string) => vi.fn().mockResolvedValue(undefined) as unknown as T,
+    toaster: { toast: vi.fn() },
+    definePlugin: (fn: unknown) => fn,
+    addEventListener: bus.mockAddEventListener,
+    removeEventListener: bus.mockRemoveEventListener,
+  };
+});
 
 // @decky/ui — explicit pass-through stubs. Auto-mock yields undefined components
 // and breaks RTL render() with "Element type is invalid".
@@ -69,6 +80,17 @@ vi.mock("@decky/ui", () => {
       }),
     Dropdown: passthrough("select"),
     showModal: vi.fn(),
+    showContextMenu: vi.fn(),
+    Menu: passthrough("div"),
+    MenuItem: ({ children, onClick }: AnyProps) =>
+      createElement("button", { onClick }, children as never),
     Router: { CloseSideMenus: vi.fn(), Navigate: vi.fn() },
+    // findSP locates Steam's <SteamRoot> iframe document for stylesheet
+    // injection. Tests run in happy-dom — no Steam, no iframe — so the
+    // safe stub returns undefined and the consumer's `!sp?.window?.document`
+    // guard short-circuits any DOM mutation.
+    findSP: vi.fn(() => undefined),
+    appActionButtonClasses: undefined,
+    basicAppDetailsSectionStylerClasses: undefined,
   };
 });

--- a/src/test-utils/decky-api-mock.ts
+++ b/src/test-utils/decky-api-mock.ts
@@ -1,0 +1,105 @@
+/**
+ * In-memory mock of the `@decky/api` event bus for component tests.
+ *
+ * `@decky/api`'s `addEventListener` / `removeEventListener` route through the
+ * Decky-loader WebSocket bridge at runtime — there is no DOM event here, so
+ * tests cannot use `window.dispatchEvent`. Anything that wants to exercise a
+ * component's `addEventListener(...)` wiring must dispatch through this
+ * harness instead.
+ *
+ * Usage (the global mock factory in `src/test-setup.ts` already wires the
+ * `@decky/api` module to this bus; tests just import the helpers):
+ *
+ *   import { emitDeckyEvent } from "../test-utils/decky-api-mock";
+ *
+ *   await act(async () => {
+ *     emitDeckyEvent<[DownloadFailedEvent]>("download_failed", {
+ *       rom_id: 1, rom_name: "X", platform_name: "PSX", error_message: "boom",
+ *     });
+ *   });
+ *
+ * `resetDeckyEventBus()` is called automatically in the global `afterEach`,
+ * so tests do not need to clean up listeners manually.
+ *
+ * This file mocks ONLY the Decky-loader event surface. DOM-level
+ * `globalThis.dispatchEvent(new CustomEvent(...))` flows (`romm_data_changed`,
+ * `romm_rom_uninstalled`, etc.) work natively in happy-dom and need no
+ * harness.
+ */
+
+// Listeners are stored untyped — each test reifies the payload via the
+// generic on `emitDeckyEvent` / `mockAddEventListener`.
+type AnyListener = (...args: unknown[]) => unknown;
+
+const listeners = new Map<string, Set<AnyListener>>();
+
+/**
+ * Stand-in for `@decky/api`'s `addEventListener`. Registers `listener` under
+ * `name` and returns it unchanged — matching the upstream signature, which
+ * returns the listener so callers can hand it straight to `removeEventListener`.
+ */
+export function mockAddEventListener<Args extends unknown[] = []>(
+  name: string,
+  listener: (...args: Args) => unknown,
+): (...args: Args) => unknown {
+  let bucket = listeners.get(name);
+  if (!bucket) {
+    bucket = new Set();
+    listeners.set(name, bucket);
+  }
+  bucket.add(listener as AnyListener);
+  return listener;
+}
+
+/**
+ * Stand-in for `@decky/api`'s `removeEventListener`. No-op if the listener
+ * was never registered (matches upstream tolerance).
+ */
+export function mockRemoveEventListener<Args extends unknown[] = []>(
+  name: string,
+  listener: (...args: Args) => unknown,
+): void {
+  const bucket = listeners.get(name);
+  if (!bucket) return;
+  bucket.delete(listener as AnyListener);
+  if (bucket.size === 0) listeners.delete(name);
+}
+
+/**
+ * Synchronously invokes every listener registered for `name` with `args`.
+ * Use inside a React Testing Library `act(async () => { ... })` block when
+ * the listener updates state so the resulting render flushes before assertions.
+ *
+ * Listener exceptions propagate — a test that wants to assert on error
+ * handling should arrange for the listener to swallow its own throw.
+ */
+export function emitDeckyEvent<Args extends unknown[] = []>(
+  name: string,
+  ...args: Args
+): void {
+  const bucket = listeners.get(name);
+  if (!bucket) return;
+  // Snapshot first so a listener that removes itself during dispatch doesn't
+  // mutate the set we're iterating.
+  for (const listener of [...bucket]) {
+    listener(...args);
+  }
+}
+
+/**
+ * Drops every registered listener. Wired into the global `afterEach` in
+ * `src/test-setup.ts`; tests that need a clean slate mid-test can call this
+ * directly.
+ */
+export function resetDeckyEventBus(): void {
+  listeners.clear();
+}
+
+/**
+ * Test-only introspection — returns the count of listeners currently
+ * registered under `name`. Useful for asserting that a component's
+ * `useEffect` cleanup actually ran on unmount.
+ */
+export function deckyEventListenerCount(name: string): number {
+  return listeners.get(name)?.size ?? 0;
+}

--- a/src/test-utils/decky-api-mock.ts
+++ b/src/test-utils/decky-api-mock.ts
@@ -12,11 +12,13 @@
  *
  *   import { emitDeckyEvent } from "../test-utils/decky-api-mock";
  *
- *   await act(async () => {
+ *   act(() => {
  *     emitDeckyEvent<[DownloadFailedEvent]>("download_failed", {
  *       rom_id: 1, rom_name: "X", platform_name: "PSX", error_message: "boom",
  *     });
  *   });
+ *
+ * Use `await act(async () => {...})` only if a listener under test is itself async.
  *
  * `resetDeckyEventBus()` is called automatically in the global `afterEach`,
  * so tests do not need to clean up listeners manually.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       exclude: [
         "src/**/*.{test,spec}.{ts,tsx}",
         "src/test-setup.ts",
+        "src/test-utils/**",
         // Aligned with sonar-project.properties `sonar.coverage.exclusions`.
         "src/types/**",
         "src/index.tsx",


### PR DESCRIPTION
## Summary

Closes #654. Parent: #621. Unblocks #684-#687.

`@decky/api`'s `addEventListener` / `removeEventListener` route through the Decky-loader WebSocket bridge at runtime — there is no DOM event there, so tests cannot use `window.dispatchEvent` to drive component listeners. The recurring workaround was aggressive helper extraction into `src/utils/*.ts` plus per-line `# istanbul ignore` markers on the listener wiring (PR #651's `download_failed` listener was the latest example).

This PR adds the missing harness so component listeners are directly testable.

## Changes

- **`src/test-utils/decky-api-mock.ts`** — in-memory event bus. `mockAddEventListener` / `mockRemoveEventListener` register handlers; `emitDeckyEvent(name, ...args)` invokes them synchronously; `resetDeckyEventBus()` clears state; `deckyEventListenerCount(name)` is a test-only introspection helper for asserting `useEffect` cleanup.
- **`src/test-setup.ts`** — `vi.mock("@decky/api", ...)` factory now wires `addEventListener` / `removeEventListener` to the bus (async factory + dynamic import is needed because `vi.mock` is hoisted above top-level imports). `afterEach` calls `resetDeckyEventBus()`. Bonus: adds `findSP`, `showContextMenu`, `Menu`, `MenuItem`, `appActionButtonClasses`, `basicAppDetailsSectionStylerClasses` to the `@decky/ui` stub so components that pull from those imports render in tests.
- **`src/components/CustomPlayButton.test.tsx`** — reference test. Four cases: listener registers on mount, button transitions back to "Download" on matching `download_failed`, mismatched `rom_id` is a no-op, listener removed on unmount.
- **`CLAUDE.md`** — short Testing-section addition documenting the harness and pointing future PRs at the reference test instead of helper-extract-everything.
- **`vitest.config.ts` + `sonar-project.properties`** — exclude `src/test-utils/**` from coverage (consumed by tests only).
- **`eslint.config.js`** — include `src/test-utils/**` in the vitest-globals files group.

## Design notes

- **Decky-loader events vs DOM events.** The harness mocks ONLY the `@decky/api` event surface. DOM-level `globalThis.dispatchEvent(new CustomEvent(...))` flows (`romm_data_changed`, `romm_rom_uninstalled`, etc.) work natively in happy-dom and need no harness. The harness file's module docstring spells this out.
- **`callable()` stays as-is** — still returns `vi.fn().mockResolvedValue(undefined)`; tests opt in to specific behavior via `vi.mocked(<name>).mockResolvedValue(...)` as before.
- **happy-dom retained** — already installed and existing tests rely on it. The issue body left jsdom vs happy-dom open; sticking with happy-dom avoids a churny swap.
- **Reference test scope** — exercises the exact case #654 was opened for (per-button `download_failed`) without expanding the suite into pre-existing untested branches. The four cases stay tight around the listener wiring.

## Test plan

- [x] `python -m pytest tests/ -q` — 2507 passed
- [x] `pnpm build` — Rollup clean
- [x] `pnpm test` — 296 passed (18 files, +4 new in CustomPlayButton.test.tsx)
- [x] `pnpm lint` — 0 errors (3 pre-existing warnings untouched)
- [x] `pnpm size` — 385.27 kB / 500 kB limit
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept, 0 broken