### PR TITLE
chore(quality): annotate generics in tests/ for reportMissingTypeArgument

### DIFF
--- a/tests/adapters/test_es_de_config.py
+++ b/tests/adapters/test_es_de_config.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import tempfile
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest import mock
 
 import pytest
@@ -249,7 +249,7 @@ class TestReadSystemOverride:
 
 
 class TestGetActiveCore:
-    GBA_SYSTEM_INFO: ClassVar[dict] = {
+    GBA_SYSTEM_INFO: ClassVar[dict[str, Any]] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",
@@ -320,7 +320,7 @@ class TestGetActiveCore:
 
 
 class TestGetAvailableCores:
-    GBA_SYSTEM_INFO: ClassVar[dict] = {
+    GBA_SYSTEM_INFO: ClassVar[dict[str, Any]] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",
@@ -545,7 +545,7 @@ class TestReadGameOverride:
 class TestGetActiveCoreWithGameOverride:
     """``get_active_core`` reads per-game overrides when ``rom_filename`` is provided."""
 
-    GBA_SYSTEM_INFO: ClassVar[dict] = {
+    GBA_SYSTEM_INFO: ClassVar[dict[str, Any]] = {
         "gba": {
             "default_core": "mgba_libretro",
             "default_label": "mGBA",

--- a/tests/adapters/test_retrodeck_paths.py
+++ b/tests/adapters/test_retrodeck_paths.py
@@ -6,12 +6,13 @@ import json
 import logging
 import os
 import time
+from typing import Any
 from unittest.mock import patch
 
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
 
 
-def _make_adapter(tmp_path, config: dict | None = None) -> RetroDeckPathsAdapter:
+def _make_adapter(tmp_path, config: dict[str, Any] | None = None) -> RetroDeckPathsAdapter:
     """Create adapter with optional retrodeck.json config."""
     user_home = str(tmp_path)
     if config is not None:

--- a/tests/domain/test_preview_delta.py
+++ b/tests/domain/test_preview_delta.py
@@ -8,6 +8,7 @@ frozen semantics, and the zero-counts boundary case.
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from typing import Any
 
 import pytest
 
@@ -15,7 +16,7 @@ from domain.preview_delta import PreviewDelta
 
 
 def _build(**overrides) -> PreviewDelta:
-    defaults: dict = {
+    defaults: dict[str, Any] = {
         "preview_id": "preview-abc",
         "created_at": 1_700_000_000.0,
         "platforms_count": 2,

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -1,5 +1,7 @@
 """Tests for domain/state_migrations.py — pure migration functions."""
 
+from typing import Any
+
 from domain.state_migrations import (
     fold_legacy_save_sync_settings,
     migrate_settings,
@@ -234,7 +236,7 @@ class TestFoldLegacySaveSyncSettings:
     """v3 → v4 cross-file lift (#822): save-sync knobs + device_name move from
     save_sync_state.json into settings.json."""
 
-    def _base_settings(self) -> dict:
+    def _base_settings(self) -> dict[str, Any]:
         """A settings dict carrying the DEFAULT_SETTINGS placeholders."""
         return {
             "version": 3,

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -8,6 +8,7 @@ must dispatch. Pure-domain only — no I/O, no service fixtures.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 from domain.sync_action import (
     Conflict,
@@ -26,7 +27,7 @@ OTHER_DEVICE_ID = "device-xyz"
 # ---------------------------------------------------------------------------
 
 
-def _local(filename: str = "save.srm", mtime: float = 1_700_000_000.0) -> dict:
+def _local(filename: str = "save.srm", mtime: float = 1_700_000_000.0) -> dict[str, Any]:
     return {
         "filename": filename,
         "path": f"/tmp/{filename}",
@@ -35,7 +36,7 @@ def _local(filename: str = "save.srm", mtime: float = 1_700_000_000.0) -> dict:
     }
 
 
-def _device_sync(device_id: str, is_current: bool) -> dict:
+def _device_sync(device_id: str, is_current: bool) -> dict[str, Any]:
     return {"device_id": device_id, "is_current": is_current}
 
 
@@ -43,8 +44,8 @@ def _server_save(
     save_id: int = 1,
     updated_at: str = "2024-01-01T12:00:00+00:00",
     slot: int = 0,
-    device_syncs: list[dict] | None = None,
-) -> dict:
+    device_syncs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     return {
         "id": save_id,
         "slot": slot,

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -1,5 +1,7 @@
 """Tests for domain.sync_diff — pure delta computations for the sync engine."""
 
+from typing import Any
+
 from domain.sync_diff import (
     ClassificationResult,
     classify_roms,
@@ -100,7 +102,7 @@ class TestClassifyRoms:
         registry = {
             "1": {"app_id": 1001, "name": "Game A", "platform_name": "SNES"},
         }
-        sd: list = []  # nothing fetched
+        sd: list[dict[str, Any]] = []  # nothing fetched
         _, _, _, stale, disabled = classify_roms(sd, registry, {"N64"})
         assert 1 in stale
         assert disabled == 1  # SNES not in {"N64"}
@@ -179,7 +181,7 @@ class TestClassifyRoms:
             "1": {"app_id": 1001, "name": "Game A", "platform_name": "GBA"},
             "2": {"app_id": 1002, "name": "Game B", "platform_name": "SNES"},
         }
-        sd: list = []
+        sd: list[dict[str, Any]] = []
         _, _, _, stale, disabled = classify_roms(sd, registry, {"N64"})
         assert len(stale) == 2
         assert disabled == 2

--- a/tests/fakes/fake_core_info_provider.py
+++ b/tests/fakes/fake_core_info_provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
@@ -17,10 +19,10 @@ class FakeCoreInfoProvider:
         self,
         *,
         active_core: tuple[str | None, str | None] = (None, None),
-        available_cores: list[dict] | None = None,
+        available_cores: list[dict[str, Any]] | None = None,
     ) -> None:
         self.active_core = active_core
-        self.available_cores: list[dict] = available_cores if available_cores is not None else []
+        self.available_cores: list[dict[str, Any]] = available_cores if available_cores is not None else []
         self.reset_cache_count = 0
 
     def get_active_core(
@@ -30,7 +32,7 @@ class FakeCoreInfoProvider:
     ) -> tuple[str | None, str | None]:
         return self.active_core
 
-    def get_available_cores(self, system_name: str) -> list[dict]:
+    def get_available_cores(self, system_name: str) -> list[dict[str, Any]]:
         return self.available_cores
 
     def reset_cache(self) -> None:

--- a/tests/fakes/fake_firmware_cache_persister.py
+++ b/tests/fakes/fake_firmware_cache_persister.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from typing import Any
 
 
 class FakeFirmwareCachePersister:
@@ -15,21 +16,23 @@ class FakeFirmwareCachePersister:
     when no on-disk cache is present.
     """
 
-    def __init__(self, *, canned_load: dict | None = None, load_side_effect: BaseException | None = None) -> None:
-        self.canned_load: dict = canned_load if canned_load is not None else {}
+    def __init__(
+        self, *, canned_load: dict[str, Any] | None = None, load_side_effect: BaseException | None = None
+    ) -> None:
+        self.canned_load: dict[str, Any] = canned_load if canned_load is not None else {}
         self.load_side_effect = load_side_effect
-        self.last_saved: dict | None = None
+        self.last_saved: dict[str, Any] | None = None
         self.save_count = 0
         self.load_count = 0
         self.save_side_effect: BaseException | None = None
 
-    def save(self, data: dict) -> None:
+    def save(self, data: dict[str, Any]) -> None:
         self.save_count += 1
         if self.save_side_effect is not None:
             raise self.save_side_effect
         self.last_saved = copy.deepcopy(data)
 
-    def load(self) -> dict:
+    def load(self) -> dict[str, Any]:
         self.load_count += 1
         if self.load_side_effect is not None:
             raise self.load_side_effect

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -44,17 +44,17 @@ class FakeRommApi:
 
     def __init__(self) -> None:
         # In-memory seeded data — tests mutate these directly.
-        self.platforms: list[dict] = []
-        self.roms: dict[int, dict] = {}
-        self.firmware_files: list[dict] = []
-        self.collections: list[dict] = []
-        self.virtual_collections: dict[str, list[dict]] = {}
-        self.smart_collections: list[dict] = []
-        self.notes: dict[int, list[dict]] = {}
-        self.saves: dict[int, dict] = {}
-        self.devices: list[dict] = []
-        self.current_user: dict = {"id": 1, "username": "tester"}
-        self.heartbeat_response: dict = {"status": "ok"}
+        self.platforms: list[dict[str, Any]] = []
+        self.roms: dict[int, dict[str, Any]] = {}
+        self.firmware_files: list[dict[str, Any]] = []
+        self.collections: list[dict[str, Any]] = []
+        self.virtual_collections: dict[str, list[dict[str, Any]]] = {}
+        self.smart_collections: list[dict[str, Any]] = []
+        self.notes: dict[int, list[dict[str, Any]]] = {}
+        self.saves: dict[int, dict[str, Any]] = {}
+        self.devices: list[dict[str, Any]] = []
+        self.current_user: dict[str, Any] = {"id": 1, "username": "tester"}
+        self.heartbeat_response: dict[str, Any] = {"status": "ok"}
         self._version: str | None = None
         self._save_content: dict[int, bytes] = {}
 
@@ -106,7 +106,7 @@ class FakeRommApi:
         self.delete_server_saves_side_effect: Exception | None = None
 
         # Observability — every method records ``(name, args, kwargs)``.
-        self.call_log: list[tuple[str, tuple, dict]] = []
+        self.call_log: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
 
         # Internal id counters for synthesised entities.
         self._next_save_id = 1000
@@ -135,7 +135,7 @@ class FakeRommApi:
         if method_side_effect is not None:
             raise method_side_effect
 
-    def _log(self, name: str, args: tuple = (), kwargs: dict | None = None) -> None:
+    def _log(self, name: str, args: tuple[Any, ...] = (), kwargs: dict[str, Any] | None = None) -> None:
         self.call_log.append((name, args, kwargs or {}))
 
     def _materialize_download(self, dest_path: str, payload: bytes) -> None:
@@ -161,12 +161,12 @@ class FakeRommApi:
         self._log("get_version")
         return self._version
 
-    def heartbeat(self) -> dict:
+    def heartbeat(self) -> dict[str, Any]:
         self._log("heartbeat")
         self._check_fail(self.heartbeat_side_effect)
         return dict(self.heartbeat_response)
 
-    def get_current_user(self) -> dict:
+    def get_current_user(self) -> dict[str, Any]:
         self._log("get_current_user")
         self._check_fail(self.get_current_user_side_effect)
         return dict(self.current_user)
@@ -175,7 +175,7 @@ class FakeRommApi:
     # RommPlatformReader
     # ------------------------------------------------------------------
 
-    def list_platforms(self) -> list[dict]:
+    def list_platforms(self) -> list[dict[str, Any]]:
         self._log("list_platforms")
         self._check_fail(self.list_platforms_side_effect)
         return [dict(p) for p in self.platforms]
@@ -184,7 +184,7 @@ class FakeRommApi:
     # RommRomReader
     # ------------------------------------------------------------------
 
-    def get_rom(self, rom_id: int) -> dict:
+    def get_rom(self, rom_id: int) -> dict[str, Any]:
         self._log("get_rom", (rom_id,))
         self._check_fail(self.get_rom_side_effect)
         rom = self.roms.get(rom_id)
@@ -192,11 +192,11 @@ class FakeRommApi:
             return {"id": rom_id}
         return dict(rom)
 
-    def _paginate(self, items: list[dict], limit: int, offset: int) -> dict:
+    def _paginate(self, items: list[dict[str, Any]], limit: int, offset: int) -> dict[str, Any]:
         sliced = items[offset : offset + limit]
         return {"items": [dict(r) for r in sliced], "total": len(items)}
 
-    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         self._log("list_roms", (platform_id,), {"limit": limit, "offset": offset})
         self._check_fail(self.list_roms_side_effect)
         items = [r for r in self.roms.values() if r.get("platform_id") == platform_id]
@@ -208,7 +208,7 @@ class FakeRommApi:
         updated_after: str,
         limit: int = 1,
         offset: int = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self._log(
             "list_roms_updated_after",
             (platform_id, updated_after),
@@ -222,7 +222,7 @@ class FakeRommApi:
         ]
         return self._paginate(items, limit, offset)
 
-    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         self._log(
             "list_roms_by_collection",
             (collection_id,),
@@ -232,7 +232,7 @@ class FakeRommApi:
         items = [r for r in self.roms.values() if collection_id in (r.get("collection_ids") or [])]
         return self._paginate(items, limit, offset)
 
-    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         self._log(
             "list_roms_by_virtual_collection",
             (virtual_id,),
@@ -242,7 +242,7 @@ class FakeRommApi:
         items = [r for r in self.roms.values() if virtual_id in (r.get("virtual_collection_ids") or [])]
         return self._paginate(items, limit, offset)
 
-    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         self._log(
             "list_roms_by_smart_collection",
             (smart_id,),
@@ -252,17 +252,17 @@ class FakeRommApi:
         items = [r for r in self.roms.values() if smart_id in (r.get("smart_collection_ids") or [])]
         return self._paginate(items, limit, offset)
 
-    def list_collections(self) -> list[dict]:
+    def list_collections(self) -> list[dict[str, Any]]:
         self._log("list_collections")
         self._check_fail(self.list_collections_side_effect)
         return [dict(c) for c in self.collections]
 
-    def list_virtual_collections(self, collection_type: str) -> list[dict]:
+    def list_virtual_collections(self, collection_type: str) -> list[dict[str, Any]]:
         self._log("list_virtual_collections", (collection_type,))
         self._check_fail(self.list_virtual_collections_side_effect)
         return [dict(c) for c in self.virtual_collections.get(collection_type, [])]
 
-    def list_smart_collections(self) -> list[dict]:
+    def list_smart_collections(self) -> list[dict[str, Any]]:
         self._log("list_smart_collections")
         self._check_fail(self.list_smart_collections_side_effect)
         return [dict(c) for c in self.smart_collections]
@@ -298,12 +298,12 @@ class FakeRommApi:
     # RommFirmwareApi
     # ------------------------------------------------------------------
 
-    def list_firmware(self) -> list[dict]:
+    def list_firmware(self) -> list[dict[str, Any]]:
         self._log("list_firmware")
         self._check_fail(self.list_firmware_side_effect)
         return [dict(f) for f in self.firmware_files]
 
-    def get_firmware(self, firmware_id: int) -> dict:
+    def get_firmware(self, firmware_id: int) -> dict[str, Any]:
         self._log("get_firmware", (firmware_id,))
         self._check_fail(self.get_firmware_side_effect)
         for fw in self.firmware_files:
@@ -322,14 +322,14 @@ class FakeRommApi:
     # RommPlaytimeApi
     # ------------------------------------------------------------------
 
-    def get_rom_with_notes(self, rom_id: int) -> dict:
+    def get_rom_with_notes(self, rom_id: int) -> dict[str, Any]:
         self._log("get_rom_with_notes", (rom_id,))
         self._check_fail(self.get_rom_with_notes_side_effect)
         detail = dict(self.roms.get(rom_id, {"id": rom_id}))
         detail["all_user_notes"] = [dict(n) for n in self.notes.get(rom_id, [])]
         return detail
 
-    def create_note(self, rom_id: int, data: dict) -> dict:
+    def create_note(self, rom_id: int, data: dict[str, Any]) -> dict[str, Any]:
         self._log("create_note", (rom_id, data))
         self._check_fail(self.create_note_side_effect)
         note_id = self._next_note_id
@@ -338,7 +338,7 @@ class FakeRommApi:
         self.notes.setdefault(rom_id, []).append(note)
         return dict(note)
 
-    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+    def update_note(self, rom_id: int, note_id: int, data: dict[str, Any]) -> dict[str, Any]:
         self._log("update_note", (rom_id, note_id, data))
         self._check_fail(self.update_note_side_effect)
         for notes in self.notes.values():
@@ -359,7 +359,7 @@ class FakeRommApi:
         client: str,
         client_version: str,
         hostname: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self._log("register_device", (name, platform, client, client_version), {"hostname": hostname})
         self._check_fail(self.register_device_side_effect)
         device_id = f"device-{self._next_device_id}"
@@ -376,12 +376,12 @@ class FakeRommApi:
         self.devices.append(device)
         return dict(device)
 
-    def list_devices(self) -> list[dict]:
+    def list_devices(self) -> list[dict[str, Any]]:
         self._log("list_devices")
         self._check_fail(self.list_devices_side_effect)
         return [dict(d) for d in self.devices]
 
-    def update_device(self, device_id: str, **fields) -> dict:
+    def update_device(self, device_id: str, **fields) -> dict[str, Any]:
         self._log("update_device", (device_id,), fields)
         self._check_fail(self.update_device_side_effect)
         for device in self.devices:
@@ -400,7 +400,7 @@ class FakeRommApi:
         *,
         device_id: str | None = None,
         slot: str | None = None,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         self._log("list_saves", (rom_id,), {"device_id": device_id, "slot": slot})
         self._check_fail(self.list_saves_side_effect)
         saves = [dict(s) for s in self.saves.values() if s.get("rom_id") == rom_id]
@@ -422,7 +422,7 @@ class FakeRommApi:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self._log(
             "upload_save",
             (rom_id, file_path, emulator),
@@ -482,15 +482,15 @@ class FakeRommApi:
         payload = self._save_content.get(save_id) or self.download_payloads.get(f"save:{save_id}", b"")
         self._materialize_download(dest_path, payload)
 
-    def confirm_download(self, save_id: int, device_id: str) -> dict:
+    def confirm_download(self, save_id: int, device_id: str) -> dict[str, Any]:
         self._log("confirm_download", (save_id, device_id))
         self._check_fail(self.confirm_download_side_effect)
         return {"status": "ok"}
 
-    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
+    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict[str, Any]:
         self._log("get_save_summary", (rom_id,), {"device_id": device_id})
         self._check_fail(self.get_save_summary_side_effect)
-        slots: dict[str | None, list[dict]] = {}
+        slots: dict[str | None, list[dict[str, Any]]] = {}
         for s in self.saves.values():
             if s.get("rom_id") == rom_id:
                 slots.setdefault(s.get("slot"), []).append(s)
@@ -506,7 +506,7 @@ class FakeRommApi:
             ],
         }
 
-    def delete_server_saves(self, save_ids: list[int]) -> dict:
+    def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         self._log("delete_server_saves", (save_ids,))
         self._check_fail(self.delete_server_saves_side_effect)
         for sid in save_ids:

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -27,18 +27,18 @@ class FakeSaveApi:
 
     def __init__(self, save_file_store: SaveFileStore | None = None) -> None:
         self.save_file_store: SaveFileStore | None = save_file_store
-        self.saves: dict[int, dict] = {}  # save_id -> save dict
-        self.roms: dict[int, dict] = {}  # rom_id -> rom detail dict
-        self.notes: dict[int, list[dict]] = {}  # rom_id -> [note dicts]
+        self.saves: dict[int, dict[str, Any]] = {}  # save_id -> save dict
+        self.roms: dict[int, dict[str, Any]] = {}  # rom_id -> rom detail dict
+        self.notes: dict[int, list[dict[str, Any]]] = {}  # rom_id -> [note dicts]
         self.uploaded_files: dict[int, str] = {}  # save_id -> source file_path (log only)
         self.downloaded_files: dict[int, str] = {}  # save_id -> dest_path (log only)
         self._save_content: dict[int, bytes] = {}  # save_id -> server-side bytes
-        self.call_log: list[tuple[str, tuple, dict]] = []
+        self.call_log: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
         self._next_save_id = 1000
         self._next_note_id = 2000
         self._fail_on_next: Exception | None = None
         self.heartbeat_raises: Exception | None = None
-        self._registered_devices: list[dict] = []
+        self._registered_devices: list[dict[str, Any]] = []
         self._next_device_id = 1
 
     def fail_on_next(self, exc: Exception) -> None:
@@ -112,21 +112,21 @@ class FakeSaveApi:
     def get_version(self) -> str | None:
         return getattr(self, "version", None)
 
-    def heartbeat(self) -> dict:
+    def heartbeat(self) -> dict[str, Any]:
         if self.heartbeat_raises is not None:
             raise self.heartbeat_raises
         return {"status": "ok"}
 
-    def list_platforms(self) -> list[dict]:
+    def list_platforms(self) -> list[dict[str, Any]]:
         raise NotImplementedError
 
-    def get_current_user(self) -> dict:
+    def get_current_user(self) -> dict[str, Any]:
         raise NotImplementedError
 
-    def get_rom(self, rom_id: int) -> dict:
+    def get_rom(self, rom_id: int) -> dict[str, Any]:
         raise NotImplementedError
 
-    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         raise NotImplementedError
 
     def list_roms_updated_after(
@@ -135,7 +135,7 @@ class FakeSaveApi:
         updated_after: str,
         limit: int = 1,
         offset: int = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         raise NotImplementedError
 
     def download_rom_content(
@@ -150,28 +150,28 @@ class FakeSaveApi:
     def download_cover(self, cover_url: str, dest: str) -> None:
         raise NotImplementedError
 
-    def list_firmware(self) -> list[dict]:
+    def list_firmware(self) -> list[dict[str, Any]]:
         raise NotImplementedError
 
-    def get_firmware(self, firmware_id: int) -> dict:
+    def get_firmware(self, firmware_id: int) -> dict[str, Any]:
         raise NotImplementedError
 
     def download_firmware(self, firmware_id: int, filename: str, dest: str) -> None:
         raise NotImplementedError
 
-    def list_collections(self) -> list[dict]:
+    def list_collections(self) -> list[dict[str, Any]]:
         raise NotImplementedError
 
-    def list_virtual_collections(self, collection_type: str) -> list[dict]:
+    def list_virtual_collections(self, collection_type: str) -> list[dict[str, Any]]:
         raise NotImplementedError
 
-    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         raise NotImplementedError
 
-    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         raise NotImplementedError
 
-    def delete_server_saves(self, save_ids: list[int]) -> dict:
+    def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         self.call_log.append(("delete_server_saves", (save_ids,), {}))
         self._check_fail()
         for sid in save_ids:
@@ -186,7 +186,7 @@ class FakeSaveApi:
         client: str,
         client_version: str,
         hostname: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self.call_log.append(("register_device", (name, platform, client, client_version), {"hostname": hostname}))
         self._check_fail()
         device_id = f"device-{self._next_device_id}"
@@ -195,12 +195,12 @@ class FakeSaveApi:
         self._registered_devices.append(device)
         return device
 
-    def list_devices(self) -> list[dict]:
+    def list_devices(self) -> list[dict[str, Any]]:
         self.call_log.append(("list_devices", (), {}))
         self._check_fail()
         return list(self._registered_devices)
 
-    def update_device(self, device_id: str, **fields) -> dict:
+    def update_device(self, device_id: str, **fields) -> dict[str, Any]:
         self.call_log.append(("update_device", (device_id,), fields))
         self._check_fail()
         for device in self._registered_devices:
@@ -225,15 +225,15 @@ class FakeSaveApi:
         self.downloaded_files[save_id] = dest_path
         self._materialize_download(save_id, dest_path)
 
-    def confirm_download(self, save_id: int, device_id: str) -> dict:
+    def confirm_download(self, save_id: int, device_id: str) -> dict[str, Any]:
         self.call_log.append(("confirm_download", (save_id, device_id), {}))
         self._check_fail()
         return {"status": "ok"}
 
-    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
+    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict[str, Any]:
         self.call_log.append(("get_save_summary", (rom_id,), {"device_id": device_id}))
         self._check_fail()
-        slots: dict[str | None, list[dict]] = {}
+        slots: dict[str | None, list[dict[str, Any]]] = {}
         for s in self.saves.values():
             if s.get("rom_id") == rom_id:
                 slot = s.get("slot")
@@ -260,7 +260,7 @@ class FakeSaveApi:
         *,
         device_id: str | None = None,
         slot: str | None = None,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         self.call_log.append(("list_saves", (rom_id,), {"device_id": device_id, "slot": slot}))
         self._check_fail()
         saves = [s for s in self.saves.values() if s.get("rom_id") == rom_id]
@@ -283,7 +283,7 @@ class FakeSaveApi:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self.call_log.append(
             (
                 "upload_save",
@@ -348,7 +348,7 @@ class FakeSaveApi:
         self.downloaded_files[save_id] = dest_path
         self._materialize_download(save_id, dest_path)
 
-    def get_rom_with_notes(self, rom_id: int) -> dict:
+    def get_rom_with_notes(self, rom_id: int) -> dict[str, Any]:
         self.call_log.append(("get_rom_with_notes", (rom_id,), {}))
         self._check_fail()
         detail = self.roms.get(rom_id, {"id": rom_id})
@@ -357,7 +357,7 @@ class FakeSaveApi:
         detail["all_user_notes"] = self.notes.get(rom_id, [])
         return detail
 
-    def create_note(self, rom_id: int, data: dict) -> dict:
+    def create_note(self, rom_id: int, data: dict[str, Any]) -> dict[str, Any]:
         self.call_log.append(("create_note", (rom_id, data), {}))
         self._check_fail()
         note_id = self._next_note_id
@@ -366,7 +366,7 @@ class FakeSaveApi:
         self.notes.setdefault(rom_id, []).append(note)
         return dict(note)
 
-    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+    def update_note(self, rom_id: int, note_id: int, data: dict[str, Any]) -> dict[str, Any]:
         self.call_log.append(("update_note", (rom_id, note_id, data), {}))
         self._check_fail()
         for notes in self.notes.values():

--- a/tests/fakes/fake_steamgrid_db_api.py
+++ b/tests/fakes/fake_steamgrid_db_api.py
@@ -46,7 +46,7 @@ Observability:
 from __future__ import annotations
 
 import pathlib
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class _ArtworkCacheSink(Protocol):
@@ -60,7 +60,7 @@ class FakeSteamGridDbApi:
 
     def __init__(self) -> None:
         # Seeded response bodies keyed by request path (longest-prefix match).
-        self._responses: dict[str, dict | None] = {}
+        self._responses: dict[str, dict[str, Any] | None] = {}
         # Staged image bytes returned by ``download_image`` writes.
         self._image_bytes: dict[str, bytes] = {}
         # Optional sink that captures ``download_image`` writes when bound.
@@ -68,7 +68,7 @@ class FakeSteamGridDbApi:
         # Default ``download_image`` return when no side_effect armed.
         self.download_image_return: bool = True
         # Body returned by ``verify_api_key`` when no side_effect armed.
-        self.verify_response: dict = {"success": True}
+        self.verify_response: dict[str, Any] = {"success": True}
 
         # Failure-injection seams.
         self._fail_on_next: Exception | None = None
@@ -77,7 +77,7 @@ class FakeSteamGridDbApi:
         self.verify_api_key_side_effect: Exception | None = None
 
         # Observability.
-        self.call_log: list[tuple[str, tuple, dict]] = []
+        self.call_log: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
         self.requested_paths: list[str] = []
         self.downloaded: list[tuple[str, str]] = []
         self.verify_calls: list[str] = []
@@ -98,14 +98,14 @@ class FakeSteamGridDbApi:
         if method_side_effect is not None:
             raise method_side_effect
 
-    def _log(self, name: str, args: tuple = (), kwargs: dict | None = None) -> None:
+    def _log(self, name: str, args: tuple[Any, ...] = (), kwargs: dict[str, Any] | None = None) -> None:
         self.call_log.append((name, args, kwargs or {}))
 
     # ------------------------------------------------------------------
     # Seeding helpers
     # ------------------------------------------------------------------
 
-    def seed_raw_response(self, path: str, body: dict | None) -> None:
+    def seed_raw_response(self, path: str, body: dict[str, Any] | None) -> None:
         """Register a raw JSON body returned by ``request`` for *path*.
 
         Matching is by prefix so callers don't need to model the
@@ -147,7 +147,7 @@ class FakeSteamGridDbApi:
         """
         self._artwork_cache = cache
 
-    def seed_verify_response(self, body: dict) -> None:
+    def seed_verify_response(self, body: dict[str, Any]) -> None:
         """Override the body returned by ``verify_api_key``."""
         self.verify_response = body
 
@@ -155,7 +155,7 @@ class FakeSteamGridDbApi:
     # SteamGridDbApi Protocol surface
     # ------------------------------------------------------------------
 
-    def request(self, path: str) -> dict | None:
+    def request(self, path: str) -> dict[str, Any] | None:
         self._log("request", (path,))
         self.requested_paths.append(path)
         self._check_fail(self.request_side_effect)
@@ -187,7 +187,7 @@ class FakeSteamGridDbApi:
             return True
         return self.download_image_return
 
-    def verify_api_key(self, api_key: str) -> dict:
+    def verify_api_key(self, api_key: str) -> dict[str, Any]:
         self._log("verify_api_key", (api_key,))
         self.verify_calls.append(api_key)
         self._check_fail(self.verify_api_key_side_effect)
@@ -206,7 +206,7 @@ _ASSET_TYPE_TO_ENDPOINT: dict[str, str] = {
 }
 
 
-def _copy(body: dict | None) -> dict | None:
+def _copy(body: dict[str, Any] | None) -> dict[str, Any] | None:
     """Return a shallow copy so mutations on the returned dict don't leak back."""
     if body is None:
         return None

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -30,23 +30,23 @@ class FakeArtworkManager:
 
     def __init__(
         self,
-        canned_download: dict | None = None,
+        canned_download: dict[str, Any] | None = None,
         finalize_override: Callable[[str | None, str, int, str], str] | None = None,
     ) -> None:
-        self.canned_download: dict = canned_download if canned_download is not None else {}
+        self.canned_download: dict[str, Any] = canned_download if canned_download is not None else {}
         self.finalize_override = finalize_override
-        self.download_calls: list[tuple[list[dict], Any, Any, int, int]] = []
+        self.download_calls: list[tuple[list[dict[str, Any]], Any, Any, int, int]] = []
         self.finalize_calls: list[tuple[str | None, str, int, str]] = []
         self.remove_calls: list[tuple[str, str | int, ShortcutRegistryEntry]] = []
 
     async def download_artwork(
         self,
-        all_roms: list[dict],
+        all_roms: list[dict[str, Any]],
         emit_progress: Awaitable[None] | Callable[..., Awaitable[None]],
         is_cancelling: Any,
         progress_step: int = 4,
         progress_total_steps: int = 6,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self.download_calls.append((list(all_roms), emit_progress, is_cancelling, progress_step, progress_total_steps))
         return dict(self.canned_download)
 

--- a/tests/lib/test_late_binding.py
+++ b/tests/lib/test_late_binding.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from lib.late_binding import LateBinding
@@ -9,7 +11,7 @@ from lib.late_binding import LateBinding
 
 def test_get_before_set_raises():
     """Accessing an unset binding must raise RuntimeError tagged with the name."""
-    binding: LateBinding[dict] = LateBinding("bios_files_index")
+    binding: LateBinding[dict[str, Any]] = LateBinding("bios_files_index")
 
     with pytest.raises(RuntimeError, match="bios_files_index"):
         binding.get()
@@ -17,7 +19,7 @@ def test_get_before_set_raises():
 
 def test_get_invokes_bound_reader():
     """After set(), get() returns whatever the reader returns."""
-    binding: LateBinding[dict] = LateBinding("pending_sync")
+    binding: LateBinding[dict[str, Any]] = LateBinding("pending_sync")
     binding.set(lambda: {"42": {"name": "Game"}})
 
     assert binding.get() == {"42": {"name": "Game"}}
@@ -33,10 +35,10 @@ def test_get_reflects_producer_rebinding():
 
     class Producer:
         def __init__(self) -> None:
-            self.value: dict = {"initial": True}
+            self.value: dict[str, Any] = {"initial": True}
 
     producer = Producer()
-    binding: LateBinding[dict] = LateBinding("producer_value")
+    binding: LateBinding[dict[str, Any]] = LateBinding("producer_value")
     binding.set(lambda: producer.value)
 
     assert binding.get() == {"initial": True}
@@ -58,8 +60,8 @@ def test_set_overwrites_previous_reader():
 
 def test_get_reflects_mutation_of_shared_reference():
     """When the reader returns a shared mutable object, mutations are visible."""
-    data: dict = {}
-    binding: LateBinding[dict] = LateBinding("pending_sync")
+    data: dict[str, Any] = {}
+    binding: LateBinding[dict[str, Any]] = LateBinding("pending_sync")
     binding.set(lambda: data)
 
     data["42"] = {"name": "Game"}
@@ -69,7 +71,7 @@ def test_get_reflects_mutation_of_shared_reference():
 
 def test_error_message_includes_name_and_hint():
     """The RuntimeError text names the binding and points at the cause."""
-    binding: LateBinding[dict] = LateBinding("bios_files_index")
+    binding: LateBinding[dict[str, Any]] = LateBinding("bios_files_index")
 
     with pytest.raises(RuntimeError) as excinfo:
         binding.get()

--- a/tests/lib/test_migration_gate.py
+++ b/tests/lib/test_migration_gate.py
@@ -29,7 +29,7 @@ class _FakeOwner:
         self._migration_service = _FakeMigrationService(pending)
         self._ret = ret
         self._raise = raise_exc
-        self.calls: list[tuple[tuple, dict]] = []
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
     @migration_blocked
     async def do_thing(self, *args, **kwargs):

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -1,5 +1,6 @@
 """Façade integration tests for LibraryService — public callable surface end-to-end."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1170,8 +1171,8 @@ class TestCollectionSyncEdgeCases:
         }
 
         # Empty shortcuts_data — no ROM was fetched from any source
-        shortcuts_data: list = []
-        fetched_platform_names: set = set()
+        shortcuts_data: list[dict[str, Any]] = []
+        fetched_platform_names: set[str] = set()
 
         new, changed, unchanged_ids, stale, _disabled_count = classify_roms(
             shortcuts_data, registry, fetched_platform_names

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -25,6 +25,7 @@ migration.
 
 import asyncio
 import os
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1786,7 +1787,7 @@ class TestPerUnitMetadataStamping:
             roms=[{"id": 10, "name": "A", "metadatum": {"genres": ["RPG"]}}],
         )
 
-        commit_calls: list[tuple] = []
+        commit_calls: list[tuple[Any, Any]] = []
         original_commit = plugin._sync_service._reporter.commit_unit_results
 
         async def tracked_commit(rid_to_aid, acked_roms):
@@ -1885,7 +1886,7 @@ class TestPerUnitMetadataStamping:
             ],
         )
 
-        commit_calls: list[tuple] = []
+        commit_calls: list[tuple[Any, Any]] = []
 
         async def capture_commit(rid_to_aid, acked_roms):
             commit_calls.append((rid_to_aid, acked_roms))

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -111,7 +111,7 @@ def _require_save_state(svc, rom_id: int) -> RomSaveState:
     return state
 
 
-def rom_save_state_from_dict(data: dict) -> RomSaveState:
+def rom_save_state_from_dict(data: dict[str, Any]) -> RomSaveState:
     """Build a ``RomSaveState`` from the legacy dict shape used across saves tests.
 
     The SQLite aggregate has no ``from_dict``; this test helper preserves the
@@ -144,7 +144,7 @@ def rom_save_state_from_dict(data: dict) -> RomSaveState:
     )
 
 
-def _seed_save_state_dict(svc, rom_id: int, data: dict, *, platform_slug: str = "gba") -> None:
+def _seed_save_state_dict(svc, rom_id: int, data: dict[str, Any], *, platform_slug: str = "gba") -> None:
     """Seed a ``RomSaveState`` from the legacy dict shape (seeds the ``Rom`` FK)."""
     _seed_save_state(svc, rom_id, rom_save_state_from_dict(data), platform_slug=platform_slug)
 
@@ -313,7 +313,7 @@ def _get_device_id(svc) -> str | None:
         return uow.kv_config.get("device_id")
 
 
-def _set_sort_settings(svc, settings: dict) -> None:
+def _set_sort_settings(svc, settings: dict[str, Any]) -> None:
     """Seed the last-seen save-sort observation marker in ``kv_config``."""
     import json
 
@@ -321,7 +321,7 @@ def _set_sort_settings(svc, settings: dict) -> None:
         uow.kv_config.set("save_sort_settings", json.dumps(settings))
 
 
-def _set_sort_settings_previous(svc, settings: dict) -> None:
+def _set_sort_settings_previous(svc, settings: dict[str, Any]) -> None:
     """Seed the pending pre-change save-sort marker in ``kv_config``."""
     import json
 
@@ -336,9 +336,9 @@ def _server_save_with_syncs(
     filename: str = "pokemon.srm",
     updated_at: str = "2026-02-17T06:00:00Z",
     file_size_bytes: int = 1024,
-    device_syncs: list[dict] | None = None,
+    device_syncs: list[dict[str, Any]] | None = None,
     slot: str | None = None,
-) -> dict:
+) -> dict[str, Any]:
     """Build a server-save dict with explicit device_syncs (no FakeApi shimming)."""
     base = _server_save(
         save_id=save_id,

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -8,6 +8,7 @@ device registration in test_devices.py; conflict rollback in test_rollback.py.
 
 import hashlib
 import os
+from typing import Any
 
 import pytest
 
@@ -370,7 +371,7 @@ class TestConfirmDownloadAfterSync:
         # Patch confirm_download to raise; the upload itself must still complete.
         original_confirm = fake.confirm_download
 
-        def boom(save_id: int, device_id: str) -> dict:
+        def boom(save_id: int, device_id: str) -> dict[str, Any]:
             fake.call_log.append(("confirm_download", (save_id, device_id), {}))
             raise RommApiError("HTTP 500: Server Error", url="/api/saves/x/downloaded", method="POST")
 
@@ -1355,7 +1356,7 @@ class TestHandleUnexpectedError:
         fake.download_save_content = _raise  # type: ignore[method-assign]
 
         errors: list[str] = []
-        conflicts: list = []
+        conflicts: list[dict[str, Any]] = []
         action = Download(server_save={"id": 100, "file_name": "pokemon.srm"})
         synced = svc._sync_engine._matrix._dispatch_sync_action(
             action,
@@ -1401,7 +1402,7 @@ class TestDispatchSyncActionErrorBranches:
         fake.download_save_content = _raise  # type: ignore[method-assign]
 
         errors: list[str] = []
-        conflicts: list = []
+        conflicts: list[dict[str, Any]] = []
         action = Download(server_save={"id": 100, "file_name": "pokemon.srm"})
         synced = svc._sync_engine._matrix._dispatch_sync_action(
             action,

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import time
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -158,7 +159,7 @@ class TestDeviceRegistrationServer:
                 super().__init__()
                 self.heartbeat_calls = 0
 
-            def heartbeat(self) -> dict:
+            def heartbeat(self) -> dict[str, Any]:
                 self.heartbeat_calls += 1
                 return {"SYSTEM": {"VERSION": "4.8.5"}}
 
@@ -180,7 +181,7 @@ class TestDeviceRegistrationServer:
                 super().__init__()
                 self.heartbeat_calls = 0
 
-            def heartbeat(self) -> dict:
+            def heartbeat(self) -> dict[str, Any]:
                 self.heartbeat_calls += 1
                 return {"SYSTEM": {"VERSION": "4.8.5"}}
 
@@ -216,7 +217,7 @@ class TestDeviceRegistrationServer:
                 super().__init__()
                 self.heartbeat_calls = 0
 
-            def heartbeat(self) -> dict:
+            def heartbeat(self) -> dict[str, Any]:
                 self.heartbeat_calls += 1
                 return {"SYSTEM": {"VERSION": "4.8.5"}}
 
@@ -706,7 +707,7 @@ class TestSaveSyncSettingsSlotAndCleanup:
     def test_upload_uses_none_slot_when_active_slot_is_none(self, tmp_path):
         """When active_slot key is present but value is None, .get() returns None (legacy mode)."""
         _svc, _ = make_service(tmp_path)
-        game_state: dict = {"active_slot": None}
+        game_state: dict[str, Any] = {"active_slot": None}
         slot = game_state.get("active_slot", "default")
         assert slot is None
 
@@ -862,7 +863,7 @@ class TestCheckCoreChange:
 
     def test_rom_filename_resolved_for_per_game_core(self, tmp_path):
         """When installed_roms has file_path, the basename is passed to get_active_core."""
-        received_args: list = []
+        received_args: list[tuple[str, str | None]] = []
 
         def capture_core(system_name, rom_filename=None):
             received_args.append((system_name, rom_filename))

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -1,5 +1,7 @@
 """Tests for VersionsService — save version history reads and rollback flow."""
 
+from typing import Any
+
 import pytest
 
 from tests.services.saves._helpers import (
@@ -291,7 +293,7 @@ class TestRollbackToVersion:
         )
 
     @staticmethod
-    def _tracked_save(save_id: int, *, updated_at: str = "2026-03-10T10:00:00Z") -> dict:
+    def _tracked_save(save_id: int, *, updated_at: str = "2026-03-10T10:00:00Z") -> dict[str, Any]:
         """Build a tracked-save fixture with our device flagged ``is_current``
         on it. Use this for tests where the matrix pre-flight should return
         ``Skip(synced)`` so the switch flow itself is what's exercised.

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import logging
 import os
+from typing import Any
 from unittest.mock import MagicMock
 
 # conftest.py patches decky before this import
@@ -52,7 +53,7 @@ def romm_api():
 
 
 @pytest.fixture
-def pending_sync_data() -> dict:
+def pending_sync_data() -> dict[str, Any]:
     """Mutable pending-sync dict; tests mutate this to stage pending entries."""
     return {}
 

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,7 +37,7 @@ def romm_api() -> MagicMock:
 
 def _make_service(
     *,
-    settings: dict,
+    settings: dict[str, Any],
     romm_api: MagicMock,
     loop: asyncio.AbstractEventLoop,
     logger: logging.Logger,
@@ -87,7 +88,7 @@ class TestTestConnectionBadPath:
 
     def test_unset_url_key_returns_config_error(self, event_loop, romm_api, logger):
         """``romm_url`` absent from settings dict → config_error."""
-        settings: dict = {}
+        settings: dict[str, Any] = {}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["error_code"] == "config_error"

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 import pytest
 from fakes.fake_core_info_provider import FakeCoreInfoProvider
@@ -45,10 +46,10 @@ class FakeBiosChecker:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str | None]] = []
-        self.payload: dict = {"needs_bios": False}
+        self.payload: dict[str, Any] = {"needs_bios": False}
         self.side_effect: BaseException | None = None
 
-    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict:
+    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict[str, Any]:
         if self.side_effect is not None:
             raise self.side_effect
         self.calls.append((platform_slug, rom_filename))

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -26,11 +26,11 @@ def _installed_rom(rom_id: int) -> InstalledRomEntry:
 class FakeRomLookup:
     """In-memory ``LaunchGateRomLookup`` for tests."""
 
-    def __init__(self, *, mapping: dict[int, dict] | None = None) -> None:
+    def __init__(self, *, mapping: dict[int, dict[str, Any]] | None = None) -> None:
         self.mapping = mapping if mapping is not None else {}
         self.calls: list[int] = []
 
-    def get_rom_by_steam_app_id(self, app_id: int) -> dict | None:
+    def get_rom_by_steam_app_id(self, app_id: int) -> dict[str, Any] | None:
         self.calls.append(app_id)
         return self.mapping.get(app_id)
 
@@ -53,17 +53,17 @@ class FakeSaveStatusReader:
     def __init__(
         self,
         *,
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
         tracked_rom_ids: set[int] | None = None,
     ) -> None:
-        self.payload: dict = payload if payload is not None else {"conflicts": []}
+        self.payload: dict[str, Any] = payload if payload is not None else {"conflicts": []}
         self.side_effect = side_effect
         self.tracked_rom_ids: set[int] = tracked_rom_ids if tracked_rom_ids is not None else set()
         self.calls: list[int] = []
         self.tracked_calls: list[int] = []
 
-    async def get_save_status(self, rom_id: int) -> dict:
+    async def get_save_status(self, rom_id: int) -> dict[str, Any]:
         self.calls.append(rom_id)
         if self.side_effect is not None:
             raise self.side_effect

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1007,7 +1008,7 @@ class TestResolveSaveSortConflict:
         os.utime(new_path, (new_mtime, new_mtime))
 
         counts: dict[str, int] = {}
-        errors: list = []
+        errors: list[str] = []
         state_updates: list[str] = []
 
         plugin._migration_service._resolve_save_sort_conflict(
@@ -1061,9 +1062,9 @@ class TestDetectSaveSortChangeThreadSafety:
         # emission from the loop thread regardless of which thread scheduled
         # it. We swap in a queue-aware ``EventEmitter`` rather than reading
         # the recorder fixture because we need an awaitable barrier.
-        emit_queue: asyncio.Queue = asyncio.Queue()
+        emit_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
 
-        async def fake_emit(event_name: str, payload: dict) -> None:
+        async def fake_emit(event_name: str, payload: dict[str, Any]) -> None:
             await emit_queue.put((event_name, payload))
 
         plugin._migration_service._emit = fake_emit
@@ -1104,7 +1105,7 @@ class TestMigrationFailureInjection:
         import decky
 
         uow = uow if uow is not None else FakeUnitOfWork()
-        defaults: dict = {
+        defaults: dict[str, Any] = {
             "settings": {},
             "loop": asyncio.get_event_loop(),
             "logger": decky.logger,
@@ -1168,7 +1169,7 @@ class TestMigrationFailureInjection:
         service = self._make_service(fake)
 
         counts: dict[str, int] = {}
-        errors: list = []
+        errors: list[str] = []
         state_updates: list[str] = []
         service._resolve_save_sort_conflict(
             label="gba/game.srm",
@@ -1201,7 +1202,7 @@ class TestMigrationFailureInjection:
         service = self._make_service(fake)
 
         counts: dict[str, int] = {}
-        errors: list = []
+        errors: list[str] = []
         state_updates: list[str] = []
         service._resolve_save_sort_conflict(
             label="gba/game.srm",

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,7 +31,7 @@ def _no_corename(core_so: str) -> str | None:
     return None
 
 
-def _seed_installs(uow, installed_roms: dict) -> None:
+def _seed_installs(uow, installed_roms: dict[str, Any]) -> None:
     """Seed Rom (FK parent) + RomInstall rows from the legacy installed_roms dict shape."""
     with uow:
         for rom_id_str, entry in installed_roms.items():
@@ -59,14 +59,14 @@ def _seed_installs(uow, installed_roms: dict) -> None:
             )
 
 
-def _read_marker(uow, key: str) -> dict:
+def _read_marker(uow, key: str) -> dict[str, Any]:
     """Decode a save-sort kv_config marker, asserting it is present."""
     raw = uow.kv_config.get(key)
     assert raw is not None, f"expected kv_config marker {key!r} to be set"
     return json.loads(raw)
 
 
-def _seed_markers(uow, state_overrides: dict) -> None:
+def _seed_markers(uow, state_overrides: dict[str, Any]) -> None:
     """Write the save-sort kv_config markers from the legacy state_overrides shape."""
     with uow:
         if "save_sort_settings" in state_overrides:
@@ -178,7 +178,7 @@ class TestDetectSaveSortChange:
         # Stub run_coroutine_threadsafe at the module level so we can
         # observe scheduling without needing a running event loop. The
         # stub closes the coroutine to avoid "never awaited" warnings.
-        scheduled: list = []
+        scheduled: list[Any] = []
 
         def fake_schedule(coro, loop):
             coro.close()

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 import pytest
 
@@ -22,14 +23,14 @@ class FakePlaytimeRecorder:
     def __init__(
         self,
         *,
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
     ) -> None:
-        self.payload: dict = payload if payload is not None else {"success": True, "total_seconds": 3600}
+        self.payload: dict[str, Any] = payload if payload is not None else {"success": True, "total_seconds": 3600}
         self.side_effect = side_effect
         self.calls: list[int] = []
 
-    async def record_session_end(self, rom_id: int) -> dict:
+    async def record_session_end(self, rom_id: int) -> dict[str, Any]:
         self.calls.append(rom_id)
         if self.side_effect is not None:
             raise self.side_effect
@@ -42,14 +43,16 @@ class FakePostExitSync:
     def __init__(
         self,
         *,
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
     ) -> None:
-        self.payload: dict = payload if payload is not None else {"success": True, "synced": 0, "conflicts": []}
+        self.payload: dict[str, Any] = (
+            payload if payload is not None else {"success": True, "synced": 0, "conflicts": []}
+        )
         self.side_effect = side_effect
         self.calls: list[int] = []
 
-    async def post_exit_sync(self, rom_id: int) -> dict:
+    async def post_exit_sync(self, rom_id: int) -> dict[str, Any]:
         self.calls.append(rom_id)
         if self.side_effect is not None:
             raise self.side_effect
@@ -62,16 +65,16 @@ class FakeAchievementSync:
     def __init__(
         self,
         *,
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
         completion_event: asyncio.Event | None = None,
     ) -> None:
-        self.payload: dict = payload if payload is not None else {"success": True}
+        self.payload: dict[str, Any] = payload if payload is not None else {"success": True}
         self.side_effect = side_effect
         self.completion_event = completion_event
         self.calls: list[int] = []
 
-    async def sync_achievements_after_session(self, rom_id: int) -> dict:
+    async def sync_achievements_after_session(self, rom_id: int) -> dict[str, Any]:
         self.calls.append(rom_id)
         try:
             if self.side_effect is not None:
@@ -88,11 +91,11 @@ class FakeMigrationReader:
     def __init__(
         self,
         *,
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
         pending: bool = False,
     ) -> None:
-        self.payload: dict = (
+        self.payload: dict[str, Any] = (
             payload if payload is not None else {"retrodeck": {"pending": False}, "save_sort": {"pending": False}}
         )
         self.side_effect = side_effect
@@ -100,7 +103,7 @@ class FakeMigrationReader:
         self.refresh_calls = 0
         self.pending_calls = 0
 
-    async def refresh_state(self) -> dict:
+    async def refresh_state(self) -> dict[str, Any]:
         self.refresh_calls += 1
         if self.side_effect is not None:
             raise self.side_effect
@@ -662,7 +665,7 @@ class TestBackgroundTaskTracking:
         blocker = asyncio.Event()
 
         class BlockingAchievementSync:
-            async def sync_achievements_after_session(self, rom_id: int) -> dict:
+            async def sync_achievements_after_session(self, rom_id: int) -> dict[str, Any]:
                 await blocker.wait()
                 return {"success": True}
 
@@ -715,7 +718,7 @@ class TestBackgroundTaskTracking:
         blocker = asyncio.Event()
 
         class BlockingAchievementSync:
-            async def sync_achievements_after_session(self, rom_id: int) -> dict:
+            async def sync_achievements_after_session(self, rom_id: int) -> dict[str, Any]:
                 await blocker.wait()
                 return {"success": True}
 

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,7 +14,7 @@ from services.settings import SettingsService, SettingsServiceConfig
 
 
 @pytest.fixture
-def settings() -> dict:
+def settings() -> dict[str, Any]:
     return {}
 
 

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -805,7 +805,7 @@ class TestSaveShortcutIcon:
 
     def test_save_icon_to_grid_writes_file(self, plugin, tmp_path):
         """Icon PNG should be written via the SteamConfigAdapter seam."""
-        written: dict = {}
+        written: dict[str, bytes] = {}
 
         def fake_write_icon(app_id, icon_bytes):
             path = os.path.join(str(tmp_path), f"{app_id}_icon.png")
@@ -875,7 +875,7 @@ class TestSaveShortcutIcon:
 
     def test_save_icon_to_grid_vdf_mismatch_still_writes_file(self, plugin, tmp_path):
         """If VDF has no matching shortcut, icon file should still be saved."""
-        written: dict = {}
+        written: dict[str, bytes] = {}
 
         def fake_write_icon(app_id, icon_bytes):
             path = os.path.join(str(tmp_path), f"{app_id}_icon.png")
@@ -908,7 +908,7 @@ class TestSaveShortcutIcon:
         """save_shortcut_icon callable should decode base64 and save."""
         import base64
 
-        written: dict = {}
+        written: dict[str, bytes] = {}
 
         def fake_write_icon(app_id, icon_bytes):
             path = os.path.join(str(tmp_path), f"{app_id}_icon.png")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from bootstrap import (
@@ -223,7 +224,7 @@ class TestWireServices:
         }
 
     @staticmethod
-    def _make_config(deps: dict) -> WiringConfig:
+    def _make_config(deps: dict[str, Any]) -> WiringConfig:
         """Build a WiringConfig from the flat deps dict produced by ``_make_deps``."""
         return WiringConfig(
             adapters=AdapterBundle(


### PR DESCRIPTION
Part of #861 — staging PR 1 of a "stage + flip-once" series. We adopt basedpyright `reportMissingTypeArgument` (~643 bare `dict`/`list`/`tuple` spots) by adding the generic type arguments across several area PRs **with the rule still off** (each independently mergeable, CI-green), then flip `reportMissingTypeArgument = "error"` in a final tiny PR.

## This PR: `tests/` area (181 spots, 30 files)
No production code touched; `pyproject.toml` unchanged (rule stays off).

**Precision policy (Option 1):** precise where the value type is obvious from the immediate context (`list[str]`, `dict[int, dict[str, Any]]`, `tuple[str, str | None]`, `asyncio.Queue[...]`, …); `dict[str, Any]` / `list[Any]` fallback for genuinely heterogeneous JSON-shaped payloads. The fakes (`tests/fakes/*`) mirror the signature of the real Protocol/adapter they emulate — RomM/SGDB JSON returns are legitimately `dict[str, Any]`, so the fakes match rather than inventing precision. ~30 precise / ~150 Any-fallback.

## Verification
- `basedpyright` (rule off) — 0 errors (validates every added precise type is accurate; a wrong one would error here)
- `ruff check .` / `ruff format --check .` — clean
- `import-linter` — 8 kept, 0 broken
- `pytest` — 2844 passed
- `git diff pyproject.toml` — empty (rule not enabled in this PR)

docs: N/A — tooling-prep (type annotations only; no user-visible, architecture, or flow change).