### PR TITLE
refactor(state): introduce PluginState + MetadataCacheEntry TypedDicts

### DIFF
--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -10,6 +10,9 @@ import fcntl
 import json
 import logging
 import os
+from typing import cast
+
+from models.state import MetadataCache, PluginState
 
 _STATE_VERSION = 1
 _METADATA_CACHE_VERSION = 1
@@ -278,12 +281,12 @@ class StatePersisterAdapter:
     this class.
     """
 
-    def __init__(self, persistence: PersistenceAdapter, state: dict) -> None:
+    def __init__(self, persistence: PersistenceAdapter, state: PluginState) -> None:
         self._persistence = persistence
         self._state = state
 
     def save_state(self) -> None:
-        self._persistence.save_state(self._state)
+        self._persistence.save_state(cast("dict", self._state))
 
 
 class SettingsPersisterAdapter:
@@ -312,12 +315,12 @@ class MetadataCachePersisterAdapter:
     never on this class.
     """
 
-    def __init__(self, persistence: PersistenceAdapter, metadata_cache: dict) -> None:
+    def __init__(self, persistence: PersistenceAdapter, metadata_cache: MetadataCache) -> None:
         self._persistence = persistence
         self._metadata_cache = metadata_cache
 
     def save_metadata(self) -> None:
-        self._persistence.save_metadata_cache(self._metadata_cache)
+        self._persistence.save_metadata_cache(cast("dict", self._metadata_cache))
 
 
 class SaveSyncStatePersisterAdapter:

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -297,6 +297,11 @@ def bootstrap(
     settings = persistence.load_settings()
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
+    # Persistence + migration round-trip through bare ``dict`` because
+    # ``load_state`` / ``migrate_state`` / ``load_metadata_cache`` predate the
+    # TypedDicts and operate on the on-disk JSON shape. Cast down to ``dict``
+    # at the boundary, cast up to ``PluginState`` / ``MetadataCache`` once the
+    # shape is in hand so the rest of bootstrap sees the typed dict.
     state = cast("PluginState", persistence.load_state(cast("dict", _default_state())))
     state = cast("PluginState", migrate_state(cast("dict", state)))
     metadata_cache = cast("MetadataCache", persistence.load_metadata_cache())

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from typing import cast
+
+from models.state import MetadataCache, PluginState, make_default_plugin_state
 
 from adapters.asyncio_sleeper import AsyncioSleeper
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
@@ -99,23 +102,16 @@ from services.startup_healing import StartupHealingService, StartupHealingServic
 from services.steamgrid import SteamGridService, SteamGridServiceConfig
 
 
-def _default_state() -> dict:
+def _default_state() -> PluginState:
     """Fresh default ``state`` dict for first-run persistence.
 
-    A factory (not a module-level constant) so that callers always receive
-    independent inner containers — services may mutate ``state`` in place,
-    and a shared module-level default would silently corrupt subsequent
-    loads.
+    Delegates to :func:`models.state.make_default_plugin_state` so the
+    canonical shape lives next to the :class:`PluginState` schema. Wrapped
+    here (rather than re-exported) to preserve the module-level factory
+    indirection — callers always receive independent inner containers
+    even if the underlying default ever changes.
     """
-    return {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {"platforms": 0, "roms": 0},
-        "downloaded_bios": {},
-        "retrodeck_home_path": "",
-        "save_sort_settings": None,
-    }
+    return make_default_plugin_state()
 
 
 @dataclass(frozen=True)
@@ -143,9 +139,9 @@ class AdapterBundle:
 class StateBundle:
     """Live mutable state stores shared across services."""
 
-    state: dict
+    state: PluginState
     settings: dict
-    metadata_cache: dict
+    metadata_cache: MetadataCache
     save_sync_state: SaveSyncState
 
 
@@ -301,9 +297,9 @@ def bootstrap(
     settings = persistence.load_settings()
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
-    state = persistence.load_state(_default_state())
-    state = migrate_state(state)
-    metadata_cache = persistence.load_metadata_cache()
+    state = cast("PluginState", persistence.load_state(cast("dict", _default_state())))
+    state = cast("PluginState", migrate_state(cast("dict", state)))
+    metadata_cache = cast("MetadataCache", persistence.load_metadata_cache())
     state_persister = StatePersisterAdapter(persistence, state)
     settings_persister = SettingsPersisterAdapter(persistence, settings)
     metadata_cache_persister = MetadataCachePersisterAdapter(persistence, metadata_cache)

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import os
 
+from models.state import ShortcutRegistryEntry
+
 
 def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
     """Transform ROM list into shortcut data dicts for frontend AddShortcut calls."""
@@ -31,9 +33,9 @@ def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
     ]
 
 
-def build_registry_entry(pending: dict, app_id: int, cover_path: str) -> dict:
+def build_registry_entry(pending: dict, app_id: int, cover_path: str) -> ShortcutRegistryEntry:
     """Build a shortcut registry entry from pending sync data."""
-    entry = {
+    entry: ShortcutRegistryEntry = {
         "app_id": app_id,
         "name": pending.get("name", ""),
         "fs_name": pending.get("fs_name", ""),

--- a/py_modules/models/state.py
+++ b/py_modules/models/state.py
@@ -1,0 +1,172 @@
+"""TypedDicts for the plugin's on-disk JSON state and metadata cache.
+
+These dicts back the live wiring carried through every ``*ServiceConfig``
+(``state``, ``metadata_cache``). They are not dataclasses because the JSON
+shape is the source of truth: persisted shape, runtime shape, and service
+contract must all be the same dict. TypedDicts give that dict a checked
+key-set without changing its runtime identity, so call sites that mutate
+``state["shortcut_registry"]`` in place keep working unchanged.
+
+Keys flagged ``NotRequired`` are the ones that are written transiently
+(e.g. ``retrodeck_home_path_previous`` only exists while a home migration
+is pending) or only after a particular event has occurred (e.g.
+``last_synced_collections`` is written by the sync reporter).
+
+The metadata cache mixes a persistence-layer ``version`` integer with
+per-ROM entries keyed by ``rom_id`` string. Only the persistence adapter
+reads/writes ``version``; services exclusively ``.get(rom_id_str)`` /
+``[rom_id_str] = entry``. The type alias narrows the service-facing
+contract to ``dict[str, MetadataCacheEntry]`` to keep the per-entry shape
+checked; the persistence adapter keeps a raw ``dict`` view to stamp the
+version field.
+"""
+
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
+
+
+class ShortcutRegistryEntry(TypedDict):
+    """One ROM's Steam-shortcut binding inside ``shortcut_registry``.
+
+    Keyed by ``rom_id`` (string). Required fields are written by
+    :func:`domain.shortcut_data.build_registry_entry` during sync;
+    optional ID fields are written on demand by SteamGridService and
+    on-the-fly RomM lookups.
+    """
+
+    app_id: int
+    name: str
+    fs_name: str
+    platform_name: str
+    platform_slug: str
+    cover_path: str
+    igdb_id: NotRequired[int]
+    sgdb_id: NotRequired[int]
+    ra_id: NotRequired[int]
+
+
+class InstalledRomEntry(TypedDict):
+    """One installed ROM record inside ``installed_roms``.
+
+    Keyed by ``rom_id`` (string). ``rom_dir`` is set only for ROMs
+    extracted from a multi-file archive (otherwise the parent directory
+    is inferred from ``file_path``).
+    """
+
+    rom_id: int
+    file_name: str
+    file_path: str
+    system: str
+    platform_slug: str
+    installed_at: str
+    rom_dir: NotRequired[str]
+
+
+class SyncStats(TypedDict):
+    """Aggregated counts surfaced by ``get_sync_stats`` callable."""
+
+    platforms: int
+    roms: int
+
+
+class DownloadedBiosEntry(TypedDict):
+    """One downloaded BIOS/firmware file record inside ``downloaded_bios``.
+
+    Keyed by the BIOS file name. Tracked so migrations can move BIOS
+    files when the RetroDECK home path changes.
+    """
+
+    file_path: str
+    firmware_id: int
+    platform_slug: str
+    downloaded_at: str
+
+
+class SaveSortSettings(TypedDict):
+    """RetroArch save-sorting settings snapshot used by save migrations."""
+
+    sort_by_content: bool
+    sort_by_core: bool
+
+
+class PluginState(TypedDict):
+    """Top-level on-disk plugin state dict (``state.json``).
+
+    The seven canonical keys mirror :func:`bootstrap._default_state` —
+    production wiring always initialises them, so they are required at
+    the type level and direct-access (``state["shortcut_registry"]``) is
+    safe. Transient keys (only present while a particular event is in
+    flight) are flagged ``NotRequired``.
+
+    Transient keys:
+
+    - ``retrodeck_home_path_previous`` — populated while a RetroDECK
+      home migration is awaiting user confirmation.
+    - ``save_sort_settings_previous`` — populated while a RetroArch
+      save-sort change is awaiting user confirmation.
+    - ``last_synced_collections`` / ``last_synced_platforms`` — written
+      after the first successful sync; absent until then.
+
+    ``save_sort_settings`` is ``None`` before RetroArch save-sort has
+    been observed for the first time.
+    """
+
+    shortcut_registry: dict[str, ShortcutRegistryEntry]
+    installed_roms: dict[str, InstalledRomEntry]
+    last_sync: str | None
+    sync_stats: SyncStats
+    downloaded_bios: dict[str, DownloadedBiosEntry]
+    retrodeck_home_path: str
+    save_sort_settings: SaveSortSettings | None
+    retrodeck_home_path_previous: NotRequired[str]
+    save_sort_settings_previous: NotRequired[SaveSortSettings]
+    last_synced_collections: NotRequired[list[str]]
+    last_synced_platforms: NotRequired[list[str]]
+
+
+def make_default_plugin_state() -> PluginState:
+    """Return a fresh default ``PluginState`` dict.
+
+    Provides a single source of truth for the canonical key set that
+    services and tests can reuse. The shape mirrors
+    :func:`bootstrap._default_state` (which delegates to this factory).
+    """
+    return {
+        "shortcut_registry": {},
+        "installed_roms": {},
+        "last_sync": None,
+        "sync_stats": {"platforms": 0, "roms": 0},
+        "downloaded_bios": {},
+        "retrodeck_home_path": "",
+        "save_sort_settings": None,
+    }
+
+
+class MetadataCacheEntry(TypedDict):
+    """One ROM's cached metadata inside ``metadata_cache``.
+
+    Mirrors :class:`models.metadata.RomMetadata` after ``asdict``: the
+    cached value is built by :meth:`services.metadata.MetadataService.extract_metadata`
+    via ``asdict(RomMetadata(...))``, so ``tuple`` fields on
+    ``RomMetadata`` flatten to ``list`` here.
+    """
+
+    summary: str
+    genres: list[str]
+    companies: list[str]
+    first_release_date: int | None
+    average_rating: float | None
+    game_modes: list[str]
+    player_count: str
+    cached_at: float
+    steam_categories: list[int]
+
+
+# Service-facing metadata cache contract. The on-disk JSON also carries a
+# persistence-layer ``version: int`` key; only adapters/persistence.py
+# reads/writes that field, and services never iterate the cache (only
+# ``.get(rom_id_str)`` / ``[rom_id_str] = entry``), so a homogeneous
+# ``dict[str, MetadataCacheEntry]`` is the honest contract at the service
+# boundary.
+MetadataCache = dict[str, MetadataCacheEntry]

--- a/py_modules/services/achievements.py
+++ b/py_modules/services/achievements.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.achievements import extract_achievements_from_rom, extract_game_progress
 
 if TYPE_CHECKING:
@@ -28,7 +30,7 @@ class AchievementsServiceConfig:
     """
 
     romm_api: RommAchievementsApi
-    state: dict
+    state: PluginState
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     clock: Clock

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -8,6 +8,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState, ShortcutRegistryEntry
+
 from domain.artwork_paths import final_filename, staging_filename
 
 if TYPE_CHECKING:
@@ -29,7 +31,7 @@ class ArtworkServiceConfig:
     romm_api: RommRomReader
     steam_config: SteamConfigStore
     cover_art_file_store: CoverArtFileStore
-    state: dict
+    state: PluginState
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     get_pending_sync: PendingSyncReader
@@ -141,7 +143,7 @@ class ArtworkService:
 
     # ── Artwork removal ────────────────────────────────────────────────────
 
-    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None:
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: ShortcutRegistryEntry) -> None:
         """Remove all artwork files for a registry entry."""
         removed = False
         # Try cover_path first (stores the final renamed path)

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -14,6 +14,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import InstalledRomEntry, PluginState
+
 from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
 from lib.errors import error_response
 
@@ -48,7 +50,7 @@ class DownloadServiceConfig:
     """
 
     romm_api: RommRomReader
-    state: dict
+    state: PluginState
     download_file_store: DownloadFileStore
     download_queue: DownloadQueueAdapter
     resolve_system: SystemResolver
@@ -284,7 +286,7 @@ class DownloadService:
         launch_file = self._collect_and_detect_launch_file(extract_dir)
 
         # Register as installed
-        installed_entry = {
+        installed_entry: InstalledRomEntry = {
             "rom_id": rom_id,
             "file_name": file_name,
             "file_path": launch_file,
@@ -302,7 +304,7 @@ class DownloadService:
         tmp_path = target_path + _TMP_EXT
         self._download_file_store.rename(tmp_path, target_path)
 
-        installed_entry = {
+        installed_entry: InstalledRomEntry = {
             "rom_id": rom_id,
             "file_name": file_name,
             "file_path": target_path,

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -12,6 +12,8 @@ import os
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain import firmware_paths
 from domain.bios import collect_firmware_status
 from lib.errors import error_response
@@ -44,7 +46,7 @@ class FirmwareServiceConfig:
     """
 
     romm_api: RommFirmwareApi
-    state: dict
+    state: PluginState
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -12,6 +12,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
 from models.metadata import AchievementSummary
+from models.state import MetadataCache, MetadataCacheEntry, PluginState, ShortcutRegistryEntry
 
 from domain.bios import compute_bios_label, compute_bios_level, format_bios_status
 from domain.save_state import SaveSyncState
@@ -37,8 +38,8 @@ class GameDetailServiceConfig:
     GameDetailService consults to assemble the game-detail payload.
     """
 
-    state: dict
-    metadata_cache: dict
+    state: PluginState
+    metadata_cache: MetadataCache
     save_sync_state: SaveSyncState
     logger: logging.Logger
     clock: Clock
@@ -58,14 +59,14 @@ class GameDetailService:
         self._bios_checker = config.bios_checker
         self._achievements = config.achievements
 
-    def _resolve_rom_by_app_id(self, app_id: int) -> tuple[int | None, dict | None]:
+    def _resolve_rom_by_app_id(self, app_id: int) -> tuple[int | None, ShortcutRegistryEntry | None]:
         """Reverse lookup: find rom_id by app_id in shortcut_registry."""
         for rid, reg in self._state["shortcut_registry"].items():
             if reg.get("app_id") == app_id:
                 return int(rid), reg
         return None, None
 
-    def _resolve_rom_file(self, rom_id_str: str, entry: dict) -> str:
+    def _resolve_rom_file(self, rom_id_str: str, entry: ShortcutRegistryEntry) -> str:
         """ROM filename from installed_roms or registry fs_name fallback."""
         rom_file = ""
         installed_rom = self._state["installed_roms"].get(rom_id_str, {})
@@ -114,7 +115,7 @@ class GameDetailService:
     def _compute_stale_fields(
         *,
         now: float,
-        metadata: dict | None,
+        metadata: MetadataCacheEntry | None,
         bios_status: dict | None,
         platform_slug: str,
         ra_id: int | None,

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -16,6 +16,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import MetadataCache, PluginState
+
 from domain.shortcut_data import build_shortcuts_data
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
@@ -57,9 +59,9 @@ class LibraryFetcherConfig:
     """
 
     romm_api: RommLibraryApi
-    state: dict
+    state: PluginState
     settings: dict
-    metadata_cache: dict
+    metadata_cache: MetadataCache
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -18,6 +18,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.shortcut_data import build_registry_entry
 from domain.sync_diff import should_include_in_platform_collection
 from domain.sync_state import SyncState
@@ -54,7 +56,7 @@ class SyncReporterConfig:
     """
 
     steam_config: SteamConfigStore
-    state: dict
+    state: PluginState
     settings: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -18,6 +18,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import MetadataCache, PluginState
+
 from lib.late_binding import LateBinding
 from services.library._state import LibrarySyncStateBox
 from services.library.fetcher import LibraryFetcher, LibraryFetcherConfig
@@ -57,9 +59,9 @@ class LibraryServiceConfig:
 
     romm_api: RommLibraryApi
     steam_config: SteamConfigStore
-    state: dict
+    state: PluginState
     settings: dict
-    metadata_cache: dict
+    metadata_cache: MetadataCache
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -262,7 +264,7 @@ class LibraryService:
         self._reporter._loop = value
 
     @property
-    def _state(self) -> dict:
+    def _state(self) -> PluginState:
         return self._config.state
 
     @property
@@ -270,7 +272,7 @@ class LibraryService:
         return self._config.settings
 
     @property
-    def _metadata_cache(self) -> dict:
+    def _metadata_cache(self) -> MetadataCache:
         return self._config.metadata_cache
 
     # Getters mirror the pre-decomposition attribute shape for external

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -18,6 +18,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import build_shortcuts_data
 from domain.sync_diff import (
@@ -81,7 +83,7 @@ class SyncOrchestratorConfig:
     reader in via ``set()`` once the reporter is built.
     """
 
-    state: dict
+    state: PluginState
     settings: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger

--- a/py_modules/services/metadata.py
+++ b/py_modules/services/metadata.py
@@ -8,9 +8,10 @@ the list API and served from cache on demand (no detail API calls).
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from models.metadata import RomMetadata
+from models.state import MetadataCache, MetadataCacheEntry, PluginState
 
 from domain.steam_categories import build_steam_categories
 
@@ -30,8 +31,8 @@ class MetadataServiceConfig:
     seams MetadataService needs at construction time.
     """
 
-    state: dict
-    metadata_cache: dict
+    state: PluginState
+    metadata_cache: MetadataCache
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     clock: Clock
@@ -54,7 +55,7 @@ class MetadataService:
         self._metadata_dirty_count = 0
         self._METADATA_FLUSH_INTERVAL = 50
 
-    def extract_metadata(self, rom):
+    def extract_metadata(self, rom: dict) -> MetadataCacheEntry:
         """Extract metadata fields from a ROM dict into cache format."""
         metadatum = rom.get("metadatum") or {}
         first_release_date = metadatum.get("first_release_date")
@@ -66,18 +67,21 @@ class MetadataService:
         genres_list = metadatum.get("genres") or []
         game_modes_list = metadatum.get("game_modes") or []
         steam_cats = build_steam_categories(genres_list, game_modes_list)
-        return asdict(
-            RomMetadata(
-                summary=rom.get("summary", "") or "",
-                genres=tuple(genres_list),
-                companies=tuple(metadatum.get("companies") or []),
-                first_release_date=first_release_date,
-                average_rating=average_rating,
-                game_modes=tuple(game_modes_list),
-                player_count=metadatum.get("player_count", "") or "",
-                cached_at=self._clock.time(),
-                steam_categories=tuple(steam_cats),
-            )
+        return cast(
+            "MetadataCacheEntry",
+            asdict(
+                RomMetadata(
+                    summary=rom.get("summary", "") or "",
+                    genres=tuple(genres_list),
+                    companies=tuple(metadatum.get("companies") or []),
+                    first_release_date=first_release_date,
+                    average_rating=average_rating,
+                    game_modes=tuple(game_modes_list),
+                    player_count=metadatum.get("player_count", "") or "",
+                    cached_at=self._clock.time(),
+                    steam_categories=tuple(steam_cats),
+                )
+            ),
         )
 
     def mark_metadata_dirty(self):

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -14,6 +14,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import InstalledRomEntry, PluginState, SaveSortSettings
+
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
 
@@ -43,7 +45,7 @@ class MigrationServiceConfig:
     """
 
     migration_file_store: MigrationFileStore
-    state: dict
+    state: PluginState
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     state_persister: StatePersister
@@ -450,7 +452,7 @@ class MigrationService:
         internals on CPython (#238 review).
         """
         sort_by_content, sort_by_core = self._get_retroarch_save_sorting()
-        current = {"sort_by_content": sort_by_content, "sort_by_core": sort_by_core}
+        current: SaveSortSettings = {"sort_by_content": sort_by_content, "sort_by_core": sort_by_core}
         stored = self._state.get("save_sort_settings")
         if stored is None:
             self._state["save_sort_settings"] = current
@@ -494,7 +496,7 @@ class MigrationService:
         corename = self._get_core_name(core_so)
         return (corename or None, core_so)
 
-    def _collect_save_sorting_items(self, old_settings: dict, new_settings: dict) -> list:
+    def _collect_save_sorting_items(self, old_settings: SaveSortSettings, new_settings: SaveSortSettings) -> list:
         """Collect save files that need migration due to sort setting change."""
         saves_base = self._retrodeck_paths.saves_path()
         roms_base = self._retrodeck_paths.roms_path()
@@ -514,11 +516,11 @@ class MigrationService:
 
     def _collect_rom_sort_items(
         self,
-        entry: dict,
+        entry: InstalledRomEntry,
         saves_base: str,
         roms_base: str,
-        old_settings: dict,
-        new_settings: dict,
+        old_settings: SaveSortSettings,
+        new_settings: SaveSortSettings,
         need_core: bool,
         items: list,
     ) -> None:
@@ -572,7 +574,9 @@ class MigrationService:
             if self._migration_file_store.exists(old_file):
                 items.append((filename, old_file, new_file, lambda: None, "save"))
 
-    def _get_save_sort_migration_status_io(self, old_settings: dict, new_settings: dict) -> dict:
+    def _get_save_sort_migration_status_io(
+        self, old_settings: SaveSortSettings, new_settings: SaveSortSettings
+    ) -> dict:
         items = self._collect_save_sorting_items(old_settings, new_settings)
         return {
             "pending": True,
@@ -660,7 +664,7 @@ class MigrationService:
             self._logger.error(f"Save-sort overwrite failed: {old_path}: {e}")
 
     def _migrate_save_sort_files_io(
-        self, old_settings: dict, new_settings: dict, conflict_strategy: str | None
+        self, old_settings: SaveSortSettings, new_settings: SaveSortSettings, conflict_strategy: str | None
     ) -> dict:
         # conflict_strategy is retained for backwards-compatibility with the
         # callable signature but is unused for save-sort migration — conflicts

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from models.state import InstalledRomEntry, MetadataCacheEntry, ShortcutRegistryEntry
+
 
 class RetryStrategy(Protocol):
     """HTTP retry wrapper pair consumed by SaveService and PlaytimeService."""
@@ -40,7 +42,7 @@ class AchievementsReader(Protocol):
 class MetadataExtractor(Protocol):
     """Metadata extraction and cache flushing consumed by LibraryService."""
 
-    def extract_metadata(self, rom: dict) -> dict: ...
+    def extract_metadata(self, rom: dict) -> MetadataCacheEntry: ...
 
     def mark_metadata_dirty(self) -> None: ...
 
@@ -61,7 +63,7 @@ class ArtworkManager(Protocol):
 
     def finalize_cover_path(self, grid: str | None, cover_path: str, app_id: int, rom_id_str: str) -> str: ...
 
-    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: ShortcutRegistryEntry) -> None: ...
 
 
 class ArtworkRemover(Protocol):
@@ -73,7 +75,7 @@ class ArtworkRemover(Protocol):
     only the single-entry deletion seam the removal flow needs.
     """
 
-    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None: ...
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: ShortcutRegistryEntry) -> None: ...
 
 
 class LaunchGateRomLookup(Protocol):
@@ -92,12 +94,12 @@ class LaunchGateInstalledChecker(Protocol):
     """ROM-installed lookup consumed by LaunchGateService.
 
     The composition root satisfies this with ``DownloadService``'s
-    ``get_installed_rom``. Returns the installed-ROM metadata dict
+    ``get_installed_rom``. Returns the installed-ROM metadata entry
     when the ROM has been downloaded, ``None`` otherwise. The gate
     treats any falsy return as "not installed".
     """
 
-    def get_installed_rom(self, rom_id: int) -> dict | None: ...
+    def get_installed_rom(self, rom_id: int) -> InstalledRomEntry | None: ...
 
 
 class LaunchGateSaveStatusReader(Protocol):

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -6,6 +6,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import InstalledRomEntry, PluginState
+
 from domain.save_state import SaveSyncState
 from lib.path_safety import is_safe_rom_path
 
@@ -27,7 +29,7 @@ class RomRemovalServiceConfig:
     limit.
     """
 
-    state: dict
+    state: PluginState
     save_sync_state: SaveSyncState
     logger: logging.Logger
     loop: asyncio.AbstractEventLoop
@@ -56,7 +58,7 @@ class RomRemovalService:
         self._retrodeck_paths = config.retrodeck_paths
         self._download_queue_cleanup = config.download_queue_cleanup
 
-    def _delete_rom_files(self, installed: dict) -> None:
+    def _delete_rom_files(self, installed: InstalledRomEntry) -> None:
         """Delete ROM files for an installed entry. Handles both single-file and multi-file ROMs."""
         rom_dir = installed.get("rom_dir", "")
         file_path = installed.get("file_path", "")
@@ -76,7 +78,7 @@ class RomRemovalService:
             elif self._rom_file_store.exists(file_path):
                 self._rom_file_store.remove_file(file_path)
 
-    def _remove_rom_io(self, rom_id_str: str, installed: dict) -> None:
+    def _remove_rom_io(self, rom_id_str: str, installed: InstalledRomEntry) -> None:
         """Sync helper for remove_rom — file deletion + state update in executor."""
         self._delete_rom_files(installed)
 

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.save_state import SaveSyncState
 
 if TYPE_CHECKING:
@@ -126,7 +128,7 @@ class SaveServiceConfig:
     romm_api: RommSyncApi
     retry: RetryStrategy
     settings: dict
-    state: dict
+    state: PluginState
     save_sync_state: SaveSyncState
     save_sync_state_persister: SaveSyncStatePersister
     save_file_store: SaveFileStore

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -16,6 +16,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState, SaveSortSettings
+
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
 
@@ -40,7 +42,7 @@ class RomInfoServiceConfig:
     RetroArch core-name provider, and the standard-library logger.
     """
 
-    state: dict
+    state: PluginState
     save_file_store: SaveFileStore
     retrodeck_paths: RetroDeckPaths
     get_active_core: CoreResolverFn
@@ -186,7 +188,7 @@ class RomInfoService:
                 results.append({"path": save_path, "filename": rom_name + ext})
         return results
 
-    def pending_sort_settings(self) -> dict | None:
+    def pending_sort_settings(self) -> SaveSortSettings | None:
         """Return previous save-sort settings if a migration is pending, else None.
 
         Rejects empty dicts to avoid the half-state where ``get_rom_save_info``'s

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from services.saves.slots.deletion import SlotDeleter
 from services.saves.slots.listing import SlotListing
 from services.saves.slots.setup import _NO_MIGRATION, SetupWizard
@@ -55,7 +57,7 @@ class SlotsServiceConfig:
     build the emulator tag for re-upload.
     """
 
-    state: dict
+    state: PluginState
     state_svc: StateService
     sync_engine: SyncEngine
     status_service: StatusService

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.emulator_tag import build_emulator_tag
 
 if TYPE_CHECKING:
@@ -38,7 +40,7 @@ class SetupWizard:
     def __init__(
         self,
         *,
-        state: dict,
+        state: PluginState,
         state_svc: StateService,
         rom_info: RomInfoService,
         romm_api: RommSaveApi,

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.save_state import (
     FileSyncState,
     RomSaveState,
@@ -36,7 +38,7 @@ class StateServiceConfig:
     """
 
     save_sync_state: SaveSyncState
-    state: dict
+    state: PluginState
     persister: SaveSyncStatePersister
     logger: logging.Logger
 

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.emulator_tag import detect_core_change
 from domain.save_attribution import compute_uploaded_by_us
 from domain.save_status import compute_save_sync_display
@@ -43,7 +45,7 @@ class StatusServiceConfig:
     frontend.
     """
 
-    state: dict
+    state: PluginState
     state_svc: StateService
     sync_engine: SyncEngine
     rom_info: RomInfoService

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -19,6 +19,8 @@ from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from services.saves._messages import DEVICE_NOT_REGISTERED, SAVE_SYNC_DISABLED
 from services.saves.sync_engine.devices import DeviceRegistry
 from services.saves.sync_engine.matrix import MatrixExecutor, MatrixOutcome
@@ -59,7 +61,7 @@ class SyncEngineConfig:
     callbacks SyncEngine consults at the entry of every public flow.
     """
 
-    state: dict
+    state: PluginState
     state_svc: StateService
     rom_info: RomInfoService
     romm_api: RommSyncApi

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.emulator_tag import build_emulator_tag
 from domain.save_state import FileSyncState, RomSaveState
 from domain.sync_action import (
@@ -80,7 +82,7 @@ class MatrixExecutor:
     def __init__(
         self,
         *,
-        state: dict,
+        state: PluginState,
         state_svc: StateService,
         rom_info: RomInfoService,
         romm_api: RommSyncApi,

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
+from models.state import PluginState
+
 if TYPE_CHECKING:
     import logging
 
@@ -37,7 +39,7 @@ class SettingsServiceConfig:
     """
 
     settings: dict
-    state: dict
+    state: PluginState
     logger: logging.Logger
     settings_persister: SettingsPersister
     steam_config: SteamConfigStore

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -6,6 +6,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 if TYPE_CHECKING:
     import logging
 
@@ -29,7 +31,7 @@ class ShortcutRemovalServiceConfig:
 
     romm_api: RommPlatformReader
     steam_config: SteamConfigStore
-    state: dict
+    state: PluginState
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     emit: EventEmitter

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.installed_roms import is_pending_migration_path
 
 if TYPE_CHECKING:
@@ -31,7 +33,7 @@ class StartupHealingServiceConfig:
     parameter budget and the service stays free of raw filesystem I/O.
     """
 
-    state: dict
+    state: PluginState
     logger: logging.Logger
     state_persister: StatePersister
     retrodeck_paths: RetroDeckPaths

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -15,6 +15,8 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.state import PluginState
+
 from domain.sgdb_artwork import (
     asset_type_endpoint,
     asset_type_name,
@@ -54,7 +56,7 @@ class SteamGridServiceConfig:
     romm_api: RommRomReader
     steam_config: SteamConfigStore
     sgdb_artwork_cache: SgdbArtworkCache
-    state: dict
+    state: PluginState
     settings: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
@@ -38,7 +39,7 @@ def plugin():
 
     p._http_adapter = RommHttpAdapter(p.settings, decky.DECKY_PLUGIN_DIR, logging.getLogger("test"))
     p._romm_api = MagicMock()
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -102,9 +102,9 @@ class TestBuildRegistryEntry:
         assert result["platform_name"] == "N64"
         assert result["platform_slug"] == "n64"
         assert result["cover_path"] == "/grid/100001p.png"
-        assert result["igdb_id"] == 100
-        assert result["sgdb_id"] == 200
-        assert result["ra_id"] == 300
+        assert result.get("igdb_id") == 100
+        assert result.get("sgdb_id") == 200
+        assert result.get("ra_id") == 300
 
     def test_omits_none_meta_keys(self):
         pending = {

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -9,7 +9,9 @@ can assert on the recorded activity.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+from models.state import MetadataCacheEntry, ShortcutRegistryEntry
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -30,9 +32,9 @@ class FakeMetadataExtractor:
         self.mark_dirty_count: int = 0
         self.flush_count: int = 0
 
-    def extract_metadata(self, rom: dict) -> dict:
+    def extract_metadata(self, rom: dict) -> MetadataCacheEntry:
         self.extract_calls.append(rom)
-        return dict(self.canned_extract)
+        return cast("MetadataCacheEntry", dict(self.canned_extract))
 
     def mark_metadata_dirty(self) -> None:
         self.mark_dirty_count += 1
@@ -62,7 +64,7 @@ class FakeArtworkManager:
         self.finalize_override = finalize_override
         self.download_calls: list[tuple[list[dict], Any, Any, int, int]] = []
         self.finalize_calls: list[tuple[str | None, str, int, str]] = []
-        self.remove_calls: list[tuple[str, str | int, dict]] = []
+        self.remove_calls: list[tuple[str, str | int, ShortcutRegistryEntry]] = []
 
     async def download_artwork(
         self,
@@ -81,5 +83,5 @@ class FakeArtworkManager:
             return self.finalize_override(grid, cover_path, app_id, rom_id_str)
         return cover_path
 
-    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: dict) -> None:
-        self.remove_calls.append((grid, rom_id, dict(entry)))
+    def remove_artwork_files(self, grid: str, rom_id: str | int, entry: ShortcutRegistryEntry) -> None:
+        self.remove_calls.append((grid, rom_id, cast("ShortcutRegistryEntry", dict(entry))))

--- a/tests/models/test_state.py
+++ b/tests/models/test_state.py
@@ -1,0 +1,75 @@
+"""Tests for models.state TypedDicts and the default-state factory."""
+
+from typing import ClassVar
+
+from models.state import make_default_plugin_state
+
+
+class TestMakeDefaultPluginState:
+    _REQUIRED_KEYS: ClassVar[set[str]] = {
+        "shortcut_registry",
+        "installed_roms",
+        "last_sync",
+        "sync_stats",
+        "downloaded_bios",
+        "retrodeck_home_path",
+        "save_sort_settings",
+    }
+
+    def test_returns_all_required_keys(self):
+        state = make_default_plugin_state()
+        assert set(state.keys()) == self._REQUIRED_KEYS
+
+    def test_default_values_match_canonical_shape(self):
+        state = make_default_plugin_state()
+        assert state["shortcut_registry"] == {}
+        assert state["installed_roms"] == {}
+        assert state["last_sync"] is None
+        assert state["sync_stats"] == {"platforms": 0, "roms": 0}
+        assert state["downloaded_bios"] == {}
+        assert state["retrodeck_home_path"] == ""
+        assert state["save_sort_settings"] is None
+
+    def test_sync_stats_zero_initialised(self):
+        state = make_default_plugin_state()
+        assert state["sync_stats"]["platforms"] == 0
+        assert state["sync_stats"]["roms"] == 0
+
+    def test_successive_calls_return_independent_containers(self):
+        """Each call must return a fresh dict tree so per-test mutations
+        don't leak across fixtures."""
+        first = make_default_plugin_state()
+        second = make_default_plugin_state()
+
+        assert first is not second
+        assert first["shortcut_registry"] is not second["shortcut_registry"]
+        assert first["installed_roms"] is not second["installed_roms"]
+        assert first["sync_stats"] is not second["sync_stats"]
+        assert first["downloaded_bios"] is not second["downloaded_bios"]
+
+    def test_mutation_does_not_leak_across_calls(self):
+        first = make_default_plugin_state()
+        second = make_default_plugin_state()
+
+        first["installed_roms"]["42"] = {  # type: ignore[typeddict-item]
+            "rom_id": 42,
+            "file_name": "game.gba",
+            "file_path": "/roms/gba/game.gba",
+            "system": "gba",
+            "platform_slug": "gba",
+            "installed_at": "2026-01-01T00:00:00",
+        }
+        first["sync_stats"]["platforms"] = 5
+        first["last_sync"] = "2026-01-01T00:00:00"
+
+        assert second["installed_roms"] == {}
+        assert second["sync_stats"] == {"platforms": 0, "roms": 0}
+        assert second["last_sync"] is None
+
+    def test_transient_keys_absent_by_default(self):
+        """NotRequired keys must be absent until a particular event populates them."""
+        state = make_default_plugin_state()
+        assert "retrodeck_home_path_previous" not in state
+        assert "save_sort_settings_previous" not in state
+        assert "last_synced_collections" not in state
+        assert "last_synced_platforms" not in state

--- a/tests/services/library/conftest.py
+++ b/tests/services/library/conftest.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
 from adapters.persistence import (
@@ -37,7 +38,7 @@ def plugin(tmp_path):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._romm_api = MagicMock()
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -12,6 +12,7 @@ from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
 from fakes.system_time import FakeClock
+from models.state import make_default_plugin_state
 
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
 from adapters.save_file import SaveFileAdapter
@@ -46,7 +47,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         romm_api=fake,
         retry=_make_retry(),
         settings={"log_level": "debug"},
-        state={"shortcut_registry": {}, "installed_roms": {}},
+        state=make_default_plugin_state(),
         save_sync_state=SaveService.make_default_state(),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
         save_file_store=save_file_store,

--- a/tests/services/saves/test_rom_info.py
+++ b/tests/services/saves/test_rom_info.py
@@ -1,5 +1,9 @@
 """Tests for RomInfoService — per-ROM save path resolution and local save discovery."""
 
+from typing import cast
+
+from models.state import SaveSortSettings
+
 from tests.services.saves._helpers import (
     _create_save,
     _install_rom,
@@ -177,7 +181,7 @@ class TestGetRomSaveInfo:
         )
         _install_rom(svc, tmp_path)
         # Half-state input: empty previous, populated current (NEW).
-        svc._state["save_sort_settings_previous"] = {}
+        svc._state["save_sort_settings_previous"] = cast("SaveSortSettings", {})
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": True}
 
         # Both call sites must agree there is NO pending migration.

--- a/tests/services/saves/test_state_service.py
+++ b/tests/services/saves/test_state_service.py
@@ -2,6 +2,9 @@
 
 import json
 import os
+from typing import cast
+
+from models.state import ShortcutRegistryEntry
 
 from domain.save_state import (
     PlaytimeEntry,
@@ -182,7 +185,7 @@ class TestStateManagement:
         svc, _ = make_service(tmp_path)
         svc._save_sync_state.saves["99"] = RomSaveState()
         svc._save_sync_state.playtime["99"] = PlaytimeEntry.from_dict({"total_seconds": 100})
-        svc._state["shortcut_registry"]["42"] = {}
+        svc._state["shortcut_registry"]["42"] = cast("ShortcutRegistryEntry", {})
 
         svc.prune_orphaned_state()
         assert "99" not in svc._save_sync_state.saves
@@ -191,7 +194,7 @@ class TestStateManagement:
     def test_prune_keeps_registered(self, tmp_path):
         svc, _ = make_service(tmp_path)
         svc._save_sync_state.saves["42"] = RomSaveState()
-        svc._state["shortcut_registry"]["42"] = {}
+        svc._state["shortcut_registry"]["42"] = cast("ShortcutRegistryEntry", {})
 
         svc.prune_orphaned_state()
         assert "42" in svc._save_sync_state.saves

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import SaveSyncState
@@ -38,12 +39,7 @@ def plugin(clock):
     }
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
-    p._state = {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {},
-    }
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -10,13 +10,14 @@ from unittest.mock import MagicMock
 import decky
 import pytest
 from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
+from models.state import make_default_plugin_state
 
 from services.artwork import ArtworkService, ArtworkServiceConfig
 
 
 @pytest.fixture
 def state():
-    return {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    return make_default_plugin_state()
 
 
 @pytest.fixture

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -11,6 +11,7 @@ from conftest import _make_testable_plugin
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.download_file import DownloadFileAdapter
 from adapters.download_queue import DownloadQueueAdapter
@@ -29,7 +30,7 @@ def plugin():
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
     p._resolve_system = MagicMock(side_effect=lambda slug, fs_slug=None: fs_slug or slug)
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -38,14 +38,7 @@ def plugin():
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
-    p._state = {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {},
-        "downloaded_bios": {},
-        "retrodeck_home_path": "",
-    }
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -11,6 +11,7 @@ from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.bios import BiosFileEntry
+from models.state import PluginState, make_default_plugin_state
 
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.steam_config import SteamConfigAdapter
@@ -24,6 +25,11 @@ from services.library import LibraryService, LibraryServiceConfig
 def _make_clock() -> FakeClock:
     """Return a fresh FakeClock pinned to a synthetic instant."""
     return FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
+
+
+def _minimal_state() -> PluginState:
+    """Default PluginState shape for FirmwareService tests."""
+    return make_default_plugin_state()
 
 
 @pytest.fixture
@@ -1443,7 +1449,7 @@ class TestBiosFilesIndexUnloadedRaises:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -1466,7 +1472,7 @@ class TestBiosFilesIndexUnloadedRaises:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir="/nonexistent",
@@ -1613,7 +1619,7 @@ class TestFirmwareListCache:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=romm_api,
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -1681,7 +1687,7 @@ class TestFirmwareListCache:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=api,
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -1764,7 +1770,7 @@ class TestCheckPlatformBiosCached:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state=state or {"shortcut_registry": {}, "installed_roms": {}, "downloaded_bios": {}},
+                state=state or _minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),
                 plugin_dir="/fake",
@@ -1844,7 +1850,7 @@ class TestCheckPlatformBiosCached:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=api,
-                state={"shortcut_registry": {}, "installed_roms": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=logging.getLogger("test"),
                 plugin_dir="/fake",
@@ -1879,7 +1885,7 @@ class TestFirmwareCachePersistence:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -1903,7 +1909,7 @@ class TestFirmwareCachePersistence:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -1925,7 +1931,7 @@ class TestFirmwareCachePersistence:
         fw = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=MagicMock(),
-                state={"shortcut_registry": {}, "downloaded_bios": {}},
+                state=_minimal_state(),
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
@@ -2090,12 +2096,7 @@ class TestBadPathFirmwareCallables:
 
         if firmware_cache_persister is None:
             firmware_cache_persister = FakeFirmwareCachePersister()
-        state = {
-            "shortcut_registry": {},
-            "installed_roms": {},
-            "downloaded_bios": {},
-            "retrodeck_home_path": "",
-        }
+        state = _minimal_state()
         svc = FirmwareService(
             config=FirmwareServiceConfig(
                 romm_api=fake_romm_api,

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -15,6 +15,7 @@ from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
@@ -39,13 +40,7 @@ def plugin(tmp_path):
         "enabled_platforms": {},
         "log_level": "warn",
     }
-    p._state = {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {},
-        "downloaded_bios": {},
-    }
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import cast
 
 import pytest
+from models.state import InstalledRomEntry
 
 from services.launch_gate import (
     LaunchGateService,
@@ -29,11 +31,11 @@ class FakeRomLookup:
 class FakeInstalledChecker:
     """In-memory ``LaunchGateInstalledChecker`` for tests."""
 
-    def __init__(self, *, installed: dict[int, dict] | None = None) -> None:
+    def __init__(self, *, installed: dict[int, InstalledRomEntry] | None = None) -> None:
         self.installed = installed if installed is not None else {}
         self.calls: list[int] = []
 
-    def get_installed_rom(self, rom_id: int) -> dict | None:
+    def get_installed_rom(self, rom_id: int) -> InstalledRomEntry | None:
         self.calls.append(rom_id)
         return self.installed.get(rom_id)
 
@@ -118,7 +120,7 @@ class TestEvaluateAllow:
     def test_installed_with_no_conflicts_allows(self, event_loop, logger):
         """ROM installed, save_status returns no conflicts → allow."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99, "name": "Game"}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(payload={"conflicts": []})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -137,7 +139,7 @@ class TestEvaluateAllow:
     def test_save_status_failure_no_tracked_saves_allows(self, event_loop, logger):
         """ROM installed, save_status raises, no tracked saves → allow (nothing to corrupt)."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(
             side_effect=RuntimeError("boom"),
             tracked_rom_ids=set(),
@@ -181,7 +183,7 @@ class TestEvaluateBlock:
     def test_save_conflict_blocks_with_resolve_toast(self, event_loop, logger):
         """ROM installed, conflicts non-empty → block, save_conflict."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(
             payload={
                 "conflicts": [
@@ -213,7 +215,7 @@ class TestEvaluateWarn:
     def test_save_status_failure_with_tracked_saves_warns(self, event_loop, logger, caplog):
         """ROM installed, save_status raises OSError, tracked saves present → warn."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(
             side_effect=OSError("network down"),
             tracked_rom_ids={99},
@@ -244,7 +246,7 @@ class TestEvaluateWarn:
     def test_save_status_failure_warn_when_only_slots_tracked(self, event_loop, logger):
         """``has_tracked_save`` returning True (e.g. slots-only entry) → warn."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(
             side_effect=RuntimeError("executor crash"),
             tracked_rom_ids={99},
@@ -266,7 +268,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_missing_conflicts_key_allows(self, event_loop, logger):
         """Save status without ``conflicts`` key is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(payload={"rom_id": 99, "files": []})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -282,7 +284,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_conflicts_none_allows(self, event_loop, logger):
         """``conflicts`` explicitly None is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(payload={"conflicts": None})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -298,7 +300,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_empty_dict_allows(self, event_loop, logger):
         """An empty save-status dict (falsy save_status branch) is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
         save_status_reader = FakeSaveStatusReader(payload={})
         service = _make_service(
             rom_lookup=rom_lookup,

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -16,6 +16,11 @@ from services.launch_gate import (
 )
 
 
+def _installed_rom(rom_id: int) -> InstalledRomEntry:
+    """Build a sparse InstalledRomEntry — this test only checks truthiness / rom_id."""
+    return cast("InstalledRomEntry", {"rom_id": rom_id})
+
+
 class FakeRomLookup:
     """In-memory ``LaunchGateRomLookup`` for tests."""
 
@@ -120,7 +125,7 @@ class TestEvaluateAllow:
     def test_installed_with_no_conflicts_allows(self, event_loop, logger):
         """ROM installed, save_status returns no conflicts → allow."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99, "name": "Game"}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(payload={"conflicts": []})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -139,7 +144,7 @@ class TestEvaluateAllow:
     def test_save_status_failure_no_tracked_saves_allows(self, event_loop, logger):
         """ROM installed, save_status raises, no tracked saves → allow (nothing to corrupt)."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(
             side_effect=RuntimeError("boom"),
             tracked_rom_ids=set(),
@@ -183,7 +188,7 @@ class TestEvaluateBlock:
     def test_save_conflict_blocks_with_resolve_toast(self, event_loop, logger):
         """ROM installed, conflicts non-empty → block, save_conflict."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(
             payload={
                 "conflicts": [
@@ -215,7 +220,7 @@ class TestEvaluateWarn:
     def test_save_status_failure_with_tracked_saves_warns(self, event_loop, logger, caplog):
         """ROM installed, save_status raises OSError, tracked saves present → warn."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(
             side_effect=OSError("network down"),
             tracked_rom_ids={99},
@@ -246,7 +251,7 @@ class TestEvaluateWarn:
     def test_save_status_failure_warn_when_only_slots_tracked(self, event_loop, logger):
         """``has_tracked_save`` returning True (e.g. slots-only entry) → warn."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(
             side_effect=RuntimeError("executor crash"),
             tracked_rom_ids={99},
@@ -268,7 +273,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_missing_conflicts_key_allows(self, event_loop, logger):
         """Save status without ``conflicts`` key is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(payload={"rom_id": 99, "files": []})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -284,7 +289,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_conflicts_none_allows(self, event_loop, logger):
         """``conflicts`` explicitly None is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(payload={"conflicts": None})
         service = _make_service(
             rom_lookup=rom_lookup,
@@ -300,7 +305,7 @@ class TestEvaluateEdgeCases:
     def test_save_status_empty_dict_allows(self, event_loop, logger):
         """An empty save-status dict (falsy save_status branch) is treated as no conflicts."""
         rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
-        installed_checker = FakeInstalledChecker(installed={99: cast("InstalledRomEntry", {"rom_id": 99})})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
         save_status_reader = FakeSaveStatusReader(payload={})
         service = _make_service(
             rom_lookup=rom_lookup,

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -10,6 +10,7 @@ from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_state_persister import FakeStatePersister
 from fakes.library_peers import FakeArtworkManager
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import MetadataCachePersisterAdapter, PersistenceAdapter
@@ -27,7 +28,7 @@ def plugin():
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -12,6 +12,7 @@ from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_state_persister import FakeStatePersister
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.migration_file import MigrationFileAdapter
@@ -46,14 +47,7 @@ def plugin(tmp_path, fake_romm_api):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
-    p._state = {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {},
-        "downloaded_bios": {},
-        "retrodeck_home_path": "",
-    }
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fakes.fake_migration_file_store import FakeMigrationFileStore
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
+from models.state import PluginState, SaveSortSettings
 
 from adapters.migration_file import MigrationFileAdapter
 from services.migration import MigrationService, MigrationServiceConfig
@@ -39,11 +40,14 @@ def _make_service(
     Pass ``migration_file_store`` to swap the real ``MigrationFileAdapter``
     for a fake when a test needs failure injection.
     """
-    state = {
+    state: PluginState = {
         "shortcut_registry": {},
         "installed_roms": installed_roms or {},
         "retrodeck_home_path": "",
         "save_sort_settings": None,
+        "last_sync": None,
+        "sync_stats": {"platforms": 0, "roms": 0},
+        "downloaded_bios": {},
     }
     if state_overrides:
         state.update(state_overrides)
@@ -140,7 +144,7 @@ class TestDetectSaveSortChange:
             migration_module.asyncio.run_coroutine_threadsafe = original  # type: ignore[assignment]
 
         assert svc._state["save_sort_settings"] == {"sort_by_content": False, "sort_by_core": True}
-        assert svc._state["save_sort_settings_previous"] == old
+        assert svc._state.get("save_sort_settings_previous") == old
         assert len(scheduled) == 1
         save_state_mock.save_state.assert_called_once()
 
@@ -180,8 +184,8 @@ class TestCollectSaveSortingItems:
         )
         svc._retrodeck_paths = FakeRetroDeckPaths(saves=str(saves_path), roms=str(roms_path))
 
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         items = svc._collect_save_sorting_items(old_settings, new_settings)
 
         assert len(items) == 1
@@ -212,7 +216,7 @@ class TestCollectSaveSortingItems:
         svc._retrodeck_paths = FakeRetroDeckPaths(saves=str(saves_path), roms=str(roms_path))
 
         # Same settings -> same dir
-        same_settings = {"sort_by_content": True, "sort_by_core": False}
+        same_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
         items = svc._collect_save_sorting_items(same_settings, same_settings)
 
         assert items == []
@@ -238,8 +242,8 @@ class TestCollectSaveSortingItems:
         svc, _ = _make_service(tmp_path, installed_roms=installed_roms)
         svc._retrodeck_paths = FakeRetroDeckPaths(saves=str(saves_path), roms=str(roms_path))
 
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         items = svc._collect_save_sorting_items(old_settings, new_settings)
 
         assert items == []
@@ -279,8 +283,8 @@ class TestSaveSortMigrationStatus:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -326,8 +330,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -383,8 +387,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -436,8 +440,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -482,8 +486,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -535,8 +539,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -585,8 +589,8 @@ class TestMigrateSaveSortFiles:
                 "platform_slug": "gba",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         svc, _ = _make_service(
             tmp_path,
             installed_roms=installed_roms,
@@ -617,8 +621,8 @@ class TestMigrateSaveSortFiles:
         roms_path.mkdir()
         saves_path.mkdir()
 
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": False}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": False}
         # No installed ROMs — migration runs with 0 items but still succeeds
         svc, _ = _make_service(
             tmp_path,
@@ -745,8 +749,8 @@ class TestSortByCoreMigrationEndToEnd:
                 "platform_slug": "snes",
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": True}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": True}
 
         def active_core(system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]:
             return ("snes9x_libretro", "Snes9x - Current")
@@ -798,8 +802,8 @@ class TestSortByCoreMigrationEndToEnd:
                 "platform_slug": "snes",  # triggers .srm extension
             }
         }
-        old_settings = {"sort_by_content": True, "sort_by_core": False}
-        new_settings = {"sort_by_content": False, "sort_by_core": True}
+        old_settings: SaveSortSettings = {"sort_by_content": True, "sort_by_core": False}
+        new_settings: SaveSortSettings = {"sort_by_content": False, "sort_by_core": True}
 
         def active_core(system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]:
             return ("oddcore_libretro", "Oddcore Label")

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fakes.fake_migration_file_store import FakeMigrationFileStore
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
-from models.state import PluginState, SaveSortSettings
+from models.state import PluginState, SaveSortSettings, make_default_plugin_state
 
 from adapters.migration_file import MigrationFileAdapter
 from services.migration import MigrationService, MigrationServiceConfig
@@ -40,15 +40,9 @@ def _make_service(
     Pass ``migration_file_store`` to swap the real ``MigrationFileAdapter``
     for a fake when a test needs failure injection.
     """
-    state: PluginState = {
-        "shortcut_registry": {},
-        "installed_roms": installed_roms or {},
-        "retrodeck_home_path": "",
-        "save_sort_settings": None,
-        "last_sync": None,
-        "sync_stats": {"platforms": 0, "roms": 0},
-        "downloaded_bios": {},
-    }
+    state: PluginState = make_default_plugin_state()
+    if installed_roms:
+        state["installed_roms"] = installed_roms
     if state_overrides:
         state.update(state_overrides)
 

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -10,6 +10,7 @@ import pytest
 from fakes.fake_download_queue_cleanup import FakeDownloadQueueCleanup
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_rom_file_store import FakeRomFileStore
+from models.state import make_default_plugin_state
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 sys.path.insert(0, os.path.dirname(__file__))
@@ -24,7 +25,7 @@ _ROMS_BASE = "/retrodeck/roms"
 
 @pytest.fixture
 def state():
-    return {"installed_roms": {}}
+    return make_default_plugin_state()
 
 
 @pytest.fixture

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
+from models.state import PluginState, make_default_plugin_state
 
 from services.settings import SettingsService, SettingsServiceConfig
 
@@ -16,8 +17,8 @@ def settings() -> dict:
 
 
 @pytest.fixture
-def state() -> dict:
-    return {"shortcut_registry": {}}
+def state() -> PluginState:
+    return make_default_plugin_state()
 
 
 @pytest.fixture

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 # conftest.py patches decky before this import
 import decky
 import pytest
+from models.state import make_default_plugin_state
 
 from adapters.steam_config import SteamConfigAdapter
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
@@ -13,7 +14,7 @@ from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalSer
 
 @pytest.fixture
 def state():
-    return {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    return make_default_plugin_state()
 
 
 @pytest.fixture

--- a/tests/services/test_startup_healing.py
+++ b/tests/services/test_startup_healing.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from fakes.fake_path_probe import FakePathProbe
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
+from models.state import InstalledRomEntry, PluginState, ShortcutRegistryEntry, make_default_plugin_state
 
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 
@@ -24,16 +26,23 @@ def state_persister() -> MagicMock:
     return MagicMock()
 
 
-def _make_state() -> dict:
-    return {
-        "installed_roms": {},
-        "shortcut_registry": {},
-    }
+def _make_state() -> PluginState:
+    return make_default_plugin_state()
+
+
+def _installed(**fields: object) -> InstalledRomEntry:
+    """Build a partial InstalledRomEntry for tests that intentionally probe sparse shapes."""
+    return cast("InstalledRomEntry", dict(fields))
+
+
+def _registry(**fields: object) -> ShortcutRegistryEntry:
+    """Build a partial ShortcutRegistryEntry for tests that intentionally probe sparse shapes."""
+    return cast("ShortcutRegistryEntry", dict(fields))
 
 
 def _make_service(
     *,
-    state: dict,
+    state: PluginState,
     logger: logging.Logger,
     state_persister: MagicMock,
     retrodeck_home: str = _RETRODECK_HOME,
@@ -56,7 +65,7 @@ class TestPruneStaleInstalledRoms:
         """Guard: retrodeck home not present on disk → skip prune, log info."""
         state = _make_state()
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/run/media/deck/Emulation/retrodeck/roms/n64/a.z64"},
+            "1": _installed(rom_id=1, file_path="/run/media/deck/Emulation/retrodeck/roms/n64/a.z64"),
         }
         # path_probe knows nothing — retrodeck home not on disk.
         service = _make_service(
@@ -75,7 +84,7 @@ class TestPruneStaleInstalledRoms:
         """Empty retrodeck_home (first-run) → skip prune."""
         state = _make_state()
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/somewhere/a.z64"},
+            "1": _installed(rom_id=1, file_path="/somewhere/a.z64"),
         }
         service = _make_service(
             state=state,
@@ -91,7 +100,7 @@ class TestPruneStaleInstalledRoms:
     def test_prune_missing_file_path(self, logger, state_persister):
         state = _make_state()
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/nonexistent/game.z64"},
+            "1": _installed(rom_id=1, file_path="/nonexistent/game.z64"),
         }
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_installed_roms()
@@ -101,7 +110,7 @@ class TestPruneStaleInstalledRoms:
     def test_preserve_existing_file_path(self, logger, state_persister):
         state = _make_state()
         rom_file = "/run/media/deck/Emulation/retrodeck/roms/n64/game.z64"
-        state["installed_roms"] = {"1": {"rom_id": 1, "file_path": rom_file}}
+        state["installed_roms"] = {"1": _installed(rom_id=1, file_path=rom_file)}
         probe = FakePathProbe(paths={_RETRODECK_HOME, rom_file})
         service = _make_service(state=state, logger=logger, state_persister=state_persister, path_probe=probe)
         service.prune_stale_installed_roms()
@@ -113,11 +122,11 @@ class TestPruneStaleInstalledRoms:
         state = _make_state()
         rom_dir = "/run/media/deck/Emulation/retrodeck/roms/psx/FF7"
         state["installed_roms"] = {
-            "1": {
-                "rom_id": 1,
-                "file_path": f"{rom_dir}/FF7.m3u",  # file gone
-                "rom_dir": rom_dir,
-            },
+            "1": _installed(
+                rom_id=1,
+                file_path=f"{rom_dir}/FF7.m3u",  # file gone
+                rom_dir=rom_dir,
+            ),
         }
         probe = FakePathProbe(paths={_RETRODECK_HOME, rom_dir})
         service = _make_service(state=state, logger=logger, state_persister=state_persister, path_probe=probe)
@@ -130,7 +139,7 @@ class TestPruneStaleInstalledRoms:
         state = _make_state()
         state["retrodeck_home_path_previous"] = "/old/retrodeck"
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/old/retrodeck/roms/n64/zelda.z64"},
+            "1": _installed(rom_id=1, file_path="/old/retrodeck/roms/n64/zelda.z64"),
         }
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         with caplog.at_level(logging.INFO):
@@ -151,8 +160,8 @@ class TestPruneStaleInstalledRoms:
         state = _make_state()
         existing = "/run/media/deck/Emulation/retrodeck/roms/n64/keep.z64"
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": existing},
-            "2": {"rom_id": 2, "file_path": "/gone/dead.z64"},
+            "1": _installed(rom_id=1, file_path=existing),
+            "2": _installed(rom_id=2, file_path="/gone/dead.z64"),
         }
         probe = FakePathProbe(paths={_RETRODECK_HOME, existing})
         service = _make_service(state=state, logger=logger, state_persister=state_persister, path_probe=probe)
@@ -166,7 +175,7 @@ class TestPruneStaleInstalledRoms:
         state = _make_state()
         state["retrodeck_home_path_previous"] = "/foo"
         state["installed_roms"] = {
-            "1": {"rom_id": 1, "file_path": "/foobar/x.z64"},
+            "1": _installed(rom_id=1, file_path="/foobar/x.z64"),
         }
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_installed_roms()
@@ -177,7 +186,7 @@ class TestPruneStaleInstalledRoms:
 class TestPruneStaleRegistry:
     def test_prune_missing_app_id(self, logger, state_persister):
         state = _make_state()
-        state["shortcut_registry"] = {"1": {"name": "Game"}}
+        state["shortcut_registry"] = {"1": _registry(name="Game")}
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()
         assert "1" not in state["shortcut_registry"]
@@ -185,28 +194,28 @@ class TestPruneStaleRegistry:
 
     def test_prune_zero_app_id(self, logger, state_persister):
         state = _make_state()
-        state["shortcut_registry"] = {"1": {"app_id": 0, "name": "Game"}}
+        state["shortcut_registry"] = {"1": _registry(app_id=0, name="Game")}
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()
         assert "1" not in state["shortcut_registry"]
 
     def test_prune_string_app_id(self, logger, state_persister):
         state = _make_state()
-        state["shortcut_registry"] = {"1": {"app_id": "42", "name": "Game"}}
+        state["shortcut_registry"] = {"1": _registry(app_id="42", name="Game")}
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()
         assert "1" not in state["shortcut_registry"]
 
     def test_prune_none_app_id(self, logger, state_persister):
         state = _make_state()
-        state["shortcut_registry"] = {"1": {"app_id": None, "name": "Game"}}
+        state["shortcut_registry"] = {"1": _registry(app_id=None, name="Game")}
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()
         assert "1" not in state["shortcut_registry"]
 
     def test_preserve_valid_app_id(self, logger, state_persister):
         state = _make_state()
-        state["shortcut_registry"] = {"1": {"app_id": 1234567890, "name": "Game"}}
+        state["shortcut_registry"] = {"1": _registry(app_id=1234567890, name="Game")}
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()
         assert "1" in state["shortcut_registry"]
@@ -221,9 +230,9 @@ class TestPruneStaleRegistry:
     def test_mixed_prune_some_preserve_others(self, logger, state_persister):
         state = _make_state()
         state["shortcut_registry"] = {
-            "1": {"app_id": 100, "name": "Keep"},
-            "2": {"name": "Drop"},
-            "3": {"app_id": "stringy", "name": "Drop2"},
+            "1": _registry(app_id=100, name="Keep"),
+            "2": _registry(name="Drop"),
+            "3": _registry(app_id="stringy", name="Drop2"),
         }
         service = _make_service(state=state, logger=logger, state_persister=state_persister)
         service.prune_stale_registry()

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -1,8 +1,10 @@
 """Tests for services.saves.state.StateService."""
 
 import logging
+from typing import cast
 
 from fakes.fake_save_sync_state_persister import FakeSaveSyncStatePersister
+from models.state import ShortcutRegistryEntry, make_default_plugin_state
 
 from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
 from services.saves.state import StateService, StateServiceConfig
@@ -12,7 +14,7 @@ def _make_state_svc(
     persister: FakeSaveSyncStatePersister | None = None,
 ) -> tuple[StateService, FakeSaveSyncStatePersister]:
     save_sync_state = StateService.make_default_state()
-    state: dict = {"shortcut_registry": {}, "installed_roms": {}}
+    state = make_default_plugin_state()
     p = persister or FakeSaveSyncStatePersister()
     return (
         StateService(
@@ -178,7 +180,7 @@ class TestLoadState:
 class TestPruneOrphanedState:
     def test_prune_persists_when_entries_removed(self):
         svc, persister = _make_state_svc()
-        svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
+        svc._state["shortcut_registry"] = {"42": cast("ShortcutRegistryEntry", {"app_id": 1})}
         svc.state.saves["42"] = RomSaveState()
         svc.state.saves["999"] = RomSaveState()  # orphaned
         svc.state.playtime["888"] = PlaytimeEntry()  # orphaned
@@ -192,7 +194,7 @@ class TestPruneOrphanedState:
 
     def test_prune_does_not_persist_when_nothing_removed(self):
         svc, persister = _make_state_svc()
-        svc._state["shortcut_registry"] = {"42": {"app_id": 1}}
+        svc._state["shortcut_registry"] = {"42": cast("ShortcutRegistryEntry", {"app_id": 1})}
         svc.state.saves["42"] = RomSaveState()
 
         svc.prune_orphaned_state()

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -8,6 +8,7 @@ from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_state_persister import FakeStatePersister
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.steam_config import SteamConfigAdapter
@@ -30,7 +31,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api):
     p = Plugin()
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._romm_api = fake_romm_api
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky
@@ -688,7 +689,7 @@ class TestDebugLoggerProtocolSeam:
         p = Plugin()
         p.settings = {"log_level": "debug", "steamgriddb_api_key": ""}
         p._romm_api = fake_romm_api
-        p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+        p._state = make_default_plugin_state()
         p._metadata_cache = {}
 
         captured: list[str] = []

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from bootstrap import (
@@ -29,6 +30,7 @@ from fakes.fake_rom_file_store import FakeRomFileStore
 from fakes.fake_save_file_store import FakeSaveFileStore
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import ShortcutRegistryEntry
 
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
@@ -108,7 +110,7 @@ class TestBootstrap:
         state = result.stores.state
         # Inner containers were independently constructed; mutating them
         # does not bleed into a future bootstrap call's state.
-        state["shortcut_registry"]["sentinel"] = {"app_id": 1}
+        state["shortcut_registry"]["sentinel"] = cast("ShortcutRegistryEntry", {"app_id": 1})
         state["sync_stats"]["platforms"] = 42
 
         second = _bootstrap_for(tmp_path)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -30,7 +30,7 @@ from fakes.fake_rom_file_store import FakeRomFileStore
 from fakes.fake_save_file_store import FakeSaveFileStore
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
-from models.state import ShortcutRegistryEntry
+from models.state import ShortcutRegistryEntry, make_default_plugin_state
 
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
@@ -137,13 +137,7 @@ class TestWireServices:
         settings = {}
         http_adapter = MagicMock(spec=RommHttpAdapter)
         steam_config = SteamConfigAdapter(user_home=str(tmp_path), logger=logger)
-        state = {
-            "shortcut_registry": {},
-            "installed_roms": {},
-            "last_sync": None,
-            "sync_stats": {},
-            "downloaded_bios": {},
-        }
+        state = make_default_plugin_state()
         romm_api = MagicMock(spec=RommApiAdapter)
         return {
             "http_adapter": http_adapter,
@@ -428,8 +422,9 @@ class TestWireServices:
         MigrationService must see that write through the same live dict.
         """
         deps = self._make_deps(tmp_path)
-        # The default mock returns (True, False); no prior state seeded.
-        assert "save_sort_settings" not in deps["state"]
+        # The default mock returns (True, False); no prior state seeded
+        # (the factory default for ``save_sort_settings`` is ``None``).
+        assert deps["state"]["save_sort_settings"] is None
         result = wire_services(self._make_config(deps))
         save_sync_service = result["save_sync_service"]
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,6 +12,7 @@ from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_state_persister import FakeStatePersister
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import PersistenceAdapter, SettingsPersisterAdapter
@@ -32,7 +33,7 @@ def plugin():
     p.settings = {"romm_url": "", "romm_user": "", "romm_pass": "", "enabled_platforms": {}}
     p._http_adapter = MagicMock()
     p._romm_api = MagicMock()
-    p._state = {"shortcut_registry": {}, "installed_roms": {}, "last_sync": None, "sync_stats": {}}
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
     # Default to "/tmp" so the prune guard sees an existing home in tests that
     # don't override it. Tests exercising the guard rebuild this with a
@@ -895,15 +896,7 @@ class TestMainStartupOrdering:
                 core_info_provider=MagicMock(),
             ),
             stores=StateBundle(
-                state={
-                    "shortcut_registry": {},
-                    "installed_roms": {},
-                    "last_sync": None,
-                    "sync_stats": {"platforms": 0, "roms": 0},
-                    "downloaded_bios": {},
-                    "retrodeck_home_path": "",
-                    "save_sort_settings": None,
-                },
+                state=make_default_plugin_state(),
                 settings={},
                 metadata_cache={},
                 save_sync_state=MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -14,6 +14,7 @@ from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
 from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+from models.state import make_default_plugin_state
 
 from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
@@ -39,12 +40,7 @@ def plugin(tmp_path):
     }
     p._http_adapter = RommHttpAdapter(p.settings, __import__("decky").DECKY_PLUGIN_DIR, logging.getLogger("test"))
     p._romm_api = MagicMock()
-    p._state = {
-        "shortcut_registry": {},
-        "installed_roms": {},
-        "last_sync": None,
-        "sync_stats": {},
-    }
+    p._state = make_default_plugin_state()
     p._metadata_cache = {}
 
     import decky


### PR DESCRIPTION
## Summary

- Replaces `state: dict` / `metadata_cache: dict` across the wiring with TypedDicts living in `models/state.py`. basedpyright now surfaces every key typo as a real error.
- `PluginState` has 7 required keys mirroring `bootstrap._default_state` plus 4 `NotRequired` transients; sub-shapes (`ShortcutRegistryEntry`, `InstalledRomEntry`, `SyncStats`, `DownloadedBiosEntry`, `SaveSortSettings`, `MetadataCacheEntry`) carry their own required/optional split. `make_default_plugin_state()` lives next to the schema and is the single source of truth.
- 22 `*ServiceConfig` fields + 2 internal sub-service ctor params + the `StateBundle` retyped. Three cross-service Protocols (`LaunchGateInstalledChecker`, `MetadataExtractor`, `ArtworkRemover` / `ArtworkManager`) accept TypedDicts to keep the variance honest.
- `domain.shortcut_data.build_registry_entry` returns `ShortcutRegistryEntry`; `MetadataService.extract_metadata` returns `MetadataCacheEntry`.

## The WIN

basedpyright surfaced **86 errors** after the first pass (all variations of "key not required in PluginState" — exposed the design decision to mark the 7 canonical keys required, keeping `total=True` + `NotRequired` on transients). After redesigning to required + NotRequired and retyping internal helpers + test fixtures, pyright is clean at **0 errors**.

The errors fell into three real categories:
- **Internal method signatures** still using `dict` — 6 service helpers (`_resolve_rom_by_app_id`, `_resolve_rom_file`, `_compute_stale_fields`, `_delete_rom_files`, `_collect_save_sorting_items`, `_migrate_save_sort_files_io`) and property getters retyped from `dict` to the appropriate TypedDict.
- **Dict-literal assignment sites** needing TypedDict annotation — two download-completion `installed_entry` literals (`InstalledRomEntry`), migration's `current` save-sort literal (`SaveSortSettings`).
- **Test fixtures** passing sparse dicts — `_minimal_state()` helper in `test_firmware`, `_installed()` / `_registry()` partial builders in `test_startup_healing`, `cast("InstalledRomEntry", ...)` in `test_launch_gate` fakes for intentionally-sparse shapes, fake-peer Protocol signatures updated.

No schema gaps surfaced — the 7 keys in `_default_state` plus the 4 transient writes match the runtime usage exactly.

## Test plan

- [x] `python -m pytest tests/ -q` — 2500 passed
- [x] `ruff check py_modules/ main.py tests/` — all checks passed
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors
- [x] `bash scripts/check_cosmic_call_bans.sh` — OK
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept (Models layer rule still satisfied)
- [x] `pnpm build` — rollup OK
- [x] `pnpm test` — 601 passed

Closes #692