### PR TITLE
fix(types): make @decky/ui + callable boundary types honest

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -145,7 +145,17 @@ export const removePlatformShortcuts = callable<
 >("remove_platform_shortcuts");
 export const removeAllShortcuts = callable<
   [],
-  { success: boolean; message: string; removed_count: number; app_ids: number[]; rom_ids: (string | number)[] }
+  {
+    success: boolean;
+    // The success path returns only success/app_ids/rom_ids; the
+    // @migration_blocked gate short-circuits to success/message/
+    // blocked_by_migration, omitting app_ids/rom_ids. Every field below the
+    // discriminant is therefore path-dependent.
+    message?: string;
+    app_ids?: number[];
+    rom_ids?: (string | number)[];
+    blocked_by_migration?: boolean;
+  }
 >("remove_all_shortcuts");
 export const getArtworkBase64 = callable<[number], { base64: string | null }>("get_artwork_base64");
 export const refreshCoverArtwork = callable<

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -11,17 +11,8 @@
 
 import { useState, useEffect, useRef, FC } from "react";
 import { addEventListener, removeEventListener, toaster } from "@decky/api";
-import {
-  Focusable,
-  DialogButton,
-  ConfirmModal,
-  Menu,
-  MenuItem,
-  showContextMenu,
-  showModal,
-  appActionButtonClasses,
-  basicAppDetailsSectionStylerClasses,
-} from "@decky/ui";
+import { Focusable, DialogButton, ConfirmModal, Menu, MenuItem, showContextMenu, showModal } from "@decky/ui";
+import { appActionButtonClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { hideNativePlaySection, showNativePlaySection } from "../utils/styleInjector";
 import { hasAnySaveConflict } from "../utils/saveStatus";
 import {

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -76,7 +76,6 @@ describe("DangerZone", () => {
     vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
       success: true,
       message: "",
-      removed_count: 0,
       app_ids: [],
       rom_ids: [],
     });
@@ -564,7 +563,6 @@ describe("DangerZone", () => {
       vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
         success: true,
         message: "Removed 5",
-        removed_count: 5,
         app_ids: [10, 20],
         rom_ids: [1, 2],
       });
@@ -594,7 +592,6 @@ describe("DangerZone", () => {
       vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
         success: true,
         message: "Removed 0",
-        removed_count: 0,
         app_ids: [],
         rom_ids: [],
       });

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -210,7 +210,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         await reportRemovalResults(result.rom_ids);
       }
       await clearAllRomMCollections();
-      setStatus(result.message);
+      setStatus(result.message ?? "All shortcuts removed");
     } catch {
       setStatus("Failed to remove shortcuts");
     }

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -114,6 +114,12 @@ vi.mock("@decky/ui", async () => {
   const { createElement: ce } = await import("react");
   return {
     basicAppDetailsSectionStylerClasses: { PlaySection: "play-section-cls" },
+    // deckyUiInternals re-exports these @decky/ui internals; they must exist on
+    // the mock even when this suite doesn't assert on them.
+    appActionButtonClasses: undefined,
+    appDetailsClasses: undefined,
+    playSectionClasses: undefined,
+    findSP: vi.fn(() => undefined),
     ConfirmModal: (p: AnyProps) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),
     DialogButton: ({
       children,

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -13,7 +13,6 @@
 import { useState, useEffect, useRef, FC, createElement } from "react";
 import { toaster } from "@decky/api";
 import {
-  basicAppDetailsSectionStylerClasses,
   ConfirmModal,
   DialogButton,
   Focusable,
@@ -23,6 +22,7 @@ import {
   showContextMenu,
   showModal,
 } from "@decky/ui";
+import { basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icons/fa";
 import { CustomPlayButton } from "./CustomPlayButton";
 import { SgdbGamePickerModalContent } from "./SgdbGamePickerModal";

--- a/src/patches/gameDetailPatch.tsx
+++ b/src/patches/gameDetailPatch.tsx
@@ -9,14 +9,8 @@
 
 import { createElement } from "react";
 import { routerHook } from "@decky/api";
-import {
-  afterPatch,
-  findInReactTree,
-  appDetailsClasses,
-  createReactTreePatcher,
-  playSectionClasses,
-  basicAppDetailsSectionStylerClasses,
-} from "@decky/ui";
+import { afterPatch, findInReactTree, createReactTreePatcher } from "@decky/ui";
+import { appDetailsClasses, playSectionClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { RomMPlaySection } from "../components/RomMPlaySection";
 import { RomMGameInfoPanel } from "../components/RomMGameInfoPanel";
 import { debugLog } from "../api/backend";
@@ -87,10 +81,12 @@ function deepTreeDump(node: any, depth: number, index: number, prefix: string): 
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
 function findInsertionPoint(ret: any): any {
+  const innerContainerClass = appDetailsClasses?.InnerContainer;
+  if (!innerContainerClass) return undefined;
   return findInReactTree(
     ret,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Steam internal React tree; runtime shape is dynamic, no upstream types ship
-    (x: any) => Array.isArray(x?.props?.children) && x?.props?.className?.includes(appDetailsClasses.InnerContainer),
+    (x: any) => Array.isArray(x?.props?.children) && x?.props?.className?.includes(innerContainerClass),
   );
 }
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -147,5 +147,7 @@ vi.mock("@decky/ui", () => {
     findSP: vi.fn(() => undefined),
     appActionButtonClasses: undefined,
     basicAppDetailsSectionStylerClasses: undefined,
+    appDetailsClasses: undefined,
+    playSectionClasses: undefined,
   };
 });

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -14,7 +14,12 @@ declare var SteamClient: {
       assetType: number,
     ): Promise<void>;
     ClearCustomArtworkForApp(appId: number, assetType: number): Promise<void>;
-    RegisterForAppDetails(appId: number, callback: (details: SteamAppDetails) => void): { unregister: () => void };
+    // The runtime may invoke the callback with no details before the app's
+    // data is loaded — `details` is genuinely absent on early fires.
+    RegisterForAppDetails(
+      appId: number,
+      callback: (details: SteamAppDetails | undefined) => void,
+    ): { unregister: () => void };
     RunGame(gameId: string | number, launchId: string, param2: number, param3: number): void;
     TerminateApp(appId: number, force: boolean): void;
     RegisterForGameActionStart(
@@ -88,7 +93,9 @@ interface SteamCollection {
 }
 
 declare var collectionStore: {
-  deckDesktopApps: { apps: Map<number, any> };
+  // Populated asynchronously by Steam — absent until the desktop-apps
+  // collection is built, so reads must guard.
+  deckDesktopApps?: { apps: Map<number, any> };
   localGamesCollection?: { apps: Map<number, any> };
   userCollections: SteamCollection[];
   GetCollection(id: string): SteamCollection | undefined;

--- a/src/utils/deckyUiInternals.ts
+++ b/src/utils/deckyUiInternals.ts
@@ -1,0 +1,32 @@
+/**
+ * Honest-typed re-exports of @decky/ui internal lookups whose runtime presence
+ * isn't guaranteed.
+ *
+ * @decky/ui populates its class-map consts and `findSP` via `findClassModule` /
+ * webpack module probes that can return `undefined` at runtime — its own code
+ * even writes `findSP() || window`. Upstream still types them as always-present
+ * (`declare const x: T`, `findSP(): Window`), so direct consumers get a lying
+ * non-null type and their defensive `?.` guards read as dead code. TS cannot
+ * re-type a `const`/function via `declare module` augmentation, so this thin
+ * runtime re-export module re-declares each as `T | undefined`, making the
+ * guards legitimate.
+ *
+ * Any future @decky/ui value sourced from a findClassModule-style probe belongs
+ * here, typed honestly.
+ */
+
+import {
+  appActionButtonClasses as _appActionButtonClasses,
+  basicAppDetailsSectionStylerClasses as _basicAppDetailsSectionStylerClasses,
+  appDetailsClasses as _appDetailsClasses,
+  playSectionClasses as _playSectionClasses,
+  findSP as _findSP,
+} from "@decky/ui";
+
+export const appActionButtonClasses: typeof _appActionButtonClasses | undefined = _appActionButtonClasses;
+export const basicAppDetailsSectionStylerClasses: typeof _basicAppDetailsSectionStylerClasses | undefined =
+  _basicAppDetailsSectionStylerClasses;
+export const appDetailsClasses: typeof _appDetailsClasses | undefined = _appDetailsClasses;
+export const playSectionClasses: typeof _playSectionClasses | undefined = _playSectionClasses;
+
+export const findSP = (): Window | undefined => _findSP();

--- a/src/utils/scrollHelpers.ts
+++ b/src/utils/scrollHelpers.ts
@@ -45,7 +45,7 @@ type FocusLike = { currentTarget: EventTarget | null };
  * scroll container. Use on DialogButton elements for gamepad navigation.
  */
 export function scrollFocusedToCenter(e: FocusLike): void {
-  const el = e.currentTarget as HTMLElement;
+  const el = e.currentTarget as HTMLElement | null;
   setTimeout(() => {
     if (!el) return;
     const scrollParent = findScrollParent(el);
@@ -63,7 +63,7 @@ export function scrollFocusedToCenter(e: FocusLike): void {
  * Use on the Play button so navigating back up reveals the banner/hero.
  */
 export function scrollToTop(e: FocusLike): void {
-  const el = e.currentTarget as HTMLElement;
+  const el = e.currentTarget as HTMLElement | null;
   setTimeout(() => {
     if (!el) return;
     // Use the outermost scroll parent so the banner/hero scrolls into view,

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -14,7 +14,10 @@ export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
 
   if (typeof collectionStore === "undefined") return result;
 
-  const appIds = Array.from(collectionStore.deckDesktopApps.apps.keys());
+  const deckApps = collectionStore.deckDesktopApps?.apps;
+  if (!deckApps) return result;
+
+  const appIds = Array.from(deckApps.keys());
 
   // Fire up to 10 RegisterForAppDetails calls in parallel to avoid 2s-per-shortcut overhead
   const CONCURRENCY = 10;

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -1,4 +1,4 @@
-import { findSP } from "@decky/ui";
+import { findSP } from "./deckyUiInternals";
 
 const ROMM_PLAY_HIDE_ID = "romm-hide-native-play";
 const ROMM_FOCUS_STYLES_ID = "romm-focus-styles";


### PR DESCRIPTION
Foundation for adopting `no-unnecessary-condition` (ratchet box of #838) — the first of two PRs for that box. Must stay open against the umbrella; the box stays unticked until PR2 enables the rule.

## Why
The lint rule flags ~38 defensive guards as 'unnecessary' because the boundary types **lie** — they declare non-null what is actually runtime-optional (Steam internals, `@decky/ui` lookups, a callable return shape). Rather than suppress the rule where it's wrong, this PR makes the types **honest**, so the guards become legitimate. After this lands, the rule's residual is only the genuinely-redundant guards (PR2 removes those + turns the rule on).

## Changes
**Honest boundary types (KIND-A):**
- **New `src/utils/deckyUiInternals.ts`** — honest re-exports of the `@decky/ui` class-maps (`appActionButtonClasses`, `basicAppDetailsSectionStylerClasses`, `appDetailsClasses`, `playSectionClasses`) + `findSP`, each typed `T | undefined`. They're `findClassModule`/`findSP` results that can be absent at runtime (upstream's own code writes `findSP() || window`) but are declared non-null. TS can't re-type a `const`/function via `declare module` augmentation, so a thin runtime re-export is the honest seam. Consumers switch import source; existing `?.` guards become legitimate.
- **`steam.d.ts`** — `RegisterForAppDetails` callback `details` and `collectionStore.deckDesktopApps` widened to optional (+ a guarded ripple in `steamShortcuts.ts`).
- **`scrollHelpers.ts`** — `as HTMLElement` → `as HTMLElement | null` (deferred `setTimeout` `currentTarget` can be null).

**Real type-lie bug (KIND-B):**
- **`removeAllShortcuts`** return type: the `@migration_blocked` gate short-circuits to `{success:False, message, blocked_by_migration:True}` (omits `app_ids`/`rom_ids`), and the success path returns only `{success, app_ids, rom_ids}` (omits `message`). Made `message`/`app_ids`/`rom_ids` optional, added `blocked_by_migration?`, and **dropped the dead `removed_count`** (never sent on any path; that field belongs to `uninstallAllRoms`). `DangerZone` now falls back to "All shortcuts removed" when `message` is absent.

The 3 `decky.emit` event-payload candidates (`platform_app_ids`, `platform_name`, `file_name`) were checked against Python — **always emitted**, so left as redundant guards for PR2 to remove (not over-widened).

## Verification
- `pnpm typecheck`: 0 · `pnpm lint`: 0 (+2 baseline warnings) · `pnpm format:check`: clean · `pnpm test`: 1059 passed · `check_no_bare_ignores`: OK. No `as any`, no bare ignores.
- A code-reviewer pass cross-checked the `removeAllShortcuts` shape against the Python on all paths and verified the re-export module is runtime-identical; its one LOW finding (drop dead `removed_count`) is applied.

docs: N/A — type-honesty fix + internal boundary typing; no user-facing, architecture, or flow change (the "All shortcuts removed" fallback restores the intended message the lying type had masked).