### PR TITLE
refactor(settings): move save-sync settings + device_name to settings.json

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -582,11 +582,12 @@ Save sync state is stored in a separate file from the main `state.json` to avoid
 
 Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
 
+The save-sync **feature toggles** (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) and the **device label** (`device_name`) live in `settings.json`, not here — they are user-intent config, not synced relational state (ADR-0003). `StateService` reads and writes them through the live settings dict; only `device_id` / `server_device_id` (server-issued identity) remain on this file.
+
 ```json
 {
   "version": 1,
   "device_id": "550e8400-e29b-41d4-a716-446655440000",
-  "device_name": null,
   "server_device_id": "81445610-e5a1-46b5-9389-9d159f99c21c",
   "saves": {
     "42": {
@@ -618,13 +619,6 @@ Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
       "last_session_duration_sec": 1800,
       "note_id": 456
     }
-  },
-  "settings": {
-    "save_sync_enabled": false,
-    "sync_before_launch": true,
-    "sync_after_exit": true,
-    "default_slot": "default",
-    "autocleanup_limit": 10
   }
 }
 ```
@@ -635,7 +629,6 @@ Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
 | --- | --- | --- |
 | `version` | integer | State schema version (currently 1) |
 | `device_id` | string (UUID v4) | Unique identifier for this machine, generated on first use |
-| `device_name` | string / null | Human-readable device name (reserved for future use) |
 | `server_device_id` | string / null | RomM server device UUID. Null until first device registration. |
 | `saves` | object | Per-ROM sync metadata, keyed by `rom_id` (string) |
 | `saves.<id>.system` | string | RetroDECK system slug (e.g. `"gba"`, `"snes"`) |
@@ -659,12 +652,8 @@ Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
 | `playtime.<id>.last_session_start` | ISO-8601 / null | Start time of current session (null when not playing). |
 | `playtime.<id>.last_session_duration_sec` | integer / null | Duration of last completed session. |
 | `playtime.<id>.note_id` | integer / null | Cached RomM note ID for playtime storage (avoids ROM detail fetch). |
-| `settings` | object | Save sync settings. |
-| `settings.save_sync_enabled` | boolean | Master toggle for save sync feature. |
-| `settings.sync_before_launch` | boolean | Auto-sync saves before game launch. |
-| `settings.sync_after_exit` | boolean | Auto-sync saves after game exit. |
-| `settings.default_slot` | string | Default slot name for new games (default: `"default"`). |
-| `settings.autocleanup_limit` | integer | Max save versions per slot on server (default: 10). |
+
+The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this file. `save_sync_enabled` is the master feature toggle; `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs; `default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on the server (10).
 
 Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom_saves` and `_get_save_status_io` and surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the next sync as long as the underlying state still produces matrix row 12.
 
@@ -674,8 +663,7 @@ Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom
 
 - **`saves.<id>.active_core`** → renamed to `saves.<id>.last_synced_core` (per-game; `last_synced_core` wins if both are present).
 - **`saves.<id>.files.<fn>.dismissed_newer_save_id`** → dropped. Was used by the removed newer-in-slot detection. Users upgrading from v0.15.x and earlier may have this field; it's silently removed.
-- **`settings.conflict_mode`** → dropped. The `ask_me` / `prefer_local` / `prefer_remote` setting was removed in v0.18.x; conflicts are now always surfaced via the conflict modal.
-- **`settings.clock_skew_tolerance_sec`** → dropped. The newest-wins matrix model in v0.16.x made the tolerance window irrelevant; comparisons are exact.
+- **`settings` block + `device_name`** → no longer parsed from or written to this file. The save-sync feature toggles and the device label moved to `settings.json` (ADR-0003); a one-time `settings.json` schema bump (v3 → v4) reads the legacy values out of `save_sync_state.json` and folds them in. On the next state write they disappear from this file. The legacy `settings.conflict_mode` / `settings.clock_skew_tolerance_sec` keys (dropped in earlier releases) are not carried over.
 
 The dropped `pending_conflicts`, `dismissed_saves_state`, and other obsolete sync-state fields are simply not loaded. They never appear in the rebuilt aggregate, and the next state write produces a clean file.
 

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -17,7 +17,7 @@ from models.state import MetadataCache, PluginState
 _STATE_VERSION = 1
 _METADATA_CACHE_VERSION = 1
 _FIRMWARE_CACHE_VERSION = 1
-_SETTINGS_VERSION = 3
+_SETTINGS_VERSION = 4
 _LOCK_EXT = ".lock"
 
 DEFAULT_SETTINGS: dict = {
@@ -31,6 +31,12 @@ DEFAULT_SETTINGS: dict = {
     "steamgriddb_api_key": "",
     "romm_allow_insecure_ssl": False,
     "log_level": "warn",
+    "save_sync_enabled": False,
+    "sync_before_launch": True,
+    "sync_after_exit": True,
+    "default_slot": "default",
+    "autocleanup_limit": 10,
+    "device_name": None,
 }
 
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -52,7 +52,7 @@ from adapters.steamgriddb import SteamGridDbAdapter
 from adapters.system_clock import SystemClock
 from adapters.system_uuid_gen import SystemUuidGen
 from domain.save_state import SaveSyncState
-from domain.state_migrations import migrate_settings, migrate_state
+from domain.state_migrations import fold_legacy_save_sync_settings, migrate_settings, migrate_state
 from lib.late_binding import LateBinding
 from services.achievements import AchievementsService, AchievementsServiceConfig
 from services.artwork import ArtworkService, ArtworkServiceConfig
@@ -314,6 +314,12 @@ def bootstrap(
     firmware_cache_persister = FirmwareCachePersisterAdapter(persistence)
     save_sync_state_persister = SaveSyncStatePersisterAdapter(persistence)
     settings = persistence.load_settings()
+    # One-time JSON→JSON lift (ADR-0003): fold the legacy save-sync knobs +
+    # device_name out of save_sync_state.json before the schema bump stamps
+    # version 4. Idempotent — after the first run save_settings stamps the
+    # new version and this branch is skipped.
+    if settings.get("version", 0) < 4:
+        settings = fold_legacy_save_sync_settings(settings, persistence.load_save_sync_state())
     settings = migrate_settings(settings)
     persistence.save_settings(settings)
     # Persistence + migration round-trip through bare ``dict`` because
@@ -456,6 +462,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         state=cfg.stores.state,
         save_sync_state=cfg.stores.save_sync_state,
         save_sync_state_persister=cfg.callbacks.save_sync_state_persister,
+        settings_persister=cfg.callbacks.settings_persister,
         save_file_store=cfg.adapters.save_file_store,
         loop=cfg.runtime.loop,
         logger=cfg.runtime.logger,
@@ -479,6 +486,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             romm_api=cfg.adapters.romm_api,
             retry=cfg.adapters.http_adapter,
             save_sync_state=cfg.stores.save_sync_state,
+            settings=cfg.stores.settings,
             loop=cfg.runtime.loop,
             logger=cfg.runtime.logger,
             clock=cfg.runtime.clock,
@@ -636,6 +644,7 @@ def wire_services(cfg: WiringConfig) -> dict:
             state=cfg.stores.state,
             metadata_cache=cfg.stores.metadata_cache,
             save_sync_state=cfg.stores.save_sync_state,
+            settings=cfg.stores.settings,
             logger=cfg.runtime.logger,
             clock=cfg.runtime.clock,
             bios_checker=firmware_service,

--- a/py_modules/domain/save_state.py
+++ b/py_modules/domain/save_state.py
@@ -5,10 +5,17 @@ Pure data shapes — no I/O, no logging, no service/adapter imports.
 JSON via ``SaveSyncState.from_dict`` / ``SaveSyncState.to_dict``.
 Legacy schema migrations apply inside ``from_dict``.
 
-Aggregate root is :class:`SaveSyncState`. Per-ROM, per-file, playtime,
-and settings shapes are reflected in dedicated dataclasses. Mutation
-is supported (dataclasses are *not* frozen) so existing code paths
-that update nested fields in place continue to work.
+The on-disk file carries device identity (``device_id`` /
+``server_device_id``), per-ROM save state, and playtime tracking. The
+save-sync feature toggles and the device label live in ``settings.json``
+(owned by ``StateService`` over the live settings dict), not here.
+
+Aggregate root is :class:`SaveSyncState`. Per-ROM, per-file, and
+playtime shapes are reflected in dedicated dataclasses. Mutation is
+supported (dataclasses are *not* frozen) so existing code paths that
+update nested fields in place continue to work. :class:`SaveSyncSettings`
+is a read-view value object built by ``StateService`` from the settings
+dict — it is no longer parsed from or persisted to this file.
 """
 
 from __future__ import annotations
@@ -254,11 +261,13 @@ class PlaytimeEntry:
 
 @dataclass
 class SaveSyncSettings:
-    """Save-sync feature settings (user-toggleable).
+    """Read-view value object for the five save-sync feature toggles.
 
-    Legacy keys (``conflict_mode``, ``clock_skew_tolerance_sec``)
-    are dropped at :meth:`from_dict`. Any forward-compatible unknown
-    keys are preserved in ``extra``.
+    The authoritative store is ``settings.json`` — ``StateService``
+    builds this object from the live settings dict on demand. It is not
+    parsed from or persisted to ``save_sync_state.json``; :meth:`to_dict`
+    exists only to surface the five knobs to the frontend in the shape it
+    already expects.
     """
 
     save_sync_enabled: bool = False
@@ -266,73 +275,35 @@ class SaveSyncSettings:
     sync_after_exit: bool = True
     default_slot: str | None = "default"
     autocleanup_limit: int = 10
-    extra: dict[str, Any] = field(default_factory=dict)
-
-    _KNOWN_KEYS = frozenset(
-        {
-            "save_sync_enabled",
-            "sync_before_launch",
-            "sync_after_exit",
-            "default_slot",
-            "autocleanup_limit",
-        }
-    )
-    _LEGACY_DROPPED_KEYS = frozenset({"conflict_mode", "clock_skew_tolerance_sec"})
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SaveSyncSettings:
-        """Build from a raw dict, dropping legacy keys."""
-        if not isinstance(data, dict):
-            return cls()
-        extra = {k: v for k, v in data.items() if k not in cls._KNOWN_KEYS and k not in cls._LEGACY_DROPPED_KEYS}
-        # ``default_slot=None`` is the legacy ("no slots") mode; preserve it
-        # rather than collapsing it to the "default" string default.
-        raw_slot = data.get("default_slot", "default") if "default_slot" in data else "default"
-        if raw_slot is None:
-            default_slot: str | None = None
-        else:
-            slot_str = str(raw_slot)
-            default_slot = slot_str if slot_str else None
-        return cls(
-            save_sync_enabled=bool(data.get("save_sync_enabled", False)),
-            sync_before_launch=bool(data.get("sync_before_launch", True)),
-            sync_after_exit=bool(data.get("sync_after_exit", True)),
-            default_slot=default_slot,
-            autocleanup_limit=int(data.get("autocleanup_limit", 10) or 10),
-            extra=extra,
-        )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to the on-disk JSON dict."""
-        out: dict[str, Any] = {
+        """Serialise the five knobs to the frontend-facing dict shape."""
+        return {
             "save_sync_enabled": self.save_sync_enabled,
             "sync_before_launch": self.sync_before_launch,
             "sync_after_exit": self.sync_after_exit,
             "default_slot": self.default_slot,
             "autocleanup_limit": self.autocleanup_limit,
         }
-        for k, v in self.extra.items():
-            out[k] = v
-        return out
 
 
 @dataclass
 class SaveSyncState:
     """Aggregate root for the on-disk ``save_sync_state.json``.
 
-    Carries device identity, per-ROM save state, playtime tracking,
-    and feature settings. Persistence flows through :meth:`to_dict` /
-    :meth:`from_dict`; schema migrations apply on load. Mutation is
-    in-place — held by reference across services.
+    Carries device identity, per-ROM save state, and playtime tracking.
+    The save-sync feature toggles and the device label live in
+    ``settings.json`` (owned by ``StateService``), not on this aggregate.
+    Persistence flows through :meth:`to_dict` / :meth:`from_dict`; schema
+    migrations apply on load. Mutation is in-place — held by reference
+    across services.
     """
 
     version: int = _SCHEMA_VERSION
     device_id: str | None = None
-    device_name: str | None = None
     server_device_id: int | str | None = None
     saves: dict[str, RomSaveState] = field(default_factory=dict)
     playtime: dict[str, PlaytimeEntry] = field(default_factory=dict)
-    settings: SaveSyncSettings = field(default_factory=SaveSyncSettings)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SaveSyncState:
@@ -352,11 +323,9 @@ class SaveSyncState:
         return cls(
             version=int(data.get("version", _SCHEMA_VERSION) or _SCHEMA_VERSION),
             device_id=data.get("device_id"),
-            device_name=data.get("device_name"),
             server_device_id=data.get("server_device_id"),
             saves=saves,
             playtime=playtime,
-            settings=SaveSyncSettings.from_dict(data.get("settings", {})),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -368,11 +337,9 @@ class SaveSyncState:
         return {
             "version": self.version,
             "device_id": self.device_id,
-            "device_name": self.device_name,
             "server_device_id": self.server_device_id,
             "saves": {rid: rs.to_dict() for rid, rs in self.saves.items()},
             "playtime": {rid: pe.to_dict() for rid, pe in self.playtime.items()},
-            "settings": self.settings.to_dict(),
         }
 
     def replace_with(self, other: SaveSyncState) -> None:
@@ -384,11 +351,9 @@ class SaveSyncState:
         """
         self.version = other.version
         self.device_id = other.device_id
-        self.device_name = other.device_name
         self.server_device_id = other.server_device_id
         self.saves = other.saves
         self.playtime = other.playtime
-        self.settings = other.settings
 
 
 __all__ = [

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -19,7 +19,42 @@ def migrate_settings(data: dict) -> dict:
         new_data = _migrate_v0_to_v1(new_data)
     if version < 3:
         new_data = _migrate_v2_to_v3(new_data)
+    if version < 4:
+        new_data = _migrate_v3_to_v4(new_data)
     return new_data
+
+
+_SAVE_SYNC_KNOBS = (
+    "save_sync_enabled",
+    "sync_before_launch",
+    "sync_after_exit",
+    "default_slot",
+    "autocleanup_limit",
+)
+
+
+def fold_legacy_save_sync_settings(settings: dict, save_sync_raw: dict | None) -> dict:
+    """Fold the legacy save-sync knobs + ``device_name`` into *settings*.
+
+    Returns a new dict — the inputs are never mutated. The five feature
+    knobs are copied out of ``save_sync_raw["settings"]`` (per-key, only
+    for keys actually present) and ``device_name`` out of the top level,
+    overwriting the ``DEFAULT_SETTINGS`` placeholders. Device identity
+    (``device_id`` / ``server_device_id``) is left in the save-sync file.
+    A falsy *save_sync_raw* (``None`` or empty) returns *settings*
+    unchanged.
+    """
+    if not save_sync_raw:
+        return dict(settings)
+    folded = dict(settings)
+    raw_knobs = save_sync_raw.get("settings")
+    if isinstance(raw_knobs, dict):
+        for key in _SAVE_SYNC_KNOBS:
+            if key in raw_knobs:
+                folded[key] = raw_knobs[key]
+    if "device_name" in save_sync_raw:
+        folded["device_name"] = save_sync_raw["device_name"]
+    return folded
 
 
 def _migrate_v0_to_v1(data: dict) -> dict:
@@ -92,6 +127,18 @@ def _is_partial_nested_collections(value: dict) -> bool:
 def _fill_missing_buckets(value: dict) -> dict[str, dict[str, bool]]:
     """Return a complete three-bucket dict, filling missing buckets with ``{}``."""
     return {kind: dict(value.get(kind, {})) for kind in _BUCKET_KEYS}
+
+
+def _migrate_v3_to_v4(data: dict) -> dict:
+    """v<4 → v4: stamp the version after the save-sync fold.
+
+    The cross-file lift of the save-sync knobs + ``device_name`` from
+    ``save_sync_state.json`` into ``settings.json`` is orchestrated in
+    ``bootstrap`` (domain code cannot do I/O); this step only advances
+    the schema version so the fold runs exactly once.
+    """
+    data["version"] = 4
+    return data
 
 
 def migrate_state(data: dict) -> dict:

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -32,15 +32,16 @@ ACHIEVEMENT_TTL_SEC = 3600  # 1 hour
 class GameDetailServiceConfig:
     """Frozen wiring bundle handed to ``GameDetailService.__init__``.
 
-    Holds the live state and metadata cache dicts, the typed save-sync
-    aggregate, runtime infrastructure, clock seam, and the Protocol-
-    typed reader adapters (``BiosChecker``, ``AchievementsReader``)
+    Holds the live state, metadata cache, and settings dicts, the typed
+    save-sync aggregate, runtime infrastructure, clock seam, and the
+    Protocol-typed reader adapters (``BiosChecker``, ``AchievementsReader``)
     GameDetailService consults to assemble the game-detail payload.
     """
 
     state: PluginState
     metadata_cache: MetadataCache
     save_sync_state: SaveSyncState
+    settings: dict
     logger: logging.Logger
     clock: Clock
     bios_checker: BiosChecker
@@ -54,6 +55,7 @@ class GameDetailService:
         self._state = config.state
         self._metadata_cache = config.metadata_cache
         self._save_sync_state = config.save_sync_state
+        self._settings = config.settings
         self._logger = config.logger
         self._clock = config.clock
         self._bios_checker = config.bios_checker
@@ -159,7 +161,7 @@ class GameDetailService:
         installed = rom_id_str in self._state["installed_roms"]
 
         # Save sync
-        save_sync_enabled = self._save_sync_state.settings.save_sync_enabled
+        save_sync_enabled = bool(self._settings.get("save_sync_enabled", False))
         save_status = self._build_save_status(rom_id_str)
         save_sync_display = None
         if save_status is not None:

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -32,14 +32,16 @@ class PlaytimeServiceConfig:
     """Frozen wiring bundle handed to ``PlaytimeService.__init__``.
 
     Holds the Protocol-typed RomM adapter and retry strategy, the typed
-    save-sync aggregate, runtime infrastructure, clock/debug-logger
-    seams, and the persistence callback PlaytimeService needs at
-    construction time.
+    save-sync aggregate, the live ``settings.json`` dict (home of the
+    device label stamped onto synced playtime notes), runtime
+    infrastructure, clock/debug-logger seams, and the persistence
+    callback PlaytimeService needs at construction time.
     """
 
     romm_api: RommPlaytimeApi
     retry: RetryStrategy
     save_sync_state: SaveSyncState
+    settings: dict
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     clock: Clock
@@ -56,6 +58,7 @@ class PlaytimeService:
         self._romm_api = config.romm_api
         self._retry = config.retry
         self._save_sync_state = config.save_sync_state
+        self._settings = config.settings
         self._loop = config.loop
         self._logger = config.logger
         self._clock = config.clock
@@ -135,7 +138,7 @@ class PlaytimeService:
             return
 
         local_total = entry.total_seconds
-        device_name = self._save_sync_state.device_name or ""
+        device_name = self._settings.get("device_name") or ""
 
         try:
             note = self._retry.with_retry(self._get_playtime_note, rom_id)

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         SaveFileStore,
         SaveSortChangeFn,
         SaveSyncStatePersister,
+        SettingsPersister,
     )
 
 
@@ -60,6 +61,12 @@ class SaveServiceConfig:
         Protocol-typed I/O wrapper for ``save_sync_state.json``. The
         ``StateService`` uses ``.save(data)`` / ``.load() -> dict | None``
         — file path, locking, and atomic-write are adapter-internal.
+    settings_persister:
+        Protocol-typed zero-arg flush for ``settings.json``. The
+        ``StateService`` calls ``.save_settings()`` after mutating the
+        save-sync feature toggles or the device label in the live
+        ``settings`` dict — those values live in settings.json, not the
+        save-sync aggregate.
     save_file_store:
         Protocol-typed filesystem adapter for local save files. Owns the
         raw POSIX, ``open()``, ``tempfile``, and ``hashlib``-on-file
@@ -131,6 +138,7 @@ class SaveServiceConfig:
     state: PluginState
     save_sync_state: SaveSyncState
     save_sync_state_persister: SaveSyncStatePersister
+    settings_persister: SettingsPersister
     save_file_store: SaveFileStore
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -52,7 +52,9 @@ class SaveService:
             config=StateServiceConfig(
                 save_sync_state=config.save_sync_state,
                 state=config.state,
+                settings=config.settings,
                 persister=config.save_sync_state_persister,
+                settings_persister=config.settings_persister,
                 logger=config.logger,
             ),
         )

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -63,7 +63,7 @@ class SlotListing:
         rom_id_str = str(rom_id)
         device_id = self._state_svc.get_server_device_id()
         rom_state = self._state_svc.state.saves.get(rom_id_str)
-        default_slot = self._state_svc.state.settings.default_slot or "default"
+        default_slot = self._state_svc.get_settings().default_slot or "default"
         # ROM not tracked → fall back to the global default slot. ROM
         # tracked with ``active_slot=None`` → preserve legacy mode (None
         # means "no slots"; the persisted slots dict will contain ``""``).

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -109,7 +109,7 @@ class SetupWizard:
                 f"get_save_setup_info({rom_id}): failed to list server saves: {e}",
             )
             game_state = self._state_svc.state.saves.get(rom_id_str)
-            default_slot = self._state_svc.state.settings.default_slot or "default"
+            default_slot = self._state_svc.get_settings().default_slot or "default"
             slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
             active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
             return {
@@ -152,7 +152,7 @@ class SetupWizard:
 
         # State info
         game_state = self._state_svc.state.saves.get(rom_id_str)
-        default_slot = self._state_svc.state.settings.default_slot or "default"
+        default_slot = self._state_svc.get_settings().default_slot or "default"
         slot_confirmed = bool(game_state.slot_confirmed) if game_state else False
         active_slot = game_state.active_slot if (game_state and slot_confirmed) else None
 

--- a/py_modules/services/saves/state.py
+++ b/py_modules/services/saves/state.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     import logging
 
     from services.protocols import SaveSyncStatePersister
+    from services.protocols.persistence import SettingsPersister
 
 
 @dataclass(frozen=True)
@@ -34,23 +35,35 @@ class StateServiceConfig:
 
     Holds the live :class:`SaveSyncState` aggregate, the main plugin
     state dict (used for orphan-pruning against the shortcut registry),
-    the Protocol-typed persister, and the standard-library logger.
+    the live ``settings.json`` dict + its Protocol-typed persister (the
+    home of the save-sync feature toggles and the device label), the
+    save-sync-state persister, and the standard-library logger.
     """
 
     save_sync_state: SaveSyncState
     state: PluginState
+    settings: dict
     persister: SaveSyncStatePersister
+    settings_persister: SettingsPersister
     logger: logging.Logger
 
 
 class StateService:
-    """Owns the live ``SaveSyncState`` aggregate and its persistence."""
+    """Owns the live ``SaveSyncState`` aggregate and its persistence.
+
+    Also the settings.json-backed owner of the five save-sync feature
+    toggles and the device label: those values live in the injected
+    settings dict and flush through the ``SettingsPersister``, not the
+    save-sync aggregate.
+    """
 
     def __init__(self, *, config: StateServiceConfig) -> None:
         self._config = config
         self._save_sync_state = config.save_sync_state
         self._state = config.state
+        self._settings = config.settings
         self._persister = config.persister
+        self._settings_persister = config.settings_persister
         self._logger = config.logger
 
     @property
@@ -104,8 +117,26 @@ class StateService:
         return rom.files.get(filename)
 
     def get_settings(self) -> SaveSyncSettings:
-        """Return the live settings dataclass."""
-        return self._save_sync_state.settings
+        """Build a read-view of the five save-sync knobs from the settings dict.
+
+        Applies the same coercions the legacy on-disk parse did: booleans
+        via ``bool(...)``; ``default_slot`` keeps ``None`` (no-slots mode)
+        and collapses empty strings to ``None``; ``autocleanup_limit`` via
+        ``int(...)`` with a ``or 10`` guard against ``0`` / ``None``.
+        """
+        raw_slot = self._settings.get("default_slot", "default")
+        if raw_slot is None:
+            default_slot: str | None = None
+        else:
+            slot_str = str(raw_slot)
+            default_slot = slot_str if slot_str else None
+        return SaveSyncSettings(
+            save_sync_enabled=bool(self._settings.get("save_sync_enabled", False)),
+            sync_before_launch=bool(self._settings.get("sync_before_launch", True)),
+            sync_after_exit=bool(self._settings.get("sync_after_exit", True)),
+            default_slot=default_slot,
+            autocleanup_limit=int(self._settings.get("autocleanup_limit", 10) or 10),
+        )
 
     # ------------------------------------------------------------------
     # File tracking mutations
@@ -150,7 +181,7 @@ class StateService:
 
     def is_save_sync_enabled(self) -> bool:
         """Whether the save-sync feature toggle is on."""
-        return self._save_sync_state.settings.save_sync_enabled
+        return bool(self._settings.get("save_sync_enabled", False))
 
     def get_server_device_id(self) -> str | None:
         """Server-side device id (None when this device is not yet registered)."""
@@ -158,11 +189,11 @@ class StateService:
         return str(sid) if sid is not None else None
 
     def get_save_sync_settings(self) -> dict:
-        """Return current save sync settings as the on-disk dict shape."""
-        return self._save_sync_state.settings.to_dict()
+        """Return current save sync settings as the frontend dict shape."""
+        return self.get_settings().to_dict()
 
     def update_save_sync_settings(self, settings: dict) -> dict:
-        """Update save sync settings (sync toggles, slot, etc.)."""
+        """Update save sync settings (sync toggles, slot, etc.) in settings.json."""
         allowed_keys = {
             "save_sync_enabled",
             "sync_before_launch",
@@ -171,18 +202,25 @@ class StateService:
             "autocleanup_limit",
         }
 
-        current = self._save_sync_state.settings
-
         for key, value in settings.items():
             if key not in allowed_keys:
                 continue
             value, skip = self._sanitize_setting(key, value)
             if skip:
                 continue
-            setattr(current, key, value)
+            self._settings[key] = value
 
-        self.save_state()
-        return {"success": True, "settings": current.to_dict()}
+        self._settings_persister.save_settings()
+        return {"success": True, "settings": self.get_settings().to_dict()}
+
+    def get_device_name(self) -> str | None:
+        """Return the user-set device label from settings.json (``None`` if unset)."""
+        return self._settings.get("device_name")
+
+    def set_device_name(self, name: str) -> None:
+        """Persist the device label to settings.json."""
+        self._settings["device_name"] = name
+        self._settings_persister.save_settings()
 
     @staticmethod
     def _sanitize_setting(key: str, value: object) -> tuple[object, bool]:

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -99,7 +99,7 @@ class DeviceRegistry:
             return {
                 "success": True,
                 "device_id": sync_state.device_id,
-                "device_name": sync_state.device_name or "",
+                "device_name": self._state_svc.get_device_name() or "",
                 "server_device_id": has_server_id,
             }
 
@@ -118,8 +118,8 @@ class DeviceRegistry:
             server_device_id = result.get("id") or result.get("device_id")
             if server_device_id:
                 sync_state.device_id = str(server_device_id)
-                sync_state.device_name = hostname
                 sync_state.server_device_id = str(server_device_id)
+                self._state_svc.set_device_name(hostname)
                 self._state_svc.save_state()
                 self._logger.info(f"Device registered with server: {server_device_id} ({hostname})")
                 return {

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -279,7 +279,7 @@ class SyncEngine:
                     "save_sort_changed": True,
                 }
 
-            if not self._state_svc.state.settings.sync_before_launch:
+            if not self._state_svc.get_settings().sync_before_launch:
                 return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
 
             if not self._state_svc.state.device_id:
@@ -323,7 +323,7 @@ class SyncEngine:
                     "blocked_by_migration": True,
                 }
 
-            if not self._state_svc.state.settings.sync_after_exit:
+            if not self._state_svc.get_settings().sync_after_exit:
                 self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
                 return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
 

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -147,7 +147,7 @@ class MatrixExecutor:
         """Update per-file sync tracking after a successful sync operation."""
         saves = self._state_svc.state.saves
         if rom_id_str not in saves:
-            settings_default_slot = self._state_svc.state.settings.default_slot or "default"
+            settings_default_slot = self._state_svc.get_settings().default_slot or "default"
             saves[rom_id_str] = RomSaveState(
                 emulator=emulator_tag or "retroarch",
                 system=system,

--- a/tests/domain/test_save_state.py
+++ b/tests/domain/test_save_state.py
@@ -212,6 +212,8 @@ class TestPlaytimeEntry:
 
 
 class TestSaveSyncSettings:
+    """Read-view value object — built by StateService from settings.json (#822)."""
+
     def test_defaults(self) -> None:
         s = SaveSyncSettings()
         assert s.save_sync_enabled is False
@@ -220,31 +222,21 @@ class TestSaveSyncSettings:
         assert s.default_slot == "default"
         assert s.autocleanup_limit == 10
 
-    def test_from_dict_round_trip(self) -> None:
-        payload = {
+    def test_to_dict_surfaces_five_knobs(self) -> None:
+        s = SaveSyncSettings(
+            save_sync_enabled=True,
+            sync_before_launch=False,
+            sync_after_exit=False,
+            default_slot="main",
+            autocleanup_limit=5,
+        )
+        assert s.to_dict() == {
             "save_sync_enabled": True,
             "sync_before_launch": False,
             "sync_after_exit": False,
             "default_slot": "main",
             "autocleanup_limit": 5,
         }
-        s = SaveSyncSettings.from_dict(payload)
-        assert s.to_dict() == payload
-
-    def test_drops_legacy_conflict_mode(self) -> None:
-        s = SaveSyncSettings.from_dict({"conflict_mode": "ask"})
-        out = s.to_dict()
-        assert "conflict_mode" not in out
-
-    def test_drops_legacy_clock_skew(self) -> None:
-        s = SaveSyncSettings.from_dict({"clock_skew_tolerance_sec": 60})
-        out = s.to_dict()
-        assert "clock_skew_tolerance_sec" not in out
-
-    def test_unknown_keys_preserved_in_extra(self) -> None:
-        s = SaveSyncSettings.from_dict({"future_toggle": True})
-        assert s.extra == {"future_toggle": True}
-        assert s.to_dict()["future_toggle"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -256,17 +248,9 @@ def _default_state_dict() -> dict:
     return {
         "version": 1,
         "device_id": None,
-        "device_name": None,
         "server_device_id": None,
         "saves": {},
         "playtime": {},
-        "settings": {
-            "save_sync_enabled": False,
-            "sync_before_launch": True,
-            "sync_after_exit": True,
-            "default_slot": "default",
-            "autocleanup_limit": 10,
-        },
     }
 
 
@@ -283,7 +267,6 @@ class TestSaveSyncState:
         payload = {
             "version": 1,
             "device_id": "abc",
-            "device_name": "deck",
             "server_device_id": "server-1",
             "saves": {
                 "42": {
@@ -319,13 +302,6 @@ class TestSaveSyncState:
                     "note_id": 7,
                 },
             },
-            "settings": {
-                "save_sync_enabled": True,
-                "sync_before_launch": True,
-                "sync_after_exit": True,
-                "default_slot": "default",
-                "autocleanup_limit": 10,
-            },
         }
         s = SaveSyncState.from_dict(payload)
         assert s.to_dict() == payload
@@ -335,11 +311,9 @@ class TestSaveSyncState:
         payload = {
             "version": 1,
             "device_id": "d",
-            "device_name": None,
             "server_device_id": None,
             "saves": {"7": {"emulator": "retroarch", "system": "snes"}},
             "playtime": {"7": {"total_seconds": 100}},
-            "settings": {"save_sync_enabled": True},
         }
         s = SaveSyncState.from_dict(payload)
         s2 = SaveSyncState.from_dict(s.to_dict())
@@ -352,14 +326,21 @@ class TestSaveSyncState:
         assert s.saves["1"].last_synced_core == "core_libretro"
         assert "active_core" not in s.to_dict()["saves"]["1"]
 
-    def test_legacy_settings_keys_stripped(self) -> None:
+    def test_legacy_settings_and_device_name_ignored_on_load(self) -> None:
+        """The toggles + device label moved to settings.json (#822), so a
+        legacy file's ``settings`` block and ``device_name`` are not parsed
+        onto the aggregate and never written back to disk."""
         s = SaveSyncState.from_dict(
-            {"settings": {"conflict_mode": "ask", "clock_skew_tolerance_sec": 60, "save_sync_enabled": True}},
+            {
+                "settings": {"save_sync_enabled": True},
+                "device_name": "old-deck",
+                "device_id": "kept",
+            },
         )
-        out = s.to_dict()["settings"]
-        assert "conflict_mode" not in out
-        assert "clock_skew_tolerance_sec" not in out
-        assert out["save_sync_enabled"] is True
+        assert s.device_id == "kept"
+        out = s.to_dict()
+        assert "settings" not in out
+        assert "device_name" not in out
 
     def test_dismissed_newer_save_id_stripped(self) -> None:
         s = SaveSyncState.from_dict(

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -1,6 +1,10 @@
 """Tests for domain/state_migrations.py — pure migration functions."""
 
-from domain.state_migrations import migrate_settings, migrate_state
+from domain.state_migrations import (
+    fold_legacy_save_sync_settings,
+    migrate_settings,
+    migrate_state,
+)
 
 
 class TestMigrateSettings:
@@ -9,28 +13,28 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
         assert "disable_steam_input" not in result
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_v0_disable_steam_input_false(self):
         data = {"version": 0, "disable_steam_input": False}
         result = migrate_settings(data)
         assert "disable_steam_input" not in result
         assert "steam_input_mode" not in result  # False → no override set
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_v0_debug_logging_true(self):
         data = {"version": 0, "debug_logging": True}
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_v0_debug_logging_false(self):
         data = {"version": 0, "debug_logging": False}
         result = migrate_settings(data)
         assert "debug_logging" not in result
         assert "log_level" not in result  # False → no log_level override set
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_v0_both_deprecated(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -39,23 +43,30 @@ class TestMigrateSettings:
         assert result["log_level"] == "debug"
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_v0_no_deprecated_keys(self):
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_url"] == "http://example.com"
-        assert result["version"] == 3
+        assert result["version"] == 4
 
-    def test_migrate_settings_v3_no_change(self):
+    def test_migrate_settings_v3_only_bumps_version(self):
+        """v3 → v4 only advances the version stamp (the cross-file save-sync
+        fold is orchestrated in bootstrap, not here)."""
         data = {"version": 3, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
-        assert result == {"version": 3, "romm_url": "http://example.com", "log_level": "warn"}
+        assert result == {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
+
+    def test_migrate_settings_v4_no_change(self):
+        data = {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
+        result = migrate_settings(data)
+        assert result == {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
 
     def test_migrate_settings_fresh_empty(self):
         data = {}
         result = migrate_settings(data)
-        assert result["version"] == 3
+        assert result["version"] == 4
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
 
@@ -63,7 +74,7 @@ class TestMigrateSettings:
         data = {"romm_url": "http://example.com", "disable_steam_input": True}
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_debug_logging_true_overrides_log_level(self):
         """When debug_logging=True is being migrated, log_level is set to 'debug' unconditionally.
@@ -75,7 +86,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_migrate_settings_idempotent(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -101,7 +112,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_base64_keys_move_to_franchise_bucket(self):
         b64 = "eyJuYW1lIjogIkFuIFRoZSBNYXJpbyJ9"
@@ -123,7 +134,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {b64: True},
         }
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_smart_bucket_always_starts_empty(self):
         """Pre-v3 users had no smart collections — bucket must start empty."""
@@ -141,7 +152,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "romm_url": "x"}
         result = migrate_settings(data)
         assert "enabled_collections" not in result
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_already_nested_value_passes_through_unchanged(self):
         """Defensive: a half-stamped v3-shaped value must not be re-split."""
@@ -153,7 +164,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "enabled_collections": already_nested}
         result = migrate_settings(data)
         assert result["enabled_collections"] == already_nested
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_partial_nested_value_normalized_with_missing_buckets(self):
         """A partial-nested value (only one bucket present) is normalized to all three buckets."""
@@ -164,7 +175,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_partial_nested_two_buckets_fills_missing_third(self):
         """Partial-nested with two bucket keys — missing bucket is filled empty."""
@@ -178,7 +189,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {"abc": True},
         }
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_v0_to_v3_runs_both_steps(self):
         """A v0 file with both deprecated keys AND old enabled_collections gets both migrations."""
@@ -195,7 +206,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 3
+        assert result["version"] == 4
 
     def test_negative_numeric_string_keys_go_to_user(self):
         """``key.lstrip('-').isdigit()`` accepts ``-1`` as a numeric id."""
@@ -203,10 +214,10 @@ class TestMigrateSettingsV3Collections:
         result = migrate_settings(data)
         assert result["enabled_collections"]["user"] == {"-1": True}
 
-    def test_v3_file_no_resplit(self):
-        """A v3 file with the nested shape is unchanged."""
+    def test_v4_file_no_resplit(self):
+        """A v4 file with the nested shape is unchanged."""
         data = {
-            "version": 3,
+            "version": 4,
             "enabled_collections": {"user": {"1": True}, "smart": {}, "franchise": {}},
         }
         result = migrate_settings(data)
@@ -217,6 +228,100 @@ class TestMigrateSettingsV3Collections:
         original = {"version": 1, "enabled_collections": {"1": True, "abc": True}}
         migrate_settings(data)
         assert data == original
+
+
+class TestFoldLegacySaveSyncSettings:
+    """v3 → v4 cross-file lift (#822): save-sync knobs + device_name move from
+    save_sync_state.json into settings.json."""
+
+    def _base_settings(self) -> dict:
+        """A settings dict carrying the DEFAULT_SETTINGS placeholders."""
+        return {
+            "version": 3,
+            "romm_url": "http://example.com",
+            "save_sync_enabled": False,
+            "sync_before_launch": True,
+            "sync_after_exit": True,
+            "default_slot": "default",
+            "autocleanup_limit": 10,
+            "device_name": None,
+        }
+
+    def test_folds_present_knobs_and_device_name(self):
+        settings = self._base_settings()
+        raw = {
+            "device_id": "kept-id",
+            "server_device_id": 7,
+            "device_name": "steamdeck",
+            "settings": {
+                "save_sync_enabled": True,
+                "sync_before_launch": False,
+                "sync_after_exit": False,
+                "default_slot": "alt",
+                "autocleanup_limit": 3,
+            },
+        }
+        result = fold_legacy_save_sync_settings(settings, raw)
+        assert result["save_sync_enabled"] is True
+        assert result["sync_before_launch"] is False
+        assert result["sync_after_exit"] is False
+        assert result["default_slot"] == "alt"
+        assert result["autocleanup_limit"] == 3
+        assert result["device_name"] == "steamdeck"
+        # Unrelated settings keys are preserved.
+        assert result["romm_url"] == "http://example.com"
+
+    def test_does_not_copy_device_identity(self):
+        """device_id / server_device_id stay in save_sync_state.json (#784)."""
+        settings = self._base_settings()
+        raw = {"device_id": "kept-id", "server_device_id": 7, "settings": {"save_sync_enabled": True}}
+        result = fold_legacy_save_sync_settings(settings, raw)
+        assert "device_id" not in result
+        assert "server_device_id" not in result
+
+    def test_none_raw_is_noop(self):
+        settings = self._base_settings()
+        result = fold_legacy_save_sync_settings(settings, None)
+        assert result == settings
+        assert result is not settings  # returns a copy, never the input
+
+    def test_empty_raw_is_noop(self):
+        settings = self._base_settings()
+        result = fold_legacy_save_sync_settings(settings, {})
+        assert result == settings
+
+    def test_missing_settings_block_only_device_name(self):
+        """No ``settings`` block → knobs untouched, device_name still folded."""
+        settings = self._base_settings()
+        raw = {"device_id": "id", "device_name": "deck"}
+        result = fold_legacy_save_sync_settings(settings, raw)
+        assert result["device_name"] == "deck"
+        # Knobs keep the DEFAULT_SETTINGS placeholders.
+        assert result["save_sync_enabled"] is False
+        assert result["default_slot"] == "default"
+
+    def test_missing_device_name_keeps_placeholder(self):
+        settings = self._base_settings()
+        raw = {"settings": {"save_sync_enabled": True}}
+        result = fold_legacy_save_sync_settings(settings, raw)
+        assert result["device_name"] is None
+
+    def test_partial_settings_block_only_present_keys(self):
+        """Only keys present in the legacy block overwrite; the rest keep defaults."""
+        settings = self._base_settings()
+        raw = {"settings": {"save_sync_enabled": True}}
+        result = fold_legacy_save_sync_settings(settings, raw)
+        assert result["save_sync_enabled"] is True
+        assert result["sync_before_launch"] is True  # placeholder kept
+
+    def test_never_mutates_inputs(self):
+        settings = self._base_settings()
+        raw = {"device_name": "deck", "settings": {"save_sync_enabled": True}}
+        settings_before = dict(settings)
+        raw_before = {"device_name": "deck", "settings": {"save_sync_enabled": True}}
+        fold_legacy_save_sync_settings(settings, raw)
+        assert settings == settings_before
+        assert raw == raw_before
 
 
 class TestMigrateState:

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -11,6 +11,7 @@ from fakes.fake_hostname_reader import FakeHostnameReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
+from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.system_time import FakeClock
 from models.state import make_default_plugin_state
 
@@ -50,6 +51,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         state=make_default_plugin_state(),
         save_sync_state=SaveService.make_default_state(),
         save_sync_state_persister=_make_save_sync_state_persister(tmp_path),
+        settings_persister=FakeSettingsPersister(),
         save_file_store=save_file_store,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
@@ -135,7 +137,7 @@ def _file_md5(path):
 
 def _enable_sync_with_device(svc, device_id: str = "device-1") -> None:
     """Flip on save sync and bind a server device id (matches FakeSaveApi)."""
-    svc._save_sync_state.settings.save_sync_enabled = True
+    svc._config.settings["save_sync_enabled"] = True
     svc._save_sync_state.device_id = device_id
     svc._save_sync_state.server_device_id = device_id
 

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -23,7 +23,7 @@ class TestEnsureDeviceRegisteredFailurePaths:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_returns_device_not_registered_on_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id set — triggers ensure_device_registered.
         _install_rom(svc, tmp_path)
         # register_device raises → ensure_device_registered returns success=False.
@@ -39,7 +39,7 @@ class TestEnsureDeviceRegisteredFailurePaths:
     @pytest.mark.asyncio
     async def test_post_exit_sync_returns_device_not_registered_on_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id set.
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
@@ -55,7 +55,7 @@ class TestEnsureDeviceRegisteredFailurePaths:
     @pytest.mark.asyncio
     async def test_sync_rom_saves_returns_device_not_registered_on_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id set.
         _install_rom(svc, tmp_path)
         fake.fail_on_next(RommApiError("Server unreachable"))
@@ -69,7 +69,7 @@ class TestEnsureDeviceRegisteredFailurePaths:
     @pytest.mark.asyncio
     async def test_sync_all_saves_returns_device_not_registered_on_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id set.
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         fake.fail_on_next(RommApiError("Server unreachable"))

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -22,7 +22,7 @@ from tests.services.saves._helpers import (
 class TestSyncRomSaves:
     def test_local_only_uploads(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
 
@@ -34,7 +34,7 @@ class TestSyncRomSaves:
 
     def test_server_only_downloads(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         # Add server save but no local file
         ss = _server_save()
@@ -73,7 +73,7 @@ class TestSyncRomSaves:
     def test_sync_rom_saves_skips_server_only_downloads_during_pending_migration(self, tmp_path):
         """server_only matches must be skipped while migration is pending (#238)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         # Mark migration pending — detect has fired, user hasn't resolved yet.
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
@@ -96,7 +96,7 @@ class TestSyncRomSaves:
     def test_sync_rom_saves_uploads_local_only_during_pending_migration(self, tmp_path):
         """local_only matches must still upload during pending migration (#238)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         svc._state["save_sort_settings"] = {"sort_by_content": True, "sort_by_core": False}
         svc._state["save_sort_settings_previous"] = {"sort_by_content": True, "sort_by_core": False}
@@ -127,7 +127,7 @@ class TestSyncRomSaves:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
@@ -156,7 +156,7 @@ class TestSyncRomSaves:
         was needed.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -178,7 +178,7 @@ class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_syncs_multiple_roms(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
@@ -201,7 +201,7 @@ class TestSyncAllSaves:
     @pytest.mark.asyncio
     async def test_partial_failure(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
@@ -240,7 +240,7 @@ class TestSyncAllSaves:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
@@ -269,7 +269,7 @@ class TestSyncAllSaves:
         flag must stay reserved for actual errors.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
 
@@ -290,7 +290,7 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_downloads_server_saves(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -311,8 +311,8 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_pre_launch_disabled_in_settings(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
-        svc._save_sync_state.settings.sync_before_launch = False
+        svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["sync_before_launch"] = False
         svc._save_sync_state.device_id = "test-device"
 
         result = await svc.pre_launch_sync(42)
@@ -328,7 +328,7 @@ class TestPreLaunchSync:
             order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
 
         # Track when is_save_sort_changed is consulted.
@@ -351,7 +351,7 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_uploads_changed_saves(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"new save data")
@@ -370,8 +370,8 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_post_exit_disabled_in_settings(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
-        svc._save_sync_state.settings.sync_after_exit = False
+        svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["sync_after_exit"] = False
         svc._save_sync_state.device_id = "test-device"
 
         result = await svc.post_exit_sync(42)
@@ -380,7 +380,7 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_auto_registers_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id set
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
@@ -407,7 +407,7 @@ class TestPostExitSync:
             call_order.append("detect")
 
         svc, _ = make_service(tmp_path, detect_sort_change=fake_detect)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
@@ -436,7 +436,7 @@ class TestPostExitSync:
             raise RuntimeError("cfg file unreadable")
 
         svc, _ = make_service(tmp_path, detect_sort_change=boom)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"progress")
@@ -458,7 +458,7 @@ class TestPostExitSync:
         signal that sync is blocked on manual resolution.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -520,7 +520,7 @@ class TestMigrationPendingGuards:
             tmp_path,
             is_retrodeck_migration_pending=lambda: True,
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"unsyncable")
@@ -540,7 +540,7 @@ class TestMigrationPendingGuards:
             tmp_path,
             is_retrodeck_migration_pending=lambda: True,
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"unsyncable")
@@ -560,7 +560,7 @@ class TestPostExitServerOfflineGuard:
     @pytest.mark.asyncio
     async def test_post_exit_sync_returns_offline_when_heartbeat_raises(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
@@ -600,7 +600,7 @@ class TestSyncCallableErrorMessages:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_message_includes_error_count(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -618,7 +618,7 @@ class TestSyncCallableErrorMessages:
     @pytest.mark.asyncio
     async def test_post_exit_sync_message_includes_error_count(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -636,7 +636,7 @@ class TestSyncCallableErrorMessages:
     @pytest.mark.asyncio
     async def test_sync_rom_saves_message_includes_error_count(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -688,7 +688,7 @@ class TestSyncEngineDelegates:
     async def test_list_devices_delegates_to_device_registry(self, tmp_path):
         """SyncEngine.list_devices forwards to DeviceRegistry.list_devices."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "device-1"
         # Seed a registered device on the fake so list_devices returns non-empty.
         fake._registered_devices.append({"id": "device-1", "name": "test-host"})
@@ -707,7 +707,7 @@ class TestPreLaunchSaveSortGate:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_returns_save_sort_changed(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         # Flag save-sort changed via the rom_info state path used by RomInfoService.

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -189,7 +189,7 @@ class TestV47SyncFlow:
     def test_list_saves_passes_device_id(self, tmp_path):
         """v4.7: list_saves receives server_device_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "local-id"
         svc._save_sync_state.server_device_id = "server-dev-123"
         _install_rom(svc, tmp_path)
@@ -204,7 +204,7 @@ class TestV47SyncFlow:
     def test_upload_passes_device_id_and_slot(self, tmp_path):
         """v4.7: upload_save receives device_id and slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "local-id"
         svc._save_sync_state.server_device_id = "server-dev-123"
         _install_rom(svc, tmp_path)
@@ -220,7 +220,7 @@ class TestV47SyncFlow:
     def test_v47_skip_when_is_current(self, tmp_path):
         """v4.7: server says is_current=True, local unchanged → skip."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         content = b"same content"
@@ -259,7 +259,7 @@ class TestV47SyncFlow:
     def test_v47_download_when_not_current(self, tmp_path):
         """v4.7: server says is_current=False, local unchanged → download."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
         content = b"old content"
@@ -414,7 +414,7 @@ class TestTrackedSaveIdMatching:
     def test_timestamp_server_save_not_treated_as_separate_download(self, tmp_path):
         """Server save matched by tracked_save_id should not appear as server-only download."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
@@ -460,7 +460,7 @@ class TestTrackedSaveIdMatching:
     async def test_get_save_status_uses_tracked_save_id(self, tmp_path):
         """get_save_status should not show timestamp-named server save as separate file."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -505,7 +505,7 @@ class TestTrackedSaveIdMatching:
     async def test_status_fallback_matches_newest_no_phantom_downloads(self, tmp_path):
         """Status with no tracked_save_id matches newest server save, no phantom downloads."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -553,7 +553,7 @@ class TestTrackedSaveIdMatching:
         """Case 2: no local file, server has multiple timestamped saves.
         Should download only the newest, saved as the correct local filename."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # NO local save created — Case 2
@@ -600,7 +600,7 @@ class TestTrackedSaveIdMatching:
     async def test_status_server_only_shows_local_filename(self, tmp_path):
         """Status display should show local filename for server-only saves, not timestamp."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # NO local save
@@ -639,7 +639,7 @@ class TestOlderVersionSkipping:
     def test_different_slot_filtered_out(self, tmp_path):
         """Saves in a different slot should be filtered out entirely."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"local save")
@@ -692,7 +692,7 @@ class TestOwnUploadIds:
     async def test_post_upload_appends_own_upload_id(self, tmp_path):
         """After a POST upload (new save), the returned save_id is added to own_upload_ids."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -795,7 +795,7 @@ class TestOwnUploadIds:
         """When rom state exists but own_upload_ids key is absent, uploaded_by_us is None."""
         svc, fake = make_service(tmp_path)
         _install_rom(svc, tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         fake.saves[26] = _server_save(save_id=26, rom_id=42, filename="pokemon.srm")
 

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -23,7 +23,7 @@ class TestDeviceRegistration:
     @pytest.mark.asyncio
     async def test_registers_new_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is True
@@ -35,9 +35,9 @@ class TestDeviceRegistration:
     @pytest.mark.asyncio
     async def test_returns_existing_device(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "existing"
-        svc._save_sync_state.device_name = "deck"
+        svc._config.settings["device_name"] = "deck"
         svc._save_sync_state.server_device_id = "server-existing"
 
         result = await svc.ensure_device_registered()
@@ -59,7 +59,7 @@ class TestDeviceRegistrationServer:
     async def test_registers_with_server(self, tmp_path):
         """Calls register_device and stores server_device_id."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is True
@@ -78,7 +78,7 @@ class TestDeviceRegistrationServer:
         fake = FakeSaveApi()
         fake.fail_on_next(Exception("server error"))
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         result = await svc.ensure_device_registered()
         assert result["success"] is False
@@ -89,9 +89,9 @@ class TestDeviceRegistrationServer:
     async def test_returns_existing_with_server_device_id(self, tmp_path):
         """If already registered, returns existing IDs including server_device_id."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "existing-id"
-        svc._save_sync_state.device_name = "deck"
+        svc._config.settings["device_name"] = "deck"
         svc._save_sync_state.server_device_id = "server-id-123"
 
         result = await svc.ensure_device_registered()
@@ -102,10 +102,10 @@ class TestDeviceRegistrationServer:
     async def test_upgrades_local_uuid_to_server(self, tmp_path):
         """Local-only UUID gets upgraded to server registration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # Simulate existing local-only UUID (from failed registration)
         svc._save_sync_state.device_id = "local-only-uuid"
-        svc._save_sync_state.device_name = "deck"
+        svc._config.settings["device_name"] = "deck"
         svc._save_sync_state.server_device_id = None
 
         result = await svc.ensure_device_registered()
@@ -120,9 +120,9 @@ class TestDeviceRegistrationServer:
     async def test_ensure_device_registered_reconciles_client_version(self, tmp_path):
         """Already-registered path calls update_device with current plugin_version."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "existing-id"
-        svc._save_sync_state.device_name = "deck"
+        svc._config.settings["device_name"] = "deck"
         svc._save_sync_state.server_device_id = "server-abc"
 
         result = await svc.ensure_device_registered()
@@ -138,9 +138,9 @@ class TestDeviceRegistrationServer:
         """PUT raises, ensure_device_registered still returns success."""
         fake = FakeSaveApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "existing-id"
-        svc._save_sync_state.device_name = "deck"
+        svc._config.settings["device_name"] = "deck"
         svc._save_sync_state.server_device_id = "server-abc"
 
         # Make update_device fail silently
@@ -165,7 +165,7 @@ class TestDeviceRegistrationServer:
 
         fake = VersionedFakeApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         await svc.ensure_device_registered()
 
@@ -188,7 +188,7 @@ class TestDeviceRegistrationServer:
         fake = VersionedFakeApi()
         fake.set_version("4.8.1")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         await svc.ensure_device_registered()
 
@@ -201,7 +201,7 @@ class TestDeviceRegistrationServer:
         fake = FakeSaveApi()
         fake.heartbeat_raises = ConnectionError("offline")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         result = await svc.ensure_device_registered()
 
@@ -236,7 +236,7 @@ class TestListDevices:
     async def test_list_devices_marks_own_device(self, tmp_path):
         """own device_id present in state — is_current_device is True on matching entry."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "device-1"
 
         # Register two devices in fake
@@ -269,7 +269,7 @@ class TestListDevices:
         """Adapter raises — returns error response."""
         fake = FakeSaveApi()
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         fake.fail_on_next(Exception("server unavailable"))
         result = await svc.list_devices()
@@ -280,7 +280,7 @@ class TestListDevices:
     async def test_list_devices_no_own_id_all_false(self, tmp_path):
         """No server_device_id in state — all is_current_device are False."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = None
 
         fake._registered_devices = [{"id": "device-1", "name": "steamdeck"}]
@@ -293,7 +293,7 @@ class TestListDevices:
     async def test_list_devices_handles_null_id(self, tmp_path):
         """Device with id=None must not match own_id=None (avoid 'None'=='None' trap)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = None
 
         fake._registered_devices = [{"id": None, "name": "unknown"}]
@@ -309,7 +309,7 @@ class TestRetroDeckMigrationBlocksSaveSync:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
         svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -322,7 +322,7 @@ class TestRetroDeckMigrationBlocksSaveSync:
     @pytest.mark.asyncio
     async def test_post_exit_sync_skips_when_retrodeck_migration_pending(self, tmp_path):
         svc, _ = make_service(tmp_path, is_retrodeck_migration_pending=lambda: True)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
@@ -343,7 +343,7 @@ class TestRetroDeckMigrationBlocksSaveSync:
         from main import Plugin
 
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
 
@@ -369,7 +369,7 @@ class TestPostExitSyncConnectivity:
         fake = FakeSaveApi()
         fake.heartbeat_raises = ConnectionError("unreachable")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
 
         result = await svc.post_exit_sync(42)
@@ -382,7 +382,7 @@ class TestPostExitSyncConnectivity:
     async def test_proceeds_when_heartbeat_succeeds(self, tmp_path):
         """post_exit_sync proceeds normally when server is reachable."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "test-device"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"save data")
@@ -398,7 +398,7 @@ class TestPostExitSyncConnectivity:
         fake = FakeSaveApi()
         fake.heartbeat_raises = OSError("connection refused")
         svc, _ = make_service(tmp_path, fake_api=fake)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No device_id — would trigger registration if heartbeat passed
 
         result = await svc.post_exit_sync(42)
@@ -526,7 +526,7 @@ class TestEmulatorTag:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -540,7 +540,7 @@ class TestEmulatorTag:
     def test_upload_uses_fallback_when_no_core(self, tmp_path):
         """When core resolver returns None, upload falls back to 'retroarch'."""
         svc, fake = make_service(tmp_path)  # default: get_active_core returns (None, None)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
 
@@ -638,15 +638,15 @@ class TestSaveSyncSettingsSlotAndCleanup:
 
     def test_update_default_slot(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         result = svc.update_save_sync_settings({"default_slot": "desktop"})
         assert result["success"] is True
         assert result["settings"]["default_slot"] == "desktop"
 
     def test_update_default_slot_empty_string_becomes_none(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
-        svc._save_sync_state.settings.default_slot = "default"
+        svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["default_slot"] = "default"
         result = svc.update_save_sync_settings({"default_slot": ""})
         assert result["settings"]["default_slot"] is None
 
@@ -683,14 +683,14 @@ class TestSaveSyncSettingsSlotAndCleanup:
 
     def test_update_autocleanup_limit(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         result = svc.update_save_sync_settings({"autocleanup_limit": 5})
         assert result["success"] is True
         assert result["settings"]["autocleanup_limit"] == 5
 
     def test_update_autocleanup_limit_clamped(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         result = svc.update_save_sync_settings({"autocleanup_limit": 0})
         assert result["settings"]["autocleanup_limit"] == 1
 
@@ -723,7 +723,7 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("supafaust_libretro", "Supafaust"),
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
@@ -743,7 +743,7 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
@@ -756,7 +756,7 @@ class TestCheckCoreChange:
     def test_never_synced(self, tmp_path):
         """Returns changed=False when rom_id has no save entry (never synced)."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # No entry for rom_id 42
 
         result = svc.check_core_change(42)
@@ -769,7 +769,7 @@ class TestCheckCoreChange:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("snes9x_libretro", "Snes9x"),
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core=None,
@@ -785,7 +785,7 @@ class TestCheckCoreChange:
             tmp_path,
             # default: get_active_core returns (None, None)
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["42"] = self._make_save_entry(
             system="snes",
             last_synced_core="snes9x_libretro",
@@ -820,7 +820,7 @@ class TestCheckCoreChange:
             return ("supafaust_libretro", "Supafaust")
 
         svc, _ = make_service(tmp_path, get_active_core=capture_core)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["42"] = self._make_save_entry(system="snes")
         _install_rom(svc, tmp_path, rom_id=42, system="snes", file_name="mario.sfc")
 

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -23,7 +23,7 @@ class TestSaveSlots:
     @pytest.mark.asyncio
     async def test_get_save_slots(self, tmp_path):
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "server-dev-1"
 
@@ -51,7 +51,7 @@ class TestSaveSlots:
     async def test_get_save_slots_latest_updated_at_from_server(self, tmp_path):
         """latest_updated_at is populated from nested latest.updated_at, not a flat key."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "server-dev-1"
 
@@ -100,7 +100,7 @@ class TestSaveSlots:
         though they were still on the server.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
 
@@ -144,7 +144,7 @@ class TestSaveSlots:
         merged map (which keeps the active slot) is written back to disk.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         # Active slot persists through the merge (kept even when server is empty).
@@ -168,7 +168,7 @@ class TestSaveSlots:
 
     def test_set_active_slot(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.saves["123"] = RomSaveState(system="gba", active_slot="default")
         result = svc._slots.set_active_slot(123, "desktop")
         assert result["success"] is True
@@ -176,7 +176,7 @@ class TestSaveSlots:
 
     def test_set_active_slot_creates_entry(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         result = svc._slots.set_active_slot(456, "my-slot")
         assert result["success"] is True
         assert svc._save_sync_state.saves["456"].active_slot == "my-slot"
@@ -253,7 +253,7 @@ class TestGetSaveSetupInfo:
     async def test_scenario_a_no_local_server_has_saves(self, tmp_path):
         """Scenario A: No local save, server has saves."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # Don't create local save
@@ -272,7 +272,7 @@ class TestGetSaveSetupInfo:
     async def test_scenario_b_local_no_server(self, tmp_path):
         """Scenario B: Local save exists, no server saves."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -288,7 +288,7 @@ class TestGetSaveSetupInfo:
     async def test_scenario_c_local_and_server_different_slots(self, tmp_path):
         """Scenario C: Local save, server has saves in different slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -304,7 +304,7 @@ class TestGetSaveSetupInfo:
     async def test_scenario_e_local_and_server_same_default_slot(self, tmp_path):
         """Scenario E: Local save, server has saves in default slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -320,7 +320,7 @@ class TestGetSaveSetupInfo:
     async def test_already_confirmed(self, tmp_path):
         """When slot is already confirmed, report it."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
             {
@@ -339,7 +339,7 @@ class TestGetSaveSetupInfo:
     async def test_multiple_server_slots(self, tmp_path):
         """Server saves across multiple slots are grouped correctly."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         fake.saves[1] = _server_save(save_id=1, slot="default")
@@ -359,7 +359,7 @@ class TestGetSaveSetupInfo:
         first post-confirmation sync could clobber real server saves.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -376,7 +376,7 @@ class TestGetSaveSetupInfo:
     async def test_server_error_with_oserror_recommends_server_unreachable(self, tmp_path):
         """OSError (transport-layer) failure routes to server_unreachable too."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -390,7 +390,7 @@ class TestGetSaveSetupInfo:
     async def test_server_error_preserves_local_info_in_response(self, tmp_path):
         """On server failure we still surface what we know locally."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -407,7 +407,7 @@ class TestGetSaveSetupInfo:
     async def test_no_rom_installed(self, tmp_path):
         """No installed ROM means no local files."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # Don't install any ROM
         result = await svc.get_save_setup_info(42)
         assert result["has_local_saves"] is False
@@ -417,7 +417,7 @@ class TestGetSaveSetupInfo:
     async def test_get_save_setup_info_recommends_auto_confirm_when_local_saves_no_server_slots(self, tmp_path):
         """Local saves + no server slots -> wizard should auto-confirm the default slot."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -433,7 +433,7 @@ class TestGetSaveSetupInfo:
     async def test_get_save_setup_info_recommends_wizard_when_server_has_slots(self, tmp_path):
         """Local saves + server has slots -> user must choose, wizard required."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -449,7 +449,7 @@ class TestGetSaveSetupInfo:
     async def test_get_save_setup_info_recommends_wizard_when_no_local_saves(self, tmp_path):
         """No local saves -> wizard required regardless of server state."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         _install_rom(svc, tmp_path)
         # No _create_save call - no local saves
@@ -465,7 +465,7 @@ class TestConfirmSlotChoice:
     @pytest.mark.asyncio
     async def test_confirm_sets_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         result = await svc.confirm_slot_choice(42, "default")
         assert result["success"] is True
         state = svc._save_sync_state.saves["42"]
@@ -523,7 +523,7 @@ class TestConfirmSlotChoice:
         where the legacy ``None`` semantics still live.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
@@ -547,7 +547,7 @@ class TestConfirmSlotChoice:
     async def test_confirm_migration_no_old_saves(self, tmp_path):
         """Migration with no matching old saves is a no-op."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
@@ -572,7 +572,7 @@ class TestConfirmSlotChoice:
         semantics live on the slots service.
         """
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
@@ -595,7 +595,7 @@ class TestConfirmSlotChoice:
     async def test_facade_translates_none_to_no_migration(self, tmp_path):
         """Facade: ``None`` for ``migrate_from_slot`` skips migration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
@@ -615,7 +615,7 @@ class TestConfirmSlotChoice:
     async def test_facade_translates_no_migration_string_to_no_migration(self, tmp_path):
         """Facade: ``"__no_migration__"`` string (from frontend) skips migration."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
         _install_rom(svc, tmp_path)
@@ -649,7 +649,7 @@ class TestGetSlotSaves:
     async def test_happy_path(self, tmp_path):
         """Returns mapped save dicts for the requested slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "server-dev-1"
 
         fake.saves[1] = {
@@ -688,7 +688,7 @@ class TestGetSlotSaves:
     async def test_empty_slot(self, tmp_path):
         """Returns empty saves list when server has no saves for the slot."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "server-dev-1"
         # No saves added to fake
 
@@ -702,7 +702,7 @@ class TestGetSlotSaves:
     async def test_server_error(self, tmp_path):
         """Returns error response when list_saves raises an exception."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.server_device_id = "server-dev-1"
         fake.fail_on_next(RommApiError("connection timeout"))
 
@@ -753,7 +753,7 @@ class TestSwitchSlot:
     async def test_happy_path(self, tmp_path):
         """Files fully synced + server has saves in new slot → downloads and returns success."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -778,7 +778,7 @@ class TestSwitchSlot:
     async def test_pending_uploads_blocked(self, tmp_path):
         """Local file changed since last sync → switch blocked with reason + file list."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"modified save data")
 
@@ -815,7 +815,7 @@ class TestSwitchSlot:
         After the switch to an empty slot the local file should be gone.
         """
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -838,7 +838,7 @@ class TestSwitchSlot:
     async def test_server_unreachable(self, tmp_path):
         """list_saves raises → switch blocked with reason=server_unreachable."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -870,7 +870,7 @@ class TestSwitchSlot:
     async def test_not_installed(self, tmp_path):
         """ROM not installed → returns not_installed error."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # ROM 42 is NOT installed
 
         result = await svc.switch_slot(42, "desktop")
@@ -882,7 +882,7 @@ class TestSwitchSlot:
     async def test_empty_new_slot(self, tmp_path):
         """New slot has no saves on server → deletes local files and updates active_slot."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -909,7 +909,7 @@ class TestSwitchSlot:
     async def test_empty_slot_deletes_local_files(self, tmp_path):
         """New slot is empty → local save files deleted and file tracking cleared."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -934,7 +934,7 @@ class TestSwitchSlot:
     async def test_with_server_saves_downloads(self, tmp_path):
         """New slot has server saves → downloads them, replacing local file."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path, content=b"old local save")
         local_hash = _file_md5(str(save_path))
@@ -957,7 +957,7 @@ class TestSwitchSlot:
     async def test_no_local_files_is_ready(self, tmp_path):
         """ROM installed but no local save files → readiness check passes (nothing pending)."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         # No save file created on disk
         svc._save_sync_state.saves["42"] = RomSaveState.from_dict(
@@ -979,7 +979,7 @@ class TestSwitchSlot:
     async def test_switch_to_legacy_slot(self, tmp_path):
         """switch_slot("") sets active_slot=None, persists "" in slots dict, returns success."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
         local_hash = _file_md5(str(save_path))
@@ -1005,7 +1005,7 @@ class TestSwitchSlot:
     async def test_legacy_slot_persisted_in_get_save_slots(self, tmp_path):
         """get_save_slots includes the "" entry when active_slot is None and "" is in slots dict."""
         svc, _ = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
 
         # Set up state with legacy slot explicitly
         svc._save_sync_state.saves["99"] = RomSaveState.from_dict(
@@ -1031,7 +1031,7 @@ class TestSwitchSlot:
     async def test_server_legacy_save_maps_to_empty_string_not_default(self, tmp_path):
         """Server saves with slot=None (legacy) must map to "" not "default" in get_save_slots."""
         svc, fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "dev-1"
 
@@ -1066,7 +1066,7 @@ class TestDeleteSlot:
         files_state=None,
     ):
         """Set up a ROM with slot state for deletion tests."""
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         svc._save_sync_state.device_id = "dev-1"
         svc._save_sync_state.server_device_id = "server-dev-1"
         _install_rom(svc, tmp_path)
@@ -1347,7 +1347,7 @@ class TestDeleteSlot:
     async def test_delete_slot_not_installed_rom(self, tmp_path):
         """ROM not installed returns failure."""
         svc, _fake = make_service(tmp_path)
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         # Don't install any ROM
 
         result = await svc.delete_slot(42, "default")

--- a/tests/services/saves/test_state_service.py
+++ b/tests/services/saves/test_state_service.py
@@ -1,9 +1,12 @@
-"""Tests for StateService (state.py) — save_sync_state.json persistence and migrations."""
+"""Tests for StateService (state.py) — save_sync_state.json persistence,
+migrations, and the settings.json-backed save-sync feature toggles + device
+label (#822)."""
 
 import json
 import os
 from typing import cast
 
+from fakes.fake_settings_persister import FakeSettingsPersister
 from models.state import ShortcutRegistryEntry
 
 from domain.save_state import (
@@ -25,11 +28,10 @@ class TestStateManagement:
         state = SaveService.make_default_state()
         assert state.device_id is None
         assert state.saves == {}
-        assert state.settings.save_sync_enabled is False
 
     def test_init_state_populates_defaults(self, tmp_path):
         svc, _ = make_service(tmp_path, save_sync_state=SaveSyncState())
-        assert svc._save_sync_state.settings.save_sync_enabled is False
+        assert svc.get_save_sync_settings()["save_sync_enabled"] is False
         assert svc._save_sync_state.saves == {}
 
     def test_init_state_preserves_existing(self, tmp_path):
@@ -143,15 +145,14 @@ class TestStateManagement:
         # domain-level coverage in tests/domain/test_save_state.py.
         assert files["good.srm"].tracked_save_id == 100
 
-    def test_settings_legacy_keys_stripped_on_load(self, tmp_path):
-        """Legacy ``conflict_mode`` and ``clock_skew_tolerance_sec`` settings
-        are dropped when state loads from disk. Other keys survive."""
+    def test_settings_and_device_name_not_persisted_to_state_file(self, tmp_path):
+        """The feature toggles + device label live in settings.json (#822),
+        so the save_sync_state.json file no longer carries a ``settings``
+        block or a ``device_name`` key — even a legacy file's settings are
+        not round-tripped back to disk."""
         legacy = {
-            "settings": {
-                "conflict_mode": "ask_me",
-                "clock_skew_tolerance_sec": 60,
-                "save_sync_enabled": True,
-            },
+            "settings": {"save_sync_enabled": True},
+            "device_name": "old-deck",
         }
         (tmp_path / "save_sync_state.json").write_text(json.dumps(legacy))
 
@@ -160,9 +161,8 @@ class TestStateManagement:
         svc.save_state()
 
         on_disk = json.loads((tmp_path / "save_sync_state.json").read_text())
-        assert "conflict_mode" not in on_disk["settings"]
-        assert "clock_skew_tolerance_sec" not in on_disk["settings"]
-        assert on_disk["settings"]["save_sync_enabled"] is True
+        assert "settings" not in on_disk
+        assert "device_name" not in on_disk
 
     def test_save_and_load_state(self, tmp_path):
         svc, _ = make_service(tmp_path)
@@ -287,7 +287,7 @@ class TestStateBackwardCompat:
             tmp_path,
             get_active_core=lambda system_name, rom_filename=None: ("mgba_libretro", "mGBA"),
         )
-        svc._save_sync_state.settings.save_sync_enabled = True
+        svc._config.settings["save_sync_enabled"] = True
         _install_rom(svc, tmp_path)
         save_path = _create_save(tmp_path)
 
@@ -314,3 +314,129 @@ class TestStateBackwardCompat:
         file_state = svc._save_sync_state.saves["42"].files["pokemon.srm"]
         assert file_state.tracked_save_id == 99
         assert file_state.last_sync_server_save_id == 99
+
+
+class TestSaveSyncSettingsOwnership:
+    """The five feature toggles + device label live in settings.json (#822).
+
+    StateService reads them straight out of the injected settings dict and
+    flushes mutations through the SettingsPersister — never the save-sync
+    aggregate.
+    """
+
+    def _make(self, tmp_path, settings):
+        persister = FakeSettingsPersister()
+        svc, _ = make_service(tmp_path, settings=settings, settings_persister=persister)
+        return svc, persister
+
+    def test_is_save_sync_enabled_reads_settings_dict(self, tmp_path):
+        svc, _ = self._make(tmp_path, {"save_sync_enabled": True})
+        assert svc._state_svc.is_save_sync_enabled() is True
+
+    def test_is_save_sync_enabled_defaults_false_when_missing(self, tmp_path):
+        svc, _ = self._make(tmp_path, {})
+        assert svc._state_svc.is_save_sync_enabled() is False
+
+    def test_get_settings_builds_view_from_settings_dict(self, tmp_path):
+        svc, _ = self._make(
+            tmp_path,
+            {
+                "save_sync_enabled": True,
+                "sync_before_launch": False,
+                "sync_after_exit": False,
+                "default_slot": "alt",
+                "autocleanup_limit": 5,
+            },
+        )
+        settings = svc._state_svc.get_settings()
+        assert settings.save_sync_enabled is True
+        assert settings.sync_before_launch is False
+        assert settings.sync_after_exit is False
+        assert settings.default_slot == "alt"
+        assert settings.autocleanup_limit == 5
+
+    def test_get_settings_applies_default_coercions(self, tmp_path):
+        """Missing keys fall back to the legacy defaults."""
+        svc, _ = self._make(tmp_path, {})
+        settings = svc._state_svc.get_settings()
+        assert settings.save_sync_enabled is False
+        assert settings.sync_before_launch is True
+        assert settings.sync_after_exit is True
+        assert settings.default_slot == "default"
+        assert settings.autocleanup_limit == 10
+
+    def test_get_settings_preserves_none_default_slot(self, tmp_path):
+        """``default_slot=None`` is the no-slots mode and must survive."""
+        svc, _ = self._make(tmp_path, {"default_slot": None})
+        assert svc._state_svc.get_settings().default_slot is None
+
+    def test_get_settings_empty_default_slot_collapses_to_none(self, tmp_path):
+        svc, _ = self._make(tmp_path, {"default_slot": ""})
+        assert svc._state_svc.get_settings().default_slot is None
+
+    def test_get_settings_autocleanup_zero_guarded_to_ten(self, tmp_path):
+        svc, _ = self._make(tmp_path, {"autocleanup_limit": 0})
+        assert svc._state_svc.get_settings().autocleanup_limit == 10
+
+    def test_get_save_sync_settings_returns_five_knob_dict(self, tmp_path):
+        svc, _ = self._make(tmp_path, {"save_sync_enabled": True, "default_slot": "alt"})
+        result = svc._state_svc.get_save_sync_settings()
+        assert result == {
+            "save_sync_enabled": True,
+            "sync_before_launch": True,
+            "sync_after_exit": True,
+            "default_slot": "alt",
+            "autocleanup_limit": 10,
+        }
+
+    def test_update_writes_to_settings_dict_and_flushes(self, tmp_path):
+        settings = {"save_sync_enabled": False}
+        svc, persister = self._make(tmp_path, settings)
+
+        result = svc._state_svc.update_save_sync_settings(
+            {"save_sync_enabled": True, "default_slot": "alt", "autocleanup_limit": 3}
+        )
+
+        assert result["success"] is True
+        assert result["settings"]["save_sync_enabled"] is True
+        assert result["settings"]["default_slot"] == "alt"
+        assert result["settings"]["autocleanup_limit"] == 3
+        # Written into the live settings dict, not the aggregate.
+        assert settings["save_sync_enabled"] is True
+        assert settings["default_slot"] == "alt"
+        assert settings["autocleanup_limit"] == 3
+        # Flushed through the settings persister, not save_sync_state.json.
+        assert persister.save_count == 1
+
+    def test_update_ignores_unknown_keys(self, tmp_path):
+        settings = {}
+        svc, persister = self._make(tmp_path, settings)
+
+        svc._state_svc.update_save_sync_settings({"not_a_knob": "x", "save_sync_enabled": True})
+
+        assert "not_a_knob" not in settings
+        assert settings["save_sync_enabled"] is True
+        assert persister.save_count == 1
+
+    def test_update_autocleanup_limit_floored_to_one(self, tmp_path):
+        settings = {}
+        svc, _ = self._make(tmp_path, settings)
+        svc._state_svc.update_save_sync_settings({"autocleanup_limit": 0})
+        assert settings["autocleanup_limit"] == 1
+
+    def test_get_device_name_reads_settings_dict(self, tmp_path):
+        svc, _ = self._make(tmp_path, {"device_name": "steamdeck"})
+        assert svc._state_svc.get_device_name() == "steamdeck"
+
+    def test_get_device_name_none_when_unset(self, tmp_path):
+        svc, _ = self._make(tmp_path, {})
+        assert svc._state_svc.get_device_name() is None
+
+    def test_set_device_name_writes_to_settings_and_flushes(self, tmp_path):
+        settings = {}
+        svc, persister = self._make(tmp_path, settings)
+
+        svc._state_svc.set_device_name("steamdeck")
+
+        assert settings["device_name"] == "steamdeck"
+        assert persister.save_count == 1

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -89,6 +89,7 @@ def plugin(clock):
             state=p._state,
             metadata_cache=p._metadata_cache,
             save_sync_state=p._save_sync_state,
+            settings=p.settings,
             logger=decky.logger,
             clock=clock,
             bios_checker=bios_checker,

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -95,6 +95,7 @@ def plugin(tmp_path):
                     logger=logging.getLogger("test"),
                 )
             ),
+            settings_persister=MagicMock(),
             save_file_store=SaveFileAdapter(),
             retrodeck_paths=FakeRetroDeckPaths(
                 saves=saves_path,
@@ -118,6 +119,7 @@ def plugin(tmp_path):
             romm_api=fake_api,
             retry=_make_retry(),
             save_sync_state=p._save_sync_state,
+            settings=p.settings,
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -157,7 +159,7 @@ def plugin(tmp_path):
     # Store fake_api on plugin for test access
     p._fake_api = fake_api
 
-    p._save_sync_state.settings.save_sync_enabled = False
+    p.settings["save_sync_enabled"] = False
     return p
 
 
@@ -175,6 +177,7 @@ def game_detail_service(plugin, clock):
             state=plugin._state,
             metadata_cache=plugin._metadata_cache,
             save_sync_state=plugin._save_sync_state,
+            settings=plugin.settings,
             logger=logging.getLogger("test"),
             clock=clock,
             bios_checker=plugin._firmware_service,
@@ -243,7 +246,7 @@ class TestGetCachedGameDetailFound:
             "file_path": "/roms/snes/smw.sfc",
             "system": "snes",
         }
-        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin.settings["save_sync_enabled"] = True
         plugin._save_sync_state.saves["123"] = RomSaveState(
             files={
                 "smw.srm": FileSyncState(
@@ -356,7 +359,7 @@ class TestGetCachedGameDetailPartialData:
             "platform_slug": "snes",
             "platform_name": "Super Nintendo",
         }
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin.settings["save_sync_enabled"] = False
         result = game_detail_service.get_cached_game_detail(50000)
         assert result["save_sync_enabled"] is False
 
@@ -667,7 +670,7 @@ class TestGetCachedGameDetailSaveStatusConflicts:
             "platform_slug": "gba",
             "platform_name": "GBA",
         }
-        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin.settings["save_sync_enabled"] = True
         plugin._save_sync_state.saves["42"] = RomSaveState(
             files={"test.srm": FileSyncState(last_sync_hash="abc", last_sync_at="2026-01-01T00:00:00Z")},
             last_sync_check_at="2026-01-01T00:00:00Z",
@@ -781,7 +784,7 @@ class TestComputedFields:
             "platform_slug": "gba",
             "platform_name": "GBA",
         }
-        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin.settings["save_sync_enabled"] = True
         plugin._save_sync_state.saves["42"] = RomSaveState(
             files={"test.srm": FileSyncState(last_sync_hash="abc", last_sync_at="2026-01-01T00:00:00Z")},
             last_sync_check_at="2026-01-01T00:00:00Z",

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -26,17 +26,24 @@ class _RecordingStatePersister:
         self._saved.append(True)
 
 
-def make_service(tmp_path=None, fake_api=None, clock=None, **overrides):
-    """Create a PlaytimeService with sensible defaults."""
+def make_service(tmp_path=None, fake_api=None, clock=None, settings=None, **overrides):
+    """Create a PlaytimeService with sensible defaults.
+
+    Returns ``(svc, fake, state, saved)``. The device label stamped onto
+    synced playtime notes is read from the live settings.json view (#822),
+    reachable in tests as ``svc._settings``.
+    """
     fake = fake_api or FakeSaveApi()
     state = SaveSyncState()
     saved: list[bool] = []
     clk = clock or FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
+    settings_dict = settings if settings is not None else {}
 
     defaults: dict[str, Any] = dict(
         romm_api=fake,
         retry=_make_retry(),
         save_sync_state=state,
+        settings=settings_dict,
         loop=asyncio.get_event_loop(),
         logger=logging.getLogger("test"),
         clock=clk,
@@ -129,7 +136,7 @@ class TestSyncPlaytime:
             session_count=1,
             last_session_duration_sec=120,
         )
-        state.device_name = "deck"
+        svc._settings["device_name"] = "deck"
 
         svc._sync_playtime_to_romm(42, 120)
 
@@ -148,7 +155,7 @@ class TestSyncPlaytime:
             session_count=2,
             last_session_duration_sec=80,
         )
-        state.device_name = "deck"
+        svc._settings["device_name"] = "deck"
 
         # Pre-existing note on server
         fake.notes[42] = [
@@ -174,7 +181,7 @@ class TestSyncPlaytime:
             session_count=3,
             last_session_duration_sec=60,
         )
-        state.device_name = "deck"
+        svc._settings["device_name"] = "deck"
 
         fake.notes[42] = [
             {
@@ -259,7 +266,7 @@ class TestEdgeCases:
             session_count=1,
             last_session_duration_sec=60,
         )
-        state.device_name = "deck"
+        svc._settings["device_name"] = "deck"
         fake.fail_on_next(RommApiError("Oops"))
 
         # Should not raise
@@ -273,7 +280,7 @@ class TestEdgeCases:
             session_count=1,
             last_session_duration_sec=60,
         )
-        state.device_name = "deck"
+        svc._settings["device_name"] = "deck"
 
         fake.notes[42] = [
             {

--- a/tests/services/test_state.py
+++ b/tests/services/test_state.py
@@ -4,6 +4,7 @@ import logging
 from typing import cast
 
 from fakes.fake_save_sync_state_persister import FakeSaveSyncStatePersister
+from fakes.fake_settings_persister import FakeSettingsPersister
 from models.state import ShortcutRegistryEntry, make_default_plugin_state
 
 from domain.save_state import FileSyncState, PlaytimeEntry, RomSaveState
@@ -12,6 +13,7 @@ from services.saves.state import StateService, StateServiceConfig
 
 def _make_state_svc(
     persister: FakeSaveSyncStatePersister | None = None,
+    settings: dict | None = None,
 ) -> tuple[StateService, FakeSaveSyncStatePersister]:
     save_sync_state = StateService.make_default_state()
     state = make_default_plugin_state()
@@ -21,7 +23,9 @@ def _make_state_svc(
             config=StateServiceConfig(
                 save_sync_state=save_sync_state,
                 state=state,
+                settings=settings if settings is not None else {},
                 persister=p,
+                settings_persister=FakeSettingsPersister(),
                 logger=logging.getLogger("test"),
             ),
         ),
@@ -117,35 +121,37 @@ class TestLoadState:
 
         assert persister.load_count == 1
         assert svc.state.device_id == "preserved"
-        # Default settings still present (not wiped or overwritten with None).
-        assert svc.state.settings.save_sync_enabled is False
+        # The feature toggle reads from settings.json (empty → default False).
+        assert svc.is_save_sync_enabled() is False
 
     def test_load_state_merges_top_level_fields(self):
         canned = {
             "version": 1,
             "device_id": "dev-1",
-            "device_name": "deck",
+            "device_name": "deck",  # ignored — lives in settings.json now (#822)
             "server_device_id": "srv-1",
             "saves": {"42": {"files": {}}},
             "playtime": {"42": {"total_seconds": 3600}},
-            "settings": {"save_sync_enabled": True, "default_slot": "alt"},
+            "settings": {"save_sync_enabled": True, "default_slot": "alt"},  # ignored
         }
         svc, _ = _make_state_svc(FakeSaveSyncStatePersister(canned_load=canned))
 
         svc.load_state()
 
         assert svc.state.device_id == "dev-1"
-        assert svc.state.device_name == "deck"
         assert svc.state.server_device_id == "srv-1"
         assert "42" in svc.state.saves
         assert svc.state.playtime["42"].total_seconds == 3600
-        # Settings merge with defaults — explicit keys win, others stay default.
-        assert svc.state.settings.save_sync_enabled is True
-        assert svc.state.settings.default_slot == "alt"
-        assert svc.state.settings.sync_before_launch is True  # default kept
+        # The legacy settings + device_name on the loaded payload are NOT
+        # parsed onto the aggregate — they moved to settings.json (#822).
+        on_disk = svc.state.to_dict()
+        assert "settings" not in on_disk
+        assert "device_name" not in on_disk
 
     def test_load_state_runs_migration_on_loaded_payload(self):
-        """active_core → last_synced_core, drops dismissed_newer_save_id, strips legacy settings."""
+        """active_core → last_synced_core, drops dismissed_newer_save_id; the
+        settings block on a legacy payload is ignored (it moved to
+        settings.json, #822)."""
         canned = {
             "saves": {
                 "42": {
@@ -155,11 +161,7 @@ class TestLoadState:
                     },
                 }
             },
-            "settings": {
-                "save_sync_enabled": True,
-                "conflict_mode": "newest",  # legacy
-                "clock_skew_tolerance_sec": 5,  # legacy
-            },
+            "settings": {"save_sync_enabled": True},  # ignored on load
         }
         svc, _ = _make_state_svc(FakeSaveSyncStatePersister(canned_load=canned))
 
@@ -173,8 +175,7 @@ class TestLoadState:
         on_disk = svc.state.to_dict()
         assert "active_core" not in on_disk["saves"]["42"]
         assert "dismissed_newer_save_id" not in on_disk["saves"]["42"]["files"]["game.srm"]
-        assert "conflict_mode" not in on_disk["settings"]
-        assert "clock_skew_tolerance_sec" not in on_disk["settings"]
+        assert "settings" not in on_disk
 
 
 class TestPruneOrphanedState:

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -81,12 +81,15 @@ def plugin(tmp_path):
     fake_api = FakeSaveApi(save_file_store=save_file_adapter)
     p._save_sync_state = SaveService.make_default_state()
     saves_path = str(tmp_path / "retrodeck" / "saves")
+    # Shared settings.json view: the save-sync toggles + device label live
+    # here (#822), read by both SaveService's StateService and PlaytimeService.
+    p._save_settings = {"log_level": "debug"}
 
     p._save_sync_service = SaveService(
         config=SaveServiceConfig(
             romm_api=fake_api,
             retry=_make_retry(),
-            settings={"log_level": "debug"},
+            settings=p._save_settings,
             state=p._state,
             save_sync_state=p._save_sync_state,
             loop=asyncio.get_event_loop(),
@@ -99,6 +102,7 @@ def plugin(tmp_path):
                     logger=logging.getLogger("test"),
                 )
             ),
+            settings_persister=MagicMock(),
             save_file_store=save_file_adapter,
             retrodeck_paths=FakeRetroDeckPaths(
                 saves=saves_path,
@@ -122,6 +126,7 @@ def plugin(tmp_path):
             romm_api=fake_api,
             retry=_make_retry(),
             save_sync_state=p._save_sync_state,
+            settings=p._save_settings,
             loop=asyncio.get_event_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -139,7 +144,7 @@ def plugin(tmp_path):
     p._migration_service.is_retrodeck_migration_pending.return_value = False
 
     # Enable save sync for tests — matches pre-feature-flag behavior
-    p._save_sync_state.settings.save_sync_enabled = True
+    p._save_settings["save_sync_enabled"] = True
     return p
 
 
@@ -223,7 +228,7 @@ class TestDeviceRegistration:
     async def test_already_registered_returns_cached(self, plugin):
         """If device_id and server_device_id already set, returns immediately."""
         plugin._save_sync_state.device_id = "existing-uuid"
-        plugin._save_sync_state.device_name = "myhost"
+        plugin._save_settings["device_name"] = "myhost"
         plugin._save_sync_state.server_device_id = "server-uuid"
 
         result = await plugin.ensure_device_registered()
@@ -241,7 +246,7 @@ class TestDeviceRegistration:
         result = await plugin.ensure_device_registered()
 
         assert result["device_name"] == "steamdeck"
-        assert plugin._save_sync_state.device_name == "steamdeck"
+        assert plugin._save_settings["device_name"] == "steamdeck"
 
     @pytest.mark.asyncio
     async def test_generates_unique_ids(self, plugin):
@@ -283,7 +288,7 @@ class TestListDevices:
     @pytest.mark.asyncio
     async def test_list_devices_disabled_when_sync_off(self, plugin):
         """Returns disabled=True when save sync is disabled."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
 
         result = await plugin.list_devices()
 
@@ -302,7 +307,7 @@ class TestPreLaunchSync:
     @pytest.mark.asyncio
     async def test_skips_when_disabled(self, plugin):
         """Returns early when sync_before_launch is false."""
-        plugin._save_sync_state.settings.sync_before_launch = False
+        plugin._save_settings["sync_before_launch"] = False
 
         result = await plugin.pre_launch_sync(42)
 
@@ -321,7 +326,7 @@ class TestPostExitSync:
     @pytest.mark.asyncio
     async def test_skips_when_disabled(self, plugin):
         """Returns early when sync_after_exit is false."""
-        plugin._save_sync_state.settings.sync_after_exit = False
+        plugin._save_settings["sync_after_exit"] = False
 
         result = await plugin._save_sync_service.post_exit_sync(42)
 
@@ -685,10 +690,10 @@ class TestSaveSyncSettings:
         # sync_after_exit unchanged
         assert result["settings"]["sync_after_exit"] is True
 
-        # Persisted
-        path = tmp_path / "save_sync_state.json"
-        data = json.loads(path.read_text())
-        assert data["settings"]["save_sync_enabled"] is True
+        # Persisted into the live settings.json view (#822), flushed via the
+        # settings persister — not save_sync_state.json.
+        assert plugin._save_settings["save_sync_enabled"] is True
+        assert plugin._save_settings["sync_before_launch"] is False
 
     @pytest.mark.asyncio
     async def test_unknown_keys_ignored(self, plugin):
@@ -783,15 +788,15 @@ class TestSaveSyncFeatureFlag:
 
     @pytest.mark.asyncio
     async def test_default_disabled(self, plugin):
-        """save_sync_enabled defaults to False in fresh state."""
-        # Reset to defaults (no test fixture override).
-        plugin._save_sync_state.replace_with(SaveService.make_default_state())
-        assert plugin._save_sync_state.settings.save_sync_enabled is False
+        """save_sync_enabled defaults to False when absent from settings.json."""
+        # Reset to defaults — the toggle lives in settings.json now (#822).
+        plugin._save_settings.pop("save_sync_enabled", None)
+        assert plugin._save_sync_service._state_svc.is_save_sync_enabled() is False
 
     @pytest.mark.asyncio
     async def test_ensure_device_disabled(self, plugin):
         """ensure_device_registered returns disabled marker when save sync off."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin.ensure_device_registered()
         assert result["success"] is False
         assert result.get("disabled") is True
@@ -800,7 +805,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_pre_launch_sync_disabled(self, plugin):
         """pre_launch_sync skips when save sync disabled."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin.pre_launch_sync(42)
         assert result["success"] is True
         assert result["synced"] == 0
@@ -809,7 +814,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_post_exit_sync_disabled(self, plugin):
         """post_exit_sync skips when save sync disabled."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin._save_sync_service.post_exit_sync(42)
         assert result["success"] is True
         assert result["synced"] == 0
@@ -818,7 +823,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_sync_rom_saves_disabled(self, plugin):
         """sync_rom_saves returns error when save sync disabled."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin.sync_rom_saves(42)
         assert result["success"] is False
         assert "disabled" in result["message"].lower()
@@ -826,7 +831,7 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_sync_all_saves_disabled(self, plugin):
         """sync_all_saves returns error when save sync disabled."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin.sync_all_saves()
         assert result["success"] is False
         assert "disabled" in result["message"].lower()
@@ -834,17 +839,17 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_enable_via_settings_update(self, plugin):
         """save_sync_enabled can be toggled via update_save_sync_settings."""
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         result = await plugin.update_save_sync_settings({"save_sync_enabled": True})
         assert result["success"] is True
-        assert plugin._save_sync_state.settings.save_sync_enabled is True
+        assert plugin._save_settings["save_sync_enabled"] is True
 
     @pytest.mark.asyncio
     async def test_disable_via_settings_update(self, plugin):
         """save_sync_enabled can be disabled via update_save_sync_settings."""
         result = await plugin.update_save_sync_settings({"save_sync_enabled": False})
         assert result["success"] is True
-        assert plugin._save_sync_state.settings.save_sync_enabled is False
+        assert plugin._save_settings["save_sync_enabled"] is False
 
     @pytest.mark.asyncio
     async def test_get_settings_includes_flag(self, plugin):
@@ -855,9 +860,9 @@ class TestSaveSyncFeatureFlag:
     @pytest.mark.asyncio
     async def test_is_save_sync_enabled_helper(self, plugin):
         """is_save_sync_enabled (on StateService) reflects the settings value."""
-        plugin._save_sync_state.settings.save_sync_enabled = True
+        plugin._save_settings["save_sync_enabled"] = True
         assert plugin._save_sync_service._state_svc.is_save_sync_enabled() is True
-        plugin._save_sync_state.settings.save_sync_enabled = False
+        plugin._save_settings["save_sync_enabled"] = False
         assert plugin._save_sync_service._state_svc.is_save_sync_enabled() is False
 
 


### PR DESCRIPTION
## Summary

Implements the config-migration consequence of [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md). The five save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) and the `device_name` label are user-intent config, so they move from `save_sync_state.json` into `settings.json`. JSON → JSON, decoupled from the SQLite cutover — these values now survive the empty-start cutover untouched. `device_id`/`server_device_id` stay in `save_sync_state.json` (→ `kv_config` at #784).

## What changed

- **`DEFAULT_SETTINGS`** gains the six keys, defaults byte-identical to the old aggregate (`False`/`True`/`True`/`"default"`/`10`/`None`); `_SETTINGS_VERSION` 3 → 4.
- **One-time v3→v4 fold.** Pure `fold_legacy_save_sync_settings(settings, raw)` lifts the six values out of `save_sync_state.json` into `settings.json`, orchestrated in `bootstrap()` (the only place that can read the file — domain stays I/O-free), gated on `version < 4` so it runs exactly once and is idempotent. Existing installs keep their real values; fresh installs fall back to defaults.
- **`StateService` becomes the settings.json-backed owner** of the six values: `is_save_sync_enabled` / `get_settings` / `get_save_sync_settings` / `update_save_sync_settings` read/write the injected `settings` dict and flush via the `SettingsPersister`; new `get_device_name` / `set_device_name`. The `SaveSyncState` aggregate drops its `settings` + `device_name` fields.
- **Peers repointed:** saves sub-services read `get_settings().X` instead of `state.settings.X`; top-level `PlaytimeService` / `GameDetailService` read the live `settings` dict (mutated in place, so runtime toggles are seen).
- Dedicated callable shapes (`get_save_sync_settings` / `update_save_sync_settings`) are unchanged — no frontend change.

## Verification

`ruff`, `basedpyright` (0 errors), `lint-imports` (8 contracts kept), cosmic call bans, aggregate-field-assignment check, `pytest` (2796 passed) — all green. New tests cover the fold (happy / idempotent / missing-source / immutability / no device-identity copy), the v3→v4 version stamp, and the settings-dict-backed `StateService` accessors.

**On-device verification (pending):** toggle a save-sync setting in the QAM, restart, confirm it persisted in `~/homebrew/settings/decky-romm-sync/settings.json` and survives the restart.

Closes #822