### PR TITLE
chore(templates): soften required fields, fix wiki link, add discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,31 +4,16 @@ title: "bug: "
 labels: ["bug"]
 assignees: ["danielcopper"]
 body:
-  - type: textarea
-    id: repro
+  - type: markdown
     attributes:
-      label: Repro steps
-      description: Numbered steps that reproduce the bug from a known-good state.
-      placeholder: |
-        1. Open QAM > Decky > RomM Sync
-        2. Click "Sync Library"
-        3. ...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      description: What you expected to happen.
-    validations:
-      required: true
+      value: |
+        Required fields are the minimum for triage. Optional fields make things significantly easier to act on — please fill what you can, but **don't skip the report just because you can't fill everything**.
 
   - type: textarea
     id: actual
     attributes:
-      label: Actual behavior
-      description: What actually happened. Include error messages verbatim.
+      label: What happened
+      description: What actually happened. Include error messages verbatim if any.
     validations:
       required: true
 
@@ -36,35 +21,55 @@ body:
     id: plugin-version
     attributes:
       label: Plugin version
-      description: Shown in the QAM panel header, or read from plugin.json.
-      placeholder: "0.5.4"
+      description: Shown in the QAM panel header. Required for triage.
+      placeholder: "0.18.0"
     validations:
       required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Numbered steps that reproduce the bug from a known-good state. Even a one-line description of what you were doing helps.
+      placeholder: |
+        1. Open QAM > Decky > RomM Sync
+        2. Click "Sync Library"
+        3. ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen. Skip if it's obvious from "What happened".
+    validations:
+      required: false
 
   - type: input
     id: retrodeck-version
     attributes:
       label: RetroDECK version
-      description: Shown in the RetroDECK Configurator, or read from the Flatpak metadata.
+      description: Shown in the RetroDECK Configurator. If you can't find it quickly, leave blank.
       placeholder: "0.9.0b"
     validations:
-      required: true
+      required: false
 
   - type: input
     id: decky-version
     attributes:
       label: Decky Loader version
-      description: Shown in the Decky settings panel.
+      description: Shown in the Decky settings panel. If you can't find it quickly, leave blank.
       placeholder: "3.0.5"
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: logs
     attributes:
       label: Log excerpt
       description: |
-        Optional. Plugin logs live at `~/homebrew/logs/decky-romm-sync/`. Set log level to "debug" in plugin settings for full output. Decky Loader logs are in `~/homebrew/services/PluginLoader/`.
+        Plugin logs live at `~/homebrew/logs/decky-romm-sync/`. Set log level to "debug" in plugin settings for full output. Decky Loader logs are in `~/homebrew/services/PluginLoader/`.
       render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Wiki
-    url: https://github.com/danielcopper/decky-romm-sync/wiki
-    about: Architecture, file structure, and feature documentation
+  - name: Documentation
+    url: https://danielcopper.github.io/decky-romm-sync/
+    about: Architecture, file structure, user guide, and contributing docs
+  - name: Discussions
+    url: https://github.com/danielcopper/decky-romm-sync/discussions
+    about: Questions, ideas, and general conversation that aren't bug reports or specific feature requests

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,6 +4,11 @@ title: "feat: "
 labels: ["enhancement"]
 assignees: ["danielcopper"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Required fields are the minimum for triage. Optional fields make things significantly easier to act on — please fill what you can, but **don't skip the report just because you can't fill everything**.
+
   - type: textarea
     id: problem
     attributes:
@@ -16,9 +21,9 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: How should the plugin behave? Sketch the UX or the API surface.
+      description: How should the plugin behave? Sketch the UX or the API surface. If you have ideas, share them — if not, leave blank and we'll figure it out.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: alternatives


### PR DESCRIPTION
## Summary

Closes #756.

Softens required-field constraints on issue templates, fixes a broken contact link, adds GitHub Discussions.

**Bug report** — required dropped from 6 fields to 2 ('What happened' + Plugin version). Repro steps, expected behavior, RetroDECK version, Decky Loader version, and logs are all optional now with placeholders encouraging best-effort fill. Reordered so the two required fields come first. Renamed 'Actual behavior' → 'What happened' (plainer English).

**Feature request** — required dropped from 2 to 1 (just Problem). Proposed solution is now optional with placeholder 'if you have ideas, otherwise we'll figure it out'.

**config.yml** — fixed broken Wiki contact link (Wiki is retired per CLAUDE.md, only redirects) → now points at the published docs site. Added a Discussions contact link as the canonical home for questions and general conversation. Discussions enabled at the repo level alongside this PR.

**Top-of-form note** added to both bug + feature templates: required = minimum for triage; optional fields help significantly, but don't skip the report just because you can't fill everything.

Three drivers addressed:
- **Driver A** (abandonment from long forms): floor 6 → 2 on bug report
- **Driver B** (junk fills on redundant required fields): redundant fields now optional with realistic placeholders
- **Driver C** (specific painful fields, esp. RetroDECK + Decky versions): version fields optional except plugin version

## Test plan

- [x] CI check passes on this PR (only touches \`.github/ISSUE_TEMPLATE/*\` — skip-listed)
- [ ] After merge, open the 'New issue' page on GitHub and verify both templates render correctly with the new required/optional split
- [ ] Verify Discussions tab is visible on the repo and the contact link routes to it

## Docs

- [x] \`docs: N/A\` — pure GitHub template + repo-settings change, no user-facing flow or architecture affected

Closes #756