### PR TITLE
chore(quality): cherry-pick eslint no-floating-promises rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,7 @@ export default tseslint.config(
       // the no-unsafe-* noise family — the JS twin of pyright's rejected reportUnknown*).
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/no-floating-promises": "error",
     },
   },
   {

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,4 +1,5 @@
 import { callable } from "@decky/api";
+import { detach } from "../utils/detach";
 import type { PluginSettings, SyncStats, SyncProgress, DownloadItem, InstalledRom, PlatformSyncSetting, CollectionSyncSetting, CollectionKind, RegistryPlatform, FirmwareStatus, FirmwareDownloadResult, BiosStatus, BiosFileStatus, RomMetadata, SaveSyncSettings, SaveStatus, SaveSyncDisplay, SyncConflict, AvailableCore, RommErrorCode, SyncPreview, AchievementSummary, AchievementList, AchievementProgress, SaveSlotSummary, SaveSetupInfo, SlotSavesResponse, SwitchSlotResponse, LaunchVerdict, SlotDeleteInfo, DeleteSlotResult, MigrationStatus, MigrationResult, SaveSortMigrationStatus, RollbackStatus, ListFileVersionsResult, ListDevicesResponse } from "../types";
 
 export interface BackendResult {
@@ -128,9 +129,9 @@ export const setGameCore = callable<[string, string, string], { success: boolean
 export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
 export const debugLog = callable<[string], void>("debug_log");
 const frontendLog = callable<[string, string], void>("frontend_log");
-export const logInfo = (msg: string) => { void frontendLog("info", msg); };
-export const logWarn = (msg: string) => { void frontendLog("warn", msg); };
-export const logError = (msg: string) => { void frontendLog("error", msg); };
+export const logInfo = (msg: string) => { detach(frontendLog("info", msg)); };
+export const logWarn = (msg: string) => { detach(frontendLog("warn", msg)); };
+export const logError = (msg: string) => { detach(frontendLog("error", msg)); };
 export const fixRetroarchInputDriver = callable<[], { success: boolean; message: string }>("fix_retroarch_input_driver");
 export const getRomMetadata = callable<[number], RomMetadata>("get_rom_metadata");
 export const getAllMetadataCache = callable<[], Record<string, RomMetadata>>("get_all_metadata_cache");

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -128,9 +128,9 @@ export const setGameCore = callable<[string, string, string], { success: boolean
 export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
 export const debugLog = callable<[string], void>("debug_log");
 const frontendLog = callable<[string, string], void>("frontend_log");
-export const logInfo = (msg: string) => { frontendLog("info", msg); };
-export const logWarn = (msg: string) => { frontendLog("warn", msg); };
-export const logError = (msg: string) => { frontendLog("error", msg); };
+export const logInfo = (msg: string) => { void frontendLog("info", msg); };
+export const logWarn = (msg: string) => { void frontendLog("warn", msg); };
+export const logError = (msg: string) => { void frontendLog("error", msg); };
 export const fixRetroarchInputDriver = callable<[], { success: boolean; message: string }>("fix_retroarch_input_driver");
 export const getRomMetadata = callable<[number], RomMetadata>("get_rom_metadata");
 export const getAllMetadataCache = callable<[], Record<string, RomMetadata>>("get_all_metadata_cache");

--- a/src/components/CoreChangeModal.test.tsx
+++ b/src/components/CoreChangeModal.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from "@testing-library/react";
 import { cloneElement, createElement, type ReactElement } from "react";
 import { showModal } from "@decky/ui";
 import { showCoreChangeModal } from "./CoreChangeModal";
+import { detach } from "../utils/detach";
 
 // Per-file mock for @decky/ui. The global stub renders ModalRoot as a
 // pass-through <div> but discards its `closeModal` prop. Here we capture
@@ -106,7 +107,7 @@ describe("CoreChangeModal", () => {
   describe("CoreChangeModalContent — rendering", () => {
     it("renders title, label arrow, and both warning blocks", () => {
       // Drive via showCoreChangeModal so we don't depend on the non-exported FC.
-      void showCoreChangeModal("CoreA", "CoreB");
+      detach(showCoreChangeModal("CoreA", "CoreB"));
       const { container } = render(lastShownElement());
 
       expect(container.textContent).toContain("Emulator Core Changed");

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -44,6 +44,7 @@ import { handleButtonDownloadFailure } from "../utils/downloadFailure";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SyncConflict } from "../types";
+import { detach } from "../utils/detach";
 
 type PlayButtonState = "loading" | "not_romm" | "download" | "conflict" | "syncing" | "play" | "launching" | "dl_complete" | "uninstalling";
 
@@ -135,10 +136,10 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     async function init() {
       try {
         const cached = await getCachedGameDetail(appId);
-        void debugLog(`CustomPlayButton init: appId=${appId} cached.found=${cached.found} cancelled=${cancelled}`);
+        detach(debugLog(`CustomPlayButton init: appId=${appId} cached.found=${cached.found} cancelled=${cancelled}`));
         if (cancelled) return;
         if (!cached.found) {
-          void debugLog(`CustomPlayButton: -> not_romm (not in cache)`);
+          detach(debugLog(`CustomPlayButton: -> not_romm (not in cache)`));
           setState("not_romm");
           return;
         }
@@ -152,14 +153,14 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           // Check for conflicts from cached save status
           const hasConflict = hasAnySaveConflict(cached.save_status);
           if (hasConflict) {
-            void debugLog(`CustomPlayButton: -> conflict (from cache)`);
+            detach(debugLog(`CustomPlayButton: -> conflict (from cache)`));
             setState("conflict");
           } else {
-            void debugLog(`CustomPlayButton: -> play`);
+            detach(debugLog(`CustomPlayButton: -> play`));
             setState("play");
           }
         } else {
-          void debugLog(`CustomPlayButton: -> download`);
+          detach(debugLog(`CustomPlayButton: -> download`));
           setState("download");
         }
       } catch (e) {
@@ -170,7 +171,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
     }
 
-    void init();
+    detach(init());
     return () => { cancelled = true; };
   }, [appId]);
 
@@ -346,7 +347,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 15000)),
       ]);
 
-      void debugLog(`CustomPlayButton: preLaunchSync result: synced=${result.synced} conflicts=${result.conflicts?.length ?? 0} success=${result.success}`);
+      detach(debugLog(`CustomPlayButton: preLaunchSync result: synced=${result.synced} conflicts=${result.conflicts?.length ?? 0} success=${result.success}`));
 
       if (result.conflicts && result.conflicts.length > 0) {
         const conflictResult = await handleConflicts(result.conflicts);
@@ -359,7 +360,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
 
       if (!result.success && result.errors && result.errors.length > 0) {
-        void debugLog(`CustomPlayButton: pre-launch sync errors: ${result.errors.join(", ")}`);
+        detach(debugLog(`CustomPlayButton: pre-launch sync errors: ${result.errors.join(", ")}`));
         const proceed = await confirmFallbackLaunch();
         return proceed ? "proceed" : "abort";
       }
@@ -368,7 +369,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
       return "proceed";
     } catch (e) {
-      void debugLog(`CustomPlayButton: pre-launch sync failed: ${e}`);
+      detach(debugLog(`CustomPlayButton: pre-launch sync failed: ${e}`));
       const proceed = await confirmFallbackLaunch();
       return proceed ? "proceed" : "abort";
     }
@@ -386,7 +387,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     if (state === "syncing" || state === "launching") return; // debounce
     const overview = appStore.GetAppOverviewByAppID(appId);
     const gameId = overview?.GetGameID?.() ?? String(appId);
-    void debugLog(`CustomPlayButton: handlePlay appId=${appId} gameId=${gameId}`);
+    detach(debugLog(`CustomPlayButton: handlePlay appId=${appId} gameId=${gameId}`));
 
     // Pre-launch save sync
     if (romId) {
@@ -444,7 +445,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
       setState("play");
     } catch (e) {
-      void debugLog(`CustomPlayButton: resolve conflict failed: ${e}`);
+      detach(debugLog(`CustomPlayButton: resolve conflict failed: ${e}`));
       toaster.toast({ title: "RomM Sync", body: "Couldn't reach server to resolve conflict" });
       setState("conflict");
     }
@@ -467,7 +468,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
   const handleUninstall = async () => {
     if (!romId) return;
-    void debugLog(`CustomPlayButton: uninstalling romId=${romId}`);
+    detach(debugLog(`CustomPlayButton: uninstalling romId=${romId}`));
     try {
       const result = await removeRom(romId);
       if (result.success) {
@@ -488,7 +489,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const showDropdownMenu = (e: MouseEvent) => {
     showContextMenu(
       <Menu label="RomM Actions">
-        <MenuItem key="uninstall" tone="destructive" onClick={() => { void handleUninstall(); }}>
+        <MenuItem key="uninstall" tone="destructive" onClick={() => { detach(handleUninstall()); }}>
           Uninstall
         </MenuItem>
       </Menu>,
@@ -498,10 +499,10 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
   // Don't render for non-RomM games
   if (state === "not_romm" || state === "loading") {
-    void debugLog(`CustomPlayButton: returning null (state=${state})`);
+    detach(debugLog(`CustomPlayButton: returning null (state=${state})`));
     return null;
   }
-  void debugLog(`CustomPlayButton: rendering state=${state}`);
+  detach(debugLog(`CustomPlayButton: rendering state=${state}`));
 
   // Dropdown arrow button style
   const dropdownArrowStyle: React.CSSProperties = {
@@ -612,7 +613,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
             background: baseBg,
             "--romm-pulse-color": pulseColor,
           } as React.CSSProperties}
-          onClick={() => { void handleDownload(); }}
+          onClick={() => { detach(handleDownload()); }}
           disabled={actionPending || isOffline}
         >
           {/* Progress fill bar */}
@@ -723,7 +724,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
             borderRadius: "2px",
             background: "linear-gradient(to right, #d4a72c, #b8941f)",
           }}
-          onClick={() => { void handleResolveConflict(); }}
+          onClick={() => { detach(handleResolveConflict()); }}
         >
           Resolve Conflict
         </DialogButton>
@@ -753,7 +754,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           backgroundPosition: "25%",
           backgroundSize: "330% 100%",
         }}
-        onClick={() => { void handlePlay(); }}
+        onClick={() => { detach(handlePlay()); }}
         onFocus={scrollToTop}
       >
         Play

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -135,10 +135,10 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     async function init() {
       try {
         const cached = await getCachedGameDetail(appId);
-        debugLog(`CustomPlayButton init: appId=${appId} cached.found=${cached.found} cancelled=${cancelled}`);
+        void debugLog(`CustomPlayButton init: appId=${appId} cached.found=${cached.found} cancelled=${cancelled}`);
         if (cancelled) return;
         if (!cached.found) {
-          debugLog(`CustomPlayButton: -> not_romm (not in cache)`);
+          void debugLog(`CustomPlayButton: -> not_romm (not in cache)`);
           setState("not_romm");
           return;
         }
@@ -152,14 +152,14 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           // Check for conflicts from cached save status
           const hasConflict = hasAnySaveConflict(cached.save_status);
           if (hasConflict) {
-            debugLog(`CustomPlayButton: -> conflict (from cache)`);
+            void debugLog(`CustomPlayButton: -> conflict (from cache)`);
             setState("conflict");
           } else {
-            debugLog(`CustomPlayButton: -> play`);
+            void debugLog(`CustomPlayButton: -> play`);
             setState("play");
           }
         } else {
-          debugLog(`CustomPlayButton: -> download`);
+          void debugLog(`CustomPlayButton: -> download`);
           setState("download");
         }
       } catch (e) {
@@ -170,7 +170,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
     }
 
-    init();
+    void init();
     return () => { cancelled = true; };
   }, [appId]);
 
@@ -346,7 +346,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 15000)),
       ]);
 
-      debugLog(`CustomPlayButton: preLaunchSync result: synced=${result.synced} conflicts=${result.conflicts?.length ?? 0} success=${result.success}`);
+      void debugLog(`CustomPlayButton: preLaunchSync result: synced=${result.synced} conflicts=${result.conflicts?.length ?? 0} success=${result.success}`);
 
       if (result.conflicts && result.conflicts.length > 0) {
         const conflictResult = await handleConflicts(result.conflicts);
@@ -359,7 +359,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
 
       if (!result.success && result.errors && result.errors.length > 0) {
-        debugLog(`CustomPlayButton: pre-launch sync errors: ${result.errors.join(", ")}`);
+        void debugLog(`CustomPlayButton: pre-launch sync errors: ${result.errors.join(", ")}`);
         const proceed = await confirmFallbackLaunch();
         return proceed ? "proceed" : "abort";
       }
@@ -368,7 +368,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       }
       return "proceed";
     } catch (e) {
-      debugLog(`CustomPlayButton: pre-launch sync failed: ${e}`);
+      void debugLog(`CustomPlayButton: pre-launch sync failed: ${e}`);
       const proceed = await confirmFallbackLaunch();
       return proceed ? "proceed" : "abort";
     }
@@ -386,7 +386,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     if (state === "syncing" || state === "launching") return; // debounce
     const overview = appStore.GetAppOverviewByAppID(appId);
     const gameId = overview?.GetGameID?.() ?? String(appId);
-    debugLog(`CustomPlayButton: handlePlay appId=${appId} gameId=${gameId}`);
+    void debugLog(`CustomPlayButton: handlePlay appId=${appId} gameId=${gameId}`);
 
     // Pre-launch save sync
     if (romId) {
@@ -444,7 +444,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
       setState("play");
     } catch (e) {
-      debugLog(`CustomPlayButton: resolve conflict failed: ${e}`);
+      void debugLog(`CustomPlayButton: resolve conflict failed: ${e}`);
       toaster.toast({ title: "RomM Sync", body: "Couldn't reach server to resolve conflict" });
       setState("conflict");
     }
@@ -467,7 +467,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
   const handleUninstall = async () => {
     if (!romId) return;
-    debugLog(`CustomPlayButton: uninstalling romId=${romId}`);
+    void debugLog(`CustomPlayButton: uninstalling romId=${romId}`);
     try {
       const result = await removeRom(romId);
       if (result.success) {
@@ -498,10 +498,10 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
   // Don't render for non-RomM games
   if (state === "not_romm" || state === "loading") {
-    debugLog(`CustomPlayButton: returning null (state=${state})`);
+    void debugLog(`CustomPlayButton: returning null (state=${state})`);
     return null;
   }
-  debugLog(`CustomPlayButton: rendering state=${state}`);
+  void debugLog(`CustomPlayButton: rendering state=${state}`);
 
   // Dropdown arrow button style
   const dropdownArrowStyle: React.CSSProperties = {

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -180,6 +180,20 @@ describe("DangerZone", () => {
       // the assert below; loading state is still true while the promise stalls.
       expect(queryAllByTestId("spinner").length).toBeGreaterThan(0);
     });
+
+    it("logs the failure when getWhitelistSettings rejects on mount", async () => {
+      vi.mocked(backend.getWhitelistSettings).mockRejectedValue(
+        new Error("offline"),
+      );
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      // The .catch((e) => logError(...)) on the mount-time load must fire.
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load whitelist settings"),
+      );
+      logSpy.mockRestore();
+    });
   });
 
   describe("loadNonSteamApps", () => {
@@ -987,6 +1001,30 @@ describe("DangerZone", () => {
         [],
         expect.arrayContaining(["Alpha"]),
       );
+    });
+
+    it("logs the failure when updateWhitelistSettings rejects on toggle", async () => {
+      setupApps();
+      vi.mocked(backend.updateWhitelistSettings).mockRejectedValue(
+        new Error("disk full"),
+      );
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      const { getByText, getAllByTestId } = render(
+        <DangerZone onBack={vi.fn()} />,
+      );
+      await flushAsync();
+      fireEvent.click(getByText("Configure Whitelist (1 protected)"));
+      const alphaInput = (
+        getAllByTestId("toggle-input") as HTMLInputElement[]
+      ).find((i) => !i.checked);
+      if (!alphaInput) throw new Error("unchecked toggle not found");
+      fireEvent.click(alphaInput);
+      // The .catch((e) => logError(...)) must surface the rejection.
+      await flushAsync();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to update whitelist settings"),
+      );
+      logSpy.mockRestore();
     });
 
     it("toggle OFF on custom-listed app removes it from customNames", async () => {

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -31,6 +31,7 @@ import { scrollToTop } from "../utils/scrollHelpers";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
 import type { RegistryPlatform } from "../types";
+import { detach } from "../utils/detach";
 
 const DEFAULT_WHITELIST_PATTERNS: string[] = [
   "retrodeck", "moonlight", "chiaki", "chrome", "chromium",
@@ -138,7 +139,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         strOKButtonText: "Delete Save Files",
         strCancelButtonText: "Cancel",
         onOK: () => {
-          void (async () => {
+          detach((async () => {
             setActionStatus(`Deleting ${p.name} saves...`);
             try {
               const result = await deletePlatformSaves(p.slug);
@@ -147,7 +148,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             } catch {
               setActionStatus("Failed to delete saves");
             }
-          })();
+          })());
         },
       }),
     );
@@ -228,9 +229,9 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             showModal(
               <PlatformActionModal
                 platform={p}
-                onRemoveShortcuts={() => { void handleRemoveShortcuts(p); }}
+                onRemoveShortcuts={() => { detach(handleRemoveShortcuts(p)); }}
                 onDeleteSaves={() => handleDeleteSaves(p)}
-                onDeleteBios={() => { void handleDeleteBios(p); }}
+                onDeleteBios={() => { detach(handleDeleteBios(p)); }}
               />
             );
           }}
@@ -245,7 +246,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     <>
       <PanelSection title="Remove Shortcuts">
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => { void handleRemoveAllRomm(); }}>
+          <ButtonItem layout="below" onClick={() => { detach(handleRemoveAllRomm()); }}>
             {confirmRemoveAllRomm
               ? <span style={{ color: "#ff8800" }}>Confirm: remove all RomM shortcuts?</span>
               : "Remove All RomM Shortcuts"}
@@ -269,7 +270,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
 
       <PanelSection title="Installed ROMs">
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => { void handleUninstallAll(); }}>
+          <ButtonItem layout="below" onClick={() => { detach(handleUninstallAll()); }}>
             {confirmUninstall
               ? <span style={{ color: "#ff8800" }}>Confirm: delete all ROM files?</span>
               : "Uninstall All Installed ROMs"}
@@ -477,7 +478,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
       ) : (
         <>
           <PanelSectionRow>
-            <ButtonItem layout="below" onClick={() => { void handleRemoveAll(); }}>
+            <ButtonItem layout="below" onClick={() => { detach(handleRemoveAll()); }}>
               {removeButtonLabel()}
             </ButtonItem>
           </PanelSectionRow>

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -450,7 +450,7 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
     setConfirmRemoveAll(false);
     setConfirmRetrodeck(false);
     loadNonSteamApps();
-    refreshPlatforms();
+    refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
   };
 
   const removeButtonLabel = () => {
@@ -577,19 +577,19 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial async data loads on mount are the standard React pattern; the rule is overzealous here
-    refreshPlatforms();
+    refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
     loadNonSteamApps();
     getWhitelistSettings().then((s) => {
       setDisabledDefaults(s.disabled_defaults);
       setCustomNames(s.custom_names);
       setSettingsLoaded(true);
-    });
+    }).catch((e) => logError(`Failed to load whitelist settings: ${e}`));
   }, []);
 
   const persistWhitelist = (newDisabled: string[], newCustom: string[]) => {
     setDisabledDefaults(newDisabled);
     setCustomNames(newCustom);
-    updateWhitelistSettings(newDisabled, newCustom);
+    updateWhitelistSettings(newDisabled, newCustom).catch((e) => logError(`Failed to update whitelist settings: ${e}`));
   };
 
   return (

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -10,6 +10,7 @@ import { getDownloadQueue, cancelDownload } from "../api/backend";
 import { getDownloadState, setDownloads } from "../utils/downloadStore";
 import { formatBytes } from "../utils/formatters";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { detach } from "../utils/detach";
 import type { DownloadItem } from "../types";
 
 interface DownloadQueueProps {
@@ -150,7 +151,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
               <PanelSectionRow key={`cancel-${item.rom_id}`}>
                 <ButtonItem
                   layout="below"
-                  onClick={() => { void handleCancel(item.rom_id); }}
+                  onClick={() => { detach(handleCancel(item.rom_id)); }}
                 >
                   Cancel {item.rom_name}
                 </ButtonItem>

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -206,7 +206,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   useEffect(() => {
     if (activeTab === "bios" && !biosLoaded.current) {
       biosLoaded.current = true;
-      refreshBios();
+      void refreshBios();
     }
   }, [activeTab]);
 
@@ -512,16 +512,16 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 void (async () => {
                   const defaultCore = platform.available_cores?.find((c) => c.is_default);
                   const label = option.data === defaultCore?.label ? "" : option.data;
-                  debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`);
+                  void debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`);
                   try {
                     const result = await setSystemCore(platform.platform_slug, label);
-                    debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`);
+                    void debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`);
                     if (result.success) {
                       await refreshBios();
                       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: platform.platform_slug } }));
                     }
                   } catch (e) {
-                    debugLog(`setSystemCore: error: ${e}`);
+                    void debugLog(`setSystemCore: error: ${e}`);
                   }
                 })();
               }}

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -27,6 +27,7 @@ import {
 } from "../api/backend";
 import type { PlatformSyncSetting, CollectionSyncSetting, CollectionKind, CollectionScope, FirmwarePlatformExt } from "../types";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { detach } from "../utils/detach";
 
 type CollectionSubTab = "my" | "smart" | "franchise";
 
@@ -206,7 +207,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   useEffect(() => {
     if (activeTab === "bios" && !biosLoaded.current) {
       biosLoaded.current = true;
-      void refreshBios();
+      detach(refreshBios());
     }
   }, [activeTab]);
 
@@ -317,12 +318,12 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     return (
       <>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => { void handleSetAll(true); }}>
+          <ButtonItem layout="below" onClick={() => { detach(handleSetAll(true)); }}>
             Enable All
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => { void handleSetAll(false); }}>
+          <ButtonItem layout="below" onClick={() => { detach(handleSetAll(false)); }}>
             Disable All
           </ButtonItem>
         </PanelSectionRow>
@@ -332,7 +333,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               label={platform.name}
               description={`${platform.rom_count} ROMs`}
               checked={platform.sync_enabled}
-              onChange={(value: boolean) => { void handleToggle(platform.id, value); }}
+              onChange={(value: boolean) => { detach(handleToggle(platform.id, value)); }}
             />
           </PanelSectionRow>
         ))}
@@ -385,9 +386,9 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               checked={platformGroups}
               onChange={(value: boolean) => {
                 setPlatformGroups(value);
-                void (async () => {
+                detach((async () => {
                   try { await saveCollectionPlatformGroups(value); } catch { setPlatformGroups(!value); }
-                })();
+                })());
               }}
             />
           </PanelSectionRow>
@@ -397,7 +398,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                 label="Sync RomM favorites"
                 description={favoritesDescription(favoritesCollection.rom_count)}
                 checked={favoritesCollection.sync_enabled}
-                onChange={(value: boolean) => { void handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value); }}
+                onChange={(value: boolean) => { detach(handleCollectionToggle(favoritesCollection.id, favoritesCollection.kind, value)); }}
               />
             </PanelSectionRow>
           )}
@@ -430,13 +431,13 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
             >
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => { void handleSetAllCollections(true, activeSubTab); }}
+                onClick={() => { detach(handleSetAllCollections(true, activeSubTab)); }}
               >
                 Enable All
               </DialogButton>
               <DialogButton
                 style={{ flex: 1, minWidth: 0 }}
-                onClick={() => { void handleSetAllCollections(false, activeSubTab); }}
+                onClick={() => { detach(handleSetAllCollections(false, activeSubTab)); }}
               >
                 Disable All
               </DialogButton>
@@ -453,7 +454,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
                   label={collection.name}
                   description={`${collection.rom_count} ROMs`}
                   checked={collection.sync_enabled}
-                  onChange={(value: boolean) => { void handleCollectionToggle(collection.id, collection.kind, value); }}
+                  onChange={(value: boolean) => { detach(handleCollectionToggle(collection.id, collection.kind, value)); }}
                 />
               </PanelSectionRow>
             ))
@@ -509,21 +510,21 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               ]}
               selectedOption={platform.active_core_label || platform.available_cores.find((c) => c.is_default)?.label || ""}
               onChange={(option: { data: string }) => {
-                void (async () => {
+                detach((async () => {
                   const defaultCore = platform.available_cores?.find((c) => c.is_default);
                   const label = option.data === defaultCore?.label ? "" : option.data;
-                  void debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`);
+                  detach(debugLog(`setSystemCore: slug=${platform.platform_slug} label=${label} (selected=${option.data})`));
                   try {
                     const result = await setSystemCore(platform.platform_slug, label);
-                    void debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`);
+                    detach(debugLog(`setSystemCore: result success=${result.success} active_core_label=${result.bios_status?.active_core_label}`));
                     if (result.success) {
                       await refreshBios();
                       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: platform.platform_slug } }));
                     }
                   } catch (e) {
-                    void debugLog(`setSystemCore: error: ${e}`);
+                    detach(debugLog(`setSystemCore: error: ${e}`));
                   }
-                })();
+                })());
               }}
             />
           </PanelSectionRow>
@@ -599,7 +600,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={() => { void handleDownloadRequired(platform.platform_slug); }}
+              onClick={() => { detach(handleDownloadRequired(platform.platform_slug)); }}
               disabled={isDownloading}
             >
               {isDownloading ? "Downloading..." : "Download Required"}
@@ -610,7 +611,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={() => { void handleDownloadAll(platform.platform_slug); }}
+              onClick={() => { detach(handleDownloadAll(platform.platform_slug)); }}
               disabled={isDownloading}
             >
               {isDownloading ? "Downloading..." : "Download All"}

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -558,6 +558,39 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
       logSpy.mockRestore();
     });
+
+    it("logs the failure when getSyncStats rejects on mount", async () => {
+      vi.mocked(backend.getSyncStats).mockRejectedValue(new Error("boom"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load sync stats"),
+      );
+      logSpy.mockRestore();
+    });
+
+    it("logs the failure when testConnection rejects on mount", async () => {
+      vi.mocked(backend.testConnection).mockRejectedValue(new Error("net"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to test connection"),
+      );
+      logSpy.mockRestore();
+    });
+
+    it("logs the failure when getSettings rejects on mount", async () => {
+      vi.mocked(backend.getSettings).mockRejectedValue(new Error("io"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load settings"),
+      );
+      logSpy.mockRestore();
+    });
   });
 
   // ===========================================================================

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -172,16 +172,16 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         setSaveSortMigrationStatus(save_sort);
       })
       .catch((e) => logError(`Failed to refresh migration state: ${e}`));
-    getSyncStats().then(setStats);
+    getSyncStats().then(setStats).catch((e) => logError(`Failed to load sync stats: ${e}`));
     testConnection().then((r) => {
       setConnected(r.success);
       setVersionError(r.error_code === "version_error" ? r.message : null);
-    });
+    }).catch((e) => logError(`Failed to test connection: ${e}`));
     getSettings().then((s) => {
       if (s.retroarch_input_check) {
         setRetroarchWarning(s.retroarch_input_check);
       }
-    });
+    }).catch((e) => logError(`Failed to load settings: ${e}`));
 
     // Backend is authoritative for in-flight sync state. Seed the module
     // store from get_sync_status() so a QAM close/reopen recovers the live
@@ -208,7 +208,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         setSyncing(false);
         setLoading(false);
         showTransientStatus(progress.message || "Sync finished");
-        getSyncStats().then(setStats);
+        getSyncStats().then(setStats).catch((e) => logError(`Failed to refresh sync stats: ${e}`));
       }
     });
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -39,6 +39,7 @@ import { setVersionError } from "../utils/connectionState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, DownloadItem, MigrationStatus } from "../types";
+import { detach } from "../utils/detach";
 
 type Page = "settings" | "library" | "data" | "downloads";
 
@@ -363,7 +364,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             <PanelSectionRow>
               <ButtonItem
                 layout="below"
-                onClick={() => { void handleApply(); }}
+                onClick={() => { detach(handleApply()); }}
                 // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
                 onFocus={scrollToTop}
               >
@@ -371,7 +372,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </ButtonItem>
             </PanelSectionRow>
             <PanelSectionRow>
-              <ButtonItem layout="below" onClick={() => { void handleDismiss(); }}>
+              <ButtonItem layout="below" onClick={() => { detach(handleDismiss()); }}>
                 Cancel
               </ButtonItem>
             </PanelSectionRow>
@@ -380,7 +381,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
-              onClick={() => { void handleDismiss(); }}
+              onClick={() => { detach(handleDismiss()); }}
               // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
               onFocus={scrollToTop}
             >
@@ -435,7 +436,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
-            onClick={() => { void handleCancel(); }}
+            onClick={() => { detach(handleCancel()); }}
             // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
             onFocus={scrollToTop}
           >
@@ -450,7 +451,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
-            onClick={() => { void handleSync(); }}
+            onClick={() => { detach(handleSync()); }}
             disabled={loading || connected === false}
             // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
             onFocus={scrollToTop}
@@ -472,7 +473,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               layout="below"
               description="Clear cached sync data to re-fetch all platforms"
               onClick={() => {
-                void (async () => {
+                detach((async () => {
                   try {
                     const result = await clearSyncCache();
                     setStatus(result.message);
@@ -482,7 +483,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                   if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
                   statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
                   getSyncStats().then(setStats).catch((e) => logError(`Failed to refresh sync stats: ${e}`));
-                })();
+                })());
               }}
               disabled={loading || connected === false}
             >
@@ -540,7 +541,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     strOKButtonText="Apply Fix"
                     strCancelButtonText="Cancel"
                     onOK={() => {
-                      void (async () => {
+                      detach((async () => {
                         try {
                           const result = await fixRetroarchInputDriver();
                           if (result.success) {
@@ -549,7 +550,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                         } catch {
                           // ignore
                         }
-                      })();
+                      })());
                     }}
                   />
                 )}

--- a/src/components/MigrationBlockedPage.test.tsx
+++ b/src/components/MigrationBlockedPage.test.tsx
@@ -476,8 +476,7 @@ describe("useMigrationStatus hook", () => {
     // `not.toThrow()` pattern passed vacuously under React 19's silent
     // no-op-on-unmounted-setState.
     const unsubSpy = vi.fn();
-    vi.spyOn(migrationStore, "onMigrationChange").mockImplementation((cb) => {
-      void cb;
+    vi.spyOn(migrationStore, "onMigrationChange").mockImplementation((_cb) => {
       return unsubSpy;
     });
 

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -49,7 +49,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
         showModal(
           <MigrationConflictModal
             conflictCount={result.conflict_count ?? 0}
-            onChoice={(s) => { runMigration(s); }}
+            onChoice={(s) => { void runMigration(s); }}
           />,
         );
         return;
@@ -68,7 +68,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
     setMigrating(false);
   };
 
-  const handleMigrate = () => { runMigration(null); };
+  const handleMigrate = () => { void runMigration(null); };
 
   const handleDismiss = () => {
     showModal(

--- a/src/components/MigrationBlockedPage.tsx
+++ b/src/components/MigrationBlockedPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "../utils/migrationStore";
 import { MigrationConflictModal } from "./MigrationConflictModal";
 import { scrollToTop } from "../utils/scrollHelpers";
+import { detach } from "../utils/detach";
 
 /**
  * Subscribe to migration state changes.
@@ -49,7 +50,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
         showModal(
           <MigrationConflictModal
             conflictCount={result.conflict_count ?? 0}
-            onChoice={(s) => { void runMigration(s); }}
+            onChoice={(s) => { detach(runMigration(s)); }}
           />,
         );
         return;
@@ -68,7 +69,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
     setMigrating(false);
   };
 
-  const handleMigrate = () => { void runMigration(null); };
+  const handleMigrate = () => { detach(runMigration(null)); };
 
   const handleDismiss = () => {
     showModal(
@@ -82,7 +83,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
         strOKButtonText="Dismiss"
         strCancelButtonText="Cancel"
         onOK={() => {
-          void (async () => {
+          detach((async () => {
             try {
               const result = await dismissRetrodeckMigration();
               if (result.success) {
@@ -95,7 +96,7 @@ export const MigrationBlockedPage: FC<MigrationBlockedPageProps> = ({ migration 
             } catch {
               setMigrateResult("Dismiss failed");
             }
-          })();
+          })());
         }}
       />,
     );

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -132,6 +132,7 @@ vi.mock("../utils/saveSortMigrationStore", () => ({
   }),
 }));
 import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
+import { detach } from "../utils/detach";
 
 // ----- @decky/ui — global stub from test-setup.ts covers Focusable +
 // DialogButton. Pass-through is enough for this panel.
@@ -917,7 +918,7 @@ describe("RomMGameInfoPanel", () => {
         // Already rendered via mountWithRomId — get container via re-render?
         // Use a fresh render that uses the new mock.
         const view = render(<RomMGameInfoPanel appId={testAppId} />);
-        void flushAsync().then(() => resolve({ container: view.container }));
+        detach(flushAsync().then(() => resolve({ container: view.container })));
       });
       await act(async () => {
         globalThis.dispatchEvent(

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -917,7 +917,7 @@ describe("RomMGameInfoPanel", () => {
         // Already rendered via mountWithRomId — get container via re-render?
         // Use a fresh render that uses the new mock.
         const view = render(<RomMGameInfoPanel appId={testAppId} />);
-        flushAsync().then(() => resolve({ container: view.container }));
+        void flushAsync().then(() => resolve({ container: view.container }));
       });
       await act(async () => {
         globalThis.dispatchEvent(

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -271,7 +271,7 @@ async function loadData(
     // Phase 2: Background fetch for data not available in cache
     await startBackgroundRefreshes(cached, romId, cancelled, setter);
   } catch (e) {
-    debugLog(`RomMGameInfoPanel: loadData error: ${e}`);
+    void debugLog(`RomMGameInfoPanel: loadData error: ${e}`);
     if (!cancelled()) setter((prev) => ({ ...prev, loading: false, error: true }));
   }
 }
@@ -327,7 +327,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   useEffect(() => {
     let cancelled = false;
 
-    loadData(appId, () => cancelled, romIdRef, setState);
+    void loadData(appId, () => cancelled, romIdRef, setState);
 
     // Listen for uninstall events to update state (uses ref to avoid stale closure)
     const onUninstall = (e: Event) => {
@@ -427,7 +427,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
             case "cover_refreshed": await handleCoverRefreshed(detail); break;
           }
         } catch (err) {
-          debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
+          void debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
         }
       })();
     };
@@ -473,7 +473,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
           achievementsLoading: false,
         }));
       } catch (e) {
-        debugLog(`Failed to load achievements: ${e}`);
+        void debugLog(`Failed to load achievements: ${e}`);
         if (!cancelled) {
           achievementsLoadedRef.current = false;
           setState((prev) => ({ ...prev, achievementsLoading: false }));
@@ -481,7 +481,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       }
     }
 
-    loadAchievements();
+    void loadAchievements();
     return () => { cancelled = true; };
   }, [state.activeTab, state.raId, state.romId]);
 
@@ -501,7 +501,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         if (cancelled) return;
         applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => { void debugLog(msg); });
       } catch (e) {
-        debugLog(`Failed to load save slots: ${e}`);
+        void debugLog(`Failed to load save slots: ${e}`);
         if (!cancelled) {
           slotsLoadedRef.current = false;
           setState((prev) => ({ ...prev, slotsLoading: false }));
@@ -509,7 +509,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       }
     }
 
-    loadSlots();
+    void loadSlots();
     return () => { cancelled = true; };
   }, [state.activeTab, state.saveSyncEnabled, state.romId]);
 

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -44,6 +44,7 @@ import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 import { applyLoadSlotsResult, applyRefreshSlotResult } from "../utils/slotState";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
 import { MigrationBlockedCard } from "./MigrationBlockedCard";
+import { detach } from "../utils/detach";
 
 interface RomMGameInfoPanelProps {
   appId: number;
@@ -271,7 +272,7 @@ async function loadData(
     // Phase 2: Background fetch for data not available in cache
     await startBackgroundRefreshes(cached, romId, cancelled, setter);
   } catch (e) {
-    void debugLog(`RomMGameInfoPanel: loadData error: ${e}`);
+    detach(debugLog(`RomMGameInfoPanel: loadData error: ${e}`));
     if (!cancelled()) setter((prev) => ({ ...prev, loading: false, error: true }));
   }
 }
@@ -327,7 +328,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   useEffect(() => {
     let cancelled = false;
 
-    void loadData(appId, () => cancelled, romIdRef, setState);
+    detach(loadData(appId, () => cancelled, romIdRef, setState));
 
     // Listen for uninstall events to update state (uses ref to avoid stale closure)
     const onUninstall = (e: Event) => {
@@ -414,7 +415,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     };
 
     const onDataChanged = (e: Event) => {
-      void (async () => {
+      detach((async () => {
         try {
           const detail = (e as CustomEvent).detail;
           if (!romIdRef.current) return;
@@ -427,9 +428,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
             case "cover_refreshed": await handleCoverRefreshed(detail); break;
           }
         } catch (err) {
-          void debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`);
+          detach(debugLog(`RomMGameInfoPanel: onDataChanged error: ${err}`));
         }
-      })();
+      })());
     };
     globalThis.addEventListener("romm_data_changed", onDataChanged);
 
@@ -473,7 +474,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
           achievementsLoading: false,
         }));
       } catch (e) {
-        void debugLog(`Failed to load achievements: ${e}`);
+        detach(debugLog(`Failed to load achievements: ${e}`));
         if (!cancelled) {
           achievementsLoadedRef.current = false;
           setState((prev) => ({ ...prev, achievementsLoading: false }));
@@ -481,7 +482,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       }
     }
 
-    void loadAchievements();
+    detach(loadAchievements());
     return () => { cancelled = true; };
   }, [state.activeTab, state.raId, state.romId]);
 
@@ -499,9 +500,9 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         if (!state.romId) return;
         const result = await getSaveSlots(state.romId);
         if (cancelled) return;
-        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => { void debugLog(msg); });
+        applyLoadSlotsResult<PanelState>(result, setState, slotsLoadedRef, (msg) => { detach(debugLog(msg)); });
       } catch (e) {
-        void debugLog(`Failed to load save slots: ${e}`);
+        detach(debugLog(`Failed to load save slots: ${e}`));
         if (!cancelled) {
           slotsLoadedRef.current = false;
           setState((prev) => ({ ...prev, slotsLoading: false }));
@@ -509,7 +510,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       }
     }
 
-    void loadSlots();
+    detach(loadSlots());
     return () => { cancelled = true; };
   }, [state.activeTab, state.saveSyncEnabled, state.romId]);
 

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -174,7 +174,7 @@ async function loadCached(
       refreshBiosInBackground(romId, cancelled, setter);
     }
   } catch (e) {
-    debugLog(`RomMPlaySection: loadCached error: ${e}`);
+    void debugLog(`RomMPlaySection: loadCached error: ${e}`);
   }
 }
 
@@ -218,7 +218,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   useEffect(() => {
     let cancelled = false;
 
-    loadCached(appId, () => cancelled, romIdRef, setInfo);
+    void loadCached(appId, () => cancelled, romIdRef, setInfo);
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/romIdRef/setInfo closure.
@@ -279,7 +279,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             case "save_sync": await handleSaveSyncChange(detail); break;
           }
         } catch (err) {
-          debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
+          void debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
         }
       })();
     };
@@ -309,7 +309,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
         setInfo((prev) => ({ ...prev, saveSyncStatus: ss, saveSyncLabel: sl, activeSlot: saveStatus && "active_slot" in saveStatus ? saveStatus.active_slot ?? null : prev.activeSlot }));
       } catch (e) {
-        debugLog(`RomMPlaySection: background save check error: ${e}`);
+        void debugLog(`RomMPlaySection: background save check error: ${e}`);
       }
     }
 
@@ -345,7 +345,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         }
       }
     };
-    check();
+    void check();
     return () => { cancelled = true; };
   }, [info.saveSyncEnabled]);
 
@@ -376,7 +376,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       // render the refreshed image.
       const coverResult = await refreshCoverArtwork(romId).catch(
         (e): { success: boolean; reason?: string; message: string; cover_path?: string } => {
-          debugLog(`refreshCoverArtwork rejected: ${e}`);
+          void debugLog(`refreshCoverArtwork rejected: ${e}`);
           return { success: false, reason: "exception", message: String(e) };
         },
       );
@@ -386,14 +386,14 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           detail: { type: "cover_refreshed", rom_id: romId },
         }));
       } else {
-        debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
+        void debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
       }
 
       // Step 2: resolve which SGDB game id to use. The backend either picks
       // one automatically (RomM/IGDB) or hands back manual candidates.
       const resolution = await getSgdbResolution(romId).catch(
         (e): null => {
-          debugLog(`getSgdbResolution rejected: ${e}`);
+          void debugLog(`getSgdbResolution rejected: ${e}`);
           return null;
         },
       );
@@ -568,16 +568,16 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const handleChangeGameCore = async (coreLabel: string) => {
     if (!info.platformSlug || !info.romFile) return;
     const romPath = `./${info.romFile}`;
-    debugLog(`handleChangeGameCore: slug=${info.platformSlug} romPath=${romPath} coreLabel=${coreLabel}`);
+    void debugLog(`handleChangeGameCore: slug=${info.platformSlug} romPath=${romPath} coreLabel=${coreLabel}`);
     try {
       const result = await setGameCore(info.platformSlug, romPath, coreLabel);
-      debugLog(`handleChangeGameCore: result=${JSON.stringify(result)}`);
+      void debugLog(`handleChangeGameCore: result=${JSON.stringify(result)}`);
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `Core set to ${coreLabel}` });
         // Use bios_status from the set_game_core response directly (avoids cache staleness).
         // For pre-computed level/label, re-fetch via getBiosStatus which ships them.
         const bios = result.bios_status;
-        debugLog(`handleChangeGameCore: bios active_core_label=${bios?.active_core_label}`);
+        void debugLog(`handleChangeGameCore: bios active_core_label=${bios?.active_core_label}`);
         if (bios && info.romId) {
           const newLabel = bios.active_core_label ?? null;
           const cores = bios.available_cores ?? info.availableCores;

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -95,6 +95,7 @@ interface InfoState {
 import { setRommConnectionState, setVersionError } from "../utils/connectionState";
 import { useVersionError } from "./VersionErrorCard";
 import { useMigrationStatus } from "./MigrationBlockedPage";
+import { detach } from "../utils/detach";
 
 /** Cache-first initial render. Resolves the cached game detail for this appId,
  *  pushes it into InfoState, and fires the background refresh tasks (active
@@ -174,7 +175,7 @@ async function loadCached(
       refreshBiosInBackground(romId, cancelled, setter);
     }
   } catch (e) {
-    void debugLog(`RomMPlaySection: loadCached error: ${e}`);
+    detach(debugLog(`RomMPlaySection: loadCached error: ${e}`));
   }
 }
 
@@ -218,7 +219,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   useEffect(() => {
     let cancelled = false;
 
-    void loadCached(appId, () => cancelled, romIdRef, setInfo);
+    detach(loadCached(appId, () => cancelled, romIdRef, setInfo));
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/romIdRef/setInfo closure.
@@ -270,7 +271,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     };
 
     const onDataChanged = (e: Event) => {
-      void (async () => {
+      detach((async () => {
         try {
           const detail = (e as CustomEvent).detail;
           switch (detail?.type) {
@@ -279,9 +280,9 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             case "save_sync": await handleSaveSyncChange(detail); break;
           }
         } catch (err) {
-          void debugLog(`RomMPlaySection: onDataChanged error: ${err}`);
+          detach(debugLog(`RomMPlaySection: onDataChanged error: ${err}`));
         }
-      })();
+      })());
     };
     globalThis.addEventListener("romm_data_changed", onDataChanged);
 
@@ -309,7 +310,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
         setInfo((prev) => ({ ...prev, saveSyncStatus: ss, saveSyncLabel: sl, activeSlot: saveStatus && "active_slot" in saveStatus ? saveStatus.active_slot ?? null : prev.activeSlot }));
       } catch (e) {
-        void debugLog(`RomMPlaySection: background save check error: ${e}`);
+        detach(debugLog(`RomMPlaySection: background save check error: ${e}`));
       }
     }
 
@@ -345,7 +346,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         }
       }
     };
-    void check();
+    detach(check());
     return () => { cancelled = true; };
   }, [info.saveSyncEnabled]);
 
@@ -376,7 +377,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       // render the refreshed image.
       const coverResult = await refreshCoverArtwork(romId).catch(
         (e): { success: boolean; reason?: string; message: string; cover_path?: string } => {
-          void debugLog(`refreshCoverArtwork rejected: ${e}`);
+          detach(debugLog(`refreshCoverArtwork rejected: ${e}`));
           return { success: false, reason: "exception", message: String(e) };
         },
       );
@@ -386,14 +387,14 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           detail: { type: "cover_refreshed", rom_id: romId },
         }));
       } else {
-        void debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`);
+        detach(debugLog(`refreshCoverArtwork failed: ${coverResult.reason} — ${coverResult.message}`));
       }
 
       // Step 2: resolve which SGDB game id to use. The backend either picks
       // one automatically (RomM/IGDB) or hands back manual candidates.
       const resolution = await getSgdbResolution(romId).catch(
         (e): null => {
-          void debugLog(`getSgdbResolution rejected: ${e}`);
+          detach(debugLog(`getSgdbResolution rejected: ${e}`));
           return null;
         },
       );
@@ -542,7 +543,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         strOKButtonText: "Delete",
         strCancelButtonText: "Cancel",
         onOK: () => {
-          void (async () => {
+          detach((async () => {
             setActionPending("deletesaves");
             try {
               const result = await deleteLocalSaves(romId);
@@ -559,7 +560,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             } finally {
               setActionPending(null);
             }
-          })();
+          })());
         },
       }),
     );
@@ -568,16 +569,16 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const handleChangeGameCore = async (coreLabel: string) => {
     if (!info.platformSlug || !info.romFile) return;
     const romPath = `./${info.romFile}`;
-    void debugLog(`handleChangeGameCore: slug=${info.platformSlug} romPath=${romPath} coreLabel=${coreLabel}`);
+    detach(debugLog(`handleChangeGameCore: slug=${info.platformSlug} romPath=${romPath} coreLabel=${coreLabel}`));
     try {
       const result = await setGameCore(info.platformSlug, romPath, coreLabel);
-      void debugLog(`handleChangeGameCore: result=${JSON.stringify(result)}`);
+      detach(debugLog(`handleChangeGameCore: result=${JSON.stringify(result)}`));
       if (result.success) {
         toaster.toast({ title: "RomM Sync", body: `Core set to ${coreLabel}` });
         // Use bios_status from the set_game_core response directly (avoids cache staleness).
         // For pre-computed level/label, re-fetch via getBiosStatus which ships them.
         const bios = result.bios_status;
-        void debugLog(`handleChangeGameCore: bios active_core_label=${bios?.active_core_label}`);
+        detach(debugLog(`handleChangeGameCore: bios active_core_label=${bios?.active_core_label}`));
         if (bios && info.romId) {
           const newLabel = bios.active_core_label ?? null;
           const cores = bios.available_cores ?? info.availableCores;
@@ -623,7 +624,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           // override, not the ES-DE default, which is confusing.
           return createElement(MenuItem, {
             key: `core-${c.core_so}`,
-            onClick: () => { void handleChangeGameCore(c.label); },
+            onClick: () => { detach(handleChangeGameCore(c.label)); },
           }, `${c.label}${c.is_default ? " (default)" : ""}${info.activeCoreLabel === c.label ? " \u2713" : ""}`);
         }),
       ),
@@ -634,13 +635,13 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const showRomMMenu = (e: Event) => {
     showContextMenu(
       createElement(Menu, { label: "RomM Actions" },
-        createElement(MenuItem, { key: "refresh-artwork", onClick: () => { void handleRefreshArtwork(); } }, "Refresh Artwork"),
-        createElement(MenuItem, { key: "refresh-metadata", onClick: () => { void handleRefreshMetadata(); } }, "Refresh Metadata"),
-        createElement(MenuItem, { key: "sync-saves", onClick: () => { void handleSyncSaves(); } }, "Sync Save Files"),
-        createElement(MenuItem, { key: "download-bios", onClick: () => { void handleDownloadBios(); } }, "Download BIOS"),
+        createElement(MenuItem, { key: "refresh-artwork", onClick: () => { detach(handleRefreshArtwork()); } }, "Refresh Artwork"),
+        createElement(MenuItem, { key: "refresh-metadata", onClick: () => { detach(handleRefreshMetadata()); } }, "Refresh Metadata"),
+        createElement(MenuItem, { key: "sync-saves", onClick: () => { detach(handleSyncSaves()); } }, "Sync Save Files"),
+        createElement(MenuItem, { key: "download-bios", onClick: () => { detach(handleDownloadBios()); } }, "Download BIOS"),
         createElement(MenuSeparator, { key: "sep" }),
         createElement(MenuItem, { key: "delete-saves", tone: "destructive", onClick: handleDeleteSaves }, "Delete Local Saves"),
-        createElement(MenuItem, { key: "uninstall", tone: "destructive", onClick: () => { void handleUninstall(); } }, "Uninstall"),
+        createElement(MenuItem, { key: "uninstall", tone: "destructive", onClick: () => { detach(handleUninstall()); } }, "Uninstall"),
       ),
       getEventTarget(e),
     );

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -151,10 +151,10 @@ export const SavesTab: FC<SavesTabProps> = ({
                     if (result.success && result.save_status) {
                       onSlotSwitched("", result.save_status);
                     } else {
-                      debugLog(`SavesTab: legacy switch failed: ${result.reason}`);
+                      void debugLog(`SavesTab: legacy switch failed: ${result.reason}`);
                     }
                   } catch (e) {
-                    debugLog(`SavesTab: legacy switch error: ${e}`);
+                    void debugLog(`SavesTab: legacy switch error: ${e}`);
                   }
                 })();
               },
@@ -167,7 +167,7 @@ export const SavesTab: FC<SavesTabProps> = ({
             if (result.success && result.save_status) {
               onSlotSwitched(name, result.save_status);
             } else {
-              debugLog(`SavesTab: new slot switch failed: ${result.reason}`);
+              void debugLog(`SavesTab: new slot switch failed: ${result.reason}`);
               let msg = "Failed to create slot";
               if (result.reason === "pending_uploads") {
                 msg = "Sync your saves first — local changes haven't been uploaded";
@@ -179,7 +179,7 @@ export const SavesTab: FC<SavesTabProps> = ({
               newSlotErrorTimerRef.current = setTimeout(() => setNewSlotError(null), 5000);
             }
           } catch (e) {
-            debugLog(`SavesTab: new slot switch error: ${e}`);
+            void debugLog(`SavesTab: new slot switch error: ${e}`);
             setNewSlotError("An error occurred while creating the slot");
             if (newSlotErrorTimerRef.current) clearTimeout(newSlotErrorTimerRef.current);
             newSlotErrorTimerRef.current = setTimeout(() => setNewSlotError(null), 5000);

--- a/src/components/SavesTab.tsx
+++ b/src/components/SavesTab.tsx
@@ -20,6 +20,7 @@ import { MUTED_COLOR } from "./saves/helpers";
 import { NewSlotModal } from "./saves/NewSlotModal";
 import { SlotPanel } from "./saves/SlotPanel";
 import { renderSaveFileRow } from "./saves/SaveFileRow";
+import { detach } from "../utils/detach";
 
 interface SavesTabProps {
   romId: number;
@@ -138,25 +139,25 @@ export const SavesTab: FC<SavesTabProps> = ({
     showModal(
       createElement(NewSlotModal, {
         onSubmit: (name: string) => {
-          void (async () => {
+          detach((async () => {
           if (!name) {
             // Empty = legacy mode — show warning
             showModal(createElement(ConfirmModal, {
               strTitle: "Use Legacy Mode?",
               strDescription: "Legacy mode (no slot) limits saves to one version per game. Are you sure?",
               onOK: () => {
-                void (async () => {
+                detach((async () => {
                   try {
                     const result = await switchSlot(romId, "");
                     if (result.success && result.save_status) {
                       onSlotSwitched("", result.save_status);
                     } else {
-                      void debugLog(`SavesTab: legacy switch failed: ${result.reason}`);
+                      detach(debugLog(`SavesTab: legacy switch failed: ${result.reason}`));
                     }
                   } catch (e) {
-                    void debugLog(`SavesTab: legacy switch error: ${e}`);
+                    detach(debugLog(`SavesTab: legacy switch error: ${e}`));
                   }
-                })();
+                })());
               },
             }));
             return;
@@ -167,7 +168,7 @@ export const SavesTab: FC<SavesTabProps> = ({
             if (result.success && result.save_status) {
               onSlotSwitched(name, result.save_status);
             } else {
-              void debugLog(`SavesTab: new slot switch failed: ${result.reason}`);
+              detach(debugLog(`SavesTab: new slot switch failed: ${result.reason}`));
               let msg = "Failed to create slot";
               if (result.reason === "pending_uploads") {
                 msg = "Sync your saves first — local changes haven't been uploaded";
@@ -179,12 +180,12 @@ export const SavesTab: FC<SavesTabProps> = ({
               newSlotErrorTimerRef.current = setTimeout(() => setNewSlotError(null), 5000);
             }
           } catch (e) {
-            void debugLog(`SavesTab: new slot switch error: ${e}`);
+            detach(debugLog(`SavesTab: new slot switch error: ${e}`));
             setNewSlotError("An error occurred while creating the slot");
             if (newSlotErrorTimerRef.current) clearTimeout(newSlotErrorTimerRef.current);
             newSlotErrorTimerRef.current = setTimeout(() => setNewSlotError(null), 5000);
           }
-          })();
+          })());
         },
       }),
     );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -39,6 +39,7 @@ import { SaveSyncSection } from "./settings/SaveSyncSection";
 import { RegisteredDevicesSection } from "./settings/RegisteredDevicesSection";
 import { ControllerSection } from "./settings/ControllerSection";
 import { AdvancedSection } from "./settings/AdvancedSection";
+import { detach } from "../utils/detach";
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -234,7 +235,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         }
         strOKButtonText="I am sure"
         strCancelButtonText="Cancel"
-        onOK={() => { void handleSaveSyncSettingChange({ save_sync_enabled: true }); }}
+        onOK={() => { detach(handleSaveSyncSettingChange({ save_sync_enabled: true })); }}
         onCancel={() => {
           setSaveSyncToggleKey((k) => k + 1);
         }}
@@ -243,7 +244,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   };
 
   const handleDisableSaveSync = () => {
-    void handleSaveSyncSettingChange({ save_sync_enabled: false });
+    detach(handleSaveSyncSettingChange({ save_sync_enabled: false }));
   };
 
   const handleToggleSaveSync = (value: boolean) => {
@@ -262,7 +263,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         strCancelButtonText="Cancel"
         onOK={() => {
           setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: null } : prev);
-          void handleSaveSyncSettingChange({ default_slot: null });
+          detach(handleSaveSyncSettingChange({ default_slot: null }));
         }}
       />,
     );
@@ -271,15 +272,15 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // --- Connection handlers wired into ConnectionSection ---
   const handleUrlSubmit = (value: string) => {
     setUrl(value);
-    void autoSaveSettings("url", value);
+    detach(autoSaveSettings("url", value));
   };
   const handleUsernameSubmit = (value: string) => {
     setUsername(value);
-    void autoSaveSettings("username", value);
+    detach(autoSaveSettings("username", value));
   };
   const handlePasswordSubmit = (value: string) => {
     setPassword(value);
-    void autoSaveSettings("password", value);
+    detach(autoSaveSettings("password", value));
   };
   const handleAllowInsecureSslChange = (val: boolean) => {
     setAllowInsecureSsl(val);
@@ -317,20 +318,20 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     const trimmed = value.trim();
     if (trimmed) {
       setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: trimmed } : prev);
-      void handleSaveSyncSettingChange({ default_slot: trimmed });
+      detach(handleSaveSyncSettingChange({ default_slot: trimmed }));
     } else {
       confirmClearDefaultSlot();
     }
   };
   const handleResetDefaultSlot = () => {
     setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: "default" } : prev);
-    void handleSaveSyncSettingChange({ default_slot: "default" });
+    detach(handleSaveSyncSettingChange({ default_slot: "default" }));
   };
 
   // --- Controller handlers ---
   const handleSteamInputModeChange = (mode: string) => {
     setSteamInputMode(mode);
-    void saveSteamInputSetting(mode);
+    detach(saveSteamInputSetting(mode));
     setSteamInputStatus("");
   };
   const handleApplySteamInput = async () => {
@@ -358,7 +359,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // --- Advanced handlers ---
   const handleLogLevelChange = (level: string) => {
     setLogLevel(level);
-    void saveLogLevel(level);
+    detach(saveLogLevel(level));
   };
 
   // --- Save sort migration handlers ---
@@ -406,8 +407,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
           migration={saveSortMigration}
           migrating={saveSortMigrating}
           result={saveSortResult}
-          onMigrate={() => { void handleMigrateSaveSort(); }}
-          onDismiss={() => { void handleDismissSaveSort(); }}
+          onMigrate={() => { detach(handleMigrateSaveSort()); }}
+          onDismiss={() => { detach(handleDismissSaveSort()); }}
         />
       )}
       <ConnectionSection
@@ -421,14 +422,14 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onUsernameSubmit={handleUsernameSubmit}
         onPasswordSubmit={handlePasswordSubmit}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
-        onTestConnection={() => { void handleTest(); }}
+        onTestConnection={() => { detach(handleTest()); }}
       />
       <SteamGridDBSection
         sgdbApiKey={sgdbApiKey}
         sgdbStatus={sgdbStatus}
         sgdbVerifying={sgdbVerifying}
-        onSubmitKey={(value: string) => { void handleSgdbKeySubmit(value); }}
-        onVerifyKey={() => { void handleSgdbVerify(); }}
+        onSubmitKey={(value: string) => { detach(handleSgdbKeySubmit(value)); }}
+        onVerifyKey={() => { detach(handleSgdbVerify()); }}
       />
       <SaveSyncSection
         saveSyncSettings={saveSyncSettings}
@@ -437,10 +438,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         syncing={syncing}
         syncStatus={syncStatus}
         onToggleSaveSync={handleToggleSaveSync}
-        onSettingChange={(partial) => { void handleSaveSyncSettingChange(partial); }}
+        onSettingChange={(partial) => { detach(handleSaveSyncSettingChange(partial)); }}
         onDefaultSlotSubmit={handleDefaultSlotSubmit}
         onResetDefaultSlot={handleResetDefaultSlot}
-        onSyncAll={() => { void handleSyncAll(); }}
+        onSyncAll={() => { detach(handleSyncAll()); }}
       />
       {saveSyncEnabled && (devicesLoading || registeredDevices !== null) && (
         <RegisteredDevicesSection
@@ -456,8 +457,8 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         retroarchFixStatus={retroarchFixStatus}
         loading={loading}
         onModeChange={handleSteamInputModeChange}
-        onApplyMode={() => { void handleApplySteamInput(); }}
-        onFixInputDriver={() => { void handleFixInputDriver(); }}
+        onApplyMode={() => { detach(handleApplySteamInput()); }}
+        onFixInputDriver={() => { detach(handleFixInputDriver()); }}
       />
       <AdvancedSection
         logLevel={logLevel}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -243,7 +243,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   };
 
   const handleDisableSaveSync = () => {
-    handleSaveSyncSettingChange({ save_sync_enabled: false });
+    void handleSaveSyncSettingChange({ save_sync_enabled: false });
   };
 
   const handleToggleSaveSync = (value: boolean) => {
@@ -262,7 +262,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         strCancelButtonText="Cancel"
         onOK={() => {
           setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: null } : prev);
-          handleSaveSyncSettingChange({ default_slot: null });
+          void handleSaveSyncSettingChange({ default_slot: null });
         }}
       />,
     );
@@ -271,15 +271,15 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // --- Connection handlers wired into ConnectionSection ---
   const handleUrlSubmit = (value: string) => {
     setUrl(value);
-    autoSaveSettings("url", value);
+    void autoSaveSettings("url", value);
   };
   const handleUsernameSubmit = (value: string) => {
     setUsername(value);
-    autoSaveSettings("username", value);
+    void autoSaveSettings("username", value);
   };
   const handlePasswordSubmit = (value: string) => {
     setPassword(value);
-    autoSaveSettings("password", value);
+    void autoSaveSettings("password", value);
   };
   const handleAllowInsecureSslChange = (val: boolean) => {
     setAllowInsecureSsl(val);
@@ -317,20 +317,20 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     const trimmed = value.trim();
     if (trimmed) {
       setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: trimmed } : prev);
-      handleSaveSyncSettingChange({ default_slot: trimmed });
+      void handleSaveSyncSettingChange({ default_slot: trimmed });
     } else {
       confirmClearDefaultSlot();
     }
   };
   const handleResetDefaultSlot = () => {
     setSaveSyncSettings((prev) => prev ? { ...prev, default_slot: "default" } : prev);
-    handleSaveSyncSettingChange({ default_slot: "default" });
+    void handleSaveSyncSettingChange({ default_slot: "default" });
   };
 
   // --- Controller handlers ---
   const handleSteamInputModeChange = (mode: string) => {
     setSteamInputMode(mode);
-    saveSteamInputSetting(mode);
+    void saveSteamInputSetting(mode);
     setSteamInputStatus("");
   };
   const handleApplySteamInput = async () => {
@@ -358,7 +358,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // --- Advanced handlers ---
   const handleLogLevelChange = (level: string) => {
     setLogLevel(level);
-    saveLogLevel(level);
+    void saveLogLevel(level);
   };
 
   // --- Save sort migration handlers ---

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -127,7 +127,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
     try {
       const res = await searchSgdbGames(term).catch(
         (e): { success: boolean; games: SgdbCandidate[] } => {
-          debugLog(`SgdbGamePickerModal: searchSgdbGames rejected: ${e}`);
+          void debugLog(`SgdbGamePickerModal: searchSgdbGames rejected: ${e}`);
           return { success: false, games: [] };
         },
       );
@@ -151,7 +151,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
     try {
       const result = await applySgdbGameId(romId, selectedId).catch(
         (e): { success: boolean } => {
-          debugLog(`SgdbGamePickerModal: applySgdbGameId rejected: ${e}`);
+          void debugLog(`SgdbGamePickerModal: applySgdbGameId rejected: ${e}`);
           return { success: false };
         },
       );
@@ -160,7 +160,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
         return;
       }
       const applied = await applyArtwork(romId, appId).catch((e): number => {
-        debugLog(`SgdbGamePickerModal: applyArtwork rejected: ${e}`);
+        void debugLog(`SgdbGamePickerModal: applyArtwork rejected: ${e}`);
         return 0;
       });
       if (applied === -1) {

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -37,6 +37,7 @@ import {
 } from "../api/backend";
 import { applyArtwork } from "../utils/artwork";
 import { scrollToTop, scrollFocusedToCenter } from "../utils/scrollHelpers";
+import { detach } from "../utils/detach";
 
 export interface SgdbGamePickerModalProps {
   romId: number;
@@ -127,7 +128,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
     try {
       const res = await searchSgdbGames(term).catch(
         (e): { success: boolean; games: SgdbCandidate[] } => {
-          void debugLog(`SgdbGamePickerModal: searchSgdbGames rejected: ${e}`);
+          detach(debugLog(`SgdbGamePickerModal: searchSgdbGames rejected: ${e}`));
           return { success: false, games: [] };
         },
       );
@@ -151,7 +152,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
     try {
       const result = await applySgdbGameId(romId, selectedId).catch(
         (e): { success: boolean } => {
-          void debugLog(`SgdbGamePickerModal: applySgdbGameId rejected: ${e}`);
+          detach(debugLog(`SgdbGamePickerModal: applySgdbGameId rejected: ${e}`));
           return { success: false };
         },
       );
@@ -160,7 +161,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
         return;
       }
       const applied = await applyArtwork(romId, appId).catch((e): number => {
-        void debugLog(`SgdbGamePickerModal: applyArtwork rejected: ${e}`);
+        detach(debugLog(`SgdbGamePickerModal: applyArtwork rejected: ${e}`));
         return 0;
       });
       if (applied === -1) {
@@ -183,7 +184,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
   // acceptable; the structural nav fix is the primary goal.
   const onBodyButtonDown = (evt: GamepadEvent) => {
     if (evt.detail.button === GamepadButton.TRIGGER_RIGHT) {
-      void runSearch();
+      detach(runSearch());
     }
   };
 
@@ -222,7 +223,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
             />
           </div>
           <DialogButton
-            onClick={() => { void runSearch(); }}
+            onClick={() => { detach(runSearch()); }}
             onFocus={scrollToTop}
             disabled={searching}
             style={{ width: "120px", height: "40px" }}
@@ -260,7 +261,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
                 thumbUrl={game.thumb_url}
                 title={game.name}
                 subtitle={game.release_year == null ? undefined : String(game.release_year)}
-                onSelect={() => { void applySelection(game.id); }}
+                onSelect={() => { detach(applySelection(game.id)); }}
                 onFocus={scrollFocusedToCenter}
                 disabled={applying}
               />

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -11,6 +11,7 @@ import {
   type WizardSetupDeps,
 } from "../utils/saveSetup";
 import type { SaveSetupInfo } from "../types";
+import { detach } from "../utils/detach";
 
 // Local @decky/ui re-mock — gives ConfirmModal an inline OK button so RTL can
 // render-and-click the in-tree CustomSlotModal (which owns its own input state
@@ -41,7 +42,7 @@ vi.mock("@decky/ui", () => {
     createElement("div", { "data-testid": "confirm-modal" },
       createElement("button", {
         "data-testid": "confirm-modal-ok",
-        onClick: () => { void p.onOK?.(); },
+        onClick: () => { detach(Promise.resolve(p.onOK?.())); },
       }, "OK"),
       p.children as never,
     );

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -111,7 +111,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       }
     };
 
-    fetchInfo();
+    void fetchInfo();
     return () => { cancelled = true; };
   }, [romId]);
 
@@ -293,7 +293,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             createElement(CustomSlotModal, {
               onSubmit: (trimmed: string) => {
                 if (trimmed) {
-                  handleConfirm(trimmed);
+                  void handleConfirm(trimmed);
                 } else {
                   // Legacy mode
                   showModal(

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -5,6 +5,7 @@ import { scrollFocusedToCenter } from "../utils/scrollHelpers";
 import { applyWizardInitialSetupResult, applyWizardRetrySetupResult } from "../utils/saveSetup";
 import { formatBytes } from "../utils/formatters";
 import type { SaveSetupInfo } from "../types";
+import { detach } from "../utils/detach";
 
 interface SlotSetupWizardProps {
   romId: number;
@@ -111,7 +112,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
       }
     };
 
-    void fetchInfo();
+    detach(fetchInfo());
     return () => { cancelled = true; };
   }, [romId]);
 
@@ -243,7 +244,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
           <DialogButton
             className="romm-wizard-btn"
             style={btnStyle}
-            onClick={() => { void handleConfirm(s.slot ?? defaultSlot); }}
+            onClick={() => { detach(handleConfirm(s.slot ?? defaultSlot)); }}
             onFocus={scrollFocusedToCenter}
           >
             Track
@@ -273,7 +274,7 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
         <DialogButton
           className="romm-wizard-btn romm-wizard-btn-primary"
           style={btnPrimaryStyle}
-          onClick={() => { void handleConfirm(defaultSlot); }}
+          onClick={() => { detach(handleConfirm(defaultSlot)); }}
           onFocus={scrollFocusedToCenter}
         >
           Use slot &lsquo;{defaultSlot}&rsquo;
@@ -293,14 +294,14 @@ export const SlotSetupWizard: FC<SlotSetupWizardProps> = ({ romId, onComplete })
             createElement(CustomSlotModal, {
               onSubmit: (trimmed: string) => {
                 if (trimmed) {
-                  void handleConfirm(trimmed);
+                  detach(handleConfirm(trimmed));
                 } else {
                   // Legacy mode
                   showModal(
                     createElement(ConfirmModal, {
                       strTitle: "Use Legacy Mode?",
                       strDescription: "Legacy mode (no slot) limits saves to one version per game. Are you sure?",
-                      onOK: () => { void handleConfirm(""); },
+                      onOK: () => { detach(handleConfirm("")); },
                     }),
                   );
                 }

--- a/src/components/SyncConflictModal.test.tsx
+++ b/src/components/SyncConflictModal.test.tsx
@@ -18,6 +18,7 @@ import { showModal } from "@decky/ui";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import * as backend from "../api/backend";
 import type { SyncConflict } from "../types";
+import { detach } from "../utils/detach";
 
 // Per-file mock so we can capture the closeModal prop the host passes to
 // ModalRoot and assert the isLoading-suppresses-outside-close behavior.
@@ -91,33 +92,33 @@ describe("SyncConflictModal", () => {
   // ---------------------------------------------------------------------------
   describe("formatBytes (via rendered output)", () => {
     it("renders 'unknown' when local_size is null", () => {
-      void showSyncConflictModal(makeConflict({ local_size: null }));
+      detach(showSyncConflictModal(makeConflict({ local_size: null })));
       const { container } = render(lastShownElement());
       // "Your local save" block carries the bytes string.
       expect(container.textContent).toContain("unknown");
     });
 
     it("renders 'unknown' when server_size is 0", () => {
-      void showSyncConflictModal(makeConflict({ server_size: 0, local_size: 100 }));
+      detach(showSyncConflictModal(makeConflict({ server_size: 0, local_size: 100 })));
       const { container } = render(lastShownElement());
       expect(container.textContent).toContain("unknown");
     });
 
     it("renders bytes as 'X B' below 1024", () => {
-      void showSyncConflictModal(makeConflict({ local_size: 500, server_size: 1023 }));
+      detach(showSyncConflictModal(makeConflict({ local_size: 500, server_size: 1023 })));
       const { container } = render(lastShownElement());
       expect(container.textContent).toContain("500 B");
       expect(container.textContent).toContain("1023 B");
     });
 
     it("renders bytes as 'X.X KB' for exact 1024", () => {
-      void showSyncConflictModal(makeConflict({ local_size: 1024 }));
+      detach(showSyncConflictModal(makeConflict({ local_size: 1024 })));
       const { container } = render(lastShownElement());
       expect(container.textContent).toContain("1.0 KB");
     });
 
     it("renders bytes as 'X.X MB' above ~1MB", () => {
-      void showSyncConflictModal(makeConflict({ local_size: 5 * 1024 * 1024 }));
+      detach(showSyncConflictModal(makeConflict({ local_size: 5 * 1024 * 1024 })));
       const { container } = render(lastShownElement());
       expect(container.textContent).toContain("5.0 MB");
     });
@@ -137,7 +138,7 @@ describe("SyncConflictModal", () => {
         local_size: 2048,
         server_size: 4096,
       });
-      void showSyncConflictModal(conflict);
+      detach(showSyncConflictModal(conflict));
       const { container } = render(lastShownElement());
 
       expect(container.textContent).toContain("Save conflict for game.srm");
@@ -152,7 +153,7 @@ describe("SyncConflictModal", () => {
     });
 
     it("does NOT render the error block when errorMessage is null (default)", () => {
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       const { container } = render(lastShownElement());
       // Initial render before any resolveSyncConflict call → no error.
       expect(container.textContent).not.toContain("Failed to resolve conflict");
@@ -218,7 +219,7 @@ describe("SyncConflictModal", () => {
       const conflict = makeConflict({ rom_id: 7, filename: "stale.srm" });
       const resolved = vi.fn();
       const promise = showSyncConflictModal(conflict);
-      void promise.then(resolved);
+      detach(promise.then(resolved));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -254,7 +255,7 @@ describe("SyncConflictModal", () => {
       });
 
       const conflict = makeConflict();
-      void showSyncConflictModal(conflict);
+      detach(showSyncConflictModal(conflict));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -281,7 +282,7 @@ describe("SyncConflictModal", () => {
       const conflict = makeConflict({ rom_id: 11, filename: "x.srm" });
       const resolved = vi.fn();
       const promise = showSyncConflictModal(conflict);
-      void promise.then(resolved);
+      detach(promise.then(resolved));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -307,7 +308,7 @@ describe("SyncConflictModal", () => {
         success: false,
       });
 
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -333,7 +334,7 @@ describe("SyncConflictModal", () => {
       const conflict = makeConflict({ rom_id: 3, filename: "boom.srm" });
       const resolved = vi.fn();
       const promise = showSyncConflictModal(conflict);
-      void promise.then(resolved);
+      detach(promise.then(resolved));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -359,7 +360,7 @@ describe("SyncConflictModal", () => {
       // the `msg || "Failed to resolve conflict"` ternary.
       vi.mocked(backend.resolveSyncConflict).mockRejectedValue("");
 
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -378,7 +379,7 @@ describe("SyncConflictModal", () => {
         .mockImplementation(() => {});
       vi.mocked(backend.resolveSyncConflict).mockRejectedValue("bare string error");
 
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -404,7 +405,7 @@ describe("SyncConflictModal", () => {
         }),
       );
 
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       const { container } = render(lastShownElement());
 
       await act(async () => {
@@ -430,7 +431,7 @@ describe("SyncConflictModal", () => {
         }),
       );
 
-      void showSyncConflictModal(makeConflict());
+      detach(showSyncConflictModal(makeConflict()));
       render(lastShownElement());
 
       // Initial render: not loading → closeModal === handleCancel (defined).
@@ -479,7 +480,7 @@ describe("SyncConflictModal", () => {
 
       const resolved = vi.fn();
       const promise = showSyncConflictModal(makeConflict());
-      void promise.then(resolved);
+      detach(promise.then(resolved));
       const { container } = render(lastShownElement());
 
       await act(async () => {

--- a/src/components/VersionErrorCard.test.tsx
+++ b/src/components/VersionErrorCard.test.tsx
@@ -82,8 +82,7 @@ describe("useVersionError hook", () => {
     // fails this test, where the prior `not.toThrow()` pattern passed
     // vacuously under React 19's silent no-op-on-unmounted-setState.
     const unsubSpy = vi.fn();
-    vi.spyOn(connectionState, "onVersionErrorChange").mockImplementation((cb) => {
-      void cb;
+    vi.spyOn(connectionState, "onVersionErrorChange").mockImplementation((_cb) => {
       return unsubSpy;
     });
 

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -14,6 +14,7 @@ import { MUTED_COLOR, computeSyncSummary, displaySlot, slotDeleteFailureToast } 
 import { renderSaveFileRow } from "./SaveFileRow";
 import { InactiveSlotBody } from "./InactiveSlotBody";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
+import { detach } from "../../utils/detach";
 
 function renderActiveSlotBody(
   saveStatus: SaveStatus | null,
@@ -97,7 +98,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         const result = await getSlotSaves(romId, slotName);
         setSlotFiles(result.success ? result.saves : []);
       } catch (e) {
-        void debugLog(`SavesTab: failed to load slot saves for ${slotName}: ${e}`);
+        detach(debugLog(`SavesTab: failed to load slot saves for ${slotName}: ${e}`));
         setSlotFiles([]);
       } finally {
         setLoadingSlot(false);
@@ -124,7 +125,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         switchErrorTimerRef.current = setTimeout(() => setSwitchError(null), 5000);
       }
     } catch (e) {
-      void debugLog(`SavesTab: switchSlot error: ${e}`);
+      detach(debugLog(`SavesTab: switchSlot error: ${e}`));
       setSwitchError("An error occurred while switching slots");
       if (switchErrorTimerRef.current) clearTimeout(switchErrorTimerRef.current);
       switchErrorTimerRef.current = setTimeout(() => setSwitchError(null), 5000);
@@ -162,7 +163,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         strOKButtonText: "Delete",
         strCancelButtonText: "Cancel",
         onOK: () => {
-          void (async () => {
+          detach((async () => {
             try {
               const result = await deleteSlot(romId, slotName);
               if (result.success) {
@@ -172,14 +173,14 @@ export const SlotPanel: FC<SlotPanelProps> = ({
                 toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
               }
             } catch (e) {
-              void debugLog(`SavesTab: deleteSlot error: ${e}`);
+              detach(debugLog(`SavesTab: deleteSlot error: ${e}`));
               toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
             }
-          })();
+          })());
         },
       }));
     } catch (e) {
-      void debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`);
+      detach(debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`));
       toaster.toast({ title: "RomM Sync", body: "Failed to load slot info" });
     } finally {
       setDeleting(false);
@@ -216,7 +217,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
     },
     noFocusRing: false,
     onFocus: scrollFocusedToCenter,
-    onClick: () => { void handleToggle(); },
+    onClick: () => { detach(handleToggle()); },
   },
     // Left: slot name + badges
     createElement("div", { className: "romm-slot-header-left" },
@@ -254,8 +255,8 @@ export const SlotPanel: FC<SlotPanelProps> = ({
       : createElement(InactiveSlotBody, {
           key: "body",
           loadingSlot, slotFiles, switching, switchError, isOffline, deleting,
-          handleActivate: () => { void handleActivate(); },
-          handleDelete: () => { void handleDelete(); },
+          handleActivate: () => { detach(handleActivate()); },
+          handleDelete: () => { detach(handleDelete()); },
         });
   }
 

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -97,7 +97,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         const result = await getSlotSaves(romId, slotName);
         setSlotFiles(result.success ? result.saves : []);
       } catch (e) {
-        debugLog(`SavesTab: failed to load slot saves for ${slotName}: ${e}`);
+        void debugLog(`SavesTab: failed to load slot saves for ${slotName}: ${e}`);
         setSlotFiles([]);
       } finally {
         setLoadingSlot(false);
@@ -124,7 +124,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
         switchErrorTimerRef.current = setTimeout(() => setSwitchError(null), 5000);
       }
     } catch (e) {
-      debugLog(`SavesTab: switchSlot error: ${e}`);
+      void debugLog(`SavesTab: switchSlot error: ${e}`);
       setSwitchError("An error occurred while switching slots");
       if (switchErrorTimerRef.current) clearTimeout(switchErrorTimerRef.current);
       switchErrorTimerRef.current = setTimeout(() => setSwitchError(null), 5000);
@@ -172,14 +172,14 @@ export const SlotPanel: FC<SlotPanelProps> = ({
                 toaster.toast({ title: "RomM Sync", body: result.message ?? "Failed to delete slot" });
               }
             } catch (e) {
-              debugLog(`SavesTab: deleteSlot error: ${e}`);
+              void debugLog(`SavesTab: deleteSlot error: ${e}`);
               toaster.toast({ title: "RomM Sync", body: "An error occurred while deleting the slot" });
             }
           })();
         },
       }));
     } catch (e) {
-      debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`);
+      void debugLog(`SavesTab: getSlotDeleteInfo error: ${e}`);
       toaster.toast({ title: "RomM Sync", body: "Failed to load slot info" });
     } finally {
       setDeleting(false);

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -43,12 +43,12 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       if (result.status === "ok") {
         setVersions(result.versions);
       } else if (result.status === "server_unreachable") {
-        debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`);
+        void debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`);
         setVersions(null);
         setLoadError("Couldn't reach RomM. Tap retry.");
       }
     } catch (e) {
-      debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`);
+      void debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`);
       setVersions(null);
       setLoadError("Couldn't reach RomM. Tap retry.");
     } finally {
@@ -111,7 +111,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         toaster.toast({ title: "RomM Sync", body: "Version history requires RomM 4.7+" });
       }
     } catch (e) {
-      debugLog(`VersionHistoryPanel: restore error for save ${version.id}: ${e}`);
+      void debugLog(`VersionHistoryPanel: restore error for save ${version.id}: ${e}`);
     } finally {
       setRestoring(null);
     }
@@ -184,7 +184,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         noFocusRing: false,
         onFocus: scrollFocusedToCenter,
         disabled: isThisRestoring || restoring !== null || isOffline,
-        onClick: () => { handleRestore(v); },
+        onClick: () => { void handleRestore(v); },
       }, isThisRestoring ? "Restoring..." : "Restore"),
     );
   };

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -13,6 +13,7 @@ import { showSyncConflictModal } from "../SyncConflictModal";
 import { scrollFocusedToCenter } from "../../utils/scrollHelpers";
 import { formatBytes, formatTimestamp } from "../../utils/formatters";
 import { formatAttributionSegment, formatRelativeTime, pickLastSyncer } from "./helpers";
+import { detach } from "../../utils/detach";
 
 interface VersionHistoryPanelProps {
   romId: number;
@@ -43,12 +44,12 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       if (result.status === "ok") {
         setVersions(result.versions);
       } else if (result.status === "server_unreachable") {
-        void debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`);
+        detach(debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`));
         setVersions(null);
         setLoadError("Couldn't reach RomM. Tap retry.");
       }
     } catch (e) {
-      void debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`);
+      detach(debugLog(`VersionHistoryPanel: failed to load versions for ${filename}: ${e}`));
       setVersions(null);
       setLoadError("Couldn't reach RomM. Tap retry.");
     } finally {
@@ -111,7 +112,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         toaster.toast({ title: "RomM Sync", body: "Version history requires RomM 4.7+" });
       }
     } catch (e) {
-      void debugLog(`VersionHistoryPanel: restore error for save ${version.id}: ${e}`);
+      detach(debugLog(`VersionHistoryPanel: restore error for save ${version.id}: ${e}`));
     } finally {
       setRestoring(null);
     }
@@ -184,7 +185,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
         noFocusRing: false,
         onFocus: scrollFocusedToCenter,
         disabled: isThisRestoring || restoring !== null || isOffline,
-        onClick: () => { void handleRestore(v); },
+        onClick: () => { detach(handleRestore(v)); },
       }, isThisRestoring ? "Restoring..." : "Restore"),
     );
   };
@@ -212,7 +213,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
           style: { padding: "2px 8px", minWidth: "auto", fontSize: "11px", width: "auto", flexShrink: 0 },
           noFocusRing: false,
           onFocus: scrollFocusedToCenter,
-          onClick: () => { void loadVersions(); },
+          onClick: () => { detach(loadVersions()); },
         }, "Retry"),
       );
     }
@@ -245,7 +246,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({
       },
       noFocusRing: false,
       onFocus: scrollFocusedToCenter,
-      onClick: () => { void handleToggle(); },
+      onClick: () => { detach(handleToggle()); },
     },
       createElement("span", {}, expanded ? "▾" : "▸"),
       createElement("span", {}, expanded && versions !== null

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,7 @@ import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import { findOutermostScrollParent } from "./utils/scrollHelpers";
+import { detach } from "./utils/detach";
 import type { SyncProgress, DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SaveStatus, SyncPlanData, SyncStaleData, SyncCollectionsData } from "./types";
 import { removeShortcut } from "./utils/steamShortcuts";
 
@@ -139,7 +140,7 @@ export default definePlugin(() => {
     }
   }
 
-  void (async () => {
+  detach((async () => {
     while (!initDone && initAttempt < RETRY_DELAYS.length + 1) {
       try {
         await loadAppIdsAndMetadata();
@@ -150,11 +151,11 @@ export default definePlugin(() => {
         initAttempt++;
       }
     }
-  })();
+  })());
 
   // Early version check — populate version error state before any game detail page renders.
   // Retries are handled by MainPage and RomMPlaySection via their own testConnection() calls.
-  void (async () => {
+  detach((async () => {
     try {
       const result = await withTimeout(testConnection(), CALLABLE_TIMEOUT);
       if (result.error_code === "version_error") {
@@ -165,11 +166,11 @@ export default definePlugin(() => {
     } catch {
       // Silent — other components will retry; don't block startup on connection failure
     }
-  })();
+  })());
 
   // Check for pending RetroDECK path migration on startup. The QAM block page
   // and game-detail card surface this to the user — no toast needed.
-  void (async () => {
+  detach((async () => {
     try {
       const status = await getMigrationStatus();
       if (status.pending) {
@@ -178,10 +179,10 @@ export default definePlugin(() => {
     } catch (e) {
       logError(`Failed to check migration status: ${e}`);
     }
-  })();
+  })());
 
   // Check for pending save sort migration on startup
-  void (async () => {
+  detach((async () => {
     try {
       const status = await getSaveSortMigrationStatus();
       if (status.pending) {
@@ -194,10 +195,10 @@ export default definePlugin(() => {
     } catch (e) {
       logError(`Failed to check save sort migration status: ${e}`);
     }
-  })();
+  })());
 
   // Register device and initialize session manager for save sync (if enabled)
-  void (async () => {
+  detach((async () => {
     try {
       const syncSettings = await getSaveSyncSettings();
       if (syncSettings.save_sync_enabled) {
@@ -208,7 +209,7 @@ export default definePlugin(() => {
     } catch (e) {
       logError(`Failed to init save sync: ${e}`);
     }
-  })();
+  })());
 
   const onSyncComplete = (data: {
     platform_app_ids: Record<string, number[]>;
@@ -232,7 +233,7 @@ export default definePlugin(() => {
     }
 
     // Create/update platform and RomM Steam collections + clean stale ones
-    void (async () => {
+    detach((async () => {
       try {
         // Create/update platform collections
         if (data.platform_app_ids && Object.keys(data.platform_app_ids).length > 0) {
@@ -281,10 +282,10 @@ export default definePlugin(() => {
       } catch (e) {
         logError(`Failed to manage RomM collections: ${e}`);
       }
-    })();
+    })());
 
     // Re-apply playtime to Steam UI (app IDs may have changed after re-sync)
-    void (async () => {
+    detach((async () => {
       try {
         const [{ playtime }, appIdMap] = await Promise.all([
           getAllPlaytime(),
@@ -294,7 +295,7 @@ export default definePlugin(() => {
       } catch (e) {
         logError(`Failed to re-apply playtime after sync: ${e}`);
       }
-    })();
+    })());
   };
 
   const syncCompleteListener = addEventListener<

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,7 @@ export default definePlugin(() => {
 
     try {
       const { playtime } = await withTimeout(getAllPlaytime(), CALLABLE_TIMEOUT);
-      applyAllPlaytime(playtime, appIdMap);
+      await applyAllPlaytime(playtime, appIdMap);
     } catch (e) {
       // Use console — logError is a callable that may also hang
       console.warn("[RomM] Failed to apply playtime:", e);
@@ -139,7 +139,7 @@ export default definePlugin(() => {
     }
   }
 
-  (async () => {
+  void (async () => {
     while (!initDone && initAttempt < RETRY_DELAYS.length + 1) {
       try {
         await loadAppIdsAndMetadata();
@@ -154,7 +154,7 @@ export default definePlugin(() => {
 
   // Early version check — populate version error state before any game detail page renders.
   // Retries are handled by MainPage and RomMPlaySection via their own testConnection() calls.
-  (async () => {
+  void (async () => {
     try {
       const result = await withTimeout(testConnection(), CALLABLE_TIMEOUT);
       if (result.error_code === "version_error") {
@@ -169,7 +169,7 @@ export default definePlugin(() => {
 
   // Check for pending RetroDECK path migration on startup. The QAM block page
   // and game-detail card surface this to the user — no toast needed.
-  (async () => {
+  void (async () => {
     try {
       const status = await getMigrationStatus();
       if (status.pending) {
@@ -181,7 +181,7 @@ export default definePlugin(() => {
   })();
 
   // Check for pending save sort migration on startup
-  (async () => {
+  void (async () => {
     try {
       const status = await getSaveSortMigrationStatus();
       if (status.pending) {
@@ -197,7 +197,7 @@ export default definePlugin(() => {
   })();
 
   // Register device and initialize session manager for save sync (if enabled)
-  (async () => {
+  void (async () => {
     try {
       const syncSettings = await getSaveSyncSettings();
       if (syncSettings.save_sync_enabled) {
@@ -232,7 +232,7 @@ export default definePlugin(() => {
     }
 
     // Create/update platform and RomM Steam collections + clean stale ones
-    (async () => {
+    void (async () => {
       try {
         // Create/update platform collections
         if (data.platform_app_ids && Object.keys(data.platform_app_ids).length > 0) {
@@ -284,13 +284,13 @@ export default definePlugin(() => {
     })();
 
     // Re-apply playtime to Steam UI (app IDs may have changed after re-sync)
-    (async () => {
+    void (async () => {
       try {
         const [{ playtime }, appIdMap] = await Promise.all([
           getAllPlaytime(),
           getAppIdRomIdMap(),
         ]);
-        applyAllPlaytime(playtime, appIdMap);
+        await applyAllPlaytime(playtime, appIdMap);
       } catch (e) {
         logError(`Failed to re-apply playtime after sync: ${e}`);
       }

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -21,6 +21,7 @@ import { RomMPlaySection } from "../components/RomMPlaySection";
 import { RomMGameInfoPanel } from "../components/RomMGameInfoPanel";
 import { debugLog } from "../api/backend";
 import type { RoutePatch } from "@decky/api";
+import { detach } from "../utils/detach";
 
 // Cached set of RomM app IDs — updated by registerRomMAppId
 const rommAppIds = new Set<number>();
@@ -67,7 +68,7 @@ function deepTreeDump(node: any, depth: number, index: number, prefix: string): 
     childCount = 1;
   }
 
-  void debugLog(`${prefix}${indent}[${depth}:${index}] type=${typeName} key=${key} cls=${className} children=${childCount}`);
+  detach(debugLog(`${prefix}${indent}[${depth}:${index}] type=${typeName} key=${key} cls=${className} children=${childCount}`));
 
   // Recurse into children
   if (Array.isArray(childrenRaw)) {
@@ -120,40 +121,40 @@ function dumpTree(container: any, appId: number): void {
   if (!rommAppIds.has(appId) || treeDumped) return;
   treeDumped = true;
 
-  void debugLog(`===== DEEP TREE DUMP for appId=${appId} =====`);
-  void debugLog(`InnerContainer className: ${container.props.className}`);
+  detach(debugLog(`===== DEEP TREE DUMP for appId=${appId} =====`));
+  detach(debugLog(`InnerContainer className: ${container.props.className}`));
 
   const children = container.props.children;
-  void debugLog(`InnerContainer direct children count: ${children.length}`);
+  detach(debugLog(`InnerContainer direct children count: ${children.length}`));
   for (let i = 0; i < children.length; i++) {
     deepTreeDump(children[i], 0, i, "TREE: ");
   }
 
   // Search for playSectionClasses.Container deep in tree
   const psContainerClass = playSectionClasses?.Container;
-  void debugLog(`playSectionClasses.Container = "${psContainerClass || "UNDEFINED"}"`);
+  detach(debugLog(`playSectionClasses.Container = "${psContainerClass || "UNDEFINED"}"`));
   if (psContainerClass) {
     const psFound = findInReactTree(
       container,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
       (x: any) => x?.props?.className?.includes?.(psContainerClass),
     );
-    void debugLog(`findInReactTree(playSectionClasses.Container): ${psFound ? "FOUND" : "NOT FOUND"}`);
+    detach(debugLog(`findInReactTree(playSectionClasses.Container): ${psFound ? "FOUND" : "NOT FOUND"}`));
   }
 
   // Search for basicAppDetailsSectionStylerClasses.PlaySection deep in tree
   const bpsClass = basicAppDetailsSectionStylerClasses?.PlaySection;
-  void debugLog(`basicAppDetailsSectionStylerClasses.PlaySection = "${bpsClass || "UNDEFINED"}"`);
+  detach(debugLog(`basicAppDetailsSectionStylerClasses.PlaySection = "${bpsClass || "UNDEFINED"}"`));
   if (bpsClass) {
     const bpsFound = findInReactTree(
       container,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
       (x: any) => x?.props?.className?.includes?.(bpsClass),
     );
-    void debugLog(`findInReactTree(basicAppDetailsSectionStylerClasses.PlaySection): ${bpsFound ? "FOUND" : "NOT FOUND"}`);
+    detach(debugLog(`findInReactTree(basicAppDetailsSectionStylerClasses.PlaySection): ${bpsFound ? "FOUND" : "NOT FOUND"}`));
   }
 
-  void debugLog(`===== END DEEP TREE DUMP =====`);
+  detach(debugLog(`===== END DEEP TREE DUMP =====`));
 }
 
 export function registerRomMAppId(appId: number) {
@@ -207,7 +208,7 @@ export function registerGameDetailPatch() {
 
             // Only apply RomM modifications for RomM shortcuts
             const isRomM = rommAppIds.has(appId);
-            void debugLog(`gameDetailPatch: appId=${appId} isRomM=${isRomM} setSize=${rommAppIds.size}`);
+            detach(debugLog(`gameDetailPatch: appId=${appId} isRomM=${isRomM} setSize=${rommAppIds.size}`));
 
             dumpTree(container, appId);
 
@@ -245,10 +246,10 @@ export function registerGameDetailPatch() {
                 }, rommPlaySection, rommInfoPanel);
 
                 if (nativeOverviewIdx >= 0) {
-                  void debugLog(`gameDetailPatch: replacing AppDetailsOverviewPanel at index ${nativeOverviewIdx} with RomM wrapper (cls=${appDetailsClasses?.AppDetailsOverviewPanel})`);
+                  detach(debugLog(`gameDetailPatch: replacing AppDetailsOverviewPanel at index ${nativeOverviewIdx} with RomM wrapper (cls=${appDetailsClasses?.AppDetailsOverviewPanel})`));
                   children.splice(nativeOverviewIdx, 1, rommWrapper);
                 } else {
-                  void debugLog(`gameDetailPatch: AppDetailsOverviewPanel not found, inserting RomM wrapper at index 1`);
+                  detach(debugLog(`gameDetailPatch: AppDetailsOverviewPanel not found, inserting RomM wrapper at index 1`));
                   children.splice(1, 0, rommWrapper);
                 }
               }

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -67,7 +67,7 @@ function deepTreeDump(node: any, depth: number, index: number, prefix: string): 
     childCount = 1;
   }
 
-  debugLog(`${prefix}${indent}[${depth}:${index}] type=${typeName} key=${key} cls=${className} children=${childCount}`);
+  void debugLog(`${prefix}${indent}[${depth}:${index}] type=${typeName} key=${key} cls=${className} children=${childCount}`);
 
   // Recurse into children
   if (Array.isArray(childrenRaw)) {
@@ -120,40 +120,40 @@ function dumpTree(container: any, appId: number): void {
   if (!rommAppIds.has(appId) || treeDumped) return;
   treeDumped = true;
 
-  debugLog(`===== DEEP TREE DUMP for appId=${appId} =====`);
-  debugLog(`InnerContainer className: ${container.props.className}`);
+  void debugLog(`===== DEEP TREE DUMP for appId=${appId} =====`);
+  void debugLog(`InnerContainer className: ${container.props.className}`);
 
   const children = container.props.children;
-  debugLog(`InnerContainer direct children count: ${children.length}`);
+  void debugLog(`InnerContainer direct children count: ${children.length}`);
   for (let i = 0; i < children.length; i++) {
     deepTreeDump(children[i], 0, i, "TREE: ");
   }
 
   // Search for playSectionClasses.Container deep in tree
   const psContainerClass = playSectionClasses?.Container;
-  debugLog(`playSectionClasses.Container = "${psContainerClass || "UNDEFINED"}"`);
+  void debugLog(`playSectionClasses.Container = "${psContainerClass || "UNDEFINED"}"`);
   if (psContainerClass) {
     const psFound = findInReactTree(
       container,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
       (x: any) => x?.props?.className?.includes?.(psContainerClass),
     );
-    debugLog(`findInReactTree(playSectionClasses.Container): ${psFound ? "FOUND" : "NOT FOUND"}`);
+    void debugLog(`findInReactTree(playSectionClasses.Container): ${psFound ? "FOUND" : "NOT FOUND"}`);
   }
 
   // Search for basicAppDetailsSectionStylerClasses.PlaySection deep in tree
   const bpsClass = basicAppDetailsSectionStylerClasses?.PlaySection;
-  debugLog(`basicAppDetailsSectionStylerClasses.PlaySection = "${bpsClass || "UNDEFINED"}"`);
+  void debugLog(`basicAppDetailsSectionStylerClasses.PlaySection = "${bpsClass || "UNDEFINED"}"`);
   if (bpsClass) {
     const bpsFound = findInReactTree(
       container,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
       (x: any) => x?.props?.className?.includes?.(bpsClass),
     );
-    debugLog(`findInReactTree(basicAppDetailsSectionStylerClasses.PlaySection): ${bpsFound ? "FOUND" : "NOT FOUND"}`);
+    void debugLog(`findInReactTree(basicAppDetailsSectionStylerClasses.PlaySection): ${bpsFound ? "FOUND" : "NOT FOUND"}`);
   }
 
-  debugLog(`===== END DEEP TREE DUMP =====`);
+  void debugLog(`===== END DEEP TREE DUMP =====`);
 }
 
 export function registerRomMAppId(appId: number) {
@@ -207,7 +207,7 @@ export function registerGameDetailPatch() {
 
             // Only apply RomM modifications for RomM shortcuts
             const isRomM = rommAppIds.has(appId);
-            debugLog(`gameDetailPatch: appId=${appId} isRomM=${isRomM} setSize=${rommAppIds.size}`);
+            void debugLog(`gameDetailPatch: appId=${appId} isRomM=${isRomM} setSize=${rommAppIds.size}`);
 
             dumpTree(container, appId);
 
@@ -245,10 +245,10 @@ export function registerGameDetailPatch() {
                 }, rommPlaySection, rommInfoPanel);
 
                 if (nativeOverviewIdx >= 0) {
-                  debugLog(`gameDetailPatch: replacing AppDetailsOverviewPanel at index ${nativeOverviewIdx} with RomM wrapper (cls=${appDetailsClasses?.AppDetailsOverviewPanel})`);
+                  void debugLog(`gameDetailPatch: replacing AppDetailsOverviewPanel at index ${nativeOverviewIdx} with RomM wrapper (cls=${appDetailsClasses?.AppDetailsOverviewPanel})`);
                   children.splice(nativeOverviewIdx, 1, rommWrapper);
                 } else {
-                  debugLog(`gameDetailPatch: AppDetailsOverviewPanel not found, inserting RomM wrapper at index 1`);
+                  void debugLog(`gameDetailPatch: AppDetailsOverviewPanel not found, inserting RomM wrapper at index 1`);
                   children.splice(1, 0, rommWrapper);
                 }
               }

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -1,5 +1,6 @@
 import type { RomMetadata } from "../types";
 import { debugLog, logInfo } from "../api/backend";
+import { detach } from "../utils/detach";
 
 // Module-level state
 let metadataCache: Record<string, RomMetadata> = {};
@@ -99,7 +100,7 @@ export function unregisterMetadataPatches() {
 export function updatePlaytimeDisplay(appId: number, totalSeconds: number, updateLastPlayed = true): boolean {
   const overview = appStore.GetAppOverviewByAppID(appId);
   if (!overview) {
-    void debugLog(`updatePlaytimeDisplay: appId=${appId} overview=null, skipping`);
+    detach(debugLog(`updatePlaytimeDisplay: appId=${appId} overview=null, skipping`));
     return false;
   }
 
@@ -114,7 +115,7 @@ export function updatePlaytimeDisplay(appId: number, totalSeconds: number, updat
       overview.rt_last_time_played = Math.floor(Date.now() / 1000);
     }
   });
-  void debugLog(`updatePlaytimeDisplay: appId=${appId} wrote ${totalMinutes}min (was ${prevMinutes}), rt_last_time_played was ${prevLastPlayed}`);
+  detach(debugLog(`updatePlaytimeDisplay: appId=${appId} wrote ${totalMinutes}min (was ${prevMinutes}), rt_last_time_played was ${prevLastPlayed}`));
   return true;
 }
 
@@ -159,7 +160,7 @@ export async function applyAllPlaytime(
     }
   }
 
-  void debugLog(`applyAllPlaytime: ${Object.keys(playtimeMap).length} entries in playtimeMap, ${pending.length} with appId and >0 seconds`);
+  detach(debugLog(`applyAllPlaytime: ${Object.keys(playtimeMap).length} entries in playtimeMap, ${pending.length} with appId and >0 seconds`));
 
   if (pending.length === 0) return;
 
@@ -173,12 +174,12 @@ export async function applyAllPlaytime(
     pending = tryWritePlaytime(pending);
 
     if (pending.length > 0 && attempt < delays.length - 1) {
-      void debugLog(`applyAllPlaytime: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`);
+      detach(debugLog(`applyAllPlaytime: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`));
     }
   }
 
   if (pending.length > 0) {
-    void debugLog(`applyAllPlaytime: ${pending.length} apps still unavailable in appStore after all retries`);
+    detach(debugLog(`applyAllPlaytime: ${pending.length} apps still unavailable in appStore after all retries`));
   }
 }
 

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -99,7 +99,7 @@ export function unregisterMetadataPatches() {
 export function updatePlaytimeDisplay(appId: number, totalSeconds: number, updateLastPlayed = true): boolean {
   const overview = appStore.GetAppOverviewByAppID(appId);
   if (!overview) {
-    debugLog(`updatePlaytimeDisplay: appId=${appId} overview=null, skipping`);
+    void debugLog(`updatePlaytimeDisplay: appId=${appId} overview=null, skipping`);
     return false;
   }
 
@@ -114,7 +114,7 @@ export function updatePlaytimeDisplay(appId: number, totalSeconds: number, updat
       overview.rt_last_time_played = Math.floor(Date.now() / 1000);
     }
   });
-  debugLog(`updatePlaytimeDisplay: appId=${appId} wrote ${totalMinutes}min (was ${prevMinutes}), rt_last_time_played was ${prevLastPlayed}`);
+  void debugLog(`updatePlaytimeDisplay: appId=${appId} wrote ${totalMinutes}min (was ${prevMinutes}), rt_last_time_played was ${prevLastPlayed}`);
   return true;
 }
 
@@ -159,7 +159,7 @@ export async function applyAllPlaytime(
     }
   }
 
-  debugLog(`applyAllPlaytime: ${Object.keys(playtimeMap).length} entries in playtimeMap, ${pending.length} with appId and >0 seconds`);
+  void debugLog(`applyAllPlaytime: ${Object.keys(playtimeMap).length} entries in playtimeMap, ${pending.length} with appId and >0 seconds`);
 
   if (pending.length === 0) return;
 
@@ -173,12 +173,12 @@ export async function applyAllPlaytime(
     pending = tryWritePlaytime(pending);
 
     if (pending.length > 0 && attempt < delays.length - 1) {
-      debugLog(`applyAllPlaytime: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`);
+      void debugLog(`applyAllPlaytime: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`);
     }
   }
 
   if (pending.length > 0) {
-    debugLog(`applyAllPlaytime: ${pending.length} apps still unavailable in appStore after all retries`);
+    void debugLog(`applyAllPlaytime: ${pending.length} apps still unavailable in appStore after all retries`);
   }
 }
 

--- a/src/utils/detach.test.ts
+++ b/src/utils/detach.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { detach } from "./detach";
+
+/** Resolve once the microtask + macrotask queues have drained. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("detach", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("attaches a rejection handler so a rejecting promise stays handled", async () => {
+    const rejecting = Promise.reject(new Error("boom"));
+    // Spy on the actual promise — detach must call .catch on it, which is what
+    // prevents the rejection from surfacing as unhandled. (Promise.resolve(p)
+    // returns the same native promise, so the handler lands on `rejecting`.)
+    const catchSpy = vi.spyOn(rejecting, "catch");
+
+    expect(() => {
+      detach(rejecting);
+    }).not.toThrow();
+
+    expect(catchSpy).toHaveBeenCalledTimes(1);
+
+    // Drain queues — the spied .catch already swallows the rejection, so this
+    // test would fail with an unhandled rejection if detach had skipped it.
+    await flush();
+  });
+
+  it("returns undefined synchronously (does not block on the promise)", () => {
+    const result = detach(Promise.resolve(123));
+    expect(result).toBeUndefined();
+  });
+
+  it("is a no-op for a resolving promise — the value is dropped, no throw", async () => {
+    const onResolve = vi.fn();
+    const onReject = vi.fn();
+    const p = Promise.resolve("value");
+    // Observe the underlying promise still settles normally after detach().
+    p.then(onResolve, onReject).catch(() => undefined);
+
+    detach(p);
+    await flush();
+
+    expect(onResolve).toHaveBeenCalledWith("value");
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when handed a non-thenable (e.g. an undefined-returning mock)", async () => {
+    // Production always passes a real Promise, but a test mock without a
+    // mockResolvedValue returns undefined. A bare promise.catch(...) would
+    // throw "Cannot read properties of undefined". detach must stay silent.
+    expect(() => {
+      detach(undefined as unknown as Promise<unknown>);
+    }).not.toThrow();
+    await flush();
+  });
+
+  it("swallows a rejection that settles after detach was called", async () => {
+    let reject!: (reason: unknown) => void;
+    const pending = new Promise<unknown>((_, rej) => {
+      reject = rej;
+    });
+    const catchSpy = vi.spyOn(pending, "catch");
+
+    detach(pending);
+    expect(catchSpy).toHaveBeenCalledTimes(1);
+
+    // Reject after the handler is attached — must not surface as unhandled.
+    reject(new Error("late failure"));
+    await flush();
+  });
+});

--- a/src/utils/detach.ts
+++ b/src/utils/detach.ts
@@ -1,0 +1,14 @@
+/**
+ * Fire-and-forget a promise whose rejection is intentionally ignored, without
+ * the `void` operator (which SonarCloud S3735 bans and which leaves rejections
+ * unhandled). The `.catch` attaches a rejection handler so no unhandledrejection
+ * fires. For fire-and-forget work whose FAILURE SHOULD BE LOGGED, use an inline
+ * `.catch((e) => logError(...))` at the call site instead of detach().
+ */
+export function detach(promise: Promise<unknown>): void {
+  // Promise.resolve wraps the value so a rejection handler always attaches —
+  // even when a caller (e.g. a test mock) hands us a non-thenable, which would
+  // make a bare `promise.catch(...)` throw synchronously and defeat the
+  // fire-and-forget contract. In production every caller passes a real Promise.
+  Promise.resolve(promise).catch(() => undefined);
+}

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -10,13 +10,14 @@ import { isRomMAppId } from "../patches/gameDetailPatch";
 import { evaluateLaunch, refreshMigrationState, logInfo, logError } from "../api/backend";
 import { getMigrationState, setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
+import { detach } from "./detach";
 
 let gameActionHook: { unregister: () => void } | null = null;
 
 export function registerLaunchInterceptor(): void {
   gameActionHook = SteamClient.Apps.RegisterForGameActionStart(
     (gameActionId: number, appIdStr: string, action: string, _launchSource: number) => {
-      void (async () => {
+      detach((async () => {
       if (action !== "LaunchApp") return;
 
       const appId = Number.parseInt(appIdStr, 10);
@@ -69,7 +70,7 @@ export function registerLaunchInterceptor(): void {
         logError(`Launch interceptor error: ${e}`);
         // On error, don't block the launch.
       }
-      })();
+      })());
     },
   );
 


### PR DESCRIPTION
Cherry-pick of #838's type-aware ESLint adoption (3rd and last rule) — does not close the umbrella.

Adopts `@typescript-eslint/no-floating-promises` and handles all fire-and-forget promises via a new `detach()` helper (`src/utils/detach.ts`) instead of the `void` operator:
- **Why not `void`:** SonarCloud S3735 bans the `void` operator (flagged 65), and `void p` leaves rejections *unhandled* at runtime (per typescript-eslint's own docs). `detach(p)` attaches a real `.catch` → S3735 = 0 and rejections are handled.
- ~86 `void` sites in `src/` → `detach(...)`; the ~8 genuine backend-mutation sites keep inline `.catch((e) => logError(...))` (log on failure).
- Adds `detach` helper + test and non-vacuous catch-path tests (new-code coverage ~89%).

Verified: eslint 0 errors, tsc clean (bar pre-existing tsconfig deprecation), build ok, 1059 tests pass, 0 `void` operators in src/.

docs: N/A — lint-rule adoption + fire-and-forget hardening, no user-visible or architecture change.