### PR TITLE
chore(quality): resolve tests/ basedpyright import resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,14 @@ reportArgumentType = "error"
 # white-box testing is a deliberate, accepted pattern here. The
 # reportPrivateUsage guardrail targets production encapsulation, not
 # test setup, so it's disabled under tests/. extraPaths is repeated
-# because execution environments do not inherit the top-level value.
+# because execution environments do not inherit the top-level value;
+# the repo root "." is added on top so test files can resolve the
+# top-level `main` module and sibling `tests.*` packages (without it,
+# those imports are unresolved and `main.*` symbols degrade to Unknown,
+# a blind spot on the callable surface the tests exercise).
 [[tool.basedpyright.executionEnvironments]]
 root = "tests"
-extraPaths = ["py_modules"]
+extraPaths = ["py_modules", "."]
 reportPrivateUsage = "none"
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,14 +64,19 @@ def _make_testable_plugin():
         """Plugin subclass that declares test-only attributes for type safety.
 
         Only the genuinely test-fixture-only attributes (``_fake_api``,
-        ``_resolve_system``) live here. Test-fixture handles shared with
-        production wiring (``_state``, ``_http_adapter``, ...) are
-        declared on ``Plugin`` itself as ``Any``-typed annotation slots
-        so test-only construction paths type-check uniformly.
+        ``_resolve_system``, ``_save_settings``) live here. Test-fixture
+        handles shared with production wiring (``_state``,
+        ``_http_adapter``, ...) are declared on ``Plugin`` itself as
+        ``Any``-typed annotation slots so test-only construction paths
+        type-check uniformly. ``_save_settings`` is a test-only handle for
+        the settings dict tests thread into ``SaveService`` /
+        ``PlaytimeService``; production threads its settings store as
+        ``self.settings``, never under this name.
         """
 
         _fake_api: Any
         _resolve_system: Any
+        _save_settings: Any
 
     instance = TestablePlugin()
     instance._migration_service = MagicMock()


### PR DESCRIPTION
Ratchet box of #838 (the `tests/` basedpyright import-resolution box). **Does not close the umbrella.**

## What
Adds the repo root `"."` to the basedpyright `tests` executionEnvironment `extraPaths` (was `["py_modules"]`). Test files can now resolve the top-level `main` module and sibling `tests.*` packages.

## Why
- Clears **31 `reportMissingImports` warnings** (`main`, `tests.*`).
- **Restores real type-checking of `main.*` usage in test files** — previously those symbols degraded to `Unknown`, a blind spot on the callable surface the tests exercise.

## Fallout (fixed in same PR)
Restoring that type-checking surfaced **5 previously-hidden errors** in `tests/test_plugin_saves.py`, all from `_save_settings` being an undeclared test-only handle on `TestablePlugin` (4× `reportAttributeAccessIssue` + 1× `reportArgumentType`, the latter from it being inferred as `dict[str, str]`).

Fix: declare `_save_settings: Any` on `TestablePlugin` alongside the existing genuinely-test-only slots `_fake_api`/`_resolve_system`. It stays **out** of the production `Plugin` slot block because production never references this handle (it threads its settings store as `self.settings`) — consistent with the documented test-slot taxonomy, and keeps the change clear of the active SQLite epic's main.py churn.

## Verification
- basedpyright (full scope, incl. `tests/`): **0 errors, 0 warnings**
- ruff check + format: clean
- pytest: **2906 passed**

docs: N/A — type-checking config + test-fixture annotation; no user-facing, architecture, or flow change.