### PR TITLE
fix(downloads): key multi-file detection on total file count, not has_multiple_files

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -145,6 +145,8 @@ RomM exposes three mutually exclusive file-layout flags on every ROM detail. The
 
 **Why nested-single is flattened locally**: a nested-single-file ROM has no sidecars by definition — RomM would mark it `has_multiple_files` if any companion files existed. The parent folder adds no value at the local layer, so the plugin drops it and stores the ROM directly in the platform folder, matching the simple-single-file layout. Multi-file ROMs keep their per-game subfolder because they contain multiple related files that belong together.
 
+**Extract-vs-flat gate keys on `len(files) > 1`, not on `has_multiple_files`**: the plugin decides ZIP-extract vs single-file download with the `is_multi_file_download` helper (`domain/rom_files.py`), which returns `len(files) > 1 OR has_multiple_files`. This mirrors RomM's own download gate, which zips whenever the **total** file count is not exactly 1. RomM computes `has_multiple_files` from **top-level** files only, so the two counts disagree for a nested layout: a canonical Switch game (base file at the root plus `update/` and `dlc/` in subfolders) has exactly one top-level file (`has_multiple_files=False`, `has_nested_single_file=True`) yet more than one total file, so RomM serves a ZIP. Keying on `has_multiple_files` alone would take the single-file path and write the ZIP bytes verbatim into one unreadable `.nsp`. The boolean is kept as a defensive fallback for payloads that omit `files`; a genuine nested-single ROM has `len(files) == 1` and correctly stays on the flat single-file path.
+
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
 
 ### Adapters (`py_modules/adapters/`)

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -10,6 +10,34 @@ from __future__ import annotations
 _DISC_EXTENSIONS = (".cue", ".chd", ".iso")
 
 
+def is_multi_file_download(rom_detail: dict) -> bool:
+    """Decide whether RomM will serve this ROM as a ZIP that must be extracted.
+
+    This is the single multi-vs-single gate for the download path. It must
+    mirror RomM's own download gate rather than RomM's ``has_multiple_files``
+    flag, because the two are computed from different file counts:
+
+    - RomM sets ``has_multiple_files = len(top_level_files) > 1`` — it counts
+      only files at the ROM root.
+    - RomM's download/content endpoint zips whenever ``len(rom.files) != 1`` —
+      it counts *all* files, including ones in subfolders.
+
+    A canonical Switch game is a folder with the base file at the root plus
+    ``update/`` and ``dlc/`` in subfolders: exactly one top-level file, so
+    ``has_multiple_files`` is ``False`` and ``has_nested_single_file`` is
+    ``True``, yet ``len(files) > 1`` so RomM streams a ZIP. Keying on the flag
+    alone takes the single-file path and writes the ZIP bytes verbatim into one
+    file the emulator cannot read.
+
+    Returning ``len(files) > 1 OR has_multiple_files`` keys on the total file
+    count (matching the zip decision) while keeping the flag as a defensive
+    fallback for payloads that omit ``files``. Genuine nested-single ROMs have
+    ``len(files) == 1`` and correctly stay on the single-file path.
+    """
+    files = rom_detail.get("files") or []
+    return len(files) > 1 or bool(rom_detail.get("has_multiple_files", False))
+
+
 def needs_m3u(disc_files: list[str]) -> bool:
     """Return True if an M3U playlist should be generated.
 

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -16,7 +16,13 @@ from typing import TYPE_CHECKING
 
 from models.state import InstalledRomEntry, PluginState
 
-from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
+from domain.rom_files import (
+    build_m3u_content,
+    detect_launch_file,
+    is_multi_file_download,
+    needs_m3u,
+    resolve_local_file_name,
+)
 from lib.errors import error_response
 
 if TYPE_CHECKING:
@@ -186,7 +192,7 @@ class DownloadService:
         self._download_file_store.make_dirs(roms_dir)
         free_space = self._download_file_store.disk_free(roms_dir)
         buffer = 100 * 1024 * 1024
-        required = file_size * 2 + buffer if rom_detail.get("has_multiple_files") else file_size + buffer
+        required = file_size * 2 + buffer if is_multi_file_download(rom_detail) else file_size + buffer
         if file_size and free_space < required:
             self._download_in_progress.discard(rom_id)
             free_mb = free_space // (1024 * 1024)
@@ -312,7 +318,7 @@ class DownloadService:
     async def _do_download(self, rom_id, rom_detail, target_path, system, file_name):
         rom_name = rom_detail.get("name", file_name)
         platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
-        has_multiple = rom_detail.get("has_multiple_files", False)
+        has_multiple = is_multi_file_download(rom_detail)
         progress_callback = self._make_progress_callback(rom_id, rom_name, platform_name, file_name)
 
         try:
@@ -351,14 +357,14 @@ class DownloadService:
 
         except asyncio.CancelledError:
             self._download_queue[rom_id]["status"] = "cancelled"
-            self._cleanup_partial_download(target_path, rom_detail.get("has_multiple_files", False), file_name)
+            self._cleanup_partial_download(target_path, has_multiple, file_name)
             self._logger.info(f"Download cancelled: {rom_name}")
             raise
 
         except Exception as e:
             self._download_queue[rom_id]["status"] = "failed"
             self._download_queue[rom_id]["error"] = str(e)
-            self._cleanup_partial_download(target_path, rom_detail.get("has_multiple_files", False), file_name)
+            self._cleanup_partial_download(target_path, has_multiple, file_name)
             self._logger.error(f"Download failed for {rom_name}: {e}")
             await self._emit(
                 "download_failed",

--- a/tests/domain/test_rom_files.py
+++ b/tests/domain/test_rom_files.py
@@ -5,7 +5,13 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "py_modules"))
 
-from domain.rom_files import build_m3u_content, detect_launch_file, needs_m3u, resolve_local_file_name
+from domain.rom_files import (
+    build_m3u_content,
+    detect_launch_file,
+    is_multi_file_download,
+    needs_m3u,
+    resolve_local_file_name,
+)
 
 
 def _with_sizes(paths: list[str]) -> list[tuple[str, int]]:
@@ -18,6 +24,69 @@ def _with_sizes(paths: list[str]) -> list[tuple[str, int]]:
             size = 0
         result.append((p, size))
     return result
+
+
+class TestIsMultiFileDownload:
+    def test_zero_files_and_no_flag_is_single(self):
+        assert is_multi_file_download({"files": []}) is False
+
+    def test_one_file_and_no_flag_is_single(self):
+        assert is_multi_file_download({"files": [{"file_name": "game.nsp"}]}) is False
+
+    def test_two_files_is_multi(self):
+        rom_detail = {
+            "files": [{"file_name": "base.nsp"}, {"file_name": "update/patch.nsp"}],
+        }
+        assert is_multi_file_download(rom_detail) is True
+
+    def test_three_files_is_multi(self):
+        rom_detail = {
+            "files": [
+                {"file_name": "base.nsp"},
+                {"file_name": "update/patch.nsp"},
+                {"file_name": "dlc/extra.nsp"},
+            ],
+        }
+        assert is_multi_file_download(rom_detail) is True
+
+    def test_flag_true_with_one_file_falls_back_to_multi(self):
+        # Defensive fallback: trust the boolean even when files implies single.
+        rom_detail = {"has_multiple_files": True, "files": [{"file_name": "game.zip"}]}
+        assert is_multi_file_download(rom_detail) is True
+
+    def test_nested_switch_single_top_level_but_many_files_is_multi(self):
+        # #855: Switch base/update/DLC folder — exactly one top-level file so
+        # has_multiple_files is False, but total file count > 1 → RomM zips it.
+        rom_detail = {
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "base.nsp"},
+                {"file_name": "update/patch.nsp"},
+                {"file_name": "dlc/extra.nsp"},
+            ],
+        }
+        assert is_multi_file_download(rom_detail) is True
+
+    def test_genuine_nested_single_stays_single(self):
+        # has_nested_single_file with exactly one file must NOT be treated as multi.
+        rom_detail = {
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [{"file_name": "game.chd"}],
+        }
+        assert is_multi_file_download(rom_detail) is False
+
+    def test_missing_files_key_uses_flag_only(self):
+        assert is_multi_file_download({"has_multiple_files": True}) is True
+        assert is_multi_file_download({"has_multiple_files": False}) is False
+
+    def test_missing_both_keys_is_single(self):
+        assert is_multi_file_download({}) is False
+
+    def test_files_explicitly_none_uses_flag_only(self):
+        assert is_multi_file_download({"files": None, "has_multiple_files": True}) is True
+        assert is_multi_file_download({"files": None}) is False
 
 
 class TestNeedsM3u:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -551,6 +551,50 @@ class TestDiskSpaceMultiFile:
 
         assert result["success"] is True
 
+    @pytest.mark.asyncio
+    async def test_nested_multi_file_rom_requires_double_space(self, plugin, tmp_path):
+        """#855: nested-multi (has_multiple_files=False, len(files) > 1) reserves 2x."""
+        from unittest.mock import AsyncMock
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+
+        file_size = 500 * 1024 * 1024  # 500MB
+        rom_detail = {
+            "id": 44,
+            "name": "Switch Game",
+            "fs_name": "game.nsp",
+            "fs_size_bytes": file_size,
+            "platform_slug": "switch",
+            "platform_name": "Nintendo Switch",
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "game.nsp"},
+                {"file_name": "update/patch.nsp"},
+            ],
+        }
+
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
+
+        # 700MB free: enough for single-file (600MB) but not multi-file (1100MB).
+        # If the gate only read has_multiple_files (False), this would pass —
+        # the 2x reservation is what makes it fail.
+        plugin._download_service._download_file_store.disk_free = lambda _path: 700 * 1024 * 1024
+        result = await plugin.start_download(44)
+
+        assert result["success"] is False
+        assert "disk space" in result["message"].lower()
+
 
 class TestMultiFileRomDeletion:
     @pytest.mark.asyncio
@@ -815,6 +859,143 @@ class TestDoDownloadMultiFile:
         # Status is completed
         assert plugin._download_service._download_queue[55]["status"] == "completed"
 
+    @pytest.mark.asyncio
+    async def test_nested_multi_file_takes_extract_path(self, plugin, tmp_path):
+        """#855: one top-level file but len(files) > 1 → RomM zips → EXTRACT path.
+
+        Switch base/update/DLC: ``has_multiple_files=False`` (single top-level
+        file) yet ``len(files) > 1``. RomM streams a mod_zip ZIP, so the plugin
+        must extract it into a per-game folder instead of writing the ZIP bytes
+        verbatim into one .nsp.
+        """
+        import zipfile as zf
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "switch"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "Zelda.nsp")
+
+        # Real ZIP mirroring RomM's mod_zip output: base at root + nested update/DLC
+        zip_content_path = tmp_path / "source.zip"
+        with zf.ZipFile(str(zip_content_path), "w") as z:
+            z.writestr("Zelda.nsp", b"\x00" * 100)
+            z.writestr("update/Zelda_update.nsp", b"\x00" * 100)
+            z.writestr("dlc/Zelda_dlc.nsp", b"\x00" * 100)
+        zip_bytes = zip_content_path.read_bytes()
+
+        rom_detail = {
+            "id": 99,
+            "name": "Zelda",
+            "fs_name": "Zelda.nsp",
+            "fs_name_no_ext": "Zelda",
+            "platform_slug": "switch",
+            "platform_name": "Nintendo Switch",
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "Zelda.nsp"},
+                {"file_name": "update/Zelda_update.nsp"},
+                {"file_name": "dlc/Zelda_dlc.nsp"},
+            ],
+        }
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(zip_bytes)
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[99] = {"rom_id": 99, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(99, rom_detail, target_path, "switch", "Zelda.nsp")
+
+        # ZIP is extracted into a per-game folder (not written verbatim into one .nsp)
+        extract_dir = roms_dir / "Zelda"
+        assert extract_dir.is_dir()
+        assert (extract_dir / "Zelda.nsp").exists()
+        assert (extract_dir / "update" / "Zelda_update.nsp").exists()
+        assert (extract_dir / "dlc" / "Zelda_dlc.nsp").exists()
+        # The verbatim single-file artifact must NOT exist
+        assert not os.path.exists(target_path)
+        # .zip.tmp is cleaned up
+        assert not os.path.exists(target_path + ".zip.tmp")
+        # installed_roms entry registers rom_dir (extract path), not a flat file
+        installed = plugin._state["installed_roms"].get("99")
+        assert installed is not None
+        assert installed["rom_dir"] == str(extract_dir)
+        assert plugin._download_service._download_queue[99]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_nested_multi_file_cleanup_removes_extract_dir(self, plugin, tmp_path):
+        """#855: a nested-multi download failure must remove the extract dir.
+
+        The partial-download cleanup keys on the same multi-file gate, so a
+        ZIP-extraction failure for a nested-multi ROM must tear down the
+        per-game folder (the 2x-reservation multi-file branch), not leave it.
+        """
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "switch"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "Zelda.nsp")
+
+        # Pre-seed an extract dir as if extraction had partially happened.
+        extract_dir = roms_dir / "Zelda"
+        extract_dir.mkdir()
+        (extract_dir / "Zelda.nsp").write_bytes(b"\x00" * 100)
+
+        rom_detail = {
+            "id": 99,
+            "name": "Zelda",
+            "fs_name": "Zelda.nsp",
+            "fs_name_no_ext": "Zelda",
+            "platform_slug": "switch",
+            "platform_name": "Nintendo Switch",
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "Zelda.nsp"},
+                {"file_name": "update/Zelda_update.nsp"},
+            ],
+        }
+
+        def fake_download(_rom_id, _filename, _dest, _progress_callback=None):
+            raise OSError("network died mid-download")
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[99] = {"rom_id": 99, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(99, rom_detail, target_path, "switch", "Zelda.nsp")
+
+        # Failure path keyed on the multi-file gate → extract dir torn down.
+        assert not extract_dir.exists()
+        assert plugin._download_service._download_queue[99]["status"] == "failed"
+
 
 class TestDoDownloadNestedSingleFile:
     """Tests for has_nested_single_file: fs_name is the parent folder, not the file (#226)."""
@@ -915,6 +1096,10 @@ class TestDoDownloadNestedSingleFile:
         assert installed["file_path"] == target_path
         # Must NOT keep the parent-folder name from fs_name as a real on-disk file
         assert not os.path.exists(str(roms_dir / "My Game"))
+        # #855 regression: a genuine nested-single ROM (len(files) == 1) must
+        # stay on the single-file path — it flattens to a flat file and never
+        # registers an extract directory.
+        assert "rom_dir" not in installed
 
     @pytest.mark.asyncio
     async def test_nested_single_file_start_download_uses_files_entry(self, plugin, tmp_path):


### PR DESCRIPTION
## Problem

Nested multi-file ROMs — canonically a Switch game stored as a folder with the base `.nsp` at the root and `update/`/`dlc/` in subfolders — were mis-detected as single-file. The plugin wrote RomM's mod_zip archive bytes verbatim into one `.nsp`, producing a ZIP-with-a-`.nsp`-extension the emulator can't read. Reported in #837 (Switch + Eden); same symptom in `rommapp/playnite-plugin#37`.

## Root cause (verified against RomM 4.8.1 source)

RomM computes `has_multiple_files = len(top_level_files) > 1` (top-level only), but its content endpoint zips whenever `len(files) != 1` (all files incl. nested). A nested Switch folder has one top-level file (`has_multiple_files=False`, `has_nested_single_file=True`) yet `len(files) > 1` → RomM serves a ZIP, while the plugin keyed on the flag and took the single-file path.

## Fix

- New pure helper `is_multi_file_download(rom_detail)` in `domain/rom_files.py`: `len(files) > 1 or has_multiple_files` — mirrors RomM's own download gate, keeps the boolean as a defensive fallback, leaves genuine nested-single (`len == 1`) on the flat path.
- All four multi-vs-single gates in `services/downloads.py` (disk-space pre-flight, extract-vs-raw branch, both partial-download cleanups) route through the helper. No direct `has_multiple_files` read remains.
- Docs: `backend-architecture.md` notes the gate keys on `len(files) > 1`.

## Tests

11 helper unit tests + nested-multi service tests (extract path produces the folder tree and registers `rom_dir`, cleanup tears down the extract dir, 2× disk reservation) + a genuine-nested-single regression.

## Verification

`ruff check` ✓ · `basedpyright py_modules tests` 0/0/0 ✓ · `pytest tests/` 2919 passed (100% line + branch on both changed files) · cosmic call-bans ✓ · import-linter ✓

## Note for #784 (SQLite cutover)

The cutover branch rewrites `downloads.py` persistence (`installed_roms` → `uow.rom_installs`) but still carries the buggy `has_multiple_files` gates. After rebasing onto main, route those gates through `is_multi_file_download` and re-point the 3 nested-multi service tests to the uow assertion style. The helper + its unit tests are drop-in.

Closes #855
Closes #837
