### PR TITLE
chore: claude.md aggregates section + docs-in-pr enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,11 @@
 - [ ] `python -m pytest tests/ -q`
 - [ ] Manual QA on Steam Deck if UI changed
 
+## Docs
+
+- [ ] `docs/` updated in this PR
+- [ ] OR: opting out — `no-docs-change` label set / reason in Notes (pure refactor, tooling, dep bump, etc.)
+
 ## Notes
 
 <optional — follow-ups, tradeoffs, links to tracking issues, anything that doesn't fit above>

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,95 @@
+name: docs-check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-required:
+    name: Docs updated in same PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine if docs are required
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          # --- Opt-out: label ---
+          if echo "$PR_LABELS_JSON" | grep -q '"no-docs-change"'; then
+            echo "::notice::Skipping docs check — 'no-docs-change' label is set."
+            exit 0
+          fi
+
+          # --- Opt-out: PR body marker ---
+          if echo "${PR_BODY:-}" | grep -iqE 'docs:[[:space:]]*n/?a'; then
+            echo "::notice::Skipping docs check — PR description marks 'docs: N/A'."
+            exit 0
+          fi
+
+          # --- Changed files in this PR ---
+          mapfile -t changed < <(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          if [[ ${#changed[@]} -eq 0 ]]; then
+            echo "::notice::No files changed."
+            exit 0
+          fi
+
+          # --- Skip list: paths that don't require docs updates ---
+          # Inverse approach: everything triggers docs requirement UNLESS it matches this list.
+          # New file paths default to "needs docs" — additions to the skip list are explicit.
+          skip_re='^(tests|scripts|\.github|\.claude|\.worktrees)/'
+          skip_files_re='^(coverage\.json|mise\.toml|pyproject\.toml|pnpm-lock\.yaml|package-lock\.json|\.gitignore|\.editorconfig|\.gitattributes|LICENSE|CLAUDE\.md|MEMORY\.md|README\.md)$'
+
+          requires_docs=()
+          docs_touched=false
+
+          for file in "${changed[@]}"; do
+            if [[ "$file" =~ ^docs/ ]]; then
+              docs_touched=true
+              continue
+            fi
+            if [[ "$file" =~ $skip_re ]] || [[ "$file" =~ $skip_files_re ]]; then
+              continue
+            fi
+            requires_docs+=("$file")
+          done
+
+          if [[ ${#requires_docs[@]} -eq 0 ]]; then
+            echo "::notice::No doc-requiring paths changed. OK."
+            exit 0
+          fi
+
+          if [[ "$docs_touched" == "true" ]]; then
+            echo "::notice::Source changed AND docs/ updated. OK."
+            echo "Source files:"
+            printf '  - %s\n' "${requires_docs[@]}" | head -20
+            exit 0
+          fi
+
+          echo "::error::PR touches source code but no docs/ updates and no opt-out marker."
+          echo ""
+          echo "Source files changed that require docs updates:"
+          printf '  - %s\n' "${requires_docs[@]}" | head -20
+          if [[ ${#requires_docs[@]} -gt 20 ]]; then
+            echo "  ... and $(( ${#requires_docs[@]} - 20 )) more"
+          fi
+          echo ""
+          echo "Options:"
+          echo "  1. Update the relevant docs/ pages in this PR"
+          echo "  2. If genuinely doc-irrelevant: add the 'no-docs-change' label to this PR"
+          echo "  3. OR include 'docs: N/A' (with a one-line reason) in the PR description"
+          echo ""
+          echo "See CLAUDE.md > Documentation for the full rule."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,11 @@ A Decky Loader plugin that syncs a self-hosted RomM library into Steam as Non-St
 
 ## Documentation
 
-The docs live in `docs/` and are the canonical source for architecture, file structure, and feature documentation. They are built with **Material for MkDocs** and published to GitHub Pages (<https://danielcopper.github.io/decky-romm-sync/>) by `.github/workflows/docs.yml` on every push to `main`. Because the docs sit in this repo, doc updates are reviewed in the same PR as the code change — when a change affects architecture, data flows, or feature behavior, update the relevant page under `docs/` in that same PR. Preview locally with `mise run docs`.
+**Docs are updated in the same PR as the code change. This is not optional.** When a change affects architecture, data flows, feature behavior, or user-facing UI, the relevant page under `docs/` must be updated in the same PR. Documentation-debt-as-a-separate-follow-up-issue is forbidden — those follow-ups never land. If you're not sure whether a change needs docs, the default is "yes, it does." Enforced in CI by `.github/workflows/docs-check.yml`.
 
-Layout mirrors the three nav tabs: `docs/user-guide/` (end users), `docs/architecture/` (how it works), `docs/contributing/` (dev setup). The old GitHub Wiki is retired — it only redirects to the published site.
+The docs live in `docs/` and are the canonical source for architecture, file structure, and feature documentation. Built with **Material for MkDocs** and published to GitHub Pages (<https://danielcopper.github.io/decky-romm-sync/>) by `.github/workflows/docs.yml` on every push to `main`. Layout mirrors the three nav tabs: `docs/user-guide/` (end users), `docs/architecture/` (how it works), `docs/contributing/` (dev setup). The old GitHub Wiki is retired — it only redirects to the published site. Preview locally with `mise run docs`.
+
+For genuinely doc-irrelevant PRs (pure refactor with no user-visible change, no architecture shift, no new flow; tooling/CI changes; dependency bumps), set the `no-docs-change` label on the PR OR include `docs: N/A` (with a one-line reason) in the PR description. The default posture is "docs needed"; opting out is an explicit acknowledgement, not a silent omission. The CI check enforces this.
 
 ## Key Technical Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,13 @@ Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pur
 
 **Domain**: `[CP]` Pure compute only. No I/O, no state mutation, no service or adapter imports. Functions take inputs, return outputs. Anything stateless and I/O-free that's currently in a service belongs here. (Canonical domain-model purity.)
 
+**Aggregates** (CP chapters 1–7 scope — locked in #788, applies as the SQLite migration #271 lands):
+
+- `[CP]` One Repository Protocol per aggregate root, not per table. Aggregate boundaries are domain-modeling decisions; table layout is downstream and may need multiple tables to back one aggregate.
+- `[CP]` Aggregate methods are the **only** mutation API for the aggregate's state. No external field assignment (`aggregate.field = value`) from services. Services call methods; methods enforce invariants and update internal state. Field access for reads is fine.
+- `[ours]` **Mutation methods are verb-named after the domain event they conceptually represent.** `adopt_baseline(filename, hash)` not `update_baseline(...)`. `mark_installed(path)` not `set_installed(...)`. `promote_slot(slot, source)` not `update_slot_source(...)`. Why: intent-revealing names encode what *happened*, not which fields changed; the method name becomes the implicit event name (`BaselineAdopted`, `Installed`, `SlotPromoted`) if/when chapter 8+ events get added in a follow-up epic. Free refactor seam, zero cost now.
+- `[ours]` Chapter 8+ (domain events + message bus) is explicitly **out of scope** for the current SQLite epic. Trigger for revisiting: handler diversity ≥3 kinds for the same aggregate state change, OR a non-Steam consumer (CLI/web/etc.) becomes concrete, OR a telemetry/analytics layer needs to subscribe.
+
 **Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place where concrete adapters meet services. (Canonical CP composition root.)
 
 - `[ours]` `WiringConfig` holds the wiring; protocols come in, services come out. Adapter instantiation never happens in `main.py` — if a service needs a Protocol-wrapped persister, the wrapper adapter is built in `bootstrap()` and passed through `CallbackBundle`. (Our concrete shape for the composition root.)


### PR DESCRIPTION
## Summary

Two independent commits bundled into one PR (both touch CLAUDE.md and `.github/`):

**Commit 1 — `chore(claude.md): add aggregates section`**

Adds an Aggregates subsection under the Cosmic Python rules. Prep work for #788 (aggregate identification sub-issue of the #271 SQLite migration epic). Locks four conventions: one Repository per aggregate root (not per table), aggregate methods are the only mutation API, verb-naming discipline for mutation methods (free refactor seam to future events), and chapter 7 stopping point with explicit triggers to revisit chapter 8+ later.

**Commit 2 — `chore(docs): enforce docs-in-pr rule`**

Three layers of enforcement for the long-standing 'update docs in same PR' rule:

- **CLAUDE.md Documentation section rewritten** — leads with mandatory rule, explicit opt-out mechanism, references the CI check as the enforcement boundary.
- **PR template adds Docs checklist section** — author must consciously check or opt out.
- **New \`.github/workflows/docs-check.yml\`** — CI check that fails PRs touching source code without docs/ updates AND no opt-out. Inverse skip-list approach (everything triggers docs requirement unless explicitly skipped — new file paths default to 'needs docs').

Opt-outs supported by the CI check:
- \`no-docs-change\` label on the PR
- \`docs: N/A\` (with reason) in PR description

## Test plan

- [x] CI check passes on this PR (all paths touched are skip-listed: CLAUDE.md, .github/)
- [ ] After merge, manual test: open a follow-up PR that touches \`py_modules/services/\` without docs — verify check fails; then add \`no-docs-change\` label — verify check passes

## Docs

- [x] \`docs: N/A\` — pure architecture-conventions + CI tooling change, no user-facing or architecture-doc surface affected

## Notes

Part of the epic-revision work captured during the #271 SQLite migration planning session. The Aggregates conventions land here so that #788 can build on them without re-litigating discipline.