### PR TITLE
ci(release): author release-please PRs with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,21 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Mint a GitHub App installation token so release-please's PR/branch
+      # pushes are authored by the App, not GITHUB_TOKEN. Pushes made with
+      # GITHUB_TOKEN do not trigger workflows (anti-recursion), which left
+      # the release PR's required status checks stuck "Expected" and
+      # unmergeable. An App token makes those checks run automatically.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Why

release-please pushed its PR branch with the default `GITHUB_TOKEN`. GitHub does not trigger workflows for events caused by `GITHUB_TOKEN` pushes (anti-recursion). Once the required status checks (`test`/`build`/`lint`/`markdownlint`/`commitlint`) were added to the `main` ruleset (17 May), release PRs got stuck — those checks stayed `Expected` forever and the PR could only be merged via a close/reopen workaround. (Verified: old release PR #267 had only CodeQL/Analyze check-runs — the CI-workflow jobs never ran on it; it merged only because those checks weren't required yet.)

## What

Mint a GitHub App installation token via `actions/create-github-app-token@v2` and pass it to release-please as `token:`. Its pushes are then App-authored, so CI runs automatically on the release PR.

No new merge path: the App only opens/updates the release PR — merging `main` still requires a human with write access.

## Required setup (before this is useful)

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New):
   - Repository permissions: **Contents: Read & write**, **Pull requests: Read & write**.
   - No webhook needed.
2. **Install the App** on `danielcopper/decky-romm-sync`.
3. **Generate a private key** for the App (downloads a `.pem`).
4. **Add two repo secrets** (Settings → Secrets and variables → Actions):
   - `RELEASE_PLEASE_APP_ID` — the App's numeric App ID.
   - `RELEASE_PLEASE_APP_PRIVATE_KEY` — the full contents of the `.pem`.

Once the secrets exist and this is merged, the next release PR's checks will run on their own.
