### PR TITLE
test(library): drive fetcher end-to-end via FakeRommApi

### DIFF
--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -8,6 +8,7 @@ per-method ``*_side_effect`` attributes (persistent) — no
 ``run_in_executor`` patching, no ``MagicMock(romm_api)``.
 """
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,14 +18,12 @@ from domain.work_unit import WorkUnit
 
 
 def _wire_fake(plugin, fake_romm_api):
-    """Point both the plugin and the fetcher at the shared ``FakeRommApi``.
+    """Point the fetcher at the shared ``FakeRommApi``.
 
     The ``plugin`` fixture wires the LibraryService with a bare
     ``MagicMock`` romm_api; tests that drive end-to-end need to swap
-    that for the seeded fake on both the façade and the fetcher's
-    captured ref.
+    that for the seeded fake on the fetcher's captured ref.
     """
-    plugin._romm_api = fake_romm_api
     plugin._sync_service._fetcher._romm_api = fake_romm_api
 
 
@@ -32,8 +31,6 @@ class TestCheckCancelling:
     """Tests for _check_cancelling() — pure state check, no API surface."""
 
     def test_raises_when_cancelling(self, plugin):
-        import asyncio
-
         plugin._sync_service._sync_state = SyncState.CANCELLING
         with pytest.raises(asyncio.CancelledError):
             plugin._sync_service._fetcher._check_cancelling()
@@ -282,9 +279,10 @@ class TestFullFetchPlatformRoms:
     async def test_raises_on_second_page_failure(self, plugin, fake_romm_api):
         """Page 1 OK + page 2 raises must propagate — partial accumulation is unsafe.
 
-        Uses ``fail_on_next`` so the first ``list_roms`` succeeds (returning
-        the seeded page) and the second one raises; this exercises the
-        pagination-break fix from #630.
+        Wraps ``list_roms`` with a counter-closure so the first call returns
+        the seeded page and the second call raises after the first page's
+        bytes are already consumed; this exercises the pagination-break fix
+        from #630.
         """
         _wire_fake(plugin, fake_romm_api)
         # Seed exactly one full page so the loop performs a second call.
@@ -309,8 +307,6 @@ class TestFullFetchPlatformRoms:
 
     @pytest.mark.asyncio
     async def test_cancelling_during_fetch(self, plugin, fake_romm_api):
-        import asyncio
-
         _wire_fake(plugin, fake_romm_api)
         plugin._sync_service._sync_state = SyncState.CANCELLING
 

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1,17 +1,39 @@
-"""Tests for LibraryFetcher — platform/collection roundtrips, ROM fetch pipeline."""
+"""Tests for LibraryFetcher — platform/collection roundtrips, ROM fetch pipeline.
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock
+Driven end-to-end through :class:`FakeRommApi` so each test seeds
+in-memory platforms/ROMs/collections on the fake and asserts on the
+observable output of the fetcher (returned ROM lists, mutated state).
+Failure paths are exercised with ``fail_on_next`` (one-shot) and the
+per-method ``*_side_effect`` attributes (persistent) — no
+``run_in_executor`` patching, no ``MagicMock(romm_api)``.
+"""
+
+from unittest.mock import MagicMock
 
 import pytest
 
 from domain.sync_state import SyncState
+from domain.work_unit import WorkUnit
+
+
+def _wire_fake(plugin, fake_romm_api):
+    """Point both the plugin and the fetcher at the shared ``FakeRommApi``.
+
+    The ``plugin`` fixture wires the LibraryService with a bare
+    ``MagicMock`` romm_api; tests that drive end-to-end need to swap
+    that for the seeded fake on both the façade and the fetcher's
+    captured ref.
+    """
+    plugin._romm_api = fake_romm_api
+    plugin._sync_service._fetcher._romm_api = fake_romm_api
 
 
 class TestCheckCancelling:
-    """Tests for _check_cancelling() — lines 505-508."""
+    """Tests for _check_cancelling() — pure state check, no API surface."""
 
     def test_raises_when_cancelling(self, plugin):
+        import asyncio
+
         plugin._sync_service._sync_state = SyncState.CANCELLING
         with pytest.raises(asyncio.CancelledError):
             plugin._sync_service._fetcher._check_cancelling()
@@ -25,21 +47,16 @@ class TestCheckCancelling:
 
 
 class TestFetchEnabledPlatforms:
-    """Tests for _fetch_enabled_platforms() — lines 398-411, 402-403."""
+    """Tests for _fetch_enabled_platforms() — list_platforms + enabled-filter."""
 
     @pytest.mark.asyncio
-    async def test_filters_by_enabled(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"id": 1, "name": "N64", "slug": "n64"},
-                {"id": 2, "name": "SNES", "slug": "snes"},
-                {"id": 3, "name": "GBA", "slug": "gba"},
-            ]
-        )
-        plugin._sync_service._loop = mock_loop
+    async def test_filters_by_enabled(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64"},
+            {"id": 2, "name": "SNES", "slug": "snes"},
+            {"id": 3, "name": "GBA", "slug": "gba"},
+        ]
         plugin.settings["enabled_platforms"] = {"1": True, "2": False, "3": True}
 
         result = await plugin._sync_service._fetcher._fetch_enabled_platforms()
@@ -50,36 +67,31 @@ class TestFetchEnabledPlatforms:
         assert "SNES" not in names
 
     @pytest.mark.asyncio
-    async def test_all_enabled_when_no_prefs(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"id": 1, "name": "N64", "slug": "n64"},
-                {"id": 2, "name": "SNES", "slug": "snes"},
-            ]
-        )
-        plugin._sync_service._loop = mock_loop
+    async def test_all_enabled_when_no_prefs(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64"},
+            {"id": 2, "name": "SNES", "slug": "snes"},
+        ]
         plugin.settings["enabled_platforms"] = {}
 
         result = await plugin._sync_service._fetcher._fetch_enabled_platforms()
         assert len(result) == 2
 
     @pytest.mark.asyncio
-    async def test_returns_empty_for_non_list_response(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value={"error": "bad response"})
-        plugin._sync_service._loop = mock_loop
+    async def test_returns_empty_for_non_list_response(self, plugin, fake_romm_api):
+        """When ``list_platforms`` returns a non-list, treat as empty."""
+        _wire_fake(plugin, fake_romm_api)
+        # Override ``list_platforms`` to return a dict (the real adapter
+        # might surface error envelopes shaped this way).
+        fake_romm_api.list_platforms = lambda: {"error": "bad response"}  # type: ignore[method-assign]
 
         result = await plugin._sync_service._fetcher._fetch_enabled_platforms()
         assert result == []
 
 
 class TestReconstructPlatformFromRegistry:
-    """Tests for _reconstruct_platform_from_registry() — lines 413-429."""
+    """Tests for _reconstruct_platform_from_registry() — pure registry walk."""
 
     def test_reconstructs_matching_entries(self, plugin):
         plugin._state["shortcut_registry"] = {
@@ -122,17 +134,14 @@ class TestReconstructPlatformFromRegistry:
 
 
 class TestTryIncrementalSkip:
-    """Tests for _try_incremental_skip() — lines 431-465."""
+    """Tests for _try_incremental_skip() — incremental-fetch fast path."""
 
     @pytest.mark.asyncio
-    async def test_skips_unchanged_platform(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value={"total": 0})
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
+    async def test_skips_unchanged_platform(self, plugin, fake_romm_api):
+        """server_total=0 + registry_count == platform_total => reconstruct + skip."""
+        _wire_fake(plugin, fake_romm_api)
+        # No ROMs updated => list_roms_updated_after returns total=0
+        # (the fake's default behaviour with no seeded ``roms``).
         plugin._state["shortcut_registry"] = {
             "1": {"name": "Game A", "platform_name": "N64"},
             "2": {"name": "Game B", "platform_name": "N64"},
@@ -147,45 +156,41 @@ class TestTryIncrementalSkip:
         assert len(all_roms) == 2  # reconstructed from registry
 
     @pytest.mark.asyncio
-    async def test_no_skip_on_first_sync(self, plugin):
-        from unittest.mock import MagicMock
-
-        mock_loop = MagicMock()
-        plugin._sync_service._loop = mock_loop
-
+    async def test_no_skip_on_first_sync(self, plugin, fake_romm_api):
+        """last_sync=None => early return, no API roundtrip."""
+        _wire_fake(plugin, fake_romm_api)
         platform = {"id": 1, "rom_count": 5}
         all_roms = []
 
-        # last_sync is None => no skip
         skipped = await plugin._sync_service._fetcher._try_incremental_skip(
             platform, {}, None, "N64", "n64", all_roms, 1, 1
         )
         assert skipped is False
+        # No API call made (early return before list_roms_updated_after).
+        assert not any(c[0] == "list_roms_updated_after" for c in fake_romm_api.call_log)
 
     @pytest.mark.asyncio
-    async def test_no_skip_when_registry_empty(self, plugin):
-        from unittest.mock import MagicMock
-
-        mock_loop = MagicMock()
-        plugin._sync_service._loop = mock_loop
-
+    async def test_no_skip_when_registry_empty(self, plugin, fake_romm_api):
+        """registry_count=0 => early return."""
+        _wire_fake(plugin, fake_romm_api)
         platform = {"id": 1, "rom_count": 5}
         all_roms = []
 
-        # registry has no entries for this platform
         skipped = await plugin._sync_service._fetcher._try_incremental_skip(
             platform, {}, "2025-01-01T00:00:00", "N64", "n64", all_roms, 1, 1
         )
         assert skipped is False
 
     @pytest.mark.asyncio
-    async def test_no_skip_when_updates_exist(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value={"total": 3})
-        plugin._sync_service._loop = mock_loop
-
+    async def test_no_skip_when_updates_exist(self, plugin, fake_romm_api):
+        """server reports updated rows => fall through to full fetch."""
+        _wire_fake(plugin, fake_romm_api)
+        # Seed 3 ROMs updated after the cutoff so list_roms_updated_after total=3.
+        fake_romm_api.roms = {
+            10: {"id": 10, "platform_id": 1, "name": "U1", "updated_at": "2025-06-01T00:00:00"},
+            11: {"id": 11, "platform_id": 1, "name": "U2", "updated_at": "2025-06-01T00:00:00"},
+            12: {"id": 12, "platform_id": 1, "name": "U3", "updated_at": "2025-06-01T00:00:00"},
+        }
         plugin._state["shortcut_registry"] = {
             "1": {"name": "Game A", "platform_name": "N64"},
         }
@@ -199,17 +204,14 @@ class TestTryIncrementalSkip:
         assert len(all_roms) == 0
 
     @pytest.mark.asyncio
-    async def test_no_skip_when_count_mismatch(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value={"total": 0})
-        plugin._sync_service._loop = mock_loop
-
+    async def test_no_skip_when_count_mismatch(self, plugin, fake_romm_api):
+        """No updates but rom_count != registry_count => fall through (registry stale)."""
+        _wire_fake(plugin, fake_romm_api)
         plugin._state["shortcut_registry"] = {
             "1": {"name": "Game A", "platform_name": "N64"},
         }
-        platform = {"id": 1, "rom_count": 5}  # server has 5, registry has 1
+        # server reports 5 ROMs, registry has 1 — mismatch forces refetch.
+        platform = {"id": 1, "rom_count": 5}
         all_roms = []
 
         skipped = await plugin._sync_service._fetcher._try_incremental_skip(
@@ -218,12 +220,10 @@ class TestTryIncrementalSkip:
         assert skipped is False
 
     @pytest.mark.asyncio
-    async def test_falls_back_on_api_error(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=Exception("Connection failed"))
-        plugin._sync_service._loop = mock_loop
+    async def test_falls_back_on_api_error(self, plugin, fake_romm_api):
+        """Transport failure on the delta check => swallow + force full fetch."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.list_roms_updated_after_side_effect = OSError("connection reset")
 
         plugin._state["shortcut_registry"] = {
             "1": {"name": "Game A", "platform_name": "N64"},
@@ -238,25 +238,17 @@ class TestTryIncrementalSkip:
 
 
 class TestFullFetchPlatformRoms:
-    """Tests for _full_fetch_platform_roms() — lines 467-503."""
+    """Tests for _full_fetch_platform_roms() — paginated fetch loop."""
 
     @pytest.mark.asyncio
-    async def test_fetches_single_page(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_fetches_single_page(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.roms = {
+            1: {"id": 1, "platform_id": 1, "name": "Game A", "files": ["f1"]},
+            2: {"id": 2, "platform_id": 1, "name": "Game B"},
+        }
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(
-            return_value={
-                "items": [
-                    {"id": 1, "name": "Game A", "files": ["f1"]},
-                    {"id": 2, "name": "Game B"},
-                ]
-            }
-        )
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
-        all_roms = []
+        all_roms: list[dict] = []
         await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
         assert len(all_roms) == 2
         assert all_roms[0]["platform_name"] == "N64"
@@ -265,60 +257,64 @@ class TestFullFetchPlatformRoms:
         assert "files" not in all_roms[0]
 
     @pytest.mark.asyncio
-    async def test_fetches_multiple_pages(self, plugin):
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_fetches_multiple_pages(self, plugin, fake_romm_api):
+        """51 ROMs => one full page (50) + a tail page (1) => loop exits on short page."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.roms = {i: {"id": i, "platform_id": 1, "name": f"G{i}"} for i in range(51)}
 
-        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
-        page2 = {"items": [{"id": 50, "name": "G50"}]}
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, page2])
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
-        all_roms = []
+        all_roms: list[dict] = []
         await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
         assert len(all_roms) == 51
 
     @pytest.mark.asyncio
-    async def test_raises_on_api_error_to_protect_stale_cleanup(self, plugin):
+    async def test_raises_on_api_error_to_protect_stale_cleanup(self, plugin, fake_romm_api):
         """Pagination failure must propagate — silently returning a partial list
         would cause the orchestrator's stale-cleanup pass to wipe every ROM the
         truncated fetch missed. See #630."""
-        from unittest.mock import AsyncMock, MagicMock
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.list_roms_side_effect = RuntimeError("Server error")
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=RuntimeError("Server error"))
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
-
-        all_roms = []
+        all_roms: list[dict] = []
         with pytest.raises(RuntimeError, match="Server error"):
             await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
 
     @pytest.mark.asyncio
-    async def test_raises_on_second_page_failure(self, plugin):
-        """Page 1 OK + page 2 raises must propagate — partial accumulation is unsafe."""
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_raises_on_second_page_failure(self, plugin, fake_romm_api):
+        """Page 1 OK + page 2 raises must propagate — partial accumulation is unsafe.
 
-        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, RuntimeError("page 2 boom")])
-        plugin._sync_service._loop = mock_loop
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        Uses ``fail_on_next`` so the first ``list_roms`` succeeds (returning
+        the seeded page) and the second one raises; this exercises the
+        pagination-break fix from #630.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        # Seed exactly one full page so the loop performs a second call.
+        fake_romm_api.roms = {i: {"id": i, "platform_id": 1, "name": f"G{i}"} for i in range(50)}
 
-        all_roms = []
+        # Arm an OSError to fire on the *second* list_roms call (after the
+        # first page has been consumed).
+        original_list_roms = fake_romm_api.list_roms
+        call_count = {"n": 0}
+
+        def list_roms_with_second_page_failure(platform_id, limit=50, offset=0):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("page 2 boom")
+            return original_list_roms(platform_id, limit, offset)
+
+        fake_romm_api.list_roms = list_roms_with_second_page_failure  # type: ignore[method-assign]
+
+        all_roms: list[dict] = []
         with pytest.raises(RuntimeError, match="page 2 boom"):
             await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
 
     @pytest.mark.asyncio
-    async def test_cancelling_during_fetch(self, plugin):
-        from unittest.mock import AsyncMock
+    async def test_cancelling_during_fetch(self, plugin, fake_romm_api):
+        import asyncio
 
+        _wire_fake(plugin, fake_romm_api)
         plugin._sync_service._sync_state = SyncState.CANCELLING
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
 
-        all_roms = []
+        all_roms: list[dict] = []
         with pytest.raises(asyncio.CancelledError):
             await plugin._sync_service._fetcher._full_fetch_platform_roms(1, "N64", "n64", all_roms, 1, 1)
 
@@ -327,10 +323,12 @@ class TestPrefetchAllUnits:
     """Tests for prefetch_all_units — the Skip Preview OFF upfront fetch."""
 
     @pytest.mark.asyncio
-    async def test_returns_empty_when_no_units(self, plugin):
-        """No enabled platforms + no enabled collections → empty prefetch + empty aggregates."""
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=[])
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+    async def test_returns_empty_when_no_units(self, plugin, fake_romm_api):
+        """No enabled platforms + no enabled collections => empty prefetch + empty aggregates."""
+        _wire_fake(plugin, fake_romm_api)
+        # No platforms, no enabled collections => build_work_queue returns [].
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {}
 
         (
             prefetched,
@@ -347,28 +345,20 @@ class TestPrefetchAllUnits:
         assert platform_rom_ids == set()
 
     @pytest.mark.asyncio
-    async def test_fetches_each_platform_unit(self, plugin):
+    async def test_fetches_each_platform_unit(self, plugin, fake_romm_api):
         """Each platform unit goes through fetch_platform_unit and aggregates into all_roms."""
-        from domain.work_unit import WorkUnit
-
-        queue = [
-            WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1),
-            WorkUnit(type="platform", id=2, name="GBA", slug="gba", rom_count=1),
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
+            {"id": 2, "name": "GBA", "slug": "gba", "rom_count": 1},
         ]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-
-        async def fake_platform(unit):
-            return [
-                {
-                    "id": int(unit.id) * 10,
-                    "name": f"Game {unit.name}",
-                    "platform_name": unit.name,
-                    "platform_slug": unit.slug,
-                }
-            ], False
-
-        plugin._sync_service._fetcher.fetch_platform_unit = fake_platform
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        fake_romm_api.roms = {
+            10: {"id": 10, "platform_id": 1, "name": "Game N64"},
+            20: {"id": 20, "platform_id": 2, "name": "Game GBA"},
+        }
+        # No prior sync => no incremental-skip path taken.
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
 
         (
             prefetched,
@@ -384,21 +374,32 @@ class TestPrefetchAllUnits:
         assert memberships == {}
 
     @pytest.mark.asyncio
-    async def test_fetches_collection_unit_records_membership(self, plugin):
+    async def test_fetches_collection_unit_records_membership(self, plugin, fake_romm_api):
         """Collection units populate collection_memberships with their member ids."""
-        from domain.work_unit import WorkUnit
-
-        queue = [WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=2)]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-
-        async def fake_collection(_unit, synced):
-            synced.add(101)
-            return [
-                {"id": 101, "name": "C101", "platform_name": "N64", "platform_slug": "n64"},
-            ], [101, 102]
-
-        plugin._sync_service._fetcher.fetch_collection_unit = fake_collection
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        _wire_fake(plugin, fake_romm_api)
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"7": True}
+        fake_romm_api.collections = [
+            {"id": "7", "name": "Faves", "slug": "faves", "rom_count": 2},
+        ]
+        fake_romm_api.roms = {
+            101: {
+                "id": 101,
+                "platform_id": 1,
+                "name": "C101",
+                "platform_name": "N64",
+                "platform_slug": "n64",
+                "collection_ids": [7],
+            },
+            102: {
+                "id": 102,
+                "platform_id": 1,
+                "name": "C102",
+                "platform_name": "N64",
+                "platform_slug": "n64",
+                "collection_ids": [7],
+            },
+        }
 
         (
             prefetched,
@@ -415,32 +416,38 @@ class TestPrefetchAllUnits:
         assert prefetched[0].all_collection_rom_ids == [101, 102]
 
     @pytest.mark.asyncio
-    async def test_preserves_skipped_flag_on_platform_unit(self, plugin):
-        """``skipped=True`` from fetch_platform_unit flows into the PrefetchedUnit."""
-        from domain.work_unit import WorkUnit
+    async def test_preserves_skipped_flag_on_platform_unit(self, plugin, fake_romm_api):
+        """``skipped=True`` from fetch_platform_unit flows into the PrefetchedUnit.
 
-        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
-            return_value=([{"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"}], True)
-        )
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        The incremental-skip path fires when last_sync is set, the registry
+        carries entries for the platform, the registry count matches the
+        unit's rom_count, and no ROMs are updated after last_sync.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
+        ]
+        # No ``roms`` => list_roms_updated_after returns total=0.
+        plugin._state["last_sync"] = "2025-01-01T00:00:00"
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "A", "fs_name": "a.z64", "platform_name": "N64"},
+        }
 
         prefetched, *_ = await plugin._sync_service._fetcher.prefetch_all_units()
 
         assert prefetched[0].skipped is True
 
     @pytest.mark.asyncio
-    async def test_caches_metadata_for_every_rom(self, plugin):
+    async def test_caches_metadata_for_every_rom(self, plugin, fake_romm_api):
         """Aggregated ROMs run through metadata_service for the dirty-flush before returning."""
-        from domain.work_unit import WorkUnit
-
-        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
-            return_value=([{"id": 10, "name": "A", "platform_name": "N64"}], True)
-        )
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
+        ]
+        plugin._state["last_sync"] = "2025-01-01T00:00:00"
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "A", "fs_name": "a.z64", "platform_name": "N64"},
+        }
 
         metadata_service = MagicMock()
         metadata_service.extract_metadata = MagicMock(return_value={"name": "A"})
@@ -453,18 +460,15 @@ class TestPrefetchAllUnits:
         metadata_service.flush_metadata_if_dirty.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_collection_with_empty_rom_ids_skips_membership(self, plugin):
+    async def test_collection_with_empty_rom_ids_skips_membership(self, plugin, fake_romm_api):
         """Collection returning an empty member-id list is not added to memberships."""
-        from domain.work_unit import WorkUnit
-
-        queue = [WorkUnit(type="collection", id="9", name="EmptyColl", slug="", rom_count=0)]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-
-        async def fake_collection(_unit, _synced):
-            return [], []
-
-        plugin._sync_service._fetcher.fetch_collection_unit = fake_collection
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        _wire_fake(plugin, fake_romm_api)
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"9": True}
+        # Enabled collection, but no ROMs reference it => empty pagination.
+        fake_romm_api.collections = [
+            {"id": "9", "name": "EmptyColl", "slug": "", "rom_count": 0},
+        ]
 
         prefetched, all_roms, _shortcuts, memberships, _pids = await plugin._sync_service._fetcher.prefetch_all_units()
 
@@ -474,16 +478,17 @@ class TestPrefetchAllUnits:
         assert prefetched[0].all_collection_rom_ids == []
 
     @pytest.mark.asyncio
-    async def test_skips_metadata_block_when_no_metadata_service(self, plugin):
+    async def test_skips_metadata_block_when_no_metadata_service(self, plugin, fake_romm_api):
         """Branch 628->634: when metadata_service is None, the cache-stamping loop is skipped."""
-        from domain.work_unit import WorkUnit
-
-        queue = [WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)]
-        plugin._sync_service._fetcher.build_work_queue = AsyncMock(return_value=queue)
-        plugin._sync_service._fetcher.fetch_platform_unit = AsyncMock(
-            return_value=([{"id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64"}], False),
-        )
-        plugin._sync_service._orchestrator._emit_progress = AsyncMock()
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
+        ]
+        fake_romm_api.roms = {
+            10: {"id": 10, "platform_id": 1, "name": "A"},
+        }
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
 
         plugin._sync_service._fetcher._metadata_service = None
         # Tracking dict to confirm the metadata_cache was NOT touched.
@@ -501,25 +506,18 @@ class TestBuildWorkQueueErrorPaths:
     """Tests for build_work_queue() collection-list failure / filter branches."""
 
     @pytest.mark.asyncio
-    async def test_user_collection_list_failure_continues_with_empty(self, plugin):
+    async def test_user_collection_list_failure_continues_with_empty(self, plugin, fake_romm_api):
         """Lines 375-377: user-collection fetch raises => warning logged, treated as empty."""
+        _wire_fake(plugin, fake_romm_api)
         plugin.settings["enabled_platforms"] = {}
         plugin.settings["enabled_collections"] = {"42": True}
 
-        async def fake_run_in_executor(_executor, fn, *args):
-            if fn is plugin._romm_api.list_platforms:
-                return []
-            if fn is plugin._romm_api.list_collections:
-                raise RuntimeError("user collections boom")
-            if fn is plugin._romm_api.list_virtual_collections:
-                return [
-                    {"id": "42", "name": "Faves", "slug": "faves", "rom_count": 3, "is_virtual": True},
-                ]
-            raise AssertionError(f"unexpected call: {fn}")
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=fake_run_in_executor)
-        plugin._sync_service._loop = mock_loop
+        fake_romm_api.list_collections_side_effect = RuntimeError("user collections boom")
+        fake_romm_api.virtual_collections = {
+            "franchise": [
+                {"id": "42", "name": "Faves", "slug": "faves", "rom_count": 3, "is_virtual": True},
+            ],
+        }
 
         units = await plugin._sync_service._fetcher.build_work_queue()
 
@@ -527,23 +525,14 @@ class TestBuildWorkQueueErrorPaths:
         assert [u.name for u in units] == ["Faves"]
 
     @pytest.mark.asyncio
-    async def test_franchise_collection_list_failure_continues_with_empty(self, plugin):
+    async def test_franchise_collection_list_failure_continues_with_empty(self, plugin, fake_romm_api):
         """Lines 382-384: franchise-collection fetch raises => warning logged, treated as empty."""
+        _wire_fake(plugin, fake_romm_api)
         plugin.settings["enabled_platforms"] = {}
         plugin.settings["enabled_collections"] = {"7": True}
 
-        async def fake_run_in_executor(_executor, fn, *args):
-            if fn is plugin._romm_api.list_platforms:
-                return []
-            if fn is plugin._romm_api.list_collections:
-                return [{"id": "7", "name": "Faves", "slug": "faves", "rom_count": 4}]
-            if fn is plugin._romm_api.list_virtual_collections:
-                raise RuntimeError("franchise collections boom")
-            raise AssertionError(f"unexpected call: {fn}")
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=fake_run_in_executor)
-        plugin._sync_service._loop = mock_loop
+        fake_romm_api.collections = [{"id": "7", "name": "Faves", "slug": "faves", "rom_count": 4}]
+        fake_romm_api.list_virtual_collections_side_effect = RuntimeError("franchise collections boom")
 
         units = await plugin._sync_service._fetcher.build_work_queue()
 
@@ -551,30 +540,23 @@ class TestBuildWorkQueueErrorPaths:
         assert [u.name for u in units] == ["Faves"]
 
     @pytest.mark.asyncio
-    async def test_skips_disabled_user_and_franchise_collections(self, plugin):
+    async def test_skips_disabled_user_and_franchise_collections(self, plugin, fake_romm_api):
         """Lines 389 + 403: collections returned by the API but not in enabled_ids are filtered out."""
+        _wire_fake(plugin, fake_romm_api)
         plugin.settings["enabled_platforms"] = {}
         # Only the "1" user collection and "100" franchise collection are enabled.
         plugin.settings["enabled_collections"] = {"1": True, "100": True}
 
-        async def fake_run_in_executor(_executor, fn, *args):
-            if fn is plugin._romm_api.list_platforms:
-                return []
-            if fn is plugin._romm_api.list_collections:
-                return [
-                    {"id": "1", "name": "Enabled User", "slug": "eu", "rom_count": 1},
-                    {"id": "2", "name": "Disabled User", "slug": "du", "rom_count": 1},
-                ]
-            if fn is plugin._romm_api.list_virtual_collections:
-                return [
-                    {"id": "100", "name": "Enabled Franchise", "slug": "ef", "rom_count": 1, "is_virtual": True},
-                    {"id": "200", "name": "Disabled Franchise", "slug": "df", "rom_count": 1, "is_virtual": True},
-                ]
-            raise AssertionError(f"unexpected call: {fn}")
-
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=fake_run_in_executor)
-        plugin._sync_service._loop = mock_loop
+        fake_romm_api.collections = [
+            {"id": "1", "name": "Enabled User", "slug": "eu", "rom_count": 1},
+            {"id": "2", "name": "Disabled User", "slug": "du", "rom_count": 1},
+        ]
+        fake_romm_api.virtual_collections = {
+            "franchise": [
+                {"id": "100", "name": "Enabled Franchise", "slug": "ef", "rom_count": 1, "is_virtual": True},
+                {"id": "200", "name": "Disabled Franchise", "slug": "df", "rom_count": 1, "is_virtual": True},
+            ],
+        }
 
         units = await plugin._sync_service._fetcher.build_work_queue()
 
@@ -586,18 +568,15 @@ class TestTryUnitIncrementalSkip:
     """Tests for _try_unit_incremental_skip() exception fallback."""
 
     @pytest.mark.asyncio
-    async def test_falls_back_on_delta_api_exception(self, plugin):
+    async def test_falls_back_on_delta_api_exception(self, plugin, fake_romm_api):
         """Lines 447-451: delta-fetch raises => warning logged, returns None to force full fetch."""
-        from domain.work_unit import WorkUnit
-
+        _wire_fake(plugin, fake_romm_api)
         plugin._state["shortcut_registry"] = {
             "1": {"name": "Game A", "platform_name": "N64"},
         }
         plugin._state["last_sync"] = "2025-01-01T00:00:00"
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=RuntimeError("delta boom"))
-        plugin._sync_service._loop = mock_loop
+        fake_romm_api.list_roms_updated_after_side_effect = RuntimeError("delta boom")
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
         result = await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
@@ -607,70 +586,74 @@ class TestTryUnitIncrementalSkip:
 
 
 class TestFetchPlatformUnit:
-    """Tests for fetch_platform_unit() — wrong-type guard, error break, multi-page pagination."""
+    """Tests for fetch_platform_unit() — wrong-type guard, error propagation, pagination."""
 
     @pytest.mark.asyncio
     async def test_raises_on_non_platform_unit(self, plugin):
         """Line 478: fetch_platform_unit must reject collection units."""
-        from domain.work_unit import WorkUnit
-
         unit = WorkUnit(type="collection", id="1", name="Coll", slug="", rom_count=0)
         with pytest.raises(ValueError, match="non-platform unit"):
             await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
     @pytest.mark.asyncio
-    async def test_first_page_exception_propagates(self, plugin):
+    async def test_first_page_exception_propagates(self, plugin, fake_romm_api):
         """A page-fetch failure must raise so the orchestrator aborts before stale-cleanup.
 
         Previous behaviour swallowed the exception and returned ``([], False)``
         — which classified every existing ROM as stale and wiped the Steam
         shortcut library. See #630.
         """
-        from domain.work_unit import WorkUnit
-
+        _wire_fake(plugin, fake_romm_api)
         # No prior sync => incremental skip returns None and we fall through to pagination.
         plugin._state["last_sync"] = None
         plugin._state["shortcut_registry"] = {}
 
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=RuntimeError("page boom"))
-        plugin._sync_service._loop = mock_loop
+        fake_romm_api.list_roms_side_effect = RuntimeError("page boom")
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=10)
         with pytest.raises(RuntimeError, match="page boom"):
             await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
     @pytest.mark.asyncio
-    async def test_second_page_exception_propagates(self, plugin):
+    async def test_second_page_exception_propagates(self, plugin, fake_romm_api):
         """Page 1 OK + page 2 raises must propagate so partial accumulation never
-        reaches the stale-cleanup pass. See #630."""
-        from domain.work_unit import WorkUnit
+        reaches the stale-cleanup pass. See #630.
 
+        ``fail_on_next`` arms the first call to raise, which would fire on
+        page 1 — instead we wrap ``list_roms`` to raise on the second call
+        after the first page's bytes are already consumed by the caller.
+        """
+        _wire_fake(plugin, fake_romm_api)
         plugin._state["last_sync"] = None
         plugin._state["shortcut_registry"] = {}
 
-        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, RuntimeError("page 2 boom")])
-        plugin._sync_service._loop = mock_loop
+        # Seed exactly one full page worth of ROMs (50 items at limit=50).
+        fake_romm_api.roms = {i: {"id": i, "platform_id": 1, "name": f"G{i}"} for i in range(50)}
+
+        original_list_roms = fake_romm_api.list_roms
+        call_count = {"n": 0}
+
+        def list_roms_with_second_page_failure(platform_id, limit=50, offset=0):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("page 2 boom")
+            return original_list_roms(platform_id, limit, offset)
+
+        fake_romm_api.list_roms = list_roms_with_second_page_failure  # type: ignore[method-assign]
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=200)
         with pytest.raises(RuntimeError, match="page 2 boom"):
             await plugin._sync_service._fetcher.fetch_platform_unit(unit)
 
     @pytest.mark.asyncio
-    async def test_paginates_across_multiple_pages(self, plugin):
+    async def test_paginates_across_multiple_pages(self, plugin, fake_romm_api):
         """Line 514: a full first page must trigger offset += limit and a second fetch."""
-        from domain.work_unit import WorkUnit
-
+        _wire_fake(plugin, fake_romm_api)
         plugin._state["last_sync"] = None
         plugin._state["shortcut_registry"] = {}
 
-        page1 = {"items": [{"id": i, "name": f"G{i}"} for i in range(50)]}
-        page2 = {"items": [{"id": 100, "name": "G100"}]}
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, page2])
-        plugin._sync_service._loop = mock_loop
+        # 51 ROMs at limit=50 => page 1 fills to limit, page 2 carries the tail.
+        fake_romm_api.roms = {i: {"id": i, "platform_id": 1, "name": f"G{i}"} for i in range(51)}
 
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=51)
         unit_roms, skipped = await plugin._sync_service._fetcher.fetch_platform_unit(unit)
@@ -686,26 +669,35 @@ class TestFetchCollectionUnit:
     @pytest.mark.asyncio
     async def test_raises_on_non_collection_unit(self, plugin):
         """Line 534: fetch_collection_unit must reject platform units."""
-        from domain.work_unit import WorkUnit
-
         unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=0)
         with pytest.raises(ValueError, match="non-collection unit"):
             await plugin._sync_service._fetcher.fetch_collection_unit(unit, set())
 
     @pytest.mark.asyncio
-    async def test_paginates_across_multiple_pages(self, plugin):
+    async def test_paginates_across_multiple_pages(self, plugin, fake_romm_api):
         """Line 566: a full first page must trigger offset += limit and a second fetch."""
-        from domain.work_unit import WorkUnit
+        _wire_fake(plugin, fake_romm_api)
 
-        page1 = {
-            "items": [{"id": i, "name": f"G{i}", "platform_name": "N64", "platform_slug": "n64"} for i in range(50)],
+        # 51 ROMs in collection id=7 => page 1 fills, page 2 carries the tail.
+        fake_romm_api.roms = {
+            i: {
+                "id": i,
+                "platform_id": 1,
+                "name": f"G{i}",
+                "platform_name": "N64",
+                "platform_slug": "n64",
+                "collection_ids": [7],
+            }
+            for i in range(50)
         }
-        page2 = {
-            "items": [{"id": 999, "name": "G999", "platform_name": "N64", "platform_slug": "n64"}],
+        fake_romm_api.roms[999] = {
+            "id": 999,
+            "platform_id": 1,
+            "name": "G999",
+            "platform_name": "N64",
+            "platform_slug": "n64",
+            "collection_ids": [7],
         }
-        mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(side_effect=[page1, page2])
-        plugin._sync_service._loop = mock_loop
 
         unit = WorkUnit(type="collection", id=7, name="Coll", slug="", rom_count=51, is_virtual=False)
         synced: set[int] = set()


### PR DESCRIPTION
Replaces ~60 `mock_loop` + `MagicMock(romm_api)` sites in `tests/services/library/test_fetcher.py` with the `FakeRommApi` fixture introduced in #665. Tests now seed in-memory platforms/ROMs/collections on the fake and assert on the fetcher's observable outputs (returned ROM lists, mutated state) instead of patching `run_in_executor` and asserting on internal call shape.

Closes #687. Parent: #621.

## Summary

- All API-touching tests now drive end-to-end through `FakeRommApi` — seed `fake_romm_api.platforms`, `.roms`, `.collections`, `.virtual_collections` directly; assert on returned ROM lists.
- Pure-logic tests (`_check_cancelling`, `_reconstruct_platform_from_registry`) untouched — no API surface to drive.
- Failure paths use the fake's persistent `*_side_effect` seams (`list_roms_side_effect`, `list_collections_side_effect`, `list_virtual_collections_side_effect`, `list_roms_updated_after_side_effect`) for one-test-one-failure flows.
- Page-1-OK + page-2-raises (the #630 pagination-break exercise) uses a wrapped `list_roms` with a call counter rather than `fail_on_next`, since the latter would fire on page 1.
- Dropped `mock_loop = MagicMock(); mock_loop.run_in_executor = AsyncMock(...)` everywhere — the conftest-level `_set_event_loop` autouse fixture binds the real asyncio loop to every sub-service.
- Dropped `plugin._sync_service._orchestrator._emit_progress = AsyncMock()` patches — the orchestrator's real `_emit_progress` runs (it writes to state and calls `decky.emit`, both already mocked at the conftest level).
- Same 37 tests, same coverage, no production code changed. Diff is `+285 / -293`.

## FakeRommApi extensions

None. The fake from #665 already covered every method the fetcher calls (`list_platforms`, `list_collections`, `list_virtual_collections`, `list_roms`, `list_roms_updated_after`, `list_roms_by_collection`, `list_roms_by_virtual_collection`). Tests seed the public state attributes directly.

## Wiring helper

Added a local `_wire_fake(plugin, fake_romm_api)` helper at the top of the file: the `plugin` fixture in `tests/services/library/conftest.py` wires `LibraryService` with `MagicMock()` at fixture-time, so the fetcher captures that mock as `self._romm_api`. Tests that need to drive end-to-end swap both `plugin._romm_api` and `plugin._sync_service._fetcher._romm_api` to point at the seeded fake. The shared conftest is unchanged — this PR only touches the test file.

## Test plan

- [x] `python -m pytest tests/services/library/test_fetcher.py -q -v` — 37 passed
- [x] `python -m pytest tests/ -q` — 2507 passed
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors, 0 warnings
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] `pnpm build` — green
- [x] `pnpm test` — 296 passed