### PR TITLE
chore(quality): enable basedpyright reportMissingTypeArgument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ reportUnusedVariable = "warning"
 reportArgumentType = "error"
 reportUnnecessaryComparison = "error"
 reportUnnecessaryIsInstance = "error"
+reportMissingTypeArgument = "error"
 
 # Tests inspect and rebind private state of the system under test —
 # white-box testing is a deliberate, accepted pattern here. The


### PR DESCRIPTION
Closes #861 — the flip PR (final step of the "stage + flip-once" series). The annotation work landed across #893 (tests/), #894 (services/), #895 (adapters/ + domain/ + bootstrap.py + main.py); the codebase is now annotation-complete.

## What
One line: `reportMissingTypeArgument = "error"` in `[tool.basedpyright]`. Bare `dict`/`list`/`tuple`/`set` without type arguments are now enforced.

basedpyright reports **0 findings** with the rule on (all 643 originally-measured spots were annotated in the staging PRs). `node_modules` does not trip this rule, so no exclude change is needed.

## Verification
- `basedpyright` (rule on) — 0 errors
- `ruff check .` — clean

docs: N/A — tooling config (enables an existing basedpyright rule; no code, user-visible, architecture, or flow change).