### PR TITLE
feat(domain): add mid-tier aggregates for #788

### DIFF
--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -59,7 +59,7 @@ The decorator applies `@dataclass(slots=True)`, so the root gets `__init__`, `__
 How it works:
 
 1. It walks `py_modules/domain/`, parses every file, and collects the class names decorated with `@cosmic_aggregate`.
-2. It walks `py_modules/services/` and flags every assignment whose target is `<receiver>.<field> = ...` where the receiver's variable name matches an aggregate class name (case-insensitive substring). It skips `self.x = ...` (method-body internals) and subscript receivers (`d["k"].x = ...`).
+2. It walks `py_modules/services/` and flags every assignment whose target is `<receiver>.<field> = ...` where the receiver's variable name matches an aggregate class name (exact snake_case identifier match — variable `rom` matches aggregate `Rom`, `rom_state` does not). It skips `self.x = ...` (method-body internals) and subscript receivers (`d["k"].x = ...`).
 
 The heuristic is conservative by design — a guardrail, not a prover. It can false-positive (a variable named `rom` holding something else) and false-negative (assignment through a complex expression). The escape hatch is a trailing comment on the offending line:
 

--- a/py_modules/domain/bios_file.py
+++ b/py_modules/domain/bios_file.py
@@ -1,0 +1,47 @@
+"""BiosFile — one downloaded BIOS/firmware file the plugin tracks on disk.
+
+Identified by ``(platform_slug, file_name)`` — a bare filename is unsafe because
+two platforms can ship same-named BIOS. ``firmware_id`` is nullable metadata
+from RomM, not part of the identity. Tracked so migrations can move the file
+when the RetroDECK home path changes.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class BiosFile:
+    """One downloaded BIOS file, keyed by (platform_slug, file_name)."""
+
+    platform_slug: str
+    file_name: str
+    file_path: str
+    downloaded_at: str
+    firmware_id: int | None = None
+
+    @classmethod
+    def mark_downloaded(
+        cls,
+        *,
+        platform_slug: str,
+        file_name: str,
+        file_path: str,
+        downloaded_at: str,
+        firmware_id: int | None = None,
+    ) -> BiosFile:
+        """Record a freshly downloaded BIOS file at ISO timestamp ``downloaded_at``."""
+        if not platform_slug or not file_name:
+            raise ValueError("platform_slug and file_name are required")
+        return cls(
+            platform_slug=platform_slug,
+            file_name=file_name,
+            file_path=file_path,
+            downloaded_at=downloaded_at,
+            firmware_id=firmware_id,
+        )
+
+    def relocate(self, new_path: str) -> None:
+        """Move the BIOS file to a new path (RetroDECK home migration)."""
+        self.file_path = new_path

--- a/py_modules/domain/firmware_cache.py
+++ b/py_modules/domain/firmware_cache.py
@@ -1,0 +1,41 @@
+"""FirmwareCacheEntry — one item of RomM's TTL-cached firmware inventory.
+
+A snapshot of one firmware entry the server reports, cached with a short TTL so
+the BIOS-management UI doesn't re-query RomM on every open. The cache is
+replaced wholesale on refresh and the TTL check lives in the firmware service,
+so this aggregate stays a thin record.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class FirmwareCacheEntry:
+    """One cached firmware-inventory item from RomM."""
+
+    id: int | None
+    name: str
+    platform_slug: str
+    file_size_bytes: int
+    cached_at: float
+
+    @classmethod
+    def cached(
+        cls,
+        *,
+        id: int | None,
+        name: str,
+        platform_slug: str,
+        file_size_bytes: int,
+        cached_at: float,
+    ) -> FirmwareCacheEntry:
+        """Build a cached firmware entry recorded at Unix time ``cached_at``."""
+        return cls(
+            id=id,
+            name=name,
+            platform_slug=platform_slug,
+            file_size_bytes=file_size_bytes,
+            cached_at=cached_at,
+        )

--- a/py_modules/domain/platform.py
+++ b/py_modules/domain/platform.py
@@ -1,0 +1,32 @@
+"""Platform — per-platform state the plugin owns locally.
+
+Keyed by ``slug`` (the RomM platform slug). Carries the cached display name
+(survives RomM downtime) and the user's exclude-from-sync toggle. RetroDECK-
+managed per-platform state (es_systems.xml, gamelist.xml) and bundled reference
+data stay outside this aggregate — only state the plugin itself owns lives here.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class Platform:
+    """Per-platform local state owned by the plugin (one per RomM slug)."""
+
+    slug: str
+    display_name: str
+    excluded_from_sync: bool = False
+
+    def update_display_name(self, name: str) -> None:
+        """Refresh the cached display name from RomM."""
+        self.display_name = name
+
+    def exclude_from_sync(self) -> None:
+        """Mark this platform as excluded from library sync."""
+        self.excluded_from_sync = True
+
+    def include_in_sync(self) -> None:
+        """Re-include this platform in library sync."""
+        self.excluded_from_sync = False

--- a/py_modules/domain/rom.py
+++ b/py_modules/domain/rom.py
@@ -1,0 +1,66 @@
+"""Rom — the library entry for one ROM the plugin tracks locally.
+
+Identity, the Steam-shortcut binding, and the external-service ids the plugin
+resolves for a ROM. Created/updated atomically when a ROM is synced from RomM.
+References its Platform by ``platform_slug`` (FK) — the platform's display name
+is resolved through Platform, not carried here.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class Rom:
+    """One ROM as the plugin tracks it locally (identity + shortcut binding)."""
+
+    rom_id: int
+    platform_slug: str
+    name: str
+    fs_name: str
+    shortcut_app_id: int
+    last_synced_at: str
+    cover_path: str | None = None
+    igdb_id: int | None = None
+    sgdb_id: int | None = None
+    ra_id: int | None = None
+
+    @classmethod
+    def synced(
+        cls,
+        *,
+        rom_id: int,
+        platform_slug: str,
+        name: str,
+        fs_name: str,
+        shortcut_app_id: int,
+        synced_at: str,
+        igdb_id: int | None = None,
+    ) -> Rom:
+        """Build a Rom synced from RomM at ISO timestamp ``synced_at``."""
+        if rom_id <= 0:
+            raise ValueError("rom_id must be positive")
+        if not platform_slug:
+            raise ValueError("platform_slug is required")
+        return cls(
+            rom_id=rom_id,
+            platform_slug=platform_slug,
+            name=name,
+            fs_name=fs_name,
+            shortcut_app_id=shortcut_app_id,
+            last_synced_at=synced_at,
+            igdb_id=igdb_id,
+        )
+
+    def update_cover_path(self, path: str) -> None:
+        """Record the local cover-art path once artwork has been written."""
+        self.cover_path = path
+
+    def assign_sgdb_id(self, sgdb_id: int) -> None:
+        """Stamp the resolved SteamGridDB id."""
+        self.sgdb_id = sgdb_id
+
+    def assign_ra_id(self, ra_id: int) -> None:
+        """Stamp the resolved RetroAchievements id."""
+        self.ra_id = ra_id

--- a/py_modules/domain/rom_install.py
+++ b/py_modules/domain/rom_install.py
@@ -1,0 +1,52 @@
+"""RomInstall — the on-disk install record for a downloaded ROM.
+
+Exists only while a ROM is downloaded: created on download-complete, removed on
+uninstall. References its Rom by ``rom_id``. Distinguishes the install directory
+(``install_path``) from the specific launch file (``file_path``); the
+denormalized ``platform_slug``/``system`` let migration and save-sort read this
+record without joining the registry.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+
+@cosmic_aggregate
+class RomInstall:
+    """Where a downloaded ROM lives on disk and which file launches it."""
+
+    rom_id: int
+    file_path: str
+    install_path: str
+    platform_slug: str
+    system: str
+    installed_at: str
+
+    @classmethod
+    def mark_installed(
+        cls,
+        *,
+        rom_id: int,
+        file_path: str,
+        install_path: str,
+        platform_slug: str,
+        system: str,
+        installed_at: str,
+    ) -> RomInstall:
+        """Record a freshly downloaded ROM installed at ISO timestamp ``installed_at``."""
+        if rom_id <= 0:
+            raise ValueError("rom_id must be positive")
+        return cls(
+            rom_id=rom_id,
+            file_path=file_path,
+            install_path=install_path,
+            platform_slug=platform_slug,
+            system=system,
+            installed_at=installed_at,
+        )
+
+    def relocate(self, new_install_path: str, new_file_path: str) -> None:
+        """Move the install to a new directory and launch file (RetroDECK home migration)."""
+        self.install_path = new_install_path
+        self.file_path = new_file_path

--- a/py_modules/domain/rom_metadata.py
+++ b/py_modules/domain/rom_metadata.py
@@ -1,0 +1,59 @@
+"""RomMetadata — cached RomM game metadata with a staleness signal.
+
+The descriptive metadata the plugin caches per ROM (summary, genres, companies,
+ratings, derived Steam categories) plus the ``cached_at`` epoch that drives the
+7-day staleness check. Regenerated independently of library sync — staleness,
+not a schedule, prompts a refresh. References its Rom by id.
+"""
+
+from __future__ import annotations
+
+from domain._aggregate import cosmic_aggregate
+
+_METADATA_TTL_SEC = 7 * 24 * 3600  # metadata older than 7 days is stale
+
+
+@cosmic_aggregate
+class RomMetadata:
+    """Cached ROM metadata plus the epoch that drives its 7-day staleness check."""
+
+    summary: str
+    genres: tuple[str, ...]
+    companies: tuple[str, ...]
+    first_release_date: int | None
+    average_rating: float | None
+    game_modes: tuple[str, ...]
+    player_count: str
+    cached_at: float
+    steam_categories: tuple[int, ...] = ()
+
+    @classmethod
+    def cached(
+        cls,
+        *,
+        summary: str,
+        genres: tuple[str, ...],
+        companies: tuple[str, ...],
+        first_release_date: int | None,
+        average_rating: float | None,
+        game_modes: tuple[str, ...],
+        player_count: str,
+        cached_at: float,
+        steam_categories: tuple[int, ...] = (),
+    ) -> RomMetadata:
+        """Build a metadata record cached at Unix time ``cached_at``."""
+        return cls(
+            summary=summary,
+            genres=genres,
+            companies=companies,
+            first_release_date=first_release_date,
+            average_rating=average_rating,
+            game_modes=game_modes,
+            player_count=player_count,
+            cached_at=cached_at,
+            steam_categories=steam_categories,
+        )
+
+    def is_stale(self, now: float) -> bool:
+        """Return True when the cache is older than the 7-day TTL at Unix time ``now``."""
+        return (now - self.cached_at) > _METADATA_TTL_SEC

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -120,7 +120,7 @@ class StateService:
         via :meth:`save_state`.
         """
         rom = self.ensure_rom_state(rom_id_str)
-        rom.files = {}
+        rom.files = {}  # pragma: no aggregate-check  (rom is a RomSaveState; becomes a method in #788 PR4)
 
     def prune_orphaned_state(self) -> None:
         """Remove save-sync state entries for rom_ids no longer in the shortcut registry."""

--- a/scripts/check_aggregate_field_assignment.py
+++ b/scripts/check_aggregate_field_assignment.py
@@ -14,9 +14,10 @@ Heuristic (conservative by design):
      ``cosmic_aggregate``). Build a lowercase-name set.
   2. Parse every file under ``py_modules/services/``; flag every ``Assign``
      node whose target is an ``Attribute`` on a plain ``Name`` whose name
-     (case-insensitively) contains one of the aggregate names as a substring.
-     Skip ``self.x = ...`` and ``some[key].x = ...`` — those are method-body
-     internals and subscript-receiver patterns, not aggregate-field
+     (case-insensitively) exactly equals the snake_case form of one of the
+     aggregate names (variable ``rom`` matches aggregate ``Rom``; ``rom_state``
+     does not). Skip ``self.x = ...`` and ``some[key].x = ...`` — those are
+     method-body internals and subscript-receiver patterns, not aggregate-field
      assignments.
 
 The heuristic can produce both false positives (variable named ``rom``
@@ -36,6 +37,7 @@ Exit 0 on no findings, exit 1 if any findings (one line per finding).
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -91,11 +93,28 @@ def _receiver_name(target: ast.expr) -> str | None:
     return receiver.id
 
 
+def _to_snake(class_name: str) -> str:
+    """Convert a CamelCase class name to its snake_case identifier form.
+
+    ``RomInstall`` -> ``rom_install``; ``Rom`` -> ``rom``.
+    """
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", class_name).lower()
+
+
 def _name_matches_any_aggregate(name: str, aggregate_names: set[str]) -> str | None:
-    """Return the matching aggregate class name if ``name`` (case-insensitive substring) hits one."""
+    """Return the aggregate class name whose snake_case form exactly equals ``name``.
+
+    Exact-identifier match (not substring): the variable ``rom_state`` does not
+    match the aggregate ``Rom`` — only a variable named exactly ``rom`` does.
+    This keeps short aggregate names (``Rom``) from false-matching the many
+    unrelated ``rom*`` variables in the codebase. The trade-off is recall (a Rom
+    held in a differently-named variable won't be caught), accepted because this
+    is a guardrail — with the ``# pragma: no aggregate-check`` escape hatch and
+    code review as backstops — not a prover.
+    """
     lowered = name.lower()
     for agg in aggregate_names:
-        if agg.lower() in lowered:
+        if _to_snake(agg) == lowered:
             return agg
     return None
 

--- a/tests/domain/test_bios_file.py
+++ b/tests/domain/test_bios_file.py
@@ -1,0 +1,62 @@
+"""Unit tests for the ``BiosFile`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.bios_file import BiosFile
+
+
+class TestMarkDownloaded:
+    def test_with_firmware_id_sets_all_fields(self):
+        bios = BiosFile.mark_downloaded(
+            platform_slug="ps",
+            file_name="scph5501.bin",
+            file_path="/bios/scph5501.bin",
+            downloaded_at="2026-05-28T10:00:00",
+            firmware_id=99,
+        )
+        assert bios.platform_slug == "ps"
+        assert bios.file_name == "scph5501.bin"
+        assert bios.file_path == "/bios/scph5501.bin"
+        assert bios.downloaded_at == "2026-05-28T10:00:00"
+        assert bios.firmware_id == 99
+
+    def test_without_firmware_id_defaults_none(self):
+        bios = BiosFile.mark_downloaded(
+            platform_slug="ps",
+            file_name="scph5501.bin",
+            file_path="/bios/scph5501.bin",
+            downloaded_at="2026-05-28T10:00:00",
+        )
+        assert bios.firmware_id is None
+
+    def test_empty_platform_slug_raises(self):
+        with pytest.raises(ValueError, match="platform_slug and file_name are required"):
+            BiosFile.mark_downloaded(
+                platform_slug="",
+                file_name="scph5501.bin",
+                file_path="/bios/scph5501.bin",
+                downloaded_at="2026-05-28T10:00:00",
+            )
+
+    def test_empty_file_name_raises(self):
+        with pytest.raises(ValueError, match="platform_slug and file_name are required"):
+            BiosFile.mark_downloaded(
+                platform_slug="ps",
+                file_name="",
+                file_path="/bios/scph5501.bin",
+                downloaded_at="2026-05-28T10:00:00",
+            )
+
+
+class TestRelocate:
+    def test_updates_file_path(self):
+        bios = BiosFile.mark_downloaded(
+            platform_slug="ps",
+            file_name="scph5501.bin",
+            file_path="/old/scph5501.bin",
+            downloaded_at="2026-05-28T10:00:00",
+        )
+        bios.relocate("/new/scph5501.bin")
+        assert bios.file_path == "/new/scph5501.bin"

--- a/tests/domain/test_firmware_cache.py
+++ b/tests/domain/test_firmware_cache.py
@@ -1,0 +1,31 @@
+"""Unit tests for the ``FirmwareCacheEntry`` aggregate."""
+
+from __future__ import annotations
+
+from domain.firmware_cache import FirmwareCacheEntry
+
+
+class TestCached:
+    def test_with_int_id_sets_all_fields(self):
+        entry = FirmwareCacheEntry.cached(
+            id=5,
+            name="scph5501.bin",
+            platform_slug="ps",
+            file_size_bytes=524288,
+            cached_at=1000.0,
+        )
+        assert entry.id == 5
+        assert entry.name == "scph5501.bin"
+        assert entry.platform_slug == "ps"
+        assert entry.file_size_bytes == 524288
+        assert entry.cached_at == 1000.0
+
+    def test_none_id_is_preserved(self):
+        entry = FirmwareCacheEntry.cached(
+            id=None,
+            name="scph5501.bin",
+            platform_slug="ps",
+            file_size_bytes=524288,
+            cached_at=1000.0,
+        )
+        assert entry.id is None

--- a/tests/domain/test_platform.py
+++ b/tests/domain/test_platform.py
@@ -1,0 +1,41 @@
+"""Unit tests for the ``Platform`` aggregate."""
+
+from __future__ import annotations
+
+from domain.platform import Platform
+
+
+class TestConstruction:
+    def test_default_excluded_from_sync_is_false(self):
+        platform = Platform(slug="snes", display_name="Super Nintendo")
+        assert platform.slug == "snes"
+        assert platform.display_name == "Super Nintendo"
+        assert platform.excluded_from_sync is False
+
+
+class TestUpdateDisplayName:
+    def test_sets_display_name(self):
+        platform = Platform(slug="snes", display_name="Super Nintendo")
+        platform.update_display_name("Super Famicom")
+        assert platform.display_name == "Super Famicom"
+
+
+class TestExcludeFromSync:
+    def test_marks_excluded(self):
+        platform = Platform(slug="snes", display_name="Super Nintendo")
+        platform.exclude_from_sync()
+        assert platform.excluded_from_sync is True
+
+
+class TestIncludeInSync:
+    def test_marks_included(self):
+        platform = Platform(slug="snes", display_name="Super Nintendo", excluded_from_sync=True)
+        platform.include_in_sync()
+        assert platform.excluded_from_sync is False
+
+    def test_exclude_then_include_round_trip(self):
+        platform = Platform(slug="snes", display_name="Super Nintendo")
+        platform.exclude_from_sync()
+        assert platform.excluded_from_sync is True
+        platform.include_in_sync()
+        assert platform.excluded_from_sync is False

--- a/tests/domain/test_rom.py
+++ b/tests/domain/test_rom.py
@@ -1,0 +1,95 @@
+"""Unit tests for the ``Rom`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.rom import Rom
+
+
+class TestSynced:
+    def test_all_required_plus_igdb_sets_fields(self):
+        rom = Rom.synced(
+            rom_id=42,
+            platform_slug="snes",
+            name="Super Metroid",
+            fs_name="Super Metroid.sfc",
+            shortcut_app_id=123456789,
+            synced_at="2026-05-28T10:00:00",
+            igdb_id=1234,
+        )
+        assert rom.rom_id == 42
+        assert rom.platform_slug == "snes"
+        assert rom.name == "Super Metroid"
+        assert rom.fs_name == "Super Metroid.sfc"
+        assert rom.shortcut_app_id == 123456789
+        assert rom.last_synced_at == "2026-05-28T10:00:00"
+        assert rom.igdb_id == 1234
+
+    def test_without_igdb_leaves_optional_ids_none(self):
+        rom = Rom.synced(
+            rom_id=7,
+            platform_slug="gba",
+            name="Metroid Fusion",
+            fs_name="Metroid Fusion.gba",
+            shortcut_app_id=987654321,
+            synced_at="2026-05-28T11:00:00",
+        )
+        assert rom.igdb_id is None
+        assert rom.cover_path is None
+        assert rom.sgdb_id is None
+        assert rom.ra_id is None
+
+    def test_non_positive_rom_id_raises(self):
+        with pytest.raises(ValueError, match="rom_id must be positive"):
+            Rom.synced(
+                rom_id=0,
+                platform_slug="snes",
+                name="x",
+                fs_name="x.sfc",
+                shortcut_app_id=1,
+                synced_at="2026-05-28T10:00:00",
+            )
+
+    def test_empty_platform_slug_raises(self):
+        with pytest.raises(ValueError, match="platform_slug is required"):
+            Rom.synced(
+                rom_id=1,
+                platform_slug="",
+                name="x",
+                fs_name="x.sfc",
+                shortcut_app_id=1,
+                synced_at="2026-05-28T10:00:00",
+            )
+
+
+def _make_rom() -> Rom:
+    return Rom.synced(
+        rom_id=1,
+        platform_slug="snes",
+        name="x",
+        fs_name="x.sfc",
+        shortcut_app_id=1,
+        synced_at="2026-05-28T10:00:00",
+    )
+
+
+class TestUpdateCoverPath:
+    def test_sets_cover_path(self):
+        rom = _make_rom()
+        rom.update_cover_path("/covers/1.png")
+        assert rom.cover_path == "/covers/1.png"
+
+
+class TestAssignSgdbId:
+    def test_sets_sgdb_id(self):
+        rom = _make_rom()
+        rom.assign_sgdb_id(7)
+        assert rom.sgdb_id == 7
+
+
+class TestAssignRaId:
+    def test_sets_ra_id(self):
+        rom = _make_rom()
+        rom.assign_ra_id(9)
+        assert rom.ra_id == 9

--- a/tests/domain/test_rom_install.py
+++ b/tests/domain/test_rom_install.py
@@ -1,0 +1,51 @@
+"""Unit tests for the ``RomInstall`` aggregate."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.rom_install import RomInstall
+
+
+class TestMarkInstalled:
+    def test_sets_all_fields(self):
+        install = RomInstall.mark_installed(
+            rom_id=42,
+            file_path="/roms/snes/Super Metroid.sfc",
+            install_path="/roms/snes",
+            platform_slug="snes",
+            system="snes",
+            installed_at="2026-05-28T10:00:00",
+        )
+        assert install.rom_id == 42
+        assert install.file_path == "/roms/snes/Super Metroid.sfc"
+        assert install.install_path == "/roms/snes"
+        assert install.platform_slug == "snes"
+        assert install.system == "snes"
+        assert install.installed_at == "2026-05-28T10:00:00"
+
+    def test_non_positive_rom_id_raises(self):
+        with pytest.raises(ValueError, match="rom_id must be positive"):
+            RomInstall.mark_installed(
+                rom_id=0,
+                file_path="/x",
+                install_path="/",
+                platform_slug="snes",
+                system="snes",
+                installed_at="2026-05-28T10:00:00",
+            )
+
+
+class TestRelocate:
+    def test_updates_both_install_and_file_path(self):
+        install = RomInstall.mark_installed(
+            rom_id=1,
+            file_path="/old/dir/game.iso",
+            install_path="/old/dir",
+            platform_slug="ps",
+            system="psx",
+            installed_at="2026-05-28T10:00:00",
+        )
+        install.relocate("/new/dir", "/new/dir/game.iso")
+        assert install.install_path == "/new/dir"
+        assert install.file_path == "/new/dir/game.iso"

--- a/tests/domain/test_rom_metadata.py
+++ b/tests/domain/test_rom_metadata.py
@@ -1,0 +1,68 @@
+"""Unit tests for the ``RomMetadata`` aggregate."""
+
+from __future__ import annotations
+
+from domain.rom_metadata import _METADATA_TTL_SEC, RomMetadata
+
+
+def _make_metadata(*, cached_at: float, steam_categories: tuple[int, ...] | None = None) -> RomMetadata:
+    kwargs = {
+        "summary": "A great game.",
+        "genres": ("Action", "Adventure"),
+        "companies": ("Nintendo",),
+        "first_release_date": 1994,
+        "average_rating": 9.5,
+        "game_modes": ("Single player",),
+        "player_count": "1",
+        "cached_at": cached_at,
+    }
+    if steam_categories is not None:
+        kwargs["steam_categories"] = steam_categories
+    return RomMetadata.cached(**kwargs)
+
+
+class TestCached:
+    def test_sets_all_fields(self):
+        meta = RomMetadata.cached(
+            summary="A great game.",
+            genres=("Action",),
+            companies=("Nintendo",),
+            first_release_date=1994,
+            average_rating=9.5,
+            game_modes=("Single player",),
+            player_count="1",
+            cached_at=1000.0,
+            steam_categories=(2, 22),
+        )
+        assert meta.summary == "A great game."
+        assert meta.genres == ("Action",)
+        assert meta.companies == ("Nintendo",)
+        assert meta.first_release_date == 1994
+        assert meta.average_rating == 9.5
+        assert meta.game_modes == ("Single player",)
+        assert meta.player_count == "1"
+        assert meta.cached_at == 1000.0
+        assert meta.steam_categories == (2, 22)
+
+    def test_steam_categories_defaults_to_empty_tuple(self):
+        meta = _make_metadata(cached_at=1000.0)
+        assert meta.steam_categories == ()
+
+
+class TestIsStale:
+    def test_stale_when_older_than_ttl(self):
+        meta = _make_metadata(cached_at=0.0)
+        assert meta.is_stale(_METADATA_TTL_SEC + 1) is True
+
+    def test_not_stale_within_ttl(self):
+        meta = _make_metadata(cached_at=0.0)
+        assert meta.is_stale(_METADATA_TTL_SEC - 1) is False
+
+    def test_boundary_exactly_at_ttl_is_not_stale(self):
+        # Strict ``>``: exactly cached_at + TTL is NOT stale.
+        meta = _make_metadata(cached_at=100.0)
+        assert meta.is_stale(100.0 + _METADATA_TTL_SEC) is False
+
+    def test_just_past_ttl_is_stale(self):
+        meta = _make_metadata(cached_at=100.0)
+        assert meta.is_stale(100.0 + _METADATA_TTL_SEC + 1) is True

--- a/tests/scripts/test_check_aggregate_field_assignment.py
+++ b/tests/scripts/test_check_aggregate_field_assignment.py
@@ -209,20 +209,38 @@ class TestFindViolationsSkipPatterns:
 
 
 class TestFindViolationsHeuristicEdges:
-    def test_partial_substring_match_documented_false_positive(self, patched_check):
-        # Variable named ``romm_api`` partially matches class ``Rom`` — the
-        # substring heuristic flags it. This is the documented trade-off:
-        # rename the variable or use the escape hatch.
+    def test_substring_variable_not_flagged_only_exact_snake_match(self, patched_check):
+        # Variables named ``romm_api`` and ``rom_state`` merely *contain* the
+        # snake form of class ``Rom`` — the exact-identifier matcher does NOT
+        # flag them. Only a variable named exactly ``rom`` matches.
         _, findings = patched_check(
             domain_files={
                 "rom.py": ("from domain._aggregate import cosmic_aggregate\n@cosmic_aggregate\nclass Rom:\n    pass\n"),
             },
             services_files={
-                "fetcher.py": ("def setup(romm_api):\n    romm_api.timeout = 30\n"),
+                "fetcher.py": (
+                    "def setup(romm_api, rom_state):\n    romm_api.timeout = 30\n    rom_state.files = {}\n"
+                ),
+            },
+        )
+        assert findings == []
+
+    def test_exact_snake_match_flagged(self, patched_check):
+        # The variable named exactly ``rom_install`` matches aggregate
+        # ``RomInstall`` (snake_case of the CamelCase class name).
+        _, findings = patched_check(
+            domain_files={
+                "rom_install.py": (
+                    "from domain._aggregate import cosmic_aggregate\n@cosmic_aggregate\nclass RomInstall:\n    pass\n"
+                ),
+            },
+            services_files={
+                "download.py": ("def update(rom_install):\n    rom_install.file_path = '/x'\n"),
             },
         )
         assert len(findings) == 1
-        assert "romm_api.timeout" in findings[0]
+        assert "rom_install.file_path" in findings[0]
+        assert "RomInstall is @cosmic_aggregate" in findings[0]
 
     def test_escape_hatch_suppresses_finding(self, patched_check):
         _, findings = patched_check(
@@ -286,6 +304,17 @@ class TestFindViolationsHeuristicEdges:
         )
         assert names == set()
         assert findings == []
+
+
+class TestToSnake:
+    def test_single_word_lowercased(self):
+        assert check._to_snake("Rom") == "rom"
+
+    def test_camel_case_split_with_underscore(self):
+        assert check._to_snake("RomInstall") == "rom_install"
+
+    def test_multi_word_camel_case(self):
+        assert check._to_snake("FirmwareCacheEntry") == "firmware_cache_entry"
 
 
 class TestMainEntryPoint:


### PR DESCRIPTION
## Summary
- PR 3 of 4 for #788 — the six mid-tier aggregates (`Rom`, `Platform`, `RomInstall`, `RomMetadata`, `BiosFile`, `FirmwareCacheEntry`) as `@cosmic_aggregate` dataclasses with verb-named mutation methods, on PR 1's enforcement rails.
- `RomMetadata.is_stale` owns the 7-day TTL in-domain; `RomInstall` distinguishes `install_path` (install dir) from `file_path` (launch file); `Platform` stays lean per ADR-0001 (future emulator fields deferred).
- Precision fix to the AST aggregate-check: the new short name `Rom` forced exact snake_case identifier matching (substring would false-flag the saves code's `rom`/`rom_state` `RomSaveState` vars). One sanctioned `# pragma: no aggregate-check` on `state.py`'s `rom.files` (a `RomSaveState` mutation → method in PR 4).
- Not wired into any service — no runtime change. Coexists with JSON-era containers incl. the same-named `models/metadata.py:RomMetadata` DTO (resolved at cutover #784).

## Test plan
- [x] `pytest tests/ -q` → 2738 passed; 100% line+branch coverage on the six new modules
- [x] basedpyright 0 errors · ruff clean · import-linter 8 kept · cosmic-call-bans clean
- [x] `check_aggregate_field_assignment.py` clean (matcher tightened; its tests updated for exact-match semantics)

Docs: `database-design.md` updated to reflect the matcher change; the aggregate-set table stays PR 4's job per #788.