### PR TITLE
feat(domain): add Device, SyncSettings, Playtime aggregates for #788

### DIFF
--- a/py_modules/domain/device.py
+++ b/py_modules/domain/device.py
@@ -1,0 +1,33 @@
+"""Device identity — the single registered device this plugin instance runs on.
+
+Owns the server-issued device identity and its optional display name. Anything
+about *which* device this plugin is registered as belongs here. Per-device sync
+state, playtime, and saves are separate aggregates keyed by their own roots.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class Device:
+    """The registered device this plugin instance runs on (singleton).
+
+    Identity is ``device_id`` — the server-issued id RomM assigns on
+    registration. ``device_name`` is a mutable display label.
+    """
+
+    device_id: str
+    device_name: str | None = None
+
+    @classmethod
+    def register(cls, device_id: str, name: str | None = None) -> Device:
+        """Register the device under its server-issued ``device_id``."""
+        if not device_id:
+            raise ValueError("device_id is required")
+        return cls(device_id=device_id, device_name=name)
+
+    def rename(self, new_name: str) -> None:
+        """Change the device's display name."""
+        self.device_name = new_name

--- a/py_modules/domain/playtime.py
+++ b/py_modules/domain/playtime.py
@@ -1,0 +1,58 @@
+"""Per-ROM playtime — running totals plus the in-flight session marker.
+
+One Playtime per Rom (referenced by id). Tracks cumulative play seconds and
+session count, the open session's start timestamp (durable so a session
+survives a plugin reload mid-game), and the most recent session's duration.
+Individual sessions are not entities — only their start (while open) and their
+folded-in result persist. RomM is the shared server record; this aggregate is
+the local durable + read model that reconciles with it.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+from domain.iso_time import parse_iso
+
+_MAX_SESSION_SECONDS = 86_400  # a single session contributes at most 24h
+
+
+@cosmic_aggregate
+class Playtime:
+    """Cumulative playtime and the open-session marker for one ROM."""
+
+    total_seconds: int = 0
+    session_count: int = 0
+    last_session_start: str | None = None
+    last_session_duration_sec: int | None = None
+    note_id: int | None = None
+
+    def begin_session(self, at: str) -> None:
+        """Open a play session that started at ISO timestamp ``at``."""
+        self.last_session_start = at
+
+    def record_session(self, ended_at: str) -> None:
+        """Close the open session at ``ended_at`` and fold its duration into the totals.
+
+        The duration is the span from the stored ``last_session_start`` to
+        ``ended_at``, clamped to ``[0, 24h]``. Raises ``ValueError`` if no
+        session is open or either timestamp is unusable.
+        """
+        if self.last_session_start is None:
+            raise ValueError("no open session to record")
+        start = parse_iso(self.last_session_start)
+        end = parse_iso(ended_at)
+        if start is None or end is None:
+            raise ValueError("unparseable session timestamps")
+        try:
+            elapsed = (end - start).total_seconds()
+        except TypeError as exc:  # naive/aware datetime mismatch
+            raise ValueError("inconsistent session timestamps") from exc
+        seconds = int(max(0, min(elapsed, _MAX_SESSION_SECONDS)))
+        self.total_seconds += seconds
+        self.session_count += 1
+        self.last_session_duration_sec = seconds
+        self.last_session_start = None
+
+    def link_note(self, note_id: int) -> None:
+        """Associate the RomM playtime note id used for server sync."""
+        self.note_id = note_id

--- a/py_modules/domain/sync_settings.py
+++ b/py_modules/domain/sync_settings.py
@@ -1,0 +1,48 @@
+"""Save-sync feature settings (singleton).
+
+The user-toggleable knobs that govern save synchronisation: whether sync is on,
+whether it runs around launch/exit, the default slot, and the autocleanup
+retention limit. Distinct from ``settings.json`` (general plugin settings, which
+stay JSON per the persistence epic) — this aggregate owns only save-sync state.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class SyncSettings:
+    """User-controlled save-sync feature settings."""
+
+    save_sync_enabled: bool = False
+    sync_before_launch: bool = True
+    sync_after_exit: bool = True
+    default_slot: str | None = "default"
+    autocleanup_limit: int = 10
+
+    def enable_save_sync(self) -> None:
+        """Turn save sync on."""
+        self.save_sync_enabled = True
+
+    def disable_save_sync(self) -> None:
+        """Turn save sync off."""
+        self.save_sync_enabled = False
+
+    def set_sync_before_launch(self, enabled: bool) -> None:
+        """Set whether saves sync down before a game launches."""
+        self.sync_before_launch = enabled
+
+    def set_sync_after_exit(self, enabled: bool) -> None:
+        """Set whether saves sync up after a game exits."""
+        self.sync_after_exit = enabled
+
+    def set_default_slot(self, name: str | None) -> None:
+        """Set the default save slot. An empty name means 'no slots' mode (None)."""
+        self.default_slot = name or None
+
+    def set_autocleanup_limit(self, limit: int) -> None:
+        """Set how many save versions to retain. Must be non-negative."""
+        if limit < 0:
+            raise ValueError("autocleanup_limit must be >= 0")
+        self.autocleanup_limit = limit

--- a/tests/domain/test_device.py
+++ b/tests/domain/test_device.py
@@ -1,0 +1,35 @@
+"""Unit tests for the ``Device`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.device import Device
+
+
+class TestRegister:
+    def test_register_with_name_sets_both_fields(self):
+        device = Device.register("dev-123", "Steam Deck")
+        assert device.device_id == "dev-123"
+        assert device.device_name == "Steam Deck"
+
+    def test_register_without_name_defaults_to_none(self):
+        device = Device.register("dev-123")
+        assert device.device_id == "dev-123"
+        assert device.device_name is None
+
+    def test_register_with_empty_id_raises(self):
+        with pytest.raises(ValueError, match="device_id is required"):
+            Device.register("")
+
+
+class TestRename:
+    def test_rename_changes_display_name(self):
+        device = Device.register("dev-123", "Old Name")
+        device.rename("New Name")
+        assert device.device_name == "New Name"
+
+    def test_rename_from_none(self):
+        device = Device.register("dev-123")
+        device.rename("First Name")
+        assert device.device_name == "First Name"

--- a/tests/domain/test_playtime.py
+++ b/tests/domain/test_playtime.py
@@ -1,0 +1,76 @@
+"""Unit tests for the ``Playtime`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.playtime import Playtime
+
+
+class TestBeginSession:
+    def test_begin_session_sets_start(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T10:00:00")
+        assert playtime.last_session_start == "2026-05-28T10:00:00"
+
+
+class TestRecordSession:
+    def test_happy_path_folds_duration_into_totals(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T10:00:00")
+        playtime.record_session("2026-05-28T11:00:00")
+        assert playtime.total_seconds == 3600
+        assert playtime.session_count == 1
+        assert playtime.last_session_duration_sec == 3600
+        assert playtime.last_session_start is None
+
+    def test_two_cycles_accumulate(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T10:00:00")
+        playtime.record_session("2026-05-28T11:00:00")
+        playtime.begin_session("2026-05-28T12:00:00")
+        playtime.record_session("2026-05-28T12:30:00")
+        assert playtime.total_seconds == 3600 + 1800
+        assert playtime.session_count == 2
+        assert playtime.last_session_duration_sec == 1800
+
+    def test_no_open_session_raises(self):
+        playtime = Playtime()
+        with pytest.raises(ValueError, match="no open session to record"):
+            playtime.record_session("2026-05-28T11:00:00")
+
+    def test_unparseable_start_raises(self):
+        playtime = Playtime()
+        playtime.begin_session("not-a-date")
+        with pytest.raises(ValueError, match="unparseable session timestamps"):
+            playtime.record_session("2026-05-28T11:00:00")
+
+    def test_upper_clamp_caps_at_24h(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T10:00:00")
+        playtime.record_session("2026-05-30T10:00:00")
+        assert playtime.last_session_duration_sec == 86400
+        assert playtime.total_seconds == 86400
+        assert playtime.session_count == 1
+
+    def test_lower_clamp_end_before_start(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T11:00:00")
+        playtime.record_session("2026-05-28T10:00:00")
+        assert playtime.last_session_duration_sec == 0
+        assert playtime.total_seconds == 0
+        assert playtime.session_count == 1
+        assert playtime.last_session_start is None
+
+    def test_mixed_naive_aware_timestamps_raise(self):
+        playtime = Playtime()
+        playtime.begin_session("2026-05-28T10:00:00")  # naive
+        with pytest.raises(ValueError, match="inconsistent session timestamps"):
+            playtime.record_session("2026-05-28T11:00:00Z")  # aware (Z -> +00:00)
+
+
+class TestLinkNote:
+    def test_link_note_sets_id(self):
+        playtime = Playtime()
+        playtime.link_note(42)
+        assert playtime.note_id == 42

--- a/tests/domain/test_sync_settings.py
+++ b/tests/domain/test_sync_settings.py
@@ -1,0 +1,85 @@
+"""Unit tests for the ``SyncSettings`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.sync_settings import SyncSettings
+
+
+class TestDefaults:
+    def test_default_construction(self):
+        settings = SyncSettings()
+        assert settings.save_sync_enabled is False
+        assert settings.sync_before_launch is True
+        assert settings.sync_after_exit is True
+        assert settings.default_slot == "default"
+        assert settings.autocleanup_limit == 10
+
+
+class TestSaveSyncToggle:
+    def test_enable_save_sync(self):
+        settings = SyncSettings()
+        settings.enable_save_sync()
+        assert settings.save_sync_enabled is True
+
+    def test_disable_save_sync(self):
+        settings = SyncSettings(save_sync_enabled=True)
+        settings.disable_save_sync()
+        assert settings.save_sync_enabled is False
+
+
+class TestSyncTimingFlags:
+    def test_set_sync_before_launch_false(self):
+        settings = SyncSettings()
+        settings.set_sync_before_launch(False)
+        assert settings.sync_before_launch is False
+
+    def test_set_sync_before_launch_true(self):
+        settings = SyncSettings(sync_before_launch=False)
+        settings.set_sync_before_launch(True)
+        assert settings.sync_before_launch is True
+
+    def test_set_sync_after_exit_false(self):
+        settings = SyncSettings()
+        settings.set_sync_after_exit(False)
+        assert settings.sync_after_exit is False
+
+    def test_set_sync_after_exit_true(self):
+        settings = SyncSettings(sync_after_exit=False)
+        settings.set_sync_after_exit(True)
+        assert settings.sync_after_exit is True
+
+
+class TestDefaultSlot:
+    def test_set_named_slot(self):
+        settings = SyncSettings()
+        settings.set_default_slot("slotA")
+        assert settings.default_slot == "slotA"
+
+    def test_set_empty_slot_becomes_none(self):
+        settings = SyncSettings()
+        settings.set_default_slot("")
+        assert settings.default_slot is None
+
+    def test_set_none_slot_stays_none(self):
+        settings = SyncSettings()
+        settings.set_default_slot(None)
+        assert settings.default_slot is None
+
+
+class TestAutocleanupLimit:
+    def test_set_zero(self):
+        settings = SyncSettings()
+        settings.set_autocleanup_limit(0)
+        assert settings.autocleanup_limit == 0
+
+    def test_set_positive(self):
+        settings = SyncSettings()
+        settings.set_autocleanup_limit(25)
+        assert settings.autocleanup_limit == 25
+
+    def test_set_negative_raises(self):
+        settings = SyncSettings()
+        with pytest.raises(ValueError, match="autocleanup_limit must be >= 0"):
+            settings.set_autocleanup_limit(-1)


### PR DESCRIPTION
## Summary
- PR 2 of 4 for #788 — the three shallow-invariant aggregates as `@cosmic_aggregate` dataclasses with verb-named mutation methods, on PR 1's enforcement rails (#814).
- `Playtime.record_session(ended_at)` computes duration from the stored open-session start and owns the 0–24h clamp as a domain invariant.
- Not wired into any service — no runtime change. The JSON-era containers in `domain/save_state.py` stay live until cutover (#784).

## Test plan
- [x] `pytest tests/ -q` → 2706 passed; 100% line+branch coverage on the three new modules
- [x] basedpyright 0 errors · ruff clean · import-linter 8 kept · cosmic-call-bans clean
- [x] `check_aggregate_field_assignment.py` clean (aggregates now carry the decorator; no service violations)

`docs: N/A` — domain dataclasses only, unwired; the aggregate-set table in `docs/architecture/database-design.md` is PR 4's job per #788.