### PR TITLE
chore(quality): adopt basedpyright reportUnnecessaryComparison

### DIFF
--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -62,3 +62,7 @@ class LibrarySyncStateBox:
     # for the active unit. Surfaces the result so the orchestrator can
     # accumulate the per-unit registry into the cross-run accumulators.
     last_unit_results: dict[str, int] | None = None
+
+    def is_cancelling(self) -> bool:
+        """True while a cancel has been requested for the in-flight run."""
+        return self.sync_state is SyncState.CANCELLING

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -175,7 +175,7 @@ class SyncOrchestrator:
 
             total_units = len(work_queue)
             for unit_index, unit in enumerate(work_queue, 1):
-                if box.sync_state == SyncState.CANCELLING:
+                if box.is_cancelling():
                     raise asyncio.CancelledError(_SYNC_CANCELLED)
                 await self.emit_progress(
                     SyncStage.FETCHING,
@@ -429,7 +429,7 @@ class SyncOrchestrator:
             await self._loop.run_in_executor(None, self._open_sync_run, run_id, platforms_planned, total_roms_planned)
 
             for unit_index, unit in enumerate(work_queue):
-                if box.sync_state == SyncState.CANCELLING:
+                if box.is_cancelling():
                     cancelled = True
                     break
 
@@ -443,7 +443,7 @@ class SyncOrchestrator:
                 )
                 total_games_applied += applied
 
-                if box.sync_state == SyncState.CANCELLING:
+                if box.is_cancelling():
                     cancelled = True
                     break
 
@@ -625,7 +625,7 @@ class SyncOrchestrator:
                 collection_memberships=collection_memberships,
             )
 
-        if box.sync_state == SyncState.CANCELLING:
+        if box.is_cancelling():
             return 0
 
         # Per-unit incremental skip: registry already matches the
@@ -650,7 +650,7 @@ class SyncOrchestrator:
             for sd in shortcuts_data:
                 sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
 
-        if box.sync_state == SyncState.CANCELLING:
+        if box.is_cancelling():
             return 0
 
         # Stage pending_sync for this unit so the reporter's commit step
@@ -747,7 +747,7 @@ class SyncOrchestrator:
         """
         box = self._sync_state
         while not event.is_set():
-            if box.sync_state == SyncState.CANCELLING:
+            if box.is_cancelling():
                 self._logger.info(f"Per-unit cancel observed while waiting for unit {unit.name}")
                 return None
             elapsed = self._clock.monotonic() - box.sync_last_heartbeat
@@ -818,7 +818,7 @@ class SyncOrchestrator:
         return await self._artwork.download_artwork(
             all_roms,
             emit_progress=self.emit_progress,
-            is_cancelling=lambda: box.sync_state == SyncState.CANCELLING,
+            is_cancelling=box.is_cancelling,
             progress_step=progress_step,
             progress_total_steps=progress_total_steps,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ pythonVersion = "3.11"
 extraPaths = ["py_modules"]
 stubPath = "typings"
 typeCheckingMode = "basic"
-exclude = ["py_modules/_vendor", "scripts", ".venv"]
+exclude = ["py_modules/_vendor", "scripts", ".venv", ".worktrees"]
 reportMissingModuleSource = "none"
 reportMissingImports = "warning"
 reportPrivateUsage = "error"
@@ -11,6 +11,7 @@ reportRedeclaration = "none"
 reportUnusedParameter = "none"
 reportUnusedVariable = "warning"
 reportArgumentType = "error"
+reportUnnecessaryComparison = "error"
 
 # Tests inspect and rebind private state of the system under test —
 # white-box testing is a deliberate, accepted pattern here. The

--- a/tests/lib/test_list_result.py
+++ b/tests/lib/test_list_result.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from typing import cast
 
 import pytest
 
@@ -147,7 +148,7 @@ class TestMatchNarrowing:
     """``match`` statement narrows the union cleanly too."""
 
     def test_match_success_branch(self):
-        result: ListResult[int] = OkListResult(items=[1, 2, 3])
+        result = cast("ListResult[int]", OkListResult(items=[1, 2, 3]))
         match result:
             case OkListResult(items=items):
                 total = sum(items)
@@ -156,7 +157,7 @@ class TestMatchNarrowing:
         assert total == 6
 
     def test_match_failure_branch(self):
-        result: ListResult[int] = FailedListResult(error=ErrorCode.SERVER_UNREACHABLE)
+        result = cast("ListResult[int]", FailedListResult(error=ErrorCode.SERVER_UNREACHABLE))
         match result:
             case OkListResult():
                 outcome = "ok"
@@ -167,7 +168,7 @@ class TestMatchNarrowing:
         assert outcome == "retry"
 
     def test_match_empty_ok(self):
-        result: ListResult[str] = OkListResult(items=[])
+        result = cast("ListResult[str]", OkListResult(items=[]))
         match result:
             case OkListResult(items=items):
                 count = len(items)


### PR DESCRIPTION
Closes #841. basedpyright cherry-pick box from the #838 tooling umbrella — raise one rule to `error`, fix the fallout, lock it in. Project stays in `basic` mode.

## Findings (re-measured on post-cutover `main`: 6, not the stale 7)
None are dead code — all are type-narrowing artifacts:

- **`services/library/sync_orchestrator.py` (3 sites).** After `box.sync_state = SyncState.RUNNING`, pyright narrows `box.sync_state` to `Literal[RUNNING]` and flags the later `== SyncState.CANCELLING` polls as always-False. They're correct: a concurrent coroutine flips the state to `CANCELLING` via `request_cancel`, which pyright's flow analysis can't model.
- **`tests/lib/test_list_result.py` (3 sites).** `TestMatchNarrowing` assigns a concrete `OkListResult`/`FailedListResult` to a `ListResult[int]` local, so pyright narrows to the variant and reads the other `match` arm as unreachable.

## Fixes (no `# pyright: ignore`)
- `LibrarySyncStateBox.is_cancelling()` — new read predicate (`self.sync_state is SyncState.CANCELLING`). Every `box.sync_state == SyncState.CANCELLING` read in the orchestrator now routes through it (and the artwork-cancel `lambda` becomes a `box.is_cancelling` method reference), so pyright sees `bool` instead of a flow-narrowed literal at the cancel polls. All reads converted for consistency; write sites untouched. `SyncState` is a plain `enum.Enum`, so `is` ≡ `==` for members.
- The 3 match tests wrap construction in `cast("ListResult[int]", …)` so `result` is genuinely the union — the exhaustive arms stay reachable and the tests exercise the real union case. (String forward-ref form because `ListResult` is a string `TypeAlias`; the bare subscript would raise at runtime.)

## Bundled hygiene
Added `.worktrees` to the basedpyright `exclude` — otherwise local runs recurse into sibling worktrees and inflate counts ~30×. CI is unaffected (no `.worktrees/` there). Surfaced by this ratchet's measurement.

## Verification
- `basedpyright` — 0 errors
- `ruff check .` / `ruff format --check .` — clean
- `import-linter` — 8 kept, 0 broken
- `pytest` — 2844 passed

docs: N/A — tooling config (basedpyright rule adoption + a read-accessor refactor; no user-visible, architecture, or flow change).