### PR TITLE
docs(saves): fix false savefile_directory fallback claim in save-sync architecture

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -218,7 +218,9 @@ This path varies depending on where RetroDECK was installed:
 - **Internal SSD**: `/home/deck/retrodeck/saves/`
 - **SD card**: `/run/media/deck/Emulation/retrodeck/saves/`
 
-The backend reads `retrodeck.json` as the primary source, with RetroArch's `retroarch.cfg` → `savefile_directory` as a fallback. The path is never hardcoded.
+The backend reads `retrodeck.json` → `paths.saves_path` as the source of truth (`py_modules/adapters/retrodeck_paths.py`). When that file is unreadable — e.g. a fresh install with no RetroDECK configured yet — it falls back to the hardcoded RetroDECK default `~/retrodeck/saves`.
+
+The plugin deliberately does **not** read `savefile_directory` from `retroarch.cfg`. RetroDECK re-derives `savefile_directory = saves_path` on every launch/reset/move (its `component_prepare.sh` rewrites the key, and the "move data" flow updates `retrodeck.json` and `retroarch.cfg` in lockstep), so `retrodeck.json` is the single source of truth and reading the cfg key would only track a value RetroDECK is about to overwrite.
 
 ### RetroArch .srm pattern
 


### PR DESCRIPTION
## Summary

- `docs/architecture/save-file-sync-architecture.md` claimed the backend falls back to `retroarch.cfg` → `savefile_directory` and that "the path is never hardcoded" — both untrue. The backend reads only `retrodeck.json` → `paths.saves_path` (`retrodeck_paths.py:77-78`), with a hardcoded `~/retrodeck/saves` fallback (`retrodeck_paths.py:63-69`); `savefile_directory` is never read.
- Corrects the resolution description and adds a one-line rationale for why I deliberately don't read `savefile_directory` (RetroDECK re-derives it from `saves_path` on every launch/reset/move, so reading it would track a soon-to-be-clobbered value).

Documentation-only, no code change.

## Test plan

- [x] Docs-only change — `docs-check` CI passes (a `docs/` file is touched).
- [x] No code, no unit tests affected.

Closes #811