### PR TITLE
fix(docs): exclude adr/ from published MkDocs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,13 @@ site_name: decky-romm-sync
 site_description: Decky Loader plugin to sync your RomM library to Steam as non-steam shortcuts
 site_url: https://danielcopper.github.io/decky-romm-sync/
 
+# Architectural Decision Records (`docs/adr/`) are kept in the repo for
+# contributors and AI agents — they're internal design history, not user
+# documentation. Exclude them from the published MkDocs site so they
+# don't appear as orphan pages or in on-site search.
+exclude_docs: |
+  adr/
+
 repo_url: https://github.com/danielcopper/decky-romm-sync
 repo_name: danielcopper/decky-romm-sync
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Summary

ADR-0001 (added in #808) was being published as an **orphan page** on the live site — not in the nav, but reachable via direct URL and indexed by on-site search.

Confirmed live post-merge of #808:

- HTTP 200 at <https://danielcopper.github.io/decky-romm-sync/adr/0001-adopt-platform-aggregate/>
- Search index contains 5 entries: `adr/0001-adopt-platform-aggregate/` + 4 anchor entries (#status, #context, #decision, #consequences)

ADRs are internal design history (for contributors and AI agents consulting the cross-project `CONTEXT.md`/`docs/adr/` discovery rule), not user-facing documentation. They should live in the repo but not on the published site.

## Fix

Add MkDocs `exclude_docs:` directive scoped to `adr/`. MkDocs 1.5+ honours this and skips the directory entirely — no orphan pages, no search-index leakage.

Next deploy (this PR's merge will trigger it) re-renders the site fresh; the ADR page and its search entries disappear in that overwrite.

## Test plan

`docs: N/A` does not apply — this IS a docs change (the `mkdocs.yml` config). Once merged:

- Re-fetch `https://danielcopper.github.io/decky-romm-sync/adr/0001-adopt-platform-aggregate/` → expect 404
- Re-fetch `search_index.json` → expect no `adr/` entries