### PR TITLE
chore(quality): adopt ruff RET/C4/PIE/PERF lint groups

### DIFF
--- a/py_modules/adapters/download_file.py
+++ b/py_modules/adapters/download_file.py
@@ -60,9 +60,7 @@ class DownloadFileAdapter:
             return []
         matches: list[str] = []
         for root, _dirs, files in os.walk(base_dir):
-            for filename in files:
-                if filename.endswith(suffixes):
-                    matches.append(os.path.join(root, filename))
+            matches.extend(os.path.join(root, filename) for filename in files if filename.endswith(suffixes))
         return matches
 
     def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:

--- a/py_modules/adapters/es_de_config.py
+++ b/py_modules/adapters/es_de_config.py
@@ -746,8 +746,7 @@ class GamelistXmlEditorAdapter:
         if alt_label:
             escaped = GamelistXmlEditorAdapter.escape_xml(alt_label)
             parts.append(f"\n  <alternativeEmulator>\n    <label>{escaped}</label>\n  </alternativeEmulator>")
-        for game_xml in games_xml_list:
-            parts.append(f"\n  {game_xml}")
+        parts.extend(f"\n  {game_xml}" for game_xml in games_xml_list)
         parts.append("\n</gameList>\n")
         return "".join(parts)
 

--- a/py_modules/domain/firmware_paths.py
+++ b/py_modules/domain/firmware_paths.py
@@ -24,7 +24,7 @@ def parse_firmware_slug(file_path: str) -> str:
     parts = file_path.strip("/").split("/")
     if len(parts) >= 2 and parts[0] == "bios":
         return parts[1]
-    elif len(parts) >= 2:
+    if len(parts) >= 2:
         return parts[0]
     return ""
 

--- a/py_modules/lib/certifi_bundle.py
+++ b/py_modules/lib/certifi_bundle.py
@@ -15,4 +15,4 @@ except ImportError:
 
     def ca_bundle():
         """Return the path to the certifi CA bundle, or None if unavailable."""
-        return None
+        return

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -356,16 +356,16 @@ class LibraryFetcher:
         units: list[WorkUnit] = []
 
         platforms = await self._fetch_enabled_platforms()
-        for platform in platforms:
-            units.append(
-                WorkUnit(
-                    type="platform",
-                    id=int(platform["id"]),
-                    name=platform.get("name", platform.get("display_name", "Unknown")),
-                    slug=platform.get("slug", ""),
-                    rom_count=int(platform.get("rom_count", 0)),
-                )
+        units.extend(
+            WorkUnit(
+                type="platform",
+                id=int(platform["id"]),
+                name=platform.get("name", platform.get("display_name", "Unknown")),
+                slug=platform.get("slug", ""),
+                rom_count=int(platform.get("rom_count", 0)),
             )
+            for platform in platforms
+        )
 
         buckets = self._get_enabled_collections_buckets()
         enabled_user_ids = {k for k, v in buckets["user"].items() if v}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ select = [
     "RUF",   # ruff-specific rules
     "ARG",   # unused arguments
     "ASYNC", # flake8-async — blocking I/O in async functions
+    "RET",   # flake8-return
+    "C4",    # flake8-comprehensions
+    "PIE",   # flake8-pie
+    "PERF",  # perflint
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/adapters/test_download_file.py
+++ b/tests/adapters/test_download_file.py
@@ -233,7 +233,7 @@ class TestScanFilesWithSizes:
         (tmp_path / "a.bin").write_bytes(b"\x00" * 10)
         (tmp_path / "b.bin").write_bytes(b"\x00" * 20)
         out = adapter.scan_files_with_sizes(str(tmp_path))
-        sizes = {p: s for p, s in out}
+        sizes = dict(out)
         assert sizes[str(tmp_path / "a.bin")] == 10
         assert sizes[str(tmp_path / "b.bin")] == 20
 

--- a/tests/fakes/fake_migration_file_store.py
+++ b/tests/fakes/fake_migration_file_store.py
@@ -115,14 +115,13 @@ class FakeMigrationFileStore:
             for part in dirname.split("/") if dirname else []:
                 per_dir_subdirs.setdefault(current, set()).add(part)
                 current = os.path.join(current, part)
-        triples: list[tuple[str, list[str], list[str]]] = []
         all_dirs = sorted(set(per_dir_files) | set(per_dir_subdirs) | {base_dir})
-        for d in all_dirs:
-            triples.append(
-                (
-                    d,
-                    sorted(per_dir_subdirs.get(d, set())),
-                    sorted(per_dir_files.get(d, [])),
-                )
+        triples: list[tuple[str, list[str], list[str]]] = [
+            (
+                d,
+                sorted(per_dir_subdirs.get(d, set())),
+                sorted(per_dir_files.get(d, [])),
             )
+            for d in all_dirs
+        ]
         return triples

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -388,8 +388,7 @@ class FakeRommApi:
             if str(device.get("id")) == str(device_id):
                 device.update({k: v for k, v in fields.items() if v is not None})
                 return dict(device)
-        synthesized = {"id": device_id, **{k: v for k, v in fields.items() if v is not None}}
-        return synthesized
+        return {"id": device_id, **{k: v for k, v in fields.items() if v is not None}}
 
     # ------------------------------------------------------------------
     # RommSaveApi

--- a/tests/lib/test_list_result.py
+++ b/tests/lib/test_list_result.py
@@ -139,8 +139,7 @@ class TestIsinstanceNarrowing:
         if isinstance(result, FailedListResult):
             pass
         else:
-            for item in result.items:
-                collected.append(item.upper())
+            collected.extend(item.upper() for item in result.items)
         assert collected == ["A", "B", "C"]
 
 

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -36,31 +36,31 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
     # bytes onto the shared filesystem view.
     if fake.save_file_store is None:
         fake.save_file_store = save_file_store
-    config_kwargs: dict[str, Any] = dict(
-        romm_api=fake,
-        retry=_make_retry(),
-        settings={"log_level": "debug"},
-        settings_persister=FakeSettingsPersister(),
-        save_file_store=save_file_store,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
-        retrodeck_paths=FakeRetroDeckPaths(
+    config_kwargs: dict[str, Any] = {
+        "romm_api": fake,
+        "retry": _make_retry(),
+        "settings": {"log_level": "debug"},
+        "settings_persister": FakeSettingsPersister(),
+        "save_file_store": save_file_store,
+        "loop": asyncio.get_event_loop(),
+        "logger": logging.getLogger("test"),
+        "clock": FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
+        "retrodeck_paths": FakeRetroDeckPaths(
             saves=str(tmp_path / "saves"),
             roms=str(tmp_path / "retrodeck" / "roms"),
         ),
-        get_active_core=lambda system_name, rom_filename=None: (None, None),
-        hostname_provider=FakeHostnameReader(),
-        machine_id_provider=FakeMachineIdReader(),
-        log_debug=lambda _msg: None,
-        plugin_metadata=FakePluginMetadataReader(version="0.14.0"),
-        plugin_dir=str(tmp_path / "plugin"),
-        emit=emit if emit is not None else _noop_emit,
-        get_core_name=lambda core_so: None,
-        detect_sort_change=lambda: None,
-        is_retrodeck_migration_pending=lambda: False,
-        uow_factory=FakeUnitOfWorkFactory(),
-    )
+        "get_active_core": lambda system_name, rom_filename=None: (None, None),
+        "hostname_provider": FakeHostnameReader(),
+        "machine_id_provider": FakeMachineIdReader(),
+        "log_debug": lambda _msg: None,
+        "plugin_metadata": FakePluginMetadataReader(version="0.14.0"),
+        "plugin_dir": str(tmp_path / "plugin"),
+        "emit": emit if emit is not None else _noop_emit,
+        "get_core_name": lambda core_so: None,
+        "detect_sort_change": lambda: None,
+        "is_retrodeck_migration_pending": lambda: False,
+        "uow_factory": FakeUnitOfWorkFactory(),
+    }
     config_kwargs.update(overrides)
     svc = SaveService(config=SaveServiceConfig(**config_kwargs))
     return svc, fake

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -200,7 +200,7 @@ class _RecordingLoop:
     def create_task(self, coro):
         coro.close()
         self.tasks.append(coro)
-        return None
+        return
 
 
 class TestPathChangeDetection:
@@ -1110,7 +1110,7 @@ class TestMigrationFailureInjection:
             "logger": decky.logger,
             "settings_persister": FakeSettingsPersister(),
             "emit": RecordingEmitter(),
-            "get_bios_files_index": lambda: {},
+            "get_bios_files_index": dict,
             "retrodeck_paths": FakeRetroDeckPaths(),
             "get_retroarch_save_sorting": lambda: (False, False),
             "get_active_core": lambda system, rom_filename: (None, None),

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -105,7 +105,7 @@ def _make_service(
             logger=logging.getLogger("test"),
             settings_persister=MagicMock(),
             emit=MagicMock(),
-            get_bios_files_index=lambda: {},
+            get_bios_files_index=dict,
             retrodeck_paths=FakeRetroDeckPaths(
                 saves=saves_path,
                 roms=roms_path,

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -59,16 +59,16 @@ def make_service(fake_api=None, clock=None, settings=None, uow=None, **overrides
     clk = clock or FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
     settings_dict = settings if settings is not None else {}
 
-    defaults: dict[str, Any] = dict(
-        romm_api=fake,
-        retry=_make_retry(),
-        settings=settings_dict,
-        loop=asyncio.get_event_loop(),
-        logger=logging.getLogger("test"),
-        clock=clk,
-        log_debug=lambda _msg: None,
-        uow_factory=FakeUnitOfWorkFactory(unit),
-    )
+    defaults: dict[str, Any] = {
+        "romm_api": fake,
+        "retry": _make_retry(),
+        "settings": settings_dict,
+        "loop": asyncio.get_event_loop(),
+        "logger": logging.getLogger("test"),
+        "clock": clk,
+        "log_debug": lambda _msg: None,
+        "uow_factory": FakeUnitOfWorkFactory(unit),
+    }
     defaults.update(overrides)
     svc = PlaytimeService(config=PlaytimeServiceConfig(**defaults))
     return svc, fake, unit

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -518,7 +518,7 @@ class TestPostExitSync:
                 logger=logging.getLogger("test"),
                 settings_persister=MagicMock(),
                 emit=MagicMock(),
-                get_bios_files_index=lambda: {},
+                get_bios_files_index=dict,
                 retrodeck_paths=FakeRetroDeckPaths(),
                 get_retroarch_save_sorting=lambda: (False, False),
                 get_active_core=lambda system_name, rom_filename=None: (None, None),


### PR DESCRIPTION
Part of #862 (part A). Quality-ratchet box from the #838 tooling umbrella: enable a lint group set, fix the fallout, lock it in.

## What
Adds `RET` (flake8-return), `C4` (flake8-comprehensions), `PIE` (flake8-pie) and `PERF` (perflint) to the ruff `select` set, and fixes the 15 resulting findings.

Counts were re-measured on current `main` after the SQLite cutover landed (the original #862 estimate of 18 was pre-cutover): 15 findings — PERF401 ×5, PIE807 ×3, C408 ×2, RET501 ×2, C416 ×1, RET504 ×1, RET505 ×1. Ten of them live in `tests/`.

## How
- PERF401: manual `for … append` loops collapsed into `.extend(generator)` / list comprehensions — order- and side-effect-preserving in every case.
- C408: `dict(k=v, …)` → `{"k": v, …}` literals (identical keys/values).
- C416: redundant dict comprehension → `dict(out)`.
- RET505/501/504: unnecessary `elif`-after-`return`, trailing `return None`, assign-then-return.
- PIE807: `lambda: {}` default factory → `dict`.

No `# noqa` / `# type: ignore` added to silence anything — every finding is a real fix.

## Verification
- `ruff check .` — clean
- `ruff format --check .` — clean
- `basedpyright` — 0 errors
- `pytest` — 2844 passed

docs: N/A — tooling config (ruff lint rule adoption; no user-visible, architecture, or flow change).