### PR TITLE
chore(quality): enable tsconfig noUncheckedIndexedAccess

### DIFF
--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -188,7 +188,7 @@ describe("DownloadQueue", () => {
 
       // startPolling calls setInterval(pollTick, 500). Pick out that id.
       const pollIntervalIds = setIntervalSpy.mock.results
-        .filter((_, i) => setIntervalSpy.mock.calls[i][1] === 500)
+        .filter((_, i) => setIntervalSpy.mock.calls[i]![1] === 500)
         .map((r) => r.value as ReturnType<typeof setInterval>);
       const expectedId = pollIntervalIds[pollIntervalIds.length - 1];
       expect(expectedId).toBeDefined();

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1679,7 +1679,7 @@ describe("MainPage", () => {
 
       // Capture the 1000ms (downloadPollRef) interval id.
       const downloadIds = setIntervalSpy.mock.results
-        .filter((_, i) => setIntervalSpy.mock.calls[i][1] === 1000)
+        .filter((_, i) => setIntervalSpy.mock.calls[i]![1] === 1000)
         .map((r) => r.value as ReturnType<typeof setInterval>);
       const expectedId = downloadIds[downloadIds.length - 1];
       expect(expectedId).toBeDefined();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -304,7 +304,7 @@ export default definePlugin(() => {
               if (!c.displayName.startsWith("RomM: [")) return false;
               if (!c.displayName.endsWith(suffix)) return false;
               const match = rommCollectionPattern.exec(c.displayName);
-              return match ? !activeNames.has(match[1]) : false;
+              return match ? !activeNames.has(match[1]!) : false; // group 1 present whenever match is non-null
             });
             for (const c of staleRomm) {
               logInfo(`Removing stale RomM collection "${c.displayName}"`);

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -172,7 +172,8 @@ export async function applyAllPlaytime(
   // Try up to 4 times with increasing delays (0ms, 1s, 3s, 5s)
   const delays = [0, 1000, 3000, 5000];
   for (let attempt = 0; attempt < delays.length && pending.length > 0; attempt++) {
-    if (delays[attempt] > 0) {
+    if (delays[attempt]! > 0) {
+      // attempt < delays.length (loop guard) ⇒ index in bounds
       await new Promise((r) => setTimeout(r, delays[attempt]));
     }
 

--- a/src/utils/downloadFailure.test.ts
+++ b/src/utils/downloadFailure.test.ts
@@ -91,8 +91,8 @@ describe("handleGlobalDownloadFailure", () => {
       title: "RomM Sync",
       body: "Download failed: Super Mario 64 — ",
     });
-    const [[updated]] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
-    expect(updated.error).toBe("");
+    const [updatedCall] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
+    expect(updatedCall![0].error).toBe("");
   });
 
   it("ignores entries for other roms when selecting the prior state", () => {
@@ -114,10 +114,10 @@ describe("handleGlobalDownloadFailure", () => {
 
     handleGlobalDownloadFailure(makeEvent(), store, toast);
 
-    const [[updated]] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
+    const [updatedCall] = (store.updateDownload as unknown as { mock: { calls: [DownloadItem][] } }).mock.calls;
     // Should NOT have pulled file_name / progress from rom 99.
-    expect(updated.file_name).toBe("");
-    expect(updated.progress).toBe(0);
+    expect(updatedCall![0].file_name).toBe("");
+    expect(updatedCall![0].progress).toBe(0);
   });
 });
 

--- a/src/utils/scrollHelpers.test.ts
+++ b/src/utils/scrollHelpers.test.ts
@@ -41,10 +41,10 @@ function makeElement(opts: {
 /** Build a chain root → ... → leaf, append each to its parent, mount root in body. */
 function chain(...elements: HTMLElement[]): HTMLElement {
   for (let i = 0; i < elements.length - 1; i++) {
-    elements[i].appendChild(elements[i + 1]);
+    elements[i]!.appendChild(elements[i + 1]!); // i and i+1 both < elements.length
   }
-  document.body.appendChild(elements[0]);
-  return elements[elements.length - 1];
+  document.body.appendChild(elements[0]!); // caller always passes ≥1 element
+  return elements[elements.length - 1]!;
 }
 
 afterEach(() => {

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -60,7 +60,7 @@ describe("refreshActiveSlotInBackground", () => {
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
-    const updater = setter.mock.calls[0][0];
+    const updater = setter.mock.calls[0]![0];
     expect(updater({ activeSlot: null, unrelated: 7 })).toEqual({
       activeSlot: "slot-2",
       unrelated: 7,
@@ -116,7 +116,7 @@ describe("refreshActiveSlotInBackground", () => {
     refreshActiveSlotInBackground(1, () => false, setter as unknown as Dispatch<SetStateAction<ActiveSlotState>>);
     await flushMicrotasks();
 
-    const updater = setter.mock.calls[0][0];
+    const updater = setter.mock.calls[0]![0];
     expect(updater({ activeSlot: "x", unrelated: 1 })).toEqual({
       activeSlot: null,
       unrelated: 1,
@@ -142,7 +142,7 @@ describe("refreshBiosInBackground", () => {
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
-    const next = setter.mock.calls[0][0]({
+    const next = setter.mock.calls[0]![0]({
       biosNeeded: false,
       biosStatus: null,
       biosLabel: "",
@@ -234,7 +234,7 @@ describe("refreshAchievementsInBackground", () => {
     await flushMicrotasks();
 
     expect(setter).toHaveBeenCalledOnce();
-    const next = setter.mock.calls[0][0]({
+    const next = setter.mock.calls[0]![0]({
       achievementEarned: 0,
       achievementTotal: 0,
       unrelated: true,

--- a/src/utils/slotState.test.ts
+++ b/src/utils/slotState.test.ts
@@ -48,7 +48,7 @@ const makeSetter = <S>() => vi.fn() as unknown as Dispatch<SetStateAction<S>>;
  *  the test assertions clean even though the underlying mock is `unknown`. */
 const lastUpdater = <S>(setter: Dispatch<SetStateAction<S>>): ((prev: S) => S) => {
   const calls = (setter as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-  return calls[calls.length - 1][0] as (prev: S) => S;
+  return calls[calls.length - 1]![0] as (prev: S) => S;
 };
 
 const callCount = <S>(setter: Dispatch<SetStateAction<S>>): number =>

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -53,8 +53,7 @@ async function processUnitShortcuts(
   total: number,
 ): Promise<void> {
   let lastHeartbeat = Date.now();
-  for (let i = 0; i < data.shortcuts.length; i++) {
-    const item = data.shortcuts[i];
+  for (const [i, item] of data.shortcuts.entries()) {
     try {
       updateSyncProgress({
         current: i + 1,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "types": ["vitest/globals", "@testing-library/jest-dom/vitest"]


### PR DESCRIPTION
Ratchet box of #838 (the `noUncheckedIndexedAccess` box). **Does not close the umbrella.**

First of the frontend-strictness trio; `exactOptionalPropertyTypes` follows, then `no-unnecessary-condition` last (tsconfig flags tighten types first so the lint rule doesn't flag correct guards — measured: it cuts the lint rule's surface ~40%).

## What
Adds `"noUncheckedIndexedAccess": true` to `tsconfig.json`. Indexed access (`arr[i]` / `obj[key]`) now yields `T | undefined`, so a missing element/key is a compile error instead of a silent `undefined`.

## Fallout (all fixed here)
20 errors across 9 files (3 production, 6 test) — **all mechanical, zero latent bugs**. Fix styles:
- `syncManager.ts`: indexed `for`-loop → `for (const [i, item] of data.shortcuts.entries())` — `i` still drives the progress message; behavior identical.
- `metadataPatches.ts` / `index.tsx`: `!` only where a local invariant guarantees presence (loop bound; non-optional regex capture group), each with an explanatory comment.
- test files: `!` on mock-call / fixture accesses the test provably controls (preceded by `toHaveBeenCalled*` assertions or known-length arrays).

No `@ts-ignore` / `eslint-disable` introduced.

## Verification
- `pnpm typecheck`: 0 errors
- `pnpm lint`: 0 errors (2 pre-existing `exhaustive-deps` warnings unchanged)
- `pnpm format:check`: clean
- `pnpm test`: 1059 passed

A code-reviewer pass independently re-ran all checks and verified every `!` invariant holds (no assertion masks a genuinely-possible runtime `undefined`).

docs: N/A — type-safety compiler flag + mechanical guards; no user-facing, architecture, or flow change.