### PR TITLE
ci(sonar): carry quality gate in-job to unblock Dependabot auto-merge

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,15 @@
 sonar.projectKey=danielcopper_decky-romm-sync
 sonar.organization=danielcopper
 
+# Quality Gate
+# Make the scanner poll the gate and exit non-zero when it fails, so the
+# `sonarcloud` CI job itself carries the gate verdict instead of the async
+# SonarCloud app commit status. Branch protection then requires the job — which
+# is skipped (and thus reported as passing) for Dependabot, whereas the app
+# status never posts on Dependabot PRs and deadlocks auto-merge. Human PRs still
+# hard-block: a failed gate fails the required job.
+sonar.qualitygate.wait=true
+
 # Sources
 sonar.sources=py_modules,src,main.py
 sonar.tests=tests,src


### PR DESCRIPTION
## Problem

Dependabot PRs never auto-merge. Branch protection requires the **`SonarCloud Code Analysis`** status (the SonarSource app commit status, app_id 12526). The `sonarcloud` job is skipped for Dependabot (`if: github.actor != 'dependabot[bot]'`, because the bot has no `SONAR_TOKEN`), so that app status never posts → the PR is permanently blocked ("expected, waiting for status"). Even a fully-green PR (e.g. #836) sits unmerged.

Today the `sonarcloud` GHA job only runs the scan (upload); the gate verdict lives **only** in that app status.

## Fix (two halves)

1. **This PR:** add `sonar.qualitygate.wait=true` so the scanner polls the gate and exits non-zero on failure. The gate verdict now lives in the **`sonarcloud` GHA job** (app_id 15368) — deterministic exit code, not the async app status.
2. **Branch protection (out-of-band, applied alongside merge):** remove `SonarCloud Code Analysis` from the required status checks; keep `sonarcloud` required.

### Why this is safe for human PRs
- `test`, `frontend-test`, `lint`, `build`, `markdownlint` are unconditional required checks — they always run on human PRs and can never be skipped-to-pass. The "tests must pass" guarantee is untouched.
- For human PRs the `sonarcloud` job runs and now **fails on a failing gate** → required job red → merge blocked. The coverage gate stays a hard block.
- For Dependabot the job is skipped, which branch protection treats as passing (job-level `if` skip, not a workflow-level skip) — so auto-merge proceeds.

### Why not a Dependabot secret
Rejected on security grounds: it would inject `SONAR_TOKEN` into runs that install freshly-bumped, unvetted dependencies (install-script exfiltration surface) — the worst place to hold a credential.

docs: N/A — CI configuration change, no user-visible or architectural impact.