### PR TITLE
fix(migration): wire MigrationService task shutdown into plugin unload

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,6 +142,7 @@ class Plugin:
     async def _unload(self):  # Decky lifecycle — must be async
         self._sync_service.shutdown()
         await self._download_service.shutdown()
+        await self._migration_service.shutdown()
         decky.logger.info("RomM Sync plugin unloaded")
 
     # ── Callables ──────────────────────────────────────────────────────

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -72,6 +72,35 @@ class MigrationService:
         self._get_retroarch_save_sorting = config.get_retroarch_save_sorting
         self._get_active_core = config.get_active_core
         self._get_core_name = config.get_core_name
+        # Strong refs to in-flight background tasks. ``loop.create_task``
+        # alone is not enough — without a strong ref, the loop is free to
+        # garbage-collect the task before it completes. ``add_done_callback``
+        # prunes finished entries to keep the set bounded.
+        self._background_tasks: set[asyncio.Task] = set()
+
+    def _spawn_background_task(self, coro) -> asyncio.Task:
+        """Schedule ``coro`` on the plugin loop and track the task for shutdown.
+
+        Wraps ``loop.create_task`` so the resulting task is retained in
+        ``_background_tasks`` until completion. ``shutdown()`` cancels any
+        still-pending entries on plugin unload.
+        """
+        task = self._loop.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
+    async def shutdown(self) -> None:
+        """Cancel any in-flight background tasks and await their completion.
+
+        Called from ``main._unload`` so RetroDECK path-change notification
+        coroutines do not leak across the plugin unload boundary. No-op
+        when no tasks are pending.
+        """
+        for task in self._background_tasks:
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
 
     def detect_retrodeck_path_change(self) -> None:
         """Check if RetroDECK home path changed since last run."""
@@ -104,7 +133,7 @@ class MigrationService:
             self._logger.info(f"RetroDECK home reverted to previous path; clearing migration marker: {current_home}")
             # Notify the frontend so any pending migration UI can dismiss itself.
             # ``cleared: True`` lets the listener distinguish from the path-change emit.
-            self._loop.create_task(
+            self._spawn_background_task(
                 self._emit(
                     "retrodeck_path_changed",
                     {
@@ -123,7 +152,7 @@ class MigrationService:
         self._state["retrodeck_home_path"] = current_home
         self._state_persister.save_state()
         self._logger.warning(f"RetroDECK home path changed: {old_home} -> {current_home}")
-        self._loop.create_task(
+        self._spawn_background_task(
             self._emit(
                 "retrodeck_path_changed",
                 {

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -1097,3 +1097,96 @@ class TestBadPathDismissSaveSortMigration:
         assert result == {"success": True}
         assert "save_sort_settings_previous" not in plugin._state
         assert persister.save_count == saves_before + 1
+
+
+class TestBackgroundTaskTracking:
+    """Coverage for the background-task tracking + ``shutdown()`` lifecycle.
+
+    The path-change detection schedules a ``retrodeck_path_changed`` emit
+    via ``loop.create_task``. Without strong refs into ``_background_tasks``
+    and a cancellation hook in ``shutdown()``, those tasks leak across
+    plugin unload. These tests pin the contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_spawned_task_added_to_background_set(self, plugin, tmp_path):
+        """``detect_retrodeck_path_change`` adds its emit task to the set."""
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        old_home = str(tmp_path / "old_retrodeck")
+        new_home = str(tmp_path / "new_retrodeck")
+        os.makedirs(new_home, exist_ok=True)
+
+        plugin._state["retrodeck_home_path"] = old_home
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=new_home)
+
+        assert plugin._migration_service._background_tasks == set()
+
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        # The spawned task must be tracked before any await yields control.
+        assert len(plugin._migration_service._background_tasks) == 1
+        (task,) = plugin._migration_service._background_tasks
+        assert isinstance(task, asyncio.Task)
+
+        # Drain so no pending-task warning fires at loop teardown.
+        await asyncio.gather(*plugin._migration_service._background_tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_done_callback_removes_task_on_natural_completion(self, plugin, tmp_path):
+        """When the spawned coro completes naturally, the done-callback prunes the set."""
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        old_home = str(tmp_path / "old_retrodeck")
+        new_home = str(tmp_path / "new_retrodeck")
+        os.makedirs(new_home, exist_ok=True)
+
+        plugin._state["retrodeck_home_path"] = old_home
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=new_home)
+
+        plugin._migration_service.detect_retrodeck_path_change()
+        assert len(plugin._migration_service._background_tasks) == 1
+
+        # Yield until the spawned emit coroutine finishes; the done-callback
+        # then discards the task from the set.
+        (task,) = plugin._migration_service._background_tasks
+        await task
+
+        assert plugin._migration_service._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_pending_tasks_and_empties_set(self, plugin):
+        """``shutdown()`` cancels in-flight tasks and the set is empty after."""
+        loop = asyncio.get_event_loop()
+        plugin._migration_service._loop = loop
+
+        # Spawn a task that blocks forever via an unset Event.
+        blocker = asyncio.Event()
+
+        async def _block_forever() -> None:
+            await blocker.wait()
+
+        plugin._migration_service._spawn_background_task(_block_forever())
+        assert len(plugin._migration_service._background_tasks) == 1
+        (task,) = plugin._migration_service._background_tasks
+
+        await plugin._migration_service.shutdown()
+
+        assert task.cancelled()
+        assert plugin._migration_service._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_with_empty_set_is_noop(self, plugin):
+        """``shutdown()`` on an untouched service returns immediately."""
+        assert plugin._migration_service._background_tasks == set()
+
+        # Must not raise, must not block.
+        await plugin._migration_service.shutdown()
+
+        assert plugin._migration_service._background_tasks == set()

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -734,9 +734,11 @@ class TestUnloadHook:
 
     @pytest.mark.asyncio
     async def test_unload_calls_shutdown_on_sync_and_download(self, plugin):
-        # DownloadService.shutdown is async (it awaits the poll task);
+        # DownloadService.shutdown and MigrationService.shutdown are async;
         # the bare-MagicMock default returns a non-awaitable.
         plugin._download_service.shutdown = AsyncMock()
+        plugin._migration_service.shutdown = AsyncMock()
         await plugin._unload()
         plugin._sync_service.shutdown.assert_called_once_with()
         plugin._download_service.shutdown.assert_awaited_once_with()
+        plugin._migration_service.shutdown.assert_awaited_once_with()


### PR DESCRIPTION
## Summary

`Plugin._unload` called `shutdown()` on `LibraryService` and `DownloadService` only. `MigrationService` was firing `loop.create_task(...)` at two sites (`py_modules/services/migration.py:107` and `:126` — RetroDECK path-change notifications) without tracking or cancellation. On plugin unload mid-task, the spawned tasks leaked across the unload boundary.

- `MigrationService` now tracks spawned tasks in `_background_tasks: set[asyncio.Task]`, registered via `_spawn_background_task(coro)` (idempotent `set.discard` done-callback).
- `async def shutdown()` cancels each pending task, then `await asyncio.gather(*..., return_exceptions=True)`.
- `Plugin._unload` awaits `migration_service.shutdown()` after sync + download shutdowns.

Pattern mirrors `SessionLifecycleService._background_tasks` (#727 will add the matching `shutdown()` there).

## Test plan

- [x] `TestBackgroundTaskTracking::test_spawned_task_added_to_background_set` — set membership after spawn
- [x] `TestBackgroundTaskTracking::test_done_callback_removes_task_on_natural_completion` — exercises the done-callback for real (not a manual `discard`)
- [x] `TestBackgroundTaskTracking::test_shutdown_cancels_pending_tasks_and_empties_set` — uses an `asyncio.Event` that is never set, so cancellation is genuinely observable (would fail against a no-op `shutdown()`)
- [x] `TestBackgroundTaskTracking::test_shutdown_with_empty_set_is_noop`
- [x] Extended `test_unload_calls_shutdown_on_sync_and_download` — `AsyncMock` + `assert_awaited_once_with()` for `migration_service.shutdown`
- [x] `python -m pytest tests/ -q` — 2517 pass (was 2513; +4 new)
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright py_modules/ main.py tests/` — 0/0/0
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept
- [x] `pnpm build` — clean

Closes #726