### PR TITLE
fix(library): short-circuit apply for incremental-skip units

### DIFF
--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -470,9 +470,11 @@ class LibraryFetcher:
         used to reconstruct the ROM list (avoids re-paginating).
 
         Returns ``(unit_roms, skipped)`` where ``skipped`` is True when
-        the incremental check succeeded — callers can use this to skip
-        the artwork-download step entirely if the registry already
-        carries the cover_path.
+        the incremental check succeeded. Callers use ``skipped=True`` as
+        the signal to short-circuit the entire per-unit apply + commit
+        branch — no ``sync_apply_unit`` emit, no frontend roundtrip, no
+        registry commit. The reconstructed ``unit_roms`` still flow back
+        so the caller can keep its synced-rom accounting accurate.
         """
         if unit.type != "platform":
             raise ValueError(f"fetch_platform_unit called with non-platform unit type={unit.type}")

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -339,12 +339,10 @@ class SyncOrchestrator:
         box = self._sync_state
         # Cross-unit accumulators — built up unit-by-unit, consumed by the
         # final phase. ``synced_rom_ids`` is shared with collection units
-        # for dedup. ``all_rom_id_to_app_id`` aggregates every unit's
-        # frontend-reported mapping for stale detection. ``collection_
-        # memberships`` and ``platform_rom_ids`` feed the reporter's
-        # ``_build_collection_app_ids`` once every unit has been applied.
+        # for dedup. ``collection_memberships`` and ``platform_rom_ids``
+        # feed the reporter's ``_build_collection_app_ids`` once every
+        # unit has been applied.
         synced_rom_ids: set[int] = set()
-        all_rom_id_to_app_id: dict[str, int] = {}
         collection_memberships: dict[str, list[int]] = {}
         platform_rom_ids: set[int] = set()
         total_games_applied = 0
@@ -393,7 +391,6 @@ class SyncOrchestrator:
                     synced_rom_ids=synced_rom_ids,
                     collection_memberships=collection_memberships,
                     platform_rom_ids=platform_rom_ids,
-                    all_rom_id_to_app_id=all_rom_id_to_app_id,
                 )
                 total_games_applied += applied
 
@@ -435,7 +432,6 @@ class SyncOrchestrator:
         synced_rom_ids: set[int],
         collection_memberships: dict[str, list[int]],
         platform_rom_ids: set[int],
-        all_rom_id_to_app_id: dict[str, int],
     ) -> int:
         """Process one work unit start-to-finish; return shortcuts applied.
 
@@ -446,6 +442,12 @@ class SyncOrchestrator:
         any crash between the two leaves harmless orphan metadata
         rather than orphan registry entries pointing at unstamped
         metadata (#738).
+
+        When the fetcher reports ``skipped=True`` (registry already
+        matches the server-side platform state), the entire apply +
+        commit branch is short-circuited: no frontend roundtrip, no
+        registry write. The unit's ROMs still count toward the
+        ``total_games_applied`` total returned to the user.
         """
         box = self._sync_state
         await self._emit_progress(
@@ -474,12 +476,22 @@ class SyncOrchestrator:
         if box.sync_state == SyncState.CANCELLING:
             return 0
 
+        # Per-unit incremental skip: registry already matches the
+        # server-side state for this platform, so neither apply nor
+        # commit have any work. Skip the frontend roundtrip and the
+        # no-op two-phase commit. Force Full Sync clears ``last_sync``
+        # upstream, so ``skipped`` is always False on forced runs.
+        if skipped:
+            self._logger.info(f"Per-unit apply skipped: {unit.name} ({len(unit_roms)} ROMs unchanged)")
+            return len(unit_roms)
+
         # Build shortcut data for this unit.
         shortcuts_data = build_shortcuts_data(unit_roms, self._plugin_dir)
 
-        # Download artwork for this unit (skipped if the incremental
-        # path already populated cover_path from the registry).
-        if not skipped and unit_roms:
+        # Download artwork for this unit. Empty unit_roms is a defensive
+        # guard — an empty platform that survived planning still has no
+        # artwork to fetch.
+        if unit_roms:
             cover_paths = await self._download_artwork(
                 unit_roms, progress_step=unit_index + 1, progress_total_steps=total_units
             )
@@ -519,28 +531,18 @@ class SyncOrchestrator:
             box.sync_state = SyncState.CANCELLING
             return 0
 
-        # Per-unit two-phase commit:
-        #
-        # 1) Stamp metadata cache for the acked ROMs first. Skipped
-        #    (incremental-skip) units carry thin registry-reconstructed
-        #    ROMs without a ``metadatum`` field; ``record_unit_metadata``
-        #    guards on that and is a no-op for them — so we never erase
-        #    the populated entries from a prior real fetch (#738).
-        # 2) Then commit the registry + persist state via the reporter.
-        #
-        # The ordering matters across crashes: metadata-first means an
-        # interrupted apply leaves only orphan metadata (harmless,
-        # next sync re-stamps). Registry-first would leave registry
-        # entries pointing at an unstamped (or freshly wiped) cache.
-        if not skipped:
-            acked_roms = [r for r in unit_roms if str(r["id"]) in applied]
-            await self._loop.run_in_executor(None, self._metadata_service.record_unit_metadata, acked_roms)
+        # Per-unit two-phase commit: stamp metadata cache for the acked
+        # ROMs first, then commit the registry + persist state via the
+        # reporter. The ordering matters across crashes: metadata-first
+        # means an interrupted apply leaves only orphan metadata
+        # (harmless, next sync re-stamps). Registry-first would leave
+        # registry entries pointing at an unstamped (or freshly wiped)
+        # cache (#738).
+        acked_roms = [r for r in unit_roms if str(r["id"]) in applied]
+        await self._loop.run_in_executor(None, self._metadata_service.record_unit_metadata, acked_roms)
 
         await self._reporter.get().commit_unit_results(applied)
 
-        # Mirror the rom_id_to_app_id into the cross-run accumulator
-        # for stale + Steam-collection mapping.
-        all_rom_id_to_app_id.update(applied)
         box.pending_sync = {}
         box.unit_complete_event = None
         return len(applied)

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -782,15 +782,24 @@ class TestDoSyncPerUnit:
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
-        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
-        plugin._state["shortcut_registry"] = {
-            "10": {"name": "N64", "fs_name": "n.z64", "platform_name": "N64", "platform_slug": "n64"},
-            "20": {"name": "GBA", "fs_name": "g.gba", "platform_name": "GBA", "platform_slug": "gba"},
-        }
-        fake_romm_api.platforms = [
-            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
-            {"id": 2, "name": "GBA", "slug": "gba", "rom_count": 1},
-        ]
+        # Live-fetch platforms (no last_sync, empty registry) so both
+        # units reach the apply branch and emit ``sync_apply_unit``.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        _seed_platform(
+            fake_romm_api,
+            platform_id=2,
+            name="GBA",
+            slug="gba",
+            roms=[{"id": 20, "name": "B"}],
+        )
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
         plugin.settings["enabled_platforms"] = {"1": True, "2": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
@@ -812,7 +821,16 @@ class TestDoSyncPerUnit:
         assert unit_events[1]["unit_index"] == 1
 
     @pytest.mark.asyncio
-    async def test_skips_artwork_when_incremental_skipped(self, plugin, fake_romm_api):
+    async def test_skipped_unit_short_circuits_apply(self, plugin, fake_romm_api):
+        """``skipped=True`` from the fetcher short-circuits the whole apply+commit branch.
+
+        For a unit whose registry already matches the server-side ROM
+        count and has no updates since ``last_sync``, none of these run:
+        artwork download, ``_wait_for_unit_complete``, the
+        ``sync_apply_unit`` emit, or the reporter's ``commit_unit_results``.
+        The unit's reconstructed ROMs still join ``synced_rom_ids`` so
+        the final stale-cleanup pass doesn't mistakenly remove them.
+        """
         import decky
 
         decky.emit.reset_mock()
@@ -829,12 +847,27 @@ class TestDoSyncPerUnit:
 
         download_artwork = AsyncMock(return_value={})
         plugin._sync_service._orchestrator._download_artwork = download_artwork
-        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        wait_mock = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_mock
+        commit_mock = AsyncMock()
+        plugin._sync_service._reporter.commit_unit_results = commit_mock  # type: ignore[method-assign]
         plugin._sync_service._sync_state = SyncState.RUNNING
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
-        # skipped=True from fetcher → no artwork download
+
+        # Nothing on the apply branch ran.
         download_artwork.assert_not_called()
+        wait_mock.assert_not_called()
+        apply_events = [c for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_apply_unit"]
+        assert apply_events == [], f"sync_apply_unit must not be emitted for a skipped unit, got: {apply_events}"
+        commit_mock.assert_not_called()
+
+        # Stale-cleanup still emits with an empty remove list — the
+        # skipped unit's reconstructed ROMs joined synced_rom_ids so
+        # rom_id 10 is not classified as stale.
+        stale_events = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert len(stale_events) == 1
+        assert stale_events[0] == {"remove_rom_ids": []}
 
     @pytest.mark.asyncio
     async def test_downloads_artwork_when_not_skipped(self, plugin, fake_romm_api):
@@ -866,22 +899,37 @@ class TestDoSyncPerUnit:
 
     @pytest.mark.asyncio
     async def test_cancel_between_units_stops_processing(self, plugin, fake_romm_api):
+        """Cancel flipped during the first unit's ack stops the queue mid-flight.
+
+        Both platforms take the live-fetch path (no ``last_sync``) so
+        each fully traverses ``_sync_one_unit`` rather than short-
+        circuiting. The cancel observed between units must produce
+        exactly one ``sync_apply_unit`` and a ``cancelled=True``
+        ``sync_complete``.
+        """
         import decky
 
         decky.emit.reset_mock()
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
-        # Two incremental-skip platforms in the queue.
-        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
-        plugin._state["shortcut_registry"] = {
-            "10": {"name": "A", "fs_name": "a.z64", "platform_name": "N64", "platform_slug": "n64"},
-            "20": {"name": "B", "fs_name": "b.gba", "platform_name": "GBA", "platform_slug": "gba"},
-        }
-        fake_romm_api.platforms = [
-            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 1},
-            {"id": 2, "name": "GBA", "slug": "gba", "rom_count": 1},
-        ]
+        # Two live-fetch platforms (no last_sync, empty registry).
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        _seed_platform(
+            fake_romm_api,
+            platform_id=2,
+            name="GBA",
+            slug="gba",
+            roms=[{"id": 20, "name": "B"}],
+        )
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
         plugin.settings["enabled_platforms"] = {"1": True, "2": True}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
@@ -898,7 +946,7 @@ class TestDoSyncPerUnit:
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 
         unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
-        assert len(unit_events) == 1  # second unit was skipped
+        assert len(unit_events) == 1  # cancel observed between units
         complete_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert len(complete_events) == 1
         assert complete_events[0].get("cancelled") is True
@@ -1314,7 +1362,6 @@ class TestSyncOneUnitCollectionAndCancel:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
         assert applied == 0
 
@@ -1351,7 +1398,6 @@ class TestSyncOneUnitCollectionAndCancel:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
         assert applied == 0
 
@@ -1361,11 +1407,17 @@ class TestSyncOneUnitCollectionAndCancel:
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
-        # Incremental-skip path: registry matches platform rom_count + zero updates.
-        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
-        plugin._state["shortcut_registry"] = {
-            "1": {"name": "A", "fs_name": "a.z64", "platform_name": "N64", "platform_slug": "n64"},
-        }
+        # Live-fetch path so the unit reaches the apply branch where
+        # ``_wait_for_unit_complete`` is called.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 1, "name": "A"}],
+        )
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
 
@@ -1384,7 +1436,6 @@ class TestSyncOneUnitCollectionAndCancel:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
         assert applied == 0
         # pending_sync was cleared, unit event reference dropped, state flipped.
@@ -1448,7 +1499,6 @@ class TestPerUnitMetadataStamping:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
 
         assert call_order == ["record_unit_metadata", "commit_unit_results"]
@@ -1457,9 +1507,9 @@ class TestPerUnitMetadataStamping:
     async def test_skipped_unit_does_not_stamp_metadata(self, plugin, fake_romm_api):
         """Incremental-skip platforms must NOT call ``record_unit_metadata``.
 
-        Skipped units carry registry-reconstructed thin ROMs without a
-        ``metadatum`` field. Passing them through the stamp path would
-        erase populated cache entries with empty ones — the #738 bug.
+        The skipped short-circuit returns from ``_sync_one_unit`` before
+        the metadata stamp runs, so populated cache entries from prior
+        real fetches are preserved (#738).
         """
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
@@ -1489,7 +1539,6 @@ class TestPerUnitMetadataStamping:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
 
         record_mock.assert_not_called()
@@ -1536,7 +1585,6 @@ class TestPerUnitMetadataStamping:
             synced_rom_ids=set(),
             collection_memberships={},
             platform_rom_ids=set(),
-            all_rom_id_to_app_id={},
         )
 
         assert {r["id"] for r in recorded_roms} == {1, 3, 5}


### PR DESCRIPTION
## Summary

- `_sync_one_unit` returns early on `skipped=True` — no `sync_apply_unit` emit, no frontend roundtrip, no two-phase commit. Stops the per-unit pipeline from re-publishing every shortcut in Steam on a Sync click against an up-to-date library (4× `SteamClient.Apps.Set*` per shortcut at a 50 ms cadence).
- Drops the dead `all_rom_id_to_app_id` accumulator threaded through `_do_sync_per_unit` / `_sync_one_unit` — no consumers, init + update only.
- Force Full Sync still works as before: `clear_sync_cache` clears `last_sync` upstream, the fetcher's `_try_unit_incremental_skip` then returns `None` for every unit, `skipped` is always `False`, full apply pipeline runs.

Closes #740.

## Test plan

- [x] `pytest tests/services/library/test_sync_orchestrator.py -q` — 66 passed
- [x] `pytest tests/ -q` — 2527 passed
- [x] `ruff check py_modules/ tests/` — clean
- [x] `basedpyright py_modules/ tests/` — 0 errors
- [x] `scripts/check_cosmic_call_bans.sh` — clean
- [x] `pnpm build` — clean
- [x] Manual: regular Sync against unchanged library → `decky.log` shows `Per-unit apply skipped: <Platform>` for each unit and no `sync_apply_unit received` lines
- [x] Manual: Force Full Sync → every unit emits `sync_apply_unit` and re-publishes shortcuts as before