### PR TITLE
chore(quality): cherry-pick eslint no-misused-promises rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,7 @@ export default tseslint.config(
       // above, without adopting the full recommendedTypeChecked preset (which drags in
       // the no-unsafe-* noise family — the JS twin of pyright's rejected reportUnknown*).
       "@typescript-eslint/await-thenable": "error",
+      "@typescript-eslint/no-misused-promises": "error",
     },
   },
   {

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -488,7 +488,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const showDropdownMenu = (e: MouseEvent) => {
     showContextMenu(
       <Menu label="RomM Actions">
-        <MenuItem key="uninstall" tone="destructive" onClick={handleUninstall}>
+        <MenuItem key="uninstall" tone="destructive" onClick={() => { void handleUninstall(); }}>
           Uninstall
         </MenuItem>
       </Menu>,
@@ -612,7 +612,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
             background: baseBg,
             "--romm-pulse-color": pulseColor,
           } as React.CSSProperties}
-          onClick={handleDownload}
+          onClick={() => { void handleDownload(); }}
           disabled={actionPending || isOffline}
         >
           {/* Progress fill bar */}
@@ -723,7 +723,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
             borderRadius: "2px",
             background: "linear-gradient(to right, #d4a72c, #b8941f)",
           }}
-          onClick={handleResolveConflict}
+          onClick={() => { void handleResolveConflict(); }}
         >
           Resolve Conflict
         </DialogButton>
@@ -753,7 +753,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           backgroundPosition: "25%",
           backgroundSize: "330% 100%",
         }}
-        onClick={handlePlay}
+        onClick={() => { void handlePlay(); }}
         onFocus={scrollToTop}
       >
         Play

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -137,15 +137,17 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
           "This will delete every local save file for ROMs on this platform. Any local changes that haven't been uploaded to RomM yet will be lost permanently. Make sure saves are synced first.",
         strOKButtonText: "Delete Save Files",
         strCancelButtonText: "Cancel",
-        onOK: async () => {
-          setActionStatus(`Deleting ${p.name} saves...`);
-          try {
-            const result = await deletePlatformSaves(p.slug);
-            setActionStatus(result.message);
-            globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
-          } catch {
-            setActionStatus("Failed to delete saves");
-          }
+        onOK: () => {
+          void (async () => {
+            setActionStatus(`Deleting ${p.name} saves...`);
+            try {
+              const result = await deletePlatformSaves(p.slug);
+              setActionStatus(result.message);
+              globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync" } }));
+            } catch {
+              setActionStatus("Failed to delete saves");
+            }
+          })();
         },
       }),
     );
@@ -168,17 +170,21 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     }
     setConfirmRemoveAllRomm(false);
     setStatus("Removing all shortcuts...");
-    const result = await removeAllShortcuts();
-    if (result.app_ids) {
-      for (const appId of result.app_ids) {
-        removeShortcut(appId);
+    try {
+      const result = await removeAllShortcuts();
+      if (result.app_ids) {
+        for (const appId of result.app_ids) {
+          removeShortcut(appId);
+        }
       }
+      if (result.rom_ids?.length) {
+        await reportRemovalResults(result.rom_ids);
+      }
+      await clearAllRomMCollections();
+      setStatus(result.message);
+    } catch {
+      setStatus("Failed to remove shortcuts");
     }
-    if (result.rom_ids?.length) {
-      await reportRemovalResults(result.rom_ids);
-    }
-    await clearAllRomMCollections();
-    setStatus(result.message);
     await refreshPlatforms();
     loadNonSteamApps();
   };
@@ -222,9 +228,9 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             showModal(
               <PlatformActionModal
                 platform={p}
-                onRemoveShortcuts={() => handleRemoveShortcuts(p)}
+                onRemoveShortcuts={() => { void handleRemoveShortcuts(p); }}
                 onDeleteSaves={() => handleDeleteSaves(p)}
-                onDeleteBios={() => handleDeleteBios(p)}
+                onDeleteBios={() => { void handleDeleteBios(p); }}
               />
             );
           }}
@@ -239,7 +245,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     <>
       <PanelSection title="Remove Shortcuts">
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={handleRemoveAllRomm}>
+          <ButtonItem layout="below" onClick={() => { void handleRemoveAllRomm(); }}>
             {confirmRemoveAllRomm
               ? <span style={{ color: "#ff8800" }}>Confirm: remove all RomM shortcuts?</span>
               : "Remove All RomM Shortcuts"}
@@ -263,7 +269,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
 
       <PanelSection title="Installed ROMs">
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={handleUninstallAll}>
+          <ButtonItem layout="below" onClick={() => { void handleUninstallAll(); }}>
             {confirmUninstall
               ? <span style={{ color: "#ff8800" }}>Confirm: delete all ROM files?</span>
               : "Uninstall All Installed ROMs"}
@@ -471,7 +477,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
       ) : (
         <>
           <PanelSectionRow>
-            <ButtonItem layout="below" onClick={handleRemoveAll}>
+            <ButtonItem layout="below" onClick={() => { void handleRemoveAll(); }}>
               {removeButtonLabel()}
             </ButtonItem>
           </PanelSectionRow>

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -150,7 +150,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
               <PanelSectionRow key={`cancel-${item.rom_id}`}>
                 <ButtonItem
                   layout="below"
-                  onClick={() => handleCancel(item.rom_id)}
+                  onClick={() => { void handleCancel(item.rom_id); }}
                 >
                   Cancel {item.rom_name}
                 </ButtonItem>

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -317,12 +317,12 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     return (
       <>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => handleSetAll(true)}>
+          <ButtonItem layout="below" onClick={() => { void handleSetAll(true); }}>
             Enable All
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => handleSetAll(false)}>
+          <ButtonItem layout="below" onClick={() => { void handleSetAll(false); }}>
             Disable All
           </ButtonItem>
         </PanelSectionRow>
@@ -332,9 +332,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               label={platform.name}
               description={`${platform.rom_count} ROMs`}
               checked={platform.sync_enabled}
-              onChange={(value: boolean) =>
-                handleToggle(platform.id, value)
-              }
+              onChange={(value: boolean) => { void handleToggle(platform.id, value); }}
             />
           </PanelSectionRow>
         ))}
@@ -385,9 +383,11 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               label="Show collection games in platform groups"
               description="When syncing a collection, also add its games to their platform-specific Steam group."
               checked={platformGroups}
-              onChange={async (value: boolean) => {
+              onChange={(value: boolean) => {
                 setPlatformGroups(value);
-                try { await saveCollectionPlatformGroups(value); } catch { setPlatformGroups(!value); }
+                void (async () => {
+                  try { await saveCollectionPlatformGroups(value); } catch { setPlatformGroups(!value); }
+                })();
               }}
             />
           </PanelSectionRow>
@@ -397,9 +397,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 label="Sync RomM favorites"
                 description={favoritesDescription(favoritesCollection.rom_count)}
                 checked={favoritesCollection.sync_enabled}
-                onChange={(value: boolean) =>
-                  handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value)
-                }
+                onChange={(value: boolean) => { void handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value); }}
               />
             </PanelSectionRow>
           )}
@@ -432,13 +430,13 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
             >
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => handleSetAllCollections(true, activeSubTab)}
+                onClick={() => { void handleSetAllCollections(true, activeSubTab); }}
               >
                 Enable All
               </DialogButton>
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => handleSetAllCollections(false, activeSubTab)}
+                onClick={() => { void handleSetAllCollections(false, activeSubTab); }}
               >
                 Disable All
               </DialogButton>
@@ -455,9 +453,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                   label={collection.name}
                   description={`${collection.rom_count} ROMs`}
                   checked={collection.sync_enabled}
-                  onChange={(value: boolean) =>
-                    handleCollectionToggle(collection.id, collection.kind, value)
-                  }
+                  onChange={(value: boolean) => { void handleCollectionToggle(collection.id, collection.kind, value); }}
                 />
               </PanelSectionRow>
             ))
@@ -512,16 +508,22 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 })),
               ]}
               selectedOption={platform.active_core_label || platform.available_cores.find((c) => c.is_default)?.label || ""}
-              onChange={async (option: { data: string }) => {
-                const defaultCore = platform.available_cores?.find((c) => c.is_default);
-                const label = option.data === defaultCore?.label ? "" : option.data;
-                debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`);
-                const result = await setSystemCore(platform.platform_slug, label);
-                debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`);
-                if (result.success) {
-                  await refreshBios();
-                  globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: platform.platform_slug } }));
-                }
+              onChange={(option: { data: string }) => {
+                void (async () => {
+                  const defaultCore = platform.available_cores?.find((c) => c.is_default);
+                  const label = option.data === defaultCore?.label ? "" : option.data;
+                  debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`);
+                  try {
+                    const result = await setSystemCore(platform.platform_slug, label);
+                    debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`);
+                    if (result.success) {
+                      await refreshBios();
+                      globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: platform.platform_slug } }));
+                    }
+                  } catch (e) {
+                    debugLog(`setSystemCore: error: ${e}`);
+                  }
+                })();
               }}
             />
           </PanelSectionRow>
@@ -597,7 +599,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={() => handleDownloadRequired(platform.platform_slug)}
+              onClick={() => { void handleDownloadRequired(platform.platform_slug); }}
               disabled={isDownloading}
             >
               {isDownloading ? "Downloading..." : "Download Required"}
@@ -608,7 +610,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={() => handleDownloadAll(platform.platform_slug)}
+              onClick={() => { void handleDownloadAll(platform.platform_slug); }}
               disabled={isDownloading}
             >
               {isDownloading ? "Downloading..." : "Download All"}

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -363,7 +363,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             <PanelSectionRow>
               <ButtonItem
                 layout="below"
-                onClick={handleApply}
+                onClick={() => { void handleApply(); }}
                 // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
                 onFocus={scrollToTop}
               >
@@ -371,7 +371,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </ButtonItem>
             </PanelSectionRow>
             <PanelSectionRow>
-              <ButtonItem layout="below" onClick={handleDismiss}>
+              <ButtonItem layout="below" onClick={() => { void handleDismiss(); }}>
                 Cancel
               </ButtonItem>
             </PanelSectionRow>
@@ -380,7 +380,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={handleDismiss}
+              onClick={() => { void handleDismiss(); }}
               // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
               onFocus={scrollToTop}
             >
@@ -435,7 +435,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
-            onClick={handleCancel}
+            onClick={() => { void handleCancel(); }}
             // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
             onFocus={scrollToTop}
           >
@@ -450,7 +450,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
-            onClick={handleSync}
+            onClick={() => { void handleSync(); }}
             disabled={loading || connected === false}
             // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
             onFocus={scrollToTop}
@@ -471,12 +471,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             <ButtonItem
               layout="below"
               description="Clear cached sync data to re-fetch all platforms"
-              onClick={async () => {
-                const result = await clearSyncCache();
-                setStatus(result.message);
-                if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-                statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
-                getSyncStats().then(setStats);
+              onClick={() => {
+                void (async () => {
+                  try {
+                    const result = await clearSyncCache();
+                    setStatus(result.message);
+                  } catch {
+                    setStatus("Failed to clear sync cache");
+                  }
+                  if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
+                  statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
+                  getSyncStats().then(setStats).catch((e) => logError(`Failed to refresh sync stats: ${e}`));
+                })();
               }}
               disabled={loading || connected === false}
             >
@@ -533,15 +539,17 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     strDescription="This will change input_driver to sdl2 in your RetroArch config. Controllers should work better in RetroArch menus after this change."
                     strOKButtonText="Apply Fix"
                     strCancelButtonText="Cancel"
-                    onOK={async () => {
-                      try {
-                        const result = await fixRetroarchInputDriver();
-                        if (result.success) {
-                          setRetroarchWarning(null);
+                    onOK={() => {
+                      void (async () => {
+                        try {
+                          const result = await fixRetroarchInputDriver();
+                          if (result.success) {
+                            setRetroarchWarning(null);
+                          }
+                        } catch {
+                          // ignore
                         }
-                      } catch {
-                        // ignore
-                      }
+                      })();
                     }}
                   />
                 )}

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -81,19 +81,21 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
         }
         strOKButtonText="Dismiss"
         strCancelButtonText="Cancel"
-        onOK={async () => {
-          try {
-            const result = await dismissRetrodeckMigration();
-            if (result.success) {
-              clearMigration();
-              toaster.toast({
-                title: "RomM Sync",
-                body: "Migration dismissed.",
-              });
+        onOK={() => {
+          void (async () => {
+            try {
+              const result = await dismissRetrodeckMigration();
+              if (result.success) {
+                clearMigration();
+                toaster.toast({
+                  title: "RomM Sync",
+                  body: "Migration dismissed.",
+                });
+              }
+            } catch {
+              setMigrateResult("Dismiss failed");
             }
-          } catch {
-            setMigrateResult("Dismiss failed");
-          }
+          })();
         }}
       />,
     );

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -413,21 +413,23 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       await refreshCoverArtInBackground(romId, () => cancelled, setState);
     };
 
-    const onDataChanged = async (e: Event) => {
-      try {
-        const detail = (e as CustomEvent).detail;
-        if (!romIdRef.current) return;
-        switch (detail?.type) {
-          case "save_sync_settings": await handleSaveSyncSettingsChange(detail); break;
-          case "save_sync": await handleSaveSyncChange(detail); break;
-          case "bios": await handleBiosChange(detail); break;
-          case "core_changed": await handleCoreChange(); break;
-          case "metadata": await handleMetadataChange(detail); break;
-          case "cover_refreshed": await handleCoverRefreshed(detail); break;
+    const onDataChanged = (e: Event) => {
+      void (async () => {
+        try {
+          const detail = (e as CustomEvent).detail;
+          if (!romIdRef.current) return;
+          switch (detail?.type) {
+            case "save_sync_settings": await handleSaveSyncSettingsChange(detail); break;
+            case "save_sync": await handleSaveSyncChange(detail); break;
+            case "bios": await handleBiosChange(detail); break;
+            case "core_changed": await handleCoreChange(); break;
+            case "metadata": await handleMetadataChange(detail); break;
+            case "cover_refreshed": await handleCoverRefreshed(detail); break;
+          }
+        } catch (err) {
+          debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
         }
-      } catch (err) {
-        debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
-      }
+      })();
     };
     globalThis.addEventListener("romm_data_changed", onDataChanged);
 
@@ -497,7 +499,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         if (!state.romId) return;
         const result = await getSaveSlots(state.romId);
         if (cancelled) return;
-        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, debugLog);
+        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => { void debugLog(msg); });
       } catch (e) {
         debugLog(`Failed to load save slots: ${e}`);
         if (!cancelled) {

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -269,17 +269,19 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       setInfo((prev) => ({ ...prev, saveSyncStatus, saveSyncLabel, activeSlot: saveStatus && "active_slot" in saveStatus ? saveStatus.active_slot ?? null : prev.activeSlot }));
     };
 
-    const onDataChanged = async (e: Event) => {
-      try {
-        const detail = (e as CustomEvent).detail;
-        switch (detail?.type) {
-          case "save_sync_settings": await handleSaveSyncSettingsChange(detail); break;
-          case "core_changed": await handleCoreChange(); break;
-          case "save_sync": await handleSaveSyncChange(detail); break;
+    const onDataChanged = (e: Event) => {
+      void (async () => {
+        try {
+          const detail = (e as CustomEvent).detail;
+          switch (detail?.type) {
+            case "save_sync_settings": await handleSaveSyncSettingsChange(detail); break;
+            case "core_changed": await handleCoreChange(); break;
+            case "save_sync": await handleSaveSyncChange(detail); break;
+          }
+        } catch (err) {
+          debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
         }
-      } catch (err) {
-        debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
-      }
+      })();
     };
     globalThis.addEventListener("romm_data_changed", onDataChanged);
 
@@ -539,23 +541,25 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         strDescription: "This will delete local save files for this game. Make sure saves are synced to RomM first — the next sync will re-download them from the server.",
         strOKButtonText: "Delete",
         strCancelButtonText: "Cancel",
-        onOK: async () => {
-          setActionPending("deletesaves");
-          try {
-            const result = await deleteLocalSaves(romId);
-            if (result.success) {
-              toaster.toast({ title: "RomM Sync", body: result.message });
-              // Directly update PlaySection status — no local saves remain
-              setInfo((prev) => ({ ...prev, saveSyncStatus: "none" as const, saveSyncLabel: "No saves" }));
-              globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-            } else {
-              toaster.toast({ title: "RomM Sync", body: result.message || "Failed to delete saves" });
+        onOK: () => {
+          void (async () => {
+            setActionPending("deletesaves");
+            try {
+              const result = await deleteLocalSaves(romId);
+              if (result.success) {
+                toaster.toast({ title: "RomM Sync", body: result.message });
+                // Directly update PlaySection status — no local saves remain
+                setInfo((prev) => ({ ...prev, saveSyncStatus: "none" as const, saveSyncLabel: "No saves" }));
+                globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
+              } else {
+                toaster.toast({ title: "RomM Sync", body: result.message || "Failed to delete saves" });
+              }
+            } catch {
+              toaster.toast({ title: "RomM Sync", body: "Failed to delete saves" });
+            } finally {
+              setActionPending(null);
             }
-          } catch {
-            toaster.toast({ title: "RomM Sync", body: "Failed to delete saves" });
-          } finally {
-            setActionPending(null);
-          }
+          })();
         },
       }),
     );
@@ -619,7 +623,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           // override, not the ES-DE default, which is confusing.
           return createElement(MenuItem, {
             key: `core-${c.core_so}`,
-            onClick: () => handleChangeGameCore(c.label),
+            onClick: () => { void handleChangeGameCore(c.label); },
           }, `${c.label}${c.is_default ? " (default)" : ""}${info.activeCoreLabel === c.label ? " \u2713" : ""}`);
         }),
       ),
@@ -630,13 +634,13 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const showRomMMenu = (e: Event) => {
     showContextMenu(
       createElement(Menu, { label: "RomM Actions" },
-        createElement(MenuItem, { key: "refresh-artwork", onClick: handleRefreshArtwork }, "Refresh Artwork"),
-        createElement(MenuItem, { key: "refresh-metadata", onClick: handleRefreshMetadata }, "Refresh Metadata"),
-        createElement(MenuItem, { key: "sync-saves", onClick: handleSyncSaves }, "Sync Save Files"),
-        createElement(MenuItem, { key: "download-bios", onClick: handleDownloadBios }, "Download BIOS"),
+        createElement(MenuItem, { key: "refresh-artwork", onClick: () => { void handleRefreshArtwork(); } }, "Refresh Artwork"),
+        createElement(MenuItem, { key: "refresh-metadata", onClick: () => { void handleRefreshMetadata(); } }, "Refresh Metadata"),
+        createElement(MenuItem, { key: "sync-saves", onClick: () => { void handleSyncSaves(); } }, "Sync Save Files"),
+        createElement(MenuItem, { key: "download-bios", onClick: () => { void handleDownloadBios(); } }, "Download BIOS"),
         createElement(MenuSeparator, { key: "sep" }),
         createElement(MenuItem, { key: "delete-saves", tone: "destructive", onClick: handleDeleteSaves }, "Delete Local Saves"),
-        createElement(MenuItem, { key: "uninstall", tone: "destructive", onClick: handleUninstall }, "Uninstall"),
+        createElement(MenuItem, { key: "uninstall", tone: "destructive", onClick: () => { void handleUninstall(); } }, "Uninstall"),
       ),
       getEventTarget(e),
     );

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -137,23 +137,26 @@ export const SavesTab: FC<SavesTabProps> = ({
   const handleNewSlot = () => {
     showModal(
       createElement(NewSlotModal, {
-        onSubmit: async (name: string) => {
+        onSubmit: (name: string) => {
+          void (async () => {
           if (!name) {
             // Empty = legacy mode — show warning
             showModal(createElement(ConfirmModal, {
               strTitle: "Use Legacy Mode?",
               strDescription: "Legacy mode (no slot) limits saves to one version per game. Are you sure?",
-              onOK: async () => {
-                try {
-                  const result = await switchSlot(romId, "");
-                  if (result.success && result.save_status) {
-                    onSlotSwitched("", result.save_status);
-                  } else {
-                    debugLog(`SavesTab: legacy switch failed: ${result.reason}`);
+              onOK: () => {
+                void (async () => {
+                  try {
+                    const result = await switchSlot(romId, "");
+                    if (result.success && result.save_status) {
+                      onSlotSwitched("", result.save_status);
+                    } else {
+                      debugLog(`SavesTab: legacy switch failed: ${result.reason}`);
+                    }
+                  } catch (e) {
+                    debugLog(`SavesTab: legacy switch error: ${e}`);
                   }
-                } catch (e) {
-                  debugLog(`SavesTab: legacy switch error: ${e}`);
-                }
+                })();
               },
             }));
             return;
@@ -181,6 +184,7 @@ export const SavesTab: FC<SavesTabProps> = ({
             if (newSlotErrorTimerRef.current) clearTimeout(newSlotErrorTimerRef.current);
             newSlotErrorTimerRef.current = setTimeout(() => setNewSlotError(null), 5000);
           }
+          })();
         },
       }),
     );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -234,7 +234,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         }
         strOKButtonText="I am sure"
         strCancelButtonText="Cancel"
-        onOK={() => handleSaveSyncSettingChange({ save_sync_enabled: true })}
+        onOK={() => { void handleSaveSyncSettingChange({ save_sync_enabled: true }); }}
         onCancel={() => {
           setSaveSyncToggleKey((k) => k + 1);
         }}
@@ -406,8 +406,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
           migration={saveSortMigration}
           migrating={saveSortMigrating}
           result={saveSortResult}
-          onMigrate={handleMigrateSaveSort}
-          onDismiss={handleDismissSaveSort}
+          onMigrate={() => { void handleMigrateSaveSort(); }}
+          onDismiss={() => { void handleDismissSaveSort(); }}
         />
       )}
       <ConnectionSection
@@ -421,14 +421,14 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onUsernameSubmit={handleUsernameSubmit}
         onPasswordSubmit={handlePasswordSubmit}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
-        onTestConnection={handleTest}
+        onTestConnection={() => { void handleTest(); }}
       />
       <SteamGridDBSection
         sgdbApiKey={sgdbApiKey}
         sgdbStatus={sgdbStatus}
         sgdbVerifying={sgdbVerifying}
-        onSubmitKey={handleSgdbKeySubmit}
-        onVerifyKey={handleSgdbVerify}
+        onSubmitKey={(value: string) => { void handleSgdbKeySubmit(value); }}
+        onVerifyKey={() => { void handleSgdbVerify(); }}
       />
       <SaveSyncSection
         saveSyncSettings={saveSyncSettings}
@@ -437,10 +437,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         syncing={syncing}
         syncStatus={syncStatus}
         onToggleSaveSync={handleToggleSaveSync}
-        onSettingChange={handleSaveSyncSettingChange}
+        onSettingChange={(partial) => { void handleSaveSyncSettingChange(partial); }}
         onDefaultSlotSubmit={handleDefaultSlotSubmit}
         onResetDefaultSlot={handleResetDefaultSlot}
-        onSyncAll={handleSyncAll}
+        onSyncAll={() => { void handleSyncAll(); }}
       />
       {saveSyncEnabled && (devicesLoading || registeredDevices !== null) && (
         <RegisteredDevicesSection
@@ -456,8 +456,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         retroarchFixStatus={retroarchFixStatus}
         loading={loading}
         onModeChange={handleSteamInputModeChange}
-        onApplyMode={handleApplySteamInput}
-        onFixInputDriver={handleFixInputDriver}
+        onApplyMode={() => { void handleApplySteamInput(); }}
+        onFixInputDriver={() => { void handleFixInputDriver(); }}
       />
       <AdvancedSection
         logLevel={logLevel}

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -222,7 +222,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
             />
           </div>
           <DialogButton
-            onClick={runSearch}
+            onClick={() => { void runSearch(); }}
             onFocus={scrollToTop}
             disabled={searching}
             style={{ width: "120px", height: "40px" }}
@@ -260,7 +260,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
                 thumbUrl={game.thumb_url}
                 title={game.name}
                 subtitle={game.release_year == null ? undefined : String(game.release_year)}
-                onSelect={() => applySelection(game.id)}
+                onSelect={() => { void applySelection(game.id); }}
                 onFocus={scrollFocusedToCenter}
                 disabled={applying}
               />

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -243,7 +243,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
           <DialogButton
             className="romm-wizard-btn"
             style={btnStyle}
-            onClick={() => handleConfirm(s.slot ?? defaultSlot)}
+            onClick={() => { void handleConfirm(s.slot ?? defaultSlot); }}
             onFocus={scrollFocusedToCenter}
           >
             Track
@@ -273,7 +273,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         <DialogButton
           className="romm-wizard-btn romm-wizard-btn-primary"
           style={btnPrimaryStyle}
-          onClick={() => handleConfirm(defaultSlot)}
+          onClick={() => { void handleConfirm(defaultSlot); }}
           onFocus={scrollFocusedToCenter}
         >
           Use slot &lsquo;{defaultSlot}&rsquo;
@@ -300,7 +300,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
                     createElement(ConfirmModal, {
                       strTitle: "Use Legacy Mode?",
                       strDescription: "Legacy mode (no slot) limits saves to one version per game. Are you sure?",
-                      onOK: () => handleConfirm(""),
+                      onOK: () => { void handleConfirm(""); },
                     }),
                   );
                 }

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -161,19 +161,21 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         strDescription: lines.join("\n\n"),
         strOKButtonText: "Delete",
         strCancelButtonText: "Cancel",
-        onOK: async () => {
-          try {
-            const result = await deleteSlot(romId, slotName);
-            if (result.success) {
-              toaster.toast({ title: "RomM Sync", body: `Slot '${slotName}' deleted` });
-              onSlotDeleted();
-            } else {
-              toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
+        onOK: () => {
+          void (async () => {
+            try {
+              const result = await deleteSlot(romId, slotName);
+              if (result.success) {
+                toaster.toast({ title: "RomM Sync", body: `Slot '${slotName}' deleted` });
+                onSlotDeleted();
+              } else {
+                toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
+              }
+            } catch (e) {
+              debugLog(`SavesTab: deleteSlot error: ${e}`);
+              toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
             }
-          } catch (e) {
-            debugLog(`SavesTab: deleteSlot error: ${e}`);
-            toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
-          }
+          })();
         },
       }));
     } catch (e) {
@@ -214,7 +216,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
     },
     noFocusRing: false,
     onFocus: scrollFocusedToCenter,
-    onClick: handleToggle,
+    onClick: () => { void handleToggle(); },
   },
     // Left: slot name + badges
     createElement("div", { className: "romm-slot-header-left" },
@@ -251,7 +253,9 @@ export const SlotPanel: FC<SlotPanelProps> = ({
       // eslint-disable-next-line react-hooks/refs -- createElement of an FC in a ternary branch trips the new react-hooks/refs rule; the component itself takes no ref.
       : createElement(InactiveSlotBody, {
           key: "body",
-          loadingSlot, slotFiles, switching, switchError, isOffline, handleActivate, handleDelete, deleting,
+          loadingSlot, slotFiles, switching, switchError, isOffline, deleting,
+          handleActivate: () => { void handleActivate(); },
+          handleDelete: () => { void handleDelete(); },
         });
   }
 

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -245,7 +245,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       },
       noFocusRing: false,
       onFocus: scrollFocusedToCenter,
-      onClick: handleToggle,
+      onClick: () => { void handleToggle(); },
     },
       createElement("span", {}, expanded ? "▾" : "▸"),
       createElement("span", {}, expanded && versions !== null

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -15,7 +15,8 @@ let gameActionHook: { unregister: () => void } | null = null;
 
 export function registerLaunchInterceptor(): void {
   gameActionHook = SteamClient.Apps.RegisterForGameActionStart(
-    async (gameActionId: number, appIdStr: string, action: string, _launchSource: number) => {
+    (gameActionId: number, appIdStr: string, action: string, _launchSource: number) => {
+      void (async () => {
       if (action !== "LaunchApp") return;
 
       const appId = Number.parseInt(appIdStr, 10);
@@ -68,6 +69,7 @@ export function registerLaunchInterceptor(): void {
         logError(`Launch interceptor error: ${e}`);
         // On error, don't block the launch.
       }
+      })();
     },
   );
 


### PR DESCRIPTION
Cherry-pick of #838's type-aware ESLint adoption (2nd rule, after await-thenable) — does not close the umbrella.

Adopts `@typescript-eslint/no-misused-promises` (full rule, no `checksVoidReturn` opt-outs) on top of the existing `projectService` infra, and fixes all 65 findings — async functions in void-return slots, void-wrapped at the call site (`() => { void fn(); }`).

Three findings were genuine **unhandled-rejection bugs** (bare `callable()` awaits among otherwise-guarded siblings), fixed with a try/catch matching each file's sibling pattern before the void-wrap:
- `DangerZone.tsx` — `handleRemoveAllRomm`
- `LibraryPage.tsx` — Active-Core `onChange` / `setSystemCore`
- `MainPage.tsx` — Force-Full-Sync / `clearSyncCache`

Verified: eslint 0 errors, tsc clean (bar the pre-existing tsconfig deprecation), build ok, 1049 tests pass. Next: `no-floating-promises` (~102).

docs: N/A — lint-rule adoption + internal error-handling hardening, no user-visible or architecture change.