### PR TITLE
fix(saves): record PUT uploads in own_upload_ids for correct attribution

### DIFF
--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -264,7 +264,6 @@ class MatrixExecutor:
         device_id = self._state_svc.get_server_device_id()
         slot = self._resolve_upload_slot(rom_id_str, device_id)
 
-        is_post = save_id is None
         result = self._retry.with_retry(
             lambda: self._romm_api.upload_save(
                 int(rom_id), file_path, emulator, save_id, device_id=device_id, slot=slot
@@ -275,8 +274,7 @@ class MatrixExecutor:
             rom_id_str, filename, result, file_path, system, emulator_tag=emulator, core_so=core_so
         )
 
-        if is_post:
-            self._record_own_upload(rom_id_str, result.get("id"))
+        self._record_own_upload(rom_id_str, result.get("id"))
 
         if slot:
             self._promote_local_slot_to_server(rom_id_str, slot)
@@ -292,11 +290,16 @@ class MatrixExecutor:
         return result
 
     def _record_own_upload(self, rom_id_str: str, new_id: int | None) -> None:
-        """Track a save_id we POSTed ourselves for uploader attribution.
+        """Track a save_id whose current content this device uploaded.
 
-        POST = brand-new save; PUT updates an existing tracked save without
-        changing ownership. Assumes POST is not upsert-by-filename on the
-        server — if RomM ever changes that, revisit this tracker.
+        Records the id for any upload this device performs — POST (new save)
+        or PUT (new content pushed to an existing id) alike. The attribution
+        question it answers is "did this device upload the bytes currently at
+        this save id?", so both paths qualify.
+
+        Attribution is id-granular, not content-hash-granular: if another
+        device later PUTs over the same id, this device still lists it. That
+        stale-attribution window is accepted as a known limitation.
 
         Pure in-memory mutation. The caller (:meth:`do_upload_save`) owns the
         single persistence point so every upload outcome lands on disk exactly

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -740,8 +740,8 @@ class TestOwnUploadIds:
         assert rom_state.own_upload_ids.count(1000) == 1
 
     @pytest.mark.asyncio
-    async def test_put_upload_does_not_touch_own_list(self, tmp_path):
-        """Updating an existing tracked save (PUT path) does not modify own_upload_ids."""
+    async def test_put_upload_appends_own_upload_id(self, tmp_path):
+        """A PUT upload (existing save id) records that id in own_upload_ids."""
         svc, fake = make_service(tmp_path)
         _install_rom(svc, tmp_path)
         save_file = _create_save(tmp_path)
@@ -761,8 +761,34 @@ class TestOwnUploadIds:
         svc._sync_engine._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=server_save)
 
         rom_state = svc._save_sync_state.saves["42"]
-        # own_upload_ids must not have changed (100 not added, 99 still there)
-        assert rom_state.own_upload_ids == [99]
+        # This device pushed new content to id 100 → 100 is now ours; 99 untouched.
+        assert rom_state.own_upload_ids == [99, 100]
+
+    @pytest.mark.asyncio
+    async def test_put_upload_idempotent_in_own_list(self, tmp_path):
+        """Two PUT uploads to the same save id record it only once (dedup)."""
+        svc, fake = make_service(tmp_path)
+        _install_rom(svc, tmp_path)
+        save_file = _create_save(tmp_path)
+
+        fake.saves[100] = _server_save(save_id=100, rom_id=42)
+        svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
+            {
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "old"}},
+                "system": "gba",
+                "active_slot": "default",
+                "own_upload_ids": [],
+            }
+        )
+
+        server_save = fake.saves[100]
+        svc._sync_engine._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=server_save)
+        svc._sync_engine._do_upload_save(42, str(save_file), "pokemon.srm", "42", "gba", server_save=server_save)
+
+        rom_state = svc._save_sync_state.saves["42"]
+        assert rom_state.own_upload_ids is not None
+        assert rom_state.own_upload_ids.count(100) == 1
+        assert rom_state.own_upload_ids == [100]
 
     @pytest.mark.asyncio
     async def test_get_save_status_legacy_rom_state_returns_none(self, tmp_path):
@@ -789,8 +815,8 @@ class TestOwnUploadIds:
         assert files_by_id[26]["uploaded_by_us"] is None
 
     @pytest.mark.asyncio
-    async def test_rollback_to_foreign_version_preserves_own_upload_ids(self, tmp_path):
-        """Rolling back to a foreign save (not in own_upload_ids) does not modify own_upload_ids."""
+    async def test_rollback_to_foreign_version_records_target_id(self, tmp_path):
+        """Rolling back PUTs the target's content back, so this device now owns that id."""
         svc, fake = make_service(tmp_path)
         _install_rom(svc, tmp_path)
 
@@ -812,15 +838,16 @@ class TestOwnUploadIds:
             }
         )
         fake.saves[26] = _server_save(save_id=26, rom_id=42, slot="default")
-        # Foreign older version to roll back to
+        # Older version to roll back to
         fake.saves[27] = _server_save(save_id=27, rom_id=42, slot="default", updated_at="2026-01-01T00:00:00Z")
 
         result = await svc.rollback_to_version(42, "default", 27)
 
         assert result["status"] == "ok"
-        # own_upload_ids must be unchanged — 27 was not POSTed by us
+        # The switch re-uploads (PUTs) id=27's content to bump updated_at, so this
+        # device is now the uploader of the bytes at id 27 → 27 joins the own list.
         rom_state = svc._save_sync_state.saves["42"]
-        assert rom_state.own_upload_ids == [26]
+        assert rom_state.own_upload_ids == [26, 27]
 
 
 class TestPromoteLocalSlotPersistsState:


### PR DESCRIPTION
## What
`own_upload_ids` (per-ROM, in save_sync_state) drives the "uploaded by this device" attribution badge in the SAVES tab / version history. It was POST-only, so after this device PUT new content to an existing server save id, the badge wrongly showed "(not this device)" — even though this device uploaded the current bytes.

## Change
- `do_upload_save`: record the uploaded save id on **both POST and PUT** (dropped the POST-only `is_post` guard). `_record_own_upload` dedup keeps repeated PUTs idempotent.
- `_record_own_upload` docstring: new contract — *"saves whose current content this device uploaded (POST or PUT)"* — with the id-granularity limitation noted (a later foreign PUT to the same id leaves a stale attribution; this is #276 Option 1).

## Scope / safety
Display attribution only — the conflict matrix never reads `own_upload_ids`, so sync/conflict behavior is unchanged. Version-rollback re-uploads (PUTs) the target version to bump `updated_at`, so a rolled-back foreign version now correctly attributes to this device (it issued the PUT that set the current bytes); the rollback test was updated to assert this.

## Tests
PUT-appends, PUT-dedup edge case, and rollback attribution updated. Full suite **2574 passed**; ruff + basedpyright clean.

Closes #276