### PR TITLE
fix(library): stop registry writes from clobbering peer-owned fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,8 @@ class Plugin:
     _state_persister: Any
     _settings_persister: Any
     _metadata_cache_persister: Any
+    _registry_store: Any
+    _metadata_store: Any
     _http_adapter: Any
     _romm_api: Any
     _steam_config: Any
@@ -289,6 +291,10 @@ class Plugin:
 
     async def get_artwork_base64(self, rom_id):
         return await self._artwork_service.get_artwork_base64(rom_id)
+
+    @migration_blocked
+    async def refresh_cover_artwork(self, rom_id):
+        return await self._artwork_service.refresh_cover(int(rom_id))
 
     @migration_blocked
     async def clear_sync_cache(self):

--- a/py_modules/adapters/metadata_cache_store.py
+++ b/py_modules/adapters/metadata_cache_store.py
@@ -1,0 +1,30 @@
+"""Field-owning store over the live ``metadata_cache`` dict.
+
+Implements :class:`services.protocols.MetadataCacheStore`. Mirrors
+:class:`adapters.registry_store.RegistryStoreAdapter`: in-memory
+mutation only — flushing to disk stays the caller's job via the
+``MetadataCachePersister`` Protocol.
+"""
+
+from __future__ import annotations
+
+from models.metadata_patches import MetadataStampPatch
+from models.state import MetadataCache
+
+
+class MetadataCacheStoreAdapter:
+    """In-memory store for ``metadata_cache[rom_id_str]`` writes.
+
+    Parameters
+    ----------
+    metadata_cache:
+        The live ``MetadataCache`` dict shared with every service via
+        the existing persister adapter.
+    """
+
+    def __init__(self, metadata_cache: MetadataCache) -> None:
+        self._metadata_cache = metadata_cache
+
+    def apply_stamp(self, patch: MetadataStampPatch) -> None:
+        """Replace ``metadata_cache[rom_id_str]`` with ``patch.entry``."""
+        self._metadata_cache[patch.rom_id_str] = patch.entry

--- a/py_modules/adapters/registry_store.py
+++ b/py_modules/adapters/registry_store.py
@@ -1,0 +1,123 @@
+"""Field-owning store over the live ``shortcut_registry`` dict.
+
+Implements :class:`services.protocols.ShortcutRegistryStore`. The
+adapter mutates the in-memory ``state["shortcut_registry"]`` dict that
+all services share — flushing to disk stays the caller's job via the
+``StatePersister`` Protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from models.registry_patches import (
+    RegistryCoverPathPatch,
+    RegistryDeletePatch,
+    RegistryIdsPatch,
+    RegistrySgdbIdPatch,
+    RegistrySyncApplyPatch,
+)
+from models.state import PluginState, ShortcutRegistryEntry
+
+
+class RegistryStoreAdapter:
+    """In-memory store for ``state["shortcut_registry"]`` writes.
+
+    Parameters
+    ----------
+    state:
+        The live ``PluginState`` dict whose ``shortcut_registry`` is
+        being mutated. The same dict is shared with every service via
+        the existing persister adapters.
+    logger:
+        A standard-library ``logging.Logger`` used to warn on stale
+        patches against missing rows.
+    """
+
+    def __init__(self, state: PluginState, logger: logging.Logger) -> None:
+        self._state = state
+        self._logger = logger
+
+    def apply_sync(self, patch: RegistrySyncApplyPatch) -> None:
+        """Write the sync-apply row, preserving optional IDs not in *patch*.
+
+        For each optional ID (``igdb_id``, ``sgdb_id``, ``ra_id``): a
+        non-``None`` value on the patch wins; otherwise the existing
+        value (if any) is preserved; otherwise the field is omitted.
+        """
+        registry = self._state["shortcut_registry"]
+        existing = registry.get(patch.rom_id_str)
+
+        new_entry: ShortcutRegistryEntry = {
+            "app_id": patch.app_id,
+            "name": patch.name,
+            "fs_name": patch.fs_name,
+            "platform_name": patch.platform_name,
+            "platform_slug": patch.platform_slug,
+            "cover_path": patch.cover_path,
+        }
+
+        self._merge_optional_id(new_entry, existing, patch.igdb_id, "igdb_id")
+        self._merge_optional_id(new_entry, existing, patch.sgdb_id, "sgdb_id")
+        self._merge_optional_id(new_entry, existing, patch.ra_id, "ra_id")
+
+        registry[patch.rom_id_str] = new_entry
+
+    def apply_cover_path(self, patch: RegistryCoverPathPatch) -> None:
+        """Update ``cover_path`` on an existing row; no-op when absent."""
+        entry = self._state["shortcut_registry"].get(patch.rom_id_str)
+        if entry is None:
+            self._logger.warning(
+                "RegistryStoreAdapter.apply_cover_path: stale patch — rom_id_str=%s has no registry entry",
+                patch.rom_id_str,
+            )
+            return
+        entry["cover_path"] = patch.cover_path
+
+    def apply_sgdb_id(self, patch: RegistrySgdbIdPatch) -> None:
+        """Set ``sgdb_id`` on an existing row; no-op when absent."""
+        entry = self._state["shortcut_registry"].get(patch.rom_id_str)
+        if entry is None:
+            self._logger.warning(
+                "RegistryStoreAdapter.apply_sgdb_id: stale patch — rom_id_str=%s has no registry entry",
+                patch.rom_id_str,
+            )
+            return
+        entry["sgdb_id"] = patch.sgdb_id
+
+    def apply_ids(self, patch: RegistryIdsPatch) -> None:
+        """Set ``sgdb_id`` and/or ``igdb_id`` on an existing row.
+
+        No-op when both ID fields on the patch are ``None`` (a failed
+        upstream lookup) or when the row does not exist.
+        """
+        if patch.sgdb_id is None and patch.igdb_id is None:
+            return
+        entry = self._state["shortcut_registry"].get(patch.rom_id_str)
+        if entry is None:
+            self._logger.warning(
+                "RegistryStoreAdapter.apply_ids: stale patch — rom_id_str=%s has no registry entry",
+                patch.rom_id_str,
+            )
+            return
+        if patch.sgdb_id is not None:
+            entry["sgdb_id"] = patch.sgdb_id
+        if patch.igdb_id is not None:
+            entry["igdb_id"] = patch.igdb_id
+
+    def delete(self, patch: RegistryDeletePatch) -> ShortcutRegistryEntry | None:
+        """Pop and return the row, or ``None`` when nothing was stored."""
+        return self._state["shortcut_registry"].pop(patch.rom_id_str, None)
+
+    @staticmethod
+    def _merge_optional_id(
+        new_entry: ShortcutRegistryEntry,
+        existing: ShortcutRegistryEntry | None,
+        patch_value: int | None,
+        key: str,
+    ) -> None:
+        if patch_value is not None:
+            cast("dict", new_entry)[key] = patch_value
+        elif existing is not None and key in existing:
+            cast("dict", new_entry)[key] = cast("dict", existing)[key]

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -25,6 +25,7 @@ from adapters.download_queue import DownloadQueueAdapter
 from adapters.es_de_config import CoreResolver, GamelistXmlEditorAdapter
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.hostname import HostnameAdapter
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
 from adapters.migration_file import MigrationFileAdapter
 from adapters.path_probe import PathProbeAdapter
 from adapters.persistence import (
@@ -36,6 +37,7 @@ from adapters.persistence import (
     StatePersisterAdapter,
 )
 from adapters.plugin_metadata import PluginMetadataAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.retroarch_config import RetroArchConfigAdapter
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
@@ -77,6 +79,7 @@ from services.protocols import (
     GamelistXmlEditor,
     HostnameReader,
     MetadataCachePersister,
+    MetadataCacheStore,
     MigrationFileStore,
     PathExistsReader,
     PluginMetadataReader,
@@ -88,6 +91,7 @@ from services.protocols import (
     SaveSyncStatePersister,
     SettingsPersister,
     SgdbArtworkCache,
+    ShortcutRegistryStore,
     Sleeper,
     StatePersister,
     SteamConfigStore,
@@ -172,6 +176,8 @@ class CallbackBundle:
     metadata_cache_persister: MetadataCachePersister
     firmware_cache_persister: FirmwareCachePersister
     save_sync_state_persister: SaveSyncStatePersister
+    registry_store: ShortcutRegistryStore
+    metadata_store: MetadataCacheStore
     log_debug: DebugLogger
     plugin_metadata: PluginMetadataReader
 
@@ -308,6 +314,8 @@ def bootstrap(
     state_persister = StatePersisterAdapter(persistence, state)
     settings_persister = SettingsPersisterAdapter(persistence, settings)
     metadata_cache_persister = MetadataCachePersisterAdapter(persistence, metadata_cache)
+    registry_store = RegistryStoreAdapter(state=state, logger=logger)
+    metadata_store = MetadataCacheStoreAdapter(metadata_cache=metadata_cache)
     plugin_metadata = PluginMetadataAdapter()
     # Single source of truth for outgoing User-Agent — read package.json
     # version once at boot and thread the string to every HTTP-talking
@@ -366,6 +374,8 @@ def bootstrap(
         metadata_cache_persister=metadata_cache_persister,
         firmware_cache_persister=firmware_cache_persister,
         save_sync_state_persister=save_sync_state_persister,
+        registry_store=registry_store,
+        metadata_store=metadata_store,
         log_debug=debug_logger,
         plugin_metadata=plugin_metadata,
     )
@@ -474,6 +484,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             logger=cfg.runtime.logger,
             clock=cfg.runtime.clock,
             metadata_cache_persister=cfg.callbacks.metadata_cache_persister,
+            metadata_store=cfg.callbacks.metadata_store,
             log_debug=cfg.callbacks.log_debug,
         ),
     )
@@ -487,6 +498,8 @@ def wire_services(cfg: WiringConfig) -> dict:
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
             get_pending_sync=pending_sync_binding.get,
+            registry_store=cfg.callbacks.registry_store,
+            state_persister=cfg.callbacks.state_persister,
         ),
     )
 
@@ -499,6 +512,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             logger=cfg.runtime.logger,
             emit=cfg.runtime.emit,
             state_persister=cfg.callbacks.state_persister,
+            registry_store=cfg.callbacks.registry_store,
             artwork_remover=artwork_service,
         ),
     )
@@ -519,6 +533,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             sleeper=cfg.runtime.sleeper,
             state_persister=cfg.callbacks.state_persister,
             settings_persister=cfg.callbacks.settings_persister,
+            registry_store=cfg.callbacks.registry_store,
             log_debug=cfg.callbacks.log_debug,
             metadata_service=metadata_service,
             artwork=artwork_service,
@@ -591,6 +606,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             logger=cfg.runtime.logger,
             state_persister=cfg.callbacks.state_persister,
             settings_persister=cfg.callbacks.settings_persister,
+            registry_store=cfg.callbacks.registry_store,
             get_pending_sync=pending_sync_binding.get,
             log_debug=cfg.callbacks.log_debug,
         ),
@@ -655,6 +671,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             state=cfg.stores.state,
             logger=cfg.runtime.logger,
             state_persister=cfg.callbacks.state_persister,
+            registry_store=cfg.callbacks.registry_store,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             path_probe=cfg.adapters.path_probe,
         ),

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 import os
 
-from models.state import ShortcutRegistryEntry
-
 
 def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
     """Transform ROM list into shortcut data dicts for frontend AddShortcut calls."""
@@ -31,19 +29,3 @@ def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
         }
         for rom in roms
     ]
-
-
-def build_registry_entry(pending: dict, app_id: int, cover_path: str) -> ShortcutRegistryEntry:
-    """Build a shortcut registry entry from pending sync data."""
-    entry: ShortcutRegistryEntry = {
-        "app_id": app_id,
-        "name": pending.get("name", ""),
-        "fs_name": pending.get("fs_name", ""),
-        "platform_name": pending.get("platform_name", ""),
-        "platform_slug": pending.get("platform_slug", ""),
-        "cover_path": cover_path,
-    }
-    for meta_key in ("igdb_id", "sgdb_id", "ra_id"):
-        if pending.get(meta_key):
-            entry[meta_key] = pending[meta_key]
-    return entry

--- a/py_modules/models/metadata_patches.py
+++ b/py_modules/models/metadata_patches.py
@@ -1,0 +1,27 @@
+"""Typed mutation records for ``metadata_cache[rom_id_str]``.
+
+The metadata cache is single-writer — only the metadata service writes
+entries — so the patch surface is narrow. Patches keep the cache writer
+aligned with the typed ``MetadataCacheEntry`` shape and give the store
+a uniform call site.
+
+This module is data-only: no I/O, no service or adapter imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from models.state import MetadataCacheEntry
+
+
+@dataclass(frozen=True)
+class MetadataStampPatch:
+    """Replace ``metadata_cache[rom_id_str]`` with a freshly-built entry.
+
+    Owner: metadata service. ``entry`` is the full ``MetadataCacheEntry``
+    payload — the store assigns it as-is rather than merging.
+    """
+
+    rom_id_str: str
+    entry: MetadataCacheEntry

--- a/py_modules/models/registry_patches.py
+++ b/py_modules/models/registry_patches.py
@@ -1,0 +1,81 @@
+"""Typed mutation records for ``shortcut_registry[rom_id_str]``.
+
+Every writer that touches the registry expresses its intent as one of
+these frozen dataclasses. The patch type carries exactly the fields the
+writer is allowed to change — the registry store applies the patch,
+preserves all other fields on the row, and the type checker rejects any
+attempt to widen a writer's surface beyond what its patch owns.
+
+This module is data-only: no I/O, no service or adapter imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RegistrySyncApplyPatch:
+    """Full-row write at sync-apply commit.
+
+    Owner: sync apply. Required fields rebuild the registry row from
+    scratch; optional ID fields are ``None`` to mean "preserve whatever
+    the existing row carries" and a concrete value to mean "set it".
+    """
+
+    rom_id_str: str
+    app_id: int
+    name: str
+    fs_name: str
+    platform_name: str
+    platform_slug: str
+    cover_path: str
+    igdb_id: int | None = None
+    sgdb_id: int | None = None
+    ra_id: int | None = None
+
+
+@dataclass(frozen=True)
+class RegistryCoverPathPatch:
+    """Refresh of ``cover_path`` only.
+
+    Owner: artwork refresh. The store no-ops on a missing row — a stale
+    patch for a deleted shortcut is expected, not an error.
+    """
+
+    rom_id_str: str
+    cover_path: str
+
+
+@dataclass(frozen=True)
+class RegistrySgdbIdPatch:
+    """Write of ``sgdb_id`` only.
+
+    Owner: SteamGridDB lazy lookup. The store no-ops on a missing row.
+    """
+
+    rom_id_str: str
+    sgdb_id: int
+
+
+@dataclass(frozen=True)
+class RegistryIdsPatch:
+    """Write of ``sgdb_id`` and/or ``igdb_id``.
+
+    Owner: SteamGridDB RomM-API fetch. ``None`` on either field means
+    "leave that field alone"; if both are ``None`` the call is a no-op.
+    """
+
+    rom_id_str: str
+    sgdb_id: int | None
+    igdb_id: int | None
+
+
+@dataclass(frozen=True)
+class RegistryDeletePatch:
+    """Removal of the row.
+
+    Owner: shortcut removal and startup healing.
+    """
+
+    rom_id_str: str

--- a/py_modules/models/state.py
+++ b/py_modules/models/state.py
@@ -29,8 +29,8 @@ from typing import NotRequired, TypedDict
 class ShortcutRegistryEntry(TypedDict):
     """One ROM's Steam-shortcut binding inside ``shortcut_registry``.
 
-    Keyed by ``rom_id`` (string). Required fields are written by
-    :func:`domain.shortcut_data.build_registry_entry` during sync;
+    Keyed by ``rom_id`` (string). Required fields are written through
+    :class:`models.registry_patches.RegistrySyncApplyPatch` during sync;
     optional ID fields are written on demand by SteamGridService and
     on-the-fly RomM lookups.
     """
@@ -165,8 +165,6 @@ class MetadataCacheEntry(TypedDict):
 
 # Service-facing metadata cache contract. The on-disk JSON also carries a
 # persistence-layer ``version: int`` key; only adapters/persistence.py
-# reads/writes that field, and services never iterate the cache (only
-# ``.get(rom_id_str)`` / ``[rom_id_str] = entry``), so a homogeneous
-# ``dict[str, MetadataCacheEntry]`` is the honest contract at the service
-# boundary.
+# reads/writes that field, so a homogeneous ``dict[str, MetadataCacheEntry]``
+# is the honest contract at the service boundary.
 MetadataCache = dict[str, MetadataCacheEntry]

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -8,15 +8,24 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.registry_patches import RegistryCoverPathPatch
 from models.state import PluginState, ShortcutRegistryEntry
 
 from domain.artwork_paths import final_filename, staging_filename
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
 
-    from services.protocols import CoverArtFileStore, PendingSyncReader, RommRomReader, SteamConfigStore
+    from services.protocols import (
+        CoverArtFileStore,
+        PendingSyncReader,
+        RommRomReader,
+        ShortcutRegistryStore,
+        StatePersister,
+        SteamConfigStore,
+    )
 
 
 @dataclass(frozen=True)
@@ -35,6 +44,8 @@ class ArtworkServiceConfig:
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     get_pending_sync: PendingSyncReader
+    registry_store: ShortcutRegistryStore
+    state_persister: StatePersister
 
 
 class ArtworkService:
@@ -48,6 +59,8 @@ class ArtworkService:
         self._loop = config.loop
         self._logger = config.logger
         self._get_pending_sync = config.get_pending_sync
+        self._registry_store = config.registry_store
+        self._state_persister = config.state_persister
 
     # ── Existing cover path check ──────────────────────────────────────────
 
@@ -193,6 +206,13 @@ class ArtworkService:
             if self._cover_art_file_store.exists(staging):
                 cover_path = staging
 
+        # The canonical {app_id}p.png may be on disk even when the registry
+        # row has no cover_path — recover it via the registry's app_id.
+        if not cover_path:
+            fallback = self.existing_cover_path(rom_id, grid)
+            if fallback:
+                cover_path = fallback
+
         if cover_path and self._cover_art_file_store.exists(cover_path):
             try:
                 data = await self._loop.run_in_executor(None, self._cover_art_file_store.read_bytes, cover_path)
@@ -201,6 +221,84 @@ class ArtworkService:
                 self._logger.warning(f"Failed to read artwork for rom {rom_id}: {e}")
 
         return {"base64": None}
+
+    # ── Cover refresh (single-ROM repair) ──────────────────────────────────
+
+    async def refresh_cover(self, rom_id: int) -> dict:
+        """Re-download a ROM's RomM cover and update its registry row.
+
+        Looks up the ROM's current registry entry to get its ``app_id``,
+        fetches the fresh cover URL from RomM, downloads to staging,
+        renames to ``{app_id}p.png``, and applies a
+        :class:`RegistryCoverPathPatch` so the registry's ``cover_path``
+        catches up. Returns the canonical ``{success, reason, message}``
+        failure shape on every failure branch — see
+        ``lib/list_result.py``.
+        """
+        reg = self._state["shortcut_registry"].get(str(rom_id))
+        if not reg or not reg.get("app_id"):
+            return {
+                "success": False,
+                "reason": "not_synced",
+                "message": "ROM is not synced to Steam",
+            }
+        app_id = reg["app_id"]
+
+        grid = self._steam_config.grid_dir()
+        if not grid:
+            return {
+                "success": False,
+                "reason": "no_grid_dir",
+                "message": "Steam grid directory not found",
+            }
+
+        try:
+            rom = await self._loop.run_in_executor(None, self._romm_api.get_rom, rom_id)
+        except Exception as e:
+            self._logger.warning(f"refresh_cover: failed to fetch rom {rom_id}: {e}")
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Could not fetch ROM from server",
+            }
+        if not rom:
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Could not fetch ROM from server",
+            }
+
+        cover_url = rom.get("path_cover_large") or rom.get("path_cover_small")
+        if not cover_url:
+            return {
+                "success": False,
+                "reason": "no_cover",
+                "message": "ROM has no cover artwork",
+            }
+
+        staging = os.path.join(grid, staging_filename(rom_id))
+        try:
+            await self._loop.run_in_executor(None, self._romm_api.download_cover, cover_url, staging)
+        except Exception as e:
+            self._logger.warning(f"refresh_cover: failed to download cover for rom {rom_id}: {e}")
+            return {
+                "success": False,
+                "reason": "download_failed",
+                "message": str(e),
+            }
+
+        final = self.finalize_cover_path(grid, staging, app_id, str(rom_id))
+
+        self._registry_store.apply_cover_path(
+            RegistryCoverPathPatch(rom_id_str=str(rom_id), cover_path=final),
+        )
+        await self._loop.run_in_executor(None, self._state_persister.save_state)
+
+        return {
+            "success": True,
+            "message": "Cover refreshed",
+            "cover_path": final,
+        }
 
     # ── Staging file housekeeping ──────────────────────────────────────────
 

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -20,9 +20,9 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.registry_patches import RegistrySyncApplyPatch
 from models.state import PluginState
 
-from domain.shortcut_data import build_registry_entry
 from domain.sync_diff import should_include_in_platform_collection
 from domain.sync_state import SyncState
 from services.library._state import LibrarySyncStateBox
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
         ArtworkManager,
         Clock,
         EventEmitter,
+        ShortcutRegistryStore,
         StatePersister,
         SteamConfigStore,
     )
@@ -65,6 +66,7 @@ class SyncReporterConfig:
     emit: EventEmitter
     clock: Clock
     state_persister: StatePersister
+    registry_store: ShortcutRegistryStore
     sync_state_box: LibrarySyncStateBox
     emit_progress: EmitProgressFn
     artwork: ArtworkManager
@@ -82,6 +84,7 @@ class SyncReporter:
         self._emit = config.emit
         self._clock = config.clock
         self._state_persister = config.state_persister
+        self._registry_store = config.registry_store
         self._sync_state = config.sync_state_box
         self._emit_progress = config.emit_progress
         self._artwork = config.artwork
@@ -91,10 +94,6 @@ class SyncReporter:
     def _finalize_cover_path(self, grid, cover_path, app_id, rom_id_str):
         """Delegate to ArtworkService for the final ``{app_id}p.png`` cover-path."""
         return self._artwork.finalize_cover_path(grid, cover_path, app_id, rom_id_str)
-
-    def _build_registry_entry(self, pending, app_id, cover_path):
-        """Build a registry entry dict from pending sync data."""
-        return build_registry_entry(pending, app_id, cover_path)
 
     def _build_collection_app_ids(
         self,
@@ -218,7 +217,20 @@ class SyncReporter:
         for rom_id_str, app_id in rom_id_to_app_id.items():
             pending = box.pending_sync.get(int(rom_id_str), {})
             cover_path = self._finalize_cover_path(grid, pending.get("cover_path", ""), app_id, rom_id_str)
-            self._state["shortcut_registry"][rom_id_str] = self._build_registry_entry(pending, app_id, cover_path)
+            self._registry_store.apply_sync(
+                RegistrySyncApplyPatch(
+                    rom_id_str=rom_id_str,
+                    app_id=app_id,
+                    name=pending.get("name", ""),
+                    fs_name=pending.get("fs_name", ""),
+                    platform_name=pending.get("platform_name", ""),
+                    platform_slug=pending.get("platform_slug", ""),
+                    cover_path=cover_path,
+                    igdb_id=pending.get("igdb_id"),
+                    sgdb_id=pending.get("sgdb_id"),
+                    ra_id=pending.get("ra_id"),
+                )
+            )
 
         steam_input_mode = self._settings.get("steam_input_mode", "default")
         if steam_input_mode != "default" and rom_id_to_app_id:

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         MetadataExtractor,
         RommLibraryApi,
         SettingsPersister,
+        ShortcutRegistryStore,
         Sleeper,
         StatePersister,
         SteamConfigStore,
@@ -71,6 +72,7 @@ class LibraryServiceConfig:
     sleeper: Sleeper
     state_persister: StatePersister
     settings_persister: SettingsPersister
+    registry_store: ShortcutRegistryStore
     log_debug: DebugLogger
     metadata_service: MetadataExtractor
     artwork: ArtworkManager
@@ -150,6 +152,7 @@ class LibraryService:
                 emit=config.emit,
                 clock=config.clock,
                 state_persister=config.state_persister,
+                registry_store=config.registry_store,
                 sync_state_box=self._box,
                 emit_progress=self._emit_progress_proxy,
                 artwork=config.artwork,

--- a/py_modules/services/metadata.py
+++ b/py_modules/services/metadata.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, cast
 
 from models.metadata import RomMetadata
+from models.metadata_patches import MetadataStampPatch
 from models.state import MetadataCache, MetadataCacheEntry, PluginState
 
 from domain.steam_categories import build_steam_categories
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     import asyncio
     import logging
 
-    from services.protocols import Clock, DebugLogger, MetadataCachePersister
+    from services.protocols import Clock, DebugLogger, MetadataCachePersister, MetadataCacheStore
 
 
 @dataclass(frozen=True)
@@ -39,6 +40,7 @@ class MetadataServiceConfig:
     logger: logging.Logger
     clock: Clock
     metadata_cache_persister: MetadataCachePersister
+    metadata_store: MetadataCacheStore
     log_debug: DebugLogger
 
 
@@ -52,6 +54,7 @@ class MetadataService:
         self._logger = config.logger
         self._clock = config.clock
         self._metadata_cache_persister = config.metadata_cache_persister
+        self._metadata_store = config.metadata_store
         self._log_debug = config.log_debug
 
         self._metadata_dirty_count = 0
@@ -114,7 +117,9 @@ class MetadataService:
             if not rom.get("metadatum"):
                 continue
             rom_id_str = str(rom["id"])
-            self._metadata_cache[rom_id_str] = self.extract_metadata(rom)
+            self._metadata_store.apply_stamp(
+                MetadataStampPatch(rom_id_str=rom_id_str, entry=self.extract_metadata(rom))
+            )
             self.mark_metadata_dirty()
         self.flush_metadata_if_dirty()
 

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -73,9 +73,11 @@ from services.protocols.paths import (
 from services.protocols.persistence import (
     FirmwareCachePersister,
     MetadataCachePersister,
+    MetadataCacheStore,
     PluginMetadataReader,
     SaveSyncStatePersister,
     SettingsPersister,
+    ShortcutRegistryStore,
     StatePersister,
 )
 from services.protocols.transport import (
@@ -118,6 +120,7 @@ __all__ = [
     "LaunchGateRomLookup",
     "LaunchGateSaveStatusReader",
     "MetadataCachePersister",
+    "MetadataCacheStore",
     "MetadataExtractor",
     "MigrationFileStore",
     "MigrationPendingFn",
@@ -151,6 +154,7 @@ __all__ = [
     "SessionPostExitSync",
     "SettingsPersister",
     "SgdbArtworkCache",
+    "ShortcutRegistryStore",
     "Sleeper",
     "StatePersister",
     "SteamConfigStore",

--- a/py_modules/services/protocols/persistence.py
+++ b/py_modules/services/protocols/persistence.py
@@ -7,11 +7,26 @@ adapters. Each Protocol carries a domain-specific method name
 (``save_state`` / ``save_settings`` / ``save_metadata`` / ``save``)
 rather than a generic ``__call__`` so the type checker rejects
 mis-wires between the three plugin-level persisters.
+
+Field-owning stores (``ShortcutRegistryStore``, ``MetadataCacheStore``)
+live here too: they expose typed-patch mutation seams over the live
+state and metadata-cache dicts. Stores mutate but do not flush — the
+caller drives the matching ``*Persister.save_*`` after a batch.
 """
 
 from __future__ import annotations
 
 from typing import Protocol
+
+from models.metadata_patches import MetadataStampPatch
+from models.registry_patches import (
+    RegistryCoverPathPatch,
+    RegistryDeletePatch,
+    RegistryIdsPatch,
+    RegistrySgdbIdPatch,
+    RegistrySyncApplyPatch,
+)
+from models.state import ShortcutRegistryEntry
 
 
 class StatePersister(Protocol):
@@ -82,3 +97,33 @@ class PluginMetadataReader(Protocol):
         abort on a metadata read.
         """
         ...
+
+
+class ShortcutRegistryStore(Protocol):
+    """Owned mutations for ``shortcut_registry[rom_id_str]``.
+
+    Every mutation goes through a typed patch — writers may only touch
+    fields the patch type owns. The store does not persist; callers
+    drive ``StatePersister.save_state()`` after a batch of writes.
+    """
+
+    def apply_sync(self, patch: RegistrySyncApplyPatch) -> None: ...
+
+    def apply_cover_path(self, patch: RegistryCoverPathPatch) -> None: ...
+
+    def apply_sgdb_id(self, patch: RegistrySgdbIdPatch) -> None: ...
+
+    def apply_ids(self, patch: RegistryIdsPatch) -> None: ...
+
+    def delete(self, patch: RegistryDeletePatch) -> ShortcutRegistryEntry | None: ...
+
+
+class MetadataCacheStore(Protocol):
+    """Owned mutations for ``metadata_cache[rom_id_str]``.
+
+    Mirrors :class:`ShortcutRegistryStore`: typed patches in, in-memory
+    mutations out, no flush. The caller drives the matching
+    ``MetadataCachePersister.save_metadata()`` after a batch.
+    """
+
+    def apply_stamp(self, patch: MetadataStampPatch) -> None: ...

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.registry_patches import RegistryDeletePatch
 from models.state import PluginState
 
 if TYPE_CHECKING:
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
         ArtworkRemover,
         EventEmitter,
         RommPlatformReader,
+        ShortcutRegistryStore,
         StatePersister,
         SteamConfigStore,
     )
@@ -36,6 +38,7 @@ class ShortcutRemovalServiceConfig:
     logger: logging.Logger
     emit: EventEmitter
     state_persister: StatePersister
+    registry_store: ShortcutRegistryStore
     artwork_remover: ArtworkRemover
 
 
@@ -50,6 +53,7 @@ class ShortcutRemovalService:
         self._logger = config.logger
         self._emit = config.emit
         self._state_persister = config.state_persister
+        self._registry_store = config.registry_store
         self._artwork_remover = config.artwork_remover
 
     # ── Registry helpers ───────────────────────────────────────────────────
@@ -128,7 +132,7 @@ class ShortcutRemovalService:
 
         grid = self._steam_config.grid_dir()
         for rom_id in removed_rom_ids:
-            entry = self._state["shortcut_registry"].pop(str(rom_id), None)
+            entry = self._registry_store.delete(RegistryDeletePatch(rom_id_str=str(rom_id)))
             if entry and grid:
                 self._artwork_remover.remove_artwork_files(grid, rom_id, entry)
 

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.registry_patches import RegistryDeletePatch
 from models.state import PluginState
 
 from domain.installed_roms import is_pending_migration_path
@@ -20,7 +21,7 @@ from domain.installed_roms import is_pending_migration_path
 if TYPE_CHECKING:
     import logging
 
-    from services.protocols import PathExistsReader, RetroDeckPaths, StatePersister
+    from services.protocols import PathExistsReader, RetroDeckPaths, ShortcutRegistryStore, StatePersister
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,7 @@ class StartupHealingServiceConfig:
     state: PluginState
     logger: logging.Logger
     state_persister: StatePersister
+    registry_store: ShortcutRegistryStore
     retrodeck_paths: RetroDeckPaths
     path_probe: PathExistsReader
 
@@ -47,6 +49,7 @@ class StartupHealingService:
         self._state = config.state
         self._logger = config.logger
         self._state_persister = config.state_persister
+        self._registry_store = config.registry_store
         self._retrodeck_paths = config.retrodeck_paths
         self._path_probe = config.path_probe
 
@@ -100,6 +103,6 @@ class StartupHealingService:
                 self._logger.info(f"Pruned stale registry entry: rom_id={rom_id} (invalid app_id={app_id})")
                 pruned.append(rom_id)
         for rom_id in pruned:
-            del self._state["shortcut_registry"][rom_id]
+            self._registry_store.delete(RegistryDeletePatch(rom_id_str=rom_id))
         if pruned:
             self._state_persister.save_state()

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -15,6 +15,7 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models.registry_patches import RegistryIdsPatch, RegistrySgdbIdPatch
 from models.state import PluginState
 
 from domain.sgdb_artwork import (
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
         RommRomReader,
         SettingsPersister,
         SgdbArtworkCache,
+        ShortcutRegistryStore,
         StatePersister,
         SteamConfigStore,
         SteamGridDbApi,
@@ -62,6 +64,7 @@ class SteamGridServiceConfig:
     logger: logging.Logger
     state_persister: StatePersister
     settings_persister: SettingsPersister
+    registry_store: ShortcutRegistryStore
     get_pending_sync: PendingSyncReader
     log_debug: DebugLogger
 
@@ -80,6 +83,7 @@ class SteamGridService:
         self._logger = config.logger
         self._state_persister = config.state_persister
         self._settings_persister = config.settings_persister
+        self._registry_store = config.registry_store
         self._get_pending_sync = config.get_pending_sync
         self._log_debug = config.log_debug
 
@@ -150,8 +154,8 @@ class SteamGridService:
         # Fallback: look up SGDB via IGDB ID
         if not sgdb_id and igdb_id:
             sgdb_id = await self._loop.run_in_executor(None, self._get_sgdb_game_id, igdb_id)
-            if sgdb_id and rom_id_str in self._state["shortcut_registry"]:
-                self._state["shortcut_registry"][rom_id_str]["sgdb_id"] = sgdb_id
+            if sgdb_id:
+                self._registry_store.apply_sgdb_id(RegistrySgdbIdPatch(rom_id_str=rom_id_str, sgdb_id=sgdb_id))
                 self._state_persister.save_state()
 
         return sgdb_id
@@ -166,11 +170,10 @@ class SteamGridService:
                 sgdb_id = rom_data.get("sgdb_id")
                 igdb_id = igdb_id or rom_data.get("igdb_id")
             self._log_debug(f"SGDB artwork: fetched sgdb_id={sgdb_id}, igdb_id={igdb_id} from RomM for rom_id={rom_id}")
-            if rom_id_str in self._state["shortcut_registry"]:
-                if sgdb_id:
-                    self._state["shortcut_registry"][rom_id_str]["sgdb_id"] = sgdb_id
-                if igdb_id:
-                    self._state["shortcut_registry"][rom_id_str]["igdb_id"] = igdb_id
+            if sgdb_id or igdb_id:
+                self._registry_store.apply_ids(
+                    RegistryIdsPatch(rom_id_str=rom_id_str, sgdb_id=sgdb_id or None, igdb_id=igdb_id or None)
+                )
                 self._state_persister.save_state()
         except Exception as e:
             self._logger.warning(f"SGDB artwork: failed to fetch IDs from RomM for rom_id={rom_id}: {e}")

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -74,6 +74,10 @@ export const getRegistryPlatforms = callable<[], { platforms: RegistryPlatform[]
 export const removePlatformShortcuts = callable<[string], { success: boolean; app_ids: number[]; rom_ids: (string | number)[]; platform_name: string }>("remove_platform_shortcuts");
 export const removeAllShortcuts = callable<[], { success: boolean; message: string; removed_count: number; app_ids: number[]; rom_ids: (string | number)[] }>("remove_all_shortcuts");
 export const getArtworkBase64 = callable<[number], { base64: string | null }>("get_artwork_base64");
+export const refreshCoverArtwork = callable<
+  [number],
+  { success: boolean; reason?: string; message: string; cover_path?: string }
+>("refresh_cover_artwork");
 export const getSgdbArtworkBase64 = callable<[number, number], { base64: string | null; no_api_key?: boolean }>("get_sgdb_artwork_base64");
 export const reportUnitResults = callable<[Record<string, number>], { success: boolean; count: number }>("report_unit_results");
 export const reportRemovalResults = callable<[(string | number)[]], { success: boolean; message: string }>("report_removal_results");

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -402,6 +402,17 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       setState((prev) => ({ ...prev, metadata: meta }));
     };
 
+    const handleCoverRefreshed = async (detail: Extract<RommDataChangedDetail, { type: "cover_refreshed" }>) => {
+      if (detail.rom_id !== romIdRef.current) return;
+      const romId = romIdRef.current;
+      if (!romId) return;
+      // Re-fetch the cover image. Backend has already patched the registry's
+      // cover_path; getArtworkBase64 will now resolve the freshly-downloaded
+      // file. Catch swallowed because the .then handles the success path —
+      // the rejection branch surfaces via the empty-cover render.
+      await refreshCoverArtInBackground(romId, () => cancelled, setState);
+    };
+
     const onDataChanged = async (e: Event) => {
       try {
         const detail = (e as CustomEvent).detail;
@@ -412,6 +423,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
           case "bios": await handleBiosChange(detail); break;
           case "core_changed": await handleCoreChange(); break;
           case "metadata": await handleMetadataChange(detail); break;
+          case "cover_refreshed": await handleCoverRefreshed(detail); break;
         }
       } catch (err) {
         debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -256,6 +256,13 @@ describe("RomMPlaySection", () => {
       message: "Connected",
     });
     vi.mocked(backend.debugLog).mockResolvedValue(undefined);
+    // refreshCoverArtwork defaults to success so the artwork-refresh action
+    // doesn't spew "refreshCoverArtwork failed" debugLogs into unrelated tests.
+    vi.mocked(backend.refreshCoverArtwork).mockResolvedValue({
+      success: true,
+      message: "Cover refreshed",
+      cover_path: "/grid/p.png",
+    });
   });
 
   afterEach(() => {
@@ -1090,6 +1097,123 @@ describe("RomMPlaySection", () => {
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
         expect.objectContaining({ body: "ROM info not loaded yet" }),
       );
+      // No backend call when romId is null
+      expect(vi.mocked(backend.refreshCoverArtwork)).not.toHaveBeenCalled();
+    });
+
+    it("calls refreshCoverArtwork BEFORE SGDB and dispatches 'cover_refreshed' on success", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 77,
+      });
+      vi.mocked(backend.refreshCoverArtwork).mockResolvedValue({
+        success: true,
+        message: "Cover refreshed",
+        cover_path: "/grid/999p.png",
+      });
+      vi.mocked(backend.getSgdbArtworkBase64).mockResolvedValue({
+        base64: null,
+        no_api_key: false,
+      });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+
+      const items = await openRomMMenuAndGetItems(testAppId);
+      vi.mocked(backend.refreshCoverArtwork).mockClear();
+      vi.mocked(backend.getSgdbArtworkBase64).mockClear();
+
+      const listener = vi.fn();
+      globalThis.addEventListener("romm_data_changed", listener);
+      try {
+        await act(async () => {
+          await items[0]!.props.onClick?.();
+        });
+
+        // refreshCoverArtwork called once with the rom_id
+        expect(vi.mocked(backend.refreshCoverArtwork)).toHaveBeenCalledWith(77);
+
+        // Order: refreshCoverArtwork before getSgdbArtworkBase64
+        const refreshOrder = vi.mocked(backend.refreshCoverArtwork).mock.invocationCallOrder[0]!;
+        const sgdbOrder = vi.mocked(backend.getSgdbArtworkBase64).mock.invocationCallOrder[0]!;
+        expect(refreshOrder).toBeLessThan(sgdbOrder);
+
+        // cover_refreshed event dispatched with the rom_id
+        const ev = listener.mock.calls
+          .map((c) => c[0] as CustomEvent)
+          .find((e) => e.detail?.type === "cover_refreshed");
+        expect(ev?.detail).toEqual({ type: "cover_refreshed", rom_id: 77 });
+      } finally {
+        globalThis.removeEventListener("romm_data_changed", listener);
+      }
+    });
+
+    it("on refreshCoverArtwork {success: false}, logs and STILL runs the SGDB step", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 77,
+      });
+      vi.mocked(backend.refreshCoverArtwork).mockResolvedValue({
+        success: false,
+        reason: "not_synced",
+        message: "ROM is not synced to Steam",
+      });
+      vi.mocked(backend.getSgdbArtworkBase64).mockResolvedValue({
+        base64: null,
+        no_api_key: false,
+      });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+
+      const items = await openRomMMenuAndGetItems(testAppId);
+      vi.mocked(backend.getSgdbArtworkBase64).mockClear();
+      vi.mocked(backend.debugLog).mockClear();
+      const listener = vi.fn();
+      globalThis.addEventListener("romm_data_changed", listener);
+      try {
+        await act(async () => {
+          await items[0]!.props.onClick?.();
+        });
+        // SGDB step still runs (graceful fall-through)
+        expect(vi.mocked(backend.getSgdbArtworkBase64)).toHaveBeenCalledTimes(4);
+        // debugLog surfaced the failure reason + message
+        expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+          expect.stringContaining("not_synced"),
+        );
+        // No cover_refreshed event on failure
+        const ev = listener.mock.calls
+          .map((c) => c[0] as CustomEvent)
+          .find((e) => e.detail?.type === "cover_refreshed");
+        expect(ev).toBeUndefined();
+      } finally {
+        globalThis.removeEventListener("romm_data_changed", listener);
+      }
+    });
+
+    it("on refreshCoverArtwork rejection, debugLogs the rejection and continues to SGDB", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 77,
+      });
+      vi.mocked(backend.refreshCoverArtwork).mockRejectedValue(new Error("network down"));
+      vi.mocked(backend.getSgdbArtworkBase64).mockResolvedValue({
+        base64: null,
+        no_api_key: false,
+      });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+
+      const items = await openRomMMenuAndGetItems(testAppId);
+      vi.mocked(backend.getSgdbArtworkBase64).mockClear();
+      vi.mocked(backend.debugLog).mockClear();
+      await act(async () => {
+        await items[0]!.props.onClick?.();
+      });
+      // Non-vacuous catch assertion: debugLog observed the rejection.
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+        expect.stringContaining("refreshCoverArtwork rejected"),
+      );
+      // SGDB step still runs
+      expect(vi.mocked(backend.getSgdbArtworkBase64)).toHaveBeenCalledTimes(4);
     });
 
     it("toasts 'Failed to refresh artwork' when SteamClient.SetCustomArtworkForApp throws", async () => {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -36,6 +36,7 @@ import {
   getBiosStatus,
   getSgdbArtworkBase64,
   getRomMetadata,
+  refreshCoverArtwork,
   removeRom,
   downloadAllFirmware,
   syncRomSaves,
@@ -401,9 +402,29 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       toaster.toast({ title: "RomM Sync", body: "ROM info not loaded yet" });
       return;
     }
+    const romId = info.romId;
     setActionPending("artwork");
     try {
-      const applied = await applyArtwork(info.romId, appId);
+      // Step 1: re-download the RomM cover, rename to {app_id}p.png, and
+      // patch cover_path on the registry row so the game info panel can
+      // render the refreshed image.
+      const coverResult = await refreshCoverArtwork(romId).catch(
+        (e): { success: boolean; reason?: string; message: string; cover_path?: string } => {
+          debugLog(`refreshCoverArtwork rejected: ${e}`);
+          return { success: false, reason: "exception", message: String(e) };
+        },
+      );
+      if (!coverResult.success) {
+        debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
+      } else {
+        // Notify the game info panel so it can re-render the cover image.
+        globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
+          detail: { type: "cover_refreshed", rom_id: romId },
+        }));
+      }
+
+      // Step 2: refresh SGDB artwork (hero, logo, grid, icon).
+      const applied = await applyArtwork(romId, appId);
       if (applied === -1) {
         toaster.toast({ title: "RomM Sync", body: "Set a SteamGridDB API key in settings first" });
       } else if (applied > 0) {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -414,13 +414,13 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           return { success: false, reason: "exception", message: String(e) };
         },
       );
-      if (!coverResult.success) {
-        debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
-      } else {
+      if (coverResult.success) {
         // Notify the game info panel so it can re-render the cover image.
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", {
           detail: { type: "cover_refreshed", rom_id: romId },
         }));
+      } else {
+        debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
       }
 
       // Step 2: refresh SGDB artwork (hero, logo, grid, icon).

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -16,7 +16,8 @@ export type RommDataChangedDetail =
   | { type: "save_sync_settings"; save_sync_enabled: boolean }
   | { type: "metadata"; rom_id: number }
   | { type: "bios"; platform_slug: string }
-  | { type: "core_changed"; platform_slug: string };
+  | { type: "core_changed"; platform_slug: string }
+  | { type: "cover_refreshed"; rom_id: number };
 
 export interface RommRomUninstalledDetail {
   rom_id: number;

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -9,6 +9,7 @@ from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import make_default_plugin_state
 
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.steam_config import SteamConfigAdapter
 from lib.errors import (
@@ -63,6 +64,7 @@ def plugin():
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/adapters/test_metadata_cache_store.py
+++ b/tests/adapters/test_metadata_cache_store.py
@@ -1,0 +1,56 @@
+"""Tests for ``MetadataCacheStoreAdapter`` — typed-patch writes over the live cache dict."""
+
+import pytest
+from models.metadata_patches import MetadataStampPatch
+from models.state import MetadataCache, MetadataCacheEntry
+
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
+
+
+def _make_entry(summary: str = "Summary") -> MetadataCacheEntry:
+    return {
+        "summary": summary,
+        "genres": ["RPG"],
+        "companies": ["Acme"],
+        "first_release_date": 1234567890,
+        "average_rating": 90.0,
+        "game_modes": ["Single player"],
+        "player_count": "1",
+        "cached_at": 1700.0,
+        "steam_categories": [1],
+    }
+
+
+@pytest.fixture
+def cache() -> MetadataCache:
+    return {}
+
+
+@pytest.fixture
+def store(cache: MetadataCache) -> MetadataCacheStoreAdapter:
+    return MetadataCacheStoreAdapter(metadata_cache=cache)
+
+
+class TestApplyStamp:
+    def test_creates_entry_on_empty_cache(self, store, cache):
+        entry = _make_entry()
+        store.apply_stamp(MetadataStampPatch(rom_id_str="42", entry=entry))
+
+        assert cache["42"] == entry
+
+    def test_replaces_existing_entry(self, store, cache):
+        cache["42"] = _make_entry(summary="Old")
+        new = _make_entry(summary="New")
+
+        store.apply_stamp(MetadataStampPatch(rom_id_str="42", entry=new))
+
+        assert cache["42"]["summary"] == "New"
+
+    def test_other_entries_untouched(self, store, cache):
+        cache["1"] = _make_entry(summary="One")
+        cache["2"] = _make_entry(summary="Two")
+
+        store.apply_stamp(MetadataStampPatch(rom_id_str="2", entry=_make_entry(summary="Updated")))
+
+        assert cache["1"]["summary"] == "One"
+        assert cache["2"]["summary"] == "Updated"

--- a/tests/adapters/test_registry_store.py
+++ b/tests/adapters/test_registry_store.py
@@ -1,0 +1,235 @@
+"""Tests for ``RegistryStoreAdapter`` — typed-patch writes over the live state dict."""
+
+import logging
+from typing import cast
+
+import pytest
+from models.registry_patches import (
+    RegistryCoverPathPatch,
+    RegistryDeletePatch,
+    RegistryIdsPatch,
+    RegistrySgdbIdPatch,
+    RegistrySyncApplyPatch,
+)
+from models.state import PluginState, ShortcutRegistryEntry, make_default_plugin_state
+
+from adapters.registry_store import RegistryStoreAdapter
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_registry_store")
+
+
+@pytest.fixture
+def state() -> PluginState:
+    return make_default_plugin_state()
+
+
+@pytest.fixture
+def store(state: PluginState, logger: logging.Logger) -> RegistryStoreAdapter:
+    return RegistryStoreAdapter(state=state, logger=logger)
+
+
+def _make_existing_entry(**overrides: object) -> ShortcutRegistryEntry:
+    entry: ShortcutRegistryEntry = {
+        "app_id": 100,
+        "name": "Old Name",
+        "fs_name": "old",
+        "platform_name": "Platform",
+        "platform_slug": "plat",
+        "cover_path": "/covers/old.png",
+    }
+    cast("dict", entry).update(overrides)
+    return entry
+
+
+def _base_sync_patch(**overrides: object) -> RegistrySyncApplyPatch:
+    params: dict = {
+        "rom_id_str": "42",
+        "app_id": 123,
+        "name": "Game",
+        "fs_name": "game",
+        "platform_name": "Game Boy",
+        "platform_slug": "gb",
+        "cover_path": "/covers/42.png",
+    }
+    params.update(overrides)
+    return RegistrySyncApplyPatch(**params)
+
+
+class TestApplySync:
+    def test_creates_entry_with_required_fields_only(self, store, state):
+        store.apply_sync(_base_sync_patch())
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry == {
+            "app_id": 123,
+            "name": "Game",
+            "fs_name": "game",
+            "platform_name": "Game Boy",
+            "platform_slug": "gb",
+            "cover_path": "/covers/42.png",
+        }
+        assert "igdb_id" not in entry
+        assert "sgdb_id" not in entry
+        assert "ra_id" not in entry
+
+    def test_writes_optional_ids_from_patch(self, store, state):
+        store.apply_sync(_base_sync_patch(igdb_id=999, sgdb_id=888, ra_id=777))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["igdb_id"] == 999
+        assert entry["sgdb_id"] == 888
+        assert entry["ra_id"] == 777
+
+    def test_preserves_existing_sgdb_id_when_patch_none(self, store, state):
+        """Field-clobber regression: a patch with sgdb_id=None must not wipe
+        a previously-set sgdb_id on the existing row."""
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555, igdb_id=666, ra_id=777)
+
+        store.apply_sync(_base_sync_patch())  # all optional IDs default to None
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 555
+        assert entry["igdb_id"] == 666
+        assert entry["ra_id"] == 777
+
+    def test_patch_value_replaces_existing_when_provided(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555)
+
+        store.apply_sync(_base_sync_patch(sgdb_id=999))
+
+        assert state["shortcut_registry"]["42"]["sgdb_id"] == 999
+
+    def test_mixed_provided_and_preserved(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555, igdb_id=666)
+
+        store.apply_sync(_base_sync_patch(sgdb_id=999))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 999  # patch value wins
+        assert entry["igdb_id"] == 666  # existing preserved
+        assert "ra_id" not in entry  # neither side carried it
+
+    def test_replaces_required_fields_on_existing_entry(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry()
+
+        store.apply_sync(_base_sync_patch())
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["app_id"] == 123
+        assert entry["name"] == "Game"
+        assert entry["cover_path"] == "/covers/42.png"
+
+
+class TestApplyCoverPath:
+    def test_no_op_on_missing_entry(self, store, state, caplog):
+        with caplog.at_level(logging.WARNING):
+            store.apply_cover_path(RegistryCoverPathPatch(rom_id_str="42", cover_path="/new.png"))
+
+        assert "42" not in state["shortcut_registry"]
+        assert any("apply_cover_path" in rec.message for rec in caplog.records)
+
+    def test_mutates_only_cover_path(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555)
+
+        store.apply_cover_path(RegistryCoverPathPatch(rom_id_str="42", cover_path="/new.png"))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["cover_path"] == "/new.png"
+        # Other fields untouched
+        assert entry["app_id"] == 100
+        assert entry["name"] == "Old Name"
+        assert entry["fs_name"] == "old"
+        assert entry["platform_name"] == "Platform"
+        assert entry["platform_slug"] == "plat"
+        assert entry["sgdb_id"] == 555
+
+
+class TestApplySgdbId:
+    def test_no_op_on_missing_entry(self, store, state, caplog):
+        with caplog.at_level(logging.WARNING):
+            store.apply_sgdb_id(RegistrySgdbIdPatch(rom_id_str="42", sgdb_id=888))
+
+        assert "42" not in state["shortcut_registry"]
+        assert any("apply_sgdb_id" in rec.message for rec in caplog.records)
+
+    def test_mutates_only_sgdb_id(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(igdb_id=666)
+
+        store.apply_sgdb_id(RegistrySgdbIdPatch(rom_id_str="42", sgdb_id=888))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 888
+        assert entry["igdb_id"] == 666
+        assert entry["cover_path"] == "/covers/old.png"
+
+
+class TestApplyIds:
+    def test_both_none_is_noop_existing_entry_unchanged(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555, igdb_id=666)
+        before = dict(state["shortcut_registry"]["42"])
+
+        store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=None, igdb_id=None))
+
+        assert state["shortcut_registry"]["42"] == before
+
+    def test_both_none_on_missing_entry_is_noop(self, store, state, caplog):
+        with caplog.at_level(logging.WARNING):
+            store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=None, igdb_id=None))
+
+        assert "42" not in state["shortcut_registry"]
+        # No warning either — there's nothing to apply, so the missing-row
+        # branch isn't reached.
+        assert not any("apply_ids" in rec.message for rec in caplog.records)
+
+    def test_only_sgdb_id_leaves_igdb_id_untouched(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(igdb_id=666)
+
+        store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=888, igdb_id=None))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 888
+        assert entry["igdb_id"] == 666
+
+    def test_only_igdb_id_leaves_sgdb_id_untouched(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry(sgdb_id=555)
+
+        store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=None, igdb_id=999))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["igdb_id"] == 999
+        assert entry["sgdb_id"] == 555
+
+    def test_both_set_writes_both(self, store, state):
+        state["shortcut_registry"]["42"] = _make_existing_entry()
+
+        store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=888, igdb_id=999))
+
+        entry = state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 888
+        assert entry["igdb_id"] == 999
+
+    def test_missing_entry_with_value_warns(self, store, state, caplog):
+        with caplog.at_level(logging.WARNING):
+            store.apply_ids(RegistryIdsPatch(rom_id_str="42", sgdb_id=888, igdb_id=None))
+
+        assert "42" not in state["shortcut_registry"]
+        assert any("apply_ids" in rec.message for rec in caplog.records)
+
+
+class TestDelete:
+    def test_returns_evicted_entry_and_removes_key(self, store, state):
+        entry = _make_existing_entry(sgdb_id=555)
+        state["shortcut_registry"]["42"] = entry
+
+        result = store.delete(RegistryDeletePatch(rom_id_str="42"))
+
+        assert result == entry
+        assert "42" not in state["shortcut_registry"]
+
+    def test_returns_none_on_missing_entry(self, store, state):
+        result = store.delete(RegistryDeletePatch(rom_id_str="42"))
+        assert result is None
+        assert "42" not in state["shortcut_registry"]

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -2,7 +2,7 @@
 
 import os
 
-from domain.shortcut_data import build_registry_entry, build_shortcuts_data
+from domain.shortcut_data import build_shortcuts_data
 
 
 class TestBuildShortcutsData:
@@ -80,61 +80,3 @@ class TestBuildShortcutsData:
         for item in result:
             for field in required_fields:
                 assert field in item, f"Missing field '{field}' in shortcut data"
-
-
-class TestBuildRegistryEntry:
-    """Tests for build_registry_entry()."""
-
-    def test_builds_full_entry(self):
-        pending = {
-            "name": "Game A",
-            "fs_name": "gamea.z64",
-            "platform_name": "N64",
-            "platform_slug": "n64",
-            "igdb_id": 100,
-            "sgdb_id": 200,
-            "ra_id": 300,
-        }
-        result = build_registry_entry(pending, 100001, "/grid/100001p.png")
-        assert result["app_id"] == 100001
-        assert result["name"] == "Game A"
-        assert result["fs_name"] == "gamea.z64"
-        assert result["platform_name"] == "N64"
-        assert result["platform_slug"] == "n64"
-        assert result["cover_path"] == "/grid/100001p.png"
-        assert result.get("igdb_id") == 100
-        assert result.get("sgdb_id") == 200
-        assert result.get("ra_id") == 300
-
-    def test_omits_none_meta_keys(self):
-        pending = {
-            "name": "Game B",
-            "fs_name": "",
-            "platform_name": "SNES",
-            "platform_slug": "snes",
-            "igdb_id": None,
-            "sgdb_id": None,
-            "ra_id": None,
-        }
-        result = build_registry_entry(pending, 100002, "")
-        assert "igdb_id" not in result
-        assert "sgdb_id" not in result
-        assert "ra_id" not in result
-
-    def test_missing_keys_default_to_empty(self):
-        pending = {}
-        result = build_registry_entry(pending, 100003, "")
-        assert result["name"] == ""
-        assert result["fs_name"] == ""
-        assert result["platform_name"] == ""
-        assert result["platform_slug"] == ""
-
-    def test_cover_path_stored(self):
-        pending = {"name": "Game", "platform_name": "N64", "platform_slug": "n64", "fs_name": ""}
-        result = build_registry_entry(pending, 99, "/grid/99p.png")
-        assert result["cover_path"] == "/grid/99p.png"
-
-    def test_empty_cover_path_stored(self):
-        pending = {"name": "Game", "platform_name": "N64", "platform_slug": "n64", "fs_name": ""}
-        result = build_registry_entry(pending, 99, "")
-        assert result["cover_path"] == ""

--- a/tests/models/test_metadata_patches.py
+++ b/tests/models/test_metadata_patches.py
@@ -1,0 +1,34 @@
+"""Tests for the frozen metadata-patch dataclasses."""
+
+import dataclasses
+
+import pytest
+from models.metadata_patches import MetadataStampPatch
+from models.state import MetadataCacheEntry
+
+
+def _make_entry() -> MetadataCacheEntry:
+    return {
+        "summary": "A game.",
+        "genres": ["RPG"],
+        "companies": ["Acme"],
+        "first_release_date": 1234567890,
+        "average_rating": 90.0,
+        "game_modes": ["Single player"],
+        "player_count": "1",
+        "cached_at": 1700.0,
+        "steam_categories": [1],
+    }
+
+
+class TestMetadataStampPatch:
+    def test_fields(self):
+        entry = _make_entry()
+        patch = MetadataStampPatch(rom_id_str="42", entry=entry)
+        assert patch.rom_id_str == "42"
+        assert patch.entry == entry
+
+    def test_frozen(self):
+        patch = MetadataStampPatch(rom_id_str="42", entry=_make_entry())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.rom_id_str = "0"  # type: ignore[misc]

--- a/tests/models/test_registry_patches.py
+++ b/tests/models/test_registry_patches.py
@@ -1,0 +1,128 @@
+"""Tests for the frozen registry-patch dataclasses."""
+
+import dataclasses
+
+import pytest
+from models.registry_patches import (
+    RegistryCoverPathPatch,
+    RegistryDeletePatch,
+    RegistryIdsPatch,
+    RegistrySgdbIdPatch,
+    RegistrySyncApplyPatch,
+)
+
+
+class TestRegistrySyncApplyPatch:
+    def test_required_fields_assigned(self):
+        patch = RegistrySyncApplyPatch(
+            rom_id_str="42",
+            app_id=123,
+            name="Game",
+            fs_name="game",
+            platform_name="Game Boy",
+            platform_slug="gb",
+            cover_path="/covers/42.png",
+        )
+        assert patch.rom_id_str == "42"
+        assert patch.app_id == 123
+        assert patch.name == "Game"
+        assert patch.fs_name == "game"
+        assert patch.platform_name == "Game Boy"
+        assert patch.platform_slug == "gb"
+        assert patch.cover_path == "/covers/42.png"
+
+    def test_optional_ids_default_to_none(self):
+        patch = RegistrySyncApplyPatch(
+            rom_id_str="42",
+            app_id=123,
+            name="Game",
+            fs_name="game",
+            platform_name="Game Boy",
+            platform_slug="gb",
+            cover_path="/covers/42.png",
+        )
+        assert patch.igdb_id is None
+        assert patch.sgdb_id is None
+        assert patch.ra_id is None
+
+    def test_optional_ids_can_be_set(self):
+        patch = RegistrySyncApplyPatch(
+            rom_id_str="42",
+            app_id=123,
+            name="Game",
+            fs_name="game",
+            platform_name="Game Boy",
+            platform_slug="gb",
+            cover_path="/covers/42.png",
+            igdb_id=999,
+            sgdb_id=888,
+            ra_id=777,
+        )
+        assert patch.igdb_id == 999
+        assert patch.sgdb_id == 888
+        assert patch.ra_id == 777
+
+    def test_frozen(self):
+        patch = RegistrySyncApplyPatch(
+            rom_id_str="42",
+            app_id=123,
+            name="Game",
+            fs_name="game",
+            platform_name="Game Boy",
+            platform_slug="gb",
+            cover_path="/covers/42.png",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.app_id = 456  # type: ignore[misc]
+
+
+class TestRegistryCoverPathPatch:
+    def test_fields(self):
+        patch = RegistryCoverPathPatch(rom_id_str="42", cover_path="/covers/42.png")
+        assert patch.rom_id_str == "42"
+        assert patch.cover_path == "/covers/42.png"
+
+    def test_frozen(self):
+        patch = RegistryCoverPathPatch(rom_id_str="42", cover_path="/covers/42.png")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.cover_path = "/other.png"  # type: ignore[misc]
+
+
+class TestRegistrySgdbIdPatch:
+    def test_fields(self):
+        patch = RegistrySgdbIdPatch(rom_id_str="42", sgdb_id=888)
+        assert patch.rom_id_str == "42"
+        assert patch.sgdb_id == 888
+
+    def test_frozen(self):
+        patch = RegistrySgdbIdPatch(rom_id_str="42", sgdb_id=888)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.sgdb_id = 0  # type: ignore[misc]
+
+
+class TestRegistryIdsPatch:
+    def test_both_set(self):
+        patch = RegistryIdsPatch(rom_id_str="42", sgdb_id=888, igdb_id=999)
+        assert patch.sgdb_id == 888
+        assert patch.igdb_id == 999
+
+    def test_both_none(self):
+        patch = RegistryIdsPatch(rom_id_str="42", sgdb_id=None, igdb_id=None)
+        assert patch.sgdb_id is None
+        assert patch.igdb_id is None
+
+    def test_frozen(self):
+        patch = RegistryIdsPatch(rom_id_str="42", sgdb_id=888, igdb_id=999)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.sgdb_id = 0  # type: ignore[misc]
+
+
+class TestRegistryDeletePatch:
+    def test_fields(self):
+        patch = RegistryDeletePatch(rom_id_str="42")
+        assert patch.rom_id_str == "42"
+
+    def test_frozen(self):
+        patch = RegistryDeletePatch(rom_id_str="42")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            patch.rom_id_str = "0"  # type: ignore[misc]

--- a/tests/services/library/conftest.py
+++ b/tests/services/library/conftest.py
@@ -18,11 +18,13 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import make_default_plugin_state
 
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
 from adapters.persistence import (
     MetadataCachePersisterAdapter,
     PersistenceAdapter,
     StatePersisterAdapter,
 )
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -50,6 +52,8 @@ def plugin(tmp_path):
     p._state_persister = StatePersisterAdapter(p._persistence, p._state)
     p._settings_persister = FakeSettingsPersister()
     p._metadata_cache_persister = MetadataCachePersisterAdapter(p._persistence, p._metadata_cache)
+    p._registry_store = RegistryStoreAdapter(state=p._state, logger=decky.logger)
+    p._metadata_store = MetadataCacheStoreAdapter(metadata_cache=p._metadata_cache)
     steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
     p._steam_config = steam_config
 
@@ -61,6 +65,7 @@ def plugin(tmp_path):
             logger=decky.logger,
             clock=FakeClock(),
             metadata_cache_persister=p._metadata_cache_persister,
+            metadata_store=p._metadata_store,
             log_debug=p._log_debug,
         ),
     )
@@ -75,6 +80,8 @@ def plugin(tmp_path):
             loop=asyncio.get_event_loop(),
             logger=decky.logger,
             get_pending_sync=dict,
+            registry_store=p._registry_store,
+            state_persister=MagicMock(),
         ),
     )
     p._artwork_service = artwork_service
@@ -95,6 +102,7 @@ def plugin(tmp_path):
             sleeper=FakeSleeper(),
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
+            registry_store=p._registry_store,
             log_debug=p._log_debug,
             metadata_service=metadata_service,
             artwork=artwork_service,
@@ -110,6 +118,7 @@ def plugin(tmp_path):
             logger=decky.logger,
             emit=decky.emit,
             state_persister=p._state_persister,
+            registry_store=p._registry_store,
             artwork_remover=artwork_service,
         ),
     )

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -183,52 +183,60 @@ class TestFinalizeCoverPath:
         assert result == staging_path
 
 
-class TestBuildRegistryEntry:
-    """Tests for _build_registry_entry() — lines 714-727."""
+class TestCommitUnitResults:
+    """Tests for _commit_unit_results_io — registry write via store with field preservation."""
 
-    def test_builds_full_entry(self, plugin):
-        pending = {
-            "name": "Game A",
-            "fs_name": "gamea.z64",
+    def test_commit_preserves_sgdb_id_when_pending_lacks_it(self, plugin):
+        """Field-clobber regression (#745): pending without sgdb_id must not wipe an existing sgdb_id."""
+        plugin._state["shortcut_registry"]["42"] = {
+            "app_id": 100001,
+            "name": "Old",
+            "fs_name": "old.z64",
             "platform_name": "N64",
             "platform_slug": "n64",
-            "igdb_id": 100,
-            "sgdb_id": 200,
-            "ra_id": 300,
+            "cover_path": "/covers/old.png",
+            "sgdb_id": 999,
         }
-        result = plugin._sync_service._reporter._build_registry_entry(pending, 100001, "/grid/100001p.png")
-        assert result["app_id"] == 100001
-        assert result["name"] == "Game A"
-        assert result["fs_name"] == "gamea.z64"
-        assert result["platform_name"] == "N64"
-        assert result["platform_slug"] == "n64"
-        assert result["cover_path"] == "/grid/100001p.png"
-        assert result["igdb_id"] == 100
-        assert result["sgdb_id"] == 200
-        assert result["ra_id"] == 300
-
-    def test_omits_none_meta_keys(self, plugin):
-        pending = {
-            "name": "Game B",
-            "fs_name": "",
-            "platform_name": "SNES",
-            "platform_slug": "snes",
-            "igdb_id": None,
-            "sgdb_id": None,
-            "ra_id": None,
+        plugin._sync_service._box.pending_sync[42] = {
+            "name": "Game",
+            "fs_name": "game.z64",
+            "platform_name": "Game Boy",
+            "platform_slug": "gb",
+            "cover_path": "",
         }
-        result = plugin._sync_service._reporter._build_registry_entry(pending, 100002, "")
-        assert "igdb_id" not in result
-        assert "sgdb_id" not in result
-        assert "ra_id" not in result
 
-    def test_missing_keys_default_to_empty(self, plugin):
-        pending = {}
-        result = plugin._sync_service._reporter._build_registry_entry(pending, 100003, "")
-        assert result["name"] == ""
-        assert result["fs_name"] == ""
-        assert result["platform_name"] == ""
-        assert result["platform_slug"] == ""
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001})
+
+        entry = plugin._state["shortcut_registry"]["42"]
+        assert entry["sgdb_id"] == 999
+        assert entry["name"] == "Game"
+        assert entry["app_id"] == 100001
+
+    def test_commit_preserves_igdb_and_ra_ids_when_pending_lacks_them(self, plugin):
+        """The preservation guarantee extends to igdb_id and ra_id."""
+        plugin._state["shortcut_registry"]["42"] = {
+            "app_id": 100001,
+            "name": "Old",
+            "fs_name": "old.z64",
+            "platform_name": "N64",
+            "platform_slug": "n64",
+            "cover_path": "/covers/old.png",
+            "igdb_id": 555,
+            "ra_id": 777,
+        }
+        plugin._sync_service._box.pending_sync[42] = {
+            "name": "Game",
+            "fs_name": "game.z64",
+            "platform_name": "Game Boy",
+            "platform_slug": "gb",
+            "cover_path": "",
+        }
+
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001})
+
+        entry = plugin._state["shortcut_registry"]["42"]
+        assert entry["igdb_id"] == 555
+        assert entry["ra_id"] == 777
 
 
 class TestClearSyncCache:

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -7,6 +7,7 @@ from fakes.library_peers import FakeArtworkManager, FakeMetadataExtractor
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import make_default_plugin_state
 
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import SaveSyncState
 
@@ -63,6 +64,7 @@ def plugin(clock):
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -12,6 +12,7 @@ import pytest
 from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
 from models.state import make_default_plugin_state
 
+from adapters.registry_store import RegistryStoreAdapter
 from services.artwork import ArtworkService, ArtworkServiceConfig
 
 
@@ -46,7 +47,19 @@ def pending_sync_data() -> dict:
 
 
 @pytest.fixture
-def artwork_service(state, steam_config, file_store, romm_api, pending_sync_data):
+def registry_store(state) -> RegistryStoreAdapter:
+    return RegistryStoreAdapter(state=state, logger=decky.logger)
+
+
+@pytest.fixture
+def state_persister() -> MagicMock:
+    p = MagicMock()
+    p.save_state = MagicMock(return_value=None)
+    return p
+
+
+@pytest.fixture
+def artwork_service(state, steam_config, file_store, romm_api, pending_sync_data, registry_store, state_persister):
     # _loop is replaced by the autouse fixture below for async tests; for
     # sync tests it is never touched, so a MagicMock is fine here.
     return ArtworkService(
@@ -58,6 +71,8 @@ def artwork_service(state, steam_config, file_store, romm_api, pending_sync_data
             loop=MagicMock(),
             logger=decky.logger,
             get_pending_sync=lambda: pending_sync_data,
+            registry_store=registry_store,
+            state_persister=state_persister,
         ),
     )
 
@@ -368,6 +383,55 @@ class TestGetArtworkBase64:
         assert result["base64"] is None
 
     @pytest.mark.asyncio
+    async def test_registry_app_id_fallback_when_cover_path_empty(
+        self, artwork_service, state, steam_config, file_store, tmp_path
+    ):
+        """Defensive fallback: cover_path empty but {app_id}p.png exists on disk."""
+        steam_config.grid_dir.return_value = str(tmp_path)
+
+        final = os.path.join(str(tmp_path), "999p.png")
+        file_store.files[final] = b"PNGDATA"
+        state["shortcut_registry"]["42"] = {"app_id": 999, "cover_path": ""}
+
+        result = await artwork_service.get_artwork_base64(42)
+        assert result["base64"] == base64.b64encode(b"PNGDATA").decode("ascii")
+
+    @pytest.mark.asyncio
+    async def test_registry_app_id_fallback_when_file_missing(self, artwork_service, state, steam_config, tmp_path):
+        """Registry app_id present but {app_id}p.png not on disk → no fallback possible."""
+        steam_config.grid_dir.return_value = str(tmp_path)
+
+        state["shortcut_registry"]["42"] = {"app_id": 999, "cover_path": ""}
+
+        result = await artwork_service.get_artwork_base64(42)
+        assert result["base64"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_registry_lacks_app_id(self, artwork_service, state, steam_config, tmp_path):
+        """Registry entry exists but lacks app_id — fallback must not crash or false-positive."""
+        steam_config.grid_dir.return_value = str(tmp_path)
+
+        state["shortcut_registry"]["42"] = {"name": "Game", "cover_path": ""}
+
+        result = await artwork_service.get_artwork_base64(42)
+        assert result["base64"] is None
+
+    @pytest.mark.asyncio
+    async def test_primary_registry_cover_path_still_works(
+        self, artwork_service, state, steam_config, file_store, tmp_path
+    ):
+        """Sanity check: primary registry cover_path lookup is not short-circuited by fallback."""
+        steam_config.grid_dir.return_value = str(tmp_path)
+
+        cover = os.path.join(str(tmp_path), "100001p.png")
+        file_store.files[cover] = b"primary png"
+        # cover_path is set — must be used directly, fallback path should not run.
+        state["shortcut_registry"]["42"] = {"app_id": 100001, "cover_path": cover}
+
+        result = await artwork_service.get_artwork_base64(42)
+        assert result["base64"] == base64.b64encode(b"primary png").decode("ascii")
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_read_raises(self, artwork_service, steam_config, file_store, tmp_path, caplog):
         steam_config.grid_dir.return_value = str(tmp_path)
 
@@ -383,6 +447,224 @@ class TestGetArtworkBase64:
             result = await artwork_service.get_artwork_base64(42)
         assert result["base64"] is None
         assert any("Failed to read artwork" in r.message for r in caplog.records)
+
+
+# ── TestRefreshCover ──────────────────────────────────────────────────────────
+
+
+class TestRefreshCover:
+    """Tests for refresh_cover() — single-ROM artwork repair."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        file_store,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        grid = str(tmp_path)
+        steam_config.grid_dir.return_value = grid
+        state["shortcut_registry"]["42"] = {
+            "app_id": 999,
+            "name": "Game",
+            "fs_name": "Game",
+            "platform_name": "Plat",
+            "platform_slug": "plat",
+            "cover_path": "",
+        }
+        romm_api.get_rom.return_value = {"id": 42, "path_cover_large": "/c.png"}
+
+        # download_cover writes the staging file; finalize then renames it.
+        def fake_download(_url: str, dest: str) -> None:
+            file_store.files[dest] = b"new cover bytes"
+
+        romm_api.download_cover.side_effect = fake_download
+
+        result = await artwork_service.refresh_cover(42)
+
+        expected_final = os.path.join(grid, "999p.png")
+        assert result == {"success": True, "message": "Cover refreshed", "cover_path": expected_final}
+        # Registry was patched with the final path
+        assert state["shortcut_registry"]["42"]["cover_path"] == expected_final
+        # save_state was driven once after the patch
+        state_persister.save_state.assert_called_once()
+        # File was renamed from staging to final
+        assert expected_final in file_store.files
+        assert file_store.files[expected_final] == b"new cover bytes"
+
+    @pytest.mark.asyncio
+    async def test_not_synced_when_registry_missing(
+        self,
+        artwork_service,
+        state_persister,
+        romm_api,
+    ):
+        result = await artwork_service.refresh_cover(42)
+        assert result == {
+            "success": False,
+            "reason": "not_synced",
+            "message": "ROM is not synced to Steam",
+        }
+        state_persister.save_state.assert_not_called()
+        romm_api.get_rom.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_synced_when_registry_lacks_app_id(
+        self,
+        artwork_service,
+        state,
+        state_persister,
+        romm_api,
+    ):
+        state["shortcut_registry"]["42"] = {"name": "No app_id yet"}
+        result = await artwork_service.refresh_cover(42)
+        assert result["success"] is False
+        assert result["reason"] == "not_synced"
+        state_persister.save_state.assert_not_called()
+        romm_api.get_rom.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_grid_dir(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        state_persister,
+        romm_api,
+    ):
+        state["shortcut_registry"]["42"] = {"app_id": 999}
+        steam_config.grid_dir.return_value = None
+
+        result = await artwork_service.refresh_cover(42)
+        assert result == {
+            "success": False,
+            "reason": "no_grid_dir",
+            "message": "Steam grid directory not found",
+        }
+        state_persister.save_state.assert_not_called()
+        romm_api.get_rom.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_server_unreachable_when_get_rom_raises(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        state["shortcut_registry"]["42"] = {"app_id": 999}
+        steam_config.grid_dir.return_value = str(tmp_path)
+        romm_api.get_rom.side_effect = Exception("network down")
+
+        result = await artwork_service.refresh_cover(42)
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        assert result["message"] == "Could not fetch ROM from server"
+        state_persister.save_state.assert_not_called()
+        romm_api.download_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_server_unreachable_when_get_rom_returns_none(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        state["shortcut_registry"]["42"] = {"app_id": 999}
+        steam_config.grid_dir.return_value = str(tmp_path)
+        romm_api.get_rom.return_value = None
+
+        result = await artwork_service.refresh_cover(42)
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        state_persister.save_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_cover_url_in_rom_payload(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        state["shortcut_registry"]["42"] = {"app_id": 999}
+        steam_config.grid_dir.return_value = str(tmp_path)
+        romm_api.get_rom.return_value = {"id": 42, "name": "No Cover"}
+
+        result = await artwork_service.refresh_cover(42)
+        assert result == {
+            "success": False,
+            "reason": "no_cover",
+            "message": "ROM has no cover artwork",
+        }
+        state_persister.save_state.assert_not_called()
+        romm_api.download_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_small_cover_url(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        file_store,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        """``path_cover_small`` is used when ``path_cover_large`` is absent."""
+        grid = str(tmp_path)
+        steam_config.grid_dir.return_value = grid
+        state["shortcut_registry"]["42"] = {"app_id": 999, "cover_path": ""}
+        romm_api.get_rom.return_value = {"id": 42, "path_cover_small": "/small.png"}
+
+        def fake_download(_url: str, dest: str) -> None:
+            file_store.files[dest] = b"small"
+
+        romm_api.download_cover.side_effect = fake_download
+
+        result = await artwork_service.refresh_cover(42)
+        assert result["success"] is True
+        # download_cover was called with the small URL
+        romm_api.download_cover.assert_called_once()
+        assert romm_api.download_cover.call_args[0][0] == "/small.png"
+        state_persister.save_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_download_failure_does_not_mutate_registry(
+        self,
+        artwork_service,
+        state,
+        steam_config,
+        romm_api,
+        state_persister,
+        tmp_path,
+    ):
+        """When ``download_cover`` raises, registry and persister must remain untouched."""
+        grid = str(tmp_path)
+        steam_config.grid_dir.return_value = grid
+        state["shortcut_registry"]["42"] = {"app_id": 999, "cover_path": "old/path.png"}
+        romm_api.get_rom.return_value = {"id": 42, "path_cover_large": "/c.png"}
+        romm_api.download_cover.side_effect = Exception("disk full")
+
+        result = await artwork_service.refresh_cover(42)
+        assert result["success"] is False
+        assert result["reason"] == "download_failed"
+        assert "disk full" in result["message"]
+        # Registry cover_path unchanged
+        assert state["shortcut_registry"]["42"]["cover_path"] == "old/path.png"
+        # No persistence on failure
+        state_persister.save_state.assert_not_called()
 
 
 # ── TestIsStagingFileOrphaned ─────────────────────────────────────────────────

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -15,6 +15,7 @@ from models.state import make_default_plugin_state
 
 from adapters.download_file import DownloadFileAdapter
 from adapters.download_queue import DownloadQueueAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.rom_files import RomFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import SaveSyncState
@@ -54,6 +55,7 @@ def plugin():
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -14,6 +14,7 @@ from models.bios import BiosFileEntry
 from models.state import PluginState, make_default_plugin_state
 
 from adapters.firmware_file import FirmwareFileAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -81,6 +82,7 @@ def plugin():
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -19,6 +19,7 @@ from models.state import make_default_plugin_state
 
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.save_state import FileSyncState, RomSaveState
@@ -64,6 +65,7 @@ def plugin(tmp_path):
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -13,7 +13,9 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
 from adapters.persistence import MetadataCachePersisterAdapter, PersistenceAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -40,6 +42,8 @@ def plugin():
     p._state_persister = FakeStatePersister()
     p._settings_persister = FakeSettingsPersister()
     p._metadata_cache_persister = FakeMetadataCachePersister()
+    p._registry_store = RegistryStoreAdapter(state=p._state, logger=decky.logger)
+    p._metadata_store = MetadataCacheStoreAdapter(metadata_cache=p._metadata_cache)
 
     metadata_service = MetadataService(
         config=MetadataServiceConfig(
@@ -49,6 +53,7 @@ def plugin():
             logger=decky.logger,
             clock=FakeClock(),
             metadata_cache_persister=p._metadata_cache_persister,
+            metadata_store=p._metadata_store,
             log_debug=p._log_debug,
         ),
     )
@@ -70,6 +75,7 @@ def plugin():
             sleeper=FakeSleeper(),
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
+            registry_store=p._registry_store,
             log_debug=p._log_debug,
             metadata_service=metadata_service,
             artwork=FakeArtworkManager(),

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -17,6 +17,7 @@ from models.state import make_default_plugin_state
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -92,6 +93,7 @@ def plugin(tmp_path, fake_romm_api):
             sleeper=FakeSleeper(),
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -8,6 +8,7 @@ import decky
 import pytest
 from models.state import make_default_plugin_state
 
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 
@@ -38,6 +39,7 @@ def svc(state, steam_config, artwork_remover_mock):
             logger=decky.logger,
             emit=decky.emit,
             state_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=state, logger=decky.logger),
             artwork_remover=artwork_remover_mock,
         ),
     )
@@ -239,6 +241,8 @@ class TestRemovalCleansUpArtwork:
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 get_pending_sync=dict,
+                registry_store=RegistryStoreAdapter(state=state, logger=decky.logger),
+                state_persister=MagicMock(),
             ),
         )
 
@@ -251,6 +255,7 @@ class TestRemovalCleansUpArtwork:
                 logger=decky.logger,
                 emit=decky.emit,
                 state_persister=MagicMock(),
+                registry_store=RegistryStoreAdapter(state=state, logger=decky.logger),
                 artwork_remover=artwork_svc,
             ),
         )
@@ -281,6 +286,8 @@ class TestRemovalCleansUpArtwork:
                 loop=asyncio.get_event_loop(),
                 logger=decky.logger,
                 get_pending_sync=dict,
+                registry_store=RegistryStoreAdapter(state=state, logger=decky.logger),
+                state_persister=MagicMock(),
             ),
         )
 
@@ -293,6 +300,7 @@ class TestRemovalCleansUpArtwork:
                 logger=decky.logger,
                 emit=decky.emit,
                 state_persister=MagicMock(),
+                registry_store=RegistryStoreAdapter(state=state, logger=decky.logger),
                 artwork_remover=artwork_svc,
             ),
         )

--- a/tests/services/test_startup_healing.py
+++ b/tests/services/test_startup_healing.py
@@ -11,6 +11,7 @@ from fakes.fake_path_exists_reader import FakePathExistsReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from models.state import InstalledRomEntry, PluginState, ShortcutRegistryEntry, make_default_plugin_state
 
+from adapters.registry_store import RegistryStoreAdapter
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 
 _RETRODECK_HOME = "/run/media/deck/Emulation/retrodeck"
@@ -54,6 +55,7 @@ def _make_service(
             state=state,
             logger=logger,
             state_persister=state_persister,
+            registry_store=RegistryStoreAdapter(state=state, logger=logger),
             retrodeck_paths=FakeRetroDeckPaths(home=retrodeck_home),
             path_probe=probe,
         ),

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -11,6 +11,8 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 from lib.errors import SgdbApiError, SteamGridDirMissingError
 
@@ -42,6 +44,8 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api):
 
     p._state_persister = FakeStatePersister()
     p._settings_persister = FakeSettingsPersister()
+    p._registry_store = RegistryStoreAdapter(state=p._state, logger=decky.logger)
+    p._metadata_store = MetadataCacheStoreAdapter(metadata_cache=p._metadata_cache)
     p._sync_service = LibraryService(
         config=LibraryServiceConfig(
             romm_api=p._romm_api,
@@ -58,6 +62,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api):
             sleeper=FakeSleeper(),
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
+            registry_store=p._registry_store,
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),
@@ -80,6 +85,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api):
             logger=decky.logger,
             state_persister=FakeStatePersister(),
             settings_persister=FakeSettingsPersister(),
+            registry_store=p._registry_store,
             get_pending_sync=lambda: p._sync_service._pending_sync,
             log_debug=p._log_debug,
         ),
@@ -377,6 +383,29 @@ class TestGetSgdbArtworkBase64:
 
         assert result["base64"] is None
         assert result["no_api_key"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_ids_returned_does_not_persist(self, plugin, fake_romm_api):
+        """RomM returns a row without sgdb_id/igdb_id → no patch, no save_state."""
+        plugin.settings["steamgriddb_api_key"] = "some-key"
+        plugin._sgdb_service._loop = asyncio.get_event_loop()
+
+        persister = FakeStatePersister()
+        plugin._sgdb_service._state_persister = persister
+
+        plugin._state["shortcut_registry"]["42"] = {
+            "app_id": 100001,
+            "name": "Zelda",
+            "platform_name": "N64",
+        }
+        fake_romm_api.roms[42] = {"id": 42, "igdb_id": None, "sgdb_id": None}
+
+        result = await plugin.get_sgdb_artwork_base64(42, 1)
+
+        assert result["base64"] is None
+        assert persister.save_count == 0
+        assert "sgdb_id" not in plugin._state["shortcut_registry"]["42"]
+        assert "igdb_id" not in plugin._state["shortcut_registry"]["42"]
 
     @pytest.mark.asyncio
     async def test_sgdb_id_cached_in_registry(self, plugin, sgdb_artwork_cache, fake_steamgrid_db_api):
@@ -700,6 +729,7 @@ class TestDebugLoggerProtocolSeam:
         steam_config = SteamConfigAdapter(user_home=decky.DECKY_USER_HOME, logger=decky.logger)
         p._steam_config = steam_config
 
+        registry_store = RegistryStoreAdapter(state=p._state, logger=decky.logger)
         p._sync_service = LibraryService(
             config=LibraryServiceConfig(
                 romm_api=p._romm_api,
@@ -716,6 +746,7 @@ class TestDebugLoggerProtocolSeam:
                 sleeper=FakeSleeper(),
                 state_persister=FakeStatePersister(),
                 settings_persister=FakeSettingsPersister(),
+                registry_store=registry_store,
                 log_debug=capture,
                 metadata_service=FakeMetadataExtractor(),
                 artwork=FakeArtworkManager(),
@@ -735,6 +766,7 @@ class TestDebugLoggerProtocolSeam:
                 logger=decky.logger,
                 state_persister=FakeStatePersister(),
                 settings_persister=FakeSettingsPersister(),
+                registry_store=registry_store,
                 get_pending_sync=lambda: p._sync_service._pending_sync,
                 log_debug=capture,
             ),

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -32,6 +32,8 @@ from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from models.state import ShortcutRegistryEntry, make_default_plugin_state
 
+from adapters.metadata_cache_store import MetadataCacheStoreAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApiAdapter
@@ -186,6 +188,7 @@ class TestWireServices:
         http_adapter = MagicMock(spec=RommHttpAdapter)
         steam_config = SteamConfigAdapter(user_home=str(tmp_path), logger=logger)
         state = make_default_plugin_state()
+        metadata_cache: dict = {}
         romm_api = MagicMock(spec=RommApiAdapter)
         return {
             "http_adapter": http_adapter,
@@ -204,7 +207,7 @@ class TestWireServices:
             "path_probe": FakePathExistsReader(),
             "state": state,
             "settings": settings,
-            "metadata_cache": {},
+            "metadata_cache": metadata_cache,
             "save_sync_state": {"saves": {}, "playtime": {}, "settings": {}},
             "loop": asyncio.new_event_loop(),
             "logger": logger,
@@ -230,6 +233,8 @@ class TestWireServices:
             "firmware_cache_persister": FakeFirmwareCachePersister(),
             "core_info_provider": FakeCoreInfoProvider(),
             "save_sync_state_persister": MagicMock(load=MagicMock(return_value=None), save=MagicMock()),
+            "registry_store": RegistryStoreAdapter(state=state, logger=logger),
+            "metadata_store": MetadataCacheStoreAdapter(metadata_cache=metadata_cache),
             "log_debug": MagicMock(),
             "plugin_metadata": FakePluginMetadataReader(version="0.14.0"),
         }
@@ -281,6 +286,8 @@ class TestWireServices:
                 metadata_cache_persister=deps["metadata_cache_persister"],
                 firmware_cache_persister=deps["firmware_cache_persister"],
                 save_sync_state_persister=deps["save_sync_state_persister"],
+                registry_store=deps["registry_store"],
+                metadata_store=deps["metadata_store"],
                 log_debug=deps["log_debug"],
                 plugin_metadata=deps["plugin_metadata"],
             ),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,6 +16,7 @@ from models.state import make_default_plugin_state
 
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import PersistenceAdapter, SettingsPersisterAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.steam_config import SteamConfigAdapter
 
 # conftest.py patches decky before this import
@@ -53,6 +54,7 @@ def plugin():
     p._state_persister = FakeStatePersister()
     p._settings_persister = FakeSettingsPersister()
     p._metadata_cache_persister = FakeMetadataCachePersister()
+    p._registry_store = RegistryStoreAdapter(state=p._state, logger=decky.logger)
 
     p._sync_service = LibraryService(
         config=LibraryServiceConfig(
@@ -70,6 +72,7 @@ def plugin():
             sleeper=FakeSleeper(),
             state_persister=p._state_persister,
             settings_persister=p._settings_persister,
+            registry_store=p._registry_store,
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),
@@ -88,6 +91,7 @@ def plugin():
             logger=decky.logger,
             state_persister=FakeStatePersister(),
             settings_persister=FakeSettingsPersister(),
+            registry_store=p._registry_store,
             get_pending_sync=lambda: p._sync_service._pending_sync,
             log_debug=p._log_debug,
         ),
@@ -118,6 +122,7 @@ def plugin():
             state=p._state,
             logger=decky.logger,
             state_persister=p._state_persister,
+            registry_store=p._registry_store,
             retrodeck_paths=p._retrodeck_paths,
             path_probe=FakePathExistsReader(),
         ),
@@ -910,6 +915,8 @@ class TestMainStartupOrdering:
                 metadata_cache_persister=MagicMock(),
                 firmware_cache_persister=MagicMock(),
                 save_sync_state_persister=MagicMock(),
+                registry_store=MagicMock(),
+                metadata_store=MagicMock(),
                 log_debug=MagicMock(),
                 plugin_metadata=MagicMock(),
             ),

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -391,6 +391,24 @@ class TestArtworkCallableDelegation:
         plugin._artwork_service.get_artwork_base64.assert_awaited_once_with(42)
         assert result == {"base64": None}
 
+    @pytest.mark.asyncio
+    async def test_refresh_cover_artwork_delegates(self, plugin):
+        plugin._artwork_service.refresh_cover = AsyncMock(
+            return_value={"success": True, "message": "Cover refreshed", "cover_path": "/grid/999p.png"},
+        )
+        result = await plugin.refresh_cover_artwork(42)
+        plugin._artwork_service.refresh_cover.assert_awaited_once_with(42)
+        assert result["success"] is True
+        assert result["cover_path"] == "/grid/999p.png"
+
+    @pytest.mark.asyncio
+    async def test_refresh_cover_artwork_coerces_string_rom_id(self, plugin):
+        plugin._artwork_service.refresh_cover = AsyncMock(return_value={"success": True, "message": "ok"})
+        # Decky callables receive args as JSON — defensive int() coercion guards
+        # against the frontend accidentally sending a string.
+        await plugin.refresh_cover_artwork("42")
+        plugin._artwork_service.refresh_cover.assert_awaited_once_with(42)
+
 
 # ── Launch / session lifecycle callables ───────────────────────────────
 

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -18,6 +18,7 @@ from models.state import make_default_plugin_state
 
 from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter, SaveSyncStatePersisterAdapter
+from adapters.registry_store import RegistryStoreAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
@@ -66,6 +67,7 @@ def plugin(tmp_path):
             sleeper=FakeSleeper(),
             state_persister=MagicMock(),
             settings_persister=MagicMock(),
+            registry_store=RegistryStoreAdapter(state=p._state, logger=decky.logger),
             log_debug=p._log_debug,
             metadata_service=FakeMetadataExtractor(),
             artwork=FakeArtworkManager(),


### PR DESCRIPTION
## Summary

- Closes #745. Same class of bug as #738: writers were doing full-replace dict assignments into `shortcut_registry[rom_id]` / `metadata_cache[rom_id_str]` and silently dropping fields owned by other writers. The user-visible symptom: `cover_path=""` for every synced ROM in `state.json` even though `{app_id}p.png` was on disk, so the game-info panel rendered no image. SGDB and IGDB IDs set by `SteamGridService` had the same failure mode on the next sync apply.
- Adds a typed-patch + store layer so every writer can only touch fields its patch type carries. Each patch type maps to one SQL `UPDATE` for the upcoming SQLite migration — no rewriting writers when the store implementation swaps.
- Ships three fixes from #745: (A) the architectural store, (B) a defensive read fallback in `get_artwork_base64` so existing broken-state registries render their covers without a forced re-sync, and (C) a working "Refresh Artwork" — it now re-fetches the RomM cover and patches `cover_path`, instead of only touching Steam's custom-artwork slots.

## Notable changes

- New: `models/{registry,metadata}_patches.py`, `adapters/{registry,metadata_cache}_store.py`, `ShortcutRegistryStore` + `MetadataCacheStore` Protocols.
- Migrated writers: `SyncReporter`, `SteamGridService` (x2 sites), `ShortcutRemovalService`, `StartupHealingService`, `MetadataService`. Bootstrap threads both stores through `CallbackBundle`.
- `RegistryStoreAdapter.apply_sync` preserves existing optional IDs (`igdb_id` / `sgdb_id` / `ra_id`) when the patch field is `None` — regression tests in `tests/services/library/test_reporter.py`.
- `services/artwork.py:refresh_cover` + `refresh_cover_artwork` callable in `main.py`. Frontend `RomMPlaySection.handleRefreshArtwork` calls it before the SGDB step and dispatches `romm_data_changed { type: "cover_refreshed" }` on success; `RomMGameInfoPanel` listens and re-fetches the cover base64.

## SQLite-migration mapping

| Patch | SQL |
|---|---|
| `RegistrySyncApplyPatch` | `INSERT OR REPLACE INTO shortcut_registry ...` |
| `RegistryCoverPathPatch` | `UPDATE shortcut_registry SET cover_path=? WHERE rom_id=?` |
| `RegistrySgdbIdPatch` | `UPDATE shortcut_registry SET sgdb_id=? WHERE rom_id=?` |
| `RegistryIdsPatch` | `UPDATE shortcut_registry SET sgdb_id=COALESCE(?,sgdb_id), igdb_id=COALESCE(?,igdb_id) WHERE rom_id=?` |
| `RegistryDeletePatch` | `DELETE FROM shortcut_registry WHERE rom_id=? RETURNING *` |
| `MetadataStampPatch` | `INSERT OR REPLACE INTO metadata_cache ...` |

## Test plan

- [x] On-device: regular sync of an up-to-date library — `state.json` `cover_path` fields stay populated (no clobber on apply).
- [x] On-device: force-full-sync on a registry with `cover_path=""` rows — covers render in game info panel via the defensive fallback even before the row is rewritten.
- [x] On-device: open the RomM menu on a game info page → "Refresh Artwork" → cover image refreshes in-place without leaving the page.
- [x] On-device: full sync followed by a regular sync — verify no `sgdb_id` / `igdb_id` loss across runs (covered by unit regression test; on-device confirms).
- [x] Python: `pytest tests/` — 2573 passed.
- [x] Frontend: `pnpm test` — 991 passed.
- [x] `ruff`, `basedpyright`, `lint-imports`, `cosmic_call_bans`, `pnpm build` — all clean.