### PR TITLE
chore(quality): annotate generics in services/ for reportMissingTypeArgument

### DIFF
--- a/py_modules/services/achievements.py
+++ b/py_modules/services/achievements.py
@@ -11,7 +11,7 @@ policy, and the pure progress extraction live here.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.achievements import extract_achievements_from_rom, extract_game_progress
 
@@ -55,7 +55,7 @@ class AchievementsService:
         self._clock = config.clock
         self._log_debug = config.log_debug
 
-        self._achievements_cache: dict = {}
+        self._achievements_cache: dict[str, Any] = {}
 
     def _read_ra_id(self, rom_id: int) -> int | None:
         """Return the ROM's RetroAchievements id from ``uow.roms``, or ``None``.

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.artwork_paths import final_filename, staging_filename
 from domain.sync_stage import SyncStage
@@ -14,7 +14,7 @@ from lib.list_result import ErrorCode
 if TYPE_CHECKING:
     import asyncio
     import logging
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
     from models.state import ShortcutRegistryEntry
 
@@ -81,9 +81,9 @@ class ArtworkService:
 
     async def download_artwork(
         self,
-        all_roms: list[dict],
-        emit_progress: Callable,
-        is_cancelling: Callable,
+        all_roms: list[dict[str, Any]],
+        emit_progress: Callable[..., Awaitable[None]],
+        is_cancelling: Callable[[], bool],
         progress_step: int = 4,
         progress_total_steps: int = 6,
     ) -> dict[int, str]:
@@ -180,7 +180,7 @@ class ArtworkService:
 
     # ── Artwork base64 query ───────────────────────────────────────────────
 
-    async def get_artwork_base64(self, rom_id: int) -> dict:
+    async def get_artwork_base64(self, rom_id: int) -> dict[str, Any]:
         """Return base64-encoded cover artwork for a single ROM."""
         grid = self._steam_config.grid_dir()
         if not grid:
@@ -221,7 +221,7 @@ class ArtworkService:
 
     # ── Cover refresh (single-ROM repair) ──────────────────────────────────
 
-    async def refresh_cover(self, rom_id: int) -> dict:
+    async def refresh_cover(self, rom_id: int) -> dict[str, Any]:
         """Re-download a ROM's RomM cover and update its ``roms`` row.
 
         Looks up the ROM's current ``shortcut_app_id`` from ``uow.roms``,
@@ -311,7 +311,7 @@ class ArtworkService:
 
     # ── Staging file housekeeping ──────────────────────────────────────────
 
-    def is_staging_file_orphaned(self, grid: str, registry: dict, rom_id: str) -> bool:
+    def is_staging_file_orphaned(self, grid: str, registry: dict[str, int], rom_id: str) -> bool:
         """Check if a staging artwork file is orphaned (not bound or has final artwork).
 
         *registry* is a ``{str(rom_id): shortcut_app_id}`` map of the

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.version import meets_min_version
 from lib.errors import error_response
@@ -35,7 +35,7 @@ class ConnectionServiceConfig:
     plugin entrypoint.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     romm_api: RommConnectionApi
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
@@ -52,7 +52,7 @@ class ConnectionService:
         self._logger = config.logger
         self._min_required_version = config.min_required_version
 
-    async def test_connection(self) -> dict:
+    async def test_connection(self) -> dict[str, Any]:
         """Probe the configured server and return a frontend-shaped result dict.
 
         The result dict always carries ``success`` and ``message``. On
@@ -98,7 +98,7 @@ class ConnectionService:
                 "romm_version": version,
             }
 
-        result: dict = {"success": True, "message": "Connected to RomM"}
+        result: dict[str, Any] = {"success": True, "message": "Connected to RomM"}
         if version and version != "development":
             result["message"] = f"Connected to RomM {version}"
             result["romm_version"] = version

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -14,7 +14,7 @@ cross-service BIOS recheck are this service's concern.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import asyncio
@@ -57,7 +57,7 @@ class CoreService:
         self._retrodeck_paths = config.retrodeck_paths
         self._bios_checker = config.bios_checker
 
-    async def get_available_cores(self, platform_slug: str) -> dict:
+    async def get_available_cores(self, platform_slug: str) -> dict[str, Any]:
         """Return available cores for a platform along with the active selection."""
         cores = self._core_info.get_available_cores(platform_slug)
         active_so, active_label = self._core_info.get_active_core(platform_slug)
@@ -76,7 +76,7 @@ class CoreService:
         self._gamelist_editor.set_system_override(retrodeck_home, platform_slug, core_label or None)
         self._core_info.reset_cache()
 
-    async def set_system_core(self, platform_slug: str, core_label: str) -> dict:
+    async def set_system_core(self, platform_slug: str, core_label: str) -> dict[str, Any]:
         """Set or clear the system-wide core override for a platform.
 
         Empty ``core_label`` clears the override (reverts to the ES-DE
@@ -113,7 +113,7 @@ class CoreService:
         self._gamelist_editor.set_game_override(retrodeck_home, platform_slug, rom_path, core_label or None)
         self._core_info.reset_cache()
 
-    async def set_game_core(self, platform_slug: str, rom_path: str, core_label: str) -> dict:
+    async def set_game_core(self, platform_slug: str, rom_path: str, core_label: str) -> dict[str, Any]:
         """Set or clear the per-game core override.
 
         Empty ``core_label`` clears the per-game override (reverts to

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_files import (
     build_m3u_content,
@@ -82,9 +82,9 @@ class DownloadService:
         self._uow_factory = config.uow_factory
 
         # Owned state
-        self._download_in_progress: set = set()
-        self._download_queue: dict = {}
-        self._download_tasks: dict = {}
+        self._download_in_progress: set[int] = set()
+        self._download_queue: dict[int, dict[str, Any]] = {}
+        self._download_tasks: dict[int, asyncio.Task[None]] = {}
 
     async def shutdown(self) -> None:
         """Cancel in-flight per-ROM download tasks on plugin unload.
@@ -418,7 +418,7 @@ class DownloadService:
             self._download_in_progress.discard(rom_id)
             self._prune_download_queue()
 
-    def _maybe_generate_m3u_io(self, extract_dir: str, rom_detail: dict) -> None:
+    def _maybe_generate_m3u_io(self, extract_dir: str, rom_detail: dict[str, Any]) -> None:
         """Auto-generate an M3U playlist if none exists and multiple disc files are found."""
         all_files = self._download_file_store.scan_files_with_sizes(extract_dir)
         # Check if an M3U already exists (search recursively)

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain import firmware_paths
 from domain.bios import collect_firmware_status
@@ -77,14 +77,14 @@ class FirmwareService:
         self._retrodeck_paths = config.retrodeck_paths
         self._core_info = config.core_info
         self._uow_factory = config.uow_factory
-        self._bios_registry: dict = {}
-        self._bios_files_index: dict | None = None
-        self._firmware_cache: list | None = None
+        self._bios_registry: dict[str, Any] = {}
+        self._bios_files_index: dict[str, dict[str, Any]] | None = None
+        self._firmware_cache: list[dict[str, Any]] | None = None
         self._firmware_cache_epoch: float = 0
         self._restore_firmware_cache()
 
     @property
-    def bios_files_index(self) -> dict:
+    def bios_files_index(self) -> dict[str, dict[str, Any]]:
         """Flat reverse index of BIOS files: {filename: entry_data}.
 
         Raises ``RuntimeError`` if accessed before ``load_bios_registry()`` —
@@ -187,7 +187,7 @@ class FirmwareService:
         self._logger.info("Restored firmware cache from DB (%d items)", len(entries))
 
     @staticmethod
-    def _entry_to_firmware_dict(entry: FirmwareCacheEntry) -> dict:
+    def _entry_to_firmware_dict(entry: FirmwareCacheEntry) -> dict[str, Any]:
         """Reconstruct an in-memory firmware dict from a thin cache aggregate."""
         return {
             "id": entry.id,
@@ -221,7 +221,7 @@ class FirmwareService:
         except Exception as e:
             self._logger.warning(f"Failed to persist firmware cache: {e}")
 
-    def _get_firmware_list(self) -> list:
+    def _get_firmware_list(self) -> list[dict[str, Any]]:
         """Return firmware list, using cache if TTL has not expired.
 
         TTL is checked against the wall-clock cache epoch so a cache

--- a/py_modules/services/game_detail.py
+++ b/py_modules/services/game_detail.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from models.metadata import AchievementSummary
 
@@ -54,7 +54,7 @@ class GameDetailServiceConfig:
     game-detail payload.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     logger: logging.Logger
     clock: Clock
     uow_factory: UnitOfWorkFactory
@@ -81,7 +81,7 @@ class GameDetailService:
         return rom.fs_name
 
     @staticmethod
-    def _build_save_status(save_state: RomSaveState | None) -> dict | None:
+    def _build_save_status(save_state: RomSaveState | None) -> dict[str, Any] | None:
         """Build cached save-sync status from the ROM's save state, or None."""
         if save_state is None:
             return None
@@ -102,7 +102,7 @@ class GameDetailService:
             "conflicts": [],  # cached only — full conflicts via get_save_status()
         }
 
-    def _build_achievement_summary(self, rom_id_str: str, ra_id: int | None) -> dict | None:
+    def _build_achievement_summary(self, rom_id_str: str, ra_id: int | None) -> dict[str, Any] | None:
         """Build cached achievement summary for badge rendering, or None."""
         if not ra_id or not self._achievements.get_ra_username():
             return None
@@ -149,10 +149,10 @@ class GameDetailService:
         *,
         now: float,
         metadata: MetadataCacheEntry | None,
-        bios_status: dict | None,
+        bios_status: dict[str, Any] | None,
         platform_slug: str,
         ra_id: int | None,
-        achievement_summary: dict | None,
+        achievement_summary: dict[str, Any] | None,
     ) -> list[str]:
         """Return list of cache keys that are stale and need background refresh."""
         stale: list[str] = []
@@ -176,7 +176,7 @@ class GameDetailService:
 
         return stale
 
-    def get_cached_game_detail(self, app_id) -> dict:
+    def get_cached_game_detail(self, app_id) -> dict[str, Any]:
         """Return cached data for a game keyed by its Steam ``app_id``."""
         app_id = int(app_id)
 
@@ -263,7 +263,7 @@ class GameDetailService:
             "stale_fields": stale_fields,
         }
 
-    async def get_bios_status(self, rom_id) -> dict:
+    async def get_bios_status(self, rom_id) -> dict[str, Any]:
         """Return BIOS status for a ROM by looking up platform/rom_file from SQLite.
 
         Response always includes ``bios_status`` (dict or ``None``), ``bios_level``

--- a/py_modules/services/launch_gate.py
+++ b/py_modules/services/launch_gate.py
@@ -13,7 +13,7 @@ not block the launch.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     import logging
@@ -71,7 +71,7 @@ class LaunchGateServiceConfig:
     logger: logging.Logger
 
 
-def _has_any_save_conflict(save_status: dict | None) -> bool:
+def _has_any_save_conflict(save_status: dict[str, Any] | None) -> bool:
     """Mirror the frontend ``hasAnySaveConflict`` predicate.
 
     The canonical conflict signal is a non-empty ``conflicts`` list on

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -11,7 +11,7 @@ than reaching through ``service._state.x``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.sync_state import SyncState
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from domain.preview_delta import PreviewDelta
 
 
-def _default_progress() -> dict:
+def _default_progress() -> dict[str, Any]:
     return {
         "running": False,
         "stage": "",
@@ -48,10 +48,10 @@ class LibrarySyncStateBox:
     sync_state: SyncState = SyncState.IDLE
     current_sync_id: str | None = None
     sync_last_heartbeat: float = 0.0
-    sync_progress: dict = field(default_factory=_default_progress)
-    pending_sync: dict = field(default_factory=dict)
+    sync_progress: dict[str, Any] = field(default_factory=_default_progress)
+    pending_sync: dict[int, dict[str, Any]] = field(default_factory=dict)
     pending_delta: PreviewDelta | None = None
-    pending_collection_memberships: dict = field(default_factory=dict)
+    pending_collection_memberships: dict[str, list[int]] = field(default_factory=dict)
     pending_platform_rom_ids: set[int] | None = None
     # Per-unit pipeline coordination. ``unit_complete_event`` is set by
     # :meth:`SyncReporter.report_unit_results` when the frontend reports

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.sync_state import SyncState
 from domain.work_unit import CollectionKind, WorkUnit
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 _SYNC_CANCELLED = "Sync cancelled"
 
 
-def _collection_units(collections: list[dict], enabled_ids: set[str], kind: CollectionKind) -> list[WorkUnit]:
+def _collection_units(collections: list[dict[str, Any]], enabled_ids: set[str], kind: CollectionKind) -> list[WorkUnit]:
     """Build WorkUnits for collections whose id is in *enabled_ids*, tagged with *kind*."""
     units: list[WorkUnit] = []
     for c in collections:
@@ -74,7 +74,7 @@ class LibraryFetcherConfig:
     """
 
     romm_api: RommLibraryApi
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -249,7 +249,7 @@ class LibraryFetcher:
 
     async def _apply_user_bucket(
         self, *, buckets: dict[str, dict[str, bool]], enabled: bool, scope: str | None
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         """Fetch user collections and stamp the ``user`` bucket. Returns failure dict or None."""
         if scope not in (None, "my"):
             return None
@@ -267,7 +267,7 @@ class LibraryFetcher:
 
     async def _apply_smart_bucket(
         self, *, buckets: dict[str, dict[str, bool]], enabled: bool, scope: str | None
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         """Fetch smart collections and stamp the ``smart`` bucket. Returns failure dict or None."""
         if scope not in (None, "smart"):
             return None
@@ -286,7 +286,7 @@ class LibraryFetcher:
 
     async def _apply_franchise_bucket(
         self, *, buckets: dict[str, dict[str, bool]], enabled: bool, scope: str | None
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         """Fetch franchise collections and stamp the ``franchise`` bucket. Returns failure dict or None."""
         if scope not in (None, "franchise"):
             return None
@@ -418,7 +418,7 @@ class LibraryFetcher:
             collections = []
         return _collection_units(collections, enabled_ids, "franchise")
 
-    def _read_incremental_baseline(self, platform_slug: str) -> tuple[str | None, list[dict]]:
+    def _read_incremental_baseline(self, platform_slug: str) -> tuple[str | None, list[dict[str, Any]]]:
         """Read ``(last_sync_iso, reconstructed_roms)`` for *platform_slug* from SQLite.
 
         ``last_sync`` is the ``finished_at`` of the newest completed
@@ -446,7 +446,9 @@ class LibraryFetcher:
         return last_sync, roms
 
     @staticmethod
-    def _decorate_reconstructed(roms: list[dict], platform_name: str, platform_slug: str) -> list[dict]:
+    def _decorate_reconstructed(
+        roms: list[dict[str, Any]], platform_name: str, platform_slug: str
+    ) -> list[dict[str, Any]]:
         """Stamp the live platform display name/slug onto reconstructed ROM dicts."""
         for rom in roms:
             rom["platform_name"] = platform_name
@@ -454,7 +456,7 @@ class LibraryFetcher:
             rom["platform_display_name"] = platform_name
         return roms
 
-    async def _try_unit_incremental_skip(self, unit: WorkUnit) -> list[dict] | None:
+    async def _try_unit_incremental_skip(self, unit: WorkUnit) -> list[dict[str, Any]] | None:
         """Per-unit incremental-skip pre-check for a platform unit.
 
         Returns the roms-reconstructed ROM list when the platform is
@@ -505,7 +507,7 @@ class LibraryFetcher:
         )
         return None
 
-    async def fetch_platform_unit(self, unit: WorkUnit) -> tuple[list[dict], bool]:
+    async def fetch_platform_unit(self, unit: WorkUnit) -> tuple[list[dict[str, Any]], bool]:
         """Fetch ROMs for a single platform unit.
 
         Tries the incremental-skip path first: if the platform's
@@ -531,7 +533,7 @@ class LibraryFetcher:
         platform_name = unit.name
         platform_slug = unit.slug
 
-        unit_roms: list[dict] = []
+        unit_roms: list[dict[str, Any]] = []
         offset = 0
         limit = 50
         while True:
@@ -540,7 +542,7 @@ class LibraryFetcher:
                 # ``dict | list`` keeps the isinstance guard below genuine:
                 # the paginated endpoint returns ``{"items": [...]}`` but the
                 # else-branch tolerates a bare-list response shape.
-                page: dict | list = await self._loop.run_in_executor(
+                page: dict[str, Any] | list[dict[str, Any]] = await self._loop.run_in_executor(
                     None,
                     self._romm_api.list_roms,
                     platform_id,
@@ -568,7 +570,9 @@ class LibraryFetcher:
 
         return unit_roms, False
 
-    async def fetch_collection_unit(self, unit: WorkUnit, synced_rom_ids: set[int]) -> tuple[list[dict], list[int]]:
+    async def fetch_collection_unit(
+        self, unit: WorkUnit, synced_rom_ids: set[int]
+    ) -> tuple[list[dict[str, Any]], list[int]]:
         """Fetch ROMs for a single collection unit.
 
         Mutates *synced_rom_ids* in place: every ROM seen via this
@@ -586,7 +590,7 @@ class LibraryFetcher:
         if unit.type != "collection":
             raise ValueError(f"fetch_collection_unit called with non-collection unit type={unit.type}")
 
-        new_roms: list[dict] = []
+        new_roms: list[dict[str, Any]] = []
         all_collection_rom_ids: list[int] = []
 
         offset = 0
@@ -597,7 +601,7 @@ class LibraryFetcher:
                 # ``dict | list`` keeps the isinstance guard below genuine:
                 # the paginated endpoint returns ``{"items": [...]}`` but the
                 # else-branch tolerates a bare-list response shape.
-                page: dict | list = await self._loop.run_in_executor(
+                page: dict[str, Any] | list[dict[str, Any]] = await self._loop.run_in_executor(
                     None, self._romm_api.list_roms_by_virtual_collection, str(unit.id), limit, offset
                 )
             elif unit.collection_kind == "smart":

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.platform_names import decode_platform_names
 from domain.rom import Rom
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         Clock,
         EventEmitter,
         SteamConfigStore,
+        UnitOfWork,
         UnitOfWorkFactory,
     )
 
@@ -70,7 +71,7 @@ class SyncReporterConfig:
     """
 
     steam_config: SteamConfigStore
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     emit: EventEmitter
@@ -104,11 +105,11 @@ class SyncReporter:
 
     def _build_collection_app_ids(
         self,
-        uow,
+        uow: UnitOfWork,
         pending_platform_rom_ids: set[int] | None,
         pending_collection_memberships: dict[str, list[int]],
         platform_names: dict[str, str],
-    ) -> tuple[dict, dict[str, list]]:
+    ) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
         """Build platform_app_ids and romm_collection_app_ids from ``uow.roms``.
 
         Platform collections are grouped from the full ``roms`` table
@@ -121,7 +122,7 @@ class SyncReporter:
         whose ``shortcut_app_id`` is ``None`` (unbound / stale).
         """
         create_groups = self._settings.get("collection_create_platform_groups", False)
-        platform_app_ids: dict = {}
+        platform_app_ids: dict[str, list[int]] = {}
         for rom in uow.roms.iter_all():
             if rom.shortcut_app_id is None:
                 continue
@@ -130,7 +131,7 @@ class SyncReporter:
             display = platform_names.get(rom.platform_slug, rom.platform_slug)
             platform_app_ids.setdefault(display, []).append(rom.shortcut_app_id)
 
-        romm_collection_app_ids: dict[str, list] = {}
+        romm_collection_app_ids: dict[str, list[int]] = {}
         for coll_name, rom_ids in pending_collection_memberships.items():
             app_ids = [
                 rom.shortcut_app_id
@@ -150,7 +151,7 @@ class SyncReporter:
         pending_platform_rom_ids: set[int] | None,
         platform_names: dict[str, str],
         stale_rom_ids: list[int] | None = None,
-    ) -> tuple[dict, dict[str, list]]:
+    ) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
         """Unbind stale ROMs, refresh the name cache, and build collection maps.
 
         By the time this runs, every per-unit ``commit_unit_results``
@@ -341,7 +342,7 @@ class SyncReporter:
 
         self._stamp_rom_metadata(uow, rom_id, roms_by_id.get(rom_id))
 
-    def _stamp_rom_metadata(self, uow, rom_id: int, rom: dict | None) -> None:
+    def _stamp_rom_metadata(self, uow, rom_id: int, rom: dict[str, Any] | None) -> None:
         """Stamp the ROM's cached metadata into ``uow.rom_metadata`` for this commit.
 
         No-op when the acked ROM carries no ``metadatum`` (defensive: thin
@@ -418,7 +419,7 @@ class SyncReporter:
     def _read_registry_platforms_io(self):
         with self._uow_factory() as uow:
             names = self._read_platform_name_cache(uow)
-            platforms: dict[str, dict] = {}
+            platforms: dict[str, dict[str, Any]] = {}
             for rom in uow.roms.iter_all():
                 if rom.shortcut_app_id is None:
                     continue

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -15,7 +15,7 @@ in-flight sync state belongs in a sub-service.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lib.late_binding import LateBinding
 from services.library._state import LibrarySyncStateBox
@@ -58,7 +58,7 @@ class LibraryServiceConfig:
 
     romm_api: RommLibraryApi
     steam_config: SteamConfigStore
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -166,7 +166,7 @@ class LibraryService:
         return self._box.sync_state
 
     @property
-    def pending_sync(self) -> dict:
+    def pending_sync(self) -> dict[int, dict[str, Any]]:
         """Public accessor for pending sync data (used by SteamGridService)."""
         return self._box.pending_sync
 
@@ -186,11 +186,11 @@ class LibraryService:
         self._box.sync_state = value
 
     @property
-    def _pending_sync(self) -> dict:
+    def _pending_sync(self) -> dict[int, dict[str, Any]]:
         return self._box.pending_sync
 
     @_pending_sync.setter
-    def _pending_sync(self, value: dict) -> None:
+    def _pending_sync(self, value: dict[int, dict[str, Any]]) -> None:
         self._box.pending_sync = value
 
     @property
@@ -202,11 +202,11 @@ class LibraryService:
         self._box.pending_delta = value
 
     @property
-    def _pending_collection_memberships(self) -> dict:
+    def _pending_collection_memberships(self) -> dict[str, list[int]]:
         return self._box.pending_collection_memberships
 
     @_pending_collection_memberships.setter
-    def _pending_collection_memberships(self, value: dict) -> None:
+    def _pending_collection_memberships(self, value: dict[str, list[int]]) -> None:
         self._box.pending_collection_memberships = value
 
     @property
@@ -218,11 +218,11 @@ class LibraryService:
         self._box.pending_platform_rom_ids = value
 
     @property
-    def _sync_progress(self) -> dict:
+    def _sync_progress(self) -> dict[str, Any]:
         return self._box.sync_progress
 
     @_sync_progress.setter
-    def _sync_progress(self, value: dict) -> None:
+    def _sync_progress(self, value: dict[str, Any]) -> None:
         self._box.sync_progress = value
 
     @property
@@ -242,7 +242,7 @@ class LibraryService:
         self._box.current_sync_id = value
 
     @property
-    def _settings(self) -> dict:
+    def _settings(self) -> dict[str, Any]:
         return self._config.settings
 
     # ── Public callable surface ──────────────────────────────────

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import build_shortcuts_data
@@ -84,7 +84,7 @@ class SyncOrchestratorConfig:
     plugs the reader in via ``set()`` once the reporter is built.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     plugin_dir: str
@@ -168,7 +168,7 @@ class SyncOrchestrator:
             await self.emit_progress(SyncStage.DISCOVERING, message="Fetching platforms...")
             work_queue = await self._fetcher.build_work_queue()
 
-            all_roms: list[dict] = []
+            all_roms: list[dict[str, Any]] = []
             platform_rom_ids: set[int] = set()
             collection_memberships: dict[str, list[int]] = {}
             synced_rom_ids: set[int] = set()
@@ -250,7 +250,7 @@ class SyncOrchestrator:
     async def _fetch_preview_unit(
         self,
         unit: WorkUnit,
-        all_roms: list[dict],
+        all_roms: list[dict[str, Any]],
         platform_rom_ids: set[int],
         synced_rom_ids: set[int],
         collection_memberships: dict[str, list[int]],
@@ -324,7 +324,7 @@ class SyncOrchestrator:
         }
         await self._emit("sync_progress", self._sync_state.sync_progress)
 
-    def get_sync_status(self) -> dict:
+    def get_sync_status(self) -> dict[str, Any]:
         """Return the persisted progress snapshot — the authoritative sync state.
 
         Idle returns the default ``running: False`` snapshot; a live run
@@ -548,7 +548,9 @@ class SyncOrchestrator:
             transition(run)
             uow.sync_runs.save(run)
 
-    def _read_preview_baseline(self, slug_to_name: dict[str, str]) -> tuple[dict, list[str], list[str]]:
+    def _read_preview_baseline(
+        self, slug_to_name: dict[str, str]
+    ) -> tuple[dict[str, dict[str, Any]], list[str], list[str]]:
         """Read the classify baseline from SQLite in one short read UoW.
 
         Returns ``(registry, last_synced_platforms, last_synced_collections)``
@@ -560,7 +562,7 @@ class SyncOrchestrator:
         ``SyncRun``.
         """
         with self._uow_factory() as uow:
-            registry: dict = {}
+            registry: dict[str, dict[str, Any]] = {}
             for rom in uow.roms.iter_all():
                 if rom.shortcut_app_id is None:
                     continue
@@ -701,7 +703,7 @@ class SyncOrchestrator:
         *,
         synced_rom_ids: set[int],
         platform_rom_ids: set[int],
-    ) -> tuple[list[dict], bool]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         """Resolve ROMs for a platform unit and update cross-unit accumulators.
 
         Returns ``(unit_roms, skipped)`` for the caller's downstream
@@ -720,7 +722,7 @@ class SyncOrchestrator:
         *,
         synced_rom_ids: set[int],
         collection_memberships: dict[str, list[int]],
-    ) -> tuple[list[dict], bool]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         """Resolve ROMs for a collection unit and record its membership.
 
         Returns ``(unit_roms, skipped)`` — ``skipped`` is always

--- a/py_modules/services/metadata.py
+++ b/py_modules/services/metadata.py
@@ -12,7 +12,7 @@ service's concern.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import asyncio
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     )
 
 
-def _empty_metadata_entry() -> dict:
+def _empty_metadata_entry() -> dict[str, Any]:
     """Build the empty-default metadata entry returned on a cache miss.
 
     Array fields are empty lists (not tuples) to match the ``RomMetadata``
@@ -45,7 +45,7 @@ def _empty_metadata_entry() -> dict:
     }
 
 
-def _metadata_to_entry(metadata: RomMetadata) -> dict:
+def _metadata_to_entry(metadata: RomMetadata) -> dict[str, Any]:
     """Map a ``rom_metadata`` aggregate to the frontend wire entry.
 
     Tuple fields flatten to lists to match the ``RomMetadata`` interface

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
@@ -58,12 +58,12 @@ class MigrationServiceConfig:
     """
 
     migration_file_store: MigrationFileStore
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     settings_persister: SettingsPersister
     emit: EventEmitter
-    get_bios_files_index: Callable[[], dict]
+    get_bios_files_index: Callable[[], dict[str, dict[str, Any]]]
     retrodeck_paths: RetroDeckPaths
     get_retroarch_save_sorting: RetroArchSaveSortingProvider
     get_active_core: CoreResolverFn
@@ -91,9 +91,9 @@ class MigrationService:
         # alone is not enough — without a strong ref, the loop is free to
         # garbage-collect the task before it completes. ``add_done_callback``
         # prunes finished entries to keep the set bounded.
-        self._background_tasks: set[asyncio.Task] = set()
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
-    def _spawn_background_task(self, coro) -> asyncio.Task:
+    def _spawn_background_task(self, coro) -> asyncio.Task[Any]:
         """Schedule ``coro`` on the plugin loop and track the task for shutdown.
 
         Wraps ``loop.create_task`` so the resulting task is retained in
@@ -184,7 +184,7 @@ class MigrationService:
         with self._uow_factory() as uow:
             return bool(uow.kv_config.get(_KV_RETRODECK_HOME_PREVIOUS))
 
-    def dismiss_retrodeck_migration(self) -> dict:
+    def dismiss_retrodeck_migration(self) -> dict[str, Any]:
         """Dismiss the RetroDECK path migration warning without migrating files."""
         with self._uow_factory() as uow:
             uow.kv_config.delete(_KV_RETRODECK_HOME_PREVIOUS)
@@ -668,7 +668,7 @@ class MigrationService:
         old_settings: SaveSortSettings,
         new_settings: SaveSortSettings,
         installs: list[RomInstall],
-    ) -> list:
+    ) -> list[tuple[str, str, str, object, str]]:
         """Collect save files that need migration due to sort setting change.
 
         ``installs`` is the pre-snapshotted ``RomInstall`` list (the caller opens
@@ -698,7 +698,7 @@ class MigrationService:
         old_settings: SaveSortSettings,
         new_settings: SaveSortSettings,
         need_core: bool,
-        items: list,
+        items: list[tuple[str, str, str, object, str]],
     ) -> None:
         """Collect migration items for a single ROM's save files."""
         system = install.system
@@ -752,7 +752,7 @@ class MigrationService:
 
     def _get_save_sort_migration_status_io(
         self, old_settings: SaveSortSettings, new_settings: SaveSortSettings
-    ) -> dict:
+    ) -> dict[str, Any]:
         with self._uow_factory() as uow:
             installs = list(uow.rom_installs.iter_all())
         items = self._collect_save_sorting_items(old_settings, new_settings, installs)
@@ -763,13 +763,13 @@ class MigrationService:
             "saves_count": len(items),
         }
 
-    def dismiss_save_sort_migration(self) -> dict:
+    def dismiss_save_sort_migration(self) -> dict[str, Any]:
         """Dismiss the save sort migration warning without migrating files."""
         with self._uow_factory() as uow:
             uow.kv_config.delete(_KV_SAVE_SORT_PREVIOUS)
         return {"success": True}
 
-    async def get_save_sort_migration_status(self) -> dict:
+    async def get_save_sort_migration_status(self) -> dict[str, Any]:
         with self._uow_factory() as uow:
             old = self._read_save_sort_settings_previous(uow)
             new = self._read_save_sort_settings(uow)
@@ -777,7 +777,7 @@ class MigrationService:
             return {"pending": False}
         return await self._loop.run_in_executor(None, self._get_save_sort_migration_status_io, old, new)
 
-    async def refresh_state(self) -> dict:
+    async def refresh_state(self) -> dict[str, Any]:
         """Run both detection passes and return combined migration state.
 
         Detects any RetroDECK home-path change and any RetroArch save-sort
@@ -796,9 +796,9 @@ class MigrationService:
         old_path: str,
         new_path: str,
         state_updater,
-        counts: dict,
+        counts: dict[str, int],
         count_key: str,
-        errors: list,
+        errors: list[str],
     ) -> None:
         """Newest-wins resolution for a save-sort conflict.
 
@@ -844,7 +844,7 @@ class MigrationService:
 
     def _migrate_save_sort_files_io(
         self, old_settings: SaveSortSettings, new_settings: SaveSortSettings, conflict_strategy: str | None
-    ) -> dict:
+    ) -> dict[str, Any]:
         # conflict_strategy is retained for backwards-compatibility with the
         # callable signature but is unused for save-sort migration — conflicts
         # are resolved in place via newest-wins (see _resolve_save_sort_conflict).
@@ -868,7 +868,7 @@ class MigrationService:
                 uow.kv_config.delete(_KV_SAVE_SORT_PREVIOUS)
         return self._build_migration_result(counts, errors)
 
-    async def migrate_save_sort_files(self, conflict_strategy: str | None = None) -> dict:
+    async def migrate_save_sort_files(self, conflict_strategy: str | None = None) -> dict[str, Any]:
         with self._uow_factory() as uow:
             old = self._read_save_sort_settings_previous(uow)
             new = self._read_save_sort_settings(uow)

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -13,7 +13,7 @@ import contextlib
 import json
 import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.playtime import Playtime
 
@@ -43,7 +43,7 @@ class PlaytimeServiceConfig:
 
     romm_api: RommPlaytimeApi
     retry: RetryStrategy
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     clock: Clock
@@ -70,7 +70,7 @@ class PlaytimeService:
     # Playtime Notes API Helpers
     # ------------------------------------------------------------------
 
-    def _get_playtime_note(self, rom_id: int) -> dict | None:
+    def _get_playtime_note(self, rom_id: int) -> dict[str, Any] | None:
         """Fetch the playtime note for a ROM via the save API protocol.
 
         Reads ``all_user_notes`` from ROM detail and filters by title.
@@ -86,7 +86,7 @@ class PlaytimeService:
                 return note
         return None
 
-    def _create_playtime_note(self, rom_id: int, playtime_data: dict) -> dict:
+    def _create_playtime_note(self, rom_id: int, playtime_data: dict[str, Any]) -> dict[str, Any]:
         """Create a new playtime note for a ROM."""
         return self._romm_api.create_note(
             rom_id,
@@ -97,7 +97,7 @@ class PlaytimeService:
             },
         )
 
-    def _update_playtime_note(self, rom_id: int, note_id: int, playtime_data: dict) -> dict:
+    def _update_playtime_note(self, rom_id: int, note_id: int, playtime_data: dict[str, Any]) -> dict[str, Any]:
         """Update an existing playtime note."""
         return self._romm_api.update_note(
             rom_id,
@@ -106,7 +106,7 @@ class PlaytimeService:
         )
 
     @staticmethod
-    def _parse_playtime_note_content(content: str) -> dict | None:
+    def _parse_playtime_note_content(content: str) -> dict[str, Any] | None:
         """Parse JSON content from a playtime note. Returns dict or None."""
         if not content:
             return None
@@ -193,7 +193,7 @@ class PlaytimeService:
     # Public methods
     # ------------------------------------------------------------------
 
-    def record_session_start(self, rom_id: int) -> dict:
+    def record_session_start(self, rom_id: int) -> dict[str, Any]:
         """Record the start of a play session for playtime tracking.
 
         Opens (or re-opens) the session marker on the ROM's ``Playtime``
@@ -212,7 +212,7 @@ class PlaytimeService:
             return {"success": False, "message": "Unknown ROM"}
         return {"success": True}
 
-    async def record_session_end(self, rom_id: int) -> dict:
+    async def record_session_end(self, rom_id: int) -> dict[str, Any]:
         """Record end of play session, accumulate playtime delta.
 
         Only handles playtime — save sync is handled separately. The work runs
@@ -222,7 +222,7 @@ class PlaytimeService:
         """
         return await self._loop.run_in_executor(None, self._record_session_end_io, int(rom_id))
 
-    def _record_session_end_io(self, rom_id: int) -> dict:
+    def _record_session_end_io(self, rom_id: int) -> dict[str, Any]:
         """Synchronous twin of :meth:`record_session_end` (runs in the executor).
 
         Phase A — fold the closed session into the aggregate in a short write
@@ -259,7 +259,7 @@ class PlaytimeService:
             "session_count": session_count,
         }
 
-    def get_all_playtime(self) -> dict:
+    def get_all_playtime(self) -> dict[str, Any]:
         """Return all local playtime entries keyed by rom_id string.
 
         Wire shape is the minimal pair the frontend types and reads:

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -27,9 +27,11 @@ class RetryStrategy(Protocol):
 class BiosChecker(Protocol):
     """BIOS status checking consumed by GameDetailService."""
 
-    def check_platform_bios_cached(self, platform_slug: str, rom_filename: str | None = None) -> dict | None: ...
+    def check_platform_bios_cached(
+        self, platform_slug: str, rom_filename: str | None = None
+    ) -> dict[str, Any] | None: ...
 
-    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict: ...
+    async def check_platform_bios(self, platform_slug: str, rom_filename: str | None = None) -> dict[str, Any]: ...
 
 
 class AchievementsReader(Protocol):
@@ -37,7 +39,7 @@ class AchievementsReader(Protocol):
 
     def get_ra_username(self) -> str: ...
 
-    def get_progress_cache_entry(self, rom_id_str: str) -> dict | None: ...
+    def get_progress_cache_entry(self, rom_id_str: str) -> dict[str, Any] | None: ...
 
 
 class ArtworkManager(Protocol):
@@ -45,12 +47,12 @@ class ArtworkManager(Protocol):
 
     async def download_artwork(
         self,
-        all_roms: list[dict],
+        all_roms: list[dict[str, Any]],
         emit_progress: Any,
         is_cancelling: Any,
         progress_step: int = 4,
         progress_total_steps: int = 6,
-    ) -> dict: ...
+    ) -> dict[Any, Any]: ...
 
     def finalize_cover_path(self, grid: str | None, cover_path: str, app_id: int, rom_id_str: str) -> str: ...
 
@@ -78,7 +80,7 @@ class LaunchGateRomLookup(Protocol):
     gate uses to allow the launch through unmodified.
     """
 
-    def get_rom_by_steam_app_id(self, app_id: int) -> dict | None: ...
+    def get_rom_by_steam_app_id(self, app_id: int) -> dict[str, Any] | None: ...
 
 
 class LaunchGateInstalledChecker(Protocol):
@@ -105,7 +107,7 @@ class LaunchGateSaveStatusReader(Protocol):
     allowed (no tracked saves — nothing to corrupt).
     """
 
-    async def get_save_status(self, rom_id: int) -> dict: ...
+    async def get_save_status(self, rom_id: int) -> dict[str, Any]: ...
 
     def has_tracked_save(self, rom_id: int) -> bool: ...
 
@@ -120,7 +122,7 @@ class SessionPlaytimeRecorder(Protocol):
     on the returned DTO so the frontend leaves the display untouched.
     """
 
-    async def record_session_end(self, rom_id: int) -> dict: ...
+    async def record_session_end(self, rom_id: int) -> dict[str, Any]: ...
 
 
 class SessionPostExitSync(Protocol):
@@ -133,7 +135,7 @@ class SessionPostExitSync(Protocol):
     toast.
     """
 
-    async def post_exit_sync(self, rom_id: int) -> dict: ...
+    async def post_exit_sync(self, rom_id: int) -> dict[str, Any]: ...
 
 
 class SessionAchievementSync(Protocol):
@@ -145,7 +147,7 @@ class SessionAchievementSync(Protocol):
     logged backend-side; the frontend never observes the outcome.
     """
 
-    async def sync_achievements_after_session(self, rom_id: int) -> dict: ...
+    async def sync_achievements_after_session(self, rom_id: int) -> dict[str, Any]: ...
 
 
 class SessionMigrationReader(Protocol):

--- a/py_modules/services/protocols/infra.py
+++ b/py_modules/services/protocols/infra.py
@@ -9,7 +9,7 @@ would otherwise require service-to-service concrete imports.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class EventEmitter(Protocol):
@@ -80,7 +80,7 @@ class PendingSyncReader(Protocol):
     keeps the typed seam narrow to "give me the current mapping".
     """
 
-    def __call__(self) -> dict: ...
+    def __call__(self) -> dict[int, dict[str, Any]]: ...
 
 
 class DownloadQueueCleanup(Protocol):

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -11,7 +11,7 @@ which owns the read side.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class SystemResolver(Protocol):
@@ -66,7 +66,7 @@ class CoreInfoProvider(Protocol):
         rom_filename: str | None = None,
     ) -> tuple[str | None, str | None]: ...
 
-    def get_available_cores(self, system_name: str) -> list[dict]: ...
+    def get_available_cores(self, system_name: str) -> list[dict[str, Any]]: ...
 
     def reset_cache(self) -> None: ...
 

--- a/py_modules/services/protocols/persistence.py
+++ b/py_modules/services/protocols/persistence.py
@@ -10,7 +10,7 @@ plugin-level persisters.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class SettingsPersister(Protocol):
@@ -30,9 +30,9 @@ class FirmwareCachePersister(Protocol):
     ``"items" in data`` without a None-check.
     """
 
-    def save(self, data: dict) -> None: ...
+    def save(self, data: dict[str, Any]) -> None: ...
 
-    def load(self) -> dict: ...
+    def load(self) -> dict[str, Any]: ...
 
 
 class PluginMetadataReader(Protocol):

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -16,12 +16,12 @@ class SteamConfigStore(Protocol):
     """Protocol for Steam configuration operations."""
 
     def grid_dir(self) -> str | None: ...
-    def read_shortcuts(self) -> dict: ...
-    def write_shortcuts(self, data: dict) -> None: ...
-    def set_steam_input_config(self, app_ids: list, mode: str = "default") -> None: ...
+    def read_shortcuts(self) -> dict[str, Any]: ...
+    def write_shortcuts(self, data: dict[str, Any]) -> None: ...
+    def set_steam_input_config(self, app_ids: list[int], mode: str = "default") -> None: ...
     def write_shortcut_icon(self, app_id: int, icon_bytes: bytes) -> str: ...
-    def check_retroarch_input_driver(self) -> dict | None: ...
-    def fix_retroarch_input_driver(self) -> dict: ...
+    def check_retroarch_input_driver(self) -> dict[str, Any] | None: ...
+    def fix_retroarch_input_driver(self) -> dict[str, Any]: ...
 
 
 class RommDeviceApi(Protocol):
@@ -34,7 +34,7 @@ class RommDeviceApi(Protocol):
         client: str,
         client_version: str,
         hostname: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Register this client as a sync device on the RomM server.
 
         ``name`` is the friendly display label. ``hostname`` is the stable
@@ -46,14 +46,14 @@ class RommDeviceApi(Protocol):
         """
         ...
 
-    def list_devices(self) -> list[dict]:
+    def list_devices(self) -> list[dict[str, Any]]:
         """List all devices registered with the RomM server for the current user.
 
         Returns a list of device dicts from /api/devices.
         """
         ...
 
-    def update_device(self, device_id: str, **fields) -> dict:
+    def update_device(self, device_id: str, **fields) -> dict[str, Any]:
         """Update a registered device's metadata on the RomM server.
 
         Currently the plugin only sends ``client_version`` via the reconciliation
@@ -67,14 +67,14 @@ class RommDeviceApi(Protocol):
 class RommFirmwareApi(Protocol):
     """RomM firmware/BIOS API surface."""
 
-    def list_firmware(self) -> list[dict]:
+    def list_firmware(self) -> list[dict[str, Any]]:
         """Fetch all available firmware/BIOS files from the server.
 
         Returns a list of firmware dicts from /api/firmware.
         """
         ...
 
-    def get_firmware(self, firmware_id: int) -> dict:
+    def get_firmware(self, firmware_id: int) -> dict[str, Any]:
         """Fetch metadata for a single firmware file.
 
         Returns firmware dict from /api/firmware/{firmware_id}.
@@ -92,7 +92,7 @@ class RommFirmwareApi(Protocol):
 class RommPlatformReader(Protocol):
     """Read-only RomM platform listing surface."""
 
-    def list_platforms(self) -> list[dict]:
+    def list_platforms(self) -> list[dict[str, Any]]:
         """Fetch all platforms configured on the RomM server.
 
         Returns a list of platform dicts from /api/platforms.
@@ -112,14 +112,14 @@ class RommPlaytimeApi(Protocol):
         """
         ...
 
-    def create_note(self, rom_id: int, data: dict) -> dict:
+    def create_note(self, rom_id: int, data: dict[str, Any]) -> dict[str, Any]:
         """Create a note on a ROM.
 
         Used for playtime tracking. POST /api/roms/{rom_id}/notes.
         """
         ...
 
-    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+    def update_note(self, rom_id: int, note_id: int, data: dict[str, Any]) -> dict[str, Any]:
         """Update an existing note on a ROM.
 
         PUT /api/roms/{rom_id}/notes/{note_id}.
@@ -130,14 +130,14 @@ class RommPlaytimeApi(Protocol):
 class RommRomReader(Protocol):
     """RomM ROM-listing, ROM-download, and cover-download surface."""
 
-    def get_rom(self, rom_id: int) -> dict:
+    def get_rom(self, rom_id: int) -> dict[str, Any]:
         """Fetch a single ROM by ID.
 
         Returns the ROM dict from /api/roms/{rom_id}.
         """
         ...
 
-    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         """List ROMs for a platform with pagination.
 
         Returns paginated response {"items": [...], "total": N}
@@ -151,7 +151,7 @@ class RommRomReader(Protocol):
         updated_after: str,
         limit: int = 1,
         offset: int = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """List ROMs updated after a given timestamp.
 
         Used for incremental sync to detect changes since last sync.
@@ -159,7 +159,7 @@ class RommRomReader(Protocol):
         """
         ...
 
-    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         """List ROMs belonging to a user-created collection with pagination.
 
         Returns paginated response {"items": [...], "total": N}
@@ -167,7 +167,7 @@ class RommRomReader(Protocol):
         """
         ...
 
-    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         """List ROMs belonging to a virtual (autogenerated) collection with pagination.
 
         Returns paginated response {"items": [...], "total": N}
@@ -175,7 +175,7 @@ class RommRomReader(Protocol):
         """
         ...
 
-    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         """List ROMs belonging to a smart (filter-defined) collection with pagination.
 
         Returns paginated response {"items": [...], "total": N}
@@ -185,15 +185,15 @@ class RommRomReader(Protocol):
         """
         ...
 
-    def list_collections(self) -> list[dict]:
+    def list_collections(self) -> list[dict[str, Any]]:
         """Fetch all user-created collections from the RomM server."""
         ...
 
-    def list_virtual_collections(self, collection_type: str) -> list[dict]:
+    def list_virtual_collections(self, collection_type: str) -> list[dict[str, Any]]:
         """Fetch virtual (autogenerated) collections of a given type (e.g., 'franchise')."""
         ...
 
-    def list_smart_collections(self) -> list[dict]:
+    def list_smart_collections(self) -> list[dict[str, Any]]:
         """Fetch all user-defined smart collections from the RomM server.
 
         Smart collections are filter-defined: the server resolves
@@ -234,7 +234,7 @@ class RommSaveApi(Protocol):
         *,
         device_id: str | None = None,
         slot: str | None = None,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         """Return saves for ``rom_id``; ``device_id`` enriches with device_syncs and ``slot`` filters."""
         ...
 
@@ -248,7 +248,7 @@ class RommSaveApi(Protocol):
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Upload (or replace) a save; raises ``RommConflictError`` on 409 unless ``overwrite=True``."""
         ...
 
@@ -263,11 +263,11 @@ class RommSaveApi(Protocol):
         """Stream save content; ``optimistic=False`` with ``device_id`` defers the sync ack to ``confirm_download``."""
         ...
 
-    def confirm_download(self, save_id: int, device_id: str) -> dict:
+    def confirm_download(self, save_id: int, device_id: str) -> dict[str, Any]:
         """Acknowledge a deferred-sync save download (paired with ``optimistic=False``)."""
         ...
 
-    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
+    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict[str, Any]:
         """Return ``/api/saves/summary`` grouped by slot; ``device_id`` includes per-device sync status."""
         ...
 
@@ -275,7 +275,7 @@ class RommSaveApi(Protocol):
         """Stream a single save file to ``dest_path`` via ``/api/saves/{save_id}/content``."""
         ...
 
-    def delete_server_saves(self, save_ids: list[int]) -> dict:
+    def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         """Delete the given save ids via ``POST /api/saves/delete``."""
         ...
 
@@ -296,14 +296,14 @@ class RommVersion(Protocol):
         """Return the detected RomM server version string, or ``None`` if unset."""
         ...
 
-    def heartbeat(self) -> dict:
+    def heartbeat(self) -> dict[str, Any]:
         """Check server connectivity and retrieve version info.
 
         Returns the raw heartbeat response dict from /api/heartbeat.
         """
         ...
 
-    def get_current_user(self) -> dict:
+    def get_current_user(self) -> dict[str, Any]:
         """Fetch the currently authenticated user profile.
 
         Returns user dict from /api/users/me.
@@ -342,7 +342,7 @@ class RommApi(
 class SteamGridDbApi(Protocol):
     """SteamGridDB HTTP API — search, artwork fetch, key verification."""
 
-    def request(self, path: str) -> dict | None:
+    def request(self, path: str) -> dict[str, Any] | None:
         """Authenticated GET to SGDB API v2. Returns parsed JSON or None if no API key."""
         ...
 
@@ -350,7 +350,7 @@ class SteamGridDbApi(Protocol):
         """Download image from URL to dest_path with atomic write. Returns True on success."""
         ...
 
-    def verify_api_key(self, api_key: str) -> dict:
+    def verify_api_key(self, api_key: str) -> dict[str, Any]:
         """Verify an API key against SGDB. Returns parsed JSON response.
 
         Raises ``lib.errors.SgdbApiError`` on non-2xx HTTP responses

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -9,7 +9,7 @@ metadata all survive — only the on-disk files and the install record go.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lib.path_safety import is_safe_rom_path
 
@@ -98,7 +98,7 @@ class RomRemovalService:
         with self._uow_factory() as uow:
             uow.rom_installs.delete(rom_id)
 
-    async def remove_rom(self, rom_id: int | str) -> dict:
+    async def remove_rom(self, rom_id: int | str) -> dict[str, Any]:
         """Remove a single installed ROM: delete files and drop the install record."""
         rom_id_int = int(rom_id)
         with self._uow_factory() as uow:
@@ -117,7 +117,7 @@ class RomRemovalService:
 
         return {"success": True, "message": "ROM removed"}
 
-    def _uninstall_all_roms_io(self) -> tuple[int, list[dict]]:
+    def _uninstall_all_roms_io(self) -> tuple[int, list[dict[str, str]]]:
         """Sync helper for uninstall_all_roms — bulk file deletion (outside UoW) then row deletes in a write UoW.
 
         Reads every install record in a short read UoW, deletes files outside
@@ -129,7 +129,7 @@ class RomRemovalService:
             installs = list(uow.rom_installs.iter_all())
 
         count = 0
-        errors: list[dict] = []
+        errors: list[dict[str, str]] = []
         successfully_deleted: list[int] = []
         for install in installs:
             try:
@@ -145,7 +145,7 @@ class RomRemovalService:
                 uow.rom_installs.delete(rom_id)
         return count, errors
 
-    async def uninstall_all_roms(self) -> dict:
+    async def uninstall_all_roms(self) -> dict[str, Any]:
         """Remove all installed ROMs: delete files and drop their install records.
 
         Returns ``success`` (True only when every per-ROM deletion

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -8,7 +8,7 @@ references, plugin metadata, and callbacks into other services.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import asyncio
@@ -131,7 +131,7 @@ class SaveServiceConfig:
 
     romm_api: RommSyncApi
     retry: RetryStrategy
-    settings: dict
+    settings: dict[str, Any]
     settings_persister: SettingsPersister
     save_file_store: SaveFileStore
     loop: asyncio.AbstractEventLoop

--- a/py_modules/services/saves/_helpers.py
+++ b/py_modules/services/saves/_helpers.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from domain.save_path import compute_local_save_target
 
 _logger = logging.getLogger(__name__)
 
 
-def local_save_target(server_save: dict, rom_name: str) -> str:
+def local_save_target(server_save: dict[str, Any], rom_name: str) -> str:
     """Resolve the local filename for *server_save*, logging any sanitization."""
     result = compute_local_save_target(server_save, rom_name)
     if result.fallback_extension is not None:

--- a/py_modules/services/saves/_settings.py
+++ b/py_modules/services/saves/_settings.py
@@ -12,22 +12,22 @@ from __future__ import annotations
 from typing import Any
 
 
-def save_sync_enabled(settings: dict) -> bool:
+def save_sync_enabled(settings: dict[str, Any]) -> bool:
     """Whether the save-sync feature toggle is on."""
     return bool(settings.get("save_sync_enabled", False))
 
 
-def sync_before_launch(settings: dict) -> bool:
+def sync_before_launch(settings: dict[str, Any]) -> bool:
     """Whether the pre-launch download is enabled."""
     return bool(settings.get("sync_before_launch", True))
 
 
-def sync_after_exit(settings: dict) -> bool:
+def sync_after_exit(settings: dict[str, Any]) -> bool:
     """Whether the post-exit upload is enabled."""
     return bool(settings.get("sync_after_exit", True))
 
 
-def resolve_default_slot(settings: dict) -> str | None:
+def resolve_default_slot(settings: dict[str, Any]) -> str | None:
     """The configured default slot, collapsing empty/None to ``None`` (legacy mode)."""
     raw_slot = settings.get("default_slot", "default")
     if raw_slot is None:
@@ -36,12 +36,12 @@ def resolve_default_slot(settings: dict) -> str | None:
     return slot_str if slot_str else None
 
 
-def autocleanup_limit(settings: dict) -> int:
+def autocleanup_limit(settings: dict[str, Any]) -> int:
     """The auto-cleanup retention limit, guarded against ``0`` / ``None``."""
     return int(settings.get("autocleanup_limit", 10) or 10)
 
 
-def save_sync_settings_view(settings: dict) -> dict[str, Any]:
+def save_sync_settings_view(settings: dict[str, Any]) -> dict[str, Any]:
     """Build the frontend-facing dict of the five save-sync knobs."""
     return {
         "save_sync_enabled": save_sync_enabled(settings),

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.save_extensions import get_save_extensions
 from domain.save_path import resolve_save_dir
@@ -72,7 +72,7 @@ class RomInfoService:
         self._get_core_name = config.get_core_name
         self._logger = config.logger
 
-    def get_rom_save_info(self, rom_id: int) -> dict | None:
+    def get_rom_save_info(self, rom_id: int) -> dict[str, Any] | None:
         """Get save-related info for an installed ROM.
 
         Returns dict with keys: system, rom_name, saves_dir, platform_slug, file_path
@@ -178,7 +178,7 @@ class RomInfoService:
         corename = self._get_core_name(core_so)
         return (corename or None, core_so)
 
-    def find_save_files(self, rom_id: int) -> list[dict]:
+    def find_save_files(self, rom_id: int) -> list[dict[str, str]]:
         """Find local save files for a ROM.
 
         Returns list of ``{"path": str, "filename": str}``.

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -12,7 +12,7 @@ single-sub-service logic does not.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from services.saves._config import SaveServiceConfig
@@ -149,11 +149,11 @@ class SaveService:
     # Device registration (delegated to SyncEngine)
     # ------------------------------------------------------------------
 
-    async def ensure_device_registered(self) -> dict:
+    async def ensure_device_registered(self) -> dict[str, Any]:
         """Ensure this device is registered with the RomM server for save sync tracking."""
         return await self._sync_engine.ensure_device_registered()
 
-    async def list_devices(self) -> dict:
+    async def list_devices(self) -> dict[str, Any]:
         """List all devices registered with the RomM server for this user."""
         return await self._sync_engine.list_devices()
 
@@ -161,7 +161,7 @@ class SaveService:
     # Status (delegated to StatusService)
     # ------------------------------------------------------------------
 
-    async def get_save_status(self, rom_id: int) -> dict:
+    async def get_save_status(self, rom_id: int) -> dict[str, Any]:
         """Get save sync status for a ROM (local files, server saves, conflict state)."""
         return await self._status.get_save_status(rom_id)
 
@@ -169,7 +169,7 @@ class SaveService:
         """Run full save status check in background and emit result to frontend."""
         await self._status.check_save_status_background(rom_id)
 
-    def check_core_change(self, rom_id: int) -> dict:
+    def check_core_change(self, rom_id: int) -> dict[str, Any]:
         """Check if emulator core changed since last sync for a ROM."""
         return self._status.check_core_change(rom_id)
 
@@ -193,19 +193,19 @@ class SaveService:
     # Sync orchestration (delegated to SyncEngine)
     # ------------------------------------------------------------------
 
-    async def pre_launch_sync(self, rom_id: int) -> dict:
+    async def pre_launch_sync(self, rom_id: int) -> dict[str, Any]:
         """Download newer saves from server before game launch."""
         return await self._sync_engine.pre_launch_sync(rom_id)
 
-    async def post_exit_sync(self, rom_id: int) -> dict:
+    async def post_exit_sync(self, rom_id: int) -> dict[str, Any]:
         """Upload changed saves after game exit."""
         return await self._sync_engine.post_exit_sync(rom_id)
 
-    async def sync_rom_saves(self, rom_id: int) -> dict:
+    async def sync_rom_saves(self, rom_id: int) -> dict[str, Any]:
         """Bidirectional sync for a single ROM (manual trigger from game detail)."""
         return await self._sync_engine.sync_rom_saves(rom_id)
 
-    async def sync_all_saves(self) -> dict:
+    async def sync_all_saves(self) -> dict[str, Any]:
         """Manual full sync of all ROMs with shortcuts (both directions)."""
         return await self._sync_engine.sync_all_saves()
 
@@ -215,7 +215,7 @@ class SaveService:
         filename: str,
         server_save_id: int,
         action: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Resolve a pending sync conflict (true two-sided divergence)."""
         return await self._sync_engine.resolve_sync_conflict(rom_id, filename, server_save_id, action)
 
@@ -223,23 +223,23 @@ class SaveService:
     # Slots (delegated to SlotsService)
     # ------------------------------------------------------------------
 
-    async def get_save_slots(self, rom_id: int) -> dict:
+    async def get_save_slots(self, rom_id: int) -> dict[str, Any]:
         """List available save slots for a ROM."""
         return await self._slots.get_save_slots(rom_id)
 
-    async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_saves(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Fetch server save files for a specific slot."""
         return await self._slots.get_slot_saves(rom_id, slot)
 
-    async def switch_slot(self, rom_id: int, new_slot: str) -> dict:
+    async def switch_slot(self, rom_id: int, new_slot: str) -> dict[str, Any]:
         """Switch the active save slot with immediate state sync."""
         return await self._slots.switch_slot(rom_id, new_slot)
 
-    def is_save_tracking_configured(self, rom_id: int) -> dict:
+    def is_save_tracking_configured(self, rom_id: int) -> dict[str, Any]:
         """Check if save slot tracking is configured for a game."""
         return self._slots.is_save_tracking_configured(rom_id)
 
-    async def get_save_setup_info(self, rom_id: int) -> dict:
+    async def get_save_setup_info(self, rom_id: int) -> dict[str, Any]:
         """Get info needed for the first-sync setup wizard."""
         return await self._slots.get_save_setup_info(rom_id)
 
@@ -248,7 +248,7 @@ class SaveService:
         rom_id: int,
         chosen_slot: str,
         migrate_from_slot: str | None | object = NO_MIGRATION,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync.
 
         ``migrate_from_slot`` may be the ``NO_MIGRATION`` sentinel, ``None``,
@@ -259,11 +259,11 @@ class SaveService:
             migrate_from_slot = NO_MIGRATION
         return await self._slots.confirm_slot_choice(rom_id, chosen_slot, migrate_from_slot)
 
-    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Return info about what deleting a slot would do, for the confirmation modal."""
         return await self._slots.get_slot_delete_info(rom_id, slot)
 
-    async def delete_slot(self, rom_id: int, slot: str) -> dict:
+    async def delete_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Delete a save slot and all its saves (local state + server if applicable)."""
         return await self._slots.delete_slot(rom_id, slot)
 
@@ -271,11 +271,11 @@ class SaveService:
     # Versions (delegated to VersionsService)
     # ------------------------------------------------------------------
 
-    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict:
+    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict[str, Any]:
         """List server-side versions of *filename* in the active slot."""
         return await self._versions.list_file_versions(rom_id, slot, filename)
 
-    async def rollback_to_version(self, rom_id: int, slot: str, save_id: int) -> dict:
+    async def rollback_to_version(self, rom_id: int, slot: str, save_id: int) -> dict[str, Any]:
         """Switch the local + tracked save to a chosen older server version."""
         return await self._versions.rollback_to_version(rom_id, slot, save_id)
 
@@ -287,11 +287,11 @@ class SaveService:
         """Whether the save-sync feature toggle is on."""
         return save_sync_enabled(self._settings)
 
-    def get_save_sync_settings(self) -> dict:
+    def get_save_sync_settings(self) -> dict[str, Any]:
         """Return current save sync settings as the frontend dict shape."""
         return save_sync_settings_view(self._settings)
 
-    def update_save_sync_settings(self, settings: dict) -> dict:
+    def update_save_sync_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
         """Update save sync settings (sync toggles, slot, etc.) in settings.json."""
         for key, value in settings.items():
             if key not in ALLOWED_SETTINGS_KEYS:
@@ -354,7 +354,7 @@ class SaveService:
 
         return total_deleted, errors
 
-    def delete_local_saves(self, rom_id: int) -> dict:
+    def delete_local_saves(self, rom_id: int) -> dict[str, Any]:
         """Delete local save files (.srm, .rtc) for a ROM."""
         rom_id = int(rom_id)
 
@@ -380,7 +380,7 @@ class SaveService:
         with self._uow_factory() as uow:
             return [install.rom_id for install in uow.rom_installs.iter_all() if install.platform_slug == platform_slug]
 
-    def delete_platform_saves(self, platform_slug: str) -> dict:
+    def delete_platform_saves(self, platform_slug: str) -> dict[str, Any]:
         """Delete local save files for all installed ROMs on a platform."""
         rom_ids = self._installed_rom_ids_on_platform(platform_slug)
 

--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -10,7 +10,7 @@ operation's own narrow Unit of Work (ADR-0006).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lib.list_result import ErrorCode
 from services.saves._settings import save_sync_enabled
@@ -35,7 +35,7 @@ class SlotDeleter:
     def __init__(
         self,
         *,
-        settings: dict,
+        settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
         rom_info: RomInfoService,
         romm_api: RommSaveApi,
@@ -65,7 +65,9 @@ class SlotDeleter:
         with self._uow_factory() as uow:
             uow.rom_save_states.save(rom_id, save_state)
 
-    def _validate_slot_operation(self, rom_id: int, slot: str) -> dict | tuple[RomSaveState, dict[str, dict]]:
+    def _validate_slot_operation(
+        self, rom_id: int, slot: str
+    ) -> dict[str, Any] | tuple[RomSaveState, dict[str, dict[str, Any]]]:
         """Shared validation for slot delete operations.
 
         Returns an error dict on failure, or a (rom_state, slots_dict) tuple on
@@ -79,12 +81,12 @@ class SlotDeleter:
         save_state = self._read_save_state(rom_id)
         if save_state is None:
             return {"success": False, "reason": "not_found"}
-        slots_dict: dict[str, dict] = save_state.slots
+        slots_dict: dict[str, dict[str, Any]] = save_state.slots
         if slot not in slots_dict:
             return {"success": False, "reason": "not_found"}
         return save_state, slots_dict
 
-    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Return info about what deleting a slot would do, for the confirmation modal."""
         rom_id = int(rom_id)
         slot = str(slot).strip() if slot else ""
@@ -104,7 +106,7 @@ class SlotDeleter:
         if source == "server":
             device_id = await self._loop.run_in_executor(None, self._read_device_id)
             try:
-                server_saves: list[dict] = await self._loop.run_in_executor(
+                server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                     None,
                     lambda: self._retry.with_retry(
                         lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
@@ -145,11 +147,11 @@ class SlotDeleter:
             "is_active": is_active,
         }
 
-    async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict:
+    async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Delete all server saves in a slot. Returns result dict with count and IDs."""
         device_id = await self._loop.run_in_executor(None, self._read_device_id)
         try:
-            server_saves: list[dict] = await self._loop.run_in_executor(
+            server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),
@@ -172,7 +174,7 @@ class SlotDeleter:
                 "message": f"Failed to delete server saves: {e}",
             }
 
-    async def delete_slot(self, rom_id: int, slot: str) -> dict:
+    async def delete_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Delete a save slot and all its saves (local state + server if applicable)."""
         rom_id = int(rom_id)
         slot = str(slot).strip() if slot else ""

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -8,7 +8,7 @@ slot deletion belong in their own sub-modules.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from lib.list_result import ErrorCode
@@ -32,7 +32,7 @@ class SlotListing:
     def __init__(
         self,
         *,
-        settings: dict,
+        settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
         romm_api: RommSaveApi,
         retry: RetryStrategy,
@@ -52,7 +52,7 @@ class SlotListing:
             device_id = uow.kv_config.get("device_id")
         return state, device_id
 
-    async def get_save_slots(self, rom_id: int) -> dict:
+    async def get_save_slots(self, rom_id: int) -> dict[str, Any]:
         """List available save slots for a ROM.
 
         Merges server slots with locally-created slots. Persists the merged
@@ -77,7 +77,7 @@ class SlotListing:
         # means "no slots"; the persisted slots dict will contain ``""``).
         if rom_state is None:
             active_slot: str | None = default_slot
-            persisted_slots: dict[str, dict] = {}
+            persisted_slots: dict[str, dict[str, Any]] = {}
         else:
             active_slot = rom_state.active_slot
             persisted_slots = rom_state.slots
@@ -102,10 +102,10 @@ class SlotListing:
                 "slots": [],
                 "active_slot": active_slot,
             }
-        server_slots_list: list[dict] = summary.get("slots", [])
+        server_slots_list: list[dict[str, Any]] = summary.get("slots", [])
 
         # Merge: update persisted slots with server data, promote local→server
-        merged: dict[str, dict] = {}
+        merged: dict[str, dict[str, Any]] = {}
         for s in server_slots_list:
             raw = s.get("slot") or s.get("slot_name")
             name = raw if raw else ""
@@ -146,8 +146,8 @@ class SlotListing:
 
     @staticmethod
     def _merge_persisted_slots(
-        persisted: dict[str, dict],
-        merged: dict[str, dict],
+        persisted: dict[str, dict[str, Any]],
+        merged: dict[str, dict[str, Any]],
         active_slot: str | None,
     ) -> None:
         """Add persisted local slots (or the active slot) that aren't on the server.
@@ -165,7 +165,7 @@ class SlotListing:
             elif info.get("source") == "server" and name == (active_slot or ""):
                 merged[name] = {"source": "server", "count": 0, "latest_updated_at": None}
 
-    async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_saves(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Fetch server save files for a specific slot.
 
         Used by the frontend to show save files when expanding an inactive slot panel.
@@ -186,7 +186,7 @@ class SlotListing:
         device_id = await self._loop.run_in_executor(None, self._read_device_id)
 
         try:
-            server_saves: list[dict] = await self._loop.run_in_executor(
+            server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot),

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -15,7 +15,7 @@ persistence is each operation's own narrow Unit of Work (ADR-0006).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from services.saves.slots.deletion import SlotDeleter
 from services.saves.slots.listing import SlotListing
@@ -59,7 +59,7 @@ class SlotsServiceConfig:
     re-upload.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
     status_service: StatusService
@@ -130,11 +130,11 @@ class SlotsService:
     # Slot listing — delegates to :class:`SlotListing`.
     # ------------------------------------------------------------------
 
-    async def get_save_slots(self, rom_id: int) -> dict:
+    async def get_save_slots(self, rom_id: int) -> dict[str, Any]:
         """List available save slots for a ROM."""
         return await self._listing.get_save_slots(rom_id)
 
-    async def get_slot_saves(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_saves(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Fetch server save files for a specific slot."""
         return await self._listing.get_slot_saves(rom_id, slot)
 
@@ -144,11 +144,11 @@ class SlotsService:
     # continue to drive the same code path.
     # ------------------------------------------------------------------
 
-    def set_active_slot(self, rom_id: int, slot: str) -> dict:
+    def set_active_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Set the active save slot for a specific game."""
         return self._switcher.set_active_slot(rom_id, slot)
 
-    async def switch_slot(self, rom_id: int, new_slot: str) -> dict:
+    async def switch_slot(self, rom_id: int, new_slot: str) -> dict[str, Any]:
         """Switch the active save slot with immediate state sync."""
         return await self._switcher.switch_slot(rom_id, new_slot)
 
@@ -156,11 +156,11 @@ class SlotsService:
     # Save setup wizard — delegates to :class:`SetupWizard`.
     # ------------------------------------------------------------------
 
-    def is_save_tracking_configured(self, rom_id: int) -> dict:
+    def is_save_tracking_configured(self, rom_id: int) -> dict[str, Any]:
         """Check if save slot tracking is configured for a game."""
         return self._setup.is_save_tracking_configured(rom_id)
 
-    async def get_save_setup_info(self, rom_id: int) -> dict:
+    async def get_save_setup_info(self, rom_id: int) -> dict[str, Any]:
         """Get info needed for the first-sync setup wizard."""
         return await self._setup.get_save_setup_info(rom_id)
 
@@ -169,7 +169,7 @@ class SlotsService:
         rom_id: int,
         chosen_slot: str,
         migrate_from_slot: str | None | object = NO_MIGRATION,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync."""
         return await self._setup.confirm_slot_choice(rom_id, chosen_slot, migrate_from_slot)
 
@@ -177,10 +177,10 @@ class SlotsService:
     # Slot deletion — delegates to :class:`SlotDeleter`.
     # ------------------------------------------------------------------
 
-    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict:
+    async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Return info about what deleting a slot would do."""
         return await self._deleter.get_slot_delete_info(rom_id, slot)
 
-    async def delete_slot(self, rom_id: int, slot: str) -> dict:
+    async def delete_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Delete a save slot and all its saves (local state + server if applicable)."""
         return await self._deleter.delete_slot(rom_id, slot)

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -10,7 +10,7 @@ operation's own narrow Unit of Work (ADR-0006).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
 from domain.rom_save_state import RomSaveState
@@ -41,7 +41,7 @@ class SetupWizard:
     def __init__(
         self,
         *,
-        settings: dict,
+        settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
         rom_info: RomInfoService,
         resolve_core: Callable[[int], str | None],
@@ -77,7 +77,7 @@ class SetupWizard:
         with self._uow_factory() as uow:
             uow.rom_save_states.save(rom_id, save_state)
 
-    def is_save_tracking_configured(self, rom_id: int) -> dict:
+    def is_save_tracking_configured(self, rom_id: int) -> dict[str, Any]:
         """Check if save slot tracking is configured for a game.
 
         Fast, synchronous check — reads only from local state.
@@ -89,7 +89,7 @@ class SetupWizard:
         active_slot = game_state.active_slot if (game_state and configured) else None
         return {"configured": configured, "active_slot": active_slot}
 
-    async def get_save_setup_info(self, rom_id: int) -> dict:
+    async def get_save_setup_info(self, rom_id: int) -> dict[str, Any]:
         """Get info needed for the first-sync setup wizard.
 
         Fetches server saves, checks local files, determines which
@@ -113,7 +113,7 @@ class SetupWizard:
         game_state, device_id = await self._loop.run_in_executor(None, self._read_setup_inputs, rom_id)
         default_slot = resolve_default_slot(self._settings) or "default"
         try:
-            server_saves: list[dict] = await self._loop.run_in_executor(
+            server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
@@ -137,7 +137,7 @@ class SetupWizard:
             }
 
         # Group server saves by slot
-        slots_map: dict[str | None, list[dict]] = {}
+        slots_map: dict[str | None, list[dict[str, Any]]] = {}
         for ss in server_saves:
             slot_key = ss.get("slot")
             slots_map.setdefault(slot_key, []).append(ss)
@@ -198,7 +198,7 @@ class SetupWizard:
         rom_id: int,
         chosen_slot: str,
         migrate_from_slot: str | None | object = NO_MIGRATION,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Confirm which slot to use for a game's save sync.
 
         Sets slot_confirmed=true and active_slot in state.

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -10,7 +10,7 @@ sub-modules. Persistence is each operation's own narrow Unit of Work
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from lib.list_result import ErrorCode
@@ -45,7 +45,7 @@ class SlotSwitcher:
     def __init__(
         self,
         *,
-        settings: dict,
+        settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
         sync_engine: SyncEngine,
         status_service: StatusService,
@@ -79,7 +79,7 @@ class SlotSwitcher:
         with self._uow_factory() as uow:
             uow.rom_save_states.save(rom_id, save_state)
 
-    def set_active_slot(self, rom_id: int, slot: str) -> dict:
+    def set_active_slot(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Set the active save slot for a specific game.
 
         If the slot doesn't exist yet (not on server), it is persisted
@@ -99,7 +99,7 @@ class SlotSwitcher:
         self._loop.create_task(self._status_service.check_save_status_background(rom_id))
         return {"success": True, "active_slot": resolved_slot}
 
-    def _check_slot_switch_readiness(self, rom_id: int, save_state: RomSaveState) -> dict:
+    def _check_slot_switch_readiness(self, rom_id: int, save_state: RomSaveState) -> dict[str, Any]:
         """Check whether it is safe to switch slots for this ROM.
 
         A switch is unsafe if local files have changed since the last sync
@@ -127,7 +127,7 @@ class SlotSwitcher:
 
         return {"ready": True}
 
-    async def switch_slot(self, rom_id: int, new_slot: str) -> dict:
+    async def switch_slot(self, rom_id: int, new_slot: str) -> dict[str, Any]:
         """Switch the active save slot with immediate state sync.
 
         Pre-checks (all must pass):
@@ -177,7 +177,7 @@ class SlotSwitcher:
 
         # 5. Fetch server saves for the new slot (also proves server is reachable)
         try:
-            all_server_saves: list[dict] = await self._loop.run_in_executor(
+            all_server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(
                     lambda: self._romm_api.list_saves(rom_id, device_id=device_id),
@@ -232,7 +232,7 @@ class SlotSwitcher:
 
     def _do_switch_downloads(
         self,
-        slot_saves: list[dict],
+        slot_saves: list[dict[str, Any]],
         saves_dir: str,
         save_state: RomSaveState,
         device_id: str | None,

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import detect_core_change
 from domain.iso_time import parse_iso_to_epoch
@@ -46,7 +46,7 @@ class StatusServiceConfig:
     status updates to the frontend.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
     rom_info: RomInfoService
@@ -83,7 +83,7 @@ class StatusService:
         rom_id: int,
         server_device_id: str | None,
         own_upload_ids: list[int] | None,
-    ) -> tuple[dict, dict | None]:
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
         """Build the status DTO + optional conflict descriptor for one outcome.
 
         Returns ``(status_entry, conflict_entry_or_None)``. The conflict
@@ -104,7 +104,7 @@ class StatusService:
             server_device_id=server_device_id,
             uploaded_by_us=compute_uploaded_by_us(chosen_server, own_upload_ids),
         )
-        conflict_entry: dict | None = None
+        conflict_entry: dict[str, Any] | None = None
         if isinstance(action, Conflict):
             self._log_debug(
                 f"_get_save_status_io({rom_id}): conflict {outcome.filename} "
@@ -120,8 +120,8 @@ class StatusService:
         rom_id: int,
         save_state: RomSaveState,
         device_id: str | None,
-        server_in_slot: list[dict],
-        info: dict,
+        server_in_slot: list[dict[str, Any]],
+        info: dict[str, Any],
     ) -> tuple[MatrixOutcome | None, list[MatrixOutcome], bool]:
         """Iterate matrix outcomes for the active slot, splitting them into local/server-only buckets.
 
@@ -151,10 +151,10 @@ class StatusService:
     def _get_save_status_io(
         self,
         rom_id: int,
-        server_saves: list[dict],
+        server_saves: list[dict[str, Any]],
         *,
         server_query_failed: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Sync helper for get_save_status — runs in executor.
 
         Builds the saves-tab status for one ROM as a single-entry view of
@@ -199,8 +199,8 @@ class StatusService:
 
         own_upload_ids: list[int] | None = save_state.own_upload_ids if save_state else None
 
-        file_statuses: list[dict] = []
-        conflicts: list[dict] = []
+        file_statuses: list[dict[str, Any]] = []
+        conflicts: list[dict[str, Any]] = []
 
         if info is not None:
             # The baseline-adopt path mutates a working copy; an absent aggregate
@@ -258,7 +258,7 @@ class StatusService:
     # Public callable surface — invoked via the SaveService aggregate root
     # ------------------------------------------------------------------
 
-    async def get_save_status(self, rom_id: int) -> dict:
+    async def get_save_status(self, rom_id: int) -> dict[str, Any]:
         """Get save sync status for a ROM (local files, server saves, conflict state).
 
         When the ``list_saves`` call raises (transient network blip, server
@@ -276,7 +276,7 @@ class StatusService:
         """
         rom_id = int(rom_id)
 
-        server_saves: list[dict] = []
+        server_saves: list[dict[str, Any]] = []
         server_query_failed = False
         try:
             device_id = await self._loop.run_in_executor(None, self._read_device_id)
@@ -310,7 +310,7 @@ class StatusService:
         except Exception as e:
             self._log_debug(f"Background save status check failed for rom {rom_id}: {e}")
 
-    def check_core_change(self, rom_id: int) -> dict:
+    def check_core_change(self, rom_id: int) -> dict[str, Any]:
         """Check if emulator core changed since last sync for a ROM."""
         if not save_sync_enabled(self._settings):
             return {"changed": False}
@@ -365,7 +365,7 @@ def _outcome_server_sort_key(outcome: MatrixOutcome) -> float:
     return parse_iso_to_epoch(newest.get("updated_at")) or 0.0
 
 
-def _playtime_to_dict(playtime) -> dict:
+def _playtime_to_dict(playtime) -> dict[str, Any]:
     """Project the ``Playtime`` aggregate onto the frontend dict, or ``{}`` when absent."""
     if playtime is None:
         return {}
@@ -378,7 +378,7 @@ def _playtime_to_dict(playtime) -> dict:
     }
 
 
-def _redact_server_fields(entry: dict) -> dict:
+def _redact_server_fields(entry: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *entry* with status="unknown" and server fields nulled out.
 
     Used when the ``list_saves`` query failed: the matrix ran against an

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -14,7 +14,7 @@ the file-level transfer logic live elsewhere in the package
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from services.saves._settings import save_sync_enabled
 
@@ -55,7 +55,7 @@ class DeviceRegistry:
         self,
         *,
         uow_factory: UnitOfWorkFactory,
-        settings: dict,
+        settings: dict[str, Any],
         romm_api: RommSyncApi,
         retry: RetryStrategy,
         logger: logging.Logger,
@@ -93,7 +93,7 @@ class DeviceRegistry:
         loop: asyncio.AbstractEventLoop,
         hostname_provider: HostnameReader,
         machine_id_provider: MachineIdReader,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Ensure this device is registered with the RomM server for save sync tracking.
 
         ``hostname_provider`` supplies the friendly display ``name``;
@@ -168,7 +168,7 @@ class DeviceRegistry:
 
         return {"success": False, "device_id": "", "device_name": "", "error": "registration_failed"}
 
-    async def list_devices(self, *, loop: asyncio.AbstractEventLoop) -> dict:
+    async def list_devices(self, *, loop: asyncio.AbstractEventLoop) -> dict[str, Any]:
         """List all devices registered with the RomM server for this user."""
         if not save_sync_enabled(self._settings):
             return {"success": False, "devices": [], "disabled": True}

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from services.saves._messages import DEVICE_NOT_REGISTERED, SAVE_SYNC_DISABLED
@@ -71,7 +71,7 @@ class SyncEngineConfig:
     SyncEngine consults at the entry of every public flow.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     rom_info: RomInfoService
     romm_api: RommSyncApi
@@ -198,13 +198,13 @@ class SyncEngine:
         device_id: str | None,
         core_so: str | None,
         default_slot: str | None = None,
-    ) -> tuple[int, list[str], list[dict]]:
+    ) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Sync saves for a single ROM (delegate to :class:`MatrixExecutor`)."""
         return self._matrix.sync_rom_saves(rom_id, save_state, device_id, core_so, default_slot)
 
     def do_download_save(
         self,
-        server_save: dict,
+        server_save: dict[str, Any],
         saves_dir: str,
         filename: str,
         save_state: RomSaveState,
@@ -224,9 +224,9 @@ class SyncEngine:
         device_id: str | None,
         system: str,
         core_so: str | None,
-        server_save: dict | None = None,
+        server_save: dict[str, Any] | None = None,
         default_slot: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Upload a local save file to server (delegate to :class:`MatrixExecutor`)."""
         return self._matrix.do_upload_save(
             rom_id, file_path, filename, save_state, device_id, system, core_so, server_save, default_slot
@@ -235,11 +235,11 @@ class SyncEngine:
     def iter_matrix_outcomes(
         self,
         rom_id: int,
-        server_in_slot: list[dict],
+        server_in_slot: list[dict[str, Any]],
         *,
         save_state: RomSaveState | None,
         device_id: str | None,
-        info: dict,
+        info: dict[str, Any],
     ) -> Iterator[MatrixOutcome]:
         """Yield one :class:`MatrixOutcome` per save file in the ROM's active slot."""
         return self._matrix.iter_matrix_outcomes(
@@ -251,7 +251,9 @@ class SyncEngine:
         self._matrix.adopt_baseline_hash(save_state, filename, local_hash)
 
     @staticmethod
-    def filter_server_saves_to_slot(server_saves: list[dict], active_slot: str | None) -> list[dict]:
+    def filter_server_saves_to_slot(
+        server_saves: list[dict[str, Any]], active_slot: str | None
+    ) -> list[dict[str, Any]]:
         """Filter server saves to the active slot."""
         return MatrixExecutor.filter_server_saves_to_slot(server_saves, active_slot)
 
@@ -259,10 +261,10 @@ class SyncEngine:
         self,
         rom_id: int,
         filename: str,
-        server: dict,
+        server: dict[str, Any],
         local_path: str | None,
         local_hash: str | None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Build a Phase-2 ``sync_conflict`` descriptor for the frontend."""
         return self._matrix.build_sync_conflict_entry(rom_id, filename, server, local_path, local_hash)
 
@@ -274,7 +276,7 @@ class SyncEngine:
     # with its callers avoids a constructor callback.
     # ------------------------------------------------------------------
 
-    async def ensure_device_registered(self) -> dict:
+    async def ensure_device_registered(self) -> dict[str, Any]:
         """Ensure this device is registered with the RomM server for save sync tracking."""
         return await self._devices.ensure_device_registered(
             loop=self._loop,
@@ -282,7 +284,7 @@ class SyncEngine:
             machine_id_provider=self._machine_id_provider,
         )
 
-    async def list_devices(self) -> dict:
+    async def list_devices(self) -> dict[str, Any]:
         """List all devices registered with the RomM server for this user."""
         return await self._devices.list_devices(loop=self._loop)
 
@@ -337,7 +339,7 @@ class SyncEngine:
                 e,
             )
 
-    async def _run_rom_sync(self, rom_id: int) -> tuple[int, list[str], list[dict]]:
+    async def _run_rom_sync(self, rom_id: int) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Read inputs → sync in executor → persist, for one ROM under its lock.
 
         The narrow-UoW shape (ADR-0006): a short read UoW loads the aggregate +
@@ -361,7 +363,7 @@ class SyncEngine:
         await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
         return synced, errors, conflicts
 
-    async def pre_launch_sync(self, rom_id: int) -> dict:
+    async def pre_launch_sync(self, rom_id: int) -> dict[str, Any]:
         """Download newer saves from server before game launch."""
         rom_id = int(rom_id)
         async with self.rom_lock(rom_id):
@@ -414,7 +416,7 @@ class SyncEngine:
                 "conflicts": list(conflicts),
             }
 
-    async def post_exit_sync(self, rom_id: int) -> dict:
+    async def post_exit_sync(self, rom_id: int) -> dict[str, Any]:
         """Upload changed saves after game exit."""
         self._logger.info("post_exit_sync called for rom_id=%d", rom_id)
         rom_id = int(rom_id)
@@ -477,7 +479,7 @@ class SyncEngine:
                 "conflicts": list(conflicts),
             }
 
-    async def sync_rom_saves(self, rom_id: int) -> dict:
+    async def sync_rom_saves(self, rom_id: int) -> dict[str, Any]:
         """Bidirectional sync for a single ROM (manual trigger from game detail)."""
         rom_id = int(rom_id)
         async with self.rom_lock(rom_id):
@@ -515,7 +517,7 @@ class SyncEngine:
         with self._uow_factory() as uow:
             return sorted(install.rom_id for install in uow.rom_installs.iter_all())
 
-    async def sync_all_saves(self) -> dict:
+    async def sync_all_saves(self) -> dict[str, Any]:
         """Manual full sync of all ROMs with shortcuts (both directions)."""
         if not self.is_save_sync_enabled():
             return {"success": False, "message": SAVE_SYNC_DISABLED, "synced": 0, "conflicts": 0}
@@ -533,7 +535,7 @@ class SyncEngine:
 
         total_synced = 0
         total_errors: list[str] = []
-        all_conflicts: list[dict] = []
+        all_conflicts: list[dict[str, Any]] = []
         rom_count = 0
 
         # Only iterate installed ROMs — non-installed ROMs have no save files
@@ -570,7 +572,7 @@ class SyncEngine:
         filename: str,
         server_save_id: int,
         action: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Resolve a pending sync conflict (true two-sided divergence).
 
         Reached when ``compute_sync_action`` returned ``Conflict`` — the

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -16,7 +16,7 @@ import contextlib
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
 from domain.rom_save_state import FileSyncState, RomSaveState
@@ -63,7 +63,7 @@ class MatrixOutcome:
     local_mtime_iso: str | None
     local_size: int | None
     file_state: FileSyncState
-    server_candidates: list[dict]
+    server_candidates: list[dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -78,7 +78,7 @@ class DispatchSink:
     """
 
     errors: list[str]
-    conflicts: list[dict]
+    conflicts: list[dict[str, Any]]
 
 
 class MatrixExecutor:
@@ -118,7 +118,7 @@ class MatrixExecutor:
     # Server Save Hash Helper
     # ------------------------------------------------------------------
 
-    def get_server_save_hash(self, server_save: dict) -> str | None:
+    def get_server_save_hash(self, server_save: dict[str, Any]) -> str | None:
         """Download a server save to temp and compute its MD5 hash.
 
         Used for slow-path conflict detection when no content_hash is available.
@@ -147,7 +147,7 @@ class MatrixExecutor:
         self,
         save_state: RomSaveState,
         filename: str,
-        server_response: dict,
+        server_response: dict[str, Any],
         local_path: str,
         system: str,
         *,
@@ -207,7 +207,7 @@ class MatrixExecutor:
 
     def do_download_save(
         self,
-        server_save: dict,
+        server_save: dict[str, Any],
         saves_dir: str,
         filename: str,
         save_state: RomSaveState,
@@ -274,9 +274,9 @@ class MatrixExecutor:
         device_id: str | None,
         system: str,
         core_so: str | None,
-        server_save: dict | None = None,
+        server_save: dict[str, Any] | None = None,
         default_slot: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Upload a local save file to server.
 
         Mutates *save_state* in memory (per-file baseline, own-upload
@@ -335,7 +335,9 @@ class MatrixExecutor:
             self._save_file_store.remove_file(tmp)
 
     @staticmethod
-    def filter_server_saves_to_slot(server_saves: list[dict], active_slot: str | None) -> list[dict]:
+    def filter_server_saves_to_slot(
+        server_saves: list[dict[str, Any]], active_slot: str | None
+    ) -> list[dict[str, Any]]:
         """Filter server saves to the active slot.
 
         Saves with ``slot=None`` (legacy/no-slot) are accepted under any active
@@ -345,7 +347,7 @@ class MatrixExecutor:
             return [ss for ss in server_saves if ss.get("slot") == active_slot or ss.get("slot") is None]
         return [ss for ss in server_saves if not ss.get("slot")]
 
-    def _build_local_input(self, local_path: str, filename: str) -> dict:
+    def _build_local_input(self, local_path: str, filename: str) -> dict[str, Any]:
         """Build the dict shape consumed by ``compute_sync_action``."""
         exists = self._save_file_store.is_file(local_path)
         return {
@@ -359,10 +361,10 @@ class MatrixExecutor:
         self,
         rom_id: int,
         filename: str,
-        server: dict,
+        server: dict[str, Any],
         local_path: str | None,
         local_hash: str | None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Build a Phase-2 ``sync_conflict`` descriptor for the frontend."""
         local_mtime = None
         local_size = None
@@ -412,7 +414,7 @@ class MatrixExecutor:
         system: str,
         core_so: str | None,
         default_slot: str | None,
-        server_saves: list[dict],
+        server_saves: list[dict[str, Any]],
         errors: list[str],
     ) -> bool:
         """Execute an ``Upload`` action. Returns True iff the upload was issued."""
@@ -453,7 +455,7 @@ class MatrixExecutor:
         system: str,
         core_so: str | None,
         default_slot: str | None,
-        server_saves: list[dict],
+        server_saves: list[dict[str, Any]],
         sink: DispatchSink,
     ) -> bool:
         """Execute one ``SyncAction`` outcome. Returns True if a transfer happened.
@@ -518,11 +520,11 @@ class MatrixExecutor:
     def iter_matrix_outcomes(
         self,
         rom_id: int,
-        server_in_slot: list[dict],
+        server_in_slot: list[dict[str, Any]],
         *,
         save_state: RomSaveState | None,
         device_id: str | None,
-        info: dict,
+        info: dict[str, Any],
     ) -> Iterator[MatrixOutcome]:
         """Yield one :class:`MatrixOutcome` per save file in the ROM's active slot.
 
@@ -574,7 +576,7 @@ class MatrixExecutor:
         # Group server saves by canonical local target filename. Server-only
         # groups (no local file) get matrix-evaluated against their own group;
         # compute_sync_action picks newest-in-group internally.
-        server_only_groups: dict[str, list[dict]] = {}
+        server_only_groups: dict[str, list[dict[str, Any]]] = {}
         for ss in server_in_slot:
             target = local_save_target(ss, rom_name)
             if target in handled_filenames:
@@ -608,7 +610,7 @@ class MatrixExecutor:
         device_id: str | None,
         core_so: str | None,
         default_slot: str | None = None,
-    ) -> tuple[int, list[str], list[dict]]:
+    ) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Sync saves for a single ROM, mutating *save_state* in memory.
 
         Drives :meth:`iter_matrix_outcomes` and dispatches each emitted
@@ -646,7 +648,7 @@ class MatrixExecutor:
         )
 
         errors: list[str] = []
-        conflicts: list[dict] = []
+        conflicts: list[dict[str, Any]] = []
         sink = DispatchSink(errors=errors, conflicts=conflicts)
         synced = 0
 
@@ -690,7 +692,7 @@ class MatrixExecutor:
         return synced, errors, conflicts
 
 
-def _file_state_to_dict(file_state: FileSyncState) -> dict:
+def _file_state_to_dict(file_state: FileSyncState) -> dict[str, Any]:
     """Project a :class:`FileSyncState` value object onto the dict shape
     ``compute_sync_action`` consumes (the legacy ``to_dict`` surface)."""
     return {

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -19,7 +19,7 @@ rollback flow (older save versions) lives in
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
@@ -101,7 +101,7 @@ class RollbackOrchestrator:
         action: str,
         *,
         loop: asyncio.AbstractEventLoop,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Drive the post-lock conflict-resolution flow.
 
         ``loop`` is passed per call so :class:`SyncEngine` can hand its
@@ -203,7 +203,7 @@ class RollbackOrchestrator:
             self._logger.error(f"resolve_sync_conflict({rom_id}, {filename}, {action}) failed: {e}")
             return {"success": False, "message": str(e)}
 
-    def _validate_filename(self, rom_id: int, action: str, filename: str) -> dict | None:
+    def _validate_filename(self, rom_id: int, action: str, filename: str) -> dict[str, Any] | None:
         """Reject non-basename filenames; ``None`` if the filename is safe.
 
         The frontend-supplied filename flows into
@@ -234,7 +234,7 @@ class RollbackOrchestrator:
         self,
         save_state: RomSaveState,
         device_id: str | None,
-        server: dict,
+        server: dict[str, Any],
         saves_dir: str,
         system: str,
         rom_name: str,
@@ -255,7 +255,7 @@ class RollbackOrchestrator:
         save_state: RomSaveState,
         device_id: str | None,
         core_so: str | None,
-        server: dict,
+        server: dict[str, Any],
         saves_dir: str,
         system: str,
         rom_name: str,

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from services.saves._helpers import local_save_target
@@ -42,7 +42,7 @@ class VersionsServiceConfig:
     and the ``DebugLogger`` seam.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
     rom_info: RomInfoService
@@ -93,7 +93,7 @@ class VersionsService:
     # Version History API
     # ------------------------------------------------------------------
 
-    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict:
+    async def list_file_versions(self, rom_id: int, slot: str, filename: str) -> dict[str, Any]:
         """List server-side saves in the active slot, excluding the currently-tracked one.
 
         The slot is the unit, not the filename. Saves uploaded by other
@@ -158,9 +158,9 @@ class VersionsService:
         device_id: str | None,
         core_so: str | None,
         save_id: int,
-        info: dict,
-        server_saves: list[dict],
-    ) -> dict:
+        info: dict[str, Any],
+        server_saves: list[dict[str, Any]],
+    ) -> dict[str, Any]:
         """Blocking I/O portion of the version-switch flow — runs in executor.
 
         The caller is responsible for the matrix pre-flight: by the time
@@ -234,7 +234,7 @@ class VersionsService:
 
         return {"status": "ok"}
 
-    async def rollback_to_version(self, rom_id: int, slot: str, save_id: int) -> dict:
+    async def rollback_to_version(self, rom_id: int, slot: str, save_id: int) -> dict[str, Any]:
         """Switch the local + tracked save to a chosen older server version.
 
         Flow:
@@ -314,7 +314,7 @@ class VersionsService:
             # Re-fetch server saves after the pre-flight: it may have created
             # or modified saves the switch needs to see.
             try:
-                server_saves: list[dict] = await self._loop.run_in_executor(
+                server_saves: list[dict[str, Any]] = await self._loop.run_in_executor(
                     None,
                     lambda: self._retry.with_retry(
                         lambda: self._romm_api.list_saves(rom_id, device_id=device_id, slot=slot if slot else None)

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import logging
@@ -51,7 +51,7 @@ class SessionFinalizeSyncResult:
     offline: bool
     success: bool
     synced: int | None
-    conflicts: list[dict]
+    conflicts: list[dict[str, Any]]
     toast_title: str | None
     toast_body: str | None
     conflicts_toast: str | None
@@ -66,8 +66,8 @@ class SessionFinalizeMigration:
     without re-deriving them from a loose dict.
     """
 
-    retrodeck: dict
-    save_sort: dict
+    retrodeck: dict[str, Any]
+    save_sort: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -126,7 +126,7 @@ def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> t
     return _TOAST_TITLE, _TOAST_BODY_FAILED
 
 
-def _render_conflicts_toast(conflicts: list[dict]) -> str | None:
+def _render_conflicts_toast(conflicts: list[dict[str, Any]]) -> str | None:
     """Render the additive "N save conflict(s) need resolution" body.
 
     Singular when ``count == 1``, plural otherwise. Returns ``None``
@@ -152,7 +152,7 @@ class SessionLifecycleService:
         # alone is not enough — without a strong ref, the loop is free to
         # garbage-collect the task before it completes. ``add_done_callback``
         # prunes finished entries to keep the set bounded.
-        self._background_tasks: set[asyncio.Task] = set()
+        self._background_tasks: set[asyncio.Task[None]] = set()
 
     async def shutdown(self) -> None:
         """Cancel any in-flight background tasks and await their completion.
@@ -273,7 +273,7 @@ class SessionLifecycleService:
         raw_synced = result.get("synced")
         synced = raw_synced if isinstance(raw_synced, int) else None
         raw_conflicts = result.get("conflicts")
-        conflicts: list[dict] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
+        conflicts: list[dict[str, Any]] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
 
         toast_title, toast_body = _render_sync_toast(offline=offline, success=success, synced=synced)
         conflicts_toast = _render_conflicts_toast(conflicts)

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -14,7 +14,7 @@ from the live settings dict and dispatches to the runtime logger.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     import logging
@@ -38,7 +38,7 @@ class SettingsServiceConfig:
     Bundled here so the ctor stays within the S107 parameter budget.
     """
 
-    settings: dict
+    settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     logger: logging.Logger
     settings_persister: SettingsPersister
@@ -65,7 +65,7 @@ class SettingsService:
         romm_user: str,
         romm_pass: str,
         allow_insecure_ssl: bool | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Persist server credentials.
 
         The masked placeholder (``"••••"``) leaves the stored password
@@ -86,7 +86,7 @@ class SettingsService:
             self._logger.error(f"Failed to save settings: {e}")
             return {"success": False, "message": f"Save failed: {e}"}
 
-    def get_settings(self) -> dict:
+    def get_settings(self) -> dict[str, Any]:
         """Return the read-shape settings dict for the frontend.
 
         Secrets (RomM password, SteamGridDB API key) are reported as
@@ -108,7 +108,7 @@ class SettingsService:
 
     # ── Log level ────────────────────────────────────────────────────────
 
-    def save_log_level(self, level: str) -> dict:
+    def save_log_level(self, level: str) -> dict[str, Any]:
         """Validate and persist the runtime log level."""
         if level not in _VALID_LOG_LEVELS:
             return {"success": False, "message": "Invalid log level"}
@@ -135,7 +135,7 @@ class SettingsService:
 
     # ── Steam Input ──────────────────────────────────────────────────────
 
-    def save_steam_input_setting(self, mode: str) -> dict:
+    def save_steam_input_setting(self, mode: str) -> dict[str, Any]:
         """Validate and persist the Steam Input mode preference."""
         if mode not in _VALID_STEAM_INPUT_MODES:
             return {"success": False, "message": f"Invalid mode: {mode}"}
@@ -143,7 +143,7 @@ class SettingsService:
         self._settings_persister.save_settings()
         return {"success": True}
 
-    def apply_steam_input_setting(self) -> dict:
+    def apply_steam_input_setting(self) -> dict[str, Any]:
         """Apply the current Steam Input mode to every bound ROM shortcut."""
         mode = self._settings.get("steam_input_mode", "default")
         with self._uow_factory() as uow:
@@ -159,20 +159,20 @@ class SettingsService:
 
     # ── RetroArch input driver ──────────────────────────────────────────
 
-    def fix_retroarch_input_driver(self) -> dict:
+    def fix_retroarch_input_driver(self) -> dict[str, Any]:
         """Repair a problematic RetroArch ``input_driver`` value (``x`` -> ``sdl2``)."""
         return self._steam_config.fix_retroarch_input_driver()
 
     # ── Whitelist (non-Steam shortcut removal) ──────────────────────────
 
-    def get_whitelist_settings(self) -> dict:
+    def get_whitelist_settings(self) -> dict[str, Any]:
         """Return whitelist settings used by the non-Steam game removal feature."""
         return {
             "disabled_defaults": self._settings.get("whitelist_disabled_defaults", []),
             "custom_names": self._settings.get("whitelist_custom_names", []),
         }
 
-    def update_whitelist_settings(self, disabled_defaults: object, custom_names: object) -> dict:
+    def update_whitelist_settings(self, disabled_defaults: object, custom_names: object) -> dict[str, Any]:
         """Validate and persist whitelist settings.
 
         Both arguments must be lists of strings. Anything else is
@@ -190,7 +190,7 @@ class SettingsService:
 
     # ── Collection grouping ─────────────────────────────────────────────
 
-    def save_collection_platform_groups(self, enabled: bool) -> dict:
+    def save_collection_platform_groups(self, enabled: bool) -> dict[str, Any]:
         """Persist the collection platform-group toggle."""
         self._settings["collection_create_platform_groups"] = bool(enabled)
         self._settings_persister.save_settings()

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -11,7 +11,7 @@ cache the library sync refreshes each run.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.platform_names import decode_platform_names
 
@@ -63,7 +63,7 @@ class ShortcutRemovalService:
 
     # ── Removal queries ────────────────────────────────────────────────────
 
-    def remove_all_shortcuts(self) -> dict:
+    def remove_all_shortcuts(self) -> dict[str, Any]:
         """Return app_ids and rom_ids for the frontend to remove via SteamClient.
 
         Bound ROMs contribute their ``shortcut_app_id``; every ROM contributes
@@ -77,7 +77,7 @@ class ShortcutRemovalService:
         rom_ids = [str(rom.rom_id) for rom in roms]
         return {"success": True, "app_ids": app_ids, "rom_ids": rom_ids}
 
-    async def remove_platform_shortcuts(self, platform_slug: str) -> dict:
+    async def remove_platform_shortcuts(self, platform_slug: str) -> dict[str, Any]:
         """Return app_ids and rom_ids for a platform for the frontend to remove via SteamClient.
 
         Filters ``uow.roms`` by ``platform_slug`` directly; the display name in
@@ -90,7 +90,7 @@ class ShortcutRemovalService:
             self._logger.error(f"Failed to get platform shortcuts: {e}")
             return {"success": False, "message": f"Failed: {e}", "app_ids": [], "rom_ids": []}
 
-    def _remove_platform_shortcuts_io(self, platform_slug: str) -> dict:
+    def _remove_platform_shortcuts_io(self, platform_slug: str) -> dict[str, Any]:
         with self._uow_factory() as uow:
             roms = list(uow.roms.iter_by_platform(platform_slug))
             platform_name = self._read_platform_name_cache(uow).get(platform_slug, platform_slug)
@@ -104,7 +104,7 @@ class ShortcutRemovalService:
 
     # ── Removal results ────────────────────────────────────────────────────
 
-    def _report_removal_results_io(self, removed_rom_ids: list) -> None:
+    def _report_removal_results_io(self, removed_rom_ids: list[int | str]) -> None:
         """Sync helper for report_removal_results — Steam-Input reset, artwork deletion, unbind."""
         with self._uow_factory() as uow:
             roms = {rom_id: uow.roms.get(int(rom_id)) for rom_id in removed_rom_ids}
@@ -142,7 +142,7 @@ class ShortcutRemovalService:
             entry["app_id"] = rom.shortcut_app_id
         return entry  # type: ignore[return-value]
 
-    async def report_removal_results(self, removed_rom_ids: list) -> dict:
+    async def report_removal_results(self, removed_rom_ids: list[int | str]) -> dict[str, Any]:
         """Called by frontend after removing shortcuts via SteamClient."""
         await self._loop.run_in_executor(None, self._report_removal_results_io, removed_rom_ids)
         return {"success": True, "message": f"Removed {len(removed_rom_ids)} shortcuts"}

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -14,7 +14,7 @@ import asyncio
 import base64
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from domain.sgdb_artwork import (
     asset_type_endpoint,
@@ -59,7 +59,7 @@ class SteamGridServiceConfig:
     romm_api: RommRomReader
     steam_config: SteamConfigStore
     sgdb_artwork_cache: SgdbArtworkCache
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     settings_persister: SettingsPersister


### PR DESCRIPTION
Part of #861 — staging PR 2 of the "stage + flip-once" series (tests/ shipped in #893). Adds generic type arguments with the rule still off; the final PR flips `reportMissingTypeArgument = "error"`.

## This PR: `py_modules/services/` area (324 spots, 42 files)
`pyproject.toml` unchanged (rule stays off).

**Precision policy (Option 1):** precise where the value type is obvious — `dict[int, int]` id→id maps, `list[Rom]`-style domain lists, `set[asyncio.Task[None]]`, `Callable[..., Awaitable[None]]` callbacks, sync-result tuples; `dict[str, Any]` / `list[dict[str, Any]]` fallback for JSON-shaped RomM payloads, on-disk state, and sync-result/conflict/status dicts. Protocol return types in `transport.py`/`cross_service.py` aligned with the fakes annotated in #893 (they must stay structurally compatible).

**Two precise types surfaced real type mismatches — fixed at the source, not papered over:**
- `reporter._build_collection_app_ids`: typed its `uow` param as `UnitOfWork` (one internal caller) so `rom.platform_slug` resolves to `str` and the precise `dict[str, list[int]]` becomes valid.
- `ArtworkManager.download_artwork` Protocol: real impl returns `dict[int, str]`, fake returns `dict[str, Any]`; `dict` keys are invariant so the Protocol return is `dict[Any, Any]` (the only type assignable from both) — an internal non-JSON map, outside the RomM-JSON alignment.

## Verification
- `basedpyright` (rule off) — 0 errors (validates every precise type)
- `ruff check .` / `ruff format --check .` — clean
- `import-linter` — 8 kept, 0 broken
- `pytest` — 2844 passed
- `git diff pyproject.toml` — empty

docs: N/A — tooling-prep (type annotations only; no user-visible, architecture, or flow change).