### PR TITLE
chore(quality): enable tsconfig exactOptionalPropertyTypes

### DIFF
--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -122,7 +122,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
             {active.map((item) => (
               <PanelSectionRow key={item.rom_id}>
                 <ProgressBarWithInfo
-                  nProgress={item.total_bytes > 0 ? (item.bytes_downloaded / item.total_bytes) * 100 : undefined}
+                  {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
                   indeterminate={item.total_bytes === 0}
                   sOperationText={`${item.rom_name} (${item.platform_name})`}
                   sTimeRemaining={

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -453,7 +453,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               <span data-testid="sync-stage">{stageLabel(syncProgress?.stage)}</span>
               {stepText && <span data-testid="sync-step">{stepText}</span>}
             </div>
-            <ProgressBar indeterminate={coarseFraction === undefined} nProgress={coarseFraction} />
+            <ProgressBar
+              indeterminate={coarseFraction === undefined}
+              {...(coarseFraction !== undefined ? { nProgress: coarseFraction } : {})}
+            />
           </div>
         </PanelSectionRow>
         {hasFineDetail && (
@@ -651,7 +654,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           {activeDownloads.slice(0, 2).map((item) => (
             <PanelSectionRow key={item.rom_id}>
               <ProgressBarWithInfo
-                nProgress={item.total_bytes > 0 ? (item.bytes_downloaded / item.total_bytes) * 100 : undefined}
+                {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
                 indeterminate={item.total_bytes === 0}
                 sOperationText={item.rom_name}
                 sTimeRemaining={

--- a/src/components/SgdbGamePickerModal.tsx
+++ b/src/components/SgdbGamePickerModal.tsx
@@ -42,15 +42,15 @@ export interface SgdbGamePickerModalProps {
 const Tile: FC<{
   thumbUrl: string | null;
   title: string;
-  subtitle?: string;
+  subtitle?: string | undefined;
   onSelect: () => void;
   onFocus?: (e: { currentTarget: EventTarget | null }) => void;
   disabled?: boolean;
 }> = ({ thumbUrl, title, subtitle, onSelect, onFocus, disabled }) => (
   <DialogButton
     onClick={onSelect}
-    onFocus={onFocus}
-    disabled={disabled}
+    {...(onFocus !== undefined ? { onFocus } : {})}
+    {...(disabled !== undefined ? { disabled } : {})}
     style={{
       display: "flex",
       flexDirection: "column",
@@ -169,7 +169,7 @@ export const SgdbGamePickerModalContent: FC<SgdbGamePickerModalProps> = ({
 
   return (
     <ConfirmModal
-      closeModal={closeModal}
+      {...(closeModal !== undefined ? { closeModal } : {})}
       onOK={() => closeModal?.()}
       onCancel={() => closeModal?.()}
       strTitle="Choose SteamGridDB Game"

--- a/src/components/SlotSetupWizard.tsx
+++ b/src/components/SlotSetupWizard.tsx
@@ -65,7 +65,7 @@ const CustomSlotModal: FC<{
   return createElement(
     ConfirmModal,
     {
-      closeModal,
+      ...(closeModal !== undefined ? { closeModal } : {}),
       strTitle: "Custom Slot Name",
       bDisableBackgroundDismiss: true,
       onOK: () => {

--- a/src/components/saves/NewSlotModal.test.tsx
+++ b/src/components/saves/NewSlotModal.test.tsx
@@ -8,10 +8,10 @@ import { NewSlotModal } from "./NewSlotModal";
 // silently drops them.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 const captured: {
-  onOK?: () => void;
-  bDisableBackgroundDismiss?: boolean;
+  onOK?: (() => void) | undefined;
+  bDisableBackgroundDismiss?: boolean | undefined;
   closeModal?: unknown;
-  strTitle?: string;
+  strTitle?: string | undefined;
 } = {};
 
 vi.mock("@decky/ui", () => ({

--- a/src/components/saves/NewSlotModal.tsx
+++ b/src/components/saves/NewSlotModal.tsx
@@ -15,7 +15,7 @@ export const NewSlotModal: FC<{
   return createElement(
     ConfirmModal,
     {
-      closeModal,
+      ...(closeModal !== undefined ? { closeModal } : {}),
       onOK: () => {
         onSubmit(value.trim());
       },

--- a/src/components/settings/SaveSortMigrationSection.test.tsx
+++ b/src/components/settings/SaveSortMigrationSection.test.tsx
@@ -21,14 +21,27 @@ vi.mock("@decky/ui", () => ({
   }) => createElement("button", { onClick, disabled }, children as never),
 }));
 
-function makeMigration(overrides: Partial<SaveSortMigrationStatus> = {}): SaveSortMigrationStatus {
-  return {
+function makeMigration(
+  overrides: { [K in keyof SaveSortMigrationStatus]?: SaveSortMigrationStatus[K] | undefined } = {},
+): SaveSortMigrationStatus {
+  const result: Record<string, unknown> = {
     pending: true,
     old_settings: { sort_by_content: false, sort_by_core: false },
     new_settings: { sort_by_content: true, sort_by_core: false },
     saves_count: 12,
-    ...overrides,
   };
+  // An explicit `undefined` override removes the (optional) field entirely so
+  // the component's truthiness checks see it as absent — passing through
+  // `{ field: undefined }` would leave the key present under
+  // exactOptionalPropertyTypes.
+  for (const [key, val] of Object.entries(overrides)) {
+    if (val === undefined) {
+      delete result[key];
+    } else {
+      result[key] = val;
+    }
+  }
+  return result as unknown as SaveSortMigrationStatus;
 }
 
 function defaultProps(overrides: Partial<React.ComponentProps<typeof SaveSortMigrationSection>> = {}) {

--- a/src/components/settings/TextInputModal.test.tsx
+++ b/src/components/settings/TextInputModal.test.tsx
@@ -8,12 +8,12 @@ import { TextInputModal, pendingEdits } from "./TextInputModal";
 // <div> drops them. Mirrors the NewSlotModal test pattern.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 interface CapturedConfirm {
-  onOK?: () => void;
-  bDisableBackgroundDismiss?: boolean;
+  onOK?: (() => void) | undefined;
+  bDisableBackgroundDismiss?: boolean | undefined;
   closeModal?: unknown;
-  strTitle?: string;
+  strTitle?: string | undefined;
 }
-const captured: CapturedConfirm & { textFieldPassword?: boolean } = {};
+const captured: CapturedConfirm & { textFieldPassword?: boolean | undefined } = {};
 
 vi.mock("@decky/ui", () => ({
   ConfirmModal: (p: AnyProps & CapturedConfirm) => {

--- a/src/components/settings/TextInputModal.tsx
+++ b/src/components/settings/TextInputModal.tsx
@@ -31,7 +31,7 @@ export const TextInputModal: FC<TextInputModalProps> = ({
   const [value, setValue] = useState(initial);
   return (
     <ConfirmModal
-      closeModal={closeModal}
+      {...(closeModal !== undefined ? { closeModal } : {})}
       onOK={() => {
         if (field) {
           pendingEdits[field] = value;
@@ -45,7 +45,7 @@ export const TextInputModal: FC<TextInputModalProps> = ({
         focusOnMount={true}
         label={label}
         value={value}
-        bIsPassword={bIsPassword}
+        {...(bIsPassword !== undefined ? { bIsPassword } : {})}
         onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
       />
     </ConfirmModal>

--- a/src/test-utils/steamStubs.ts
+++ b/src/test-utils/steamStubs.ts
@@ -36,8 +36,8 @@ export function stubAppStore(overviews: Record<number, OverviewLike>): void {
         appid: o.appid ?? id,
         display_name: o.display_name ?? "",
         strDisplayName: o.strDisplayName ?? "",
-        rt_last_time_played: o.rt_last_time_played,
-        minutes_playtime_forever: o.minutes_playtime_forever,
+        ...(o.rt_last_time_played !== undefined ? { rt_last_time_played: o.rt_last_time_played } : {}),
+        ...(o.minutes_playtime_forever !== undefined ? { minutes_playtime_forever: o.minutes_playtime_forever } : {}),
       };
     }),
     allApps: [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "types": ["vitest/globals", "@testing-library/jest-dom/vitest"]


### PR DESCRIPTION
Ratchet box of #838 (the `exactOptionalPropertyTypes` box). **Does not close the umbrella.**

Second of the frontend-strictness trio (after #854 `noUncheckedIndexedAccess`). `no-unnecessary-condition` is the planned third, to be re-assessed separately (it's judgment-heavy).

## What
Adds `"exactOptionalPropertyTypes": true` to `tsconfig.json`. TypeScript now distinguishes an **absent** optional property (`{x?: T}`) from one explicitly set to `undefined` (`{x: T | undefined}`), so an accidental explicit-`undefined` assignment to an optional field is a compile error.

## Fallout (all fixed here)
21 errors across 10 files (mostly test/stub) — **all mechanical, zero latent bugs**. Fixes:
- **`@decky/ui` props we don't own** (`nProgress`, `closeModal`, `onFocus`, `disabled`, `bIsPassword`): conditionally include the prop rather than pass explicit `undefined` (`{...(cond ? {prop: x} : {})}`). For these consumers omit ≡ undefined, so the indeterminate/unset behavior is identical — verified per-site.
- **our own `Tile.subtitle`**: widened the declaration to `string | undefined` (the call site genuinely passes conditional-undefined — the honest declaration).
- **test fixtures/stubs**: omit undefined-valued keys so they're *absent* (not explicit-undefined), matching the "field missing" intent the tests assert.

No `@ts-ignore` / `eslint-disable`. One localized `as unknown as` in the `SaveSortMigrationSection` test helper to support key-deletion (commented; the type has plain optionals and those tests need the key absent).

## Verification
- `pnpm typecheck`: 0 errors · `pnpm lint`: 0 (+2 baseline warnings) · `pnpm format:check`: clean · `pnpm test`: 1059 passed
- A code-reviewer pass independently re-ran all checks and verified every conditional-include is runtime-identical to before (no HIGH/MEDIUM findings; the lone double-cast verdicted acceptable-as-is).

docs: N/A — type-safety compiler flag + mechanical prop/fixture adjustments; no user-facing, architecture, or flow change.