### PR TITLE
chore(quality): enable ruff ASYNC lint group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,17 @@ select = [
     "B",    # bugbear — common pitfalls
     "SIM",  # simplify — unnecessary complexity
     "UP",   # pyupgrade — modern Python syntax
-    "RUF",  # ruff-specific rules
-    "ARG",  # unused arguments
+    "RUF",   # ruff-specific rules
+    "ARG",   # unused arguments
+    "ASYNC", # flake8-async — blocking I/O in async functions
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "main.py" = ["E402"]
-"tests/**" = ["ARG"]
+# pytest-asyncio test bodies legitimately do blocking setup I/O (open,
+# os.path) — ASYNC's event-loop concern is a production-only worry, not
+# a test one, so the group is disabled under tests/ (same rationale as ARG).
+"tests/**" = ["ARG", "ASYNC"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["lib", "domain", "services", "adapters"]


### PR DESCRIPTION
Ratchet box of #838 — does not close the umbrella.

Enables flake8-async (`ASYNC`) in ruff. Prod code is already clean (0 hits); the rule is preventative. The 41 existing hits are legitimate pytest-asyncio test setup, ignored under `tests/**` like ARG.

docs: N/A — pure lint-config change, no user-visible or architecture impact.