### PR TITLE
docs(arch): add CONTEXT glossary and ADR-0001 for Platform aggregate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,62 @@
+# CONTEXT.md — decky-romm-sync domain glossary
+
+This file is a glossary. It defines the canonical meaning of project-specific
+terms so that conversations, issues, PRs, and code stay aligned. It is *not* a
+spec or design doc — implementation docs live in `docs/architecture/`, and
+architectural decisions live in `docs/adr/`.
+
+When a term resolves during a discussion, it gets added here. When a term's
+meaning changes, the entry gets rewritten — not appended to.
+
+## Terms
+
+### Aggregate
+
+A cluster of domain objects treated as a single unit for data consistency. Per
+Cosmic Python chapters 1–7:
+
+- Has **one root** entity (a dataclass) that is the only external entry point.
+- Enforces all of its own **invariants** — outside code cannot violate them.
+- Is the **transaction boundary**: saved atomically as a unit.
+- Has exactly one **identity**. Other aggregates reference it by ID only, never
+  by holding a Python reference to its internals.
+- Mutation is **only via methods on the root**, named after the domain event
+  that occurred (`adopt_baseline(...)`, `confirm_slot(...)`,
+  `mark_installed(...)`). Direct field assignment from services is forbidden.
+- Has exactly **one Repository** Protocol. The Repository's job is "give me
+  this aggregate by ID, save this aggregate" — it may touch multiple tables
+  under the hood.
+
+What an aggregate is *not*: a DTO sent to the frontend, a query projection, or
+"stuff that happens to live in the same file." Aggregate boundaries are
+**invariant boundaries**, not storage boundaries.
+
+Chapters 8+ of the CP book (domain events + message bus) are explicitly out of
+scope. Triggers for revisiting that scope are documented in `CLAUDE.md`.
+
+### kv_config
+
+A key-value table for small singleton configuration values that don't justify
+their own aggregate or table. One row per key.
+
+Used for misc state like the schema version, the RetroDECK home path snapshot,
+the in-progress save-sort settings change. **Not** a dumping ground — anything
+with its own lifecycle, invariants, or repeat-row potential gets its own
+aggregate. `kv_config` is for the truly small, the truly singleton, and the
+truly miscellaneous.
+
+### Rom (aggregate) vs ROM (file) vs RomM (server)
+
+Three things spell similarly; distinct meanings:
+
+- **Rom** — the aggregate / domain entity owned by this plugin
+  (`domain/rom.py`). Represents one ROM as the plugin tracks it locally:
+  identity, sync metadata, the Steam shortcut binding.
+- **ROM** (or "ROM file") — the actual playable game file on disk (e.g.
+  `.iso`, `.cue`, `.gba`). What `RomInstall` records once a `Rom` has been
+  downloaded.
+- **RomM** — the upstream self-hosted server. The source of truth this plugin
+  syncs *from*.
+
+Convention: always write `Rom` (PascalCase) when referring to the aggregate.
+Write "ROM file" when referring to the on-disk artifact.

--- a/docs/adr/0001-adopt-platform-aggregate.md
+++ b/docs/adr/0001-adopt-platform-aggregate.md
@@ -1,0 +1,60 @@
+# Adopt Platform as an aggregate
+
+## Status
+
+Proposed
+
+## Context
+
+The plugin syncs ROMs from RomM, which provides each ROM with a
+`platform_slug` and `platform_name`. Today these strings are denormalized
+across `shortcut_registry`, `installed_roms`, and `downloaded_bios` — there
+is no `Platform` entity locally.
+
+When migrating to SQLite (#271), we considered three options for platform
+identity:
+
+1. **No Platform aggregate.** Keep `platform_slug: str` denormalized on every
+   row. Cheapest. Matches today.
+2. **Singleton `kv_config` blob.** Stuff a `platform_display_names` JSON map
+   into the key-value table. Works for cached names; fails when we need
+   user-editable per-platform settings.
+3. **Adopt `Platform` as a full aggregate.** New table, new Repository, new
+   domain dataclass. Costs a sync-ordering constraint (platforms refresh
+   before ROMs).
+
+## Decision
+
+Adopt Platform as a full aggregate.
+
+The deciding factor was the standalone-emulator roadmap: extending the
+plugin beyond RetroDECK (EmuDeck, manually-installed emulators) requires
+local state we genuinely own (`emulation_stack`, `manual_emulator_path`,
+future `excluded_from_sync` toggle). RetroDECK's own configuration files
+(`es_systems.xml`, `gamelist.xml`) own most existing per-platform state —
+but that doesn't cover the non-RetroDECK case, which is the explicit
+direction of travel.
+
+Other rationale:
+
+- `display_name` caching survives RomM downtime for QAM display
+- A normalized `platforms` table is a cleaner home for "per-platform
+  preferences we own" than scattering them across `kv_config` keys
+- Bundled reference data (`bios_registry.json`, `core_defaults.json`,
+  RetroDECK's `es_systems.xml`) stays where it is — Platform only carries
+  state we genuinely own and mutate
+
+## Consequences
+
+- `Rom`, `RomInstall`, `BiosFile`, `RomSaveState` carry `platform_slug` as
+  an FK into the `platforms` table — not a free-floating string.
+- `Rom` drops the denormalized `platform_name` column (resolve via JOIN).
+- Sync must refresh `platforms` before refreshing ROMs (foreign-key
+  dependency) — small ordering constraint.
+- Bundled defaults (`core_defaults.json`) and RetroDECK-managed state
+  (`gamelist.xml` overrides) stay outside the Platform aggregate. The
+  aggregate is for state we own locally, not for caching read-only
+  reference data.
+- The Platform aggregate stays lean today (`slug`, `display_name`,
+  `excluded_from_sync` once shipped, `emulation_stack` once shipped) —
+  not all future fields land at once.


### PR DESCRIPTION
## Summary

Captures the design language and first architectural decision produced during #788 planning.

- `CONTEXT.md` (new) — initial glossary: `Aggregate` (Cosmic Python chapters 1–7 form), `kv_config`, `Rom`/`ROM`/`RomM` disambiguation.
- `docs/adr/0001-adopt-platform-aggregate.md` (new) — records the decision to adopt `Platform` as an aggregate. Driven by the standalone-emulator roadmap, which introduces per-platform state owned locally (vs RetroDECK-managed state in `es_systems.xml` / `gamelist.xml`).

ADR status is `Proposed`; flips to `Accepted` when #788 merges.

## Test plan

Pure docs change. CI docs-check should pass; no source-code impact. I'll verify rendering on the published site post-merge.

Refs #788, #271