### PR TITLE
chore(quality): annotate generics in adapters/ + domain/ for reportMissingTypeArgument

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from lib.migration_gate import migration_blocked
 
 
 class Plugin:
-    settings: dict
+    settings: dict[str, Any]
     loop: asyncio.AbstractEventLoop
 
     # Test-only attribute slots — production ``Plugin`` does not read

--- a/py_modules/adapters/debug_logger.py
+++ b/py_modules/adapters/debug_logger.py
@@ -9,7 +9,7 @@ underlying :class:`logging.Logger` it emits through.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     import logging
@@ -28,7 +28,7 @@ class SettingsAwareDebugLogger:
 
     _LOG_LEVELS: ClassVar[dict[str, int]] = {"debug": 0, "info": 1, "warn": 2, "error": 3}
 
-    def __init__(self, *, settings: dict, logger: logging.Logger) -> None:
+    def __init__(self, *, settings: dict[str, Any], logger: logging.Logger) -> None:
         self._settings = settings
         self._logger = logger
 

--- a/py_modules/adapters/es_de_config.py
+++ b/py_modules/adapters/es_de_config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import logging
@@ -58,10 +58,10 @@ class CoreResolver:
         self._plugin_dir = plugin_dir
         self._logger = logger
         self._get_retrodeck_home = get_retrodeck_home
-        self._es_systems_cache: dict | None = None
+        self._es_systems_cache: dict[str, Any] | None = None
         self._es_systems_mtime: float | None = None
         self._es_systems_path: str | None = None
-        self._core_defaults_cache: dict | None = None
+        self._core_defaults_cache: dict[str, Any] | None = None
         self._core_defaults_mtime: float | None = None
         self._core_defaults_path: str | None = None
 
@@ -402,7 +402,7 @@ class CoreResolver:
             self._logger.warning("es_de_config: failed to read %s: %s", xml_path, e)
             return {}
 
-        systems: dict = {}
+        systems: dict[str, Any] = {}
         state = {
             "path": [],  # element name stack
             "text": "",  # accumulated character data
@@ -436,7 +436,7 @@ class CoreResolver:
 
     # -- internal cache methods ----------------------------------------------
 
-    def _load_core_defaults(self) -> dict:
+    def _load_core_defaults(self) -> dict[str, Any]:
         """Load the static core_defaults.json fallback.
 
         Re-reads from disk if the file's mtime has changed (handles plugin updates).
@@ -471,7 +471,7 @@ class CoreResolver:
         self._core_defaults_mtime = current_mtime
         return self._core_defaults_cache or {}
 
-    def _load_es_systems(self) -> dict:
+    def _load_es_systems(self) -> dict[str, Any]:
         """Load and cache es_systems.xml parse result.
 
         Re-reads from disk if the file's mtime has changed (handles flatpak updates).
@@ -684,7 +684,7 @@ class GamelistXmlEditorAdapter:
         except ImportError:
             return None
 
-        result: dict = {
+        result: dict[str, Any] = {
             "alt_emulator_label": None,
             "games": [],
         }
@@ -808,7 +808,7 @@ class GamelistXmlEditorAdapter:
         except ImportError:
             return raw_xml
 
-        elements: list = []
+        elements: list[tuple[str, str]] = []
         state = {"path": [], "text": "", "skip_altemulator": False}
 
         parser = expat.ParserCreate()

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -10,12 +10,13 @@ import fcntl
 import json
 import logging
 import os
+from typing import Any
 
 _FIRMWARE_CACHE_VERSION = 1
 _SETTINGS_VERSION = 4
 _LOCK_EXT = ".lock"
 
-DEFAULT_SETTINGS: dict = {
+DEFAULT_SETTINGS: dict[str, Any] = {
     "romm_url": "",
     "romm_user": "",
     "romm_pass": "",
@@ -59,7 +60,7 @@ class PersistenceAdapter:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _locked_write(self, path: str, data: dict, *, rotate_to: str | None = None) -> None:
+    def _locked_write(self, path: str, data: dict[str, Any], *, rotate_to: str | None = None) -> None:
         """Atomic write of *data* to *path* under an exclusive file lock.
 
         When ``rotate_to`` is provided, the existing file at ``path`` is
@@ -92,7 +93,7 @@ class PersistenceAdapter:
     # Settings
     # ------------------------------------------------------------------
 
-    def load_settings(self) -> dict:
+    def load_settings(self) -> dict[str, Any]:
         """Read ``settings.json``, apply defaults, and fix permissions.
 
         Migration logic (e.g. renaming old keys) is intentionally NOT
@@ -121,7 +122,7 @@ class PersistenceAdapter:
 
         return settings
 
-    def save_settings(self, data: dict) -> None:
+    def save_settings(self, data: dict[str, Any]) -> None:
         """Atomic write of *data* to ``settings.json`` with flock, stamping version."""
         data["version"] = _SETTINGS_VERSION
         settings_path = os.path.join(self._settings_dir, "settings.json")
@@ -131,7 +132,7 @@ class PersistenceAdapter:
     # Firmware cache
     # ------------------------------------------------------------------
 
-    def load_firmware_cache(self) -> dict:
+    def load_firmware_cache(self) -> dict[str, Any]:
         """Read ``firmware_cache.json`` with version check.
 
         Returns an empty cache dict if the file is missing, corrupt, or
@@ -149,7 +150,7 @@ class PersistenceAdapter:
         except (FileNotFoundError, json.JSONDecodeError):
             return {"version": _FIRMWARE_CACHE_VERSION}
 
-    def save_firmware_cache(self, data: dict) -> None:
+    def save_firmware_cache(self, data: dict[str, Any]) -> None:
         """Atomic write of *data* to ``firmware_cache.json`` with flock, stamping version."""
         data["version"] = _FIRMWARE_CACHE_VERSION
         cache_path = os.path.join(self._runtime_dir, "firmware_cache.json")
@@ -159,7 +160,7 @@ class PersistenceAdapter:
     # Save-sync state (legacy read — consumed only by the settings fold)
     # ------------------------------------------------------------------
 
-    def load_save_sync_state(self) -> dict | None:
+    def load_save_sync_state(self) -> dict[str, Any] | None:
         """Read ``save_sync_state.json`` and return the raw dict.
 
         Returns ``None`` when the file is missing, corrupt, or not a
@@ -188,7 +189,7 @@ class SettingsPersisterAdapter:
     on this class.
     """
 
-    def __init__(self, persistence: PersistenceAdapter, settings: dict) -> None:
+    def __init__(self, persistence: PersistenceAdapter, settings: dict[str, Any]) -> None:
         self._persistence = persistence
         self._settings = settings
 
@@ -208,8 +209,8 @@ class FirmwareCachePersisterAdapter:
     def __init__(self, persistence: PersistenceAdapter) -> None:
         self._persistence = persistence
 
-    def save(self, data: dict) -> None:
+    def save(self, data: dict[str, Any]) -> None:
         self._persistence.save_firmware_cache(data)
 
-    def load(self) -> dict:
+    def load(self) -> dict[str, Any]:
         return self._persistence.load_firmware_cache()

--- a/py_modules/adapters/retrodeck_paths.py
+++ b/py_modules/adapters/retrodeck_paths.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import logging
@@ -27,7 +27,7 @@ class RetroDeckPathsAdapter:
     def __init__(self, *, user_home: str, logger: logging.Logger) -> None:
         self._user_home = user_home
         self._logger = logger
-        self._cached_config: dict | None = None
+        self._cached_config: dict[str, Any] | None = None
         self._cache_time = 0.0
 
     def _config_path(self) -> str:
@@ -41,7 +41,7 @@ class RetroDeckPathsAdapter:
             "retrodeck.json",
         )
 
-    def _load_config(self) -> dict | None:
+    def _load_config(self) -> dict[str, Any] | None:
         now = time.monotonic()
         if self._cached_config is not None and (now - self._cache_time) < self._CACHE_TTL:
             return self._cached_config

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -16,7 +16,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from lib.certifi_bundle import ca_bundle as _ca_bundle
 from lib.errors import (
@@ -53,7 +53,7 @@ class RommHttpAdapter:
     _READ_TIMEOUT = 60
     _DOWNLOAD_BLOCK_SIZE = 65536
 
-    def __init__(self, settings: dict, plugin_dir: str, logger: logging.Logger, user_agent: str) -> None:
+    def __init__(self, settings: dict[str, Any], plugin_dir: str, logger: logging.Logger, user_agent: str) -> None:
         self._settings = settings
         self._plugin_dir = plugin_dir
         self._logger = logger
@@ -63,7 +63,7 @@ class RommHttpAdapter:
     # Platform map
     # ------------------------------------------------------------------
 
-    def load_platform_map(self) -> dict:
+    def load_platform_map(self) -> dict[str, str]:
         """Load the platform slug -> RetroDECK system mapping from config.json."""
         # Check plugin root first (Decky CLI moves defaults/ contents to root),
         # then defaults/ subdirectory (dev deploys via mise run deploy)
@@ -130,7 +130,7 @@ class RommHttpAdapter:
         if entry:
             cls, tpl = entry
             text = tpl.format(method=method, url=url) if tpl else msg
-            kwargs: dict = {"url": url, "method": method}
+            kwargs: dict[str, Any] = {"url": url, "method": method}
             if cls is RommServerError:
                 kwargs["status_code"] = code
             return cls(text, **kwargs)

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -7,7 +7,7 @@ directly to HTTP endpoints via RommHttpAdapter.
 from __future__ import annotations
 
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from adapters.romm.http import RommHttpAdapter
@@ -30,21 +30,21 @@ class RommApiAdapter:
 
     # ── Server / Auth ─────────────────────────────────────────────────
 
-    def heartbeat(self) -> dict:
+    def heartbeat(self) -> dict[str, Any]:
         return self._client.request("/api/heartbeat")
 
-    def list_platforms(self) -> list[dict]:
+    def list_platforms(self) -> list[dict[str, Any]]:
         return self._client.request("/api/platforms")
 
-    def get_current_user(self) -> dict:
+    def get_current_user(self) -> dict[str, Any]:
         return self._client.request("/api/users/me")
 
     # ── ROMs ──────────────────────────────────────────────────────────
 
-    def get_rom(self, rom_id: int) -> dict:
+    def get_rom(self, rom_id: int) -> dict[str, Any]:
         return self._client.request(f"/api/roms/{rom_id}")
 
-    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms(self, platform_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         return self._client.request(f"/api/roms?platform_ids={platform_id}&limit={limit}&offset={offset}")
 
     def list_roms_updated_after(
@@ -53,7 +53,7 @@ class RommApiAdapter:
         updated_after: str,
         limit: int = 1,
         offset: int = 0,
-    ) -> dict:
+    ) -> dict[str, Any]:
         quoted_after = urllib.parse.quote(updated_after)
         return self._client.request(
             f"/api/roms?platform_ids={platform_id}&limit={limit}&offset={offset}&updated_after={quoted_after}"
@@ -78,34 +78,34 @@ class RommApiAdapter:
 
     # ── Collections ───────────────────────────────────────────────────
 
-    def list_collections(self) -> list[dict]:
+    def list_collections(self) -> list[dict[str, Any]]:
         result = self._client.request("/api/collections")
         return result if isinstance(result, list) else []
 
-    def list_virtual_collections(self, collection_type: str) -> list[dict]:
+    def list_virtual_collections(self, collection_type: str) -> list[dict[str, Any]]:
         result = self._client.request(f"/api/collections/virtual?type={collection_type}")
         return result if isinstance(result, list) else []
 
-    def list_smart_collections(self) -> list[dict]:
+    def list_smart_collections(self) -> list[dict[str, Any]]:
         result = self._client.request("/api/collections/smart")
         return result if isinstance(result, list) else []
 
-    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_collection(self, collection_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         return self._client.request(f"/api/roms?collection_id={collection_id}&limit={limit}&offset={offset}")
 
-    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_virtual_collection(self, virtual_id: str, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         encoded_id = urllib.parse.quote(str(virtual_id), safe="")
         return self._client.request(f"/api/roms?virtual_collection_id={encoded_id}&limit={limit}&offset={offset}")
 
-    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict:
+    def list_roms_by_smart_collection(self, smart_id: int, limit: int = 50, offset: int = 0) -> dict[str, Any]:
         return self._client.request(f"/api/roms?smart_collection_id={smart_id}&limit={limit}&offset={offset}")
 
     # ── Firmware / BIOS ───────────────────────────────────────────────
 
-    def list_firmware(self) -> list[dict]:
+    def list_firmware(self) -> list[dict[str, Any]]:
         return self._client.request("/api/firmware")
 
-    def get_firmware(self, firmware_id: int) -> dict:
+    def get_firmware(self, firmware_id: int) -> dict[str, Any]:
         return self._client.request(f"/api/firmware/{firmware_id}")
 
     def download_firmware(self, firmware_id: int, filename: str, dest: str) -> None:
@@ -123,7 +123,7 @@ class RommApiAdapter:
         *,
         device_id: str | None = None,
         slot: str | None = None,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         query = f"/api/saves?rom_id={rom_id}"
         if device_id is not None:
             query += f"&device_id={urllib.parse.quote(device_id, safe='')}"
@@ -142,7 +142,7 @@ class RommApiAdapter:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         params = f"rom_id={rom_id}&emulator={urllib.parse.quote(emulator, safe='')}"
         if device_id is not None:
             params += f"&device_id={urllib.parse.quote(device_id, safe='')}"
@@ -171,19 +171,19 @@ class RommApiAdapter:
             path += f"?device_id={urllib.parse.quote(device_id, safe='')}&optimistic={opt}"
         self._client.download(path, dest_path)
 
-    def confirm_download(self, save_id: int, device_id: str) -> dict:
+    def confirm_download(self, save_id: int, device_id: str) -> dict[str, Any]:
         return self._client.post_json(
             f"/api/saves/{save_id}/downloaded",
             {"device_id": device_id},
         )
 
-    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict:
+    def get_save_summary(self, rom_id: int, device_id: str | None = None) -> dict[str, Any]:
         query = f"/api/saves/summary?rom_id={rom_id}"
         if device_id is not None:
             query += f"&device_id={urllib.parse.quote(device_id, safe='')}"
         return self._client.request(query)
 
-    def delete_server_saves(self, save_ids: list[int]) -> dict:
+    def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         return self._client.post_json("/api/saves/delete", {"saves": save_ids})
 
     # ── Devices ───────────────────────────────────────────────────────
@@ -195,7 +195,7 @@ class RommApiAdapter:
         client: str,
         client_version: str,
         hostname: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         payload = {
             "name": name,
             "platform": platform,
@@ -206,21 +206,21 @@ class RommApiAdapter:
             payload["hostname"] = hostname
         return self._client.post_json("/api/devices", payload)
 
-    def list_devices(self) -> list[dict]:
+    def list_devices(self) -> list[dict[str, Any]]:
         result = self._client.request("/api/devices")
         return result if isinstance(result, list) else []
 
-    def update_device(self, device_id: str, **fields) -> dict:
+    def update_device(self, device_id: str, **fields) -> dict[str, Any]:
         payload = {k: v for k, v in fields.items() if v is not None}
         return self._client.put_json(f"/api/devices/{urllib.parse.quote(device_id, safe='')}", payload)
 
     # ── Notes / Playtime ──────────────────────────────────────────────
 
-    def get_rom_with_notes(self, rom_id: int) -> dict:
+    def get_rom_with_notes(self, rom_id: int) -> dict[str, Any]:
         return self._client.request(f"/api/roms/{rom_id}")
 
-    def create_note(self, rom_id: int, data: dict) -> dict:
+    def create_note(self, rom_id: int, data: dict[str, Any]) -> dict[str, Any]:
         return self._client.post_json(f"/api/roms/{rom_id}/notes", data)
 
-    def update_note(self, rom_id: int, note_id: int, data: dict) -> dict:
+    def update_note(self, rom_id: int, note_id: int, data: dict[str, Any]) -> dict[str, Any]:
         return self._client.put_json(f"/api/roms/{rom_id}/notes/{note_id}", data)

--- a/py_modules/adapters/steam_config.py
+++ b/py_modules/adapters/steam_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from _vendor import vdf
 
@@ -62,14 +62,14 @@ class SteamConfigAdapter:
 
     # -- VDF read/write (deprecated — frontend uses SteamClient API) ----------
 
-    def read_shortcuts(self) -> dict:
+    def read_shortcuts(self) -> dict[str, Any]:
         path = self.shortcuts_vdf_path()
         if not path or not os.path.exists(path):
             return {"shortcuts": {}}
         with open(path, "rb") as f:
             return vdf.binary_loads(f.read())
 
-    def write_shortcuts(self, data: dict) -> None:
+    def write_shortcuts(self, data: dict[str, Any]) -> None:
         path = self.shortcuts_vdf_path()
         if not path:
             raise RuntimeError("Cannot find Steam shortcuts.vdf path")
@@ -105,14 +105,15 @@ class SteamConfigAdapter:
 
     # -- Steam Input config ---------------------------------------------------
 
-    def set_steam_input_config(self, app_ids: list, mode: str = "default") -> None:
+    def set_steam_input_config(self, app_ids: list[int], mode: str = "default") -> None:
         """Set UseSteamControllerConfig for given app_ids in localconfig.vdf.
 
         mode: "default" (remove key / "1"), "force_on" ("2"), "force_off" ("0")
         """
-        data, localconfig_path = self._load_localconfig()
-        if data is None:
+        loaded = self._load_localconfig()
+        if loaded[0] is None:
             return
+        data, localconfig_path = loaded
 
         apps = self._navigate_to_apps_section(data, create=mode != "default")
         if apps is None:
@@ -122,7 +123,7 @@ class SteamConfigAdapter:
         if changed:
             self._write_localconfig(data, localconfig_path, mode, len(app_ids))
 
-    def _load_localconfig(self) -> tuple:
+    def _load_localconfig(self) -> tuple[dict[str, Any], str] | tuple[None, None]:
         """Load and parse localconfig.vdf. Returns (data, path) or (None, None)."""
         user_dir = self.find_steam_user_dir()
         if not user_dir:
@@ -141,7 +142,7 @@ class SteamConfigAdapter:
             self._logger.error(f"Failed to parse localconfig.vdf: {e}")
             return None, None
 
-    def _navigate_to_apps_section(self, data: dict, *, create: bool) -> dict | None:
+    def _navigate_to_apps_section(self, data: dict[str, Any], *, create: bool) -> dict[str, Any] | None:
         """Navigate to UserLocalConfigStore.Apps, optionally creating missing keys."""
         node = data
         for key in ("UserLocalConfigStore", "Apps"):
@@ -154,7 +155,7 @@ class SteamConfigAdapter:
         return node
 
     @staticmethod
-    def _apply_steam_input_mode(apps: dict, app_ids: list, mode: str) -> bool:
+    def _apply_steam_input_mode(apps: dict[str, Any], app_ids: list[int], mode: str) -> bool:
         """Apply or remove UseSteamControllerConfig for each app_id. Returns True if changed."""
         value_map = {"force_on": "2", "force_off": "0"}
         changed = False
@@ -172,7 +173,7 @@ class SteamConfigAdapter:
                 changed = True
         return changed
 
-    def _write_localconfig(self, data: dict, path: str, mode: str, count: int) -> None:
+    def _write_localconfig(self, data: dict[str, Any], path: str, mode: str, count: int) -> None:
         """Atomically write localconfig.vdf back to disk."""
         try:
             tmp_path = path + ".tmp"
@@ -185,7 +186,7 @@ class SteamConfigAdapter:
 
     # -- RetroArch input driver check -----------------------------------------
 
-    def check_retroarch_input_driver(self) -> dict | None:
+    def check_retroarch_input_driver(self) -> dict[str, Any] | None:
         """Check if RetroArch input_driver is set to a problematic value."""
         candidates = [
             "~/.var/app/net.retrodeck.retrodeck/config/retroarch/retroarch.cfg",
@@ -211,7 +212,7 @@ class SteamConfigAdapter:
                 continue
         return None
 
-    def fix_retroarch_input_driver(self) -> dict:
+    def fix_retroarch_input_driver(self) -> dict[str, Any]:
         """Change RetroArch input_driver from 'x' to 'sdl2'."""
         check = self.check_retroarch_input_driver()
         if not check or not check.get("warning"):

--- a/py_modules/adapters/steamgriddb.py
+++ b/py_modules/adapters/steamgriddb.py
@@ -8,7 +8,7 @@ import os
 import ssl
 import urllib.error
 import urllib.request
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lib.certifi_bundle import ca_bundle as _ca_bundle
 from lib.errors import SgdbApiError
@@ -33,7 +33,7 @@ class SteamGridDbAdapter:
         SteamGridDB rejects the default ``Python-urllib`` UA with 403.
     """
 
-    def __init__(self, *, settings: dict, logger: logging.Logger, user_agent: str) -> None:
+    def __init__(self, *, settings: dict[str, Any], logger: logging.Logger, user_agent: str) -> None:
         self._settings = settings
         self._logger = logger
         self._user_agent = user_agent
@@ -41,7 +41,7 @@ class SteamGridDbAdapter:
     def _ssl_context(self) -> ssl.SSLContext:
         return ssl.create_default_context(cafile=_ca_bundle())
 
-    def request(self, path: str) -> dict | None:
+    def request(self, path: str) -> dict[str, Any] | None:
         """Authenticated GET to SGDB API v2."""
         api_key = self._settings.get("steamgriddb_api_key", "")
         if not api_key:
@@ -78,7 +78,7 @@ class SteamGridDbAdapter:
                     os.remove(tmp_path)
             return False
 
-    def verify_api_key(self, api_key: str) -> dict:
+    def verify_api_key(self, api_key: str) -> dict[str, Any]:
         """Verify an API key against SGDB.
 
         Raises ``SgdbApiError`` on non-2xx HTTP responses so callers can

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -70,6 +70,7 @@ from services.steamgrid import SteamGridService, SteamGridServiceConfig
 if TYPE_CHECKING:
     import asyncio
     import logging
+    from typing import Any
 
     from services.protocols import (
         Clock,
@@ -129,7 +130,7 @@ class AdapterBundle:
 class StateBundle:
     """Live mutable state shared across services."""
 
-    settings: dict
+    settings: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -377,7 +378,7 @@ def bootstrap(
     )
 
 
-def wire_services(cfg: WiringConfig) -> dict:
+def wire_services(cfg: WiringConfig) -> dict[str, Any]:
     """Create service instances after plugin state is initialised.
 
     Called from ``Plugin._main()`` after save-sync state is populated
@@ -394,8 +395,8 @@ def wire_services(cfg: WiringConfig) -> dict:
     # binding is populated via ``.set(...)`` once the producer exists.
     # Accessing ``.get()`` before ``.set()`` raises RuntimeError instead of
     # the NameError a bare forward-ref lambda would produce.
-    bios_files_index_binding: LateBinding[dict] = LateBinding("bios_files_index")
-    pending_sync_binding: LateBinding[dict] = LateBinding("pending_sync")
+    bios_files_index_binding: LateBinding[dict[str, dict[str, Any]]] = LateBinding("bios_files_index")
+    pending_sync_binding: LateBinding[dict[int, dict[str, Any]]] = LateBinding("pending_sync")
 
     # MigrationService is constructed before SaveService so that
     # save_sync_service can receive a bound reference to

--- a/py_modules/domain/achievements.py
+++ b/py_modules/domain/achievements.py
@@ -8,8 +8,10 @@ the wall clock belongs in ``services/achievements.py``, not here.
 
 from __future__ import annotations
 
+from typing import Any
 
-def extract_achievements_from_rom(rom_data: dict) -> list[dict]:
+
+def extract_achievements_from_rom(rom_data: dict[str, Any]) -> list[dict[str, Any]]:
     """Return the normalized achievement list from a RomM ROM detail dict.
 
     Prefers ``ra_metadata``; falls back to ``merged_ra_metadata`` (which has
@@ -38,11 +40,11 @@ def extract_achievements_from_rom(rom_data: dict) -> list[dict]:
 
 
 def extract_game_progress(
-    ra_progression: dict | None,
+    ra_progression: dict[str, Any] | None,
     ra_id: int,
     total: int,
     cached_at: float,
-) -> dict:
+) -> dict[str, Any]:
     """Reduce a user's RA progression payload into a per-game progress dict.
 
     Looks up the entry whose ``rom_ra_id`` matches ``ra_id``. Returns a

--- a/py_modules/domain/bios.py
+++ b/py_modules/domain/bios.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -24,7 +25,7 @@ class BiosFileEntry:
     required: bool
     description: str
     classification: str  # "required" | "optional" | "unknown"
-    cores: dict[str, dict]  # {core_so: {"required": bool}}
+    cores: dict[str, dict[str, Any]]  # {core_so: {"required": bool}}
     used_by_active: bool
 
 
@@ -45,7 +46,7 @@ class BiosStatus:
     cached_at: float = 0.0
 
 
-def format_bios_status(bios: dict, platform_slug: str, *, cached_at: float = 0.0) -> BiosStatus:
+def format_bios_status(bios: dict[str, Any], platform_slug: str, *, cached_at: float = 0.0) -> BiosStatus:
     """Build a frontend-ready BiosStatus dataclass from raw firmware check result."""
     raw_files = bios.get("files", [])
     if raw_files and isinstance(raw_files[0], dict):
@@ -91,7 +92,7 @@ def format_bios_status(bios: dict, platform_slug: str, *, cached_at: float = 0.0
 
 
 def classify_firmware_file(
-    reg_entry: dict | None,
+    reg_entry: dict[str, Any] | None,
     file_name: str,
     active_core_so: str | None,
 ) -> tuple[bool, str, str]:
@@ -114,7 +115,7 @@ def classify_firmware_file(
     return is_required, classification, description
 
 
-def build_cores_info(reg_entry: dict | None) -> dict:
+def build_cores_info(reg_entry: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     """Build per-core info dict for frontend display."""
     if not reg_entry or "cores" not in reg_entry:
         return {}
@@ -124,7 +125,7 @@ def build_cores_info(reg_entry: dict | None) -> dict:
     }
 
 
-def is_used_by_active_core(reg_entry: dict | None, active_core_so: str | None) -> bool:
+def is_used_by_active_core(reg_entry: dict[str, Any] | None, active_core_so: str | None) -> bool:
     """Check if a firmware file is used by the active core."""
     if not active_core_so or not reg_entry or "cores" not in reg_entry:
         return True
@@ -135,7 +136,7 @@ def build_file_entry(
     file_name: str,
     downloaded: bool,
     dest: str,
-    reg_entry: dict | None,
+    reg_entry: dict[str, Any] | None,
     active_core_so: str | None,
 ) -> BiosFileEntry:
     """Build a single file status entry as a BiosFileEntry dataclass."""
@@ -153,8 +154,8 @@ def build_file_entry(
 
 
 def collect_firmware_status(
-    items: list[dict],
-    registry_platform: dict,
+    items: list[dict[str, Any]],
+    registry_platform: dict[str, Any],
     active_core_so: str | None,
 ) -> tuple[BiosFileEntry, ...]:
     """Build BiosFileEntry objects for a list of pre-resolved firmware items.

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -7,10 +7,12 @@ as parameters.
 
 from __future__ import annotations
 
+from typing import Any
+
 _DISC_EXTENSIONS = (".cue", ".chd", ".iso")
 
 
-def is_multi_file_download(rom_detail: dict) -> bool:
+def is_multi_file_download(rom_detail: dict[str, Any]) -> bool:
     """Decide whether RomM will serve this ROM as a ZIP that must be extracted.
 
     This is the single multi-vs-single gate for the download path. It must
@@ -131,7 +133,7 @@ def detect_launch_file(files: list[tuple[str, int]]) -> str | None:
     return max(files, key=lambda t: t[1])[0]
 
 
-def resolve_local_file_name(rom_detail: dict) -> tuple[str, bool]:
+def resolve_local_file_name(rom_detail: dict[str, Any]) -> tuple[str, bool]:
     """Resolve the on-disk filename for a ROM.
 
     For nested-single-file ROMs RomM reports ``fs_name`` as the parent

--- a/py_modules/domain/rom_metadata_mapping.py
+++ b/py_modules/domain/rom_metadata_mapping.py
@@ -9,11 +9,13 @@ clock is read here; staleness and persistence live elsewhere.
 
 from __future__ import annotations
 
+from typing import Any
+
 from domain.rom_metadata import RomMetadata
 from domain.steam_categories import build_steam_categories
 
 
-def build_rom_metadata(rom: dict, cached_at: float) -> RomMetadata:
+def build_rom_metadata(rom: dict[str, Any], cached_at: float) -> RomMetadata:
     """Map a RomM ROM dict + ``cached_at`` epoch into a ``RomMetadata`` aggregate.
 
     Reads the nested ``metadatum`` block, normalising RomM's wire quirks:

--- a/py_modules/domain/save_attribution.py
+++ b/py_modules/domain/save_attribution.py
@@ -6,9 +6,11 @@ and the per-ROM ``own_upload_ids`` list. Pure: no I/O, no logging.
 
 from __future__ import annotations
 
+from typing import Any
+
 
 def compute_uploaded_by_us(
-    server_save: dict | None,
+    server_save: dict[str, Any] | None,
     own_upload_ids: list[int] | None,
 ) -> bool | None:
     """Three-way attribution: True/False when ``own_upload_ids`` is known

--- a/py_modules/domain/save_path.py
+++ b/py_modules/domain/save_path.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Any
 
 
 def resolve_save_dir(
@@ -128,7 +129,7 @@ class LocalSaveTarget:
     sanitized_from: str | None = None
 
 
-def compute_local_save_target(server_save: dict, rom_name: str) -> LocalSaveTarget:
+def compute_local_save_target(server_save: dict[str, Any], rom_name: str) -> LocalSaveTarget:
     """The canonical local filename for a server save: ``<rom_name>.<ext>``.
 
     ``rom_name`` is the deterministic identity from RetroArch's

--- a/py_modules/domain/save_status.py
+++ b/py_modules/domain/save_status.py
@@ -6,7 +6,7 @@ No I/O, no service/adapter imports. Stateless functions only.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 SaveSyncStatus = Literal["synced", "conflict", "none"]
 
@@ -30,7 +30,7 @@ class SaveSyncDisplay:
 
 
 def compute_save_sync_display(
-    files: list[dict] | None,
+    files: list[dict[str, Any]] | None,
     last_sync_check_at: str | None,
     *,
     server_query_failed: bool = False,

--- a/py_modules/domain/save_status_builders.py
+++ b/py_modules/domain/save_status_builders.py
@@ -9,6 +9,8 @@ state, or network — belongs here. Code that needs the live
 
 from __future__ import annotations
 
+from typing import Any
+
 from domain.iso_time import parse_iso_to_epoch
 from domain.sync_action import Conflict, Download, Skip, Upload
 
@@ -20,12 +22,12 @@ def build_file_status(
     local_hash: str | None,
     local_mtime: str | None,
     local_size: int | None,
-    server: dict | None,
+    server: dict[str, Any] | None,
     last_sync_at: str | None,
     status: str,
     server_device_id: str | None = None,
     uploaded_by_us: bool | None = None,
-) -> dict:
+) -> dict[str, Any]:
     """Build a file status dict for the frontend."""
     server_device_syncs = server.get("device_syncs", []) if server else []
     device_syncs = [
@@ -79,7 +81,7 @@ def status_from_action(action: object) -> str:
     return "synced"
 
 
-def resolve_chosen_server(action: object, candidates: list[dict]) -> dict | None:
+def resolve_chosen_server(action: object, candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Pick the server-save dict to display alongside the file-status row.
 
     - ``Download`` and ``Conflict`` carry the chosen save explicitly on the

--- a/py_modules/domain/sgdb_artwork.py
+++ b/py_modules/domain/sgdb_artwork.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import struct
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import quote
 
 # Discriminant returned by ``classify_resolution`` describing which
@@ -78,7 +78,7 @@ def build_autocomplete_path(term: str) -> str:
     return f"/search/autocomplete/{quote(term)}"
 
 
-def parse_autocomplete_results(payload: dict | None) -> list[dict]:
+def parse_autocomplete_results(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Normalise an SGDB autocomplete response into candidate dicts.
 
     From the SGDB shape ``{"success": true, "data": [{"id", "name",
@@ -94,7 +94,7 @@ def parse_autocomplete_results(payload: dict | None) -> list[dict]:
     data = payload.get("data")
     if not isinstance(data, list):
         return []
-    results: list[dict] = []
+    results: list[dict[str, Any]] = []
     for entry in data:
         if not isinstance(entry, dict):
             continue
@@ -112,7 +112,7 @@ def parse_autocomplete_results(payload: dict | None) -> list[dict]:
     return results
 
 
-def first_grid_url(payload: dict | None) -> str | None:
+def first_grid_url(payload: dict[str, Any] | None) -> str | None:
     """Return a thumbnail URL for the first grid in a ``/grids/...`` response.
 
     Prefers the ``thumb`` field, falling back to ``url``. Returns

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -6,9 +6,10 @@ No I/O, no imports from services, adapters, or lib.
 from __future__ import annotations
 
 import os
+from typing import Any
 
 
-def build_shortcuts_data(roms: list[dict], plugin_dir: str) -> list[dict]:
+def build_shortcuts_data(roms: list[dict[str, Any]], plugin_dir: str) -> list[dict[str, Any]]:
     """Transform ROM list into shortcut data dicts for frontend AddShortcut calls."""
     exe = os.path.join(plugin_dir, "bin", "romm-launcher")
     start_dir = os.path.join(plugin_dir, "bin")

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -7,8 +7,10 @@ reading and writing is the caller's responsibility.
 
 from __future__ import annotations
 
+from typing import Any
 
-def migrate_settings(data: dict) -> dict:
+
+def migrate_settings(data: dict[str, Any]) -> dict[str, Any]:
     """Bring *data* from any older settings schema to the current version.
 
     Value semantics — the caller's dict is never mutated.
@@ -33,7 +35,7 @@ _SAVE_SYNC_KNOBS = (
 )
 
 
-def fold_legacy_save_sync_settings(settings: dict, save_sync_raw: dict | None) -> dict:
+def fold_legacy_save_sync_settings(settings: dict[str, Any], save_sync_raw: dict[str, Any] | None) -> dict[str, Any]:
     """Fold the legacy save-sync knobs + ``device_name`` into *settings*.
 
     Returns a new dict — the inputs are never mutated. The five feature
@@ -57,7 +59,7 @@ def fold_legacy_save_sync_settings(settings: dict, save_sync_raw: dict | None) -
     return folded
 
 
-def _migrate_v0_to_v1(data: dict) -> dict:
+def _migrate_v0_to_v1(data: dict[str, Any]) -> dict[str, Any]:
     """v0 → v1: rename deprecated boolean keys."""
     if data.pop("disable_steam_input", None):
         data["steam_input_mode"] = "force_off"
@@ -67,7 +69,7 @@ def _migrate_v0_to_v1(data: dict) -> dict:
     return data
 
 
-def _migrate_v2_to_v3(data: dict) -> dict:
+def _migrate_v2_to_v3(data: dict[str, Any]) -> dict[str, Any]:
     """v<3 → v3: normalize ``enabled_collections`` to nested-by-kind shape.
 
     Splits a flat dict into user/smart/franchise buckets. Numeric string
@@ -84,7 +86,7 @@ def _migrate_v2_to_v3(data: dict) -> dict:
     return data
 
 
-def _normalize_enabled_collections(flat: dict) -> dict[str, dict[str, bool]]:
+def _normalize_enabled_collections(flat: dict[str, Any]) -> dict[str, dict[str, bool]]:
     """Coerce *flat* to the full three-bucket shape."""
     if _is_nested_collections(flat):
         return flat
@@ -93,7 +95,7 @@ def _normalize_enabled_collections(flat: dict) -> dict[str, dict[str, bool]]:
     return _split_flat_to_buckets(flat)
 
 
-def _split_flat_to_buckets(flat: dict) -> dict[str, dict[str, bool]]:
+def _split_flat_to_buckets(flat: dict[Any, Any]) -> dict[str, dict[str, bool]]:
     """Split a pre-v3 flat enabled_collections dict into user/franchise buckets."""
     nested: dict[str, dict[str, bool]] = {"user": {}, "smart": {}, "franchise": {}}
     for key, value in flat.items():
@@ -124,12 +126,12 @@ def _is_partial_nested_collections(value: object) -> bool:
     return all(isinstance(v, dict) for v in value.values())
 
 
-def _fill_missing_buckets(value: dict) -> dict[str, dict[str, bool]]:
+def _fill_missing_buckets(value: dict[str, Any]) -> dict[str, dict[str, bool]]:
     """Return a complete three-bucket dict, filling missing buckets with ``{}``."""
     return {kind: dict(value.get(kind, {})) for kind in _BUCKET_KEYS}
 
 
-def _migrate_v3_to_v4(data: dict) -> dict:
+def _migrate_v3_to_v4(data: dict[str, Any]) -> dict[str, Any]:
     """v<4 → v4: stamp the version after the save-sync fold.
 
     The cross-file lift of the save-sync knobs + ``device_name`` from
@@ -141,7 +143,7 @@ def _migrate_v3_to_v4(data: dict) -> dict:
     return data
 
 
-def migrate_state(data: dict) -> dict:
+def migrate_state(data: dict[str, Any]) -> dict[str, Any]:
     """Bring *data* from any older state schema to the current version."""
     # No migrations at v1 — infrastructure for future changes
     return data

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -40,6 +40,7 @@ No I/O. No imports from services or adapters. Stdlib only.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from domain.iso_time import parse_iso_to_epoch
 
@@ -77,14 +78,14 @@ class Upload:
 class Download:
     """Adopt the chosen server save (raw RomM API dict)."""
 
-    server_save: dict
+    server_save: dict[str, Any]
 
 
 @dataclass(frozen=True)
 class Conflict:
     """Both sides changed. User must decide via the resolve callable."""
 
-    server_save: dict
+    server_save: dict[str, Any]
 
 
 SyncAction = Skip | Upload | Download | Conflict
@@ -95,7 +96,7 @@ SyncAction = Skip | Upload | Download | Conflict
 # ---------------------------------------------------------------------------
 
 
-def _local_mtime_ge_server_updated_at(local_file: dict, server: dict) -> bool:
+def _local_mtime_ge_server_updated_at(local_file: dict[str, Any], server: dict[str, Any]) -> bool:
     """Return True iff local mtime is at-or-after the server save's updated_at.
 
     On any parse failure (missing/garbled timestamps) we conservatively return
@@ -117,7 +118,7 @@ def _local_mtime_ge_server_updated_at(local_file: dict, server: dict) -> bool:
 
 
 def _decide_when_is_current(
-    server: dict, local_file: dict | None, local_hash: str | None, last_sync_hash: str | None
+    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
 ) -> SyncAction:
     """Branch 4: ``our_entry.is_current=True`` on the chosen save."""
     if local_file is None:
@@ -135,7 +136,7 @@ def _decide_when_is_current(
 
 
 def _decide_when_not_current(
-    server: dict, local_file: dict | None, local_hash: str | None, last_sync_hash: str | None
+    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
 ) -> SyncAction:
     """Branch 5: ``our_entry`` exists but ``is_current=False`` (server moved past us)."""
     if local_file is None or not last_sync_hash:
@@ -147,7 +148,7 @@ def _decide_when_not_current(
     return Download(server_save=server)
 
 
-def _decide_when_no_entry(server: dict, local_file: dict | None) -> SyncAction:
+def _decide_when_no_entry(server: dict[str, Any], local_file: dict[str, Any] | None) -> SyncAction:
     """Branch 6: no ``device_syncs`` entry for our device on the chosen save."""
     if local_file is None:
         return Download(server_save=server)
@@ -158,9 +159,9 @@ def _decide_when_no_entry(server: dict, local_file: dict | None) -> SyncAction:
 
 
 def compute_sync_action(
-    local_file: dict | None,
-    server_saves_in_slot: list[dict],
-    files_state: dict,
+    local_file: dict[str, Any] | None,
+    server_saves_in_slot: list[dict[str, Any]],
+    files_state: dict[str, Any],
     device_id: str,
     local_hash: str | None,
 ) -> SyncAction:

--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -12,20 +12,20 @@ slices as primitive parameters and returns primitives or NamedTuple results.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 
 class ClassificationResult(NamedTuple):
-    new: list[dict]
-    changed: list[dict]
+    new: list[dict[str, Any]]
+    changed: list[dict[str, Any]]
     unchanged_ids: list[int]
     stale: list[int]
     disabled_count: int
 
 
 def classify_roms(
-    shortcuts_data: list[dict],
-    registry: dict,
+    shortcuts_data: list[dict[str, Any]],
+    registry: dict[str, Any],
     fetched_platform_names: set[str],
 ) -> ClassificationResult:
     """Bucket fetched ROMs against the saved shortcut registry.
@@ -39,8 +39,8 @@ def classify_roms(
     Changed ROMs are returned as fresh dicts with an added ``existing_app_id``
     key — the caller's shortcuts_data is not mutated.
     """
-    new: list[dict] = []
-    changed: list[dict] = []
+    new: list[dict[str, Any]] = []
+    changed: list[dict[str, Any]] = []
     unchanged_ids: list[int] = []
 
     for sd in shortcuts_data:
@@ -68,7 +68,7 @@ def classify_roms(
 def compute_collection_diff(
     collection_memberships: dict[str, list[int]],
     last_synced_collections: list[str],
-) -> dict:
+) -> dict[str, Any]:
     """Diff enabled collections (by name) against the last-synced set.
 
     Returns ``{"has_changes": bool, "added": [...], "removed": [...]}``.
@@ -106,11 +106,11 @@ def should_include_in_platform_collection(
 
 
 def compute_platform_collection_diff(
-    shortcuts_data: list[dict],
+    shortcuts_data: list[dict[str, Any]],
     platform_rom_ids: set[int] | None,
     last_synced_platforms: list[str],
     create_platform_groups: bool,
-) -> dict:
+) -> dict[str, Any]:
     """Diff future platform-group collections against last-synced platforms.
 
     Returns ``{"has_changes": bool, "added_count": int, "removed_count": int}``.

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -13,7 +13,7 @@ threaded through separately — the unit itself is a static descriptor.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 UnitType = Literal["platform", "collection"]
 CollectionKind = Literal["user", "smart", "franchise"]
@@ -32,9 +32,9 @@ class WorkUnit:
     # ``None`` is only valid when ``type == "platform"``.
     collection_kind: CollectionKind | None = None
 
-    def to_event_payload(self) -> dict:
+    def to_event_payload(self) -> dict[str, Any]:
         """Serialise to the shape emitted in ``sync_plan`` / ``sync_apply_unit``."""
-        payload: dict = {
+        payload: dict[str, Any] = {
             "type": self.type,
             "id": self.id,
             "name": self.name,


### PR DESCRIPTION
Part of #861 — final annotation staging PR (tests/ #893, services/ #894 shipped). Rule still off; the next PR flips `reportMissingTypeArgument = "error"`.

## This PR: `adapters/` (64) + `domain/` (69) + `bootstrap.py` (4) + `main.py` (1) = 138 spots
`pyproject.toml` unchanged. **After this PR the whole project is annotation-complete** — with the rule temporarily on, total `reportMissingTypeArgument` == 0, which de-risks the flip.

**Precision policy (Option 1):** precise where obvious (`dict[str, str]` platform map, `list[tuple[str, str]]`, `dict[int, dict[str, Any]]` pending-sync, `LateBinding[...]`); `dict[str, Any]` / `list[dict[str, Any]]` fallback for RomM JSON payloads (`adapters/romm/`), on-disk JSON (`persistence.py`, retrodeck.json), migration dicts, parsed-XML structures. Adapter concrete returns aligned with their `RommApi` / `SteamGridDbApi` / `SteamConfig` Protocols.

**Domain purity preserved:** every `domain/` annotation uses stdlib `typing.Any` only — no `adapters`/`services`/`_vendor` imports introduced; `lint-imports` stays 8/0.

**Two precise types surfaced real mismatches — fixed at the source:**
- `steam_config`: typed `_load_localconfig` as a correlated `tuple[dict[str, Any], str] | tuple[None, None]`; narrow on the tuple before unpacking so `_write_localconfig` gets a `str` path.
- `state_migrations._split_flat_to_buckets`: kept one param `dict[Any, Any]` to preserve a defensive `isinstance(key, str)` guard (this file overlaps in-flight #849; trivial conflict for whoever lands second).

## Verification
- `basedpyright` (rule off) — 0 errors
- `ruff check .` / `ruff format --check .` — clean
- `import-linter` — 8 kept, 0 broken (domain purity)
- `pytest` — 2844 passed
- `git diff pyproject.toml` — empty

docs: N/A — tooling-prep (type annotations only; no user-visible, architecture, or flow change).