### PR TITLE
fix(saves): register device with /etc/machine-id fingerprint

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -72,12 +72,18 @@ RomM v4.7 introduces **save slots** — named containers for save files. This en
 
 Each machine running the plugin registers as a device with the RomM server. This allows RomM to track which device uploaded each save.
 
-1. On first use with save sync enabled, the plugin calls `POST /api/devices` with hostname, platform, client info
+1. On first use with save sync enabled, the plugin calls `POST /api/devices` with the friendly device label (`name`), platform, client info, and the contents of `/etc/machine-id` as the `hostname` fingerprint
 2. Server returns a `device_id` (UUID) stored as `server_device_id` in state
 3. This ID is passed to `list_saves` (populates `device_syncs` per save) and `upload_save` / `download_save_content` (tracks sync status)
 4. `device_syncs` array on each save shows per-device sync status: `device_id`, `device_name`, `is_current`, `last_synced_at`
 5. `is_current = false` means another device uploaded since our last sync
 6. Server returns HTTP 409 on POST when device has stale sync record (additional safety net)
+
+### Why `/etc/machine-id` is the fingerprint
+
+RomM ≥4.8.1 dedupes devices by fingerprint — `mac_address`, OR `hostname` + `platform` — and returns the existing device instead of minting a duplicate (`allow_existing` defaults true). The `name` field is **not** fingerprinted, so without a stable fingerprint every local-state wipe (the SQLite reinstall path) would create a fresh duplicate device on each reinstall.
+
+The plugin sends `/etc/machine-id` as the RomM `hostname`: it is machine-derived (survives a reinstall), unique per device (two Steam Decks stay distinct), and stable. The real OS hostname is deliberately **not** sent — two stock Steam Decks both report `steamdeck`, so a `hostname` + `platform` fingerprint built from the OS hostname would collide them into one server device. The friendly OS hostname remains the display-only `name`. When `/etc/machine-id` is unreadable the `hostname` field is omitted entirely, degrading to the pre-4.8.1 no-fingerprint behaviour rather than sending a colliding value.
 
 ### RomM account requirement
 

--- a/main.py
+++ b/main.py
@@ -91,6 +91,7 @@ class Plugin:
                     uuid_gen=result.runtime_adapters.uuid_gen,
                     sleeper=result.runtime_adapters.sleeper,
                     hostname_provider=result.runtime_adapters.hostname_provider,
+                    machine_id_provider=result.runtime_adapters.machine_id_provider,
                 ),
                 callbacks=result.callbacks,
                 min_required_version=self._MIN_REQUIRED_VERSION,

--- a/py_modules/adapters/machine_id.py
+++ b/py_modules/adapters/machine_id.py
@@ -1,0 +1,30 @@
+"""Machine-id adapter — concrete ``MachineIdReader`` Protocol implementation.
+
+Reads ``/etc/machine-id`` so services can supply the stable, machine-derived
+device identity to RomM device registration without touching the filesystem
+directly. The single source of truth here is ``/etc/machine-id`` alone — no
+fallback chain — so an unreadable or empty file degrades to ``None`` and the
+caller falls back to no-fingerprint registration.
+"""
+
+from __future__ import annotations
+
+_MACHINE_ID_PATH = "/etc/machine-id"
+
+
+class MachineIdAdapter:
+    """Real ``MachineIdReader`` backed by ``/etc/machine-id``."""
+
+    def get(self) -> str | None:
+        """Return the stripped ``/etc/machine-id`` value, or ``None`` when unreadable.
+
+        Returns ``None`` on a missing file, empty/whitespace-only content, or
+        any ``OSError`` so registration can degrade to no-fingerprint behaviour
+        rather than sending an empty or invalid identity.
+        """
+        try:
+            with open(_MACHINE_ID_PATH, encoding="utf-8") as f:
+                machine_id = f.read().strip()
+        except OSError:
+            return None
+        return machine_id or None

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -186,16 +186,23 @@ class RommApiAdapter:
 
     # ── Devices ───────────────────────────────────────────────────────
 
-    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
-        return self._client.post_json(
-            "/api/devices",
-            {
-                "name": name,
-                "platform": platform,
-                "client": client,
-                "client_version": client_version,
-            },
-        )
+    def register_device(
+        self,
+        name: str,
+        platform: str,
+        client: str,
+        client_version: str,
+        hostname: str | None = None,
+    ) -> dict:
+        payload = {
+            "name": name,
+            "platform": platform,
+            "client": client,
+            "client_version": client_version,
+        }
+        if hostname is not None:
+            payload["hostname"] = hostname
+        return self._client.post_json("/api/devices", payload)
 
     def list_devices(self) -> list[dict]:
         result = self._client.request("/api/devices")

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -23,6 +23,7 @@ from adapters.download_file import DownloadFileAdapter
 from adapters.es_de_config import CoreResolver, GamelistXmlEditorAdapter
 from adapters.firmware_file import FirmwareFileAdapter
 from adapters.hostname import HostnameAdapter
+from adapters.machine_id import MachineIdAdapter
 from adapters.migration_file import MigrationFileAdapter
 from adapters.path_probe import PathProbeAdapter
 from adapters.persistence import (
@@ -71,6 +72,7 @@ from services.protocols import (
     FirmwareFileStore,
     GamelistXmlEditor,
     HostnameReader,
+    MachineIdReader,
     MigrationFileStore,
     PathExistsReader,
     PluginMetadataReader,
@@ -139,6 +141,7 @@ class RuntimeBundle:
     uuid_gen: UuidGen
     sleeper: Sleeper
     hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
 
 
 @dataclass(frozen=True)
@@ -157,7 +160,7 @@ class CallbackBundle:
 
 @dataclass(frozen=True)
 class RuntimeAdaptersBundle:
-    """Concrete adapters for the Clock/UuidGen/Sleeper/HostnameReader seams.
+    """Concrete adapters for the Clock/UuidGen/Sleeper/HostnameReader/MachineIdReader seams.
 
     Bootstrap owns adapter instantiation, but the ``RuntimeBundle``
     handed to ``wire_services`` also needs runtime-only state ``main.py``
@@ -170,6 +173,7 @@ class RuntimeAdaptersBundle:
     uuid_gen: UuidGen
     sleeper: Sleeper
     hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
 
 
 @dataclass(frozen=True)
@@ -319,6 +323,7 @@ def bootstrap(
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
     hostname_provider = HostnameAdapter()
+    machine_id_provider = MachineIdAdapter()
     debug_logger = SettingsAwareDebugLogger(settings=settings, logger=logger)
 
     adapters = AdapterBundle(
@@ -355,6 +360,7 @@ def bootstrap(
         uuid_gen=uuid_gen,
         sleeper=sleeper,
         hostname_provider=hostname_provider,
+        machine_id_provider=machine_id_provider,
     )
     handles = BootstrapHandles(debug_logger=debug_logger)
 
@@ -420,6 +426,7 @@ def wire_services(cfg: WiringConfig) -> dict:
         retrodeck_paths=cfg.callbacks.retrodeck_paths,
         get_active_core=cfg.adapters.core_info_provider.get_active_core,
         hostname_provider=cfg.runtime.hostname_provider,
+        machine_id_provider=cfg.runtime.machine_id_provider,
         log_debug=cfg.callbacks.log_debug,
         get_core_name=cfg.callbacks.get_core_name,
         plugin_metadata=cfg.callbacks.plugin_metadata,

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -54,6 +54,7 @@ from services.protocols.infra import (
     DownloadQueueCleanup,
     EventEmitter,
     HostnameReader,
+    MachineIdReader,
     PathExistsReader,
     PendingSyncReader,
 )
@@ -126,6 +127,7 @@ __all__ = [
     "LaunchGateInstalledChecker",
     "LaunchGateRomLookup",
     "LaunchGateSaveStatusReader",
+    "MachineIdReader",
     "MigrationFileStore",
     "MigrationPendingFn",
     "PathExistsReader",

--- a/py_modules/services/protocols/infra.py
+++ b/py_modules/services/protocols/infra.py
@@ -37,6 +37,24 @@ class HostnameReader(Protocol):
         ...
 
 
+class MachineIdReader(Protocol):
+    """Stable machine-derived device identity source.
+
+    Supplies the per-machine identifier device registration sends to RomM
+    as the fingerprint ``hostname`` so the server dedupes this device
+    across local-state wipes and reinstalls. Services consume this
+    Protocol instead of reading the identity file directly so device
+    registration stays free of raw I/O and tests can pin the value
+    without touching the filesystem. ``None`` signals the identity is
+    unreadable — callers degrade to no-fingerprint registration rather
+    than substituting a colliding value.
+    """
+
+    def get(self) -> str | None:
+        """Return the stable machine id, or ``None`` when unreadable."""
+        ...
+
+
 class PathExistsReader(Protocol):
     """Generic filesystem existence probe.
 

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -27,8 +27,20 @@ class SteamConfigStore(Protocol):
 class RommDeviceApi(Protocol):
     """RomM device registration / sync API surface."""
 
-    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
+    def register_device(
+        self,
+        name: str,
+        platform: str,
+        client: str,
+        client_version: str,
+        hostname: str | None = None,
+    ) -> dict:
         """Register this client as a sync device on the RomM server.
+
+        ``name`` is the friendly display label. ``hostname`` is the stable
+        machine-derived fingerprint the server dedupes on (``mac_address``
+        OR ``hostname`` + ``platform``); when ``None`` it is omitted from
+        the payload and registration degrades to no-fingerprint behaviour.
 
         Returns device dict with id, name, created_at.
         """

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         DebugLogger,
         EventEmitter,
         HostnameReader,
+        MachineIdReader,
         MigrationPendingFn,
         PluginMetadataReader,
         RetroDeckPaths,
@@ -73,6 +74,13 @@ class SaveServiceConfig:
         ``HostnameReader`` Protocol seam — supplies the local device
         hostname used as the registered device name during initial
         server-side device registration.
+    machine_id_provider:
+        ``MachineIdReader`` Protocol seam — supplies the stable
+        ``/etc/machine-id`` value sent as the RomM ``hostname``
+        fingerprint during initial server-side device registration so the
+        server dedupes this device across reinstalls. ``None`` when the
+        machine id is unreadable, which degrades registration to the
+        no-fingerprint path.
     get_core_name:
         Callable returning the RetroArch canonical ``corename`` field
         from a core's ``.info`` file for a given ``core_so`` (e.g.
@@ -132,6 +140,7 @@ class SaveServiceConfig:
     retrodeck_paths: RetroDeckPaths
     get_active_core: CoreResolverFn
     hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
     log_debug: DebugLogger
     plugin_metadata: PluginMetadataReader
     plugin_dir: str

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -87,6 +87,7 @@ class SaveService:
                 log_debug=config.log_debug,
                 get_active_core=config.get_active_core,
                 hostname_provider=config.hostname_provider,
+                machine_id_provider=config.machine_id_provider,
                 settings_persister=config.settings_persister,
                 plugin_version=plugin_version,
                 detect_sort_change=config.detect_sort_change,

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from services.protocols import (
         DebugLogger,
         HostnameReader,
+        MachineIdReader,
         RetryStrategy,
         RommSyncApi,
         SettingsPersister,
@@ -44,9 +45,10 @@ class DeviceRegistry:
     The server device id is read from and written to
     ``kv_config["device_id"]`` through the injected Unit-of-Work factory;
     the device label flows through ``settings.json``. The async entry
-    points take ``loop`` and ``hostname_provider`` per call so
-    :class:`SyncEngine` can pass its live (test-rebindable) attributes
-    without having to thread reassignments through this sub-module.
+    points take ``loop``, ``hostname_provider``, and ``machine_id_provider``
+    per call so :class:`SyncEngine` can pass its live (test-rebindable)
+    attributes without having to thread reassignments through this
+    sub-module.
     """
 
     def __init__(
@@ -90,8 +92,16 @@ class DeviceRegistry:
         *,
         loop: asyncio.AbstractEventLoop,
         hostname_provider: HostnameReader,
+        machine_id_provider: MachineIdReader,
     ) -> dict:
-        """Ensure this device is registered with the RomM server for save sync tracking."""
+        """Ensure this device is registered with the RomM server for save sync tracking.
+
+        ``hostname_provider`` supplies the friendly display ``name``;
+        ``machine_id_provider`` supplies the stable ``/etc/machine-id``
+        fingerprint sent as the RomM ``hostname`` so the server dedupes
+        this device across reinstalls. When the machine id is unreadable
+        (``None``) the call degrades to no-fingerprint registration.
+        """
         if not save_sync_enabled(self._settings):
             return {"success": False, "device_id": "", "device_name": "", "disabled": True}
 
@@ -128,6 +138,7 @@ class DeviceRegistry:
             }
 
         hostname = hostname_provider.get()
+        machine_id = machine_id_provider.get()
 
         try:
             result = await loop.run_in_executor(
@@ -137,6 +148,7 @@ class DeviceRegistry:
                     platform="linux",
                     client="decky-romm-sync",
                     client_version=self._plugin_version,
+                    hostname=machine_id,
                 ),
             )
             server_device_id = result.get("id") or result.get("device_id")

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         CoreResolverFn,
         DebugLogger,
         HostnameReader,
+        MachineIdReader,
         MigrationPendingFn,
         RetryStrategy,
         RommSyncApi,
@@ -63,7 +64,8 @@ class SyncEngineConfig:
     Protocol-typed RomM adapter and retry strategy, runtime
     infrastructure (loop, logger, clock), the Protocol-typed filesystem
     adapter, the ``DebugLogger`` seam, the ES-DE core resolver, the
-    hostname provider + settings persister used for device registration,
+    hostname provider + machine-id provider + settings persister used for
+    device registration,
     the plugin version string passed to the server on register/update,
     and the optional sort-change and migration-pending callbacks
     SyncEngine consults at the entry of every public flow.
@@ -81,6 +83,7 @@ class SyncEngineConfig:
     log_debug: DebugLogger
     get_active_core: CoreResolverFn
     hostname_provider: HostnameReader
+    machine_id_provider: MachineIdReader
     settings_persister: SettingsPersister
     plugin_version: str
     detect_sort_change: SaveSortChangeFn
@@ -104,6 +107,7 @@ class SyncEngine:
         self._log_debug = config.log_debug
         self._get_active_core = config.get_active_core
         self._hostname_provider = config.hostname_provider
+        self._machine_id_provider = config.machine_id_provider
         self._settings_persister = config.settings_persister
         self._plugin_version = config.plugin_version
         self._detect_sort_change = config.detect_sort_change
@@ -275,6 +279,7 @@ class SyncEngine:
         return await self._devices.ensure_device_registered(
             loop=self._loop,
             hostname_provider=self._hostname_provider,
+            machine_id_provider=self._machine_id_provider,
         )
 
     async def list_devices(self) -> dict:

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -264,6 +264,26 @@ class TestRegisterDevice:
             },
         )
 
+    def test_includes_hostname_when_passed(self):
+        api, client = _make_api()
+        client.post_json.return_value = {"id": "abc-123"}
+        api.register_device(
+            "steamdeck",
+            "linux",
+            "decky-romm-sync",
+            "0.13.0",
+            hostname="machine-abc-123",
+        )
+        _path, payload = client.post_json.call_args[0]
+        assert payload["hostname"] == "machine-abc-123"
+
+    def test_omits_hostname_when_none(self):
+        api, client = _make_api()
+        client.post_json.return_value = {"id": "abc-123"}
+        api.register_device("steamdeck", "linux", "decky-romm-sync", "0.13.0", hostname=None)
+        _path, payload = client.post_json.call_args[0]
+        assert "hostname" not in payload
+
 
 class TestListDevices:
     def test_returns_array(self):

--- a/tests/adapters/test_machine_id.py
+++ b/tests/adapters/test_machine_id.py
@@ -1,0 +1,34 @@
+"""Tests for the MachineIdAdapter — reads /etc/machine-id."""
+
+from __future__ import annotations
+
+from unittest.mock import mock_open, patch
+
+from adapters.machine_id import MachineIdAdapter
+
+
+class TestMachineIdAdapter:
+    def test_get_returns_stripped_machine_id(self):
+        adapter = MachineIdAdapter()
+        with patch("adapters.machine_id.open", mock_open(read_data="  abc123def456\n")):
+            assert adapter.get() == "abc123def456"
+
+    def test_get_returns_none_when_file_missing(self):
+        adapter = MachineIdAdapter()
+        with patch("adapters.machine_id.open", side_effect=FileNotFoundError("no such file")):
+            assert adapter.get() is None
+
+    def test_get_returns_none_on_oserror(self):
+        adapter = MachineIdAdapter()
+        with patch("adapters.machine_id.open", side_effect=OSError("boom")):
+            assert adapter.get() is None
+
+    def test_get_returns_none_when_file_empty(self):
+        adapter = MachineIdAdapter()
+        with patch("adapters.machine_id.open", mock_open(read_data="")):
+            assert adapter.get() is None
+
+    def test_get_returns_none_when_file_whitespace_only(self):
+        adapter = MachineIdAdapter()
+        with patch("adapters.machine_id.open", mock_open(read_data="   \n\t ")):
+            assert adapter.get() is None

--- a/tests/fakes/fake_machine_id_reader.py
+++ b/tests/fakes/fake_machine_id_reader.py
@@ -1,0 +1,18 @@
+"""In-memory ``MachineIdReader`` implementation for service tests."""
+
+from __future__ import annotations
+
+
+class FakeMachineIdReader:
+    """In-memory ``MachineIdReader`` for tests.
+
+    Returns the ``machine_id`` value configured at construction (``None``
+    models an unreadable ``/etc/machine-id``). Tests that assert on the
+    registration fingerprint read the same value back through the service.
+    """
+
+    def __init__(self, machine_id: str | None = "test-machine-id") -> None:
+        self.machine_id = machine_id
+
+    def get(self) -> str | None:
+        return self.machine_id

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -352,8 +352,15 @@ class FakeRommApi:
     # RommDeviceApi
     # ------------------------------------------------------------------
 
-    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
-        self._log("register_device", (name, platform, client, client_version))
+    def register_device(
+        self,
+        name: str,
+        platform: str,
+        client: str,
+        client_version: str,
+        hostname: str | None = None,
+    ) -> dict:
+        self._log("register_device", (name, platform, client, client_version), {"hostname": hostname})
         self._check_fail(self.register_device_side_effect)
         device_id = f"device-{self._next_device_id}"
         self._next_device_id += 1
@@ -363,6 +370,7 @@ class FakeRommApi:
             "platform": platform,
             "client": client,
             "client_version": client_version,
+            "hostname": hostname,
             "created_at": datetime.now(UTC).isoformat(),
         }
         self.devices.append(device)

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -179,8 +179,15 @@ class FakeSaveApi:
             self._save_content.pop(sid, None)
         return {"deleted": len(save_ids)}
 
-    def register_device(self, name: str, platform: str, client: str, client_version: str) -> dict:
-        self.call_log.append(("register_device", (name, platform, client, client_version), {}))
+    def register_device(
+        self,
+        name: str,
+        platform: str,
+        client: str,
+        client_version: str,
+        hostname: str | None = None,
+    ) -> dict:
+        self.call_log.append(("register_device", (name, platform, client, client_version), {"hostname": hostname}))
         self._check_fail()
         device_id = f"device-{self._next_device_id}"
         self._next_device_id += 1

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from conftest import _make_retry
 from fakes.fake_hostname_reader import FakeHostnameReader
+from fakes.fake_machine_id_reader import FakeMachineIdReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
@@ -50,6 +51,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         ),
         get_active_core=lambda system_name, rom_filename=None: (None, None),
         hostname_provider=FakeHostnameReader(),
+        machine_id_provider=FakeMachineIdReader(),
         log_debug=lambda _msg: None,
         plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
         plugin_dir=str(tmp_path / "plugin"),

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -6,13 +6,85 @@ test_engine.py.
 """
 
 import pytest
+from fakes.fake_hostname_reader import FakeHostnameReader
+from fakes.fake_machine_id_reader import FakeMachineIdReader
 
 from lib.errors import RommApiError
 from tests.services.saves._helpers import (
     _create_save,
+    _enable_sync_with_device,
     _install_rom,
     make_service,
 )
+
+
+def _register_call(fake):
+    """Return the recorded ``register_device`` call entry, or ``None``."""
+    for entry in fake.call_log:
+        if entry[0] == "register_device":
+            return entry
+    return None
+
+
+class TestEnsureDeviceRegisteredFingerprint:
+    """The machine-id is sent as the RomM ``hostname`` fingerprint so the
+    server dedupes this device across reinstalls; the friendly OS hostname
+    is the display ``name`` only and must never leak into the fingerprint."""
+
+    @pytest.mark.asyncio
+    async def test_register_sends_machine_id_as_hostname(self, tmp_path):
+        svc, fake = make_service(
+            tmp_path,
+            hostname_provider=FakeHostnameReader(hostname="steamdeck"),
+            machine_id_provider=FakeMachineIdReader(machine_id="machine-abc-123"),
+        )
+        svc._config.settings["save_sync_enabled"] = True
+        # No device_id persisted → registration branch.
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        entry = _register_call(fake)
+        assert entry is not None
+        name, _platform, _client, _version = entry[1]
+        # Friendly OS hostname is the display name only.
+        assert name == "steamdeck"
+        # Machine-id is the fingerprint hostname — NOT the OS hostname.
+        assert entry[2]["hostname"] == "machine-abc-123"
+
+    @pytest.mark.asyncio
+    async def test_register_omits_hostname_when_machine_id_none(self, tmp_path):
+        svc, fake = make_service(
+            tmp_path,
+            hostname_provider=FakeHostnameReader(hostname="steamdeck"),
+            machine_id_provider=FakeMachineIdReader(machine_id=None),
+        )
+        svc._config.settings["save_sync_enabled"] = True
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        entry = _register_call(fake)
+        assert entry is not None
+        name, _platform, _client, _version = entry[1]
+        # Degrades to no-fingerprint — hostname is None, never the OS hostname.
+        assert entry[2]["hostname"] is None
+        assert name != entry[2]["hostname"]
+
+    @pytest.mark.asyncio
+    async def test_existing_device_id_skips_registration(self, tmp_path):
+        svc, fake = make_service(
+            tmp_path,
+            machine_id_provider=FakeMachineIdReader(machine_id="machine-abc-123"),
+        )
+        _enable_sync_with_device(svc, "server-uuid")
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        assert result["device_id"] == "server-uuid"
+        # Already registered → no register_device call, machine-id unused.
+        assert _register_call(fake) is None
 
 
 class TestEnsureDeviceRegisteredFailurePaths:

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import _make_retry, _make_testable_plugin
 from fakes.fake_core_info_provider import FakeCoreInfoProvider
 from fakes.fake_hostname_reader import FakeHostnameReader
+from fakes.fake_machine_id_reader import FakeMachineIdReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
@@ -90,6 +91,7 @@ def plugin(tmp_path):
             ),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameReader(),
+            machine_id_provider=FakeMachineIdReader(),
             log_debug=p._log_debug,
             plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
             plugin_dir=str(tmp_path / "plugin"),

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -20,6 +20,7 @@ from fakes.fake_download_file_store import FakeDownloadFileStore
 from fakes.fake_firmware_cache_persister import FakeFirmwareCachePersister
 from fakes.fake_firmware_file_store import FakeFirmwareFileStore
 from fakes.fake_hostname_reader import FakeHostnameReader
+from fakes.fake_machine_id_reader import FakeMachineIdReader
 from fakes.fake_migration_file_store import FakeMigrationFileStore
 from fakes.fake_path_exists_reader import FakePathExistsReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
@@ -115,12 +116,13 @@ class TestBootstrap:
         assert result.handles.debug_logger is result.callbacks.log_debug
 
     def test_runtime_adapters_bundle_populated(self, tmp_path):
-        """Bootstrap owns instantiation of clock/uuid/sleeper/hostname for ``main.py`` to compose RuntimeBundle."""
+        """Bootstrap instantiates clock/uuid/sleeper/hostname/machine-id for ``main.py`` to compose RuntimeBundle."""
         result = _bootstrap_for(tmp_path)
         assert result.runtime_adapters.clock is not None
         assert result.runtime_adapters.uuid_gen is not None
         assert result.runtime_adapters.sleeper is not None
         assert result.runtime_adapters.hostname_provider is not None
+        assert result.runtime_adapters.machine_id_provider is not None
 
     def test_user_agent_threaded_to_romm_http_adapter(self, tmp_path):
         """Bootstrap reads ``package.json`` once and threads the resulting
@@ -202,6 +204,7 @@ class TestWireServices:
             "uuid_gen": FakeUuidGen(),
             "sleeper": FakeSleeper(),
             "hostname_provider": FakeHostnameReader(),
+            "machine_id_provider": FakeMachineIdReader(),
             "min_required_version": (4, 8, 1),
             "retrodeck_paths": FakeRetroDeckPaths(
                 saves=str(tmp_path / "saves"),
@@ -252,6 +255,7 @@ class TestWireServices:
                 uuid_gen=deps["uuid_gen"],
                 sleeper=deps["sleeper"],
                 hostname_provider=deps["hostname_provider"],
+                machine_id_provider=deps["machine_id_provider"],
             ),
             callbacks=CallbackBundle(
                 retrodeck_paths=deps["retrodeck_paths"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -885,6 +885,7 @@ class TestMainStartupOrdering:
                 uuid_gen=MagicMock(),
                 sleeper=MagicMock(),
                 hostname_provider=MagicMock(),
+                machine_id_provider=MagicMock(),
             ),
             handles=BootstrapHandles(debug_logger=MagicMock()),
         )

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -8,6 +8,7 @@ import pytest
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
 from conftest import _make_retry, _make_testable_plugin
 from fakes.fake_hostname_reader import FakeHostnameReader
+from fakes.fake_machine_id_reader import FakeMachineIdReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_api import FakeSaveApi
@@ -96,6 +97,7 @@ def plugin(tmp_path):
             ),
             get_active_core=lambda system_name, rom_filename=None: (None, None),
             hostname_provider=FakeHostnameReader(),
+            machine_id_provider=FakeMachineIdReader(),
             log_debug=p._log_debug,
             plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
             plugin_dir=str(tmp_path / "plugin"),


### PR DESCRIPTION
## Problem

Device registration sent only `name` + `platform` to RomM. RomM ≥4.8.1 dedupes a device by **fingerprint** (`mac_address`, or `hostname` + `platform`) and returns the existing device (`allow_existing` defaults true) — but `name` is **not** fingerprinted. So every reinstall, and the SQLite cutover's local-state wipe, registered a brand-new device, orphaning the prior registration and the server-side per-device save/slot views (`list_saves` / `get_save_summary` / `request_download` / `confirm_download` all pass `device_id`).

## Fix

Send `/etc/machine-id` as the RomM `hostname` field on registration:

- **Machine-derived** → survives the local wipe; after reinstall RomM fingerprint-matches and hands back the same device. No JSON→SQLite migration (consistent with the deliberate empty-DB cutover).
- **Unique per device** → two Steam Decks stay distinct. The real OS hostname can't be used: the `mac OR (hostname+platform)` fingerprint would collide two stock `steamdeck` hosts.
- `name` stays the friendly display label.
- When `/etc/machine-id` is unreadable, **no** hostname is sent — degrades to the prior no-fingerprint behavior, never a colliding value.

New `MachineIdReader` Protocol + `MachineIdAdapter`, threaded as a per-call `machine_id_provider` alongside the existing `hostname_provider`.

## Scope

Cleaning up duplicate devices that **earlier** installs already created is out of scope here — it's tracked in #828 (release-notes guidance) and is safe (deleting a device on RomM removes only its per-device sync-tracking rows, never the saves).

Docs updated in the same PR (`docs/architecture/save-file-sync-architecture.md`).

Closes #878.
