### PR TITLE
chore: gitignore coverage.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ log.txt
 .worktrees/
 .coverage
 coverage.xml
+coverage.json
 
 # Frontend test coverage
 coverage/


### PR DESCRIPTION
Adds `coverage.json` to `.gitignore`, next to the already-ignored `.coverage` and `coverage.xml`. It's the only sibling coverage-report format that wasn't ignored; a stray one was sitting untracked in the repo root. A manual `coverage json` run won't get committed by accident now.

Not part of any ratchet box — pure repo housekeeping.

docs: N/A — tooling/repo-config change, no user-facing or architectural impact.