### PR TITLE
fix(saves): show focus outline on slot wizard buttons

### DIFF
--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -153,6 +153,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         <div className="romm-panel-section-title">Save Slot Setup</div>
         <div style={{ color: "#d4513f", fontSize: "12px", marginBottom: "8px" }}>{error}</div>
         <DialogButton
+          className="romm-wizard-btn"
           style={btnStyle}
           onClick={() => {
             setError(null);
@@ -240,6 +241,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             </div>
           </div>
           <DialogButton
+            className="romm-wizard-btn"
             style={btnStyle}
             onClick={() => handleConfirm(s.slot ?? defaultSlot)}
             onFocus={scrollFocusedToCenter}
@@ -269,6 +271,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       </div>,
       <div key="default-btn" style={{ marginBottom: "6px" }}>
         <DialogButton
+          className="romm-wizard-btn romm-wizard-btn-primary"
           style={btnPrimaryStyle}
           onClick={() => handleConfirm(defaultSlot)}
           onFocus={scrollFocusedToCenter}
@@ -282,6 +285,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
   rightChildren.push(
     <div key="custom-toggle">
       <DialogButton
+        className="romm-wizard-btn"
         style={btnStyle}
         onFocus={scrollFocusedToCenter}
         onClick={() => {

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -55,6 +55,22 @@ export function hideNativePlaySection(playSectionClass: string) {
   outline: 2px solid #1a9fff;
   outline-offset: 2px;
 }
+.romm-wizard-btn:hover,
+.romm-wizard-btn:focus,
+.romm-wizard-btn.gpfocus {
+  background: rgba(255, 255, 255, 0.1) !important;
+  border-color: rgba(255, 255, 255, 0.7) !important;
+  outline: 2px solid #1a9fff !important;
+  outline-offset: 2px;
+}
+.romm-wizard-btn-primary:hover,
+.romm-wizard-btn-primary:focus,
+.romm-wizard-btn-primary.gpfocus {
+  background: rgba(26, 159, 255, 0.3) !important;
+  border-color: rgba(26, 159, 255, 0.9) !important;
+  outline: 2px solid #1a9fff !important;
+  outline-offset: 2px;
+}
 @keyframes romm-spin {
   to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- Inline `btnStyle` / `btnPrimaryStyle` overrode `DialogButton`'s default focus visualization, and Steam doesn't auto-apply `.gpfocus` to plugin DialogButtons — focused wizard buttons gave no visual cue during controller navigation.
- Adds `.romm-wizard-btn` / `.romm-wizard-btn-primary` to `styleInjector.ts` with `:hover`, `:focus`, and `.gpfocus` triggers (blue outline + brighter border/background) and applies them to each wizard button in `SlotSetupWizard.tsx`.

Closes #757

## Test plan
- [x] `pnpm test src/components/SlotSetupWizard.test.tsx` — 33/33 pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — no new warnings
- [x] Manual: game with no slot configured, navigate wizard buttons with controller in Game Mode → focused button shows blue outline + brighter border/background