### PR TITLE
fix(saves): serialize StatusService save-status RMW under rom_lock

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -412,9 +412,9 @@ Earlier drafts persisted a `deferred` field in per-file state to suppress the mo
 
 ### Per-rom asyncio.Lock
 
-`SyncEngine._rom_sync_locks: dict[int, asyncio.Lock]` (`services/saves/sync_engine/engine.py`) serializes `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`, and `resolve_sync_conflict` for the same `rom_id`. Different rom_ids have independent locks, so cross-game concurrency (e.g. Sync All Saves running concurrently with a resolve on one specific rom) is unaffected. The lock is created lazily on first access.
+`SyncEngine._rom_sync_locks: dict[int, asyncio.Lock]` (`services/saves/sync_engine/engine.py`) serializes `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`, and `resolve_sync_conflict` for the same `rom_id`. `StatusService.get_save_status` also takes the lock — not for the read, but for its one write: the executor body adopts a baseline hash (`Skip(adopt_baseline=True)`) and persists it through a `rom_save_states` read-modify-write, which would otherwise race a concurrent sync and clobber that sync's update. The lock-free server-saves network fetch stays outside the lock; only the local RMW is the critical section. Different rom_ids have independent locks, so cross-game concurrency (e.g. Sync All Saves running concurrently with a resolve on one specific rom) is unaffected. The lock is created lazily on first access (`SyncEngine.rom_lock(rom_id)`).
 
-The realistic race the lock prevents: user clicks Keep Local → executor runs PUT + state mutation → in parallel, `post_exit_sync` for a game that just stopped runs and mutates the same per-file state → last-writer-wins on `save_sync_state.json` persist, dropping one set of fields. The lock makes the resolve-and-persist sequence atomic relative to background syncs.
+The realistic race the lock prevents: user clicks Keep Local → executor runs PUT + state mutation → in parallel, `post_exit_sync` for a game that just stopped runs and mutates the same per-file state → last-writer-wins on the `rom_save_states` aggregate, dropping one set of fields. The same lost-update window applies to `get_save_status`'s baseline-adopt write versus a concurrent pre-launch / post-exit / manual sync. The lock makes each read-modify-write-and-persist sequence atomic relative to the others.
 
 ## Local Save File Naming
 

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -266,6 +266,13 @@ class StatusService:
         and each surfaced file is marked ``status="unknown"`` instead of
         the matrix-derived "ready to upload" label that an empty server
         list would otherwise produce — see ``_get_save_status_io``.
+
+        The ``rom_save_states`` read-modify-write (the baseline-adopt
+        write in ``_get_save_status_io``) runs under the per-ROM sync lock
+        (``SyncEngine.rom_lock(rom_id)``), so it cannot interleave with a
+        concurrent ``do_sync_rom_saves`` and lose that sync's update. The
+        server-saves network fetch stays outside the lock — only the local
+        RMW is the critical section.
         """
         rom_id = int(rom_id)
 
@@ -281,14 +288,15 @@ class StatusService:
             self._log_debug(f"Failed to fetch saves for rom {rom_id}: {e}")
             server_query_failed = True
 
-        return await self._loop.run_in_executor(
-            None,
-            lambda: self._get_save_status_io(
-                rom_id,
-                server_saves,
-                server_query_failed=server_query_failed,
-            ),
-        )
+        async with self._sync_engine.rom_lock(rom_id):
+            return await self._loop.run_in_executor(
+                None,
+                lambda: self._get_save_status_io(
+                    rom_id,
+                    server_saves,
+                    server_query_failed=server_query_failed,
+                ),
+            )
 
     def _read_device_id(self) -> str | None:
         with self._uow_factory() as uow:

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -1,5 +1,8 @@
 """Tests for StatusService — save-status DTO building and read-only status checks."""
 
+import asyncio
+import threading
+
 import pytest
 
 from domain.rom_save_state import RomSaveState
@@ -7,6 +10,7 @@ from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
     _file_md5,
+    _get_save_state,
     _install_rom,
     _seed_save_state,
     _seed_save_state_dict,
@@ -482,3 +486,146 @@ class TestCompositeServerQueryFailedDomain:
         assert display.status == "synced"
         assert display.label is None
         assert display.last_sync_check_at == "2026-04-01T08:00:00+00:00"
+
+
+def _seed_baseline_adopt_scenario(svc, fake, tmp_path) -> str:
+    """Seed the state that drives ``get_save_status`` to adopt + persist a baseline.
+
+    A local file is present, the server save reports our device as
+    ``is_current=True``, and the tracked entry has **no** ``last_sync_hash``
+    baseline yet — so the matrix returns ``Skip(adopt_baseline=True)`` and the
+    status RMW records the local hash as the new baseline (an observable
+    ``rom_save_states.save``). Returns the local file's md5.
+    """
+    _enable_sync_with_device(svc)
+    _install_rom(svc, tmp_path)
+    save_path = _create_save(tmp_path, content=b"matches baseline")
+    local_hash = _file_md5(str(save_path))
+
+    ss = _server_save_with_syncs(device_syncs=[{"device_id": "device-1", "is_current": True}])
+    fake.saves[100] = ss
+    # Realistic (hashful) tracked entry, but deliberately no last_sync_hash
+    # baseline — that absence is what triggers the adopt-baseline write.
+    _seed_save_state_dict(
+        svc,
+        42,
+        {
+            "files": {
+                "pokemon.srm": {
+                    "tracked_save_id": 100,
+                    "last_sync_server_updated_at": ss["updated_at"],
+                    "last_sync_server_save_id": 100,
+                    "last_sync_local_size": 1024,
+                }
+            }
+        },
+    )
+    return local_hash
+
+
+def _adopted_baseline(svc) -> str | None:
+    """Read back the persisted baseline hash for pokemon.srm, or ``None``."""
+    state = _get_save_state(svc, 42)
+    if state is None or "pokemon.srm" not in state.files:
+        return None
+    return state.files["pokemon.srm"].last_sync_hash
+
+
+async def _drain_until(predicate, *, attempts: int = 200, step: float = 0.005) -> bool:
+    """Drive the loop + thread-pool executor until *predicate* holds (or attempts run out).
+
+    ``run_in_executor`` resolves its result future via a cross-thread
+    ``call_soon_threadsafe`` callback, so a bare ``asyncio.sleep(0)`` does not
+    reliably drain an in-flight executor round-trip. A short real-time sleep
+    per iteration lets the worker thread finish and its callback land. Returns
+    whether *predicate* became true within the budget.
+    """
+    for _ in range(attempts):
+        if predicate():
+            return True
+        await asyncio.sleep(step)
+    return predicate()
+
+
+class TestGetSaveStatusRomLockSerialization:
+    """The status RMW (baseline adopt) must serialize under ``rom_lock``.
+
+    ``get_save_status`` does a get→mutate→save of ``rom_save_states``. Held
+    under ``SyncEngine.rom_lock(rom_id)``, it cannot interleave with a
+    concurrent ``do_sync_rom_saves`` and clobber that sync's write (#871).
+    """
+
+    @pytest.mark.asyncio
+    async def test_status_rmw_blocks_while_rom_lock_held(self, tmp_path):
+        """While the per-ROM lock is held, get_save_status must not enter or persist its RMW.
+
+        ``_get_save_status_io`` is the executor body that holds the entire
+        read-modify-write. Spying on it gives a cross-thread signal for *when*
+        the critical section starts. With the lock held by the test, the task
+        must park on ``rom_lock`` *before* that body runs — so the spy must not
+        fire and the baseline must stay unadopted until the lock is released.
+        """
+        svc, fake = make_service(tmp_path)
+        local_hash = _seed_baseline_adopt_scenario(svc, fake, tmp_path)
+        assert _adopted_baseline(svc) is None
+
+        status_svc = svc._status
+        entered_rmw = threading.Event()
+        original_io = status_svc._get_save_status_io
+
+        def spy_io(*args, **kwargs):
+            entered_rmw.set()
+            return original_io(*args, **kwargs)
+
+        status_svc._get_save_status_io = spy_io  # type: ignore[method-assign]
+
+        engine = svc._sync_engine
+        async with engine.rom_lock(42):
+            task = asyncio.create_task(svc.get_save_status(42))
+            # Drain the loop + executor so the lock-free network-fetch round
+            # trips complete and the task genuinely reaches the rom_lock await.
+            # If the lock did NOT guard the RMW, the executor body (spy) would
+            # fire here. Give it a generous window to *try*.
+            await _drain_until(entered_rmw.is_set)
+
+            assert not entered_rmw.is_set(), "RMW executor body ran while rom_lock was held"
+            assert not task.done(), "get_save_status completed while rom_lock was held"
+            # Non-vacuous: the persisted baseline is still unadopted.
+            assert _adopted_baseline(svc) is None
+
+        # Lock released → the task acquires it, runs the RMW body, and persists.
+        result = await asyncio.wait_for(task, timeout=5)
+
+        assert entered_rmw.is_set()
+        assert result["files"][0]["status"] == "synced"
+        # Observe the actual persisted state change, not just that a call happened.
+        assert _adopted_baseline(svc) == local_hash
+
+    @pytest.mark.asyncio
+    async def test_status_rmw_runs_when_lock_free(self, tmp_path):
+        """Control: with no contender holding the lock, the RMW persists immediately."""
+        svc, fake = make_service(tmp_path)
+        local_hash = _seed_baseline_adopt_scenario(svc, fake, tmp_path)
+
+        assert _adopted_baseline(svc) is None
+        result = await svc.get_save_status(42)
+
+        assert result["files"][0]["status"] == "synced"
+        assert _adopted_baseline(svc) == local_hash
+
+    @pytest.mark.asyncio
+    async def test_status_does_not_block_on_other_rom_lock(self, tmp_path):
+        """Holding rom_lock for a different rom_id must not stall this ROM's status RMW.
+
+        Proves the lock is per-ROM, not global: rom 42's status RMW completes
+        and persists while the test holds ``rom_lock(999)``.
+        """
+        svc, fake = make_service(tmp_path)
+        local_hash = _seed_baseline_adopt_scenario(svc, fake, tmp_path)
+
+        engine = svc._sync_engine
+        async with engine.rom_lock(999):
+            result = await asyncio.wait_for(svc.get_save_status(42), timeout=5)
+
+        assert result["files"][0]["status"] == "synced"
+        assert _adopted_baseline(svc) == local_hash


### PR DESCRIPTION
## Problem

`StatusService.get_save_status` performs a read-modify-write of `rom_save_states` — it reads the `RomSaveState`, adopts a baseline hash when the matrix returns `Skip(adopt_baseline=True)`, and writes it back (inside `_get_save_status_io`, run in an executor). Unlike `SyncEngine`, which serializes every such RMW under a per-ROM `rom_lock`, the status path took no lock. A concurrent pre-launch / post-exit / manual `do_sync_rom_saves` (which holds `rom_lock`) could interleave: status reads old state, the sync writes new state, status overwrites it with its stale-derived copy — silently losing the adopted baseline and anything the sync persisted (`own_upload_ids`, slot promotion, core/emulator stamps).

A race window, not a deterministic failure: it needs a SAVES-tab background check to overlap an active sync on the same ROM.

## Fix

Wrap the status RMW executor call in `async with self._sync_engine.rom_lock(rom_id):`, mirroring the engine's own pattern. The server-saves network fetch stays outside the lock — only the `rom_save_states` critical section is serialized. `StatusService` already holds the same `SyncEngine` instance the sync callables use, so both contend on the identical per-ROM lock.

## Test

`test_status.py` adds serialization coverage: while `rom_lock(rom_id)` is held, `get_save_status` does not perform its write (asserted by reading the still-unadopted baseline back from `rom_save_states`); after release it completes and the baseline is persisted. Plus control tests for lock-free progress and per-ROM lock independence.

## Docs

`docs/architecture/save-file-sync-architecture.md` — the per-ROM `asyncio.Lock` section now includes `StatusService.get_save_status` in the serialization set.

## Out of scope

The larger refactor (making status reads fully read-only by moving the baseline-adopt into the sync path) is deferred.

Closes #871
