### PR TITLE
chore(saves): unify server-unreachable response shape across 5 sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,17 @@ Protocol names carry a suffix that signals shape, so the call site reads correct
 
 When a sibling Protocol set mixes shapes (e.g. `RetroArchConfigReader` next to `RetroArchSaveSortingProvider`), that mix is intentional and reflects the shape difference, not a naming inconsistency.
 
+## Callable response shapes — canonical failure shape
+
+Decky callables that return a plain `dict` and can fail use the canonical failure shape `{success: False, reason: ErrorCode | str, message: str}`. Reuse `lib.list_result.ErrorCode` for server-reachability failures (`ErrorCode.SERVER_UNREACHABLE`). Never duplicate `reason` into a second `error` field; never replace `message` with `error`. `[ours]`
+
+Two carve-outs:
+
+- **Discriminated-status unions** (the `status: "ok" | "server_unreachable" | "version_deleted" | …` shape used by the saves version-history callables) keep the `status` discriminant — they carry more than two outcomes, so a binary `success` boolean would erase the routing slug. Failure branches still carry `message: str`, not `error: str`.
+- **Partial-success responses** that return a full payload alongside a failure flag (e.g. `get_save_status`'s additive `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action: "server_unreachable" | ...`) keep the additive flag. The call has half-broken half-working semantics that the binary boolean would erase.
+
+Full convention paragraph lives in the `lib/list_result.py` module docstring.
+
 ## Refactor wave plan (live — see #277 for current status)
 
 The full Cosmic Python migration is tracked under [#277](https://github.com/danielcopper/decky-romm-sync/issues/277) (umbrella). Order is chosen to minimize rework: cross-cutting Protocols first, then domain promotions, then per-service vertical refactors smallest-to-largest.

--- a/py_modules/lib/list_result.py
+++ b/py_modules/lib/list_result.py
@@ -21,6 +21,42 @@ the ``else`` untyped under basic mode.
 Lives in ``lib/`` rather than ``models/`` because it is a cross-cutting
 control-flow primitive: services, adapters, and domain logic may all
 construct or consume it, and it has no place in the persisted-data layer.
+
+Canonical failure response shape for dict-returning callables
+=============================================================
+
+For Decky callables that return a plain ``dict`` (rather than the typed
+:data:`ListResult` union above) and that can fail because the RomM server
+is unreachable, the canonical failure shape is::
+
+    {"success": False, "reason": ErrorCode | str, "message": str, **extras}
+
+Three required fields:
+
+* ``success: False`` — binary success discriminant.
+* ``reason`` — coarse routing slug. For server-reachability failures use
+  :data:`ErrorCode.SERVER_UNREACHABLE`; for static guards (sync_disabled,
+  not_installed, not_found, active_slot, …) a plain string literal is fine.
+  Never duplicate ``reason`` into a second ``error`` field.
+* ``message: str`` — human-readable detail for logs and UI. Carries the
+  exception text on transport-layer failures.
+
+Optional payload-shape extras (``slot``, ``saves``, ``active_slot``, …) may
+appear alongside on a per-callable basis when the frontend needs to render
+fallback UI on failure.
+
+Two carve-outs:
+
+* **Discriminated-status unions** (e.g. ``versions.rollback_to_version``,
+  ``versions.list_file_versions``) keep the ``status: "ok" | "..."``
+  discriminant; the ``server_unreachable`` branch still carries
+  ``message: str`` instead of the legacy ``error: str``.
+* **Partial-success responses** that return a full data payload alongside
+  a failure flag (e.g. ``status.get_save_status``'s
+  ``server_query_failed: bool``, ``setup.get_save_setup_info``'s
+  ``recommended_action: "server_unreachable" | ...``) keep the additive
+  flag — the call has half-broken half-working semantics that the binary
+  ``success`` boolean would erase.
 """
 
 from __future__ import annotations

--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from domain.save_state import RomSaveState
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -104,8 +105,7 @@ class SlotDeleter:
                 )
                 return {
                     "success": False,
-                    "reason": "server_unreachable",
-                    "error": "server_unreachable",
+                    "reason": ErrorCode.SERVER_UNREACHABLE,
                     "message": "Cannot inspect slot — server unreachable",
                 }
 

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -52,7 +52,13 @@ class SlotListing:
         """
         rom_id = int(rom_id)
         if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "slots": [], "active_slot": "default"}
+            return {
+                "success": False,
+                "reason": "sync_disabled",
+                "message": SAVE_SYNC_DISABLED,
+                "slots": [],
+                "active_slot": "default",
+            }
 
         rom_id_str = str(rom_id)
         device_id = self._state_svc.get_server_device_id()

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from lib.list_result import ErrorCode
 from services.saves._messages import SAVE_SYNC_DISABLED
 
 if TYPE_CHECKING:
@@ -82,9 +83,10 @@ class SlotListing:
             self._log_debug(f"Failed to fetch save slots for rom {rom_id}: {e}")
             return {
                 "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE,
+                "message": str(e),
                 "slots": [],
                 "active_slot": active_slot,
-                "error": str(e),
             }
         server_slots_list: list[dict] = summary.get("slots", [])
 
@@ -150,7 +152,13 @@ class SlotListing:
         slot = str(slot).strip() if slot else ""
 
         if not self._state_svc.is_save_sync_enabled():
-            return {"success": False, "slot": slot, "saves": [], "error": SAVE_SYNC_DISABLED}
+            return {
+                "success": False,
+                "reason": "sync_disabled",
+                "message": SAVE_SYNC_DISABLED,
+                "slot": slot,
+                "saves": [],
+            }
 
         device_id = self._state_svc.get_server_device_id()
 
@@ -173,4 +181,10 @@ class SlotListing:
             ]
             return {"success": True, "slot": slot, "saves": saves}
         except Exception as e:
-            return {"success": False, "slot": slot, "saves": [], "error": str(e)}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE,
+                "message": str(e),
+                "slot": slot,
+                "saves": [],
+            }

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from lib.list_result import ErrorCode
 from services.saves._helpers import _local_save_target
 
 if TYPE_CHECKING:
@@ -173,8 +174,12 @@ class SlotSwitcher:
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
                 ),
             )
-        except Exception:
-            return {"success": False, "reason": "server_unreachable"}
+        except Exception as e:
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE,
+                "message": str(e),
+            }
 
         # Filter to the target slot (FakeSaveApi doesn't filter, real API may not either)
         # Normalize "" and None both to None before comparing (legacy saves may use either)

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -98,7 +98,7 @@ class VersionsService:
           contains: id, file_name, emulator, updated_at, file_size_bytes,
           device_syncs, uploaded_by_us. ``versions`` may be empty — the
           server answered, nothing matched.
-        - ``{"status": "server_unreachable", "error": ...}`` if the
+        - ``{"status": "server_unreachable", "message": ...}`` if the
           ``list_saves`` call failed (network, server, auth, etc.). The
           frontend distinguishes this from an empty list so it can show a
           retry affordance instead of "no versions available".
@@ -116,7 +116,7 @@ class VersionsService:
             )
         except Exception as e:
             self._log_debug(f"list_file_versions: failed to list saves: {e}")
-            return {"status": "server_unreachable", "error": str(e)}
+            return {"status": "server_unreachable", "message": str(e)}
 
         file_state = self._find_file_state(rom_id_str, filename)
         tracked_id = file_state.tracked_save_id if file_state else None
@@ -210,7 +210,7 @@ class VersionsService:
                 save_id,
                 e,
             )
-            return {"status": "put_failed", "error": str(e)}
+            return {"status": "put_failed", "message": str(e)}
 
         return {"status": "ok"}
 
@@ -247,7 +247,7 @@ class VersionsService:
         - ``{"status": "version_deleted"}`` if the chosen save id is no
           longer on the server (genuinely deleted — the ``list_saves``
           call succeeded and the id was absent).
-        - ``{"status": "server_unreachable", "error": ...}`` if the
+        - ``{"status": "server_unreachable", "message": ...}`` if the
           post-preflight ``list_saves`` call failed (network, server,
           auth, etc.). The frontend distinguishes this from
           ``version_deleted`` so it can show a retry affordance instead
@@ -258,11 +258,11 @@ class VersionsService:
         - ``{"status": "preflight_failed", "errors": [...]}`` if the
           pre-flight hit non-conflict errors (network, server, etc.).
           No switch was attempted.
-        - ``{"status": "put_failed", "error": ...}`` if the local download
-          succeeded but the server-side ``updated_at`` bump failed. Local
-          file and state already point at the target; retrying is safe
-          and idempotent. Without a successful re-PUT the switch will not
-          propagate cross-device.
+        - ``{"status": "put_failed", "message": ...}`` if the local
+          download succeeded but the server-side ``updated_at`` bump
+          failed. Local file and state already point at the target;
+          retrying is safe and idempotent. Without a successful re-PUT
+          the switch will not propagate cross-device.
         """
         rom_id = int(rom_id)
         rom_id_str = str(rom_id)
@@ -300,7 +300,7 @@ class VersionsService:
                 )
             except Exception as e:
                 self._log_debug(f"rollback_to_version: failed to list saves: {e}")
-                return {"status": "server_unreachable", "error": str(e)}
+                return {"status": "server_unreachable", "message": str(e)}
 
             result = await self._loop.run_in_executor(
                 None,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -150,7 +150,7 @@ export const resolveSyncConflict = callable<
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");
 export const updateSaveSyncSettings = callable<[SaveSyncSettings], { success: boolean }>("update_save_sync_settings");
-export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSlotSummary[]; active_slot: string; error?: string }>("get_save_slots");
+export const getSaveSlots = callable<[number], { success: boolean; slots: SaveSlotSummary[]; active_slot: string; reason?: string; message?: string }>("get_save_slots");
 export const getSlotSaves = callable<[number, string], SlotSavesResponse>("get_slot_saves");
 export const switchSlot = callable<[number, string], SwitchSlotResponse>("switch_slot");
 
@@ -163,10 +163,9 @@ export interface SlotDeleteInfo {
   local_file_count?: number;
   local_filenames?: string[];
   is_active?: boolean;
+  // Coarse failure category for routing (e.g. "server_unreachable",
+  // "not_found", "not_installed", "disabled", "active_slot").
   reason?: string;
-  // Coarse failure category for routing (e.g. "server_unreachable").
-  // Mirrors `reason` for the cases the modal needs to handle differently.
-  error?: string;
   message?: string;
 }
 
@@ -288,14 +287,14 @@ export type RollbackStatus =
   | { status: "rom_not_installed" }
   | { status: "version_deleted" }
   | { status: "unsupported" }
-  | { status: "server_unreachable"; error: string }
+  | { status: "server_unreachable"; message: string }
   | { status: "conflict_blocked"; conflicts: SyncConflict[] }
   | { status: "preflight_failed"; errors: string[] }
-  | { status: "put_failed"; error: string };
+  | { status: "put_failed"; message: string };
 
 export type ListFileVersionsResult =
   | { status: "ok"; versions: SaveVersionEntry[] }
-  | { status: "server_unreachable"; error: string };
+  | { status: "server_unreachable"; message: string };
 
 export const savesListFileVersions = callable<[number, string, string], ListFileVersionsResult>("saves_list_file_versions");
 export const savesRollbackToVersion = callable<[number, string, number], RollbackStatus>("saves_rollback_to_version");

--- a/src/components/saves/VersionHistoryPanel.test.tsx
+++ b/src/components/saves/VersionHistoryPanel.test.tsx
@@ -139,7 +139,7 @@ describe("VersionHistoryPanel", () => {
   it("shows error body + Retry button when server is unreachable on load", async () => {
     vi.mocked(backend.savesListFileVersions).mockResolvedValue({
       status: "server_unreachable",
-      error: "ECONNREFUSED",
+      message: "ECONNREFUSED",
     });
     const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
     fireEvent.click(getByText("Previous Versions"));
@@ -150,7 +150,7 @@ describe("VersionHistoryPanel", () => {
 
   it("Retry button retriggers loadVersions", async () => {
     vi.mocked(backend.savesListFileVersions)
-      .mockResolvedValueOnce({ status: "server_unreachable", error: "boom" })
+      .mockResolvedValueOnce({ status: "server_unreachable", message: "boom" })
       .mockResolvedValueOnce({ status: "ok", versions: [makeVersion({ id: 7 })] });
 
     const { getByText, container } = render(<VersionHistoryPanel {...defaultProps()} />);
@@ -318,7 +318,7 @@ describe("VersionHistoryPanel", () => {
     it("status 'put_failed' toasts the local-success warning, collapses, and calls onRestored", async () => {
       vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
         status: "put_failed",
-        error: "503",
+        message: "503",
       });
       const { getByText, onRestored } = await expand();
       fireEvent.click(getByText("Restore"));
@@ -360,7 +360,7 @@ describe("VersionHistoryPanel", () => {
     it("status 'server_unreachable' toasts the connection-prompt message", async () => {
       vi.mocked(backend.savesRollbackToVersion).mockResolvedValue({
         status: "server_unreachable",
-        error: "ECONNREFUSED",
+        message: "ECONNREFUSED",
       });
       const { getByText } = await expand();
       fireEvent.click(getByText("Restore"));

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -43,7 +43,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       if (result.status === "ok") {
         setVersions(result.versions);
       } else if (result.status === "server_unreachable") {
-        debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.error}`);
+        debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`);
         setVersions(null);
         setLoadError("Couldn't reach RomM. Tap retry.");
       }

--- a/src/components/saves/helpers.test.ts
+++ b/src/components/saves/helpers.test.ts
@@ -241,15 +241,6 @@ describe("slotDeleteFailureToast", () => {
     );
   });
 
-  it("surfaces the server-unreachable warning when only error='server_unreachable'", () => {
-    const info: SlotDeleteInfo = {
-      success: false,
-      error: "server_unreachable",
-      message: "boom",
-    };
-    expect(slotDeleteFailureToast(info)).toBe("boom");
-  });
-
   it("falls back to a generic server-unreachable message when no message is provided", () => {
     const info: SlotDeleteInfo = { success: false, reason: "server_unreachable" };
     expect(slotDeleteFailureToast(info)).toBe(

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -95,7 +95,7 @@ export function slotDeleteFailureToast(info: SlotDeleteInfo): string {
   if (info.reason === "active_slot" || info.is_active) {
     return "Cannot delete the active slot. Switch to a different slot first.";
   }
-  if (info.reason === "server_unreachable" || info.error === "server_unreachable") {
+  if (info.reason === "server_unreachable") {
     return info.message ?? "Cannot inspect slot — RomM server is not reachable";
   }
   return info.message ?? "Cannot delete this slot";

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -105,12 +105,14 @@ export interface SlotSavesResponse {
   success: boolean;
   slot: string;
   saves: SlotSaveFile[];
-  error?: string;
+  reason?: "server_unreachable" | "sync_disabled";
+  message?: string;
 }
 
 export interface SwitchSlotResponse {
   success: boolean;
   reason?: "pending_uploads" | "server_unreachable" | "sync_disabled" | "not_installed";
+  message?: string;
   files?: string[];
   save_status?: SaveStatus;
 }

--- a/src/utils/slotState.test.ts
+++ b/src/utils/slotState.test.ts
@@ -57,7 +57,7 @@ const callCount = <S>(setter: Dispatch<SetStateAction<S>>): number =>
 describe("applyRefreshSlotResult", () => {
   it("skips the setter when success=false (preserves persisted state)", () => {
     const setter = makeSetter<RefreshState>();
-    const result: SlotsResponse = { success: false, slots: [], error: "boom" };
+    const result: SlotsResponse = { success: false, slots: [], message: "boom" };
     applyRefreshSlotResult<RefreshState>(result, setter);
     expect(callCount(setter)).toBe(0);
   });
@@ -107,7 +107,7 @@ describe("applyLoadSlotsResult", () => {
     const setter = makeSetter<LoadState>();
     const loadedRef: MutableRefObject<boolean> = { current: true };
     const logError = vi.fn();
-    const result: SlotsResponse = { success: false, slots: [], error: "boom" };
+    const result: SlotsResponse = { success: false, slots: [], message: "boom" };
     applyLoadSlotsResult<LoadState>(result, setter, loadedRef, logError);
 
     expect(logError).toHaveBeenCalledWith("Failed to load save slots: boom");

--- a/src/utils/slotState.ts
+++ b/src/utils/slotState.ts
@@ -17,7 +17,8 @@ export interface SlotsResponse {
   success: boolean;
   slots: SaveSlotSummary[];
   active_slot?: string | null;
-  error?: string;
+  reason?: string;
+  message?: string;
 }
 
 export interface RefreshSlotFields {
@@ -55,7 +56,7 @@ export function applyLoadSlotsResult<S extends LoadSlotsFields>(
   logError: (msg: string) => void,
 ): void {
   if (!result.success) {
-    logError(`Failed to load save slots: ${result.error ?? "unknown"}`);
+    logError(`Failed to load save slots: ${result.message ?? result.reason ?? "unknown"}`);
     loadedRef.current = false;
     setter((prev) => ({ ...prev, slotsLoading: false }));
     return;

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -85,6 +85,10 @@ class TestSaveSlots:
         svc, _ = make_service(tmp_path)
         result = await svc.get_save_slots(123)
         assert result["success"] is False
+        assert result["reason"] == "sync_disabled"
+        assert "disabled" in result["message"].lower()
+        assert result["slots"] == []
+        assert result["active_slot"] == "default"
 
     @pytest.mark.asyncio
     async def test_get_save_slots_preserves_map_on_api_failure(self, tmp_path):

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -122,9 +122,10 @@ class TestSaveSlots:
 
         # Response indicates failure with the carried-over active slot.
         assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
         assert result["slots"] == []
         assert result["active_slot"] == "default"
-        assert "connection refused" in result["error"]
+        assert "connection refused" in result["message"]
         # In-memory slot map is untouched (no merge / overwrite happened).
         assert svc._save_sync_state.saves["123"].slots == original_slots
         # On-disk state is unchanged — no save_state() call after the failure.
@@ -704,9 +705,10 @@ class TestGetSlotSaves:
         result = await svc.get_slot_saves(42, "default")
 
         assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
         assert result["slot"] == "default"
         assert result["saves"] == []
-        assert "connection timeout" in result["error"]
+        assert "connection timeout" in result["message"]
 
     @pytest.mark.asyncio
     async def test_sync_disabled(self, tmp_path):
@@ -717,9 +719,10 @@ class TestGetSlotSaves:
         result = await svc.get_slot_saves(42, "default")
 
         assert result["success"] is False
+        assert result["reason"] == "sync_disabled"
         assert result["slot"] == "default"
         assert result["saves"] == []
-        assert "disabled" in result["error"].lower()
+        assert "disabled" in result["message"].lower()
 
 
 class TestSwitchSlot:
@@ -1170,8 +1173,11 @@ class TestDeleteSlot:
 
         assert result["success"] is False
         assert result["reason"] == "server_unreachable"
-        assert result["error"] == "server_unreachable"
         assert "message" in result
+        # Drift guard: the legacy duplicate ``error`` field was dropped in #652.
+        # Frontend now reads ``reason`` only. Re-adding ``error`` would
+        # reintroduce the dual-write that was deliberately removed.
+        assert "error" not in result
         # Critically: no fake "0 saves" count that would let the confirm modal
         # render "delete 0 saves".
         assert "server_save_count" not in result

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -158,7 +158,10 @@ class TestListFileVersions:
         result = await svc.list_file_versions(42, "default", "pokemon.srm")
 
         assert result["status"] == "server_unreachable"
-        assert "network" in result["error"].lower()
+        assert "network" in result["message"].lower()
+        # Drift guard: the legacy ``error`` field was renamed to ``message``
+        # in #652 to align with the canonical {success, reason, message} shape.
+        assert "error" not in result
         # Must NOT be the same shape as the happy-path empty case.
         assert result != {"status": "ok", "versions": []}
 
@@ -528,7 +531,10 @@ class TestRollbackToVersion:
             fake.list_saves = original_list  # type: ignore[method-assign]
 
         assert result["status"] == "server_unreachable"
-        assert "unreachable" in result.get("error", "").lower()
+        assert "unreachable" in result.get("message", "").lower()
+        # Drift guard: the legacy ``error`` field was renamed to ``message``
+        # in #652 to align with the canonical {success, reason, message} shape.
+        assert "error" not in result
         # Critical: must NOT collide with the "genuinely deleted" case.
         assert result["status"] != "version_deleted"
 
@@ -631,7 +637,7 @@ class TestRollbackToVersion:
             fake.upload_save = original_upload  # type: ignore[method-assign]
 
         assert result["status"] == "put_failed"
-        assert "PUT failed" in result.get("error", "")
+        assert "PUT failed" in result.get("message", "")
         # Download did happen
         download_calls = [c for c in fake.call_log if c[0] == "download_save_content"]
         assert any(c[1][0] == 50 for c in download_calls)


### PR DESCRIPTION
## Summary

Post-#619 cleanup. The silent-failure hardening epic (#622) landed 5 callables reporting "server unreachable" with 5 different shapes. This PR converges them on the canonical failure shape `{success: False, reason, message}` plus two principled carve-outs, and drops the redundant `error` field that `get_slot_delete_info` was dual-writing.

### Canonical shape (3 sites)

`slots/listing.py` (`get_save_slots`, `get_slot_saves`), `slots/deletion.py` (`get_slot_delete_info`), `slots/switching.py` (`switch_slot`):

```python
{"success": False, "reason": ErrorCode.SERVER_UNREACHABLE, "message": str(e), **payload-extras}
```

- `ErrorCode` (already in `lib/list_result.py`) is reused — no new enum.
- The duplicate `error` field that `get_slot_delete_info` was dual-writing alongside `reason` is dropped; the frontend reads `reason` only.

### Discriminated-status carve-out (`versions.py`)

`list_file_versions` and `rollback_to_version` keep their `status: "ok" | "server_unreachable" | "version_deleted" | …` discriminant — they carry 7+ outcomes, so collapsing to a binary `success` would erase the routing slug. Failure branches rename `error: str` to `message: str` for vocab parity with the canonical shape.

### Partial-success carve-out (`status/service.py`, `slots/setup.py`)

`get_save_status` keeps its additive `server_query_failed: bool` flag and `get_save_setup_info` keeps `recommended_action: "server_unreachable"` — both return a full payload alongside the failure flag. The call has half-broken half-working semantics that the binary `success` boolean would erase.

### Convention doc

Full paragraph in `lib/list_result.py` module docstring (next to the existing `ErrorCode` enum). Summary in `CLAUDE.md` under a new `## Callable response shapes — canonical failure shape` section.

### Frontend

- `src/api/backend.ts`: `RollbackStatus` + `ListFileVersionsResult` rename `error` → `message`; `SlotDeleteInfo` drops the duplicate `error` field; `getSaveSlots` callable typing carries `reason`+`message`.
- `src/types/saves.ts`: `SlotSavesResponse` adds `reason`+`message`, drops `error`; `SwitchSlotResponse` adds `message`.
- `src/components/saves/helpers.ts::slotDeleteFailureToast` drops the legacy `error === "server_unreachable"` read.
- `src/components/saves/VersionHistoryPanel.tsx` reads `result.message` instead of `result.error`.

## Test plan

- [x] `python -m pytest tests/ -q` — 2507 passed
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 kept, 0 broken
- [x] `pnpm build` — success
- [x] `pnpm test` — 449/449 passed

Closes #652