### PR TITLE
chore(quality): raise basedpyright reportArgumentType to error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ reportPrivateUsage = "error"
 reportRedeclaration = "none"
 reportUnusedParameter = "none"
 reportUnusedVariable = "warning"
+reportArgumentType = "error"
 
 # Tests inspect and rebind private state of the system under test —
 # white-box testing is a deliberate, accepted pattern here. The


### PR DESCRIPTION
Ratchet box of #838 — does not close the umbrella.

Raises `reportArgumentType` to `error` in basedpyright (stays in `basic` mode). Measured fallout: **0 errors** — the codebase is already clean (the issue's ~4 estimate predates the Cosmic Python migration). Pure preventative lock-in, no code changes.

docs: N/A — pure type-checker config change, no user-visible or architecture impact.