### PR TITLE
chore(deps): pin pytest-asyncio<1.4 (1.4.0 breaks test fixtures)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=9.0.3,<10.0
-pytest-asyncio>=1.3.0,<2.0
+pytest-asyncio>=1.3.0,<1.4  # 1.4.0 changed event-loop semantics; tracked in #806
 pytest-cov>=7.1.0,<8.0
 ruff>=0.15.14,<0.16
 basedpyright>=1.39.5,<2.0


### PR DESCRIPTION
## Summary

pytest-asyncio 1.4.0 (released 2026-05-26) ships a behavior change that breaks our test suite. Pinning to `<1.4` as an interim mitigation; the proper fix (migrate test fixtures off `asyncio.get_event_loop()` in sync contexts) is tracked in #806.

## Empirical evidence

Same code, same Python 3.11.15, same fresh venv — only difference is pytest-asyncio version:

- `pytest-asyncio==1.4.0` → **140 failed, 1762 passed, 744 errors**
- `pytest-asyncio==1.3.0` → **2646 passed, 0 errors**

Error pattern across all 744 errors: `RuntimeError: There is no current event loop in thread 'MainThread'` at sync-fixture call sites that do `asyncio.get_event_loop()`. pytest-asyncio <1.4 implicitly set a thread-default loop policy that made this call succeed; 1.4 removed that, exposing Python 3.10+'s `get_event_loop` deprecation as a hard `RuntimeError`.

This isn't caused by any recent code change — it's caused by pip resolving to 1.4.0 today. Main HEAD reproduces the same failure on a fresh 3.11 venv. PRs #804 and #805 are red for the same reason.

## Change

- `requirements-dev.txt`: `pytest-asyncio>=1.3.0,<2.0` → `pytest-asyncio>=1.3.0,<1.4` (plus an inline comment referencing #806)

## Follow-up

#806 tracks the proper fix: migrate `tests/conftest.py` shared fixtures and the per-file `plugin` fixtures off sync-context `asyncio.get_event_loop()` calls, then unpin to `<2.0`.

docs: N/A — dependency pin, no `docs/` page applies.

## Test plan

- [x] Local pytest with pytest-asyncio 1.3.0: 2646 passed in 47s
- [x] Local pytest with pytest-asyncio 1.4.0: 140 failed + 744 errors (the failure being mitigated)
- [ ] CI confirmation once pushed