### PR TITLE
chore(dev): slim pre-commit hook + switch mise venv to uv

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Pre-commit hook: format and lint staged Python files with ruff.
-# On feature branches, also run basedpyright + pytest before allowing the commit.
-# Heavy checks are skipped when committing directly to main.
+# Pre-commit hook: format and lint staged Python files with ruff. Fast only —
+# heavy validation (basedpyright, lint-imports, cosmic bans, pytest) runs in CI
+# on PR push, not in the commit hook. Keep this hook fast (<2s) so commits don't
+# become friction; CI + branch protection is where correctness is enforced.
 
 # Find ruff — prefer Mason binary, fall back to PATH
 RUFF="${HOME}/.local/share/nvim/mason/bin/ruff"
@@ -13,8 +14,7 @@ if [ -z "$RUFF" ]; then
     exit 0
 fi
 
-# Get staged Python files. Hook exits early if no Python changed —
-# heavy checks below also skip in that case.
+# Get staged Python files. Hook exits early if no Python changed.
 STAGED=$(git diff --cached --name-only --diff-filter=ACM -- '*.py')
 if [ -z "$STAGED" ]; then
     exit 0
@@ -35,32 +35,4 @@ done
 if ! $RUFF check $STAGED; then
     echo "pre-commit: ruff found unfixable errors, aborting commit"
     exit 1
-fi
-
-# Heavy checks only on feature branches — skip when on main
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$BRANCH" = "main" ]; then
-    exit 0
-fi
-
-# basedpyright (full repo scan, ~10-20s)
-if command -v basedpyright >/dev/null 2>&1; then
-    echo "pre-commit: running basedpyright..."
-    if ! basedpyright; then
-        echo "pre-commit: basedpyright found errors, aborting commit"
-        exit 1
-    fi
-else
-    echo "pre-commit: basedpyright not in PATH, skipping type check"
-fi
-
-# pytest (full suite, ~1m)
-if command -v pytest >/dev/null 2>&1; then
-    echo "pre-commit: running pytest..."
-    if ! python -m pytest tests/ -q; then
-        echo "pre-commit: pytest failed, aborting commit"
-        exit 1
-    fi
-else
-    echo "pre-commit: pytest not in PATH, skipping tests"
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Roadmap and open work: [GitHub Projects board](https://github.com/users/danielco
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev` (build + restart plugin_loader)
 - **Tooling**: mise manages node, pnpm, python. Venv auto-activates via `_.python.venv` in mise.toml.
+- **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): runs `ruff format` + `ruff check` on staged Python files. Stays fast (<2s) so commits don't become friction — heavy validation (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR push, never in the commit hook. CI + branch protection enforces correctness; don't re-introduce heavy checks here.
 
 ## Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Roadmap and open work: [GitHub Projects board](https://github.com/users/danielco
 - **Coverage**: `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev` (build + restart plugin_loader)
-- **Tooling**: mise manages node, pnpm, python. Venv auto-activates via `_.python.venv` in mise.toml.
+- **Tooling**: mise manages node, pnpm, python, uv. Venv auto-creates at `.venv` (via `_.python.venv` in mise.toml) using uv as the underlying tool; `mise run setup` installs Python deps via `uv pip install` (uv is the canonical Python package manager in this project).
 - **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): runs `ruff format` + `ruff check` on staged Python files. Stays fast (<2s) so commits don't become friction — heavy validation (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR push, never in the commit hook. CI + branch protection enforces correctness; don't re-introduce heavy checks here.
 
 ## Code Quality

--- a/mise.toml
+++ b/mise.toml
@@ -2,13 +2,14 @@
 node = "lts"
 pnpm = "latest"
 python = "3.11"  # match Decky Loader's embedded Python (libpython3.11)
+uv = "latest"    # mise creates venvs via uv internally; expose it so the setup task can install deps without bootstrapping pip
 
 [env]
 _.python.venv = { path = ".venv", create = true }
 
 [tasks.setup]
 description = "Install JS and Python dependencies"
-run = ["pnpm install", "pip install -r requirements-dev.txt", "git config core.hooksPath .githooks"]
+run = ["pnpm install", "uv pip install -r requirements-dev.txt", "git config core.hooksPath .githooks"]
 
 [tasks.build]
 description = "Build frontend (dev: with source maps)"


### PR DESCRIPTION
## Summary

Two developer-tooling fixes in one PR — both about making local-dev infrastructure work properly so future contributors (and future-me) don't trip over the same things.

### 1. Slim pre-commit hook to ruff-only

`.githooks/pre-commit` was running `basedpyright` + the full `pytest` suite on every commit to a feature branch (~60s per commit). Wrong layer — pre-commit should be fast (<2s) so commits don't become friction; PR CI + branch protection already enforces correctness. Also wasn't even buying CI parity: locally we were picking up Python 3.12 instead of mise's pinned 3.11, so the hook said "tests pass" while CI said "tests fail" on the same code (PR #804). That bonus discovery led to fix #2.

### 2. Switch mise venv setup to uv-managed

`mise.toml` pinned `python = "3.11"` but `.venv/bin/python` was symlinked to 3.12 (created Feb 16 by older mise, never recreated when the pin changed). When I nuked `.venv` to recreate it, mise's auto-create produced a **venv without pip** — `pyvenv.cfg` revealed mise creates venvs via uv 0.10.2 internally, and uv doesn't seed pip by default. So `mise run setup`'s `pip install -r requirements-dev.txt` was latently broken on fresh checkouts (relied on legacy stdlib-created venvs that included pip).

Fix: expose uv as a tracked mise tool and use `uv pip install` in the setup task — uses what mise uses anyway, no manual `ensurepip` bootstrap, ~10x faster installs.

## Changes

**Pre-commit hook:**
- `.githooks/pre-commit`: drop basedpyright + pytest sections. Keep ruff format + `ruff check --fix` on staged Python files plus the final ruff check that aborts on unfixable errors. 67 → 38 LOC.
- `CLAUDE.md` (Development section): note that pre-commit is intentionally ruff-only, full validation lives in CI; flag against re-introducing heavy checks here.

**Mise venv setup:**
- `mise.toml` `[tools]`: add `uv = "latest"` (mise was using it internally anyway; this just makes it accessible to the setup task and to contributors).
- `mise.toml` `[tasks.setup]`: replace `pip install -r requirements-dev.txt` with `uv pip install -r requirements-dev.txt`.
- `CLAUDE.md` (Development > Tooling): note that mise creates the venv via uv and `mise run setup` installs deps via `uv pip install`.

## Local cleanup (not part of this PR)

`.git/hooks/pre-commit` is leftover dead code on machines that had the repo from before the `core.hooksPath = .githooks` switch. Not tracked by git. Each local clone needs `rm .git/hooks/pre-commit` once. (Already done here.)

docs: N/A — dev tooling config + CLAUDE.md note; no `docs/` page applies.

## Test plan

- [x] `bash -n .githooks/pre-commit` — syntax OK
- [x] `rm -rf .venv && mise install && mise run setup` from a clean state — creates a Python 3.11 venv via uv, installs all deps via uv pip, hooks path configured, zero manual steps
- [x] `.venv/bin/python --version` → Python 3.11.15 (was 3.12.12 before — the stale symlink)
- [x] `.venv/bin/python -m pytest --version` → pytest 9.0.3 (available without ensurepip workaround)

## Note on the failing CI test job

The `test` job currently fails for an unrelated reason — pytest-asyncio 1.4.0 (released today) ships a behavior change that breaks the test suite. Same failure reproduces on main HEAD with a fresh 3.11 venv, so this PR doesn't cause it. Tracked as the next chunk of work; will resolve before merge.