### PR TITLE
chore: add RommApi composite, drop rom_id casts, value-semantics migrate

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,7 +282,7 @@ class Plugin:
         return await self._shortcut_removal_service.report_removal_results(removed_rom_ids)
 
     async def get_artwork_base64(self, rom_id):
-        return await self._artwork_service.get_artwork_base64(int(rom_id))
+        return await self._artwork_service.get_artwork_base64(rom_id)
 
     @migration_blocked
     async def clear_sync_cache(self):
@@ -292,11 +292,11 @@ class Plugin:
         return self._sync_service.get_sync_stats()
 
     async def evaluate_launch(self, steam_app_id):
-        verdict = await self._launch_gate_service.evaluate(int(steam_app_id))
+        verdict = await self._launch_gate_service.evaluate(steam_app_id)
         return asdict(verdict)
 
     async def finalize_game_session(self, rom_id):
-        result = await self._session_lifecycle_service.finalize(int(rom_id))
+        result = await self._session_lifecycle_service.finalize(rom_id)
         return asdict(result)
 
     # ── Download delegation to DownloadService ──────────────

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -80,6 +80,7 @@ from services.protocols import (
     RetroArchSaveSortingProvider,
     RetroDeckPaths,
     RomFileAdapter,
+    RommApi,
     SaveFileAdapter,
     SaveSyncStatePersister,
     SettingsPersister,
@@ -122,7 +123,7 @@ class AdapterBundle:
     """Concrete I/O adapters wired into services."""
 
     http_adapter: RommHttpAdapter
-    romm_api: RommApiAdapter
+    romm_api: RommApi
     steam_config: SteamConfigProtocol
     sgdb_adapter: SteamGridDbAdapter
     cover_art_file_store: CoverArtFileStore

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -9,16 +9,20 @@ from __future__ import annotations
 
 
 def migrate_settings(data: dict) -> dict:
-    """Bring *data* from any older settings schema to the current version."""
-    version = data.get("version", 0)
+    """Bring *data* from any older settings schema to the current version.
+
+    Value semantics — the caller's dict is never mutated.
+    """
+    new_data = dict(data)
+    version = new_data.get("version", 0)
     if version < 1:
         # v0 → v1: rename deprecated boolean keys
-        if data.pop("disable_steam_input", None):
-            data["steam_input_mode"] = "force_off"
-        if data.pop("debug_logging", None):
-            data["log_level"] = "debug"
-        data["version"] = 1
-    return data
+        if new_data.pop("disable_steam_input", None):
+            new_data["steam_input_mode"] = "force_off"
+        if new_data.pop("debug_logging", None):
+            new_data["log_level"] = "debug"
+        new_data["version"] = 1
+    return new_data
 
 
 def migrate_state(data: dict) -> dict:

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -78,6 +78,7 @@ from services.protocols.persistence import (
 )
 from services.protocols.transport import (
     RommAchievementsApi,
+    RommApi,
     RommConnectionApi,
     RommDeviceApi,
     RommFirmwareApi,
@@ -127,6 +128,7 @@ __all__ = [
     "RetryStrategy",
     "RomFileAdapter",
     "RommAchievementsApi",
+    "RommApi",
     "RommConnectionApi",
     "RommDeviceApi",
     "RommFirmwareApi",

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -301,7 +301,6 @@ class RommApi(
     RommAchievementsApi,
     RommFirmwareApi,
     RommPlaytimeApi,
-    RommSaveApi,
     Protocol,
 ):
     """Umbrella Protocol composing all per-domain RomM API Protocols."""

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -294,6 +294,19 @@ class RommSyncApi(RommSaveApi, RommVersion, RommDeviceApi, Protocol):
     """RomM surface for save-sync — saves cluster + server identity + device registration."""
 
 
+class RommApi(
+    RommSyncApi,
+    RommLibraryApi,
+    RommConnectionApi,
+    RommAchievementsApi,
+    RommFirmwareApi,
+    RommPlaytimeApi,
+    RommSaveApi,
+    Protocol,
+):
+    """Umbrella Protocol composing all per-domain RomM API Protocols."""
+
+
 class SteamGridDbApi(Protocol):
     """SteamGridDB HTTP API — search, artwork fetch, key verification."""
 

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -83,6 +83,12 @@ class TestMigrateSettings:
         result2 = migrate_settings(result1.copy())
         assert result1 == result2
 
+    def test_migrate_settings_does_not_mutate_caller_dict(self):
+        data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
+        original = dict(data)
+        migrate_settings(data)
+        assert data == original
+
 
 class TestMigrateState:
     def test_migrate_state_passthrough(self):

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -385,9 +385,9 @@ class TestShortcutRemovalCallableDelegation:
 
 class TestArtworkCallableDelegation:
     @pytest.mark.asyncio
-    async def test_get_artwork_base64_delegates_and_casts_id(self, plugin):
+    async def test_get_artwork_base64_delegates(self, plugin):
         plugin._artwork_service.get_artwork_base64 = AsyncMock(return_value={"base64": None})
-        result = await plugin.get_artwork_base64("42")  # str → int cast
+        result = await plugin.get_artwork_base64(42)
         plugin._artwork_service.get_artwork_base64.assert_awaited_once_with(42)
         assert result == {"base64": None}
 
@@ -406,7 +406,7 @@ class TestLifecycleCallableDelegation:
             reason: str
 
         plugin._launch_gate_service.evaluate = AsyncMock(return_value=Verdict(allowed=True, reason="ok"))
-        result = await plugin.evaluate_launch("12345")
+        result = await plugin.evaluate_launch(12345)
         plugin._launch_gate_service.evaluate.assert_awaited_once_with(12345)
         assert result == {"allowed": True, "reason": "ok"}
 
@@ -419,7 +419,7 @@ class TestLifecycleCallableDelegation:
             synced: bool
 
         plugin._session_lifecycle_service.finalize = AsyncMock(return_value=Outcome(synced=False))
-        result = await plugin.finalize_game_session("7")
+        result = await plugin.finalize_game_session(7)
         plugin._session_lifecycle_service.finalize.assert_awaited_once_with(7)
         assert result == {"synced": False}
 


### PR DESCRIPTION
## Summary

- Add umbrella `RommApi` composite Protocol in `services/protocols/transport.py` and retype `AdapterBundle.romm_api` from concrete `RommApiAdapter` to `RommApi` — every adapter field in the bundle is now Protocol-typed.
- Drop `int()` casts in `main.py` callables (`get_artwork_base64`, `evaluate_launch`, `finalize_game_session`). Single policy: services accept `int`, Decky coerces at the JSON boundary. Aligns with the ~25 other callables that already rely on this.
- Rewrite `migrate_settings` in `domain/state_migrations.py` to build a new dict rather than mutating the caller's input. Value semantics is the safer default (the function already returns the dict).

## Test plan

- [x] `python -m pytest tests/ -q` — 2507 passed
- [x] `ruff check py_modules/ main.py tests/`
- [x] `basedpyright py_modules/ main.py tests/`
- [x] `bash scripts/check_cosmic_call_bans.sh`
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept
- [x] `pnpm build`
- [x] `pnpm test` — 450 passed

Closes #694