### PR TITLE
fix(ui): make backend authoritative for sync progress, fix indicator + button state

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,6 +272,9 @@ class Plugin:
     async def sync_cancel_preview(self):
         return self._sync_service.sync_cancel_preview()
 
+    async def get_sync_status(self):
+        return self._sync_service.get_sync_status()
+
     async def report_unit_results(self, rom_id_to_app_id):
         return await self._sync_service.report_unit_results(rom_id_to_app_id)
 

--- a/py_modules/domain/sync_stage.py
+++ b/py_modules/domain/sync_stage.py
@@ -1,0 +1,22 @@
+"""SyncStage enum — the on-the-wire stage label for a library sync run.
+
+The single vocabulary the backend uses to describe where a sync run
+is, shared by the live ``sync_progress`` event and the
+``get_sync_status`` snapshot query. Each member's value is the exact
+string the frontend's ``SyncProgress.stage`` discriminant expects, so
+``str``-based members serialize straight onto the wire without a lookup
+table. Anything that needs to name a phase of the sync lifecycle uses a
+member here rather than a bare string literal.
+"""
+
+from enum import StrEnum
+
+
+class SyncStage(StrEnum):
+    DISCOVERING = "discovering"
+    FETCHING = "fetching"
+    APPLYING = "applying"
+    FINALIZING = "finalizing"
+    DONE = "done"
+    CANCELLED = "cancelled"
+    ERROR = "error"

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -12,6 +12,7 @@ from models.registry_patches import RegistryCoverPathPatch
 from models.state import PluginState, ShortcutRegistryEntry
 
 from domain.artwork_paths import final_filename, staging_filename
+from domain.sync_stage import SyncStage
 from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
@@ -110,7 +111,7 @@ class ArtworkService:
                 return cover_paths
 
             await emit_progress(
-                "applying",
+                SyncStage.APPLYING,
                 current=i + 1,
                 total=total,
                 message=f"Downloading artwork {i + 1}/{total}",

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -23,10 +23,12 @@ if TYPE_CHECKING:
 def _default_progress() -> dict:
     return {
         "running": False,
-        "phase": "",
+        "stage": "",
         "current": 0,
         "total": 0,
         "message": "",
+        "step": 0,
+        "totalSteps": 0,
     }
 
 

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from models.state import MetadataCache, PluginState
 
+from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 from lib.errors import classify_error
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
     )
 
     # Orchestrator-supplied progress emitter. Matches the kw-only signature
-    # of ``SyncOrchestrator._emit_progress``: phase positional, every other
+    # of ``SyncOrchestrator._emit_progress``: stage positional, every other
     # field keyword. Sub-services consume this through the Config seam.
     EmitProgressFn = Callable[..., Awaitable[None]]
 
@@ -278,9 +279,11 @@ class LibraryFetcher:
                 self._logger.info(f"Skipping {platform_name}: {registry_count} ROMs unchanged")
                 all_roms.extend(self._reconstruct_platform_from_registry(registry, platform_name, platform_slug))
                 await self._emit_progress(
-                    "roms",
+                    SyncStage.FETCHING,
                     current=len(all_roms),
                     message=f"{platform_name} unchanged ({pi}/{total_platforms})",
+                    step=pi,
+                    total_steps=total_platforms,
                 )
                 return True
 
@@ -297,9 +300,11 @@ class LibraryFetcher:
         offset = 0
         limit = 50
         await self._emit_progress(
-            "roms",
+            SyncStage.FETCHING,
             current=len(all_roms),
             message=f"Fetching {platform_name}... {len(all_roms)} found ({pi}/{total_platforms})",
+            step=pi,
+            total_steps=total_platforms,
         )
 
         while True:
@@ -328,9 +333,11 @@ class LibraryFetcher:
 
             all_roms.extend(rom_list)
             await self._emit_progress(
-                "roms",
+                SyncStage.FETCHING,
                 current=len(all_roms),
                 message=f"Fetching {platform_name}... {len(all_roms)} found ({pi}/{total_platforms})",
+                step=pi,
+                total_steps=total_platforms,
             )
             if len(rom_list) < limit:
                 break

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -24,6 +24,7 @@ from models.registry_patches import RegistrySyncApplyPatch
 from models.state import PluginState
 
 from domain.sync_diff import should_include_in_platform_collection
+from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
 from services.library._state import LibrarySyncStateBox
 
@@ -188,7 +189,7 @@ class SyncReporter:
         total = len(self._state["shortcut_registry"])
         if cancelled:
             await self._emit_progress(
-                "done",
+                SyncStage.CANCELLED,
                 current=total_games,
                 total=total,
                 message=f"Sync cancelled: {total_games} of {total} games processed",
@@ -196,7 +197,7 @@ class SyncReporter:
             )
         else:
             await self._emit_progress(
-                "done",
+                SyncStage.DONE,
                 current=total,
                 total=total,
                 message=f"Sync complete: {total} games from {len(platform_app_ids)} platforms",

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -128,6 +128,7 @@ class SyncReporter:
         self,
         pending_collection_memberships: dict[str, list[int]],
         pending_platform_rom_ids: set[int] | None,
+        stale_rom_ids: list[int] | None = None,
     ) -> tuple[dict, dict[str, list]]:
         """Build collection app-id maps and persist last_sync metadata.
 
@@ -135,7 +136,18 @@ class SyncReporter:
         has already updated the registry, so we only need to build the
         cross-unit collection mappings and write the final
         ``last_sync`` / ``last_synced_*`` fields.
+
+        ``stale_rom_ids`` are the rom_ids the sync determined are no
+        longer present (disabled platform, removed from server). They are
+        pruned from the registry first so collections are built from — and
+        the persisted registry reflects — only the still-synced ROMs.
+        Registry keys are JSON strings; ``stale_rom_ids`` are ints, so we
+        pop by ``str(rid)``.
         """
+        registry = self._state["shortcut_registry"]
+        for rid in stale_rom_ids or []:
+            registry.pop(str(rid), None)
+
         platform_app_ids, romm_collection_app_ids = self._build_collection_app_ids(
             self._state["shortcut_registry"],
             pending_platform_rom_ids,
@@ -155,18 +167,23 @@ class SyncReporter:
         pending_platform_rom_ids: set[int] | None,
         total_games: int,
         cancelled: bool = False,
+        stale_rom_ids: list[int] | None = None,
     ):
         """Emit ``sync_collections`` + ``sync_complete`` after all units finish.
 
         Stale-removal is emitted separately by the orchestrator via
         ``sync_stale`` so the frontend can apply removals before
-        collections are recomputed.
+        collections are recomputed. ``stale_rom_ids`` (default ``None`` =
+        prune nothing) are pruned from the backend ``shortcut_registry``
+        before collections are built and state is persisted, keeping the
+        backend registry in sync with the frontend removals.
         """
         platform_app_ids, romm_collection_app_ids = await self._loop.run_in_executor(
             None,
             self._finalize_per_unit_run_io,
             pending_collection_memberships,
             pending_platform_rom_ids,
+            stale_rom_ids,
         )
 
         await self._emit(

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -160,14 +160,14 @@ class LibraryService:
         )
         reporter_binding.set(lambda: self._reporter)
 
-    async def _emit_progress_proxy(self, phase, **kwargs):
+    async def _emit_progress_proxy(self, stage, **kwargs):
         """Late-bound proxy to the orchestrator's _emit_progress.
 
         Threaded into the fetcher's config at ctor time before
         ``self._orchestrator`` exists — calls resolve at invocation
         time, by which point both sub-services are wired.
         """
-        await self._orchestrator._emit_progress(phase, **kwargs)
+        await self._orchestrator._emit_progress(stage, **kwargs)
 
     # ── Public properties ────────────────────────────────────────
 
@@ -351,6 +351,9 @@ class LibraryService:
 
     def sync_cancel_preview(self):
         return self._orchestrator.sync_cancel_preview()
+
+    def get_sync_status(self):
+        return self._orchestrator.get_sync_status()
 
     # Reporting
     async def report_unit_results(self, rom_id_to_app_id):

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -678,6 +678,7 @@ class SyncOrchestrator:
             pending_platform_rom_ids=platform_rom_ids,
             total_games=total_games_applied,
             cancelled=cancelled,
+            stale_rom_ids=stale_rom_ids,
         )
 
     # ── Artwork delegation ───────────────────────────────────────

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -30,6 +30,7 @@ from domain.sync_diff import (
     compute_collection_diff,
     compute_platform_collection_diff,
 )
+from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 from lib.errors import classify_error
@@ -170,7 +171,7 @@ class SyncOrchestrator:
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
         try:
-            await self._emit_progress("platforms", message="Fetching platforms...")
+            await self._emit_progress(SyncStage.DISCOVERING, message="Fetching platforms...")
             work_queue = await self._fetcher.build_work_queue()
 
             all_roms: list[dict] = []
@@ -183,9 +184,11 @@ class SyncOrchestrator:
                 if box.sync_state == SyncState.CANCELLING:
                     raise asyncio.CancelledError(_SYNC_CANCELLED)
                 await self._emit_progress(
-                    "roms",
+                    SyncStage.FETCHING,
                     current=len(all_roms),
                     message=f"Fetching {unit.name}... ({unit_index}/{total_units})",
+                    step=unit_index,
+                    total_steps=total_units,
                 )
                 if unit.type == "platform":
                     unit_roms, _skipped = await self._fetcher.fetch_platform_unit(unit)
@@ -216,7 +219,7 @@ class SyncOrchestrator:
                 total_roms=len(all_roms),
             )
 
-            await self._emit_progress("done", message="Preview ready", running=False)
+            await self._emit_progress(SyncStage.DONE, message="Preview ready", running=False)
 
             return {
                 "success": True,
@@ -251,7 +254,7 @@ class SyncOrchestrator:
             self._logger.error(f"Sync preview failed: {e}\n{traceback.format_exc()}")
             box.pending_delta = None
             _code, _msg = classify_error(e)
-            await self._emit_progress("error", message=_msg, running=False)
+            await self._emit_progress(SyncStage.ERROR, message=_msg, running=False)
             return {"success": False, "message": _msg, "error_code": _code}
         finally:
             box.sync_state = SyncState.IDLE
@@ -293,11 +296,21 @@ class SyncOrchestrator:
 
     # ── Progress & safety ────────────────────────────────────────
 
-    async def _emit_progress(self, phase, current=0, total=0, message="", running=True, step=0, total_steps=0):
-        """Update _sync_progress and emit sync_progress event to frontend."""
+    async def _emit_progress(self, stage, current=0, total=0, message="", running=True, step=0, total_steps=0):
+        """Persist the progress snapshot and emit the sync_progress event.
+
+        ``stage`` is a :class:`SyncStage` (or its string value); ``step``
+        / ``total_steps`` are the coarse unit index / total units that
+        drive the determinate main bar — stages without a unit index yet
+        (discovering, fetching) pass ``0`` / ``0``, which the frontend
+        treats as indeterminate. ``current`` / ``total`` are the fine
+        within-unit counters. The snapshot is written to the box first so
+        :meth:`get_sync_status` always returns the latest state even if
+        the event never reaches a freshly remounted QAM.
+        """
         self._sync_state.sync_progress = {
             "running": running,
-            "phase": phase,
+            "stage": SyncStage(stage).value,
             "current": current,
             "total": total,
             "message": message,
@@ -306,16 +319,26 @@ class SyncOrchestrator:
         }
         await self._emit("sync_progress", self._sync_state.sync_progress)
 
+    def get_sync_status(self) -> dict:
+        """Return the persisted progress snapshot — the authoritative sync state.
+
+        Idle returns the default ``running: False`` snapshot; a live run
+        returns the latest snapshot written by :meth:`_emit_progress`.
+        """
+        return self._sync_state.sync_progress
+
     # ── Sync termination ─────────────────────────────────────────
 
     async def _finish_sync(self, message):
         box = self._sync_state
         box.sync_progress = {
             "running": False,
-            "phase": "cancelled",
+            "stage": SyncStage.CANCELLED.value,
             "current": box.sync_progress.get("current", 0),
             "total": box.sync_progress.get("total", 0),
             "message": message,
+            "step": box.sync_progress.get("step", 0),
+            "totalSteps": box.sync_progress.get("totalSteps", 0),
         }
         await self._emit("sync_progress", box.sync_progress)
         box.sync_state = SyncState.IDLE
@@ -357,7 +380,7 @@ class SyncOrchestrator:
             except Exception as e:
                 self._logger.error(f"Failed to build work queue: {e}")
                 _code, _msg = classify_error(e)
-                await self._emit_progress("error", message=_msg, running=False)
+                await self._emit_progress(SyncStage.ERROR, message=_msg, running=False)
                 box.sync_state = SyncState.IDLE
                 return
 
@@ -374,7 +397,7 @@ class SyncOrchestrator:
             )
 
             if total_units == 0:
-                await self._emit_progress("done", message="Nothing to sync", running=False)
+                await self._emit_progress(SyncStage.DONE, message="Nothing to sync", running=False)
                 box.sync_state = SyncState.IDLE
                 box.current_sync_id = None
                 return
@@ -399,6 +422,17 @@ class SyncOrchestrator:
                     break
 
             # Final phase: stale cleanup + Steam collections + sync_complete.
+            # Surface a non-terminal finalizing snapshot before the terminal
+            # done/cancelled emit so the bar stays full while the reporter
+            # commits collections. Cancelled runs skip it — their next emit
+            # is the terminal cancelled snapshot from the reporter.
+            if not cancelled:
+                await self._emit_progress(
+                    SyncStage.FINALIZING,
+                    message="Finalizing…",
+                    step=total_units,
+                    total_steps=total_units,
+                )
             await self._finalize_per_unit(
                 total_games_applied=total_games_applied,
                 synced_rom_ids=synced_rom_ids,
@@ -413,10 +447,12 @@ class SyncOrchestrator:
             _code, _msg = classify_error(e)
             box.sync_progress = {
                 "running": False,
-                "phase": "error",
+                "stage": SyncStage.ERROR.value,
                 "current": 0,
                 "total": 0,
                 "message": f"Sync failed — {_msg}",
+                "step": 0,
+                "totalSteps": 0,
             }
             self._loop.create_task(self._emit("sync_progress", box.sync_progress))
             box.sync_state = SyncState.IDLE
@@ -451,10 +487,10 @@ class SyncOrchestrator:
         """
         box = self._sync_state
         await self._emit_progress(
-            "unit",
-            current=unit_index,
-            total=total_units,
+            SyncStage.APPLYING,
             message=f"{unit.name} ({unit_index + 1}/{total_units})",
+            step=unit_index + 1,
+            total_steps=total_units,
         )
 
         # Fetch this unit's ROMs. Platform units may incremental-skip;

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,5 @@
 import { callable } from "@decky/api";
-import type { PluginSettings, SyncStats, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse, LaunchVerdict, SlotDeleteInfo, DeleteSlotResult, MigrationStatus, MigrationResult, SaveSortMigrationStatus, RollbackStatus, ListFileVersionsResult, ListDevicesResponse } from "../types";
+import type { PluginSettings, SyncStats, SyncProgress, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse, LaunchVerdict, SlotDeleteInfo, DeleteSlotResult, MigrationStatus, MigrationResult, SaveSortMigrationStatus, RollbackStatus, ListFileVersionsResult, ListDevicesResponse } from "../types";
 
 export interface BackendResult {
   success: boolean;
@@ -55,6 +55,7 @@ export const syncHeartbeat = callable<[], { success: boolean }>("sync_heartbeat"
 export const syncPreview = callable<[], SyncPreview>("sync_preview");
 export const syncApplyDelta = callable<[string], BackendResult>("sync_apply_delta");
 export const syncCancelPreview = callable<[], BackendResult>("sync_cancel_preview");
+export const getSyncStatus = callable<[], SyncProgress>("get_sync_status");
 export const clearSyncCache = callable<[], BackendResult>("clear_sync_cache");
 export const getSyncStats = callable<[], SyncStats>("get_sync_stats");
 export const startDownload = callable<[number], BackendResult>("start_download");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -535,7 +535,7 @@ describe("MainPage", () => {
       // button) and the determinate bar shows the recovered stage label.
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       expect(buttonByExactText(container, "Sync Library")).toBeNull();
-      expect(container.querySelector('[data-testid="progress-op"]')?.textContent)
+      expect(container.querySelector('[data-testid="sync-stage"]')?.textContent)
         .toContain("Fetching library");
     });
 
@@ -874,10 +874,10 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      const op = container.querySelector('[data-testid="progress-op"]');
+      const op = container.querySelector('[data-testid="sync-stage"]');
       expect(op?.textContent).toContain("Applying shortcuts");
-      // sTimeRemaining carries the coarse "step/totalSteps" counter.
-      expect(container.querySelector('[data-testid="progress-remaining"]')?.textContent)
+      // The caption's step span carries the coarse "step/totalSteps" counter.
+      expect(container.querySelector('[data-testid="sync-step"]')?.textContent)
         .toContain("2/5");
       // Determinate: 2/5 * 100 = 40.
       expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("40");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -199,6 +199,13 @@ vi.mock("@decky/ui", async () => {
         ce("span", { "data-testid": "progress-progress" }, String(p.nProgress)),
         ce("span", { "data-testid": "progress-indeterminate" }, String(p.indeterminate)),
       ),
+    ProgressBar: (p: AnyProps & { nProgress?: number; indeterminate?: boolean }) =>
+      ce(
+        "div",
+        { "data-testid": "progress" },
+        ce("span", { "data-testid": "progress-progress" }, String(p.nProgress)),
+        ce("span", { "data-testid": "progress-indeterminate" }, String(p.indeterminate)),
+      ),
     showModal: vi.fn(),
   };
 });

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -274,7 +274,7 @@ describe("MainPage", () => {
     setDownloads([]);
     setSyncProgress({
       running: false,
-      phase: "",
+      stage: "",
       current: 0,
       total: 0,
       message: "",
@@ -357,6 +357,13 @@ describe("MainPage", () => {
     });
     vi.mocked(backend.syncCancelPreview).mockResolvedValue({
       success: true,
+      message: "",
+    });
+    vi.mocked(backend.getSyncStatus).mockResolvedValue({
+      running: false,
+      stage: "",
+      current: 0,
+      total: 0,
       message: "",
     });
     vi.mocked(backend.cancelSync).mockResolvedValue({
@@ -512,10 +519,12 @@ describe("MainPage", () => {
       expect(container.textContent).not.toContain("RetroArch: input_driver");
     });
 
-    it("recovers in-flight sync state from getSyncProgress() on mount", async () => {
-      setSyncProgress({
+    it("recovers in-flight sync state from getSyncStatus() on mount", async () => {
+      // Backend is authoritative: the mount query returns a live run, so the
+      // in-flight UI is shown even though the event-fed store was idle.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
-        phase: "fetching",
+        stage: "fetching",
         message: "Fetching library...",
         step: 1,
         totalSteps: 5,
@@ -523,11 +532,24 @@ describe("MainPage", () => {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       // In-flight: Cancel Sync button is rendered (replaces the Sync Library
-      // button) and the ProgressBarWithInfo shows the recovered message.
+      // button) and the determinate bar shows the recovered stage label.
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       expect(buttonByExactText(container, "Sync Library")).toBeNull();
       expect(container.querySelector('[data-testid="progress-op"]')?.textContent)
         .toContain("Fetching library");
+    });
+
+    it("logs the failure when getSyncStatus rejects on mount", async () => {
+      vi.mocked(backend.getSyncStatus).mockRejectedValue(new Error("offline"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to query sync status"),
+      );
+      // Falls back to the idle UI — the Sync Library button stays available.
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      logSpy.mockRestore();
     });
   });
 
@@ -839,37 +861,75 @@ describe("MainPage", () => {
     });
   });
 
-  describe("formatProgressText (via in-flight sync ProgressBarWithInfo)", () => {
-    it("renders 'Syncing...' fallback when message is empty (no step info)", async () => {
-      setSyncProgress({
+  describe("two-level in-flight progress UI", () => {
+    it("main bar shows the coarse step/totalSteps and stage label", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
-        step: 1,
-        totalSteps: 2,
-        message: "",
+        stage: "applying",
+        step: 2,
+        totalSteps: 5,
+        current: 3,
+        total: 10,
+        message: "N64: 3/10",
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toContain("[1/2]");
-      expect(op?.textContent).toContain("Syncing...");
+      expect(op?.textContent).toContain("Applying shortcuts");
+      // sTimeRemaining carries the coarse "step/totalSteps" counter.
+      expect(container.querySelector('[data-testid="progress-remaining"]')?.textContent)
+        .toContain("2/5");
+      // Determinate: 2/5 * 100 = 40.
+      expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("40");
+      expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("false");
     });
 
-    it("truncates long messages with an ellipsis", async () => {
-      // 40-char budget — produce a 60-char message and assert truncation.
-      const longMsg = "x".repeat(60);
-      setSyncProgress({
+    it("main bar goes indeterminate when totalSteps is 0", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
+        stage: "fetching",
+        step: 0,
+        totalSteps: 0,
+        message: "Fetching platforms...",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("true");
+    });
+
+    it("detail line renders the fine current/total message with a step prefix", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 2,
+        current: 4,
+        total: 8,
+        message: "N64: 4/8",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // The detail line is the field-label; it carries the step-prefixed message.
+      expect(container.textContent).toContain("[1/2]");
+      expect(container.textContent).toContain("N64: 4/8");
+    });
+
+    it("truncates long detail messages with an ellipsis", async () => {
+      const longMsg = "x".repeat(60);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
         step: 2,
         totalSteps: 5,
+        total: 60,
         message: longMsg,
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toContain("…");
-      // Step prefix counts towards the 40-char budget; total rendered length
-      // should be ~40.
-      expect((op?.textContent ?? "").length).toBeLessThanOrEqual(41);
+      const labels = fieldLabels(container);
+      const detail = labels.find((l) => l.includes("…"));
+      expect(detail).toBeDefined();
+      expect((detail ?? "").length).toBeLessThanOrEqual(41);
     });
   });
 
@@ -1133,9 +1193,10 @@ describe("MainPage", () => {
   // ===========================================================================
   describe("handleCancel", () => {
     it("clicking the in-flight 'Cancel Sync' button calls requestSyncCancel + cancelSync", async () => {
-      // Pre-arm an in-flight sync via the recovery branch on mount.
-      setSyncProgress({
+      // Pre-arm an in-flight sync via the backend-authoritative mount query.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
+        stage: "applying",
         message: "Working",
       });
       vi.mocked(backend.cancelSync).mockResolvedValue({
@@ -1156,11 +1217,12 @@ describe("MainPage", () => {
     });
 
     it("cancelSync success: surfaces result.message in the status field (un-gated)", async () => {
-      // #733 fix: handleCancel now stops polling + flips syncing/loading off
-      // before setting status, so the `status && !syncing && !preview` gate
-      // un-masks the cancel-specific message.
-      setSyncProgress({
+      // #733 fix: handleCancel flips syncing/loading off before setting status,
+      // so the `status && !syncing && !preview` gate un-masks the cancel
+      // message.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
+        stage: "applying",
         message: "Working",
       });
       vi.mocked(backend.cancelSync).mockResolvedValue({
@@ -1179,25 +1241,19 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Cancel Sync")).toBeNull();
     });
 
-    it("cancelSync success: stops polling and status auto-clears after 8s (mirrors startPolling's finish branch)", async () => {
+    it("cancelSync success: status auto-clears after 8s", async () => {
       vi.useFakeTimers({
         toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"],
       });
       try {
-        setSyncProgress({
+        vi.mocked(backend.getSyncStatus).mockResolvedValue({
           running: true,
+          stage: "applying",
           message: "Working",
         });
-        // Realistic backend behavior: cancelSync flips the progress store to
-        // running:false with a different message. This drives the poll tick's
-        // !progress.running branch — if handleCancel forgets to stopPolling(),
-        // the next tick clobbers our "cancelled-msg" with "poll-clobbered-msg".
-        vi.mocked(backend.cancelSync).mockImplementation(async () => {
-          setSyncProgress({
-            running: false,
-            message: "poll-clobbered-msg",
-          });
-          return { success: true, message: "cancelled-msg" };
+        vi.mocked(backend.cancelSync).mockResolvedValue({
+          success: true,
+          message: "cancelled-msg",
         });
         const { container } = render(<MainPage onNavigate={vi.fn()} />);
         await act(async () => {
@@ -1210,15 +1266,11 @@ describe("MainPage", () => {
           await Promise.resolve();
         });
         expect(fieldLabels(container)).toContain("cancelled-msg");
-        // Advance the 8s auto-clear timer. Without stopPolling() the 250ms
-        // poll tick would fire and clobber the status with "poll-clobbered-msg"
-        // (and arm its own 8s timer), so the auto-clear assertion below would
-        // fail in two ways: the message survives, and it's the wrong one.
+        // showTransientStatus arms an 8s auto-clear timer.
         await act(async () => {
           await vi.advanceTimersByTimeAsync(8000);
         });
         expect(fieldLabels(container)).not.toContain("cancelled-msg");
-        expect(fieldLabels(container)).not.toContain("poll-clobbered-msg");
       } finally {
         vi.useRealTimers();
       }
@@ -1227,8 +1279,9 @@ describe("MainPage", () => {
     it("cancelSync rejection: surfaces 'Failed to cancel sync' in the status field", async () => {
       // #733 fix: catch branch now uses the same cleanup-and-status helper, so
       // the failure message is visible to the user.
-      setSyncProgress({
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
+        stage: "applying",
         message: "Working",
       });
       vi.mocked(backend.cancelSync).mockRejectedValue(new Error("net"));
@@ -1611,63 +1664,113 @@ describe("MainPage", () => {
       clearIntervalSpy.mockRestore();
     });
 
-    it("pollRef (250ms sync progress) is cleared on unmount when sync is in-flight", async () => {
-      // Pre-arm in-flight sync so startPolling runs at mount.
-      setSyncProgress({ running: true, message: "Working" });
-      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
-
-      const { unmount } = render(<MainPage onNavigate={vi.fn()} />);
+    it("onSyncProgressChange subscription is removed on unmount", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        message: "Working",
+      });
+      const { container, unmount } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-
-      const pollIds = setIntervalSpy.mock.results
-        .filter((_, i) => setIntervalSpy.mock.calls[i][1] === 250)
-        .map((r) => r.value as ReturnType<typeof setInterval>);
-      const expectedId = pollIds[pollIds.length - 1];
-      expect(expectedId).toBeDefined();
-
-      const callsBeforeUnmount = clearIntervalSpy.mock.calls.length;
+      // In-flight UI is up — the subscription is live.
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
       unmount();
-      expect(clearIntervalSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
-      expect(clearIntervalSpy).toHaveBeenCalledWith(expectedId);
+      // After unmount, a store update must not throw (listener was removed)
+      // and must not resurrect the unmounted tree.
+      act(() => {
+        setSyncProgress({ running: false, stage: "done", message: "Sync complete" });
+      });
+      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+    });
+  });
 
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
+  // ===========================================================================
+  // N2. Backend-authoritative progress — store subscription drives the UI
+  // ===========================================================================
+  describe("store-driven sync UI (#751)", () => {
+    it("terminal stage tears down the in-flight UI and surfaces the final message", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 2,
+        message: "Working",
+      });
+      const statsAfter: SyncStats = {
+        ...defaultStats(),
+        roms: 7,
+        last_sync: new Date().toISOString(),
+      };
+      vi.mocked(backend.getSyncStats).mockResolvedValue(statsAfter);
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // In-flight initially.
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+
+      // A terminal sync_progress lands via the module store.
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "done", message: "Sync complete: 7 games" });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Torn down: Sync Library button back, final message surfaced, stats refreshed.
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).toBeNull();
+      expect(fieldLabels(container)).toContain("Sync complete: 7 games");
+      expect(vi.mocked(backend.getSyncStats)).toHaveBeenCalledTimes(2);
     });
 
-    it("pollRef tick stops polling when sync becomes not-running, surfaces final message + refreshes stats", async () => {
-      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"] });
-      try {
-        // Pre-arm in-flight sync.
-        setSyncProgress({ running: true, message: "Working" });
-        vi.mocked(backend.getSyncStats).mockResolvedValueOnce(defaultStats());
-        const { container } = render(<MainPage onNavigate={vi.fn()} />);
-        // First flush — mount useEffect.
-        await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    it("a bare running:false (no terminal stage) does NOT tear down the in-flight UI", async () => {
+      // Reproduces the #751 teardown race: a non-terminal running:false must
+      // not collapse the syncing UI (it would right after startSync, before
+      // events land).
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        message: "Working",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
 
-        // Flip the store to NOT running, then advance one 250ms tick — the
-        // poll handler should stop the interval, set status to the final
-        // message, and refresh stats.
-        setSyncProgress({ running: false, message: "Sync finished" });
-        const statsAfter: SyncStats = {
-          ...defaultStats(),
-          roms: 1,
-          last_sync: new Date().toISOString(),
-        };
-        vi.mocked(backend.getSyncStats).mockResolvedValue(statsAfter);
+      await act(async () => {
+        setSyncProgress({ running: false, stage: "", message: "" });
+        await Promise.resolve();
+      });
 
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(260);
-        });
+      // Still in-flight — only a terminal stage tears down.
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+    });
 
-        // The status field shows the final message.
-        expect(fieldLabels(container)).toContain("Sync finished");
-        // The Sync Library button is back (in-flight ended).
-        expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
-        expect(vi.mocked(backend.getSyncStats)).toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+    it("Sync Library button is disabled optimistically on click before the first event", async () => {
+      // skipPreview path: startSync resolves but no progress event has landed.
+      // The button must be gone (replaced by Cancel Sync) immediately.
+      let resolveStart: (v: { success: boolean; message: string }) => void = () => {};
+      vi.mocked(backend.startSync).mockImplementation(
+        () => new Promise((res) => { resolveStart = res; }),
+      );
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const toggle = container.querySelector('[data-testid="toggle-input"]') as HTMLInputElement | null;
+      fireEvent.click(toggle!);
+      await flushAsync();
+
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+      });
+      // Optimistic: in-flight UI shown before startSync even resolves.
+      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+
+      await act(async () => {
+        resolveStart({ success: true, message: "" });
+        await Promise.resolve();
+      });
+      // Still in-flight after the resolve — store subscription owns teardown.
+      expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
     });
   });
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -4,6 +4,7 @@ import {
   PanelSectionRow,
   ButtonItem,
   Field,
+  ProgressBar,
   ProgressBarWithInfo,
   ToggleField,
   Spinner,
@@ -397,10 +398,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     syncBody = (
       <>
         <PanelSectionRow>
-          {/* Own the caption in a full-width row instead of ProgressBarWithInfo's
-              sOperationText/sTimeRemaining — Steam's built-in label row overflows
-              the narrow QAM panel and clips on the right (#751). The bar itself
-              renders text-less so its widget shrinks to the panel width. */}
+          {/* Own the caption in a full-width row and use the bare ProgressBar.
+              ProgressBarWithInfo is a Steam Field (label column | bar column);
+              with no label text the empty column shoves the bar into the right
+              half and clips it (#751). The bare ProgressBar is just the bar and
+              spans the full panel width. */}
           <div style={{ width: "100%" }}>
             <div
               style={{
@@ -413,7 +415,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               <span data-testid="sync-stage">{stageLabel(syncProgress?.stage)}</span>
               {stepText && <span data-testid="sync-step">{stepText}</span>}
             </div>
-            <ProgressBarWithInfo
+            <ProgressBar
               indeterminate={coarseFraction === undefined}
               nProgress={coarseFraction}
             />

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -24,10 +24,11 @@ import {
   syncCancelPreview,
   clearSyncCache,
   refreshMigrationState,
+  getSyncStatus,
   logError,
 } from "../api/backend";
 import { formatBytes } from "../utils/formatters";
-import { getSyncProgress } from "../utils/syncProgress";
+import { getSyncProgress, setSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
@@ -36,7 +37,7 @@ import { requestSyncCancel } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedPage } from "./MigrationBlockedPage";
-import type { SyncProgress, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem } from "../types";
+import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem } from "../types";
 import type { MigrationStatus } from "../types";
 
 type Page = "settings" | "library" | "data" | "downloads";
@@ -73,6 +74,26 @@ const ConnectionIndicator: FC<{ connected: boolean | null }> = ({ connected }) =
     </>
   );
 };
+
+const TERMINAL_STAGES: ReadonlySet<SyncStage> = new Set<SyncStage>(["done", "cancelled", "error"]);
+
+function isTerminalStage(stage: SyncProgress["stage"]): boolean {
+  return !!stage && TERMINAL_STAGES.has(stage as SyncStage);
+}
+
+const STAGE_LABELS: Record<SyncStage, string> = {
+  discovering: "Discovering platforms",
+  fetching: "Fetching library",
+  applying: "Applying shortcuts",
+  finalizing: "Finalizing",
+  done: "Done",
+  cancelled: "Cancelled",
+  error: "Error",
+};
+
+function stageLabel(stage: SyncProgress["stage"]): string {
+  return stage ? STAGE_LABELS[stage as SyncStage] ?? "Syncing" : "Syncing";
+}
 
 function formatProgressText(progress: SyncProgress | null): string {
   if (!progress) return "Syncing...";
@@ -126,7 +147,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [connected, setConnected] = useState<boolean | null>(null);
   const versionError = useVersionError();
   const [syncing, setSyncing] = useState(false);
-  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
+  const [syncProgress, setSyncProgressState] = useState<SyncProgress | null>(null);
   const [status, setStatus] = useState("");
   const [preview, setPreview] = useState<SyncPreview | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
@@ -135,34 +156,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [migration, setMigration] = useState<MigrationStatus>(getMigrationState());
   const [saveSortMigration, setSaveSortMigration] = useState(getSaveSortMigrationState());
   const [downloads, setDownloads] = useState<DownloadItem[]>([]);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const downloadPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const stopPolling = () => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  };
-
-  const startPolling = (progressOnly = false) => {
-    stopPolling();
-    pollRef.current = setInterval(() => {
-      // Read directly from module-level store — no async callable, no WebSocket
-      const progress = getSyncProgress();
-      setSyncProgress(progress);
-
-      if (!progressOnly && !progress.running) {
-        stopPolling();
-        setSyncing(false);
-        setLoading(false);
-        if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-        setStatus(progress.message || "Sync finished");
-        statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
-        getSyncStats().then(setStats);
-      }
-    }, 250);
+  const showTransientStatus = (msg: string) => {
+    if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
+    setStatus(msg);
+    statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
   };
 
   useEffect(() => {
@@ -183,15 +183,34 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       }
     });
 
-    // Check if a sync is already in progress (handles QAM close/reopen)
-    const progress = getSyncProgress();
-    if (progress.running) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- recovery of in-flight sync state on QAM re-mount; legitimate mount-time setState
-      setSyncing(true);
-      setLoading(true);
-      setSyncProgress(progress);
-      startPolling();
-    }
+    // Backend is authoritative for in-flight sync state. Seed the module
+    // store from get_sync_status() so a QAM close/reopen recovers the live
+    // run rather than guessing from the event-fed store alone.
+    getSyncStatus()
+      .then((progress) => {
+        setSyncProgress(progress);
+        if (progress.running) {
+          setSyncing(true);
+          setLoading(true);
+          setSyncProgressState(progress);
+        }
+      })
+      .catch((e) => logError(`Failed to query sync status: ${e}`));
+
+    // Subscribe to the module store — every backend sync_progress event and
+    // every frontend updateSyncProgress notifies, driving a re-render. The
+    // in-progress UI is torn down ONLY on a terminal stage, never on a bare
+    // running:false (which can transiently race a fresh run's first event).
+    const unsubProgress = onSyncProgressChange(() => {
+      const progress = getSyncProgress();
+      setSyncProgressState(progress);
+      if (isTerminalStage(progress.stage)) {
+        setSyncing(false);
+        setLoading(false);
+        showTransientStatus(progress.message || "Sync finished");
+        getSyncStats().then(setStats);
+      }
+    });
 
     // Poll download state for inline display
     downloadPollRef.current = setInterval(() => {
@@ -201,7 +220,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     const unsubMigration = onMigrationChange(() => setMigration(getMigrationState()));
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
     return () => {
-      stopPolling();
+      unsubProgress();
       unsubMigration();
       unsubSaveSort();
       if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
@@ -209,13 +228,26 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     };
   }, []);
 
+  // A start/apply call never reached a running backend sync (rejected up
+  // front or threw). Reset both the local UI and the MODULE store so the
+  // store mirrors reality — the optimistic running:true must not linger.
+  const abortOptimisticSync = (msg: string) => {
+    setStatus(msg);
+    setSyncing(false);
+    setLoading(false);
+    setSyncProgress({ running: false, stage: "" });
+  };
+
   const handleSync = async () => {
+    // Optimistically disable the button and show the in-progress UI before
+    // the backend's first sync_progress event lands — writing running:true
+    // into the MODULE store (the single source of truth the subscription
+    // reads), not a shadowing local state.
     setLoading(true);
     setSyncing(true);
     setStatus("");
     setPreview(null);
-    setSyncProgress({ running: true, phase: "fetching", message: "Fetching library..." });
-    startPolling(true);
+    setSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
       // Skip Preview takes the per-unit pipeline (start_sync) — incremental
       // shortcut delivery, per-unit crash safety, no upfront full library
@@ -223,32 +255,22 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // review changes before they apply.
       if (skipPreview) {
         const startResult = await startSync();
-        if (startResult.success) {
-          startPolling();
-        } else {
-          stopPolling();
-          setStatus(startResult.message);
-          setSyncing(false);
-          setLoading(false);
+        if (!startResult.success) {
+          abortOptimisticSync(startResult.message);
         }
+        // On success the store subscription drives the UI from here.
         return;
       }
       const result = await syncPreview();
-      stopPolling();
       if (result.success) {
         setPreview(result);
         setSyncing(false);
         setLoading(false);
       } else {
-        setStatus(result.message || "Preview failed");
-        setSyncing(false);
-        setLoading(false);
+        abortOptimisticSync(result.message || "Preview failed");
       }
     } catch {
-      stopPolling();
-      setStatus("Failed to start sync");
-      setSyncing(false);
-      setLoading(false);
+      abortOptimisticSync("Failed to start sync");
     }
   };
 
@@ -258,20 +280,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setPreview(null);
     setLoading(true);
     setSyncing(true);
-    setSyncProgress({ running: true, phase: "applying", message: "Applying changes..." });
+    setSyncProgress({ running: true, stage: "applying", message: "Applying changes..." });
     try {
       const result = await syncApplyDelta(previewId);
-      if (result.success) {
-        startPolling();
-      } else {
-        setStatus(result.message);
-        setSyncing(false);
-        setLoading(false);
+      if (!result.success) {
+        abortOptimisticSync(result.message);
       }
+      // On success the store subscription drives the UI from here.
     } catch {
-      setStatus("Failed to apply sync");
-      setSyncing(false);
-      setLoading(false);
+      abortOptimisticSync("Failed to apply sync");
     }
   };
 
@@ -286,12 +303,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   const finishCancelWithStatus = (msg: string) => {
-    stopPolling();
     setSyncing(false);
     setLoading(false);
-    setStatus(msg);
-    if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-    statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
+    showTransientStatus(msg);
   };
 
   const handleCancel = async () => {
@@ -310,10 +324,14 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     }
   };
 
-  // Steam's ProgressBarWithInfo nProgress uses percentage (0-100), not fraction (0-1)
-  const progressFraction = syncProgress?.total
-    ? ((syncProgress.current ?? 0) / syncProgress.total) * 100
+  // Two-level progress. The main determinate bar tracks COARSE unit
+  // progress (step / totalSteps); 0/0 means the run hasn't reached a unit
+  // yet, so the bar goes indeterminate. Steam's ProgressBarWithInfo
+  // nProgress uses percentage (0-100), not fraction (0-1).
+  const coarseFraction = syncProgress?.totalSteps
+    ? ((syncProgress.step ?? 0) / syncProgress.totalSteps) * 100
     : undefined;
+  const hasFineDetail = !!(syncProgress?.total && syncProgress.message);
 
   const activeDownloads = downloads.filter(d => d.status === "queued" || d.status === "downloading");
   const completedDownloads = downloads.filter(d => d.status === "completed" || d.status === "failed" || d.status === "cancelled");
@@ -375,21 +393,25 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   } else if (syncing) {
     syncBody = (
       <>
-        {syncProgress?.step && syncProgress?.totalSteps ? (
-          <PanelSectionRow>
-            <ProgressBarWithInfo
-              indeterminate={progressFraction === undefined}
-              nProgress={progressFraction}
-              sOperationText={formatProgressText(syncProgress)}
-            />
-          </PanelSectionRow>
-        ) : (
+        <PanelSectionRow>
+          <ProgressBarWithInfo
+            indeterminate={coarseFraction === undefined}
+            nProgress={coarseFraction}
+            sOperationText={stageLabel(syncProgress?.stage)}
+            sTimeRemaining={
+              syncProgress?.totalSteps
+                ? `${syncProgress.step ?? 0}/${syncProgress.totalSteps}`
+                : undefined
+            }
+          />
+        </PanelSectionRow>
+        {hasFineDetail && (
           <PanelSectionRow>
             <Field
               label={
                 <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                  <Spinner width={16} height={16} />
-                  {syncProgress?.message || "Fetching..."}
+                  <Spinner width={14} height={14} />
+                  <span style={{ fontSize: "12px" }}>{formatProgressText(syncProgress)}</span>
                 </div>
               }
             />

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -391,19 +391,33 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       </>
     );
   } else if (syncing) {
+    const stepText = syncProgress?.totalSteps
+      ? `${syncProgress.step ?? 0}/${syncProgress.totalSteps}`
+      : "";
     syncBody = (
       <>
         <PanelSectionRow>
-          <ProgressBarWithInfo
-            indeterminate={coarseFraction === undefined}
-            nProgress={coarseFraction}
-            sOperationText={stageLabel(syncProgress?.stage)}
-            sTimeRemaining={
-              syncProgress?.totalSteps
-                ? `${syncProgress.step ?? 0}/${syncProgress.totalSteps}`
-                : undefined
-            }
-          />
+          {/* Own the caption in a full-width row instead of ProgressBarWithInfo's
+              sOperationText/sTimeRemaining — Steam's built-in label row overflows
+              the narrow QAM panel and clips on the right (#751). The bar itself
+              renders text-less so its widget shrinks to the panel width. */}
+          <div style={{ width: "100%" }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: "12px",
+                marginBottom: "4px",
+              }}
+            >
+              <span data-testid="sync-stage">{stageLabel(syncProgress?.stage)}</span>
+              {stepText && <span data-testid="sync-step">{stepText}</span>}
+            </div>
+            <ProgressBarWithInfo
+              indeterminate={coarseFraction === undefined}
+              nProgress={coarseFraction}
+            />
+          </div>
         </PanelSectionRow>
         {hasFineDetail && (
           <PanelSectionRow>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -29,7 +29,7 @@ import {
   logError,
 } from "../api/backend";
 import { formatBytes } from "../utils/formatters";
-import { getSyncProgress, setSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
+import { getSyncProgress, setSyncProgress as setStoredSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
@@ -38,8 +38,7 @@ import { requestSyncCancel } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedPage } from "./MigrationBlockedPage";
-import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem } from "../types";
-import type { MigrationStatus } from "../types";
+import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem, MigrationStatus } from "../types";
 
 type Page = "settings" | "library" | "data" | "downloads";
 
@@ -79,7 +78,7 @@ const ConnectionIndicator: FC<{ connected: boolean | null }> = ({ connected }) =
 const TERMINAL_STAGES: ReadonlySet<SyncStage> = new Set<SyncStage>(["done", "cancelled", "error"]);
 
 function isTerminalStage(stage: SyncProgress["stage"]): boolean {
-  return !!stage && TERMINAL_STAGES.has(stage as SyncStage);
+  return !!stage && TERMINAL_STAGES.has(stage);
 }
 
 const STAGE_LABELS: Record<SyncStage, string> = {
@@ -93,7 +92,7 @@ const STAGE_LABELS: Record<SyncStage, string> = {
 };
 
 function stageLabel(stage: SyncProgress["stage"]): string {
-  return stage ? STAGE_LABELS[stage as SyncStage] ?? "Syncing" : "Syncing";
+  return stage ? STAGE_LABELS[stage] : "Syncing";
 }
 
 function formatProgressText(progress: SyncProgress | null): string {
@@ -148,7 +147,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [connected, setConnected] = useState<boolean | null>(null);
   const versionError = useVersionError();
   const [syncing, setSyncing] = useState(false);
-  const [syncProgress, setSyncProgressState] = useState<SyncProgress | null>(null);
+  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
   const [status, setStatus] = useState("");
   const [preview, setPreview] = useState<SyncPreview | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
@@ -189,11 +188,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // run rather than guessing from the event-fed store alone.
     getSyncStatus()
       .then((progress) => {
-        setSyncProgress(progress);
+        setStoredSyncProgress(progress);
         if (progress.running) {
           setSyncing(true);
           setLoading(true);
-          setSyncProgressState(progress);
+          setSyncProgress(progress);
         }
       })
       .catch((e) => logError(`Failed to query sync status: ${e}`));
@@ -204,7 +203,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // running:false (which can transiently race a fresh run's first event).
     const unsubProgress = onSyncProgressChange(() => {
       const progress = getSyncProgress();
-      setSyncProgressState(progress);
+      setSyncProgress(progress);
       if (isTerminalStage(progress.stage)) {
         setSyncing(false);
         setLoading(false);
@@ -236,7 +235,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setStatus(msg);
     setSyncing(false);
     setLoading(false);
-    setSyncProgress({ running: false, stage: "" });
+    setStoredSyncProgress({ running: false, stage: "" });
   };
 
   const handleSync = async () => {
@@ -248,7 +247,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setSyncing(true);
     setStatus("");
     setPreview(null);
-    setSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
+    setStoredSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
       // Skip Preview takes the per-unit pipeline (start_sync) — incremental
       // shortcut delivery, per-unit crash safety, no upfront full library
@@ -281,7 +280,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setPreview(null);
     setLoading(true);
     setSyncing(true);
-    setSyncProgress({ running: true, stage: "applying", message: "Applying changes..." });
+    setStoredSyncProgress({ running: true, stage: "applying", message: "Applying changes..." });
     try {
       const result = await syncApplyDelta(previewId);
       if (!result.success) {

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -20,13 +20,26 @@ export interface CollectionSyncSetting {
   category: "favorites" | "user" | "franchise";
 }
 
+export type SyncStage =
+  | "discovering"
+  | "fetching"
+  | "applying"
+  | "finalizing"
+  | "done"
+  | "cancelled"
+  | "error";
+
 export interface SyncProgress {
   running: boolean;
-  phase?: string;
+  stage?: SyncStage | "";
+  /** Fine: items processed within the current unit. */
   current?: number;
+  /** Fine: total items in the current unit. */
   total?: number;
   message?: string;
+  /** Coarse: current unit index (1-based) driving the determinate main bar. */
   step?: number;
+  /** Coarse: total units. ``0`` means indeterminate. */
   totalSteps?: number;
 }
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -146,7 +146,7 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
 
       updateSyncProgress({
         running: true,
-        phase: "applying",
+        stage: "applying",
         current: 0,
         total,
         message: `${data.unit_name}: 0/${total}`,

--- a/src/utils/syncProgress.ts
+++ b/src/utils/syncProgress.ts
@@ -4,29 +4,42 @@
  * Updated by:
  *   - sync_progress events from the backend (persistent listener in index.tsx)
  *   - syncManager.ts during the frontend applying phase
+ *   - MainPage on mount via getSyncStatus() (backend-authoritative seed)
+ *   - MainPage on handleSync click (optimistic running:true)
  *
  * Read by:
- *   - MainPage.tsx via a cheap setInterval (no callable round-trips)
+ *   - MainPage.tsx, which subscribes via onSyncProgressChange and re-renders
+ *     on every notify (no setInterval polling).
  */
 
 import type { SyncProgress } from "../types";
 
 let _progress: SyncProgress = {
   running: false,
-  phase: "",
+  stage: "",
   current: 0,
   total: 0,
   message: "",
 };
+let _listeners: Array<() => void> = [];
 
 export function setSyncProgress(p: SyncProgress): void {
   _progress = p;
+  _listeners.forEach((fn) => fn());
 }
 
 export function updateSyncProgress(p: Partial<SyncProgress>): void {
   _progress = { ..._progress, ...p };
+  _listeners.forEach((fn) => fn());
 }
 
 export function getSyncProgress(): SyncProgress {
   return _progress;
+}
+
+export function onSyncProgressChange(fn: () => void): () => void {
+  _listeners.push(fn);
+  return () => {
+    _listeners = _listeners.filter((l) => l !== fn);
+  };
 }

--- a/tests/domain/test_sync_stage.py
+++ b/tests/domain/test_sync_stage.py
@@ -1,0 +1,33 @@
+"""Tests for the SyncStage enum — the on-the-wire stage vocabulary."""
+
+import pytest
+
+from domain.sync_stage import SyncStage
+
+
+class TestSyncStageWireValues:
+    """Member values must equal the exact strings the frontend expects."""
+
+    @pytest.mark.parametrize(
+        ("member", "expected"),
+        [
+            (SyncStage.DISCOVERING, "discovering"),
+            (SyncStage.FETCHING, "fetching"),
+            (SyncStage.APPLYING, "applying"),
+            (SyncStage.FINALIZING, "finalizing"),
+            (SyncStage.DONE, "done"),
+            (SyncStage.CANCELLED, "cancelled"),
+            (SyncStage.ERROR, "error"),
+        ],
+    )
+    def test_member_value(self, member, expected):
+        assert member.value == expected
+
+    def test_str_mixin_serializes_to_value(self):
+        """``str``-based members coerce straight onto the wire dict."""
+        assert SyncStage(SyncStage.APPLYING).value == "applying"
+        assert SyncStage("done") is SyncStage.DONE
+
+    def test_unknown_value_rejected(self):
+        with pytest.raises(ValueError):
+            SyncStage("roms")

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -335,3 +335,124 @@ class TestFinalizePerUnitRun:
         assert plugin._state["last_sync"] is not None
         assert plugin._state["last_synced_platforms"] == ["N64"]
         assert plugin._state["last_synced_collections"] == ["Faves"]
+
+    @pytest.mark.asyncio
+    async def test_prunes_stale_rom_ids_from_registry(self, plugin, tmp_path, monkeypatch):
+        """stale_rom_ids must be popped from the registry and the pruned registry persisted."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        saved = []
+        monkeypatch.setattr(plugin._sync_service._reporter._state_persister, "save_state", lambda: saved.append(True))
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+            "3": {"app_id": 1003, "name": "C", "platform_name": "GBA", "platform_slug": "gba"},
+        }
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1},
+            total_games=1,
+            stale_rom_ids=[2, 3],
+        )
+
+        assert set(plugin._state["shortcut_registry"].keys()) == {"1"}
+        assert saved == [True]
+
+    @pytest.mark.asyncio
+    async def test_stale_prune_excludes_pruned_from_collections(self, plugin, tmp_path):
+        """Collections are built from the pruned registry — stale ROMs do not appear."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+        plugin.settings["collection_create_platform_groups"] = True
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+        }
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1, 2},
+            total_games=1,
+            stale_rom_ids=[2],
+        )
+
+        collections_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_collections"]
+        payload = collections_events[0][0][1]
+        assert set(payload["platform_app_ids"].keys()) == {"N64"}
+
+    @pytest.mark.asyncio
+    async def test_no_prune_when_stale_rom_ids_default(self, plugin, tmp_path):
+        """Default stale_rom_ids=None prunes nothing — backward-compat with non-pruning callers."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+        }
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1, 2},
+            total_games=2,
+        )
+
+        assert set(plugin._state["shortcut_registry"].keys()) == {"1", "2"}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_path_does_not_prune(self, plugin, tmp_path):
+        """Cancelled finalize passes stale_rom_ids=[] — registry stays intact."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+        }
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1, 2},
+            total_games=2,
+            cancelled=True,
+            stale_rom_ids=[],
+        )
+
+        assert set(plugin._state["shortcut_registry"].keys()) == {"1", "2"}
+
+    @pytest.mark.asyncio
+    async def test_get_sync_stats_reflects_pruned_count(self, plugin, tmp_path):
+        """After a normal finalize prunes stale entries, get_sync_stats reports the pruned count."""
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        decky.emit.reset_mock()
+
+        plugin._state["shortcut_registry"] = {
+            "1": {"app_id": 1001, "name": "A", "platform_name": "N64", "platform_slug": "n64"},
+            "2": {"app_id": 1002, "name": "B", "platform_name": "SNES", "platform_slug": "snes"},
+            "3": {"app_id": 1003, "name": "C", "platform_name": "GBA", "platform_slug": "gba"},
+        }
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={},
+            pending_platform_rom_ids={1},
+            total_games=1,
+            stale_rom_ids=[2, 3],
+        )
+
+        stats = await plugin.get_sync_stats()
+        assert stats["roms"] == 1
+        assert stats["total_shortcuts"] == 1

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -520,7 +520,7 @@ class TestFinishSync:
 
         assert plugin._sync_service._sync_state == SyncState.IDLE
         assert plugin._sync_service._sync_progress["running"] is False
-        assert plugin._sync_service._sync_progress["phase"] == "cancelled"
+        assert plugin._sync_service._sync_progress["stage"] == "cancelled"
         assert plugin._sync_service._sync_progress["message"] == "Sync cancelled"
 
     @pytest.mark.asyncio
@@ -534,6 +534,38 @@ class TestFinishSync:
         await plugin._sync_service._orchestrator._finish_sync("Sync cancelled")
 
         assert plugin._sync_service._current_sync_id is None
+
+
+class TestGetSyncStatus:
+    """Backend-authoritative sync status query.
+
+    ``get_sync_status`` returns the persisted progress snapshot so a
+    freshly remounted QAM can recover in-flight state without waiting on
+    a live ``sync_progress`` event.
+    """
+
+    def test_returns_idle_default_when_no_sync(self, plugin):
+        status = plugin._sync_service.get_sync_status()
+        assert status["running"] is False
+        assert status["stage"] == ""
+
+    def test_returns_live_snapshot_mid_sync(self, plugin):
+        snapshot = {
+            "running": True,
+            "stage": "applying",
+            "current": 3,
+            "total": 10,
+            "message": "N64 (1/2)",
+            "step": 1,
+            "totalSteps": 2,
+        }
+        plugin._sync_service._sync_progress = snapshot
+
+        status = plugin._sync_service.get_sync_status()
+
+        assert status == snapshot
+        assert status["running"] is True
+        assert status["stage"] == "applying"
 
 
 class TestSyncPreviewErrorHandling:
@@ -951,6 +983,96 @@ class TestDoSyncPerUnit:
         assert len(complete_events) == 1
         assert complete_events[0].get("cancelled") is True
 
+    @pytest.mark.asyncio
+    async def test_normal_completion_emits_finalizing_running(self, plugin, fake_romm_api):
+        """A normal-completion run emits a non-terminal finalizing snapshot
+        after the unit loop, before the reporter's terminal done emit."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        finalizing = [
+            c.args[1]
+            for c in decky.emit.call_args_list
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "finalizing"
+        ]
+        assert len(finalizing) == 1
+        assert finalizing[0]["running"] is True
+        # The terminal done snapshot still follows it (running:false).
+        done = [
+            c.args[1]
+            for c in decky.emit.call_args_list
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "done"
+        ]
+        assert len(done) == 1
+        assert done[0]["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_cancelled_run_does_not_emit_finalizing(self, plugin, fake_romm_api):
+        """A cancelled run skips the finalizing snapshot — its terminal emit
+        is the reporter's cancelled snapshot."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        _seed_platform(
+            fake_romm_api,
+            platform_id=2,
+            name="GBA",
+            slug="gba",
+            roms=[{"id": 20, "name": "B"}],
+        )
+        plugin._state["last_sync"] = None
+        plugin._state["shortcut_registry"] = {}
+        plugin.settings["enabled_platforms"] = {"1": True, "2": True}
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def fake_wait(_u, event):
+            event.set()
+            plugin._sync_service._sync_state = SyncState.CANCELLING
+            return {}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        finalizing = [
+            c.args[1]
+            for c in decky.emit.call_args_list
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "finalizing"
+        ]
+        assert finalizing == []
+
 
 class TestWaitForUnitComplete:
     """Heartbeat-based per-unit timeout."""
@@ -1131,10 +1253,10 @@ class TestDoSyncPerUnitErrors:
         # _finish_sync transitioned to IDLE + cleared sync id.
         assert plugin._sync_service._sync_state == SyncState.IDLE
         assert plugin._sync_service._current_sync_id is None
-        progress_phases = [
-            c.args[1].get("phase") for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_progress"
+        progress_stages = [
+            c.args[1].get("stage") for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_progress"
         ]
-        assert "cancelled" in progress_phases
+        assert "cancelled" in progress_stages
 
     @pytest.mark.asyncio
     async def test_build_work_queue_general_exception_emits_error(self, plugin, fake_romm_api):
@@ -1155,7 +1277,7 @@ class TestDoSyncPerUnitErrors:
         error_events = [
             c
             for c in decky.emit.call_args_list
-            if c.args and c.args[0] == "sync_progress" and c.args[1].get("phase") == "error"
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "error"
         ]
         assert len(error_events) >= 1
         assert plugin._sync_service._sync_state == SyncState.IDLE
@@ -1187,7 +1309,7 @@ class TestDoSyncPerUnitErrors:
         error_events = [
             c
             for c in decky.emit.call_args_list
-            if c.args and c.args[0] == "sync_progress" and c.args[1].get("phase") == "error"
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "error"
         ]
         assert len(error_events) >= 1
         assert "Sync failed" in error_events[0].args[1]["message"]
@@ -1246,7 +1368,7 @@ class TestDoSyncPerUnitErrors:
         error_events = [
             c
             for c in decky.emit.call_args_list
-            if c.args and c.args[0] == "sync_progress" and c.args[1].get("phase") == "error"
+            if c.args and c.args[0] == "sync_progress" and c.args[1].get("stage") == "error"
         ]
         assert len(error_events) >= 1
         assert plugin._sync_service._sync_state == SyncState.IDLE

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -902,6 +902,51 @@ class TestDoSyncPerUnit:
         assert stale_events[0] == {"remove_rom_ids": []}
 
     @pytest.mark.asyncio
+    async def test_stale_entries_pruned_from_registry_after_finalize(self, plugin, fake_romm_api):
+        """End-to-end: a stale registry entry (disabled platform) is removed from the
+        backend registry during finalize, not just from the frontend via ``sync_stale``.
+
+        Regression for the inflated ``get_sync_stats`` count: the orchestrator emits
+        ``sync_stale`` so the frontend drops the shortcut, and the reporter now also
+        prunes the same rom_ids from ``shortcut_registry`` so ``len(registry)`` matches
+        the still-synced ROMs.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # rom_id 10 is the live N64 ROM (synced this run). rom_id 99 is a leftover
+        # from a now-disabled platform — present in the registry but in no enabled unit.
+        plugin._state["last_sync"] = "2025-01-01T00:00:00Z"
+        plugin._state["shortcut_registry"] = {
+            "10": {"name": "A", "fs_name": "a.z64", "platform_name": "N64", "platform_slug": "n64", "app_id": 1000},
+            "99": {"name": "Z", "fs_name": "z.gba", "platform_name": "GBA", "platform_slug": "gba", "app_id": 9900},
+        }
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = AsyncMock(return_value={})
+        plugin._sync_service._reporter.commit_unit_results = AsyncMock()  # type: ignore[method-assign]
+        plugin._sync_service._sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # Frontend was told to remove rom_id 99.
+        stale_events = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert stale_events == [{"remove_rom_ids": [99]}]
+
+        # Backend registry was pruned to match — only the synced ROM remains.
+        assert set(plugin._state["shortcut_registry"].keys()) == {"10"}
+
+        # get_sync_stats reflects the pruned count, not the pre-sync inflated count.
+        stats = await plugin.get_sync_stats()
+        assert stats["roms"] == 1
+        assert stats["total_shortcuts"] == 1
+
+    @pytest.mark.asyncio
     async def test_downloads_artwork_when_not_skipped(self, plugin, fake_romm_api):
         import decky
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -691,6 +691,7 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_registry_platforms",
     "report_removal_results",
     "get_artwork_base64",
+    "get_sync_status",
     "get_sync_stats",
     "get_rom_by_steam_app_id",
     "get_download_queue",

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -332,6 +332,13 @@ class TestLibrarySyncCallableDelegation:
         assert result == {"applied": True}
 
     @pytest.mark.asyncio
+    async def test_get_sync_status_delegates(self, plugin):
+        plugin._sync_service.get_sync_status.return_value = {"running": True, "stage": "applying"}
+        result = await plugin.get_sync_status()
+        plugin._sync_service.get_sync_status.assert_called_once_with()
+        assert result == {"running": True, "stage": "applying"}
+
+    @pytest.mark.asyncio
     async def test_report_unit_results_delegates(self, plugin):
         plugin._sync_service.report_unit_results = AsyncMock(return_value={"ok": True})
         result = await plugin.report_unit_results({"1": 100})


### PR DESCRIPTION
Closes #751.

## Problem

During a library sync the QAM showed no progress indicator and the Sync button stayed enabled. Re-pressing it only surfaced "Sync already in progress" with no other signal.

Three root causes:

1. **Teardown race** — `MainPage` polled the module store every 250ms. Right after `await startSync()` the store was still `running:false` (events hadn't landed yet), so the first poll tick tore down the syncing UI and re-enabled the button.
2. **Name collision** — `handleSync`'s optimistic `running:true` went into a local `useState` setter that shadowed the module-store `setSyncProgress`, so the value the poll read never flipped.
3. **No authoritative status query** — the module store was the only source of truth, fed solely by live events, so recovery was brittle and there was nothing to reconcile against.

## Approach

Make the **backend authoritative** for sync status and overhaul the frontend progress UI to a two-level determinate model.

### Backend
- New `SyncStage` enum (`domain/sync_stage.py`) replaces the loose phase strings.
- `_emit_progress` unified on `stage` + consistent coarse `step`/`totalSteps` (unit index / total units).
- New `get_sync_status()` callable returns the already-persisted `box.sync_progress` snapshot — no new state, just exposing what the orchestrator already tracks.
- `FINALIZING` (running:true) is now emitted before the finalize phase on normal completions (skipped on cancel).

### Frontend
- `syncProgress` store converted to subscribe/notify (matching `migrationStore`/`downloadStore`); the 250ms poll is gone, so the teardown race is structurally eliminated.
- `MainPage` seeds from `get_sync_status()` on mount → progress stays correct after closing and reopening the QAM mid-sync.
- Sync button disabled optimistically on click and while `running`; the syncing UI tears down only on a terminal stage (`done`/`cancelled`/`error`), and the module store is reset on failed starts.
- Two-level UI: determinate main bar (unit X of N) + fine within-unit detail line + stage label.

## Known limitation

Across a full plugin reload (Python restart, not just QAM close) mid-applying, the in-flight unit can't be resumed — the backend's heartbeat times that unit out. `get_sync_status()` still lets the reloaded frontend show the truthful state instead of a blank one, and the QAM close/reopen case (no Python restart) recovers exactly.

## Tests
- Backend: new `tests/domain/test_sync_stage.py`; `get_sync_status` idle + mid-sync; `finalizing` emitted on normal completion and not on cancel; callable delegation.
- Frontend: `MainPage.test.tsx` recovery rewritten for `getSyncStatus()`; added regression tests for terminal-stage teardown, the race (bare `running:false` does not tear down), optimistic disable, and subscription cleanup.

All green: 2588 pytest, 996 vitest, build/lint/basedpyright/import-linter clean.


---

## Additional fix (bundled): stale ROMs not pruned from `shortcut_registry`

While verifying on-device I noticed the Library stats over-counted ROMs (showed 133 for an 88-ROM library). Root cause: when a platform is disabled (or a ROM is removed server-side), the sync emits `sync_stale` so the frontend removes the Steam shortcuts — but the backend never removed those rom_ids from `shortcut_registry`. The registry grew across syncs, so `get_sync_stats` returned `len(registry)` = stale total, and every sync re-emitted the same stale removals.

`finalize_per_unit_run` now prunes the computed `stale_rom_ids` from the registry before building collection maps and persisting state (non-cancelled path only). A registry entry holds only shortcut bookkeeping (app_id, cover_path, ids) — no peer/save-sync data — so pruning loses nothing. Self-heals on the next sync.
