### PR TITLE
chore(quality): adopt ruff TC (flake8-type-checking)

### DIFF
--- a/py_modules/adapters/es_de_config.py
+++ b/py_modules/adapters/es_de_config.py
@@ -8,10 +8,13 @@ writing per-system / per-game core overrides back to ``gamelist.xml``.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
-from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+    from collections.abc import Callable
 
 _CORE_SO_RE = re.compile(r"%CORE_RETROARCH%/([\w-]+_libretro)\.so")
 

--- a/py_modules/adapters/retroarch_config.py
+++ b/py_modules/adapters/retroarch_config.py
@@ -14,8 +14,11 @@ needed.
 
 from __future__ import annotations
 
-import logging
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
 
 
 class RetroArchConfigAdapter:

--- a/py_modules/adapters/retroarch_core_info.py
+++ b/py_modules/adapters/retroarch_core_info.py
@@ -21,10 +21,13 @@ the ``Config Source Parsers`` wiki page for the rationale.
 
 from __future__ import annotations
 
-import logging
 import os
+from typing import TYPE_CHECKING
 
 from domain.retroarch_core_info import parse_core_info
+
+if TYPE_CHECKING:
+    import logging
 
 
 class RetroArchCoreInfoAdapter:

--- a/py_modules/adapters/retrodeck_paths.py
+++ b/py_modules/adapters/retrodeck_paths.py
@@ -11,9 +11,12 @@ plugin session.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
 
 
 class RetroDeckPathsAdapter:

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -7,8 +7,10 @@ directly to HTTP endpoints via RommHttpAdapter.
 from __future__ import annotations
 
 import urllib.parse
+from typing import TYPE_CHECKING
 
-from adapters.romm.http import RommHttpAdapter
+if TYPE_CHECKING:
+    from adapters.romm.http import RommHttpAdapter
 
 
 class RommApiAdapter:

--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -7,12 +7,15 @@ Steam ``userdata`` directory (resolved from ``DECKY_USER_HOME``).
 from __future__ import annotations
 
 import contextlib
-import logging
 import os
+from typing import TYPE_CHECKING
 
 from _vendor import vdf
 
 from lib.errors import SteamGridDirMissingError
+
+if TYPE_CHECKING:
+    import logging
 
 
 class SteamConfigAdapter:

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -10,11 +10,10 @@ caller to keep as its source of truth.
 
 from __future__ import annotations
 
-import asyncio
 import functools
-import logging
 import os
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from adapters.asyncio_sleeper import AsyncioSleeper
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
@@ -60,34 +59,6 @@ from services.library import LibraryService, LibraryServiceConfig
 from services.metadata import MetadataService, MetadataServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService, PlaytimeServiceConfig
-from services.protocols import (
-    Clock,
-    CoreInfoProvider,
-    CoreNameProviderFn,
-    CoverArtFileStore,
-    DebugLogger,
-    DownloadFileStore,
-    EventEmitter,
-    FirmwareCachePersister,
-    FirmwareFileStore,
-    GamelistXmlEditor,
-    HostnameReader,
-    MachineIdReader,
-    MigrationFileStore,
-    PathExistsReader,
-    PluginMetadataReader,
-    RetroArchSaveSortingProvider,
-    RetroDeckPaths,
-    RomFileStore,
-    RommApi,
-    SaveFileStore,
-    SettingsPersister,
-    SgdbArtworkCache,
-    Sleeper,
-    SteamConfigStore,
-    UnitOfWorkFactory,
-    UuidGen,
-)
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 from services.saves import SaveService, SaveServiceConfig
 from services.session_lifecycle import SessionLifecycleService, SessionLifecycleServiceConfig
@@ -95,6 +66,39 @@ from services.settings import SettingsService, SettingsServiceConfig
 from services.shortcut_removal import ShortcutRemovalService, ShortcutRemovalServiceConfig
 from services.startup_healing import StartupHealingService, StartupHealingServiceConfig
 from services.steamgrid import SteamGridService, SteamGridServiceConfig
+
+if TYPE_CHECKING:
+    import asyncio
+    import logging
+
+    from services.protocols import (
+        Clock,
+        CoreInfoProvider,
+        CoreNameProviderFn,
+        CoverArtFileStore,
+        DebugLogger,
+        DownloadFileStore,
+        EventEmitter,
+        FirmwareCachePersister,
+        FirmwareFileStore,
+        GamelistXmlEditor,
+        HostnameReader,
+        MachineIdReader,
+        MigrationFileStore,
+        PathExistsReader,
+        PluginMetadataReader,
+        RetroArchSaveSortingProvider,
+        RetroDeckPaths,
+        RomFileStore,
+        RommApi,
+        SaveFileStore,
+        SettingsPersister,
+        SgdbArtworkCache,
+        Sleeper,
+        SteamConfigStore,
+        UnitOfWorkFactory,
+        UuidGen,
+    )
 
 # Filename of the SQLite database inside the plugin runtime dir. Created by the
 # migration runner at startup; unused until the service cutover (#784).

--- a/py_modules/lib/late_binding.py
+++ b/py_modules/lib/late_binding.py
@@ -16,8 +16,10 @@ underlying object).
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-
-from models.state import ShortcutRegistryEntry
 
 from domain.artwork_paths import final_filename, staging_filename
 from domain.sync_stage import SyncStage
 from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
     from collections.abc import Callable
+
+    from models.state import ShortcutRegistryEntry
 
     from services.protocols import (
         CoverArtFileStore,

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -11,7 +11,6 @@ responsibility.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -24,6 +23,7 @@ from domain.firmware_cache import FirmwareCacheEntry
 from lib.errors import error_response
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
 
     from services.protocols import (

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -16,7 +16,6 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, cast
 
 from models.metadata import AchievementSummary
-from models.state import MetadataCacheEntry
 
 from domain.bios import compute_bios_label, compute_bios_level, format_bios_status
 from domain.platform_names import decode_platform_names
@@ -24,6 +23,8 @@ from domain.save_status import compute_save_sync_display
 
 if TYPE_CHECKING:
     import logging
+
+    from models.state import MetadataCacheEntry
 
     from domain.rom import Rom
     from domain.rom_install import RomInstall

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -10,13 +10,14 @@ than reaching through ``service._state.x``.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from domain.sync_state import SyncState
 
 if TYPE_CHECKING:
+    import asyncio
+
     from domain.preview_delta import PreviewDelta
 
 

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -19,12 +19,12 @@ from typing import TYPE_CHECKING
 from domain.sync_state import SyncState
 from domain.work_unit import CollectionKind, WorkUnit
 from lib.errors import classify_error
-from services.library._state import LibrarySyncStateBox
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Awaitable, Callable
 
+    from services.library._state import LibrarySyncStateBox
     from services.protocols import (
         DebugLogger,
         RommLibraryApi,

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -18,7 +18,6 @@ this sync do?" belongs in the orchestrator.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -29,12 +28,13 @@ from domain.rom_metadata_mapping import build_rom_metadata
 from domain.sync_diff import should_include_in_platform_collection
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
-from services.library._state import LibrarySyncStateBox
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
     from collections.abc import Awaitable, Callable
 
+    from services.library._state import LibrarySyncStateBox
     from services.protocols import (
         ArtworkManager,
         Clock,

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -14,7 +14,6 @@ in-flight sync state belongs in a sub-service.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -25,6 +24,7 @@ from services.library.reporter import SyncReporter, SyncReporterConfig
 from services.library.sync_orchestrator import SyncOrchestrator, SyncOrchestratorConfig
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
 
     from domain.preview_delta import PreviewDelta

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -31,14 +31,14 @@ from domain.sync_diff import (
 from domain.sync_run import SyncRun
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
-from domain.work_unit import WorkUnit
 from lib.errors import classify_error
-from lib.late_binding import LateBinding
-from services.library._state import LibrarySyncStateBox
 
 if TYPE_CHECKING:
     import logging
 
+    from domain.work_unit import WorkUnit
+    from lib.late_binding import LateBinding
+    from services.library._state import LibrarySyncStateBox
     from services.library.fetcher import LibraryFetcher
     from services.library.reporter import SyncReporter
     from services.protocols import (

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -15,14 +15,14 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from models.state import SaveSortSettings
-
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
 
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable
+
+    from models.state import SaveSortSettings
 
     from domain.rom_install import RomInstall
     from services.protocols import (

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -10,9 +10,10 @@ narrow seam one consuming service sees of another service's surface.
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
-from models.state import InstalledRomEntry, ShortcutRegistryEntry
+if TYPE_CHECKING:
+    from models.state import InstalledRomEntry, ShortcutRegistryEntry
 
 
 class RetryStrategy(Protocol):

--- a/py_modules/services/protocols/determinism.py
+++ b/py_modules/services/protocols/determinism.py
@@ -9,8 +9,10 @@ fakes live in ``tests.fakes``.
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Clock(Protocol):

--- a/py_modules/services/protocols/repositories.py
+++ b/py_modules/services/protocols/repositories.py
@@ -22,10 +22,11 @@ this Protocol surface.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from domain.bios_file import BiosFile
     from domain.firmware_cache import FirmwareCacheEntry
     from domain.playtime import Playtime

--- a/py_modules/services/protocols/uow.py
+++ b/py_modules/services/protocols/uow.py
@@ -17,10 +17,11 @@ Protocols below, so the adapter package never imports this module — keeping th
 
 from __future__ import annotations
 
-from types import TracebackType
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from services.protocols.repositories import (
         BiosFileRepository,
         FirmwareCacheRepository,

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -8,13 +8,13 @@ metadata all survive — only the on-disk files and the install record go.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from lib.path_safety import is_safe_rom_path
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
 
     from domain.rom_install import RomInstall

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -17,8 +17,6 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from models.state import SaveSortSettings
-
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
 
@@ -31,6 +29,8 @@ _KV_SAVE_SORT_PREVIOUS = "save_sort_settings_previous"
 
 if TYPE_CHECKING:
     import logging
+
+    from models.state import SaveSortSettings
 
     from services.protocols import (
         CoreNameProviderFn,

--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from domain.rom_save_state import RomSaveState
 from lib.list_result import ErrorCode
 from services.saves._settings import save_sync_enabled
 
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
     import asyncio
     import logging
 
+    from domain.rom_save_state import RomSaveState
     from services.protocols import (
         DebugLogger,
         RetryStrategy,

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,6 +32,7 @@ from services.saves.sync_engine.rollback import RollbackOrchestrator
 
 if TYPE_CHECKING:
     import logging
+    from collections.abc import Iterator
 
     from services.protocols import (
         Clock,

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -34,6 +33,7 @@ from services.saves._helpers import local_save_target
 
 if TYPE_CHECKING:
     import logging
+    from collections.abc import Iterator
 
     from services.protocols import (
         Clock,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ select = [
     "C4",    # flake8-comprehensions
     "PIE",   # flake8-pie
     "PERF",  # perflint
+    "TC",   # flake8-type-checking
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/adapters/test_path_probe.py
+++ b/tests/adapters/test_path_probe.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from adapters.path_probe import PathProbeAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestExists:

--- a/tests/adapters/test_retroarch_core_info.py
+++ b/tests/adapters/test_retroarch_core_info.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from adapters.retroarch_core_info import RetroArchCoreInfoAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _SNES9X_INFO = (
     "# Software Information\n"

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from models.state import ShortcutRegistryEntry
-
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+
+    from models.state import ShortcutRegistryEntry
 
 
 class FakeArtworkManager:

--- a/tests/fakes/test_fake_repositories.py
+++ b/tests/fakes/test_fake_repositories.py
@@ -8,6 +8,7 @@ carry coverage rather than riding on the adapters'.
 from __future__ import annotations
 
 import sqlite3
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -29,19 +30,21 @@ from fakes.fake_rom_repository import FakeRomRepository
 from fakes.fake_rom_save_state_repository import FakeRomSaveStateRepository
 from fakes.fake_sync_run_repository import FakeSyncRunRepository
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
-from services.protocols import (
-    BiosFileRepository,
-    FirmwareCacheRepository,
-    KvConfigRepository,
-    PlaytimeRepository,
-    RomInstallRepository,
-    RomMetadataRepository,
-    RomRepository,
-    RomSaveStateRepository,
-    SyncRunRepository,
-    UnitOfWork,
-    UnitOfWorkFactory,
-)
+
+if TYPE_CHECKING:
+    from services.protocols import (
+        BiosFileRepository,
+        FirmwareCacheRepository,
+        KvConfigRepository,
+        PlaytimeRepository,
+        RomInstallRepository,
+        RomMetadataRepository,
+        RomRepository,
+        RomSaveStateRepository,
+        SyncRunRepository,
+        UnitOfWork,
+        UnitOfWorkFactory,
+    )
 
 
 def _rom(rom_id: int) -> Rom:

--- a/tests/lib/test_migration_gate.py
+++ b/tests/lib/test_migration_gate.py
@@ -150,6 +150,6 @@ class TestMigrationBlockedDecorator:
         svc = MagicMock()
         svc.is_retrodeck_migration_pending.return_value = True
         owner = _Owner(svc)
-        result = cast(dict[str, Any], await owner.do())
+        result = cast("dict[str, Any]", await owner.do())
         assert result["blocked_by_migration"] is True
         svc.is_retrodeck_migration_pending.assert_called_once_with()

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
-from models.state import InstalledRomEntry
 
 from services.launch_gate import (
     LaunchGateService,
     LaunchGateServiceConfig,
     LaunchVerdict,
 )
+
+if TYPE_CHECKING:
+    from models.state import InstalledRomEntry
 
 
 def _installed_rom(rom_id: int) -> InstalledRomEntry:

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -6,18 +6,21 @@ import asyncio
 import json
 import logging
 import os
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fakes.fake_migration_file_store import FakeMigrationFileStore
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
-from models.state import SaveSortSettings
 
 from adapters.migration_file import MigrationFileAdapter
 from domain.rom import Rom
 from domain.rom_install import RomInstall
 from services.migration import MigrationService, MigrationServiceConfig
+
+if TYPE_CHECKING:
+    from models.state import SaveSortSettings
 
 
 def _active_core(system_name: str, rom_filename: str | None = None) -> tuple[str | None, str | None]:


### PR DESCRIPTION
Closes #862 (part B — completes the issue; part A `RET/C4/PIE/PERF` shipped in #889). ruff ratchet box from the #838 umbrella.

## What
Adds `TC` (flake8-type-checking) to the ruff `select` set and moves type-only imports under `if TYPE_CHECKING:`. Re-measured on post-cutover `main`: **76 findings** (down from the stale 139 — the SQLite cutover collapsed most typing-only third-party imports). Breakdown: TC001 44 (first-party), TC003 22 (stdlib), TC002 9 (third-party), TC006 1 (cast quote). 34 files touched, all mechanical.

## Safety
Every affected file already carries `from __future__ import annotations`, so the relocated imports appear only as lazy annotation strings at runtime — moving them under `TYPE_CHECKING` cannot raise `NameError`. Files that use a symbol at runtime (e.g. `asyncio.Lock`/`asyncio.gather`, `sqlite3.IntegrityError` in `except`, `cast()` first args) correctly keep their real top-level import; the one `cast` whose type moved is TC006-quoted. No logic changes, no `# noqa`/`# type: ignore`.

## Verification
- `ruff check .` / `ruff format --check .` — clean
- `basedpyright` — 0 errors (validates the `TYPE_CHECKING` imports still resolve for type-checking)
- `import-linter` — 8 kept, 0 broken
- `pytest` — 2844 passed (the runtime backstop for moved imports)
- Adversarial review scanned every moved symbol for runtime use (cast/TypeAlias/base-class/decorator/isinstance/constructor) — all confirmed annotation-only.

docs: N/A — tooling config (ruff lint rule adoption; import relocation only, no user-visible, architecture, or flow change).