### PR TITLE
fix(session): wire SessionLifecycleService task shutdown into plugin unload

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,6 +143,7 @@ class Plugin:
         self._sync_service.shutdown()
         await self._download_service.shutdown()
         await self._migration_service.shutdown()
+        await self._session_lifecycle_service.shutdown()
         decky.logger.info("RomM Sync plugin unloaded")
 
     # ── Callables ──────────────────────────────────────────────────────

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -154,6 +154,18 @@ class SessionLifecycleService:
         # prunes finished entries to keep the set bounded.
         self._background_tasks: set[asyncio.Task] = set()
 
+    async def shutdown(self) -> None:
+        """Cancel any in-flight background tasks and await their completion.
+
+        Called from ``main._unload`` so detached achievement-refresh
+        coroutines do not leak across the plugin unload boundary. No-op
+        when no tasks are pending.
+        """
+        for task in self._background_tasks:
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+
     async def finalize(self, rom_id: int) -> SessionFinalizeResult:
         """Run the four end-of-session steps and return the combined verdict.
 

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -644,3 +644,112 @@ class TestFinalizeResultShape:
                 save_sort={"pending": False},
             ),
         )
+
+
+class TestBackgroundTaskTracking:
+    """Coverage for the background-task tracking + ``shutdown()`` lifecycle.
+
+    ``finalize`` schedules the achievement refresh detached from its
+    return value via ``asyncio.create_task``. Without strong refs into
+    ``_background_tasks`` and a cancellation hook in ``shutdown()``,
+    those tasks leak across plugin unload. These tests pin the contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_spawned_task_added_to_background_set(self, logger):
+        """``finalize`` adds the achievement-sync task to ``_background_tasks``."""
+        # Block the achievement sync so the spawned task is observable as pending.
+        blocker = asyncio.Event()
+
+        class BlockingAchievementSync:
+            async def sync_achievements_after_session(self, rom_id: int) -> dict:
+                await blocker.wait()
+                return {"success": True}
+
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=BlockingAchievementSync(),  # type: ignore[arg-type]
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        await service.finalize(99)
+
+        assert len(service._background_tasks) == 1
+        (task,) = service._background_tasks
+        assert isinstance(task, asyncio.Task)
+
+        # Release the blocker and drain so no pending-task warning fires.
+        blocker.set()
+        await asyncio.gather(*service._background_tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_done_callback_removes_task_on_natural_completion(self, logger):
+        """When the achievement-sync coro completes naturally, the done-callback prunes the set."""
+        completion = asyncio.Event()
+        achievements = FakeAchievementSync(completion_event=completion)
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=achievements,
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        await service.finalize(99)
+        assert len(service._background_tasks) == 1
+
+        # Yield until the spawned achievement coroutine finishes; the
+        # done-callback then discards the task from the set.
+        (task,) = service._background_tasks
+        await task
+
+        assert service._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_pending_tasks_and_empties_set(self, logger):
+        """``shutdown()`` cancels in-flight tasks and the set is empty after."""
+        # Block the achievement sync indefinitely via an unset Event so the
+        # cancellation is genuinely observable.
+        blocker = asyncio.Event()
+
+        class BlockingAchievementSync:
+            async def sync_achievements_after_session(self, rom_id: int) -> dict:
+                await blocker.wait()
+                return {"success": True}
+
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=BlockingAchievementSync(),  # type: ignore[arg-type]
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        await service.finalize(99)
+        assert len(service._background_tasks) == 1
+        (task,) = service._background_tasks
+
+        await service.shutdown()
+
+        assert task.cancelled()
+        assert service._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_with_empty_set_is_noop(self, logger):
+        """``shutdown()`` on an untouched service returns immediately."""
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=FakePostExitSync(),
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        assert service._background_tasks == set()
+
+        # Must not raise, must not block.
+        await service.shutdown()
+
+        assert service._background_tasks == set()

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -734,11 +734,14 @@ class TestUnloadHook:
 
     @pytest.mark.asyncio
     async def test_unload_calls_shutdown_on_sync_and_download(self, plugin):
-        # DownloadService.shutdown and MigrationService.shutdown are async;
-        # the bare-MagicMock default returns a non-awaitable.
+        # DownloadService.shutdown, MigrationService.shutdown, and
+        # SessionLifecycleService.shutdown are async; the bare-MagicMock
+        # default returns a non-awaitable.
         plugin._download_service.shutdown = AsyncMock()
         plugin._migration_service.shutdown = AsyncMock()
+        plugin._session_lifecycle_service.shutdown = AsyncMock()
         await plugin._unload()
         plugin._sync_service.shutdown.assert_called_once_with()
         plugin._download_service.shutdown.assert_awaited_once_with()
         plugin._migration_service.shutdown.assert_awaited_once_with()
+        plugin._session_lifecycle_service.shutdown.assert_awaited_once_with()


### PR DESCRIPTION
## Summary

Companion to #726. `SessionLifecycleService` was already tracking `_background_tasks: set[asyncio.Task]` at `py_modules/services/session_lifecycle.py:155` (one spawn site at `_schedule_achievement_sync:215`, already using idempotent `set.discard` done-callback), but had no `shutdown()` method to drain it on plugin unload. The post-exit save sync, achievement refresh, and playtime record tasks could leak across unload.

- `async def shutdown(self) -> None` on `SessionLifecycleService` — mechanically mirrors `MigrationService.shutdown()` from #726 (cancel loop + `await asyncio.gather(*..., return_exceptions=True)` + empty-set guard).
- `Plugin._unload` now awaits `session_lifecycle_service.shutdown()` after migration shutdown. Order is `library → download → migration → session_lifecycle`; verified no earlier-shut-down service holds refs that could spawn a session-lifecycle task.

## Test plan

- [x] `TestBackgroundTaskTracking` 4 tests, parity with `tests/services/test_migration.py::TestBackgroundTaskTracking` from #726
  - `test_spawned_task_added_to_background_set`
  - `test_done_callback_removes_task_on_natural_completion`
  - `test_shutdown_cancels_pending_tasks_and_empties_set` — uses unset `asyncio.Event` blocker so cancellation is genuinely observable (would hang against a no-op `shutdown()`)
  - `test_shutdown_with_empty_set_is_noop`
- [x] Extended `test_unload_calls_shutdown_on_sync_and_download` — now mocks all 4 shutdowns (library/download/migration/session_lifecycle) and asserts each is awaited
- [x] `python -m pytest tests/ -q` — 2521 pass (was 2517; +4)
- [x] `ruff check py_modules/ main.py tests/` — clean
- [x] `basedpyright py_modules/ main.py tests/` — 0/0/0
- [x] `bash scripts/check_cosmic_call_bans.sh` — clean
- [x] `PYTHONPATH=py_modules lint-imports` — 7 contracts kept

Closes #727