### PR TITLE
chore(ci): skip requirements-dev/docs.txt in docs-check

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -50,7 +50,7 @@ jobs:
           # Inverse approach: everything triggers docs requirement UNLESS it matches this list.
           # New file paths default to "needs docs" — additions to the skip list are explicit.
           skip_re='^(tests|scripts|\.github|\.claude|\.worktrees)/'
-          skip_files_re='^(coverage\.json|mise\.toml|pyproject\.toml|pnpm-lock\.yaml|package-lock\.json|package\.json|plugin\.json|\.gitignore|\.editorconfig|\.gitattributes|\.release-please-manifest\.json|CHANGELOG\.md|LICENSE|CLAUDE\.md|MEMORY\.md|README\.md)$'
+          skip_files_re='^(coverage\.json|mise\.toml|pyproject\.toml|requirements-dev\.txt|requirements-docs\.txt|pnpm-lock\.yaml|package-lock\.json|package\.json|plugin\.json|\.gitignore|\.editorconfig|\.gitattributes|\.release-please-manifest\.json|CHANGELOG\.md|LICENSE|CLAUDE\.md|MEMORY\.md|README\.md)$'
 
           requires_docs=()
           docs_touched=false


### PR DESCRIPTION
## Problem

Pip Dependabot PRs (#834 basedpyright, #835 ruff) fail the required **Docs updated in same PR** check. They bump `requirements-dev.txt`, which is not on the docs-check skip list (`skip_files_re`), so the check treats a dependency manifest as doc-requiring source. The npm group PR passes only because `package.json` / `pnpm-lock.yaml` are already skipped.

`requirements-docs.txt` (mkdocs-material etc., e.g. former #774) has the same gap.

## Fix

Add `requirements-dev.txt` and `requirements-docs.txt` to `skip_files_re` — anchored exact-match entries, no wildcard, per the workflow's explicit-additions policy. Verified locally: the two manifests now skip; `main.py`, service modules, and an unrelated `requirements-other.txt` still require docs.

Unblocks #834 and #835 (both otherwise green).

docs: N/A — CI tooling change, no user-visible or architectural impact.