### PR TITLE
fix(ui): re-read cancelled closure in refreshBiosInBackground

### DIFF
--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -374,7 +374,7 @@ describe("RomMPlaySection", () => {
       );
       expect(sectionRefresh.refreshBiosInBackground).toHaveBeenCalledWith(
         99,
-        expect.any(Boolean),
+        expect.any(Function),
         expect.any(Function),
       );
       // Assert exact arg shape: (cached.bios_status, cached.bios_level, cached.bios_label).

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -206,7 +206,7 @@ async function loadCached(
     }
 
     if (staleFields.includes("bios")) {
-      refreshBiosInBackground(romId, cancelled(), setter);
+      refreshBiosInBackground(romId, cancelled, setter);
     }
   } catch (e) {
     debugLog(`RomMPlaySection: loadCached error: ${e}`);

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -30,6 +30,23 @@ interface AchievementState {
 
 const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+/**
+ * Build a promise that resolves only when the returned `resolve` is called.
+ * Lets a test simulate the "long-running fetch" window (e.g. the 5s
+ * `timeoutMs` race inside `getBiosStatus`) and flip a `cancelled` flag
+ * mid-await — proving the helper re-reads the closure after each await
+ * instead of capturing a stale boolean snapshot.
+ */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("refreshActiveSlotInBackground", () => {
   beforeEach(() => vi.restoreAllMocks());
 
@@ -62,11 +79,31 @@ describe("refreshActiveSlotInBackground", () => {
     expect(setter).not.toHaveBeenCalled();
   });
 
-  it("swallows backend errors", async () => {
+  it("re-reads the cancelled closure after the await (cancelled mid-await)", async () => {
+    const d = deferred<{ active_slot: string }>();
+    vi.mocked(backend.getSaveStatus).mockReturnValueOnce(
+      d.promise as unknown as ReturnType<typeof backend.getSaveStatus>,
+    );
+
+    let cancelled = false;
+    const setter = vi.fn();
+    refreshActiveSlotInBackground(1, () => cancelled, setter);
+
+    // Cancel before the backend call resolves — proves we re-read the closure.
+    cancelled = true;
+    d.resolve({ active_slot: "slot-2" });
+    await flushMicrotasks();
+
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it("swallows backend errors without invoking the setter", async () => {
     vi.mocked(backend.getSaveStatus).mockRejectedValueOnce(new Error("network"));
     const setter = vi.fn();
     refreshActiveSlotInBackground(1, () => false, setter);
     await flushMicrotasks();
+    // active-slot's `.catch` has no observable side effect beyond skipping the
+    // setter; asserting the setter never fires is the post-catch state.
     expect(setter).not.toHaveBeenCalled();
   });
 
@@ -103,7 +140,7 @@ describe("refreshBiosInBackground", () => {
     } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
 
     const setter = vi.fn<(updater: (prev: BiosState) => BiosState) => void>();
-    refreshBiosInBackground(1, false, setter as unknown as Dispatch<SetStateAction<BiosState>>);
+    refreshBiosInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<BiosState>>);
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
@@ -121,15 +158,39 @@ describe("refreshBiosInBackground", () => {
     expect(next.unrelated).toBe("keep");
   });
 
-  it("skips the setter when cancelled", async () => {
+  it("skips the setter when cancelled at call time", async () => {
     vi.mocked(backend.getBiosStatus).mockResolvedValueOnce({
       bios_status: { available_cores: [] },
       bios_level: "ok",
       bios_label: "ok",
     } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
     const setter = vi.fn();
-    refreshBiosInBackground(1, true, setter);
+    refreshBiosInBackground(1, () => true, setter);
     await flushMicrotasks();
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the cancelled closure after the await (regression — was boolean snapshot)", async () => {
+    // Regression test for #725: a `boolean` snapshot was captured at call
+    // time, so flipping `cancelled` during the 5s `timeoutMs` race in
+    // `getBiosStatus` did not prevent a setter call on an unmounted component.
+    const d = deferred<unknown>();
+    vi.mocked(backend.getBiosStatus).mockReturnValueOnce(
+      d.promise as unknown as ReturnType<typeof backend.getBiosStatus>,
+    );
+
+    let cancelled = false;
+    const setter = vi.fn();
+    refreshBiosInBackground(1, () => cancelled, setter);
+
+    cancelled = true;
+    d.resolve({
+      bios_status: { available_cores: [] },
+      bios_level: "ok",
+      bios_label: "ok",
+    });
+    await flushMicrotasks();
+
     expect(setter).not.toHaveBeenCalled();
   });
 
@@ -140,17 +201,23 @@ describe("refreshBiosInBackground", () => {
       bios_label: null,
     } as unknown as Awaited<ReturnType<typeof backend.getBiosStatus>>);
     const setter = vi.fn();
-    refreshBiosInBackground(1, false, setter);
+    refreshBiosInBackground(1, () => false, setter);
     await flushMicrotasks();
     expect(setter).not.toHaveBeenCalled();
   });
 
-  it("logs but swallows errors", async () => {
+  it("logs the error and skips the setter when the fetch rejects", async () => {
     vi.mocked(backend.getBiosStatus).mockRejectedValueOnce(new Error("network"));
+    vi.mocked(backend.debugLog).mockResolvedValue(undefined);
     const setter = vi.fn();
-    refreshBiosInBackground(1, false, setter);
+    refreshBiosInBackground(1, () => false, setter);
     await flushMicrotasks();
+
     expect(setter).not.toHaveBeenCalled();
+    // Non-vacuous catch assertion: the `.catch` calls debugLog with the error.
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+      expect.stringContaining("Background BIOS status fetch error"),
+    );
   });
 });
 
@@ -189,7 +256,7 @@ describe("refreshAchievementsInBackground", () => {
     expect(setter).not.toHaveBeenCalled();
   });
 
-  it("skips the setter when cancelled", async () => {
+  it("skips the setter when cancelled at call time", async () => {
     vi.mocked(backend.getAchievementProgress).mockResolvedValueOnce({
       success: true,
       earned: 1,
@@ -201,11 +268,34 @@ describe("refreshAchievementsInBackground", () => {
     expect(setter).not.toHaveBeenCalled();
   });
 
-  it("logs but swallows errors", async () => {
+  it("re-reads the cancelled closure after the await (cancelled mid-await)", async () => {
+    const d = deferred<unknown>();
+    vi.mocked(backend.getAchievementProgress).mockReturnValueOnce(
+      d.promise as unknown as ReturnType<typeof backend.getAchievementProgress>,
+    );
+
+    let cancelled = false;
+    const setter = vi.fn();
+    refreshAchievementsInBackground(1, () => cancelled, setter);
+
+    cancelled = true;
+    d.resolve({ success: true, earned: 1, total: 2 });
+    await flushMicrotasks();
+
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it("logs the error and skips the setter when the fetch rejects", async () => {
     vi.mocked(backend.getAchievementProgress).mockRejectedValueOnce(new Error("network"));
+    vi.mocked(backend.debugLog).mockResolvedValue(undefined);
     const setter = vi.fn();
     refreshAchievementsInBackground(1, () => false, setter);
     await flushMicrotasks();
+
     expect(setter).not.toHaveBeenCalled();
+    // Non-vacuous catch assertion: the `.catch` calls debugLog with the error.
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+      expect.stringContaining("Background achievement progress fetch error"),
+    );
   });
 });

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -37,13 +37,13 @@ export function refreshActiveSlotInBackground<S extends ActiveSlotFields>(
 
 export function refreshBiosInBackground<S extends BiosInfoFields>(
   romId: number,
-  cancelled: boolean,
+  cancelled: () => boolean,
   setter: Dispatch<SetStateAction<S>>,
 ): void {
   getBiosStatus(romId)
     .then((result) => {
       const b = result.bios_status;
-      if (!cancelled && b) {
+      if (!cancelled() && b) {
         setter((prev) => ({
           ...prev,
           ...extractBiosInfo(b as BiosStatus, result.bios_level, result.bios_label),


### PR DESCRIPTION
## Summary

`src/utils/sectionRefresh.ts:38` took `cancelled: boolean` (snapshot at call time) instead of the `() => boolean` closure its two siblings (`refreshActiveSlotInBackground`, `refreshAchievementsInBackground`) use. After the 5-second `getBiosStatus` timeout race the snapshot stayed `false` even if the component had unmounted → `setter(...)` fired on an unmounted component.

- Signature now takes the closure; `if (!cancelled())` after the await re-reads the live state.
- Call site at `RomMPlaySection.tsx:209` passes the closure directly (was passing `cancelled()` — the evaluation).
- All three helpers in `sectionRefresh.ts` now have the same shape.

## Test plan

- [x] New regression test: `refreshBiosInBackground > re-reads the cancelled closure after the await (regression — was boolean snapshot)` — flips `cancelled` between helper invocation and promise resolution; asserts setter not called.
- [x] Symmetric mid-await tests added for the two siblings (lock in the same contract).
- [x] Non-vacuous catch assertions: error-path tests now assert `debugLog` was called with the expected message substring.
- [x] `pnpm build` — clean
- [x] `pnpm test` — 913 vitest pass
- [x] `pnpm lint` — no new warnings on touched files (3 pre-existing in unrelated files)
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright py_modules/ main.py tests/` — 0 errors / 0 warnings
- [x] `python -m pytest tests/ -q` — 2513 pass
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean

Closes #725