### PR TITLE
refactor(configs): drop Optional defaults in 11 ServiceConfigs

### DIFF
--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -59,8 +59,8 @@ class DownloadServiceConfig:
     clock: Clock
     sleeper: Sleeper
     state_persister: StatePersister
-    retrodeck_paths: RetroDeckPaths | None = None
-    is_retrodeck_migration_pending: MigrationPendingFn | None = None
+    retrodeck_paths: RetroDeckPaths
+    is_retrodeck_migration_pending: MigrationPendingFn
 
 
 class DownloadService:
@@ -156,7 +156,7 @@ class DownloadService:
 
     def _clean_rom_tmp_files(self):
         """Remove leftover .tmp and .zip.tmp files from ROM directories."""
-        roms_base = self._retrodeck_paths.roms_path() if self._retrodeck_paths else ""
+        roms_base = self._retrodeck_paths.roms_path()
         if not roms_base:
             return 0
         paths = self._download_file_store.walk_files_matching_suffixes(roms_base, (_TMP_EXT, _ZIP_TMP_EXT))
@@ -164,7 +164,7 @@ class DownloadService:
 
     def _clean_bios_tmp_files(self):
         """Remove leftover .tmp files from BIOS directory."""
-        bios_base = self._retrodeck_paths.bios_path() if self._retrodeck_paths else ""
+        bios_base = self._retrodeck_paths.bios_path()
         if not bios_base:
             return 0
         paths = self._download_file_store.walk_files_matching_suffixes(bios_base, (_TMP_EXT,))
@@ -186,7 +186,7 @@ class DownloadService:
                 # short-circuit BEFORE poll_and_clear reads + clears the
                 # request file, otherwise queued requests would be silently
                 # dropped on the floor.
-                if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+                if self._is_retrodeck_migration_pending():
                     continue
                 requests = await self._loop.run_in_executor(None, self._download_queue_io.poll_and_clear, requests_path)
                 if not requests:
@@ -217,7 +217,7 @@ class DownloadService:
         platform_fs_slug = rom_detail.get("platform_fs_slug")
         system = self._resolve_system(platform_slug, platform_fs_slug)
 
-        roms_dir = os.path.join(self._retrodeck_paths.roms_path() if self._retrodeck_paths else "", system)
+        roms_dir = os.path.join(self._retrodeck_paths.roms_path(), system)
         file_name, files_missing = resolve_local_file_name(rom_detail)
         if files_missing:
             self._logger.warning(
@@ -271,7 +271,7 @@ class DownloadService:
         rom_dir_name = os.path.splitext(file_name)[0]
         extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
         self._download_file_store.make_dirs(extract_dir)
-        roms_base = self._retrodeck_paths.roms_path() if self._retrodeck_paths else ""
+        roms_base = self._retrodeck_paths.roms_path()
         tmp_zip = target_path + _ZIP_TMP_EXT
         # ZIP-slip protection: adapter validates members resolve within extract_dir
         # AND that extract_dir itself resolves within roms_base.

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -52,9 +52,8 @@ class LibraryFetcherConfig:
     settings persistence callback, debug-logger seam, the shared
     ``LibrarySyncStateBox`` (read for the cancel signal), an
     ``_emit_progress`` callback the fetcher uses to surface long
-    paginated fetches to the frontend, and the optional
-    ``MetadataExtractor`` peer service the fetcher stamps the metadata
-    cache through.
+    paginated fetches to the frontend, and the ``MetadataExtractor``
+    peer service the fetcher stamps the metadata cache through.
     """
 
     romm_api: RommLibraryApi
@@ -68,7 +67,7 @@ class LibraryFetcherConfig:
     log_debug: DebugLogger
     sync_state_box: LibrarySyncStateBox
     emit_progress: EmitProgressFn
-    metadata_service: MetadataExtractor | None = None
+    metadata_service: MetadataExtractor
 
 
 class LibraryFetcher:
@@ -633,12 +632,11 @@ class LibraryFetcher:
         shortcuts_data = build_shortcuts_data(all_roms, self._plugin_dir)
         self._check_cancelling()
 
-        if self._metadata_service is not None:
-            for rom in all_roms:
-                rom_id_str = str(rom["id"])
-                self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
-                self._metadata_service.mark_metadata_dirty()
-            self._metadata_service.flush_metadata_if_dirty()
+        for rom in all_roms:
+            rom_id_str = str(rom["id"])
+            self._metadata_cache[rom_id_str] = self._metadata_service.extract_metadata(rom)
+            self._metadata_service.mark_metadata_dirty()
+        self._metadata_service.flush_metadata_if_dirty()
         self._log_debug(f"Metadata cached for {len(all_roms)} ROMs (prefetch)")
 
         return prefetched, all_roms, shortcuts_data, collection_memberships, platform_rom_ids
@@ -649,7 +647,7 @@ class LibraryFetcher:
         Called by the per-unit pipeline after each unit so a mid-sync
         crash leaves cached metadata for every unit that completed.
         """
-        if self._metadata_service is None or not unit_roms:
+        if not unit_roms:
             return
         for rom in unit_roms:
             rom_id_str = str(rom["id"])

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -49,8 +49,8 @@ class SyncReporterConfig:
     reporter reads the pending-sync dicts populated by the orchestrator
     and clears the active sync id when reporting completes), an
     orchestrator-supplied ``emit_progress`` callback for the terminal
-    "done" event, and the optional ``ArtworkManager`` peer used for
-    cover-path finalisation.
+    "done" event, and the ``ArtworkManager`` peer used for cover-path
+    finalisation.
     """
 
     steam_config: SteamConfigStore
@@ -63,7 +63,7 @@ class SyncReporterConfig:
     state_persister: StatePersister
     sync_state_box: LibrarySyncStateBox
     emit_progress: EmitProgressFn
-    artwork: ArtworkManager | None = None
+    artwork: ArtworkManager
 
 
 class SyncReporter:
@@ -85,10 +85,8 @@ class SyncReporter:
     # ── Report sync results (frontend callback) ──────────────────
 
     def _finalize_cover_path(self, grid, cover_path, app_id, rom_id_str):
-        """Delegate to ArtworkService callback if available, else passthrough."""
-        if self._artwork is not None:
-            return self._artwork.finalize_cover_path(grid, cover_path, app_id, rom_id_str)
-        return cover_path
+        """Delegate to ArtworkService for the final ``{app_id}p.png`` cover-path."""
+        return self._artwork.finalize_cover_path(grid, cover_path, app_id, rom_id_str)
 
     def _build_registry_entry(self, pending, app_id, cover_path):
         """Build a registry entry dict from pending sync data."""

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -51,8 +51,8 @@ class LibraryServiceConfig:
     Holds the Protocol-typed adapters, the live state/settings/metadata
     cache dicts, runtime infrastructure, time/sleep/uuid seams, plugin-
     dir reference, event emitter, persistence callbacks, debug-logger
-    seam, and the optional metadata/artwork peer services LibraryService
-    needs at construction time.
+    seam, and the metadata/artwork peer services LibraryService needs
+    at construction time.
     """
 
     romm_api: RommLibraryApi
@@ -70,8 +70,8 @@ class LibraryServiceConfig:
     state_persister: StatePersister
     settings_persister: SettingsPersister
     log_debug: DebugLogger
-    metadata_service: MetadataExtractor | None = None
-    artwork: ArtworkManager | None = None
+    metadata_service: MetadataExtractor
+    artwork: ArtworkManager
 
 
 class LibraryService:

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -72,10 +72,10 @@ class SyncOrchestratorConfig:
     plugin-dir reference for shortcut data construction, the shared
     :class:`LibrarySyncStateBox`, and three peer references the
     orchestrator drives at runtime: the :class:`LibraryFetcher` it
-    delegates prefetching and per-unit fetches to, an optional
+    delegates prefetching and per-unit fetches to, an
     :class:`ArtworkManager` for the apply-phase artwork download, and
-    an optional :class:`MetadataExtractor` it asks to flush its dirty
-    metadata cache during the sync ``finally``. The ``reporter`` field
+    a :class:`MetadataExtractor` it asks to flush its dirty metadata
+    cache during the sync ``finally``. The ``reporter`` field
     is a :class:`LateBinding` because :class:`LibraryService` constructs
     the orchestrator before the reporter exists; the façade plugs the
     reader in via ``set()`` once the reporter is built.
@@ -94,8 +94,8 @@ class SyncOrchestratorConfig:
     sync_state_box: LibrarySyncStateBox
     fetcher: LibraryFetcher
     reporter: LateBinding[SyncReporter]
-    metadata_service: MetadataExtractor | None = None
-    artwork: ArtworkManager | None = None
+    metadata_service: MetadataExtractor
+    artwork: ArtworkManager
 
 
 class SyncOrchestrator:
@@ -422,8 +422,7 @@ class SyncOrchestrator:
             self._loop.create_task(self._emit("sync_progress", box.sync_progress))
             box.sync_state = SyncState.IDLE
         finally:
-            if self._metadata_service is not None:
-                self._metadata_service.flush_metadata_if_dirty()
+            self._metadata_service.flush_metadata_if_dirty()
 
     async def _sync_one_unit(
         self,
@@ -646,12 +645,10 @@ class SyncOrchestrator:
     async def _download_artwork(self, all_roms, progress_step=4, progress_total_steps=6):
         """Delegate artwork download to ArtworkService callback."""
         box = self._sync_state
-        if self._artwork is not None:
-            return await self._artwork.download_artwork(
-                all_roms,
-                emit_progress=self._emit_progress,
-                is_cancelling=lambda: box.sync_state == SyncState.CANCELLING,
-                progress_step=progress_step,
-                progress_total_steps=progress_total_steps,
-            )
-        return {}
+        return await self._artwork.download_artwork(
+            all_roms,
+            emit_progress=self._emit_progress,
+            is_cancelling=lambda: box.sync_state == SyncState.CANCELLING,
+            progress_step=progress_step,
+            progress_total_steps=progress_total_steps,
+        )

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -49,10 +49,10 @@ class MigrationServiceConfig:
     state_persister: StatePersister
     emit: EventEmitter
     get_bios_files_index: Callable[[], dict]
-    retrodeck_paths: RetroDeckPaths | None = None
-    get_retroarch_save_sorting: RetroArchSaveSortingProvider | None = None
-    get_active_core: CoreResolverFn | None = None
-    get_core_name: CoreNameProviderFn | None = None
+    retrodeck_paths: RetroDeckPaths
+    get_retroarch_save_sorting: RetroArchSaveSortingProvider
+    get_active_core: CoreResolverFn
+    get_core_name: CoreNameProviderFn
 
 
 class MigrationService:
@@ -73,7 +73,7 @@ class MigrationService:
 
     def detect_retrodeck_path_change(self) -> None:
         """Check if RetroDECK home path changed since last run."""
-        current_home = self._retrodeck_paths.retrodeck_home() if self._retrodeck_paths else ""
+        current_home = self._retrodeck_paths.retrodeck_home()
         stored_home = self._state.get("retrodeck_home_path", "")
 
         if not current_home:
@@ -198,7 +198,7 @@ class MigrationService:
         """Collect untracked BIOS migration items (downloaded before state tracking)."""
         items = []
         old_bios = os.path.join(old_home, "bios")
-        new_bios = self._retrodeck_paths.bios_path() if self._retrodeck_paths else ""
+        new_bios = self._retrodeck_paths.bios_path()
         if not self._migration_file_store.is_dir(old_bios):
             return items
         downloaded_bios = self._state.get("downloaded_bios", {})
@@ -222,7 +222,7 @@ class MigrationService:
         """
         items = []
         old_saves = os.path.join(old_home, "saves")
-        new_saves = self._retrodeck_paths.saves_path() if self._retrodeck_paths else ""
+        new_saves = self._retrodeck_paths.saves_path()
         if not self._migration_file_store.is_dir(old_saves):
             return items
         for dirpath, _dirs, filenames in self._migration_file_store.walk_files(old_saves):
@@ -449,8 +449,6 @@ class MigrationService:
         ``loop.create_task`` is NOT thread-safe and races with loop
         internals on CPython (#238 review).
         """
-        if self._get_retroarch_save_sorting is None:
-            return
         sort_by_content, sort_by_core = self._get_retroarch_save_sorting()
         current = {"sort_by_content": sort_by_content, "sort_by_core": sort_by_core}
         stored = self._state.get("save_sort_settings")
@@ -485,13 +483,11 @@ class MigrationService:
         subdirectories.
 
         Returns a ``(corename, core_so)`` tuple. ``corename`` is ``None``
-        (fail loud, no ES-DE label fallback) if either provider is
-        missing or unable to resolve. ``core_so`` is the underlying
+        (fail loud, no ES-DE label fallback) when the providers cannot
+        resolve a core for this system/ROM. ``core_so`` is the underlying
         ES-DE core ``.so`` basename when known (useful for diagnostics
         when ``corename`` is ``None``), otherwise ``None``.
         """
-        if self._get_active_core is None or self._get_core_name is None:
-            return (None, None)
         core_so, _label = self._get_active_core(system, rom_filename)
         if not core_so:
             return (None, None)
@@ -500,8 +496,6 @@ class MigrationService:
 
     def _collect_save_sorting_items(self, old_settings: dict, new_settings: dict) -> list:
         """Collect save files that need migration due to sort setting change."""
-        if not self._retrodeck_paths:
-            return []
         saves_base = self._retrodeck_paths.saves_path()
         roms_base = self._retrodeck_paths.roms_path()
         need_core = bool(old_settings.get("sort_by_core") or new_settings.get("sort_by_core"))

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -20,10 +20,11 @@ class RomRemovalServiceConfig:
     """Frozen wiring bundle handed to ``RomRemovalService.__init__``.
 
     Holds the live state dicts, runtime infrastructure, persistence
-    callbacks, the Protocol-typed filesystem adapter, optional
-    RetroDECK paths bundle, and the optional ``DownloadQueueCleanup``
-    eviction seam. Decomposes the ctor so a new dependency does not
-    push past the S107 parameter-count limit.
+    callbacks, the Protocol-typed filesystem adapter, the RetroDECK
+    paths bundle, and the ``DownloadQueueCleanup`` eviction seam
+    (``None`` when no download cleanup is wired). Decomposes the ctor
+    so a new dependency does not push past the S107 parameter-count
+    limit.
     """
 
     state: dict
@@ -33,8 +34,8 @@ class RomRemovalServiceConfig:
     state_persister: StatePersister
     save_sync_state_writer: StatePersister
     rom_file_store: RomFileStore
-    retrodeck_paths: RetroDeckPaths | None = None
-    download_queue_cleanup: DownloadQueueCleanup | None = None
+    retrodeck_paths: RetroDeckPaths
+    download_queue_cleanup: DownloadQueueCleanup | None
 
 
 class RomRemovalService:
@@ -60,7 +61,7 @@ class RomRemovalService:
         rom_dir = installed.get("rom_dir", "")
         file_path = installed.get("file_path", "")
 
-        roms_base = self._retrodeck_paths.roms_path() if self._retrodeck_paths else ""
+        roms_base = self._retrodeck_paths.roms_path()
         if rom_dir and self._rom_file_store.is_dir(rom_dir):
             if not is_safe_rom_path(rom_dir, roms_base):
                 self._logger.error(f"Refusing to delete path outside roms directory: {rom_dir}")

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -84,14 +84,14 @@ class SaveServiceConfig:
     get_core_name:
         Callable returning the RetroArch canonical ``corename`` field
         from a core's ``.info`` file for a given ``core_so`` (e.g.
-        ``"mgba_libretro"`` -> ``"mGBA"``). Optional. When
+        ``"mgba_libretro"`` -> ``"mGBA"``). When
         ``sort_savefiles_enable`` is active on RetroArch, this is the
         authoritative name used for the per-core save subdirectory — it
         is NOT the same as the ES-DE UI label returned by
         ``get_active_core`` (see the Config-Source-Parsers wiki page
-        for the one-parser-per-source rationale). When ``None`` or when
-        resolution fails at runtime, SaveService warns and falls back
-        to the parent directory path; see
+        for the one-parser-per-source rationale). When resolution fails
+        at runtime (the callable returns ``None``), SaveService warns
+        and falls back to the parent directory path; see
         ``_resolve_retroarch_corename``.
     plugin_metadata:
         ``PluginMetadataReader`` Protocol seam — read once during
@@ -101,11 +101,10 @@ class SaveServiceConfig:
         Plugin install directory (``decky.DECKY_PLUGIN_DIR``) passed to
         :meth:`PluginMetadataReader.read_version`.
     emit:
-        Optional event emitter for pushing save-sync progress to the
-        frontend. ``None`` disables emission (used in unit tests).
+        Event emitter for pushing save-sync progress to the frontend.
     detect_sort_change:
-        Optional synchronous callback that refreshes save-sort state
-        from the live RetroArch config (wired to
+        Synchronous callback that refreshes save-sort state from the
+        live RetroArch config (wired to
         ``MigrationService.detect_save_sort_change`` in ``bootstrap``).
         Save-sync MUST see fresh save-sort state before computing
         ``saves_dir`` — otherwise a direct-Steam-launch with no
@@ -113,14 +112,11 @@ class SaveServiceConfig:
         content to the wrong layout and destroy real user progress
         during the subsequent migration (#238). ``pre_launch_sync`` and
         ``post_exit_sync`` invoke this callback once at their entry
-        point. ``None`` disables the call (used only in unit tests
-        where state is seeded explicitly); failures are logged and
-        swallowed so save-sync degrades gracefully to the
-        previously-known state.
+        point; failures are logged and swallowed so save-sync degrades
+        gracefully to the previously-known state.
     is_retrodeck_migration_pending:
-        Optional callback returning ``True`` when a RetroDECK migration
-        is in flight; SaveService gates destructive operations on this
-        signal. ``None`` disables the gate (unit tests).
+        Callback returning ``True`` when a RetroDECK migration is in
+        flight; SaveService gates destructive operations on this signal.
     log_debug:
         ``DebugLogger`` Protocol seam — routes through the user's QAM
         log-level filter. Injected directly into each sub-service that
@@ -143,7 +139,7 @@ class SaveServiceConfig:
     log_debug: DebugLogger
     plugin_metadata: PluginMetadataReader
     plugin_dir: str
-    get_core_name: CoreNameProviderFn | None = None
-    emit: EventEmitter | None = None
-    detect_sort_change: SaveSortChangeFn | None = None
-    is_retrodeck_migration_pending: MigrationPendingFn | None = None
+    get_core_name: CoreNameProviderFn
+    emit: EventEmitter
+    detect_sort_change: SaveSortChangeFn
+    is_retrodeck_migration_pending: MigrationPendingFn

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -37,15 +37,14 @@ class RomInfoServiceConfig:
     Holds the main plugin state dict (for ``installed_roms`` reads and
     save-sort state), the Protocol-typed filesystem adapter, the
     RetroDECK runtime-path accessor, the ES-DE core resolver, the
-    optional RetroArch core-name provider, and the standard-library
-    logger.
+    RetroArch core-name provider, and the standard-library logger.
     """
 
     state: dict
     save_file_store: SaveFileStore
     retrodeck_paths: RetroDeckPaths
     get_active_core: CoreResolverFn
-    get_core_name: CoreNameProviderFn | None
+    get_core_name: CoreNameProviderFn
     logger: logging.Logger
 
 
@@ -154,16 +153,13 @@ class RomInfoService:
         Returns ``(corename, core_so)``. Either element may be ``None``
         when resolution fails at that step: ``core_so`` is ``None`` when
         ES-DE cannot determine the active core, ``corename`` is ``None``
-        when ``.info`` parsing returns nothing (or when ``get_core_name``
-        is not injected). Returning the tuple — rather than just
-        ``corename`` — lets callers include ``core_so`` in diagnostic
-        logs so users can identify which ``.info`` file is at fault.
-        Callers choose their own fallback strategy (e.g. warn and fall
-        back for critical-path SaveService flows; skip and warn for
-        one-shot migrations).
+        when ``.info`` parsing returns nothing. Returning the tuple —
+        rather than just ``corename`` — lets callers include ``core_so``
+        in diagnostic logs so users can identify which ``.info`` file
+        is at fault. Callers choose their own fallback strategy (e.g.
+        warn and fall back for critical-path SaveService flows; skip
+        and warn for one-shot migrations).
         """
-        if self._get_core_name is None:
-            return (None, None)
         core_so, _label = self._get_active_core(system, rom_filename)
         if not core_so:
             return (None, None)

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -39,8 +39,8 @@ class StatusServiceConfig:
     (state, sync_engine, rom_info), the Protocol-typed RomM adapter
     and retry strategy, the plugin event loop, the standard-library
     logger, the ``DebugLogger`` seam, the ES-DE core resolver, and
-    the optional event emitter used to push background status updates
-    to the frontend.
+    the event emitter used to push background status updates to the
+    frontend.
     """
 
     state: dict
@@ -53,7 +53,7 @@ class StatusServiceConfig:
     logger: logging.Logger
     log_debug: DebugLogger
     get_active_core: CoreResolverFn
-    emit: EventEmitter | None
+    emit: EventEmitter
 
 
 class StatusService:
@@ -276,8 +276,7 @@ class StatusService:
         """Run full save status check in background and emit result to frontend."""
         try:
             result = await self.get_save_status(rom_id)
-            if self._emit is not None:
-                await self._emit("save_status_updated", result)
+            await self._emit("save_status_updated", result)
         except Exception as e:
             self._log_debug(f"Background save status check failed for rom {rom_id}: {e}")
 

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -72,8 +72,8 @@ class SyncEngineConfig:
     get_active_core: CoreResolverFn
     hostname_provider: HostnameProvider
     plugin_version: str
-    detect_sort_change: SaveSortChangeFn | None
-    is_retrodeck_migration_pending: MigrationPendingFn | None
+    detect_sort_change: SaveSortChangeFn
+    is_retrodeck_migration_pending: MigrationPendingFn
 
 
 class SyncEngine:
@@ -236,8 +236,6 @@ class SyncEngine:
         previously-known state — save-sync must not abort because of a
         config read error.
         """
-        if self._detect_sort_change is None:
-            return
         try:
             await self._loop.run_in_executor(None, self._detect_sort_change)
         except Exception as e:
@@ -260,7 +258,7 @@ class SyncEngine:
             # files still living at the old home. Internal _sync_rom_saves callers
             # (sync_all_saves, rollback_to_version) are protected by the decorator
             # on their own public callables — this guard is for pre_launch_sync.
-            if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+            if self._is_retrodeck_migration_pending():
                 return {
                     "success": False,
                     "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
@@ -314,7 +312,7 @@ class SyncEngine:
             # Defense in depth: same rationale as pre_launch_sync — internal
             # _sync_rom_saves callers are protected by @migration_blocked on
             # their public callables; this guard covers post_exit_sync only.
-            if self._is_retrodeck_migration_pending and self._is_retrodeck_migration_pending():
+            if self._is_retrodeck_migration_pending():
                 self._logger.info("post_exit_sync skipped: retrodeck migration pending")
                 return {
                     "success": False,

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -5,6 +5,7 @@ import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.romm.http import RommHttpAdapter
@@ -60,6 +61,8 @@ def plugin():
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
 

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -1,0 +1,85 @@
+"""In-memory peer-service fakes consumed by the LibraryService test suite.
+
+Provides minimal ``MetadataExtractor`` and ``ArtworkManager`` Protocol
+implementations for tests that wire LibraryService (or its sub-services)
+without exercising metadata extraction or the SteamGridDB artwork
+pipeline. Both fakes record calls so tests that DO care about wiring
+can assert on the recorded activity.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class FakeMetadataExtractor:
+    """In-memory ``MetadataExtractor`` for tests.
+
+    Returns the dict configured at construction (``canned_extract``) from
+    every ``extract_metadata`` call. Counts ``mark_metadata_dirty`` and
+    ``flush_metadata_if_dirty`` invocations so tests that wire the peer
+    can assert it was reached without standing up the real service.
+    """
+
+    def __init__(self, canned_extract: dict | None = None) -> None:
+        self.canned_extract: dict = canned_extract if canned_extract is not None else {}
+        self.extract_calls: list[dict] = []
+        self.mark_dirty_count: int = 0
+        self.flush_count: int = 0
+
+    def extract_metadata(self, rom: dict) -> dict:
+        self.extract_calls.append(rom)
+        return dict(self.canned_extract)
+
+    def mark_metadata_dirty(self) -> None:
+        self.mark_dirty_count += 1
+
+    def flush_metadata_if_dirty(self) -> None:
+        self.flush_count += 1
+
+
+class FakeArtworkManager:
+    """In-memory ``ArtworkManager`` for tests.
+
+    ``download_artwork`` returns the dict configured at construction
+    (``canned_download``) and records the call args.
+    ``finalize_cover_path`` passes the input ``cover_path`` through
+    unchanged by default — tests that need a rewrite can override the
+    callable via ``finalize_override``.
+    ``remove_artwork_files`` records each call so tests can assert
+    removal was triggered without standing up the real service.
+    """
+
+    def __init__(
+        self,
+        canned_download: dict | None = None,
+        finalize_override: Callable[[str | None, str, int, str], str] | None = None,
+    ) -> None:
+        self.canned_download: dict = canned_download if canned_download is not None else {}
+        self.finalize_override = finalize_override
+        self.download_calls: list[tuple[list[dict], Any, Any, int, int]] = []
+        self.finalize_calls: list[tuple[str | None, str, int, str]] = []
+        self.remove_calls: list[tuple[str, str | int, dict]] = []
+
+    async def download_artwork(
+        self,
+        all_roms: list[dict],
+        emit_progress: Awaitable[None] | Callable[..., Awaitable[None]],
+        is_cancelling: Any,
+        progress_step: int = 4,
+        progress_total_steps: int = 6,
+    ) -> dict:
+        self.download_calls.append((list(all_roms), emit_progress, is_cancelling, progress_step, progress_total_steps))
+        return dict(self.canned_download)
+
+    def finalize_cover_path(self, grid: str | None, cover_path: str, app_id: int, rom_id_str: str) -> str:
+        self.finalize_calls.append((grid, cover_path, app_id, rom_id_str))
+        if self.finalize_override is not None:
+            return self.finalize_override(grid, cover_path, app_id, rom_id_str)
+        return cover_path
+
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None:
+        self.remove_calls.append((grid, rom_id, dict(entry)))

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -473,30 +473,6 @@ class TestPrefetchAllUnits:
         assert all_roms == []
         assert prefetched[0].all_collection_rom_ids == []
 
-    @pytest.mark.asyncio
-    async def test_skips_metadata_block_when_no_metadata_service(self, plugin, fake_romm_api):
-        """Branch 628->634: when metadata_service is None, the cache-stamping loop is skipped."""
-        _wire_fake(plugin, fake_romm_api)
-        fake_romm_api.platforms = [
-            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
-        ]
-        fake_romm_api.roms = {
-            10: {"id": 10, "platform_id": 1, "name": "A"},
-        }
-        plugin._state["last_sync"] = None
-        plugin._state["shortcut_registry"] = {}
-
-        plugin._sync_service._fetcher._metadata_service = None
-        # Tracking dict to confirm the metadata_cache was NOT touched.
-        plugin._sync_service._fetcher._metadata_cache = {}
-
-        prefetched, all_roms, *_ = await plugin._sync_service._fetcher.prefetch_all_units()
-
-        assert len(all_roms) == 1
-        assert prefetched[0].unit.name == "N64"
-        # No metadata service => metadata_cache stays empty.
-        assert plugin._sync_service._fetcher._metadata_cache == {}
-
 
 class TestBuildWorkQueueErrorPaths:
     """Tests for build_work_queue() collection-list failure / filter branches."""

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1677,12 +1677,3 @@ class TestDownloadArtworkDelegation:
         assert is_cancelling() is False
         plugin._sync_service._sync_state = SyncState.CANCELLING
         assert is_cancelling() is True
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_when_artwork_manager_missing(self, plugin):
-        """No _artwork bound → return {} without raising."""
-        plugin._sync_service._orchestrator._artwork = None
-        result = await plugin._sync_service._orchestrator._download_artwork(
-            [{"id": 1}], progress_step=1, progress_total_steps=1
-        )
-        assert result == {}

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -29,6 +29,10 @@ def _make_save_sync_state_persister(tmp_path) -> SaveSyncStatePersisterAdapter:
     )
 
 
+async def _noop_emit(_event: str, /, *_args: object) -> None:
+    """Default emitter for SaveService tests — drops all events."""
+
+
 def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["SaveService", "FakeSaveApi"]:
     """Create a SaveService with sensible defaults for testing."""
     save_file_store = SaveFileAdapter()
@@ -58,7 +62,10 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         log_debug=lambda _msg: None,
         plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
         plugin_dir=str(tmp_path / "plugin"),
-        emit=emit,
+        emit=emit if emit is not None else _noop_emit,
+        get_core_name=lambda core_so: None,
+        detect_sort_change=lambda: None,
+        is_retrodeck_migration_pending=lambda: False,
     )
     config_kwargs.update(overrides)
     svc = SaveService(config=SaveServiceConfig(**config_kwargs))

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -451,21 +451,6 @@ class TestPostExitSync:
         assert any("detect_sort_change failed" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_post_exit_sync_works_when_detect_sort_change_is_none(self, tmp_path):
-        """Default detect_sort_change=None: post_exit_sync still runs without error (#238)."""
-        svc, _ = make_service(tmp_path)  # detect_sort_change not passed → None
-        assert svc._sync_engine._detect_sort_change is None
-        svc._save_sync_state.settings.save_sync_enabled = True
-        svc._save_sync_state.device_id = "test-device"
-        _install_rom(svc, tmp_path)
-        _create_save(tmp_path, content=b"progress")
-
-        result = await svc.post_exit_sync(42)
-
-        assert result["success"] is True
-        assert result["synced"] == 1
-
-    @pytest.mark.asyncio
     async def test_post_exit_sync_message_includes_conflict_count(self, tmp_path):
         """post_exit_sync must surface conflict count in its message.
 
@@ -511,15 +496,6 @@ class TestCheckSaveStatusBackground:
         result = emitted[0][1][0]
         assert result["rom_id"] == 42
         assert len(result["files"]) >= 1
-
-    @pytest.mark.asyncio
-    async def test_no_emit_when_emit_is_none(self, tmp_path):
-        """Background check works without emit (no crash)."""
-        svc, _ = make_service(tmp_path)
-        _install_rom(svc, tmp_path)
-
-        # Should not raise even without emit
-        await svc.check_save_status_background(42)
 
     @pytest.mark.asyncio
     async def test_swallows_errors(self, tmp_path):

--- a/tests/services/saves/test_rom_info.py
+++ b/tests/services/saves/test_rom_info.py
@@ -267,17 +267,16 @@ class TestGetRomSaveInfo:
         assert warnings, "expected fallback warning"
         assert "core_so=mgba_libretro" in warnings[0]
 
-    def test_sort_by_core_falls_back_when_get_core_name_missing(self, tmp_path, caplog):
-        """Constructed without get_core_name → still warns and falls back.
+    def test_sort_by_core_falls_back_when_get_core_name_returns_none(self, tmp_path, caplog):
+        """``get_core_name`` returns ``None`` (.info unreadable) → warns and falls back.
 
-        When ``get_core_name`` is not injected, the helper short-circuits before
-        calling ``get_active_core``, so ``core_so`` is never resolved and the log
-        records ``core_so=unresolved`` for that case.
+        ``get_active_core`` succeeded so ``core_so`` is identified in the
+        diagnostic log to help the user locate the unreadable .info file.
         """
         svc, _ = make_service(
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
-            # get_core_name intentionally omitted (defaults to None)
+            get_core_name=lambda core_so: None,
         )
         _install_rom(svc, tmp_path)
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
@@ -289,7 +288,7 @@ class TestGetRomSaveInfo:
         assert result["saves_dir"].endswith("saves/gba")
         warnings = [rec.message for rec in caplog.records if "unable to resolve RetroArch corename" in rec.message]
         assert warnings, "expected fallback warning"
-        assert "core_so=unresolved" in warnings[0]
+        assert "core_so=mgba_libretro" in warnings[0]
 
     def test_sort_by_core_falls_back_when_active_core_unresolved(self, tmp_path, caplog):
         """sort_by_core=True but get_active_core returns (None, None) → warn + fall back.

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.steam_config import SteamConfigAdapter
@@ -67,6 +68,8 @@ def plugin(clock):
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
     p._achievements_service = AchievementsService(

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -9,6 +9,7 @@ import pytest
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
 from conftest import _make_testable_plugin
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.download_file import DownloadFileAdapter
@@ -53,6 +54,8 @@ def plugin():
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
     p._save_sync_state = SaveSyncState()
@@ -74,6 +77,7 @@ def plugin():
                 roms=os.path.join(os.path.expanduser("~"), "retrodeck", "roms"),
                 bios=os.path.join(os.path.expanduser("~"), "retrodeck", "bios"),
             ),
+            is_retrodeck_migration_pending=lambda: False,
         ),
     )
     p._rom_removal_service = RomRemovalService(
@@ -2261,19 +2265,6 @@ class TestCleanupLeftoverTmpFilesNoRetrodeckPaths:
     / bios_path() return ""). Service must not walk an empty path.
     """
 
-    def test_no_retrodeck_paths_bundle_skips_walk(self, plugin):
-        from fakes.fake_download_file_store import FakeDownloadFileStore
-
-        fake = FakeDownloadFileStore()
-        plugin._download_service._download_file_store = fake
-        # Drop the retrodeck_paths bundle entirely — both clean helpers
-        # must short-circuit before walking.
-        plugin._download_service._retrodeck_paths = None
-
-        plugin._download_service.cleanup_leftover_tmp_files()
-
-        assert fake.walk_calls == []
-
     def test_empty_roms_and_bios_paths_skip_walk(self, plugin):
         from fakes.fake_download_file_store import FakeDownloadFileStore
 
@@ -2342,7 +2333,7 @@ class TestPollDownloadRequestsLoopBody:
         from fakes.fake_download_queue_adapter import FakeDownloadQueueAdapter
 
         plugin._download_service._runtime_dir = str(tmp_path)
-        plugin._download_service._is_retrodeck_migration_pending = None
+        plugin._download_service._is_retrodeck_migration_pending = lambda: False
 
         class _CancellingSleeper:
             def __init__(self):
@@ -2371,7 +2362,7 @@ class TestPollDownloadRequestsLoopBody:
         import logging
 
         plugin._download_service._runtime_dir = str(tmp_path)
-        plugin._download_service._is_retrodeck_migration_pending = None
+        plugin._download_service._is_retrodeck_migration_pending = lambda: False
 
         # Sleeper cancels after a couple of iterations so the loop
         # body runs at least once after the failing poll.

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -8,6 +8,7 @@ from fakes.fake_core_info_provider import FakeCoreInfoProvider
 from fakes.fake_firmware_cache_persister import FakeFirmwareCachePersister
 from fakes.fake_firmware_file_store import FakeFirmwareFileStore
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.bios import BiosFileEntry
 
@@ -82,6 +83,8 @@ def plugin():
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
     return p

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -13,6 +13,7 @@ from fakes.fake_hostname_provider import FakeHostnameProvider
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
@@ -69,6 +70,8 @@ def plugin(tmp_path):
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
     decky.DECKY_USER_HOME = str(tmp_path)
@@ -105,6 +108,10 @@ def plugin(tmp_path):
             log_debug=p._log_debug,
             plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
             plugin_dir=str(tmp_path / "plugin"),
+            emit=AsyncMock(),
+            get_core_name=lambda core_so: None,
+            detect_sort_change=lambda: None,
+            is_retrodeck_migration_pending=lambda: False,
         ),
     )
     p._save_sync_service.init_state()

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -8,6 +8,7 @@ import pytest
 from fakes.fake_metadata_cache_persister import FakeMetadataCachePersister
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_state_persister import FakeStatePersister
+from fakes.library_peers import FakeArtworkManager
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.debug_logger import SettingsAwareDebugLogger
@@ -70,6 +71,7 @@ def plugin():
             settings_persister=p._settings_persister,
             log_debug=p._log_debug,
             metadata_service=metadata_service,
+            artwork=FakeArtworkManager(),
         ),
     )
     return p

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -10,6 +10,7 @@ from fakes.fake_migration_file_store import FakeMigrationFileStore
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_state_persister import FakeStatePersister
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
@@ -98,6 +99,8 @@ def plugin(tmp_path, fake_romm_api):
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
 

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -144,24 +144,6 @@ class TestDetectSaveSortChange:
         assert len(scheduled) == 1
         save_state_mock.save_state.assert_called_once()
 
-    def test_no_callback_noop(self, tmp_path):
-        """No get_retroarch_save_sorting callback — method is a no-op."""
-        save_state_mock = MagicMock()
-        svc = MigrationService(
-            config=MigrationServiceConfig(
-                migration_file_store=MigrationFileAdapter(),
-                state={"save_sort_settings": None, "installed_roms": {}},
-                loop=asyncio.get_event_loop(),
-                logger=logging.getLogger("test"),
-                state_persister=save_state_mock,
-                emit=MagicMock(),
-                get_bios_files_index=lambda: {},
-            ),
-        )
-        # Should not raise, no state changes
-        svc.detect_save_sort_change()
-        save_state_mock.save_state.assert_not_called()
-
 
 class TestCollectSaveSortingItems:
     def test_finds_existing_saves(self, tmp_path):
@@ -729,43 +711,6 @@ class TestResolveRetroArchCorename:
 
         svc, _ = _make_service(tmp_path, active_core=active_core, get_core_name=get_core_name)
         assert svc._resolve_retroarch_corename("blank", "Game.rom") == (None, "blank_libretro")
-
-    def test_no_core_name_callback_returns_none(self, tmp_path):
-        """Service constructed without ``get_core_name`` — method returns (None, None)."""
-
-        def active_core(system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]:
-            return ("snes9x_libretro", "Snes9x - Current")
-
-        svc = MigrationService(
-            config=MigrationServiceConfig(
-                migration_file_store=MigrationFileAdapter(),
-                state={"installed_roms": {}, "save_sort_settings": None},
-                loop=asyncio.get_event_loop(),
-                logger=logging.getLogger("test"),
-                state_persister=MagicMock(),
-                emit=MagicMock(),
-                get_bios_files_index=lambda: {},
-                get_active_core=active_core,
-                # get_core_name intentionally omitted
-            ),
-        )
-        assert svc._resolve_retroarch_corename("snes", "Zelda.sfc") == (None, None)
-
-    def test_no_active_core_callback_returns_none(self, tmp_path):
-        """Service constructed without ``get_active_core`` — method returns (None, None)."""
-        svc = MigrationService(
-            config=MigrationServiceConfig(
-                migration_file_store=MigrationFileAdapter(),
-                state={"installed_roms": {}, "save_sort_settings": None},
-                loop=asyncio.get_event_loop(),
-                logger=logging.getLogger("test"),
-                state_persister=MagicMock(),
-                emit=MagicMock(),
-                get_bios_files_index=lambda: {},
-                get_core_name=lambda core_so: "Snes9x",
-            ),
-        )
-        assert svc._resolve_retroarch_corename("snes", "Zelda.sfc") == (None, None)
 
 
 class TestSortByCoreMigrationEndToEnd:

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -6,6 +6,7 @@ import pytest
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_state_persister import FakeStatePersister
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.debug_logger import SettingsAwareDebugLogger
@@ -57,6 +58,8 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api):
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
 
@@ -713,6 +716,8 @@ class TestDebugLoggerProtocolSeam:
                 state_persister=FakeStatePersister(),
                 settings_persister=FakeSettingsPersister(),
                 log_debug=capture,
+                metadata_service=FakeMetadataExtractor(),
+                artwork=FakeArtworkManager(),
             ),
         )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,6 +10,7 @@ from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_state_persister import FakeStatePersister
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.debug_logger import SettingsAwareDebugLogger
@@ -69,6 +70,8 @@ def plugin():
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
 

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,6 +12,7 @@ from fakes.fake_hostname_provider import FakeHostnameProvider
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
+from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.migration_file import MigrationFileAdapter
@@ -68,6 +69,8 @@ def plugin(tmp_path):
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
             log_debug=p._log_debug,
+            metadata_service=FakeMetadataExtractor(),
+            artwork=FakeArtworkManager(),
         ),
     )
     decky.DECKY_USER_HOME = str(tmp_path)
@@ -106,6 +109,10 @@ def plugin(tmp_path):
             log_debug=p._log_debug,
             plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
             plugin_dir=str(tmp_path / "plugin"),
+            emit=AsyncMock(),
+            get_core_name=lambda core_so: None,
+            detect_sort_change=lambda: None,
+            is_retrodeck_migration_pending=lambda: False,
         ),
     )
     p._save_sync_service.init_state()
@@ -458,7 +465,10 @@ class TestPostExitSync:
                 state_persister=MagicMock(),
                 emit=MagicMock(),
                 get_bios_files_index=lambda: {},
+                retrodeck_paths=FakeRetroDeckPaths(),
                 get_retroarch_save_sorting=lambda: (False, False),
+                get_active_core=lambda system_name, rom_filename=None: (None, None),
+                get_core_name=lambda core_so: None,
             ),
         )
         # Sanity: same state object — mutations through migration will be


### PR DESCRIPTION
## Summary

- Drops ``Field | None = None`` test-convenience defaults across 11 ServiceConfigs so every config field is required in production. Contract is now truthful — production wires every field, only tests previously omitted them.
- Removes ``if self._x is not None`` guards in nine service bodies (downloads / migration / rom_info / saves engine / status / fetcher / orchestrator / reporter) that the new contract makes unreachable.
- Adds ``tests/fakes/library_peers.py`` with ``FakeMetadataExtractor`` + ``FakeArtworkManager`` Protocol stubs so non-sync tests can wire ``LibraryServiceConfig`` without standing up the real metadata/artwork services. New file follows the post-#713 ``tests/fakes/`` consolidated layout.
- Downstream type tightening: ``SyncEngineConfig.detect_sort_change`` / ``is_retrodeck_migration_pending`` and ``RomInfoServiceConfig.get_core_name`` drop ``| None`` since they now receive non-nullable values from ``SaveServiceConfig``.

## Per-config field decisions

| Config | Field | Decision |
|---|---|---|
| ``DownloadServiceConfig`` | ``retrodeck_paths``, ``is_retrodeck_migration_pending`` | required (drop ``\| None`` and default) |
| ``MigrationServiceConfig`` | ``retrodeck_paths``, ``get_retroarch_save_sorting``, ``get_active_core``, ``get_core_name`` | required |
| ``RomRemovalServiceConfig`` | ``retrodeck_paths`` | required |
| ``RomRemovalServiceConfig`` | ``download_queue_cleanup`` | **production-nullable** — keep ``\| None``, drop default. Tests exercise the ``None`` branch explicitly. |
| ``SaveServiceConfig`` | ``emit``, ``detect_sort_change``, ``is_retrodeck_migration_pending``, ``get_core_name`` | required |
| ``LibraryServiceConfig`` | ``metadata_service``, ``artwork`` | required |
| ``StatusServiceConfig`` | ``emit`` | required (drop ``\| None``) |
| ``SyncOrchestratorConfig`` | ``metadata_service``, ``artwork`` | required |
| ``LibraryFetcherConfig`` | ``metadata_service`` | required |
| ``SyncReporterConfig`` | ``artwork`` | required |

## Tests deleted (obsolete branches)

Five tests asserted behaviour the tightened contracts no longer admit:

- ``test_no_callback_noop`` / ``test_no_core_name_callback_returns_none`` / ``test_no_active_core_callback_returns_none`` in ``test_migration_save_sort.py``
- ``test_no_emit_when_emit_is_none`` / ``test_post_exit_sync_works_when_detect_sort_change_is_none`` in ``tests/services/saves/sync_engine/test_engine.py``
- ``test_skips_metadata_block_when_no_metadata_service`` in ``test_fetcher.py``
- ``test_returns_empty_when_artwork_manager_missing`` in ``test_sync_orchestrator.py``
- ``test_no_retrodeck_paths_bundle_skips_walk`` in ``test_downloads.py``

## Test plan

- [x] ``python -m pytest tests/ -q`` — 2500 passed
- [x] ``ruff check py_modules/ main.py tests/``
- [x] ``basedpyright py_modules/ main.py tests/``
- [x] ``bash scripts/check_cosmic_call_bans.sh``
- [x] ``PYTHONPATH=py_modules lint-imports``
- [x] ``pnpm build``
- [x] ``pnpm test`` — 550 passed

Closes #690