### PR TITLE
test(saves): make the fake repo reject hashless persisted FileSyncState

### DIFF
--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -84,10 +84,13 @@ class GameDetailService:
         """Build cached save-sync status from the ROM's save state, or None."""
         if save_state is None:
             return None
+        # Every persisted file row carries a non-empty last_sync_hash (NOT NULL in
+        # rom_save_files; both RomSaveState writers reject an empty hash), so a
+        # tracked file is always "synced" here.
         files_list = [
             {
                 "filename": fn,
-                "status": "synced" if fdata.last_sync_hash else "unknown",
+                "status": "synced",
                 "last_sync_at": fdata.last_sync_at or None,
             }
             for fn, fdata in save_state.files.items()

--- a/tests/fakes/fake_rom_save_state_repository.py
+++ b/tests/fakes/fake_rom_save_state_repository.py
@@ -26,6 +26,12 @@ class FakeRomSaveStateRepository:
         return copy.deepcopy(self._states.get(rom_id))
 
     def save(self, rom_id: int, state: RomSaveState) -> None:
+        # Mirror rom_save_files' NOT NULL on last_sync_hash so service tests reject
+        # what real SQLite rejects (db/migrations/001_initial.sql). tracked_save_id is
+        # intentionally NOT checked — it is nullable (hash-only baselines).
+        for filename, file in state.files.items():
+            if not file.last_sync_hash:
+                raise ValueError(f"rom_save_files.last_sync_hash is NOT NULL; file {filename!r} has none")
         self.save_count += 1
         self._states[rom_id] = copy.deepcopy(state)
 

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -599,7 +599,7 @@ class TestEmulatorTag:
             svc,
             1,
             RomSaveState(
-                files={"game1.srm": FileSyncState()},
+                files={"game1.srm": FileSyncState(last_sync_hash="h")},
                 active_slot="desktop",
                 slot_confirmed=True,
                 emulator="retroarch-mgba",
@@ -610,7 +610,7 @@ class TestEmulatorTag:
             svc,
             2,
             RomSaveState(
-                files={"game2.srm": FileSyncState()},
+                files={"game2.srm": FileSyncState(last_sync_hash="h")},
                 active_slot="default",
                 slot_confirmed=True,
                 own_upload_ids=[99],
@@ -648,7 +648,7 @@ class TestEmulatorTag:
             svc,
             2,
             RomSaveState(
-                files={"game2.srm": FileSyncState()},
+                files={"game2.srm": FileSyncState(last_sync_hash="h")},
                 active_slot="default",
                 slot_confirmed=True,
                 system="snes",
@@ -1065,7 +1065,7 @@ class TestHasTrackedSave:
     def test_accepts_int_rom_id_casting_to_str_key(self, tmp_path):
         """``rom_id`` is int on the wire; the aggregate is keyed by int rom_id."""
         svc, _ = make_service(tmp_path)
-        _seed_save_state(svc, 99, RomSaveState(files={"a.srm": FileSyncState(tracked_save_id=1)}))
+        _seed_save_state(svc, 99, RomSaveState(files={"a.srm": FileSyncState(tracked_save_id=1, last_sync_hash="h")}))
         assert svc.has_tracked_save(99) is True
         # Wrong rom_id misses cleanly.
         assert svc.has_tracked_save(100) is False

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -28,7 +28,7 @@ class TestListFileVersions:
                 "system": "gba",
                 "active_slot": "default",
                 "files": {
-                    "pokemon.srm": {"tracked_save_id": tracked_id},
+                    "pokemon.srm": {"tracked_save_id": tracked_id, "last_sync_hash": "h"},
                 },
             },
         )
@@ -222,7 +222,7 @@ class TestListFileVersions:
                 "active_slot": "default",
                 "own_upload_ids": [50],
                 "files": {
-                    "pokemon.srm": {"tracked_save_id": 100},
+                    "pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "h"},
                 },
             },
         )
@@ -252,7 +252,7 @@ class TestListFileVersions:
                 "active_slot": "default",
                 # own_upload_ids key intentionally absent — legacy state
                 "files": {
-                    "pokemon.srm": {"tracked_save_id": 100},
+                    "pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "h"},
                 },
             },
         )
@@ -271,18 +271,22 @@ class TestRollbackToVersion:
     def _setup_state(self, svc, tmp_path, tracked_id: int, last_sync_hash: str | None = None) -> None:
         _install_rom(svc, tmp_path)
         _enable_sync_with_device(svc)
+        # last_sync_hash=None models "no baseline adopted yet": production reaches
+        # that state with the file absent from state.files (the matrix falls back
+        # to its in-memory FileSyncState() default), not a persisted hashless row —
+        # rom_save_files.last_sync_hash is NOT NULL (db/migrations/001_initial.sql).
+        files = (
+            {"pokemon.srm": {"tracked_save_id": tracked_id, "last_sync_hash": last_sync_hash}}
+            if last_sync_hash is not None
+            else {}
+        )
         _seed_save_state_dict(
             svc,
             42,
             {
                 "system": "gba",
                 "active_slot": "default",
-                "files": {
-                    "pokemon.srm": {
-                        "tracked_save_id": tracked_id,
-                        "last_sync_hash": last_sync_hash,
-                    },
-                },
+                "files": files,
             },
         )
 
@@ -360,7 +364,7 @@ class TestRollbackToVersion:
         """
         svc, fake = make_service(tmp_path)
         _enable_sync_with_device(svc)
-        self._setup_state(svc, tmp_path, tracked_id=999)
+        self._setup_state(svc, tmp_path, tracked_id=999, last_sync_hash="h")
         _create_save(tmp_path)
         # Tracked save 999 does NOT exist on server. Only save 50 is present
         # (and is the rollback target).

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -677,20 +677,6 @@ class TestGetCachedGameDetailSaveStatusConflicts:
         assert result["save_status"]["files"] == []
         assert result["save_status"]["last_sync_check_at"] is None
 
-    @pytest.mark.asyncio
-    async def test_save_status_unknown_when_no_hash(self, plugin, game_detail_service):
-        """A tracked file with no last_sync_hash reports status 'unknown'."""
-        _seed_rom(plugin, 42, app_id=99999, name="Test", platform_slug="gba")
-        _seed_save_state(
-            plugin,
-            42,
-            files={"test.srm": FileSyncState(last_sync_hash=None, last_sync_at="")},
-            last_sync_check_at="2026-01-01T00:00:00Z",
-        )
-        result = game_detail_service.get_cached_game_detail(99999)
-        assert result["save_status"]["files"][0]["status"] == "unknown"
-        assert result["save_status"]["files"][0]["last_sync_at"] is None
-
 
 class TestComputedFields:
     """Test bios_level, bios_label, save_sync_display in response."""

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -1029,10 +1029,16 @@ async def test_delete_platform_saves(plugin, tmp_path):
     _install_rom(plugin, tmp_path, rom_id=30, system="gba", file_name="GBAGame.gba")
 
     _seed_save_state(
-        plugin, 10, RomSaveState(files={"Game1.srm": FileSyncState()}, system="snes"), platform_slug="snes"
+        plugin,
+        10,
+        RomSaveState(files={"Game1.srm": FileSyncState(last_sync_hash="h")}, system="snes"),
+        platform_slug="snes",
     )
     _seed_save_state(
-        plugin, 20, RomSaveState(files={"Game2.srm": FileSyncState()}, system="snes"), platform_slug="snes"
+        plugin,
+        20,
+        RomSaveState(files={"Game2.srm": FileSyncState(last_sync_hash="h")}, system="snes"),
+        platform_slug="snes",
     )
 
     result = await plugin.delete_platform_saves("snes")
@@ -1068,7 +1074,7 @@ class TestSavesVersionHistoryCallables:
             RomSaveState(
                 system="gba",
                 active_slot="default",
-                files={"pokemon.srm": FileSyncState(tracked_save_id=100)},
+                files={"pokemon.srm": FileSyncState(tracked_save_id=100, last_sync_hash="h")},
             ),
         )
         plugin._fake_api.saves[100] = {


### PR DESCRIPTION
## Why

Surfaced while fixing #870. `rom_save_files.last_sync_hash` is `NOT NULL`, and it's a real invariant: the only two writers of `RomSaveState.files` (`adopt_baseline`, `update_baseline_hash`) both reject an empty hash, so no production path persists a hashless file row. But `FakeRomSaveStateRepository` didn't enforce it, letting ~15 tests persist hashless rows that real SQLite would reject with the same `IntegrityError` class as #870 — the exact kind of fake↔schema gap that let #870 ship undetected.

## Changes

- **Fake repo** (`fake_rom_save_state_repository.py`): `save()` now rejects any `FileSyncState` with an empty `last_sync_hash`, mirroring the schema's NOT NULL. `tracked_save_id` is intentionally not checked (nullable since #870).
- **Dead-branch removal** (`game_detail.py`): the invariant makes `_build_save_status`'s `else "unknown"` branch unreachable (every persisted `save_state.files` row has a non-empty hash), so it collapses to `"status": "synced"`. The full `get_save_status` path still produces `"unknown"` via `server_query_failed` — that's a separate path and is untouched.
- **Tests**: fixed the ~14 tests that relied on the fake's leniency — seeded tracked files now carry a real hash; the one test that modelled "no baseline" now does so as an *untracked* file (absent from `files`, the way production reaches it via the matrix's in-memory default); the obsolete `test_save_status_unknown_when_no_hash` (sole coverage of the now-removed dead branch) is deleted — the cached "synced" path stays covered elsewhere.

No `domain/` change: a hashless `FileSyncState` stays constructible because the matrix legitimately builds bare in-memory defaults. The invariant lives only at the persistence boundary (DB NOT NULL + the fake).

docs: N/A — test-infrastructure hardening plus removal of an unreachable code branch; no user-visible behavior, architecture, or flow change.

Closes #872
