### PR TITLE
chore(quality): enable eslint no-unnecessary-condition

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,7 @@ export default tseslint.config(
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/no-misused-promises": "error",
       "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
     },
   },
   {

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -141,7 +141,18 @@ export const saveCollectionPlatformGroups = callable<[boolean], { success: boole
 export const getRegistryPlatforms = callable<[], { platforms: RegistryPlatform[] }>("get_registry_platforms");
 export const removePlatformShortcuts = callable<
   [string],
-  { success: boolean; app_ids: number[]; rom_ids: (string | number)[]; platform_name: string }
+  {
+    success: boolean;
+    // The success path returns success/app_ids/rom_ids/platform_name; the
+    // @migration_blocked gate short-circuits to success/message/
+    // blocked_by_migration, omitting app_ids/rom_ids. Every field below the
+    // discriminant is therefore path-dependent (mirrors removeAllShortcuts).
+    app_ids?: number[];
+    rom_ids?: (string | number)[];
+    platform_name?: string;
+    message?: string;
+    blocked_by_migration?: boolean;
+  }
 >("remove_platform_shortcuts");
 export const removeAllShortcuts = callable<
   [],

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -233,7 +233,7 @@ describe("DangerZone", () => {
       // textContent gives us the visible label per row.
       fireEvent.click(getByText("Configure Whitelist (0 protected)"));
       const toggleRows = getAllByTestId("toggle");
-      const renderedNames = toggleRows.map((row) => row.textContent ?? "");
+      const renderedNames = toggleRows.map((row) => row.textContent);
       expect(renderedNames).toEqual(["Apple App", "Mango App", "Zebra App"]);
       logSpy.mockRestore();
     });
@@ -396,6 +396,30 @@ describe("DangerZone", () => {
         await Promise.resolve();
       });
       expect(container.textContent).toContain("Failed to remove shortcuts");
+    });
+
+    it("surfaces the migration-blocked message and skips removal when success is false", async () => {
+      setupOnePlatform();
+      // The @migration_blocked gate returns no app_ids/rom_ids — the handler
+      // must surface the message and not attempt any removal.
+      vi.mocked(backend.removePlatformShortcuts).mockResolvedValue({
+        success: false,
+        message: "Blocked: RetroDECK migration pending",
+        blocked_by_migration: true,
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (2)"));
+      const modalProps = lastShownModalProps<{ onRemoveShortcuts?: () => void }>();
+      await act(async () => {
+        modalProps?.onRemoveShortcuts?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain("Blocked: RetroDECK migration pending");
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.reportRemovalResults)).not.toHaveBeenCalled();
+      expect(vi.mocked(clearPlatformCollection)).not.toHaveBeenCalled();
     });
 
     it("renders the singular form for a 1-game platform", async () => {

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -138,10 +138,15 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     setActionStatus(`Removing ${p.name} shortcuts...`);
     try {
       const result = await removePlatformShortcuts(p.slug);
-      if (result.app_ids) {
-        for (const appId of result.app_ids) {
-          removeShortcut(appId);
-        }
+      // The @migration_blocked gate short-circuits to { success: false,
+      // message, blocked_by_migration } with no app_ids/rom_ids — surface
+      // that message instead of cosmetically reporting a removal.
+      if (!result.success) {
+        setActionStatus(result.message ?? "Failed to remove shortcuts");
+        return;
+      }
+      for (const appId of result.app_ids ?? []) {
+        removeShortcut(appId);
       }
       if (result.rom_ids?.length) {
         await reportRemovalResults(result.rom_ids);
@@ -421,7 +426,7 @@ const WhitelistSection: FC<WhitelistSectionProps> = ({
             <TextField
               label="Search games"
               value={whitelistSearch}
-              onChange={(e) => setWhitelistSearch(e?.target?.value ?? "")}
+              onChange={(e) => setWhitelistSearch(e.target.value)}
             />
           </PanelSectionRow>
           <PanelSectionRow>
@@ -601,7 +606,7 @@ export const DangerZone: FC<DangerZoneProps> = ({ onBack }) => {
     setLoading(true);
     try {
       const result = await getRegistryPlatforms();
-      setPlatforms(result.platforms || []);
+      setPlatforms(result.platforms);
     } catch {
       setPlatforms([]);
     }

--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -80,7 +80,7 @@ function makeItem(overrides: Partial<DownloadItem> = {}): DownloadItem {
 }
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement | null {
-  const btn = Array.from(container.querySelectorAll("button")).find((b) => (b.textContent ?? "").includes(text));
+  const btn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent.includes(text));
   return (btn as HTMLButtonElement | undefined) ?? null;
 }
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -246,7 +246,7 @@ function lastConfirmModalProps<T = Record<string, unknown>>(): T | null {
 }
 
 function fieldLabels(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll('[data-testid="field-label"]')).map((n) => n.textContent ?? "");
+  return Array.from(container.querySelectorAll('[data-testid="field-label"]')).map((n) => n.textContent);
 }
 
 // -----------------------------------------------------------------------------
@@ -804,7 +804,7 @@ describe("MainPage", () => {
         remove_count: 2,
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d?.includes("ROMs: 3 added, 1 updated, 2 removed"))).toBe(true);
+      expect(descs.some((d) => d.includes("ROMs: 3 added, 1 updated, 2 removed"))).toBe(true);
     });
 
     it("renders Platforms section from platform_collection_diff", async () => {
@@ -816,7 +816,7 @@ describe("MainPage", () => {
         },
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d?.includes("Platforms: 2 added, 1 removed"))).toBe(true);
+      expect(descs.some((d) => d.includes("Platforms: 2 added, 1 removed"))).toBe(true);
     });
 
     it("renders Collections section from collection_diff", async () => {
@@ -828,7 +828,7 @@ describe("MainPage", () => {
         },
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d?.includes("Collections: 2 added, 1 removed"))).toBe(true);
+      expect(descs.some((d) => d.includes("Collections: 2 added, 1 removed"))).toBe(true);
     });
 
     it("filters zero counts from formatChanges (e.g. 0 removed → not rendered)", async () => {
@@ -839,7 +839,7 @@ describe("MainPage", () => {
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
       // Should render "ROMs: 1 added" — no "updated" or "removed" tokens.
-      const romsLine = descs.find((d) => d?.startsWith("ROMs:"));
+      const romsLine = descs.find((d) => d.startsWith("ROMs:"));
       expect(romsLine).toBe("ROMs: 1 added");
     });
   });

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -23,7 +23,7 @@ import {
   domListenerCount,
 } from "../test-utils/dom-event-listener-spy";
 import { useVersionError } from "./VersionErrorCard";
-import type { MigrationStatus, SaveSortMigrationStatus } from "../types";
+import type { MigrationStatus, SaveSortMigrationStatus, RomMetadata } from "../types";
 
 // Type-only imports — vi.mock(...) below replaces the runtime impl, but
 // pinning captured-props shapes to the real component keeps assertions in
@@ -147,6 +147,29 @@ const flushAsync = () =>
 
 let testAppId = 5000;
 
+// Complete RomMetadata fixture. The backend always serializes every field
+// (RomMetadata is a strict dataclass → MetadataCacheEntry TypedDict), so the
+// component never sees a partial metadata object. Tests that only care about a
+// subset still get a fully-shaped object so array fields (genres/companies/
+// game_modes) are present. The `& Record<string, unknown>` return makes the
+// fixture usable both for the `getRomMetadata` mock (typed `RomMetadata`) and
+// the `getCachedGameDetail` mock's loosely-typed `metadata` field — a
+// RomMetadata genuinely is a string-keyed record at runtime.
+function makeMetadata(overrides: Partial<RomMetadata> = {}): RomMetadata & Record<string, unknown> {
+  return {
+    summary: "",
+    genres: [],
+    companies: [],
+    first_release_date: null,
+    average_rating: null,
+    game_modes: [],
+    player_count: "",
+    cached_at: 0,
+    steam_categories: [],
+    ...overrides,
+  };
+}
+
 describe("RomMGameInfoPanel", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -201,7 +224,7 @@ describe("RomMGameInfoPanel", () => {
       retrodeck: { pending: false },
       save_sort: { pending: false },
     });
-    vi.mocked(backend.getRomMetadata).mockResolvedValue({} as never);
+    vi.mocked(backend.getRomMetadata).mockResolvedValue(makeMetadata());
     vi.mocked(backend.getInstalledRom).mockResolvedValue(null);
     vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: null });
     vi.mocked(backend.checkPlatformBios).mockResolvedValue({ needs_bios: false });
@@ -317,7 +340,7 @@ describe("RomMGameInfoPanel", () => {
         platform_slug: "snes",
         installed: true,
         save_sync_enabled: true,
-        metadata: { summary: "An RPG.", genres: ["RPG"] } as never,
+        metadata: makeMetadata({ summary: "An RPG.", genres: ["RPG"] }),
         ra_id: 7,
         stale_fields: ["metadata"],
         bios_status: {
@@ -347,7 +370,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 99,
-        metadata: { summary: "ok" } as never,
+        metadata: makeMetadata({ summary: "ok" }),
         stale_fields: [],
       });
       render(<RomMGameInfoPanel appId={testAppId} />);
@@ -372,7 +395,7 @@ describe("RomMGameInfoPanel", () => {
         rom_id: 99,
         installed: false,
         stale_fields: [],
-        metadata: {} as never,
+        metadata: makeMetadata(),
       });
       render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
@@ -385,7 +408,7 @@ describe("RomMGameInfoPanel", () => {
         rom_id: 99,
         save_sync_enabled: false,
         stale_fields: [],
-        metadata: {} as never,
+        metadata: makeMetadata(),
       });
       render(<RomMGameInfoPanel appId={testAppId} />);
       await flushAsync();
@@ -405,7 +428,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 42,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getSaveSlots).mockResolvedValue({
@@ -429,7 +452,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 42,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockRejectedValue(new Error("net"));
@@ -500,7 +523,7 @@ describe("RomMGameInfoPanel", () => {
         rom_id: 100,
         installed: true,
         platform_name: "Super Nintendo",
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getInstalledRom).mockResolvedValue({
@@ -533,7 +556,7 @@ describe("RomMGameInfoPanel", () => {
         rom_id: 100,
         installed: true,
         platform_name: "Super Nintendo",
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getInstalledRom).mockResolvedValue({
@@ -564,7 +587,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 100,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
@@ -586,7 +609,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 100,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -610,7 +633,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: romId,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const view = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -674,7 +697,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 55,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -944,7 +967,7 @@ describe("RomMGameInfoPanel", () => {
           all_downloaded: true,
           active_core_label: "FROM_CORE_CHANGED",
         } as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       await act(async () => {
@@ -986,7 +1009,7 @@ describe("RomMGameInfoPanel", () => {
           all_downloaded: true,
           active_core_label: "INITIAL_CORE",
         } as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const view = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1146,7 +1169,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { queryByTestId } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1163,7 +1186,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1187,7 +1210,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         platform_name: "Super Nintendo",
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1201,7 +1224,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         ra_id: null,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1214,7 +1237,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1233,7 +1256,7 @@ describe("RomMGameInfoPanel", () => {
           local_count: 0,
           all_downloaded: false,
         } as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1247,7 +1270,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         save_sync_enabled: false,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1260,7 +1283,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1284,7 +1307,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getAchievements).mockResolvedValue({
@@ -1377,7 +1400,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getAchievements).mockResolvedValue({
@@ -1410,7 +1433,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       // Hold the achievement promises so achievementsLoading stays true.
@@ -1434,7 +1457,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.getAchievements).mockRejectedValue(new Error("net"));
@@ -1464,7 +1487,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 88,
         ra_id: 42,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1511,7 +1534,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 77,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
@@ -1549,7 +1572,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 11,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
@@ -1571,7 +1594,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 22,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
@@ -1594,7 +1617,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 33,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({
@@ -1646,7 +1669,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 44,
         save_sync_enabled: true,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       // Wizard not yet completed.
@@ -1722,7 +1745,7 @@ describe("RomMGameInfoPanel", () => {
             },
           ],
         } as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1751,16 +1774,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {
-          summary: "",
-          genres: [],
-          companies: [],
-          first_release_date: 1041379200,
-          average_rating: null,
-          game_modes: [],
-          player_count: "",
-          cached_at: 0,
-        } as never,
+        metadata: makeMetadata({ first_release_date: 1041379200 }),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1775,16 +1789,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {
-          summary: "",
-          genres: [],
-          companies: [],
-          first_release_date: 0,
-          average_rating: null,
-          game_modes: [],
-          player_count: "",
-          cached_at: 0,
-        } as never,
+        metadata: makeMetadata({ first_release_date: 0 }),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1796,16 +1801,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {
-          summary: "",
-          genres: [],
-          companies: [],
-          first_release_date: -1,
-          average_rating: null,
-          game_modes: [],
-          player_count: "",
-          cached_at: 0,
-        } as never,
+        metadata: makeMetadata({ first_release_date: -1 }),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1834,7 +1830,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         bios_status: bios as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const view = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1879,7 +1875,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         bios_status: null,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1898,7 +1894,7 @@ describe("RomMGameInfoPanel", () => {
           all_downloaded: true,
           active_core_label: "MyCore",
         } as never,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1935,7 +1931,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         rom_name: "Chrono Trigger",
-        metadata: { summary: "An RPG." } as never,
+        metadata: makeMetadata({ summary: "An RPG." }),
         platform_name: "Super Nintendo",
         stale_fields: [],
       });
@@ -1961,16 +1957,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {
-          summary: "",
-          genres: [],
-          companies: [],
-          first_release_date: null,
-          average_rating: 87,
-          game_modes: [],
-          player_count: "",
-          cached_at: 0,
-        } as never,
+        metadata: makeMetadata({ average_rating: 87 }),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1982,7 +1969,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: { summary: "x" } as never,
+        metadata: makeMetadata({ summary: "x" }),
         stale_fields: [],
       });
       vi.mocked(backend.getArtworkBase64).mockResolvedValue({
@@ -1997,7 +1984,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: { summary: "x" } as never,
+        metadata: makeMetadata({ summary: "x" }),
         stale_fields: [],
       });
       vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: null });
@@ -2010,7 +1997,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: { summary: "x" } as never,
+        metadata: makeMetadata({ summary: "x" }),
         stale_fields: [],
       });
       vi.mocked(backend.getArtworkBase64).mockRejectedValue(new Error("net"));
@@ -2027,7 +2014,7 @@ describe("RomMGameInfoPanel", () => {
         found: true,
         rom_id: 1,
         installed: true,
-        metadata: { summary: "x" } as never,
+        metadata: makeMetadata({ summary: "x" }),
         stale_fields: [],
       });
       vi.mocked(backend.getInstalledRom).mockRejectedValue(new Error("net"));
@@ -2045,7 +2032,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: { summary: "from cache" } as never,
+        metadata: makeMetadata({ summary: "from cache" }),
         stale_fields: ["metadata"],
       });
       vi.mocked(backend.getRomMetadata).mockRejectedValue(new Error("net"));
@@ -2065,7 +2052,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -2084,7 +2071,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 1,
-        metadata: {} as never,
+        metadata: makeMetadata(),
         stale_fields: [],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -156,7 +156,7 @@ function refreshMetadataInBackground(
 ): Promise<void> {
   return getRomMetadata(romId)
     .then((meta) => {
-      if (!cancelled() && meta) {
+      if (!cancelled()) {
         setter((prev) => ({ ...prev, metadata: meta }));
       }
     })
@@ -644,11 +644,11 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       gameInfoChildren.push(infoRow("platform", "Platform", state.platformName));
     }
 
-    if (meta.companies && meta.companies.length > 0) {
+    if (meta.companies.length > 0) {
       gameInfoChildren.push(infoRow("companies", "Developer / Publisher", meta.companies.join(", ")));
     }
 
-    if (meta.genres && meta.genres.length > 0) {
+    if (meta.genres.length > 0) {
       gameInfoChildren.push(
         createElement(
           "div",
@@ -668,7 +668,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       gameInfoChildren.push(infoRow("release-date", "Release Date", releaseDate));
     }
 
-    if (meta.game_modes && meta.game_modes.length > 0) {
+    if (meta.game_modes.length > 0) {
       gameInfoChildren.push(infoRow("game-modes", "Game Modes", meta.game_modes.join(", ")));
     }
 
@@ -1013,7 +1013,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
             createElement("span", { key: "date", className: "romm-cheevo-date" }, formatCheevoDate(earnedData.date)),
           );
         }
-        if (isHardcore && earnedData?.date_hardcore) {
+        if (isHardcore && earnedData.date_hardcore) {
           dateChildren.push(
             createElement(
               "span",

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -1354,12 +1354,13 @@ describe("RomMPlaySection", () => {
       );
     });
 
-    it("success with synced=undefined / conflicts=undefined → treats both as 0", async () => {
+    it("success with synced=0 / conflicts=undefined → treats conflicts as 0", async () => {
       const items = await setupSavesAction();
       vi.mocked(backend.syncRomSaves).mockResolvedValue({
         success: true,
         message: "",
-      } as never);
+        synced: 0,
+      });
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
         await items[2]!.props.onClick?.();

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -328,12 +328,12 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             detail: { type: "save_sync", rom_id: romId, has_conflict: hasConflict },
           }),
         );
-        const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
+        const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus.save_sync_display, saveStatus);
         setInfo((prev) => ({
           ...prev,
           saveSyncStatus: ss,
           saveSyncLabel: sl,
-          activeSlot: saveStatus && "active_slot" in saveStatus ? (saveStatus.active_slot ?? null) : prev.activeSlot,
+          activeSlot: "active_slot" in saveStatus ? (saveStatus.active_slot ?? null) : prev.activeSlot,
         }));
       } catch (e) {
         detach(debugLog(`RomMPlaySection: background save check error: ${e}`));
@@ -488,7 +488,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     try {
       const result = await syncRomSaves(info.romId);
       if (result.success) {
-        const n = result.synced ?? 0;
+        const n = result.synced;
         const c = result.conflicts?.length ?? 0;
         let label: string;
         if (n === 0) {

--- a/src/components/SavesTab.test.tsx
+++ b/src/components/SavesTab.test.tsx
@@ -639,7 +639,7 @@ describe("SavesTab", () => {
       const initialCount = capturedSlotPanelProps.length;
       expect(initialCount).toBe(2);
       act(() => {
-        capturedSlotPanelProps[0]?.onVersionRestored?.();
+        capturedSlotPanelProps[0]?.onVersionRestored();
       });
       expect(capturedSlotPanelProps.length).toBe(initialCount + 2);
     });
@@ -650,7 +650,7 @@ describe("SavesTab", () => {
       globalThis.addEventListener("romm_data_changed", listener);
       try {
         act(() => {
-          capturedSlotPanelProps[0]?.onSlotDeleted?.();
+          capturedSlotPanelProps[0]?.onSlotDeleted();
         });
         expect(listener).toHaveBeenCalledTimes(1);
         const event = listener.mock.calls[0]?.[0] as CustomEvent;

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -257,18 +257,6 @@ describe("SettingsPage", () => {
       expect(conn?.password).toBe("pendingpass");
     });
 
-    it("falls back to defaults when steam_input_mode and log_level are absent", async () => {
-      vi.mocked(backend.getSettings).mockResolvedValue({
-        ...defaultSettings(),
-        steam_input_mode: "" as unknown as "default",
-        log_level: undefined as unknown as "warn",
-      });
-      render(<SettingsPage onBack={vi.fn()} />);
-      await flushAsync();
-      expect(capturedController[capturedController.length - 1]?.steamInputMode).toBe("default");
-      expect(capturedAdvanced[capturedAdvanced.length - 1]?.logLevel).toBe("warn");
-    });
-
     it("does not set retroarchWarning when retroarch_input_check is absent", async () => {
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -91,10 +91,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setUrl(pendingEdits.url ?? s.romm_url);
         setUsername(pendingEdits.username ?? s.romm_user);
         setPassword(pendingEdits.password ?? s.romm_pass_masked);
-        setAllowInsecureSsl(s.romm_allow_insecure_ssl ?? false);
+        setAllowInsecureSsl(s.romm_allow_insecure_ssl);
         setSgdbApiKey(s.sgdb_api_key_masked);
-        setSteamInputMode(s.steam_input_mode || "default");
-        setLogLevel(s.log_level ?? "warn");
+        setSteamInputMode(s.steam_input_mode);
+        setLogLevel(s.log_level);
         if (s.retroarch_input_check) {
           setRetroarchWarning(s.retroarch_input_check);
         }

--- a/src/components/SgdbGamePickerModal.test.tsx
+++ b/src/components/SgdbGamePickerModal.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../utils/artwork", () => ({
 
 // Find a <button> whose text content contains `text`.
 function buttonContaining(container: HTMLElement, text: string): HTMLButtonElement {
-  const btn = Array.from(container.querySelectorAll("button")).find((b) => (b.textContent ?? "").includes(text));
+  const btn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent.includes(text));
   if (!btn) throw new Error(`button containing "${text}" not found`);
   return btn as HTMLButtonElement;
 }

--- a/src/components/SlotSetupWizard.test.tsx
+++ b/src/components/SlotSetupWizard.test.tsx
@@ -557,7 +557,7 @@ describe("SlotSetupWizard", () => {
       // Match by partial textContent — the button is the only one containing
       // "Use slot" and "fresh".
       const buttons = Array.from(container.querySelectorAll("button"));
-      const useSlotBtn = buttons.find((b) => b.textContent?.includes("Use slot"));
+      const useSlotBtn = buttons.find((b) => b.textContent.includes("Use slot"));
       if (!useSlotBtn) throw new Error("Use slot button not rendered");
 
       await act(async () => {

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -209,7 +209,7 @@ export const SlotPanel: FC<SlotPanelProps> = ({
 
   const { syncSummaryText, syncSummaryColor } = computeSyncSummary(isActive, saveStatus, conflicts);
 
-  const fileCount = isActive ? (saveStatus?.files?.length ?? 0) : (slotFiles?.length ?? slot.count);
+  const fileCount = isActive ? (saveStatus?.files.length ?? 0) : (slotFiles?.length ?? slot.count);
 
   const panelClasses = ["romm-slot-panel", isActive ? "romm-slot-panel-active" : ""].filter(Boolean).join(" ");
 

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -37,7 +37,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({ romId, slot,
       const result: ListFileVersionsResult = await savesListFileVersions(romId, slot, filename);
       if (result.status === "ok") {
         setVersions(result.versions);
-      } else if (result.status === "server_unreachable") {
+      } else {
         detach(debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`));
         setVersions(null);
         setLoadError("Couldn't reach RomM. Tap retry.");
@@ -102,6 +102,7 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({ romId, slot,
         // we just couldn't reach the server to confirm. Prompt for retry
         // instead of telling the user the version is gone.
         toaster.toast({ title: "RomM Sync", body: "Couldn't reach RomM. Check your connection and try again." });
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- exhaustive final branch of the 8-member RollbackStatus union; an explicit check (vs. plain `else`) keeps the per-status symmetry and leaves any future-added status unhandled instead of silently routing it to the "unsupported" toast
       } else if (result.status === "unsupported") {
         toaster.toast({ title: "RomM Sync", body: "Version history requires RomM 4.7+" });
       }

--- a/src/components/saves/helpers.ts
+++ b/src/components/saves/helpers.ts
@@ -132,7 +132,7 @@ export function computeSyncSummary(
   }
 
   const hasConflict = conflicts.length > 0;
-  const fileCount = saveStatus.files?.length ?? 0;
+  const fileCount = saveStatus.files.length;
 
   if (hasConflict) return { syncSummaryText: "Conflict detected", syncSummaryColor: "#d94126" };
   if (fileCount > 0 && saveStatus.last_sync_check_at) {

--- a/src/components/settings/ControllerSection.tsx
+++ b/src/components/settings/ControllerSection.tsx
@@ -58,7 +58,7 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
         <>
           <PanelSectionRow>
             <Field
-              label={`RetroArch input_driver: "${retroarchWarning?.current}"`}
+              label={`RetroArch input_driver: "${retroarchWarning.current}"`}
               description="Controller navigation in RetroArch menus may not work with this setting."
             />
           </PanelSectionRow>

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -152,7 +152,7 @@ describe("RegisteredDevicesSection", () => {
         makeDevice({ id: "device-bbbb2222", name: "Desktop", is_current_device: false }),
       ];
       const { container } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
-      const matches = container.textContent?.match(/\(this device\)/g) ?? [];
+      const matches = container.textContent.match(/\(this device\)/g) ?? [];
       expect(matches).toHaveLength(1);
     });
 

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -45,7 +45,7 @@ export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
             `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`,
             ...(device.platform ? [device.platform] : []),
             `last seen ${formatRelativeTime(device.last_seen)}`,
-            `ID ${String(device.id ?? "").slice(0, 8) || "—"}`,
+            `ID ${String(device.id).slice(0, 8) || "—"}`,
           ];
           return (
             <PanelSectionRow key={device.id || `idx-${i}`}>

--- a/src/components/settings/SaveSyncSection.test.tsx
+++ b/src/components/settings/SaveSyncSection.test.tsx
@@ -319,14 +319,6 @@ describe("SaveSyncSection", () => {
       expect(dd?.selectedOption).toBe(20);
     });
 
-    it("defaults selectedOption to 10 when autocleanup_limit is missing", () => {
-      const partial = makeSettings();
-      delete (partial as { autocleanup_limit?: number }).autocleanup_limit;
-      render(<SaveSyncSection {...defaultProps({ saveSyncSettings: partial })} />);
-      const dd = dropdownCaptured.items.find((d) => d.label === "Save History Limit");
-      expect(dd?.selectedOption).toBe(10);
-    });
-
     it("dispatches partial settings with autocleanup_limit on change", () => {
       const onSettingChange = vi.fn();
       render(<SaveSyncSection {...defaultProps({ onSettingChange })} />);

--- a/src/components/settings/SaveSyncSection.tsx
+++ b/src/components/settings/SaveSyncSection.tsx
@@ -131,7 +131,7 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
                     { data: 20, label: "20" },
                     { data: 50, label: "50" },
                   ]}
-                  selectedOption={saveSyncSettings.autocleanup_limit ?? 10}
+                  selectedOption={saveSyncSettings.autocleanup_limit}
                   onChange={(option) => onSettingChange({ autocleanup_limit: option.data as number })}
                 />
               </PanelSectionRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -163,6 +163,7 @@ export default definePlugin(() => {
 
   detach(
     (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `initDone` is flipped to true inside the awaited `loadAppIdsAndMetadata()`; TS's control-flow analysis can't see that cross-function mutation and narrows it to the `false` literal here. The guard is the real loop-exit: on success `initAttempt` is never incremented (only the catch bumps it), so without `!initDone` the loop would spin forever.
       while (!initDone && initAttempt < RETRY_DELAYS.length + 1) {
         try {
           await loadAppIdsAndMetadata();
@@ -268,7 +269,7 @@ export default definePlugin(() => {
       (async () => {
         try {
           // Create/update platform collections
-          if (data.platform_app_ids && Object.keys(data.platform_app_ids).length > 0) {
+          if (Object.keys(data.platform_app_ids).length > 0) {
             await createOrUpdateCollections(data.platform_app_ids);
           }
 
@@ -281,7 +282,7 @@ export default definePlugin(() => {
             const suffix = ` (${hostname})`;
 
             // Clean stale platform collections
-            const activePlatforms = new Set(Object.keys(data.platform_app_ids ?? {}));
+            const activePlatforms = new Set(Object.keys(data.platform_app_ids));
             const stalePlatform = collectionStore.userCollections.filter((c) => {
               if (!c.displayName.startsWith("RomM: ")) return false;
               const afterPrefix = c.displayName.slice(6);
@@ -375,7 +376,7 @@ export default definePlugin(() => {
   const syncCollectionsListener = addEventListener<[SyncCollectionsData]>(
     "sync_collections",
     (data: SyncCollectionsData) => {
-      logInfo(`sync_collections received: ${Object.keys(data.platform_app_ids ?? {}).length} platforms`);
+      logInfo(`sync_collections received: ${Object.keys(data.platform_app_ids).length} platforms`);
     },
   );
 
@@ -390,8 +391,8 @@ export default definePlugin(() => {
       updateDownload({
         rom_id: data.rom_id,
         rom_name: data.rom_name,
-        platform_name: data.platform_name ?? "",
-        file_name: data.file_name ?? "",
+        platform_name: data.platform_name,
+        file_name: data.file_name,
         status: data.status as "queued" | "downloading" | "completed" | "failed" | "cancelled",
         progress: data.progress,
         bytes_downloaded: data.bytes_downloaded,

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -28,7 +28,7 @@ export function refreshActiveSlotInBackground<S extends ActiveSlotFields>(
 ): void {
   getSaveStatus(romId)
     .then((saveStatus) => {
-      if (!cancelled() && saveStatus && "active_slot" in saveStatus) {
+      if (!cancelled() && "active_slot" in saveStatus) {
         setter((prev) => ({ ...prev, activeSlot: saveStatus.active_slot ?? null }));
       }
     })

--- a/src/utils/slotState.test.ts
+++ b/src/utils/slotState.test.ts
@@ -93,13 +93,6 @@ describe("applyRefreshSlotResult", () => {
     const next = lastUpdater(setter)(refreshState({ activeSlot: "previous" }));
     expect(next.activeSlot).toBeNull();
   });
-
-  it("defaults a missing slots field to []", () => {
-    const setter = makeSetter<RefreshState>();
-    applyRefreshSlotResult<RefreshState>({ success: true } as unknown as SlotsResponse, setter);
-    const next = lastUpdater(setter)(refreshState({ availableSlots: [slot("stale")] }));
-    expect(next.availableSlots).toEqual([]);
-  });
 });
 
 describe("applyLoadSlotsResult", () => {
@@ -178,12 +171,5 @@ describe("applyLoadSlotsResult", () => {
     );
     const next = lastUpdater(setter)(loadState({ activeSlot: "previous" }));
     expect(next.activeSlot).toBeNull();
-  });
-
-  it("on success: defaults a missing slots field to []", () => {
-    const setter = makeSetter<LoadState>();
-    applyLoadSlotsResult<LoadState>({ success: true } as unknown as SlotsResponse, setter, { current: true }, vi.fn());
-    const next = lastUpdater(setter)(loadState({ availableSlots: [slot("stale")] }));
-    expect(next.availableSlots).toEqual([]);
   });
 });

--- a/src/utils/slotState.ts
+++ b/src/utils/slotState.ts
@@ -41,7 +41,7 @@ export function applyRefreshSlotResult<S extends RefreshSlotFields>(
   if (!slotResult.success) return;
   setter((prev) => ({
     ...prev,
-    availableSlots: slotResult.slots || [],
+    availableSlots: slotResult.slots,
     activeSlot: slotResult.active_slot === undefined ? prev.activeSlot : slotResult.active_slot,
   }));
 }
@@ -64,7 +64,7 @@ export function applyLoadSlotsResult<S extends LoadSlotsFields>(
   setter((prev) => ({
     ...prev,
     activeSlot: result.active_slot === undefined ? prev.activeSlot : result.active_slot,
-    availableSlots: result.slots || [],
+    availableSlots: result.slots,
     slotsLoading: false,
   }));
 }

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -10,7 +10,7 @@ const ROMM_ACHIEVEMENTS_ID = "romm-achievements-styles";
 
 export function hideNativePlaySection(playSectionClass: string) {
   const sp = findSP();
-  if (!sp?.window?.document) return;
+  if (!sp?.window.document) return;
 
   // Hide native PlaySection — display:none + visibility:hidden + pointer-events:none
   // All three are needed: display:none hides visually, visibility:hidden is belt-and-suspenders,
@@ -759,7 +759,7 @@ export function hideNativePlaySection(playSectionClass: string) {
 
 export function showNativePlaySection() {
   const sp = findSP();
-  if (!sp?.window?.document) return;
+  if (!sp?.window.document) return;
   sp.window.document.getElementById(ROMM_PLAY_HIDE_ID)?.remove();
   sp.window.document.getElementById(ROMM_FOCUS_STYLES_ID)?.remove();
   sp.window.document.getElementById(ROMM_INFO_ITEMS_ID)?.remove();


### PR DESCRIPTION
Ratchet box of #838 (the `no-unnecessary-condition` box) — second of the two PRs for it, after the boundary-honesty foundation in #858. Leaves the umbrella open (other boxes remain).

## What
Enables `@typescript-eslint/no-unnecessary-condition: error` (CI-enforced via the existing lint job) and resolves the 48 residual findings. With the lying boundary types made honest in #858, the residual was genuinely-redundant guards on honest types.

## How the 48 were resolved
- **Removed redundant** `?.` / `??` / always-truthy guards (the bulk) — behavior-preserving (the value was provably non-null).
- **2 reasoned `eslint-disable`s** (each with ` -- reason`): `VersionHistoryPanel` 8-member union exhaustiveness (keeps the explicit final discriminant so a future status isn't silently mis-routed); `index.tsx` `while (!initDone)` (TS can't track the cross-async mutation that flips it).
- **Test fixtures:** replaced ~25 lying `{} as never` metadata fixtures with a typed `makeMetadata()` factory; removed **4 vacuous tests** that forced backend-impossible states (`delete` / `as unknown as`) to exercise now-dead fallbacks — each verified against the Python (settings / slots / save-sync always serialize those fields).

## Latent bug the rule caught (fixed here)
`removePlatformShortcuts` is `@migration_blocked` (`main.py:283`) — the gate short-circuits to `{success:False, message, blocked_by_migration:True}`, **omitting `app_ids`/`rom_ids`** — but its TS type declared them non-null. Removing the 'redundant' guard would have thrown `TypeError` on the blocked path. Made the type honest (mirrors `removeAllShortcuts` from #858) and added a `result.success` gate — which also fixes a **pre-existing cosmetic lie** (it reported "Removed N games" even when blocked). New test covers the blocked path.

The broader audit of all ~30 `@migration_blocked` callable return types (same lying-non-null pattern) is a tracked follow-up — out of scope here.

## Verification
- `pnpm lint`: 0 (rule now enforced; 2 baseline warnings) · `pnpm typecheck`: 0 · `pnpm format:check`: clean · `pnpm test`: 1056 passed · `check_no_bare_ignores`: OK
- A code-reviewer pass cross-checked all 4 test removals + the factory against the Python backend, verified guard-removal behavior preservation, and surfaced the `removePlatformShortcuts` bug (now fixed).

docs: N/A — lint-rule adoption + mechanical guard cleanup + a type-honesty bugfix; no user-facing, architecture, or flow change (the migration-blocked message now shows correctly where it previously showed a false 'removed' status).