### PR TITLE
fix(ci): skip docs-check on release-please file changes

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -50,7 +50,7 @@ jobs:
           # Inverse approach: everything triggers docs requirement UNLESS it matches this list.
           # New file paths default to "needs docs" — additions to the skip list are explicit.
           skip_re='^(tests|scripts|\.github|\.claude|\.worktrees)/'
-          skip_files_re='^(coverage\.json|mise\.toml|pyproject\.toml|pnpm-lock\.yaml|package-lock\.json|\.gitignore|\.editorconfig|\.gitattributes|LICENSE|CLAUDE\.md|MEMORY\.md|README\.md)$'
+          skip_files_re='^(coverage\.json|mise\.toml|pyproject\.toml|pnpm-lock\.yaml|package-lock\.json|package\.json|plugin\.json|\.gitignore|\.editorconfig|\.gitattributes|\.release-please-manifest\.json|CHANGELOG\.md|LICENSE|CLAUDE\.md|MEMORY\.md|README\.md)$'
 
           requires_docs=()
           docs_touched=false


### PR DESCRIPTION
## Summary

Release-please PRs touch only four files — `CHANGELOG.md`, `.release-please-manifest.json`, `package.json`, `plugin.json` — none of which were in `docs-check.yml`'s `skip_files_re`. Result: every release-please PR fails the docs check until manually labelled `no-docs-change` or marked `docs: N/A` in the body.

Closes #798.

## Fix

Extend `skip_files_re` with the four release-please paths. Symmetric with the existing exemptions (`pyproject.toml`, `pnpm-lock.yaml`, `package-lock.json` were already exempt — `package.json` was simply missed when #790 landed).

Tool-agnostic by design: any future automation that touches just these files (manual version bump, changelog regen) also bypasses correctly. No coupling to release-please's branch naming or label flow.

## Test plan

- [x] Diff matches intent: one-line skip-list extension, no logic change
- [ ] After merge, next release-please PR (whenever it appears) runs `docs-check` to "no doc-requiring paths changed. OK." and passes without manual intervention

docs: N/A — CI plumbing only, no user-facing or architectural change.