### PR TITLE
feat(persistence): add SQLite migration framework (user_version) for #781

### DIFF
--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -159,7 +159,7 @@ Each aggregate gets its own table — the per-ROM cluster is **not** a single wi
 | `sync_settings` | `SyncSettings` | `id = 1` (singleton) | always |
 | `kv_config` | misc singleton scalars | `key` | per key |
 
-`Device`, `SyncSettings`, and `SyncRun` carry their own invariants, so per CONTEXT.md they get typed tables rather than untyped `kv_config` rows. `kv_config` is reserved for the truly miscellaneous: `retrodeck_home_path` (+ its pending-migration `_previous`) and `save_sort_settings` (+ `_previous`). The schema version is **not** a `kv_config` key — it is owned by the migration-framework sub-issue ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782), most likely `PRAGMA user_version`).
+`Device`, `SyncSettings`, and `SyncRun` carry their own invariants, so per CONTEXT.md they get typed tables rather than untyped `kv_config` rows. `kv_config` is reserved for the truly miscellaneous: `retrodeck_home_path` (+ its pending-migration `_previous`) and `save_sort_settings` (+ `_previous`). The schema version is **not** a `kv_config` key — it is tracked in `PRAGMA user_version` by the [migration runner](#the-migration-framework) ([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)).
 
 `SyncRun` is a **history** table, not a single "last run" row: a 1-row table would let a newly-started run (`status='running'`, no stats yet) erase the last completed run's displayable stats. "Last successful sync" is the newest row with `status='completed'`; "is a sync running" is any row with `status='running'`.
 
@@ -183,12 +183,30 @@ All tables are `STRICT` (SQLite ≥ 3.37; the Deck ships 3.50). STRICT allows on
 
 No blanket `created_at`/`updated_at` audit columns (the aggregates already model the timestamps that matter), no `systems` lookup table (`system` stays `TEXT`), and no secondary indexes yet (every lookup and cascade rides a primary key; further indexing is deferred until profiling justifies it, per the epic).
 
+## The migration framework
+
+The schema above is not loaded as a special case — it is migration `001`, applied by the same runner that applies every future schema change. The runner lives in [`py_modules/adapters/sqlite_migrations.py`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/adapters/sqlite_migrations.py) ([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)) — it does file + database I/O, so it is an adapter — and is invoked from `bootstrap()` at plugin startup, before any service is wired. stdlib `sqlite3` only; no Alembic or other third-party migration tooling.
+
+**Versioning — `PRAGMA user_version`.** SQLite keeps a single integer in the database header, readable and writable via `PRAGMA user_version`. The runner uses it as the applied-schema marker: a fresh database reports `0`; after migration `NNN` is applied the runner stamps `user_version = NNN`. There is no separate `schema_migrations` table — `user_version` is the whole mechanism (the same lean approach SDH-PlayTime and Junk-Store use). This is why the schema version is deliberately **not** a `kv_config` key.
+
+**Discovery — `NNN_descriptive_name.sql`.** Migrations are plain `.sql` files under `py_modules/db/migrations/`, named with a leading integer (`001_initial.sql`). At startup the runner scans that directory, parses the integer prefix off each filename, sorts ascending **numerically** (so `10` follows `2`, not lexically), and applies only the files whose number is greater than the database's current `user_version`. Files that don't match `NNN_*.sql` are ignored.
+
+**Atomic per migration.** Each migration runs inside its own transaction: `BEGIN` → the migration's DDL → `PRAGMA user_version = NNN` → `COMMIT`. The version bump rides the same transaction as the DDL, so a migration is all-or-nothing: if any statement fails, the transaction rolls back (DDL **and** version bump both undone) and the runner re-raises, leaving the database at the last successfully-applied version. Migration files therefore contain transaction-safe DDL only and must **not** carry their own `BEGIN`/`COMMIT` — the runner supplies the transaction.
+
+**Connection PRAGMAs.** The runner sets `journal_mode=WAL` (persistent — recorded in the database file, so it carries over to runtime connections) and `foreign_keys=ON` (so `CASCADE`-bearing DDL behaves here as it will at runtime). The full per-connection PRAGMA set for runtime Unit-of-Work connections is a separate concern ([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)).
+
+**Database location.** The database is `romm_sync.db` in the plugin runtime directory (`decky.DECKY_PLUGIN_RUNTIME_DIR`), alongside today's JSON state files. Pre-cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) nothing reads it, so creating the schema at startup is a harmless but visible behavior change; a migration failure is logged and startup continues — whether a failure should ever become fatal is a cutover-era decision, deferred to #784.
+
+### How to add a v2 migration
+
+Drop a new file `002_descriptive_name.sql` into `py_modules/db/migrations/` containing the schema change (e.g. `ALTER TABLE roms ADD COLUMN …;` or a fresh `CREATE TABLE …;`) as transaction-safe DDL with no `BEGIN`/`COMMIT`. That's the whole change — on the next startup the runner sees `002 > user_version`, applies it inside its own transaction, and bumps `user_version` to `2`. Existing databases receive only the new migration; fresh databases receive `001` then `002` in order. No code change is needed to register the file.
+
 ## Coming in later PRs
 
-With the aggregate set above now in place, the remaining persistence work lands downstream:
+With the aggregate set and the schema (applied by the migration framework above) now in place, the remaining persistence work lands downstream:
 
 - **Per-aggregate Repository Protocols** — one Repository per aggregate root (not per table), defined downstream in [#782](https://github.com/danielcopper/decky-romm-sync/issues/782).
-- **The migration framework** — how `001_initial.sql` and future numbered migrations are applied (schema versioning, connection PRAGMAs), in [#782](https://github.com/danielcopper/decky-romm-sync/issues/782).
+- **The runtime Unit-of-Work + connection PRAGMAs** — how services open and share a database connection per operation, in [#783](https://github.com/danielcopper/decky-romm-sync/issues/783).
 - **The service cutover** — wiring the aggregates + Repositories into the services and the hard cut off the JSON state, in [#784](https://github.com/danielcopper/decky-romm-sync/issues/784).
 
 Chapter 8+ of the Cosmic Python book (domain events + message bus) is explicitly out of scope for this epic; the triggers for revisiting that scope are recorded in `CLAUDE.md`.

--- a/py_modules/adapters/sqlite_migrations.py
+++ b/py_modules/adapters/sqlite_migrations.py
@@ -1,0 +1,116 @@
+"""SQLite schema migration runner — applies numbered DDL to the plugin database.
+
+Anything that creates the SQLite database or advances its schema at startup
+belongs here. The runner discovers ``NNN_*.sql`` files under
+``py_modules/db/migrations/``, applies the ones newer than the database's
+recorded version, and stamps the new version into ``PRAGMA user_version``.
+
+stdlib ``sqlite3`` only — no third-party migration tooling. The
+Repository/Unit-of-Work layer that reads the database, and the full
+per-connection runtime PRAGMA set, live elsewhere (#783); this module owns
+only schema creation and version advancement.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sqlite3
+
+# Leading-integer prefix on a ``.sql`` migration file: 001_initial.sql -> 1.
+_MIGRATION_NAME = re.compile(r"^(\d+)_.+\.sql$")
+
+# Migrations ship alongside this adapter at py_modules/db/migrations/.
+MIGRATIONS_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pardir, "db", "migrations"))
+
+_module_logger = logging.getLogger(__name__)
+
+
+def _discover_migrations(migrations_dir: str) -> list[tuple[int, str]]:
+    """Return ``(version, path)`` for every ``NNN_*.sql`` file, sorted ascending."""
+    discovered: list[tuple[int, str]] = []
+    for name in os.listdir(migrations_dir):
+        match = _MIGRATION_NAME.match(name)
+        if match is None:
+            continue
+        discovered.append((int(match.group(1)), os.path.join(migrations_dir, name)))
+    discovered.sort(key=lambda item: item[0])
+    return discovered
+
+
+def apply_migrations(
+    db_path: str,
+    migrations_dir: str = MIGRATIONS_DIR,
+    *,
+    logger: logging.Logger | None = None,
+) -> int:
+    """Apply every pending migration to the SQLite database at ``db_path``.
+
+    Discovers ``NNN_*.sql`` files under ``migrations_dir``, orders them by
+    the leading integer, and applies only those whose number is greater than
+    the database's current ``PRAGMA user_version``. Each migration runs in
+    its own ``BEGIN`` / DDL / version-bump / ``COMMIT`` transaction: on
+    failure the transaction is rolled back (leaving the database at the last
+    successfully-applied version) and the error re-raised. The database file
+    and any missing parent directory are created on first run.
+
+    Migration files must contain transaction-safe DDL only and must NOT carry
+    their own ``BEGIN`` / ``COMMIT`` — the runner supplies the transaction.
+
+    Parameters
+    ----------
+    db_path:
+        Absolute path to the SQLite database file.
+    migrations_dir:
+        Directory holding the ``NNN_*.sql`` files. Defaults to the migrations
+        shipped beside this adapter.
+    logger:
+        Logger for per-migration progress. Defaults to this module's logger.
+
+    Returns
+    -------
+    int
+        The ``user_version`` after all pending migrations have been applied
+        (unchanged when there is nothing pending).
+
+    Raises
+    ------
+    sqlite3.Error
+        If a migration fails; its transaction is rolled back before re-raising.
+    """
+    log = logger or _module_logger
+    migrations = _discover_migrations(migrations_dir)
+
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    # isolation_level=None -> autocommit, so this module drives the
+    # transaction boundaries explicitly. Each migration's BEGIN/COMMIT lives
+    # inside the script handed to executescript(): executescript() commits any
+    # pending transaction *before* it runs, so a BEGIN issued separately would
+    # be committed away and break per-migration atomicity.
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        # journal_mode=WAL is persistent (recorded in the DB file); foreign_keys
+        # is per-connection but kept ON so CASCADE-bearing DDL behaves here as it
+        # will at runtime. Both must be set outside any transaction.
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        for version, path in migrations:
+            if version <= current_version:
+                continue
+            log.info("Applying SQLite migration %s", os.path.basename(path))
+            with open(path, encoding="utf-8") as migration_file:
+                ddl = migration_file.read()
+            script = f"BEGIN;\n{ddl}\nPRAGMA user_version = {version};\nCOMMIT;"
+            try:
+                conn.executescript(script)
+            except sqlite3.Error:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise
+            current_version = version
+        return current_version
+    finally:
+        conn.close()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from dataclasses import dataclass
 from typing import cast
 
@@ -45,6 +46,7 @@ from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApiAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.sgdb_artwork_cache import SgdbArtworkCacheAdapter
+from adapters.sqlite_migrations import MIGRATIONS_DIR, apply_migrations
 from adapters.steam_config import SteamConfigAdapter
 from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
@@ -102,6 +104,10 @@ from services.settings import SettingsService, SettingsServiceConfig
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridService, SteamGridServiceConfig
+
+# Filename of the SQLite database inside the plugin runtime dir. Created by the
+# migration runner at startup; unused until the service cutover (#784).
+_DB_FILENAME = "romm_sync.db"
 
 
 def _default_state() -> PluginState:
@@ -284,6 +290,16 @@ def bootstrap(
         ``stores``, ``callbacks``) plus the small set of Plugin-only
         handles ``main.py`` itself binds (``handles.debug_logger``).
     """
+    # Bring the on-disk SQLite schema up to date before any service is wired —
+    # the composition root owns startup infra. Pre-cutover (#784) nothing reads
+    # romm_sync.db, so creating the schema now is harmless; a failed migration
+    # is logged but not fatal (cutover-aware fatal/non-fatal handling is #784).
+    db_path = os.path.join(runtime_dir, _DB_FILENAME)
+    try:
+        apply_migrations(db_path, MIGRATIONS_DIR, logger=logger)
+    except Exception:
+        logger.exception("SQLite schema migration failed; database left at last good version")
+
     retrodeck_paths = RetroDeckPathsAdapter(user_home=user_home, logger=logger)
     retroarch_config = RetroArchConfigAdapter(user_home=user_home, logger=logger)
     retroarch_core_info = RetroArchCoreInfoAdapter(user_home=user_home, logger=logger)

--- a/py_modules/db/migrations/001_initial.sql
+++ b/py_modules/db/migrations/001_initial.sql
@@ -8,10 +8,10 @@
 -- empty and the library re-syncs (BREAKING CHANGE, beta plugin).
 --
 -- HOW THIS FILE IS LOADED is intentionally out of scope here. Connection-level
--- PRAGMAs (journal_mode=WAL, synchronous=NORMAL, busy_timeout, temp_store,
--- foreign_keys=ON, isolation_level) are set per-connection by the adapter, and
--- schema versioning (PRAGMA user_version vs a schema_migrations table) is owned
--- by the migration-framework sub-issue (#782). This file only declares tables.
+-- PRAGMAs (synchronous=NORMAL, busy_timeout, temp_store, isolation_level) are
+-- set per-connection by the runtime UoW adapter (#783), and schema versioning
+-- (PRAGMA user_version) is applied by the migration runner
+-- (adapters/sqlite_migrations.py, #781). This file only declares tables.
 --
 -- NOTE: foreign_keys must be ON at runtime for the ON DELETE CASCADE clauses
 -- below to fire. That PRAGMA is per-connection (the epic locks foreign_keys=ON)
@@ -325,8 +325,8 @@ CREATE TABLE sync_settings (
 --   retrodeck_home_path_previous  pending-migration previous home (TEXT)
 --   save_sort_settings            {sort_by_content, sort_by_core} (JSON)
 --   save_sort_settings_previous   pending save-sort change (JSON)
--- Schema version is NOT a kv_config key — it is owned by the migration framework
--- (#782), most likely PRAGMA user_version.
+-- Schema version is NOT a kv_config key — it is tracked in PRAGMA user_version
+-- by the migration runner (adapters/sqlite_migrations.py, #781).
 -- -----------------------------------------------------------------------------
 CREATE TABLE kv_config (
     key   TEXT PRIMARY KEY,

--- a/tests/adapters/test_sqlite_migrations.py
+++ b/tests/adapters/test_sqlite_migrations.py
@@ -1,0 +1,214 @@
+"""Tests for the SQLite migration runner — schema creation + version advancement."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from adapters.sqlite_migrations import MIGRATIONS_DIR, apply_migrations
+
+# The 13 tables the shipped v1 schema (001_initial.sql) declares.
+_V1_TABLES = {
+    "roms",
+    "rom_installs",
+    "rom_metadata",
+    "rom_playtime",
+    "rom_save_states",
+    "rom_save_files",
+    "platforms",
+    "downloaded_bios",
+    "firmware_cache",
+    "sync_runs",
+    "device",
+    "sync_settings",
+    "kv_config",
+}
+
+
+def _user_version(db_path: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _tables(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def _set_user_version(db_path: str, version: int) -> None:
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        conn.execute(f"PRAGMA user_version = {version}")
+    finally:
+        conn.close()
+
+
+class TestEmptyDatabase:
+    """Empty DB (user_version 0) -> the full shipped schema is applied."""
+
+    def test_applies_real_v1_schema(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+
+        final_version = apply_migrations(db_path)
+
+        # Highest NNN in the shipped migrations dir is 001 -> version 1.
+        assert final_version == 1
+        assert _user_version(db_path) == 1
+        assert _tables(db_path) == _V1_TABLES
+
+    def test_creates_missing_parent_directory(self, tmp_path: Path):
+        # The runtime dir may not exist yet on first run.
+        db_path = str(tmp_path / "nested" / "dir" / "romm_sync.db")
+
+        apply_migrations(db_path)
+
+        assert Path(db_path).exists()
+        assert _user_version(db_path) == 1
+
+    def test_idempotent_second_run_is_noop(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path)
+
+        # A re-run finds nothing pending and must not re-execute 001 (which
+        # would fail on duplicate-table creation if it were re-applied).
+        final_version = apply_migrations(db_path)
+
+        assert final_version == 1
+        assert _tables(db_path) == _V1_TABLES
+
+
+class TestPartiallyMigratedDatabase:
+    """A DB already at version N -> only migrations > N are applied."""
+
+    def test_only_pending_migration_applies(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        # 001 would create t1; 002 creates t2. The DB is preset to version 1,
+        # so the runner must skip 001 entirely and apply only 002.
+        (migrations_dir / "001_first.sql").write_text("CREATE TABLE t1 (x INTEGER);")
+        (migrations_dir / "002_second.sql").write_text("CREATE TABLE t2 (y INTEGER);")
+
+        db_path = str(tmp_path / "romm_sync.db")
+        _set_user_version(db_path, 1)
+
+        final_version = apply_migrations(db_path, str(migrations_dir))
+
+        assert final_version == 2
+        assert _user_version(db_path) == 2
+        tables = _tables(db_path)
+        assert "t2" in tables  # 002 applied
+        assert "t1" not in tables  # 001 skipped, not re-run
+
+    def test_numeric_ordering_not_lexical(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        # Unpadded names: lexical sort would place "10" before "2"; the runner
+        # parses the integer prefix and applies 2 then 10.
+        (migrations_dir / "2_two.sql").write_text("CREATE TABLE t_two (x INTEGER);")
+        (migrations_dir / "10_ten.sql").write_text("CREATE TABLE t_ten (x INTEGER);")
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        final_version = apply_migrations(db_path, str(migrations_dir))
+
+        assert final_version == 10
+        assert {"t_two", "t_ten"} <= _tables(db_path)
+
+    def test_empty_migrations_dir_returns_zero(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()  # no .sql files
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        final_version = apply_migrations(db_path, str(migrations_dir))
+
+        assert final_version == 0
+        assert _tables(db_path) == set()
+
+    def test_ignores_non_migration_files(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        (migrations_dir / "001_real.sql").write_text("CREATE TABLE kept (x INTEGER);")
+        (migrations_dir / "README.md").write_text("# notes")
+        (migrations_dir / "notes.txt").write_text("ignore me")
+        (migrations_dir / "002_draft.sql.bak").write_text("CREATE TABLE nope (x INTEGER);")
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        final_version = apply_migrations(db_path, str(migrations_dir))
+
+        assert final_version == 1
+        tables = _tables(db_path)
+        assert "kept" in tables
+        assert "nope" not in tables
+
+
+class TestAtomicRollback:
+    """A failing migration rolls back fully and leaves the version untouched."""
+
+    def test_broken_migration_raises_and_rolls_back(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        # First statement is valid, second is a syntax error. The whole
+        # migration must roll back: no `good` table, version stays 0.
+        (migrations_dir / "001_broken.sql").write_text(
+            "CREATE TABLE good (x INTEGER);\nCREATE TABLE bad (this is not valid sql);"
+        )
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        with pytest.raises(sqlite3.Error):
+            apply_migrations(db_path, str(migrations_dir))
+
+        assert _user_version(db_path) == 0
+        assert "good" not in _tables(db_path)
+
+    def test_failure_preserves_prior_applied_version(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        (migrations_dir / "001_ok.sql").write_text("CREATE TABLE ok (x INTEGER);")
+        (migrations_dir / "002_broken.sql").write_text("CREATE TABLE oops (this is not valid);")
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        with pytest.raises(sqlite3.Error):
+            apply_migrations(db_path, str(migrations_dir))
+
+        # 001 committed before 002 failed: version pinned at 1, 002 rolled back.
+        assert _user_version(db_path) == 1
+        tables = _tables(db_path)
+        assert "ok" in tables
+        assert "oops" not in tables
+
+
+class TestUnreadableSource:
+    """An unreadable migration source surfaces the OS error without corrupting state."""
+
+    def test_unreadable_migration_propagates_oserror(self, tmp_path: Path):
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        # A directory named like a migration is matched by discovery but cannot
+        # be opened — open() raises IsADirectoryError (an OSError) on every OS
+        # and for every user, so this deterministically exercises the read path.
+        (migrations_dir / "001_unreadable.sql").mkdir()
+
+        db_path = str(tmp_path / "romm_sync.db")
+
+        with pytest.raises(OSError):
+            apply_migrations(db_path, str(migrations_dir))
+
+        assert _user_version(db_path) == 0
+
+
+def test_shipped_migrations_dir_resolves_to_real_schema():
+    """The default MIGRATIONS_DIR points at the shipped 001_initial.sql."""
+    assert (Path(MIGRATIONS_DIR) / "001_initial.sql").is_file()


### PR DESCRIPTION
## Summary

- Adds the SQLite schema **migration runner** (`py_modules/adapters/sqlite_migrations.py`) that applies the numbered DDL migrations under `py_modules/db/migrations/` to the plugin database, tracking the applied version in `PRAGMA user_version`. Stdlib `sqlite3` only (no Alembic).
- Discovers `NNN_*.sql` files, sorts numerically, and applies only those with `NNN > user_version`. Each migration runs in its own atomic `BEGIN` / DDL / version-bump / `COMMIT` transaction (the `BEGIN`/`COMMIT` live inside the `executescript()` payload because `executescript()` commits any pending transaction first). On failure: `ROLLBACK` + re-raise, leaving the DB at the last good version.
- Invoked from `bootstrap()` before any service is wired — the composition root owns startup infra (the `main.py`/`bootstrap.py` split is binding, so no wiring in `main.py`).
- v1 `001_initial.sql` is applied through this framework, not as a special case.
- Tests cover: empty DB → all migrations apply (version → highest `NNN`, all 13 tables present); partially-migrated DB → only pending applied (preset `user_version=1` + a 002 fixture, 001 not re-run); atomic rollback on a broken migration → raises, version unchanged, no partial objects; numeric (not lexical) ordering; non-migration files ignored; empty dir → returns 0; unreadable source propagates `OSError`.
- Docs: `docs/architecture/database-design.md` gains an implemented **migration framework** section (user_version mechanism, `NNN_*.sql` discovery, atomic-per-migration, runner location, connection PRAGMAs, DB location, and a "How to add a v2 migration" paragraph).

### Folded-in cross-reference fix

The #780 schema docs/comments wrongly credited the migration framework to **#782** — but #782 is *Repository Protocols*; the framework is this issue (#781). Fixed in `001_initial.sql` (×2 comments) and `database-design.md` (kv_config note + the "coming later" bullet). The genuine #782 Repository-Protocols reference is left intact.

## Design calls made

- **DB file**: `romm_sync.db` in `decky.DECKY_PLUGIN_RUNTIME_DIR`, alongside today's JSON state. Filename is a documented `_DB_FILENAME` constant in `bootstrap.py`.
- **Tracking**: `PRAGMA user_version` (single integer), not a `schema_migrations` table — the lean approach the locked decisions favored.
- **Runner shape**: a function `apply_migrations(db_path, migrations_dir=MIGRATIONS_DIR, *, logger=None) -> int`. No Protocol — it's called from bootstrap, not injected into a service.
- **PRAGMAs**: only `journal_mode=WAL` (persistent) and `foreign_keys=ON`. The full per-connection runtime PRAGMA set is #783, not here.
- **Failure handling**: runner raises; `bootstrap()` logs (`logger.exception`) and continues. **No** cutover-aware fatal/non-fatal logic — that's #784.

> ⚠️ **Behavior change**: the SQLite DB is now created at startup. Pre-cutover (#784) nothing reads it, so this is harmless, but it is a visible new side effect (a `romm_sync.db` file appears in the runtime dir).

## Test plan

- [x] `ruff format --check` + `ruff check` — clean
- [x] `basedpyright` (incl. `tests/`) — 0 errors
- [x] `PYTHONPATH=py_modules lint-imports` — 8/8 contracts kept
- [x] `scripts/check_cosmic_call_bans.sh` — OK
- [x] `python -m pytest tests/ -q` — 2799 passed
- [x] New-code coverage on the runner — 98% branch

Closes #781