### PR TITLE
docs(saves): add save-sync support matrix and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,15 @@ jobs:
             !node_modules
             !.worktrees
             !CHANGELOG.md
+
+  markdown-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check Markdown formatting
+        run: deno fmt --check

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,6 @@
 {
   "first-line-heading": false,
-  "MD013": false
+  "MD013": false,
+  "MD018": false,
+  "MD046": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,35 +2,73 @@
 
 ## What This Is
 
-A Decky Loader plugin that syncs a self-hosted RomM library into Steam as Non-Steam shortcuts. Games launch via RetroDECK. The QAM panel handles settings, sync, downloads, and BIOS management.
+A Decky Loader plugin that syncs a self-hosted RomM library into Steam as Non-Steam shortcuts. Games launch via
+RetroDECK. The QAM panel handles settings, sync, downloads, and BIOS management.
 
 ## Documentation
 
-**Docs are updated in the same PR as the code change. This is not optional.** When a change affects architecture, data flows, feature behavior, or user-facing UI, the relevant page under `docs/` must be updated in the same PR. Documentation-debt-as-a-separate-follow-up-issue is forbidden — those follow-ups never land. If you're not sure whether a change needs docs, the default is "yes, it does." Enforced in CI by `.github/workflows/docs-check.yml`.
+**Docs are updated in the same PR as the code change. This is not optional.** When a change affects architecture, data
+flows, feature behavior, or user-facing UI, the relevant page under `docs/` must be updated in the same PR.
+Documentation-debt-as-a-separate-follow-up-issue is forbidden — those follow-ups never land. If you're not sure whether
+a change needs docs, the default is "yes, it does." Enforced in CI by `.github/workflows/docs-check.yml`.
 
-The docs live in `docs/` and are the canonical source for architecture, file structure, and feature documentation. Built with **Material for MkDocs** and published to GitHub Pages (<https://danielcopper.github.io/decky-romm-sync/>) by `.github/workflows/docs.yml` on every push to `main`. Layout mirrors the three nav tabs: `docs/user-guide/` (end users), `docs/architecture/` (how it works), `docs/contributing/` (dev setup). The old GitHub Wiki is retired — it only redirects to the published site. Preview locally with `mise run docs`.
+The docs live in `docs/` and are the canonical source for architecture, file structure, and feature documentation. Built
+with **Material for MkDocs** and published to GitHub Pages (<https://danielcopper.github.io/decky-romm-sync/>) by
+`.github/workflows/docs.yml` on every push to `main`. Layout mirrors the three nav tabs: `docs/user-guide/` (end users),
+`docs/architecture/` (how it works), `docs/contributing/` (dev setup). The old GitHub Wiki is retired — it only
+redirects to the published site. Preview locally with `mise run docs`.
 
-For genuinely doc-irrelevant PRs (pure refactor with no user-visible change, no architecture shift, no new flow; tooling/CI changes; dependency bumps), set the `no-docs-change` label on the PR OR include `docs: N/A` (with a one-line reason) in the PR description. The default posture is "docs needed"; opting out is an explicit acknowledgement, not a silent omission. The CI check enforces this.
+For genuinely doc-irrelevant PRs (pure refactor with no user-visible change, no architecture shift, no new flow;
+tooling/CI changes; dependency bumps), set the `no-docs-change` label on the PR OR include `docs: N/A` (with a one-line
+reason) in the PR description. The default posture is "docs needed"; opting out is an explicit acknowledgement, not a
+silent omission. The CI check enforces this.
 
 ## Key Technical Constraints
 
-- **Shortcuts**: Use `SteamClient.Apps.AddShortcut()` from frontend JS, NOT VDF writes. VDF edits require Steam restart; SteamClient API is instant.
-- **Frontend API**: `@decky/ui` + `@decky/api` (NOT deprecated `decky-frontend-lib`). Use `callable()` (NOT `ServerAPI.callPluginMethod()`).
-- **RomM API quirks**: Filter param is `platform_ids` (plural). Cover URLs have unencoded spaces (must URL-encode). Paginated: `{"items": [...], "total": N}`.
-- **AddShortcut timing**: Must wait 300-500ms after `AddShortcut()` before setting properties. Use 50ms delay between operations.
-- **Large payloads**: Never send bulk base64 data through `decky.emit()` — WebSocket bridge has size limits. Use per-item callables instead.
-- **User-Agent on outgoing HTTP**: SteamGridDB **and** RomM behind Cloudflare Tunnel reject the default `Python-urllib` UA with 403 (Bot Fight Mode at the edge). Every HTTP-talking adapter (`RommHttpAdapter`, `SteamGridDbAdapter`) takes a `user_agent: str` ctor param. Bootstrap reads `package.json` once via `PluginMetadataReader` and threads `decky-romm-sync/<version>` to both — single source of truth, no hardcoded version strings.
-- **AddShortcut ignores most params**: `SteamClient.Apps.AddShortcut(name, exe, startDir, launchOptions)` ignores startDir and launchOptions (confirmed by MoonDeck plugin). Must use `Set*` calls (`SetShortcutName`, `SetShortcutExe`, `SetShortcutStartDir`, `SetAppLaunchOptions`) after a 500ms delay. Do NOT pass quoted exe paths — the API handles quoting internally.
-- **BIsModOrShortcut bypass DROPPED**: Phase 5.6 removed the bypass counter entirely. Shortcuts return `BIsModOrShortcut() = true` (natural state). We own the entire game detail UI via RomMPlaySection + future RomMGameInfoPanel.
-- **Shortcut property updates**: A shortcut's appId is derived from `exe + appName` (CRC32), so `launchOptions`/`startDir` changes are **appId-safe** (same shortcut, binding/artwork/collections survive) and `SetAppLaunchOptions`-on-existing is **reliable** (hardware-validated in #827: in-session + restart + churn). Use the fire-then-poll-`AppDetails` confirm (`setLaunchOptionsConfirmed`) since `Set*` returns void. Delete + recreate (re-sync) is only needed for **exe/name** changes, which produce a different appId. The real hazard is removal-churn corrupting Steam's in-memory shortcut state (a restart clears it).
-- **Launcher + launch_options model**: `bin/rom-launcher` (renamed from `bin/romm-launcher`, #778) is a pure `exec "$@"` wrapper — no state, no path resolution, no emulator knowledge. The Steam shortcut's `launch_options` carries the FULL launch command (`flatpak run net.retrodeck.retrodeck "<rom-path>"`) for installed ROMs, or `""` (placeholder) for uninstalled. The emulator invocation is a build-time variable (`resolve_emulator_invocation`, RetroDECK today — the #129 seam). The old `romm:<rom_id>` marker is GONE: ownership is detected by the **exe path** (`…/bin/rom-launcher`); rom_id↔appId comes from the backend `get_app_id_rom_id_map()` (`roms.shortcut_app_id`). launch_options is written at sync (installed ROMs), at download-complete, and re-resolved on RetroDECK-home migration (`migration_relaunch_options` event). See [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md).
-- **RomM minimum version**: Requires RomM >= 4.8.1. Hard-rejected in `test_connection()` — plugin is inert until server is updated. `_MIN_REQUIRED_VERSION` tuple in `main.py`.
-- **Decky callables must be async**: Even if the method body is synchronous, Decky's callable framework requires `async def`. Do not remove `async` from callable methods in main.py.
+- **Shortcuts**: Use `SteamClient.Apps.AddShortcut()` from frontend JS, NOT VDF writes. VDF edits require Steam restart;
+  SteamClient API is instant.
+- **Frontend API**: `@decky/ui` + `@decky/api` (NOT deprecated `decky-frontend-lib`). Use `callable()` (NOT
+  `ServerAPI.callPluginMethod()`).
+- **RomM API quirks**: Filter param is `platform_ids` (plural). Cover URLs have unencoded spaces (must URL-encode).
+  Paginated: `{"items": [...], "total": N}`.
+- **AddShortcut timing**: Must wait 300-500ms after `AddShortcut()` before setting properties. Use 50ms delay between
+  operations.
+- **Large payloads**: Never send bulk base64 data through `decky.emit()` — WebSocket bridge has size limits. Use
+  per-item callables instead.
+- **User-Agent on outgoing HTTP**: SteamGridDB **and** RomM behind Cloudflare Tunnel reject the default `Python-urllib`
+  UA with 403 (Bot Fight Mode at the edge). Every HTTP-talking adapter (`RommHttpAdapter`, `SteamGridDbAdapter`) takes a
+  `user_agent: str` ctor param. Bootstrap reads `package.json` once via `PluginMetadataReader` and threads
+  `decky-romm-sync/<version>` to both — single source of truth, no hardcoded version strings.
+- **AddShortcut ignores most params**: `SteamClient.Apps.AddShortcut(name, exe, startDir, launchOptions)` ignores
+  startDir and launchOptions (confirmed by MoonDeck plugin). Must use `Set*` calls (`SetShortcutName`, `SetShortcutExe`,
+  `SetShortcutStartDir`, `SetAppLaunchOptions`) after a 500ms delay. Do NOT pass quoted exe paths — the API handles
+  quoting internally.
+- **BIsModOrShortcut bypass DROPPED**: Phase 5.6 removed the bypass counter entirely. Shortcuts return
+  `BIsModOrShortcut() = true` (natural state). We own the entire game detail UI via RomMPlaySection + future
+  RomMGameInfoPanel.
+- **Shortcut property updates**: A shortcut's appId is derived from `exe + appName` (CRC32), so
+  `launchOptions`/`startDir` changes are **appId-safe** (same shortcut, binding/artwork/collections survive) and
+  `SetAppLaunchOptions`-on-existing is **reliable** (hardware-validated in #827: in-session + restart + churn). Use the
+  fire-then-poll-`AppDetails` confirm (`setLaunchOptionsConfirmed`) since `Set*` returns void. Delete + recreate
+  (re-sync) is only needed for **exe/name** changes, which produce a different appId. The real hazard is removal-churn
+  corrupting Steam's in-memory shortcut state (a restart clears it).
+- **Launcher + launch_options model**: `bin/rom-launcher` (renamed from `bin/romm-launcher`, #778) is a pure `exec "$@"`
+  wrapper — no state, no path resolution, no emulator knowledge. The Steam shortcut's `launch_options` carries the FULL
+  launch command (`flatpak run net.retrodeck.retrodeck "<rom-path>"`) for installed ROMs, or `""` (placeholder) for
+  uninstalled. The emulator invocation is a build-time variable (`resolve_emulator_invocation`, RetroDECK today — the
+  #129 seam). The old `romm:<rom_id>` marker is GONE: ownership is detected by the **exe path** (`…/bin/rom-launcher`);
+  rom_id↔appId comes from the backend `get_app_id_rom_id_map()` (`roms.shortcut_app_id`). launch_options is written at
+  sync (installed ROMs), at download-complete, and re-resolved on RetroDECK-home migration (`migration_relaunch_options`
+  event). See [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md).
+- **RomM minimum version**: Requires RomM >= 4.8.1. Hard-rejected in `test_connection()` — plugin is inert until server
+  is updated. `_MIN_REQUIRED_VERSION` tuple in `main.py`.
+- **Decky callables must be async**: Even if the method body is synchronous, Decky's callable framework requires
+  `async def`. Do not remove `async` from callable methods in main.py.
 
 ## Current State
 
-Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub Releases.
-Roadmap and open work: [GitHub Projects board](https://github.com/users/danielcopper/projects/2).
+Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub Releases. Roadmap and open work:
+[GitHub Projects board](https://github.com/users/danielcopper/projects/2).
 
 ## Development
 
@@ -39,126 +77,241 @@ Roadmap and open work: [GitHub Projects board](https://github.com/users/danielco
 - **Coverage**: `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev` (build + restart plugin_loader)
-- **Tooling**: mise manages node, pnpm, python, uv. Venv auto-creates at `.venv` (via `_.python.venv` in mise.toml) using uv as the underlying tool; `mise run setup` installs Python deps via `uv pip install` (uv is the canonical Python package manager in this project).
-- **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): runs `ruff format` + `ruff check` on staged Python files. Stays fast (<2s) so commits don't become friction — heavy validation (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR push, never in the commit hook. CI + branch protection enforces correctness; don't re-introduce heavy checks here.
+- **Tooling**: mise manages node, pnpm, python, uv. Venv auto-creates at `.venv` (via `_.python.venv` in mise.toml)
+  using uv as the underlying tool; `mise run setup` installs Python deps via `uv pip install` (uv is the canonical
+  Python package manager in this project).
+- **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): runs `ruff format` +
+  `ruff check` on staged Python files. Stays fast (<2s) so commits don't become friction — heavy validation
+  (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR push, never in the commit hook. CI + branch
+  protection enforces correctness; don't re-introduce heavy checks here.
 
 ## Code Quality
 
-- **SonarCloud**: CI-based analysis on every PR + push to main. Quality Gate enforces 80% coverage on new code, 0 bugs, 0 vulnerabilities.
+- **SonarCloud**: CI-based analysis on every PR + push to main. Quality Gate enforces 80% coverage on new code, 0 bugs,
+  0 vulnerabilities.
 - **Ruff**: Python linting in CI.
 - **basedpyright**: Type checking in CI.
 - **import-linter**: Layer boundary enforcement in CI (services ↛ adapters, adapters ↛ services, services independent).
-- **Cosmic Python call bans**: `scripts/check_cosmic_call_bans.sh` — services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` / `random.*` directly (use the corresponding Protocol).
-- **Aggregate field-assignment ban**: `scripts/check_aggregate_field_assignment.py` — AST check that fails CI if `services/` assigns `aggregate.field = value` on a `@cosmic_aggregate` root (mutation must go through verb-named methods). Enforces the Aggregates `[CP]` rule.
+- **Cosmic Python call bans**: `scripts/check_cosmic_call_bans.sh` — services may not call `datetime.now()` /
+  `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` / `random.*` directly (use the corresponding
+  Protocol).
+- **Aggregate field-assignment ban**: `scripts/check_aggregate_field_assignment.py` — AST check that fails CI if
+  `services/` assigns `aggregate.field = value` on a `@cosmic_aggregate` root (mutation must go through verb-named
+  methods). Enforces the Aggregates `[CP]` rule.
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
 ## Architecture — Cosmic Python rules
 
-Cosmic Python ("Architecture Patterns with Python", Percival & Gregory) is our north star, adapted for a single-user Decky plugin domain. The rules below mix canonical CP principles with project conventions we layered on top. Each rule carries a tag:
+Cosmic Python ("Architecture Patterns with Python", Percival & Gregory) is our north star, adapted for a single-user
+Decky plugin domain. The rules below mix canonical CP principles with project conventions we layered on top. Each rule
+carries a tag:
 
 - `[CP]` — Canonical Cosmic Python. Hard rule. Breaking it is an architectural regression.
-- `[ours]` — Project convention layered on top of CP. Implements CP, not prescribed by it. Style/consistency rule — deviations should be flagged in review but are not architectural regressions; the project rule itself can be debated and softened.
+- `[ours]` — Project convention layered on top of CP. Implements CP, not prescribed by it. Style/consistency rule —
+  deviations should be flagged in review but are not architectural regressions; the project rule itself can be debated
+  and softened.
 
-Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting utilities) / `models/` (data shapes). `import-linter` enforces direction. `[CP]`
+Backend layout: `services/` (orchestration) / `adapters/` (I/O) / `domain/` (pure compute) / `lib/` (cross-cutting
+utilities) / `models/` (data shapes). `import-linter` enforces direction. `[CP]`
 
 **Services**:
 
-- `[CP]` Depend on Protocols (defined in the `services/protocols/` package — re-exported from `__init__`, topically split across `transport`/`determinism`/`persistence`/`paths`/`infra`/`files`/`cross_service`; import via `from services.protocols import X`), never on concrete adapter classes. (Canonical dependency inversion.) Carve-out: sub-services within a single bounded context (e.g. all of `services/saves/`) may hold concrete peer-service refs in their `*ServiceConfig` dataclass when they share an aggregate (e.g. `SaveSyncState`). The `[CP]` Protocol rule applies to services across bounded contexts and to adapters. `[ours]` A method that one sub-service calls on a peer is part of that peer's **public** surface — no leading underscore. The `_` prefix is reserved for genuinely class-internal helpers, so `reportPrivateUsage` stays coherent with this carve-out: peers call public methods, not private ones.
+- `[CP]` Depend on Protocols (defined in the `services/protocols/` package — re-exported from `__init__`, topically
+  split across `transport`/`determinism`/`persistence`/`paths`/`infra`/`files`/`cross_service`; import via
+  `from services.protocols import X`), never on concrete adapter classes. (Canonical dependency inversion.) Carve-out:
+  sub-services within a single bounded context (e.g. all of `services/saves/`) may hold concrete peer-service refs in
+  their `*ServiceConfig` dataclass when they share an aggregate (e.g. `SaveSyncState`). The `[CP]` Protocol rule applies
+  to services across bounded contexts and to adapters. `[ours]` A method that one sub-service calls on a peer is part of
+  that peer's **public** surface — no leading underscore. The `_` prefix is reserved for genuinely class-internal
+  helpers, so `reportPrivateUsage` stays coherent with this carve-out: peers call public methods, not private ones.
 - `[CP]` No raw I/O.
-  - `[ours]` Concrete allow/deny list: forbidden in `services/`: `os.*` (except pure path algebra: `relpath`, `join`, `splitext`, `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`, `shutil.*`, `subprocess.*`, `hashlib.<x>(open(...))`. (Our enforcement surface; CP says "no I/O" without spelling out the call list.)
+  - `[ours]` Concrete allow/deny list: forbidden in `services/`: `os.*` (except pure path algebra: `relpath`, `join`,
+    `splitext`, `basename`, `dirname`), `open(...)`, `pathlib.Path(...).read_*` / `write_*`, `fcntl.*`, `urllib.*`,
+    `shutil.*`, `subprocess.*`, `hashlib.<x>(open(...))`. (Our enforcement surface; CP says "no I/O" without spelling
+    out the call list.)
 - `[CP]` No clocks or randomness — inject side-effecting deps via abstractions.
-  - `[ours]` Specific Protocols: `Clock` / `UuidGen` / `Sleeper`. `time.time()` / `time.monotonic()` / `datetime.now()` / `uuid.uuid4()` / `asyncio.sleep()` / `random.*` banned at the call site.
+  - `[ours]` Specific Protocols: `Clock` / `UuidGen` / `Sleeper`. `time.time()` / `time.monotonic()` / `datetime.now()`
+    / `uuid.uuid4()` / `asyncio.sleep()` / `random.*` banned at the call site.
 - `[CP]` No service-to-service concrete imports — services are independent. Cross-service deps are Protocol-typed.
-- `[ours]` Module functions from `domain/` are still a coupling — if tests need `patch("services.X.module_name.fn")`, wrap the module behind a Protocol and inject it. (Our enforcement tactic; CP doesn't prescribe Protocol-wrapping every module function.)
-- `[ours]` **Constructor shape: every service takes a single `config: XxxServiceConfig` keyword argument.** Frozen dataclass, named `<ServiceName>Config` — outer services keep the `Service` token in both class and config name (`SteamGridConfig` is wrong, `SteamGridService` + `SteamGridServiceConfig` is right). Sub-services may use role-based class names without the token (`SyncEngine` + `SyncEngineConfig`, `SyncOrchestrator` + `SyncOrchestratorConfig`) when the role name reads more naturally than the suffixed form. All deps live in the config: Protocol-typed adapters, infrastructure (loop, logger, clock, uuid_gen, sleeper), persistence callbacks, settings-derived values. No bare-param ctors, no mixed (some-explicit + some-in-config) ctors. Test setup is uniform: build `XxxServiceConfig(...)`, pass `XxxService(config=...)`. (Project pattern. CP allows explicit ctor params; this is our consistency choice.)
-- `[ours]` **Debug logging: inject the `DebugLogger` Protocol.** Don't add per-service `_log_debug` methods that re-read settings at call time, and don't reach for `decky.logger.info` to bypass log-level filtering. The Protocol's wiring decision is the only knob.
-- `[ours]` God-class signal: services > ~700 LOC — decompose into sub-services with constructor injection (see `services/saves/` for the reference pattern). Matches the `bootstrap.py` split threshold below. The S107 ctor-param threshold no longer fires because all Protocol-typed deps live in the config. (Our taste/threshold. Earlier wording said ~600 LOC; raised after audit #485 found 5 stable cohesive files in the 656-749 range — fetcher, sync_orchestrator, migration, slots/service, sync_engine/matrix.)
+- `[ours]` Module functions from `domain/` are still a coupling — if tests need `patch("services.X.module_name.fn")`,
+  wrap the module behind a Protocol and inject it. (Our enforcement tactic; CP doesn't prescribe Protocol-wrapping every
+  module function.)
+- `[ours]` **Constructor shape: every service takes a single `config: XxxServiceConfig` keyword argument.** Frozen
+  dataclass, named `<ServiceName>Config` — outer services keep the `Service` token in both class and config name
+  (`SteamGridConfig` is wrong, `SteamGridService` + `SteamGridServiceConfig` is right). Sub-services may use role-based
+  class names without the token (`SyncEngine` + `SyncEngineConfig`, `SyncOrchestrator` + `SyncOrchestratorConfig`) when
+  the role name reads more naturally than the suffixed form. All deps live in the config: Protocol-typed adapters,
+  infrastructure (loop, logger, clock, uuid_gen, sleeper), persistence callbacks, settings-derived values. No bare-param
+  ctors, no mixed (some-explicit + some-in-config) ctors. Test setup is uniform: build `XxxServiceConfig(...)`, pass
+  `XxxService(config=...)`. (Project pattern. CP allows explicit ctor params; this is our consistency choice.)
+- `[ours]` **Debug logging: inject the `DebugLogger` Protocol.** Don't add per-service `_log_debug` methods that re-read
+  settings at call time, and don't reach for `decky.logger.info` to bypass log-level filtering. The Protocol's wiring
+  decision is the only knob.
+- `[ours]` God-class signal: services > ~700 LOC — decompose into sub-services with constructor injection (see
+  `services/saves/` for the reference pattern). Matches the `bootstrap.py` split threshold below. The S107 ctor-param
+  threshold no longer fires because all Protocol-typed deps live in the config. (Our taste/threshold. Earlier wording
+  said ~600 LOC; raised after audit #485 found 5 stable cohesive files in the 656-749 range — fetcher,
+  sync_orchestrator, migration, slots/service, sync_engine/matrix.)
 
-**Adapters**: `[CP]` Own all I/O. Never import from `services/`. Implement Protocols defined in the `services/protocols/` package. (Canonical ports-and-adapters.)
+**Adapters**: `[CP]` Own all I/O. Never import from `services/`. Implement Protocols defined in the
+`services/protocols/` package. (Canonical ports-and-adapters.)
 
-**Domain**: `[CP]` Pure compute only. No I/O, no state mutation, no service or adapter imports. Functions take inputs, return outputs. Anything stateless and I/O-free that's currently in a service belongs here. (Canonical domain-model purity.)
+**Domain**: `[CP]` Pure compute only. No I/O, no state mutation, no service or adapter imports. Functions take inputs,
+return outputs. Anything stateless and I/O-free that's currently in a service belongs here. (Canonical domain-model
+purity.)
 
-**Aggregates** (CP chapters 1–7 scope — locked in #788, refined by [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md)). The aggregate roots, their tables, and the enforcement layers live in `docs/architecture/database-design.md` (canonical — 8 roots after ADR-0003). Persistence boundary: config-shaped toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`, `device_name`, `enabled_platforms`) live in `settings.json`, not SQLite — `SyncSettings`/`Platform`/`Device` were considered as aggregates and dropped. The rules below apply to the relational state that *does* live in SQLite:
+**Aggregates** (CP chapters 1–7 scope — locked in #788, refined by
+[ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md)). The aggregate roots, their tables, and the enforcement
+layers live in `docs/architecture/database-design.md` (canonical — 8 roots after ADR-0003). Persistence boundary:
+config-shaped toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
+`autocleanup_limit`, `device_name`, `enabled_platforms`) live in `settings.json`, not SQLite —
+`SyncSettings`/`Platform`/`Device` were considered as aggregates and dropped. The rules below apply to the relational
+state that _does_ live in SQLite:
 
-- `[CP]` One Repository Protocol per aggregate root, not per table. Aggregate boundaries are domain-modeling decisions; table layout is downstream and may need multiple tables to back one aggregate.
-- `[CP]` Aggregate methods are the **only** mutation API for the aggregate's state. No external field assignment (`aggregate.field = value`) from services. Services call methods; methods enforce invariants and update internal state. Field access for reads is fine.
-- `[ours]` **Mutation methods are verb-named after the domain event they conceptually represent.** `adopt_baseline(filename, hash)` not `update_baseline(...)`. `mark_installed(path)` not `set_installed(...)`. `promote_slot(slot, source)` not `update_slot_source(...)`. Why: intent-revealing names encode what *happened*, not which fields changed; the method name becomes the implicit event name (`BaselineAdopted`, `Installed`, `SlotPromoted`) if/when chapter 8+ events get added in a follow-up epic. Free refactor seam, zero cost now.
-- `[ours]` Chapter 8+ (domain events + message bus) is explicitly **out of scope** for the current SQLite epic. Trigger for revisiting: handler diversity ≥3 kinds for the same aggregate state change, OR a non-Steam consumer (CLI/web/etc.) becomes concrete, OR a telemetry/analytics layer needs to subscribe.
+- `[CP]` One Repository Protocol per aggregate root, not per table. Aggregate boundaries are domain-modeling decisions;
+  table layout is downstream and may need multiple tables to back one aggregate.
+- `[CP]` Aggregate methods are the **only** mutation API for the aggregate's state. No external field assignment
+  (`aggregate.field = value`) from services. Services call methods; methods enforce invariants and update internal
+  state. Field access for reads is fine.
+- `[ours]` **Mutation methods are verb-named after the domain event they conceptually represent.**
+  `adopt_baseline(filename, hash)` not `update_baseline(...)`. `mark_installed(path)` not `set_installed(...)`.
+  `promote_slot(slot, source)` not `update_slot_source(...)`. Why: intent-revealing names encode what _happened_, not
+  which fields changed; the method name becomes the implicit event name (`BaselineAdopted`, `Installed`, `SlotPromoted`)
+  if/when chapter 8+ events get added in a follow-up epic. Free refactor seam, zero cost now.
+- `[ours]` Chapter 8+ (domain events + message bus) is explicitly **out of scope** for the current SQLite epic. Trigger
+  for revisiting: handler diversity ≥3 kinds for the same aggregate state change, OR a non-Steam consumer (CLI/web/etc.)
+  becomes concrete, OR a telemetry/analytics layer needs to subscribe.
 
-**Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place where concrete adapters meet services. (Canonical CP composition root.)
+**Bootstrap (`bootstrap.py`)**: `[CP]` The composition root — the only place where concrete adapters meet services.
+(Canonical CP composition root.)
 
-- `[ours]` `WiringConfig` holds the wiring; protocols come in, services come out. Adapter instantiation never happens in `main.py` — if a service needs a Protocol-wrapped persister, the wrapper adapter is built in `bootstrap()` and passed through `CallbackBundle`. (Our concrete shape for the composition root.)
+- `[ours]` `WiringConfig` holds the wiring; protocols come in, services come out. Adapter instantiation never happens in
+  `main.py` — if a service needs a Protocol-wrapped persister, the wrapper adapter is built in `bootstrap()` and passed
+  through `CallbackBundle`. (Our concrete shape for the composition root.)
 
-**Vendored deps (`_vendor/`)**: `[ours]` Decky Loader has no plugin-level package manager, so third-party runtime deps are vendored under `py_modules/_vendor/<package>/` and imported as `from _vendor import <package>`. Only adapters import from `_vendor.*`; services/domain/lib stay third-party-free. The whole `_vendor/` namespace is excluded from ruff, basedpyright, and Sonar (analysis + coverage) so any future vendored package is automatically out of scope — it's not our code, we don't lint or coverage-track it, but we may patch it (e.g. fix self-imports broken by the move into `_vendor/`). Ruff's isort lists `_vendor` under `known-third-party` so the imports group alongside other third-party deps. `import-linter` enforces a `domain-stdlib-only` contract that forbids `domain` from importing `_vendor.*` (domain stays stdlib-only); no other layer forbids `_vendor`, since adapters legitimately import it.
+**Vendored deps (`_vendor/`)**: `[ours]` Decky Loader has no plugin-level package manager, so third-party runtime deps
+are vendored under `py_modules/_vendor/<package>/` and imported as `from _vendor import <package>`. Only adapters import
+from `_vendor.*`; services/domain/lib stay third-party-free. The whole `_vendor/` namespace is excluded from ruff,
+basedpyright, and Sonar (analysis + coverage) so any future vendored package is automatically out of scope — it's not
+our code, we don't lint or coverage-track it, but we may patch it (e.g. fix self-imports broken by the move into
+`_vendor/`). Ruff's isort lists `_vendor` under `known-third-party` so the imports group alongside other third-party
+deps. `import-linter` enforces a `domain-stdlib-only` contract that forbids `domain` from importing `_vendor.*` (domain
+stays stdlib-only); no other layer forbids `_vendor`, since adapters legitimately import it.
 
-**Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`) and the callable surface (one `async def` method per `@callable` exposed to the frontend). `bootstrap.py` owns adapter instantiation and service wiring. The split is binding — no callables in `bootstrap.py`, no service wiring in `main.py`. Both files grow with the surface they describe (callables for `main.py`, services for `bootstrap.py`); this is unavoidable density, not god-class. Split `bootstrap.py` into `bootstrap/{adapters,services}.py` only when it exceeds ~700 LOC. (Decky-plugin-specific; not a CP concept.)
+**Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`)
+and the callable surface (one `async def` method per `@callable` exposed to the frontend). `bootstrap.py` owns adapter
+instantiation and service wiring. The split is binding — no callables in `bootstrap.py`, no service wiring in `main.py`.
+Both files grow with the surface they describe (callables for `main.py`, services for `bootstrap.py`); this is
+unavoidable density, not god-class. Split `bootstrap.py` into `bootstrap/{adapters,services}.py` only when it exceeds
+~700 LOC. (Decky-plugin-specific; not a CP concept.)
 
-If a refactor breaks a `[CP]` rule, that's an architectural regression — call it out and fix it in the same PR or open a follow-up. `[ours]` deviations should be flagged in review but can be debated (we can choose to soften the project rule rather than change the code).
+If a refactor breaks a `[CP]` rule, that's an architectural regression — call it out and fix it in the same PR or open a
+follow-up. `[ours]` deviations should be flagged in review but can be debated (we can choose to soften the project rule
+rather than change the code).
 
 ## Protocol naming — suffix by shape
 
-Protocol names carry a suffix that signals shape, so the call site reads correctly without jumping to the definition. `[ours]`
+Protocol names carry a suffix that signals shape, so the call site reads correctly without jumping to the definition.
+`[ours]`
 
 - `…Reader` — object-shaped Protocols with multiple methods (e.g. `RetroArchConfigReader`, `RetroArchCoreInfoReader`).
-- `…Provider` or `…Fn` — call-shaped Protocols (`__call__`-only) (e.g. `RetroArchSaveSortingProvider`, `CoreNameProviderFn`).
+- `…Provider` or `…Fn` — call-shaped Protocols (`__call__`-only) (e.g. `RetroArchSaveSortingProvider`,
+  `CoreNameProviderFn`).
 - `…Store` — file-store Protocols (e.g. `CoverArtFileStore`).
 - `…Cache` — cache Protocols (e.g. `SgdbArtworkCache`).
 - `…Persister` — persistence Protocols (e.g. `StatePersister`, `FirmwareCachePersister`).
 - Bare names — pervasive cross-cutting primitives (`Clock`, `Sleeper`, `UuidGen`, `DebugLogger`).
 
-When a sibling Protocol set mixes shapes (e.g. `RetroArchConfigReader` next to `RetroArchSaveSortingProvider`), that mix is intentional and reflects the shape difference, not a naming inconsistency.
+When a sibling Protocol set mixes shapes (e.g. `RetroArchConfigReader` next to `RetroArchSaveSortingProvider`), that mix
+is intentional and reflects the shape difference, not a naming inconsistency.
 
 ## Async/sync method naming `[ours]`
 
-- Async methods carry the bare domain-verb name — no `_async` / `Async` suffix. `await` marks them at the call site (Python norm; unlike .NET).
-- When an async method needs a **synchronous twin** — typically a lock-free worker run via `run_in_executor` that a peer must call directly to avoid re-entering a lock the async path already holds — name the sync worker:
+- Async methods carry the bare domain-verb name — no `_async` / `Async` suffix. `await` marks them at the call site
+  (Python norm; unlike .NET).
+- When an async method needs a **synchronous twin** — typically a lock-free worker run via `run_in_executor` that a peer
+  must call directly to avoid re-entering a lock the async path already holds — name the sync worker:
   - `do_<verb>` if it's **public / peer-called** (e.g. `do_download_save`, `do_upload_save`, `do_sync_rom_saves`).
   - `_<verb>_io` if it's **private / internal-only** (e.g. `_remove_rom_io`, `_uninstall_all_roms_io`).
 - The async public method keeps the bare verb (`sync_rom_saves`); never disambiguate by marking the async side.
 
-The two sync-worker idioms (`do_` prefix for public, `_io` suffix for private) coexist by access level — that split is the current state, not a settled ideal. Unification (converge `do_` onto `_io`) is tracked in #813.
+The two sync-worker idioms (`do_` prefix for public, `_io` suffix for private) coexist by access level — that split is
+the current state, not a settled ideal. Unification (converge `do_` onto `_io`) is tracked in #813.
 
 ## Callable response shapes — canonical failure shape
 
-Decky callables that return a plain `dict` and can fail use the canonical failure shape `{success: False, reason: ErrorCode | str, message: str}`. Reuse `lib.list_result.ErrorCode` for server-reachability failures (`ErrorCode.SERVER_UNREACHABLE`). Never duplicate `reason` into a second `error` field; never replace `message` with `error`. `[ours]`
+Decky callables that return a plain `dict` and can fail use the canonical failure shape
+`{success: False, reason: ErrorCode | str, message: str}`. Reuse `lib.list_result.ErrorCode` for server-reachability
+failures (`ErrorCode.SERVER_UNREACHABLE`). Never duplicate `reason` into a second `error` field; never replace `message`
+with `error`. `[ours]`
 
 Two carve-outs:
 
-- **Discriminated-status unions** (the `status: "ok" | "server_unreachable" | "version_deleted" | …` shape used by the saves version-history callables) keep the `status` discriminant — they carry more than two outcomes, so a binary `success` boolean would erase the routing slug. Failure branches still carry `message: str`, not `error: str`.
-- **Partial-success responses** that return a full payload alongside a failure flag (e.g. `get_save_status`'s additive `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action: "server_unreachable" | ...`) keep the additive flag. The call has half-broken half-working semantics that the binary boolean would erase.
+- **Discriminated-status unions** (the `status: "ok" | "server_unreachable" | "version_deleted" | …` shape used by the
+  saves version-history callables) keep the `status` discriminant — they carry more than two outcomes, so a binary
+  `success` boolean would erase the routing slug. Failure branches still carry `message: str`, not `error: str`.
+- **Partial-success responses** that return a full payload alongside a failure flag (e.g. `get_save_status`'s additive
+  `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action: "server_unreachable" | ...`) keep the
+  additive flag. The call has half-broken half-working semantics that the binary boolean would erase.
 
 Full convention paragraph lives in the `lib/list_result.py` module docstring.
 
 ## Cosmic Python migration — status & reference pattern
 
-The full Cosmic Python migration (umbrella [#277](https://github.com/danielcopper/decky-romm-sync/issues/277)) is **complete**: every backend service has I/O behind Protocol-typed adapters, Clock/UuidGen/Sleeper injected, pure logic in `domain/`, and ctors decomposed via frozen `*ServiceConfig` dataclasses. The blow-by-blow (Waves 1–4 + the saves vertical) lives in closed issues #294–#340 and the git log; the only deferred item is #259 (SonarCloud arch rules, blocked on SonarCloud Python support). The separate SQLite persistence epic (#271) is ongoing — tracked via the Aggregates section above + `docs/architecture/database-design.md`.
+The full Cosmic Python migration (umbrella [#277](https://github.com/danielcopper/decky-romm-sync/issues/277)) is
+**complete**: every backend service has I/O behind Protocol-typed adapters, Clock/UuidGen/Sleeper injected, pure logic
+in `domain/`, and ctors decomposed via frozen `*ServiceConfig` dataclasses. The blow-by-blow (Waves 1–4 + the saves
+vertical) lives in closed issues #294–#340 and the git log; the only deferred item is #259 (SonarCloud arch rules,
+blocked on SonarCloud Python support). The separate SQLite persistence epic (#271) is ongoing — tracked via the
+Aggregates section above + `docs/architecture/database-design.md`.
 
-**Why that order** (kept as the playbook for future verticals): cross-cutting Protocols (Clock/UuidGen/Sleeper, #294) first, so every later vertical was a mechanical "drop the import, inject the Protocol"; domain extraction (#295) before LibraryService, to shrink the scariest service before lifting it; LibraryService last (largest blast radius — by then only ctor decomposition remained).
+**Why that order** (kept as the playbook for future verticals): cross-cutting Protocols (Clock/UuidGen/Sleeper, #294)
+first, so every later vertical was a mechanical "drop the import, inject the Protocol"; domain extraction (#295) before
+LibraryService, to shrink the scariest service before lifting it; LibraryService last (largest blast radius — by then
+only ctor decomposition remained).
 
-**Canonical reference for any future service-level work**: the Wave 3 sister-PR shape — a Protocol (in `services/protocols/`) + an adapter implementing it + a `FakeXxxAdapter` in `conftest` + `*ServiceConfig` ctor decomposition. `services/saves/` and `services/library/` are the reference decompositions for shared-state sub-services.
+**Canonical reference for any future service-level work**: the Wave 3 sister-PR shape — a Protocol (in
+`services/protocols/`) + an adapter implementing it + a `FakeXxxAdapter` in `conftest` + `*ServiceConfig` ctor
+decomposition. `services/saves/` and `services/library/` are the reference decompositions for shared-state sub-services.
 
-**Sub-issue policy**: Epic bodies do **not** carry markdown sub-issue lists — open work is tracked via GitHub's native Sub-Issues panel on each epic. If a new sub-issue is needed, link it natively (don't add a body bullet).
+**Sub-issue policy**: Epic bodies do **not** carry markdown sub-issue lists — open work is tracked via GitHub's native
+Sub-Issues panel on each epic. If a new sub-issue is needed, link it natively (don't add a body bullet).
 
 ## Subfolder layout — when a subfolder is justified
 
-Layer top-level folders (`services/`, `adapters/`, `domain/`, `lib/`, `models/`) are flat by default — one file per concept. A subfolder is justified **only when the modules within share an internal type, helper, or state**, not when they share a brand-name prefix.
+Layer top-level folders (`services/`, `adapters/`, `domain/`, `lib/`, `models/`) are flat by default — one file per
+concept. A subfolder is justified **only when the modules within share an internal type, helper, or state**, not when
+they share a brand-name prefix.
 
-- `adapters/romm/` qualifies: `http.py` is the internal HTTP transport for `romm_api.py`; the two share types and only `romm_api.py` is the public surface.
-- `services/saves/` qualifies: facade + sub-services (`sync_engine/`, `slots/`, `status/`, `versions.py`) share a `SaveSyncState` aggregate.
-- `adapters/retroarch/` would NOT qualify: `retroarch_config.py` (RetroArch.cfg reader) and `retroarch_core_info.py` (core lookup) share nothing but a brand name. False cohesion.
-- `adapters/steam/` would NOT qualify: would mix Steam (`steam_config.py`) with SteamGridDB (`steamgriddb.py`, `sgdb_artwork_cache.py`) — different vendor, different concern.
+- `adapters/romm/` qualifies: `http.py` is the internal HTTP transport for `romm_api.py`; the two share types and only
+  `romm_api.py` is the public surface.
+- `services/saves/` qualifies: facade + sub-services (`sync_engine/`, `slots/`, `status/`, `versions.py`) share a
+  `SaveSyncState` aggregate.
+- `adapters/retroarch/` would NOT qualify: `retroarch_config.py` (RetroArch.cfg reader) and `retroarch_core_info.py`
+  (core lookup) share nothing but a brand name. False cohesion.
+- `adapters/steam/` would NOT qualify: would mix Steam (`steam_config.py`) with SteamGridDB (`steamgriddb.py`,
+  `sgdb_artwork_cache.py`) — different vendor, different concern.
 
-When a service-level decomposition produces sub-services with shared state, a subfolder is the right home — `services/saves/` and `services/library/` (fetcher / sync_orchestrator / reporter sharing preview-delta state via `_state.py`) both qualify. Absent shared state, file-level layout is the default.
+When a service-level decomposition produces sub-services with shared state, a subfolder is the right home —
+`services/saves/` and `services/library/` (fetcher / sync_orchestrator / reporter sharing preview-delta state via
+`_state.py`) both qualify. Absent shared state, file-level layout is the default.
 
 ## Sub-package `__init__.py` — when populated, when empty
 
 Decision rule by how the package is consumed:
 
-- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): `__init__.py` is empty (a docstring is acceptable but not required). These exist as namespace markers; consumers always deep-import (`from adapters.romm.romm_api import RommApiAdapter`).
-- **Sub-package consumed via package import** (consumers write `from package import X`): `__init__.py` holds the package's contract-style module docstring, re-exports of the public class(es), and optional `__all__`. Examples: `services/saves/`, `services/saves/sync_engine/`, `services/saves/slots/`, `services/saves/status/`.
-- **Sub-package only consumed via deep-import** (consumers always write `from package.module import X`): empty or just docstring, no re-exports. Example: `adapters/romm/` — `bootstrap` deep-imports `from adapters.romm.romm_api import RommApiAdapter`.
+- **Top-level layer namespace** (`adapters/`, `services/`, `domain/`, `lib/`, `models/`): `__init__.py` is empty (a
+  docstring is acceptable but not required). These exist as namespace markers; consumers always deep-import
+  (`from adapters.romm.romm_api import RommApiAdapter`).
+- **Sub-package consumed via package import** (consumers write `from package import X`): `__init__.py` holds the
+  package's contract-style module docstring, re-exports of the public class(es), and optional `__all__`. Examples:
+  `services/saves/`, `services/saves/sync_engine/`, `services/saves/slots/`, `services/saves/status/`.
+- **Sub-package only consumed via deep-import** (consumers always write `from package.module import X`): empty or just
+  docstring, no re-exports. Example: `adapters/romm/` — `bootstrap` deep-imports
+  `from adapters.romm.romm_api import RommApiAdapter`.
 
-Implementation never lives in `__init__.py`. Don't put 500+ LOC class definitions there — that obscures the package's public surface and breaks the "init = namespace marker + re-export" Python convention.
+Implementation never lives in `__init__.py`. Don't put 500+ LOC class definitions there — that obscures the package's
+public surface and breaks the "init = namespace marker + re-export" Python convention.
 
 Example of a re-export-only `__init__.py`:
 
@@ -179,16 +332,23 @@ from __future__ import annotations
 
 ## Docstrings — intent over behavior
 
-**Module and class docstrings** describe **what belongs here** (the contract), not what's currently in the file/class (the behavior). Behavior listings and method enumerations rot when methods get added/changed/removed; contracts don't.
+**Module and class docstrings** describe **what belongs here** (the contract), not what's currently in the file/class
+(the behavior). Behavior listings and method enumerations rot when methods get added/changed/removed; contracts don't.
 
 - Bad (module): `"""Version history listing and rollback flow. 1. Download. 2. PUT. 3. confirm_download."""`
-- Good (module): `"""Save version history reads and the destructive version-switch flow. Anything that lists, fetches, or rolls back to an older save version lives here. Mutations of the active save record outside the rollback flow belong in SyncEngine or StatusService, not here."""`
-- Bad (class): `"""Owns save_sync_state.json — persistence, migrations, default construction."""` (rots when a 4th responsibility is added)
+- Good (module):
+  `"""Save version history reads and the destructive version-switch flow. Anything that lists, fetches, or rolls back to an older save version lives here. Mutations of the active save record outside the rollback flow belong in SyncEngine or StatusService, not here."""`
+- Bad (class): `"""Owns save_sync_state.json — persistence, migrations, default construction."""` (rots when a 4th
+  responsibility is added)
 - Good (class): `"""Owns save_sync_state.json — single source of truth for on-disk save-sync state."""`
 
-**Method docstrings are different.** A method docstring describes one specific contract (this method's behavior, parameters, return value, non-obvious how) — that contract is naturally scoped, so describing behavior is fine and stays in sync with the signature. Numpy-style parameter sections on a class's `__init__` count as method-like for this purpose.
+**Method docstrings are different.** A method docstring describes one specific contract (this method's behavior,
+parameters, return value, non-obvious how) — that contract is naturally scoped, so describing behavior is fine and stays
+in sync with the signature. Numpy-style parameter sections on a class's `__init__` count as method-like for this
+purpose.
 
-Avoid all of: "mechanical extraction from X", "during the transition", "moved from Y", "added for the Z flow", "see PR #123" — that's commit-message content that rots in source.
+Avoid all of: "mechanical extraction from X", "during the transition", "moved from Y", "added for the Z flow", "see PR
+#123" — that's commit-message content that rots in source.
 
 ## Testing
 
@@ -198,11 +358,14 @@ Every backend feature or callable where testing makes sense MUST have unit tests
 - **Bad path**: Invalid input, missing data, API errors, network failures
 - **Edge cases**: Empty strings, None values, masked values ("••••"), boundary conditions
 
-Tests mirror the source structure: `tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`. Each test file maps 1:1 to a source module. Shared mocks live in `tests/conftest.py`.
+Tests mirror the source structure: `tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`.
+Each test file maps 1:1 to a source module. Shared mocks live in `tests/conftest.py`.
 
 ### Frontend component tests — `@decky/api` event harness
 
-`src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route through (wired in `src/test-setup.ts`). Tests dispatch backend events via `emitDeckyEvent` instead of mocking `@decky/api` per-file. `src/components/CustomPlayButton.test.tsx` is the reference shape:
+`src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route
+through (wired in `src/test-setup.ts`). Tests dispatch backend events via `emitDeckyEvent` instead of mocking
+`@decky/api` per-file. `src/components/CustomPlayButton.test.tsx` is the reference shape:
 
 ```tsx
 import { emitDeckyEvent } from "../test-utils/decky-api-mock";
@@ -213,11 +376,18 @@ act(() => {
 await findByText("Download"); // assert visible side effect
 ```
 
-The bus is reset between tests by `afterEach` in `test-setup.ts`. Use `deckyEventListenerCount(name)` to assert that `useEffect` cleanup ran on unmount. DOM-level `globalThis.dispatchEvent(new CustomEvent(...))` flows (e.g. `romm_data_changed`) bypass the harness — happy-dom handles them natively.
+The bus is reset between tests by `afterEach` in `test-setup.ts`. Use `deckyEventListenerCount(name)` to assert that
+`useEffect` cleanup ran on unmount. DOM-level `globalThis.dispatchEvent(new CustomEvent(...))` flows (e.g.
+`romm_data_changed`) bypass the harness — happy-dom handles them natively.
 
-Prefer the harness over extracting listener bodies into `src/utils/*.ts` purely for testability. Helper extraction stays valid for genuinely-reusable logic.
+Prefer the harness over extracting listener bodies into `src/utils/*.ts` purely for testability. Helper extraction stays
+valid for genuinely-reusable logic.
 
-**Catch coverage assertions must be non-vacuous.** Tests that claim `.catch` coverage MUST assert the post-catch state — the fallback return value, the toast body, the `debugLog` message, the surfaced status string. Asserting only that the rejecting call was invoked is vacuous: it passes with or without the `.catch` because the rejection happens after the call returns. If you can't observe the catch's side effect, the catch either needs an observable effect or the test isn't earning its coverage.
+**Catch coverage assertions must be non-vacuous.** Tests that claim `.catch` coverage MUST assert the post-catch state —
+the fallback return value, the toast body, the `debugLog` message, the surfaced status string. Asserting only that the
+rejecting call was invoked is vacuous: it passes with or without the `.catch` because the rejection happens after the
+call returns. If you can't observe the catch's side effect, the catch either needs an observable effect or the test
+isn't earning its coverage.
 
 ## Security
 
@@ -227,9 +397,16 @@ Prefer the harness over extracting listener bodies into `src/utils/*.ts` purely 
 
 ## Working Style
 
-- **Research before implementing.** When encountering an unknown (e.g. how a third-party tool works, where files are stored, what APIs exist), STOP and research first. Do not start writing code based on assumptions. Present findings to the user and agree on an approach before any implementation.
-- **Discuss architecture decisions.** This is not a vibe coding project. Non-trivial changes require discussion before code is written. When you find a problem, explain it and propose options — don't just start fixing.
-- **Use team-swarm agents** for everything beyond trivial single-file edits — including research, exploration, and implementation. Keep main context clean and focused on architecture and coordination by delegating to agents.
-- **Sequential agent discipline.** When running agents sequentially, each agent's prompt MUST include: "When done, report back and wait for shutdown. Do NOT pick up other tasks from the task list." This prevents agents from grabbing the next unblocked task before the lead can shut them down and spawn a dedicated agent.
-- **Preserve context.** Avoid back-and-forth code changes in the main conversation. Get alignment first, then implement cleanly in one pass (via agents).
+- **Research before implementing.** When encountering an unknown (e.g. how a third-party tool works, where files are
+  stored, what APIs exist), STOP and research first. Do not start writing code based on assumptions. Present findings to
+  the user and agree on an approach before any implementation.
+- **Discuss architecture decisions.** This is not a vibe coding project. Non-trivial changes require discussion before
+  code is written. When you find a problem, explain it and propose options — don't just start fixing.
+- **Use team-swarm agents** for everything beyond trivial single-file edits — including research, exploration, and
+  implementation. Keep main context clean and focused on architecture and coordination by delegating to agents.
+- **Sequential agent discipline.** When running agents sequentially, each agent's prompt MUST include: "When done,
+  report back and wait for shutdown. Do NOT pick up other tasks from the task list." This prevents agents from grabbing
+  the next unblocked task before the lead can shut them down and spawn a dedicated agent.
+- **Preserve context.** Avoid back-and-forth code changes in the main conversation. Get alignment first, then implement
+  cleanly in one pass (via agents).
 - Refer to the [GitHub Projects board](https://github.com/users/danielcopper/projects/2) for the roadmap.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,234 +1,183 @@
 # CONTEXT.md — decky-romm-sync domain glossary
 
-This file is a glossary. It defines the canonical meaning of project-specific
-terms so that conversations, issues, PRs, and code stay aligned. It is *not* a
-spec or design doc — implementation docs live in `docs/architecture/`, and
+This file is a glossary. It defines the canonical meaning of project-specific terms so that conversations, issues, PRs,
+and code stay aligned. It is _not_ a spec or design doc — implementation docs live in `docs/architecture/`, and
 architectural decisions live in `docs/adr/`.
 
-When a term resolves during a discussion, it gets added here. When a term's
-meaning changes, the entry gets rewritten — not appended to.
+When a term resolves during a discussion, it gets added here. When a term's meaning changes, the entry gets rewritten —
+not appended to.
 
 ## Terms
 
 ### Aggregate
 
-A cluster of domain objects treated as a single unit for data consistency. Per
-Cosmic Python chapters 1–7:
+A cluster of domain objects treated as a single unit for data consistency. Per Cosmic Python chapters 1–7:
 
 - Has **one root** entity (a dataclass) that is the only external entry point.
 - Enforces all of its own **invariants** — outside code cannot violate them.
 - Is the **transaction boundary**: saved atomically as a unit.
-- Has exactly one **identity**. Other aggregates reference it by ID only, never
-  by holding a Python reference to its internals.
-- Mutation is **only via methods on the root**, named after the domain event
-  that occurred (`adopt_baseline(...)`, `confirm_slot(...)`,
-  `mark_installed(...)`). Direct field assignment from services is forbidden.
-- Has exactly **one Repository** Protocol. The Repository's job is "give me
-  this aggregate by ID, save this aggregate" — it may touch multiple tables
-  under the hood.
+- Has exactly one **identity**. Other aggregates reference it by ID only, never by holding a Python reference to its
+  internals.
+- Mutation is **only via methods on the root**, named after the domain event that occurred (`adopt_baseline(...)`,
+  `confirm_slot(...)`, `mark_installed(...)`). Direct field assignment from services is forbidden.
+- Has exactly **one Repository** Protocol. The Repository's job is "give me this aggregate by ID, save this aggregate" —
+  it may touch multiple tables under the hood.
 
-What an aggregate is *not*: a DTO sent to the frontend, a query projection, or
-"stuff that happens to live in the same file." Aggregate boundaries are
-**invariant boundaries**, not storage boundaries.
+What an aggregate is _not_: a DTO sent to the frontend, a query projection, or "stuff that happens to live in the same
+file." Aggregate boundaries are **invariant boundaries**, not storage boundaries.
 
-Chapters 8+ of the CP book (domain events + message bus) are explicitly out of
-scope. Triggers for revisiting that scope are documented in `CLAUDE.md`. The
-concrete aggregate set, its tables, and the enforcement layers live in
-`docs/architecture/database-design.md` — this entry defines the term, not the
-inventory.
+Chapters 8+ of the CP book (domain events + message bus) are explicitly out of scope. Triggers for revisiting that scope
+are documented in `CLAUDE.md`. The concrete aggregate set, its tables, and the enforcement layers live in
+`docs/architecture/database-design.md` — this entry defines the term, not the inventory.
 
 ### Value Object
 
-An immutable member of an aggregate, built whole and never mutated in place —
-a `@dataclass(frozen=True, slots=True)`, not a `@cosmic_aggregate` root. It has
-no identity of its own and no mutation surface to police, so it carries neither
-the decorator nor the verb-method discipline an aggregate root does.
-`FileSyncState` (inside `RomSaveState`) is the canonical example. The foil to
-**Aggregate**: a root has identity and methods; a value object has neither.
+An immutable member of an aggregate, built whole and never mutated in place — a `@dataclass(frozen=True, slots=True)`,
+not a `@cosmic_aggregate` root. It has no identity of its own and no mutation surface to police, so it carries neither
+the decorator nor the verb-method discipline an aggregate root does. `FileSyncState` (inside `RomSaveState`) is the
+canonical example. The foil to **Aggregate**: a root has identity and methods; a value object has neither.
 
 ### Repository
 
-The single persistence seam for one **Aggregate** — "give me this aggregate by
-id, save this aggregate." Exactly one Repository per aggregate root (Protocol in
-`services/protocols/`, SQLite adapter behind it). It may touch several tables to
-reconstruct or persist the aggregate — the `RomSaveState` repository spans
-`rom_save_states` + `rom_save_files` — but callers see only `get(id)` /
-`save(id, aggregate)`. It *is* the load/save layer; the service layer never
-wraps it in a second one (no `StateService`-style holder between service and
-repository). Reached only through the **Unit of Work** (`uow.rom_save_states`,
-`uow.rom_installs`, …), never constructed directly.
+The single persistence seam for one **Aggregate** — "give me this aggregate by id, save this aggregate." Exactly one
+Repository per aggregate root (Protocol in `services/protocols/`, SQLite adapter behind it). It may touch several tables
+to reconstruct or persist the aggregate — the `RomSaveState` repository spans `rom_save_states` + `rom_save_files` — but
+callers see only `get(id)` / `save(id, aggregate)`. It _is_ the load/save layer; the service layer never wraps it in a
+second one (no `StateService`-style holder between service and repository). Reached only through the **Unit of Work**
+(`uow.rom_save_states`, `uow.rom_installs`, …), never constructed directly.
 
 ### Unit of Work
 
-The atomic transaction boundary one operation works inside, and the carrier of
-the **Repositories** for that transaction. Owned by the service layer at the
-operation's entry (never by `main.py` callables); a `with uow:` block opens one
-connection, exposes the repositories, and commits on clean exit / rolls back on
-exception (stdlib `sqlite3` + `run_in_executor`, per
-[ADR-0004](docs/adr/0004-sync-sqlite-unit-of-work.md)). Kept **narrow** — it
-wraps only the database reads/writes, never network/file I/O or a frontend
-round-trip; cross-operation consistency comes from the operation's own
-serialization (the per-ROM save lock, the single library-sync task), not from
-holding a UoW open.
+The atomic transaction boundary one operation works inside, and the carrier of the **Repositories** for that
+transaction. Owned by the service layer at the operation's entry (never by `main.py` callables); a `with uow:` block
+opens one connection, exposes the repositories, and commits on clean exit / rolls back on exception (stdlib `sqlite3` +
+`run_in_executor`, per [ADR-0004](docs/adr/0004-sync-sqlite-unit-of-work.md)). Kept **narrow** — it wraps only the
+database reads/writes, never network/file I/O or a frontend round-trip; cross-operation consistency comes from the
+operation's own serialization (the per-ROM save lock, the single library-sync task), not from holding a UoW open.
 
 ### Persistence boundary (settings.json / save_sync_state.json / SQLite)
 
-Where a piece of persisted state lives is a deliberate decision driven by what
-the data *is*, not which file it historically lived in. Per
-[ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md), three buckets,
-and the bucket picks the store:
+Where a piece of persisted state lives is a deliberate decision driven by what the data _is_, not which file it
+historically lived in. Per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md), three buckets, and the bucket
+picks the store:
 
-1. **User-intent config** — flat, no relationships, the user sets it →
-   **`settings.json`**. Includes credentials, scalar toggles, the sync-selection
-   lists (`enabled_platforms`, `enabled_collections`), the save-sync feature
-   toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`,
-   `default_slot`, `autocleanup_limit`), and `device_name`.
-2. **Observed / derived-from-an-external-source** — read, not set → **read live
-   by default**; persisted (in `kv_config`) only as a last-seen marker for
-   cross-run change detection. The RetroDECK home path and save-sort settings
-   markers live here.
-3. **Synced / derived relational state with real invariants** — per-ROM groups,
-   history, caches of remote data → **SQLite aggregates**.
+1. **User-intent config** — flat, no relationships, the user sets it → **`settings.json`**. Includes credentials, scalar
+   toggles, the sync-selection lists (`enabled_platforms`, `enabled_collections`), the save-sync feature toggles
+   (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`), and
+   `device_name`.
+2. **Observed / derived-from-an-external-source** — read, not set → **read live by default**; persisted (in `kv_config`)
+   only as a last-seen marker for cross-run change detection. The RetroDECK home path and save-sort settings markers
+   live here.
+3. **Synced / derived relational state with real invariants** — per-ROM groups, history, caches of remote data →
+   **SQLite aggregates**.
 
-`save_sync_state.json` is the *legacy* JSON home for bucket-3 save state and
-for `device_id`; it is replaced by SQLite at the cutover. As of #822 it no
-longer holds the save-sync toggles or `device_name` (those moved to
-`settings.json`, settings schema v4) — only `device_id` remains until the
-cutover folds it into `kv_config`.
+`save_sync_state.json` is the _legacy_ JSON home for bucket-3 save state and for `device_id`; it is replaced by SQLite
+at the cutover. As of #822 it no longer holds the save-sync toggles or `device_name` (those moved to `settings.json`,
+settings schema v4) — only `device_id` remains until the cutover folds it into `kv_config`.
 
 ### Cutover
 
 The hard cut from JSON state files to SQLite ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)).
-"Hard" means **SQLite starts empty** — the JSON state is not migrated into it,
-and the JSON-era domain classes are deleted in the same wave. Bucket-1 config
-(`settings.json`) and the change-detection markers are unaffected by the
-cutover; only the relational save/library/playtime state is re-derived from
-scratch (re-synced from RomM, re-pruned against disk). The JSON→JSON moves that
-*precede* the cutover (e.g. #822) are explicitly **not** cutover work — they
+"Hard" means **SQLite starts empty** — the JSON state is not migrated into it, and the JSON-era domain classes are
+deleted in the same wave. Bucket-1 config (`settings.json`) and the change-detection markers are unaffected by the
+cutover; only the relational save/library/playtime state is re-derived from scratch (re-synced from RomM, re-pruned
+against disk). The JSON→JSON moves that _precede_ the cutover (e.g. #822) are explicitly **not** cutover work — they
 ship independently because they touch no SQLite.
 
 ### kv_config
 
-A key-value table for small singleton configuration values that don't justify
-their own aggregate or table. One row per key.
+A key-value table for small singleton configuration values that don't justify their own aggregate or table. One row per
+key.
 
-Intended residents (per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md);
-the table is created-but-unused until the cutover): the RetroDECK home path
-marker (`retrodeck_home_path` + its pending-migration `_previous`), the
-save-sort settings markers (`save_sort_settings` + `_previous`), and `device_id`
-(server-issued identity, folded in at the cutover). The schema version is
-**not** a `kv_config` key — it lives in `PRAGMA user_version`.
+Intended residents (per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md); the table is created-but-unused
+until the cutover): the RetroDECK home path marker (`retrodeck_home_path` + its pending-migration `_previous`), the
+save-sort settings markers (`save_sort_settings` + `_previous`), and `device_id` (server-issued identity, folded in at
+the cutover). The schema version is **not** a `kv_config` key — it lives in `PRAGMA user_version`.
 
-**Not** a dumping ground: anything with its own lifecycle, invariants, or
-repeat-row potential gets its own aggregate. `kv_config` is for the truly small,
-the truly singleton, and the truly miscellaneous.
+**Not** a dumping ground: anything with its own lifecycle, invariants, or repeat-row potential gets its own aggregate.
+`kv_config` is for the truly small, the truly singleton, and the truly miscellaneous.
 
 ### Rom (aggregate) vs ROM (file) vs RomM (server)
 
 Three things spell similarly; distinct meanings:
 
-- **Rom** — the aggregate / domain entity owned by this plugin
-  (`domain/rom.py`). Represents one ROM as the plugin tracks it locally:
-  identity, the denormalized `platform_slug`, sync metadata, the Steam shortcut
-  binding.
-- **ROM** (or "ROM file") — the actual playable game file on disk (e.g.
-  `.iso`, `.cue`, `.gba`). What `RomInstall` records once a `Rom` has been
-  downloaded.
-- **RomM** — the upstream self-hosted server. The source of truth this plugin
-  syncs *from*.
+- **Rom** — the aggregate / domain entity owned by this plugin (`domain/rom.py`). Represents one ROM as the plugin
+  tracks it locally: identity, the denormalized `platform_slug`, sync metadata, the Steam shortcut binding.
+- **ROM** (or "ROM file") — the actual playable game file on disk (e.g. `.iso`, `.cue`, `.gba`). What `RomInstall`
+  records once a `Rom` has been downloaded.
+- **RomM** — the upstream self-hosted server. The source of truth this plugin syncs _from_.
 
-Convention: always write `Rom` (PascalCase) when referring to the aggregate.
-Write "ROM file" when referring to the on-disk artifact.
+Convention: always write `Rom` (PascalCase) when referring to the aggregate. Write "ROM file" when referring to the
+on-disk artifact.
 
 ### file_path vs rom_dir (RomInstall paths)
 
-The two path fields on `RomInstall` (`domain/rom_install.py`) answer different
-questions and must not be conflated:
+The two path fields on `RomInstall` (`domain/rom_install.py`) answer different questions and must not be conflated:
 
-- **`file_path`** — the **launch target**: the single file RetroDECK is handed.
-  It is baked into the Steam shortcut's `launch_options`
-  (`flatpak run … "<file_path>"`) and the `rom-launcher` exec wrapper runs that
-  command (per
-  [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md),
-  which superseded the dynamic SQLite read of
-  [ADR-0005](docs/adr/0005-launcher-resolves-path-from-sqlite.md)). Present for
-  every ROM. Save-path resolution, ES-DE core resolution, and the displayed
-  filename all derive from it.
-- **`rom_dir`** — the **dedicated per-ROM directory**, present only for
-  folder-backed (multi-file) ROMs. **NULL for single-file ROMs**, which live as a
-  bare file directly in the shared `<roms>/<system>/` directory and own no
-  dedicated folder.
+- **`file_path`** — the **launch target**: the single file RetroDECK is handed. It is baked into the Steam shortcut's
+  `launch_options` (`flatpak run … "<file_path>"`) and the `rom-launcher` exec wrapper runs that command (per
+  [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md), which superseded the dynamic SQLite read
+  of [ADR-0005](docs/adr/0005-launcher-resolves-path-from-sqlite.md)). Present for every ROM. Save-path resolution,
+  ES-DE core resolution, and the displayed filename all derive from it.
+- **`rom_dir`** — the **dedicated per-ROM directory**, present only for folder-backed (multi-file) ROMs. **NULL for
+  single-file ROMs**, which live as a bare file directly in the shared `<roms>/<system>/` directory and own no dedicated
+  folder.
 
-Single-file vs multi-file is **read from `rom_dir` presence** — never re-derived
-from the file's parent directory, never stored as a separate boolean
-([ADR-0008](docs/adr/0008-rom-install-launch-file-and-rom-dir.md)). Migration
-moves `rom_dir` whole when set, else the file; uninstall removes `rom_dir` whole
-when set, else the file. A future per-file `RomFile[]` model — one row per
-physical file, each tagged with a RomM `category` (`game` / `dlc` / `update` /
-`mod` / …) — is the planned shape for the multi-file features in
+Single-file vs multi-file is **read from `rom_dir` presence** — never re-derived from the file's parent directory, never
+stored as a separate boolean ([ADR-0008](docs/adr/0008-rom-install-launch-file-and-rom-dir.md)). Migration moves
+`rom_dir` whole when set, else the file; uninstall removes `rom_dir` whole when set, else the file. A future per-file
+`RomFile[]` model — one row per physical file, each tagged with a RomM `category` (`game` / `dlc` / `update` / `mod` /
+…) — is the planned shape for the multi-file features in
 [#140](https://github.com/danielcopper/decky-romm-sync/issues/140) /
-[#129](https://github.com/danielcopper/decky-romm-sync/issues/129); it is an
-additive 1:N child of `rom_installs` (deferred until those land), and
-`file_path` + `rom_dir` are its forward-compatible projection.
+[#129](https://github.com/danielcopper/decky-romm-sync/issues/129); it is an additive 1:N child of `rom_installs`
+(deferred until those land), and `file_path` + `rom_dir` are its forward-compatible projection.
 
 ### platform_slug (denormalized)
 
-The RomM platform identifier (e.g. `gba`, `psx`) carried as a plain string on
-the rows that need it (`roms`, `rom_installs`, `downloaded_bios`,
-`firmware_cache`). There is **no local `Platform` aggregate** — that was
-proposed in ADR-0001 and **dropped by [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md)**
-on YAGNI grounds. Platform display names resolve live from RomM; sync exclusion
-is the user-intent `enabled_platforms` config in `settings.json`, not
-per-platform local state. A `Platform` aggregate is reintroduced only when a
-concrete need lands (the standalone-emulator roadmap), not speculatively.
+The RomM platform identifier (e.g. `gba`, `psx`) carried as a plain string on the rows that need it (`roms`,
+`rom_installs`, `downloaded_bios`, `firmware_cache`). There is **no local `Platform` aggregate** — that was proposed in
+ADR-0001 and **dropped by [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md)** on YAGNI grounds. Platform
+display names resolve live from RomM; sync exclusion is the user-intent `enabled_platforms` config in `settings.json`,
+not per-platform local state. A `Platform` aggregate is reintroduced only when a concrete need lands (the
+standalone-emulator roadmap), not speculatively.
 
 ### Save-sync slot
 
-A named channel for a ROM's saves (e.g. `default`). The active slot for a ROM
-is recorded on its `RomSaveState`; `default_slot` (a `settings.json` config
-value, per #822) is the slot a newly-tracked ROM starts on. Slots let the same
-ROM carry distinct save sets without clobbering one another. Confirming a slot
-(`confirm_slot(...)`) is an explicit user/flow decision — the plugin never
-silently adopts a foreign slot.
+A named channel for a ROM's saves (e.g. `default`). The active slot for a ROM is recorded on its `RomSaveState`;
+`default_slot` (a `settings.json` config value, per #822) is the slot a newly-tracked ROM starts on. Slots let the same
+ROM carry distinct save sets without clobbering one another. Confirming a slot (`confirm_slot(...)`) is an explicit
+user/flow decision — the plugin never silently adopts a foreign slot.
 
 ### Baseline
 
-The last-synced reference point recorded for a tracked save file — captured in
-a `FileSyncState` value object (filename + hash + `tracked_save_id`). The
-newest-wins matrix diffs the current local and remote state against the baseline
-to detect drift on the next sync. Adopting a baseline (`adopt_baseline(...)`) is
-how a file becomes tracked.
+The last-synced reference point recorded for a tracked save file — captured in a `FileSyncState` value object
+(filename + hash + `tracked_save_id`). The newest-wins matrix diffs the current local and remote state against the
+baseline to detect drift on the next sync. Adopting a baseline (`adopt_baseline(...)`) is how a file becomes tracked.
 
 ### Newest-wins matrix
 
-The save-sync conflict-resolution model (`services/saves/sync_engine/`). For
-each tracked file it evaluates local vs remote vs **baseline** and resolves to
-whichever side is newer, rather than blindly mirroring one direction. The
-"matrix" is the per-file evaluation table that drives the actual upload /
-download / no-op dispatch for a ROM's sync run.
+The save-sync conflict-resolution model (`services/saves/sync_engine/`). For each tracked file it evaluates local vs
+remote vs **baseline** and resolves to whichever side is newer, rather than blindly mirroring one direction. The
+"matrix" is the per-file evaluation table that drives the actual upload / download / no-op dispatch for a ROM's sync
+run.
 
 ### SyncRun
 
-One library-sync operation modelled as a first-class aggregate
-(`domain/sync_run.py`, `sync_runs` table) — a `running` → `completed` /
-`cancelled` / `errored` state machine carrying `started_at` / `finished_at`, the
-planned platform/ROM counts, and the lists of platforms/collections actually
-completed. Replaces the scattered JSON scalars `last_sync`, `sync_stats`,
-`last_synced_platforms`, `last_synced_collections`. One row per sync (inserted at
-apply-start, finalized at the end). The "how many ROMs" figure is **not** stored
-on it — that is a live `len(registry)` count computed at read time.
+One library-sync operation modelled as a first-class aggregate (`domain/sync_run.py`, `sync_runs` table) — a `running` →
+`completed` / `cancelled` / `errored` state machine carrying `started_at` / `finished_at`, the planned platform/ROM
+counts, and the lists of platforms/collections actually completed. Replaces the scattered JSON scalars `last_sync`,
+`sync_stats`, `last_synced_platforms`, `last_synced_collections`. One row per sync (inserted at apply-start, finalized
+at the end). The "how many ROMs" figure is **not** stored on it — that is a live `len(registry)` count computed at read
+time.
 
 ### Unbind / stale / prune
 
-Three deliberately-distinct ROM-removal notions (see
-[ADR-0007](docs/adr/0007-rom-retention-identity-anchor.md)):
+Three deliberately-distinct ROM-removal notions (see [ADR-0007](docs/adr/0007-rom-retention-identity-anchor.md)):
 
-- **Unbind** — drop a ROM's Steam-shortcut binding (`shortcut_app_id` → NULL, via
-  `Rom.unbind_shortcut()`) while keeping its `roms` row and all per-ROM state
-  (install, metadata, playtime, saves). What removing a shortcut does.
-- **Stale** — a ROM still in local state but no longer returned by RomM on a
-  sync. Triggers an **unbind**, never a delete: a stale signal may be a transient
-  server blip or a reversible RomM change, and local playtime/saves must survive.
-- **Prune** — an explicit, opt-in purge that `DELETE`s the `roms` row, cascading
-  every per-ROM child away atomically. The **only** thing that deletes rows; not
-  built yet (the cascade FKs exist for it).
+- **Unbind** — drop a ROM's Steam-shortcut binding (`shortcut_app_id` → NULL, via `Rom.unbind_shortcut()`) while keeping
+  its `roms` row and all per-ROM state (install, metadata, playtime, saves). What removing a shortcut does.
+- **Stale** — a ROM still in local state but no longer returned by RomM on a sync. Triggers an **unbind**, never a
+  delete: a stale signal may be a transient server blip or a reversible RomM change, and local playtime/saves must
+  survive.
+- **Prune** — an explicit, opt-in purge that `DELETE`s the `roms` row, cascading every per-ROM child away atomically.
+  The **only** thing that deletes rows; not built yet (the cascade FKs exist for it).

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ documentation site. This README is just the quick tour.
 
 - **Library sync** — Pulls platforms and ROMs from your RomM server and creates Steam shortcuts, complete with cover
   art, hero banners, and logos (with optional [SteamGridDB](https://www.steamgriddb.com/) artwork)
-- **Save sync** — Keeps save files in sync across devices through your RomM server, with newest-wins conflict
-  resolution and a manual override when you need it
+- **Save sync** — Keeps save files in sync across devices through your RomM server, with newest-wins conflict resolution
+  and a manual override when you need it
 - **ROM downloads** — Download ROMs on demand with progress tracking and a managed download queue
 - **BIOS management** — Download firmware/BIOS files from RomM for systems that need them (PSX, Dreamcast, PS2, …)
 - **Game detail page** — Install status, BIOS status, and download/uninstall actions right on each game's Steam page
@@ -36,10 +36,10 @@ documentation site. This README is just the quick tour.
 
 ## Screenshots
 
-| QAM panel | Game detail page |
-| :---: | :---: |
-| ![RomM Sync QAM panel](assets/screenshot-qam.jpg) | ![Game detail page with metadata](assets/screenshot-game-detail.jpg) |
-| **BIOS management** | **Per-game actions** |
+|                                   QAM panel                                    |                                        Game detail page                                         |
+| :----------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
+|               ![RomM Sync QAM panel](assets/screenshot-qam.jpg)                |              ![Game detail page with metadata](assets/screenshot-game-detail.jpg)               |
+|                              **BIOS management**                               |                                      **Per-game actions**                                       |
 | ![BIOS status showing a required file to download](assets/screenshot-bios.jpg) | ![RomM actions menu: sync saves, download BIOS, refresh artwork](assets/screenshot-actions.jpg) |
 
 ## Requirements
@@ -64,7 +64,8 @@ search for **RomM Sync**, and install. No Developer Mode required.
 This is the current method while v1.0 is in progress. It requires **Developer Mode** in Decky Loader (Decky settings →
 gear icon → toggle **Developer Mode**).
 
-1. Download the latest `decky-romm-sync.zip` from the [releases page](https://github.com/danielcopper/decky-romm-sync/releases)
+1. Download the latest `decky-romm-sync.zip` from the
+   [releases page](https://github.com/danielcopper/decky-romm-sync/releases)
 2. In Decky settings → **Developer** tab → **Install Plugin from ZIP** (or **from URL** with the
    [latest release link](https://github.com/danielcopper/decky-romm-sync/releases/latest/download/decky-romm-sync.zip))
 
@@ -93,16 +94,16 @@ Build from source, run the tests, and read the architecture reference on the doc
 
 This plugin stands on the shoulders of some great projects:
 
-- [RomM](https://github.com/rommapp/romm) — the self-hosted ROM manager at the heart of this plugin. RomM provides
-  the library, metadata, cover art, and save file storage that makes the entire sync experience possible
-- [RetroDECK](https://retrodeck.net/) — the all-in-one emulation solution for Steam Deck that bundles ES-DE,
-  RetroArch, and standalone emulators into a single flatpak. Our entire launch chain runs through RetroDECK
+- [RomM](https://github.com/rommapp/romm) — the self-hosted ROM manager at the heart of this plugin. RomM provides the
+  library, metadata, cover art, and save file storage that makes the entire sync experience possible
+- [RetroDECK](https://retrodeck.net/) — the all-in-one emulation solution for Steam Deck that bundles ES-DE, RetroArch,
+  and standalone emulators into a single flatpak. Our entire launch chain runs through RetroDECK
 - [Decky Loader](https://decky.xyz/) — the plugin framework that makes all of this possible
 - [Valve](https://www.valvesoftware.com/) — for the Steam Deck, SteamOS, and an open enough platform to build on
 - [Unifideck](https://github.com/ma3ke/unifideck) — inspiration for game detail page injection techniques and gamepad
   navigation patterns
-- [MetaDeck](https://github.com/EmuDeck/MetaDeck) — inspiration for store patching patterns used in metadata display
-  on non-Steam shortcuts
+- [MetaDeck](https://github.com/EmuDeck/MetaDeck) — inspiration for store patching patterns used in metadata display on
+  non-Steam shortcuts
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-|---------|--------------------|
-| Latest  | Yes                |
-| Older   | No                 |
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+| Older   | No        |
 
 Only the latest release receives security fixes.
 
@@ -14,7 +14,8 @@ Only the latest release receives security fixes.
 If you discover a security vulnerability in decky-romm-sync, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue.**
-2. Use [GitHub Security Advisories](https://github.com/danielcopper/decky-romm-sync/security/advisories/new) to report privately.
+2. Use [GitHub Security Advisories](https://github.com/danielcopper/decky-romm-sync/security/advisories/new) to report
+   privately.
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce
@@ -35,4 +36,5 @@ This plugin handles:
 
 - Settings files are stored with `0600` permissions (owner-only read/write)
 - Credentials are never logged — masked in all log output
-- The `allow_insecure_ssl` option disables certificate verification for self-hosted servers with self-signed certificates. This is an opt-in user setting with a warning in the UI.
+- The `allow_insecure_ssl` option disables certificate verification for self-hosted servers with self-signed
+  certificates. This is an opt-in user setting with a warning in the UI.

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,8 @@
+{
+  "fmt": {
+    "include": ["**/*.md"],
+    "exclude": ["CHANGELOG.md", "site/", "node_modules/", ".worktrees/"],
+    "proseWrap": "always",
+    "lineWidth": 120
+  }
+}

--- a/docs/adr/0001-adopt-platform-aggregate.md
+++ b/docs/adr/0001-adopt-platform-aggregate.md
@@ -2,72 +2,54 @@
 
 ## Status
 
-Superseded by [ADR-0003](0003-json-sqlite-persistence-boundary.md). Platform is
-**not** adopted as an aggregate — it reverts to a denormalised `platform_slug`
-string (this document's rejected option 1), and the platform sync-exclusion
-toggle stays as `enabled_platforms` in `settings.json`. See ADR-0003 for the
-reasoning (YAGNI: `excluded_from_sync` was dead code, `emulation_stack` /
-`manual_emulator_path` never existed, display-name caching is covered by
+Superseded by [ADR-0003](0003-json-sqlite-persistence-boundary.md). Platform is **not** adopted as an aggregate — it
+reverts to a denormalised `platform_slug` string (this document's rejected option 1), and the platform sync-exclusion
+toggle stays as `enabled_platforms` in `settings.json`. See ADR-0003 for the reasoning (YAGNI: `excluded_from_sync` was
+dead code, `emulation_stack` / `manual_emulator_path` never existed, display-name caching is covered by
 denormalisation). The decision below is retained as historical context.
 
 ## Context
 
-The plugin syncs ROMs from RomM, which provides each ROM with a
-`platform_slug` and `platform_name`. Today these strings are denormalized
-across `shortcut_registry`, `installed_roms`, and `downloaded_bios` — there
-is no `Platform` entity locally.
+The plugin syncs ROMs from RomM, which provides each ROM with a `platform_slug` and `platform_name`. Today these strings
+are denormalized across `shortcut_registry`, `installed_roms`, and `downloaded_bios` — there is no `Platform` entity
+locally.
 
-When migrating to SQLite (#271), we considered three options for platform
-identity:
+When migrating to SQLite (#271), we considered three options for platform identity:
 
-1. **No Platform aggregate.** Keep `platform_slug: str` denormalized on every
-   row. Cheapest. Matches today.
-2. **Singleton `kv_config` blob.** Stuff a `platform_display_names` JSON map
-   into the key-value table. Works for cached names; fails when we need
-   user-editable per-platform settings.
-3. **Adopt `Platform` as a full aggregate.** New table, new Repository, new
-   domain dataclass. Costs a sync-ordering constraint (platforms refresh
-   before ROMs).
+1. **No Platform aggregate.** Keep `platform_slug: str` denormalized on every row. Cheapest. Matches today.
+2. **Singleton `kv_config` blob.** Stuff a `platform_display_names` JSON map into the key-value table. Works for cached
+   names; fails when we need user-editable per-platform settings.
+3. **Adopt `Platform` as a full aggregate.** New table, new Repository, new domain dataclass. Costs a sync-ordering
+   constraint (platforms refresh before ROMs).
 
 ## Decision
 
 Adopt Platform as a full aggregate.
 
-The deciding factor was the standalone-emulator roadmap: extending the
-plugin beyond RetroDECK (EmuDeck, manually-installed emulators) requires
-local state we genuinely own (`emulation_stack`, `manual_emulator_path`,
-future `excluded_from_sync` toggle). RetroDECK's own configuration files
-(`es_systems.xml`, `gamelist.xml`) own most existing per-platform state —
-but that doesn't cover the non-RetroDECK case, which is the explicit
-direction of travel.
+The deciding factor was the standalone-emulator roadmap: extending the plugin beyond RetroDECK (EmuDeck,
+manually-installed emulators) requires local state we genuinely own (`emulation_stack`, `manual_emulator_path`, future
+`excluded_from_sync` toggle). RetroDECK's own configuration files (`es_systems.xml`, `gamelist.xml`) own most existing
+per-platform state — but that doesn't cover the non-RetroDECK case, which is the explicit direction of travel.
 
 Other rationale:
 
 - `display_name` caching survives RomM downtime for QAM display
-- A normalized `platforms` table is a cleaner home for "per-platform
-  preferences we own" than scattering them across `kv_config` keys
-- Bundled reference data (`bios_registry.json`, `core_defaults.json`,
-  RetroDECK's `es_systems.xml`) stays where it is — Platform only carries
-  state we genuinely own and mutate
+- A normalized `platforms` table is a cleaner home for "per-platform preferences we own" than scattering them across
+  `kv_config` keys
+- Bundled reference data (`bios_registry.json`, `core_defaults.json`, RetroDECK's `es_systems.xml`) stays where it is —
+  Platform only carries state we genuinely own and mutate
 
 ## Consequences
 
-- `Rom`, `RomInstall`, `BiosFile`, `RomSaveState` carry `platform_slug` as a
-  reference into the `platforms` table — not a free-floating string. This is a
-  **logical / join reference, not a DB-enforced `FOREIGN KEY` constraint**: the
-  selective-FK rule (epic #271, finalized in
-  [ADR-0002](0002-per-rom-table-per-aggregate-split.md)) deliberately keeps no FK
-  on `platform_slug`, because an enforced constraint would force insert ordering
-  and block platform pruning while ROMs exist — fighting the disk-truth-pruning
-  model.
+- `Rom`, `RomInstall`, `BiosFile`, `RomSaveState` carry `platform_slug` as a reference into the `platforms` table — not
+  a free-floating string. This is a **logical / join reference, not a DB-enforced `FOREIGN KEY` constraint**: the
+  selective-FK rule (epic #271, finalized in [ADR-0002](0002-per-rom-table-per-aggregate-split.md)) deliberately keeps
+  no FK on `platform_slug`, because an enforced constraint would force insert ordering and block platform pruning while
+  ROMs exist — fighting the disk-truth-pruning model.
 - `Rom` drops the denormalized `platform_name` column (resolve via JOIN).
-- Sync should refresh `platforms` before refreshing ROMs so display names
-  resolve — an application-level ordering preference, **not** a DB foreign-key
-  dependency (there is no enforced constraint to violate).
-- Bundled defaults (`core_defaults.json`) and RetroDECK-managed state
-  (`gamelist.xml` overrides) stay outside the Platform aggregate. The
-  aggregate is for state we own locally, not for caching read-only
-  reference data.
-- The Platform aggregate stays lean today (`slug`, `display_name`,
-  `excluded_from_sync` once shipped, `emulation_stack` once shipped) —
-  not all future fields land at once.
+- Sync should refresh `platforms` before refreshing ROMs so display names resolve — an application-level ordering
+  preference, **not** a DB foreign-key dependency (there is no enforced constraint to violate).
+- Bundled defaults (`core_defaults.json`) and RetroDECK-managed state (`gamelist.xml` overrides) stay outside the
+  Platform aggregate. The aggregate is for state we own locally, not for caching read-only reference data.
+- The Platform aggregate stays lean today (`slug`, `display_name`, `excluded_from_sync` once shipped, `emulation_stack`
+  once shipped) — not all future fields land at once.

--- a/docs/adr/0002-per-rom-table-per-aggregate-split.md
+++ b/docs/adr/0002-per-rom-table-per-aggregate-split.md
@@ -6,94 +6,75 @@ Accepted
 
 ## Context
 
-Epic [#271](https://github.com/danielcopper/decky-romm-sync/issues/271) proposed a
-"hybrid 5-table" layout with **one `roms` mega-table** holding all per-ROM state,
-as a *starting point* — it explicitly deferred the final layout to the schema
-sub-issue (#780). The aggregate set locked in #788 has five per-ROM aggregates:
-`Rom`, `RomInstall`, `RomMetadata`, `Playtime`, `RomSaveState` (plus the
-`FileSyncState` 1:N child). #780 had to choose how they sit in tables.
+Epic [#271](https://github.com/danielcopper/decky-romm-sync/issues/271) proposed a "hybrid 5-table" layout with **one
+`roms` mega-table** holding all per-ROM state, as a _starting point_ — it explicitly deferred the final layout to the
+schema sub-issue (#780). The aggregate set locked in #788 has five per-ROM aggregates: `Rom`, `RomInstall`,
+`RomMetadata`, `Playtime`, `RomSaveState` (plus the `FileSyncState` 1:N child). #780 had to choose how they sit in
+tables.
 
 Two options for the per-ROM cluster:
 
-1. **Mega-table.** One `roms` row carries identity + install + metadata +
-   playtime + save-state scalars. `RomRepository` inserts the row; the four
-   secondary repositories `UPDATE` their own column slices.
-2. **Table-per-aggregate.** Each per-ROM aggregate gets its own table keyed by
-   `rom_id` (`roms`, `rom_installs`, `rom_metadata`, `rom_playtime`,
-   `rom_save_states`), with `rom_save_files` as the save child.
+1. **Mega-table.** One `roms` row carries identity + install + metadata + playtime + save-state scalars. `RomRepository`
+   inserts the row; the four secondary repositories `UPDATE` their own column slices.
+2. **Table-per-aggregate.** Each per-ROM aggregate gets its own table keyed by `rom_id` (`roms`, `rom_installs`,
+   `rom_metadata`, `rom_playtime`, `rom_save_states`), with `rom_save_files` as the save child.
 
-The foreign-key policy is entangled with this choice. The epic locked
-"**selective FK only** — one FK, `rom_save_files → roms ON DELETE CASCADE`, no
-others." That rule was written for the mega-table world, where the only FK
-candidates were `platform_slug` (a cross-aggregate reference) and the single
-`rom_save_files` child.
+The foreign-key policy is entangled with this choice. The epic locked "**selective FK only** — one FK,
+`rom_save_files → roms ON DELETE CASCADE`, no others." That rule was written for the mega-table world, where the only FK
+candidates were `platform_slug` (a cross-aggregate reference) and the single `rom_save_files` child.
 
 ## Decision
 
-Adopt **table-per-aggregate** for the per-ROM cluster, and give the per-ROM
-child tables **`ON DELETE CASCADE` foreign keys to `roms`**.
+Adopt **table-per-aggregate** for the per-ROM cluster, and give the per-ROM child tables **`ON DELETE CASCADE` foreign
+keys to `roms`**.
 
-The deciding factor is **integrity, not performance**. Read performance is a
-non-issue at single-user scale (point reads in microseconds, joins in
-milliseconds — established during the #271 research), so it did not decide the
-layout. What decides it: the per-ROM aggregates are **all-or-nothing groups**.
-An install is either fully present (a launch file, an install dir, a timestamp)
-or absent; metadata is cached or not. As loose nullable columns in a mega-table,
-the schema **cannot express that** — a half-set install (`file_path` set,
-`installed_at` NULL) is a representable, invalid state, and `roms` becomes a
-~35-column grab-bag where most columns are NULL for any given ROM. As separate
-tables, the row's **existence** means "this group is present and complete"
-(`NOT NULL` within), and "not every user has saves / metadata / a download"
-becomes simply "no row."
+The deciding factor is **integrity, not performance**. Read performance is a non-issue at single-user scale (point reads
+in microseconds, joins in milliseconds — established during the #271 research), so it did not decide the layout. What
+decides it: the per-ROM aggregates are **all-or-nothing groups**. An install is either fully present (a launch file, an
+install dir, a timestamp) or absent; metadata is cached or not. As loose nullable columns in a mega-table, the schema
+**cannot express that** — a half-set install (`file_path` set, `installed_at` NULL) is a representable, invalid state,
+and `roms` becomes a ~35-column grab-bag where most columns are NULL for any given ROM. As separate tables, the row's
+**existence** means "this group is present and complete" (`NOT NULL` within), and "not every user has saves / metadata /
+a download" becomes simply "no row."
 
 Secondary factors:
 
-- **One Repository per aggregate** (the CONTEXT.md rule) maps 1:1 onto one table
-  per aggregate — no multiple repositories writing column slices of a shared
-  row, and no implicit "the `roms` row must exist before any secondary write"
-  ordering baked into the persistence layer.
-- **Legibility / AI-navigability** — "where is `RomMetadata` persisted?" answers
-  itself (`rom_metadata`). The mega-table would need column-name disambiguation
-  (`system` appears on both `RomInstall` and `RomSaveState`).
+- **One Repository per aggregate** (the CONTEXT.md rule) maps 1:1 onto one table per aggregate — no multiple
+  repositories writing column slices of a shared row, and no implicit "the `roms` row must exist before any secondary
+  write" ordering baked into the persistence layer.
+- **Legibility / AI-navigability** — "where is `RomMetadata` persisted?" answers itself (`rom_metadata`). The mega-table
+  would need column-name disambiguation (`system` appears on both `RomInstall` and `RomSaveState`).
 
-On foreign keys: the split introduces a category that did not exist when the
-"one FK only" rule was written — **per-ROM child tables that are true
-parent-child** (per-ROM state is owned by the ROM and meaningless without it).
-They take `ON DELETE CASCADE`, exactly like the one FK the epic already
-sanctioned. Cross-aggregate references (`platform_slug`) keep **no** FK. This is
-the same intent as the locked rule — FK for ownership, no FK for cross-references
-— applied to the new tables. "Playtime survives shortcut removal" is preserved:
-shortcut removal does not delete the `roms` row; only a deliberate full prune
-does, and cascading per-ROM state when the ROM is genuinely gone is correct.
+On foreign keys: the split introduces a category that did not exist when the "one FK only" rule was written — **per-ROM
+child tables that are true parent-child** (per-ROM state is owned by the ROM and meaningless without it). They take
+`ON DELETE CASCADE`, exactly like the one FK the epic already sanctioned. Cross-aggregate references (`platform_slug`)
+keep **no** FK. This is the same intent as the locked rule — FK for ownership, no FK for cross-references — applied to
+the new tables. "Playtime survives shortcut removal" is preserved: shortcut removal does not delete the `roms` row; only
+a deliberate full prune does, and cascading per-ROM state when the ROM is genuinely gone is correct.
 
 ## Consequences
 
 - ~13 tables instead of the mega-table's ~9.
-- A full game-detail read (all per-ROM aggregates for one ROM) becomes a few
-  point reads / a join rather than one row read — sub-millisecond and rare. In
-  exchange, the hot library-list scan and the frequent playtime write touch
+- A full game-detail read (all per-ROM aggregates for one ROM) becomes a few point reads / a join rather than one row
+  read — sub-millisecond and rare. In exchange, the hot library-list scan and the frequent playtime write touch
   **narrower** rows.
-- A library prune is a single `DELETE FROM roms WHERE …` — the CASCADE FKs clear
-  every per-ROM child. No app-level multi-table cleanup, no orphan risk.
-- Foreign-key count goes 1 → 5. `PRAGMA foreign_keys=ON` (already locked by the
-  epic, set per-connection by the adapter) is required for the cascades to fire.
-- This **deviates from the epic's literal wording** ("one `roms` mega-table",
-  "no other FKs"). Both were explicit starting points written before the split;
-  #780 is the sanctioned place to finalize the layout, so this is a resolution,
-  not a relitigation. ADR-0001's "`platform_slug` as an FK" wording is clarified
-  there to mean a logical reference, not a DB constraint.
-- It is **not a one-way door.** Merging back to a mega-table (or splitting a
-  table further) later is an internal numbered migration plus a repository SQL
-  rewrite — not a user-facing breaking change.
+- A library prune is a single `DELETE FROM roms WHERE …` — the CASCADE FKs clear every per-ROM child. No app-level
+  multi-table cleanup, no orphan risk.
+- Foreign-key count goes 1 → 5. `PRAGMA foreign_keys=ON` (already locked by the epic, set per-connection by the adapter)
+  is required for the cascades to fire.
+- This **deviates from the epic's literal wording** ("one `roms` mega-table", "no other FKs"). Both were explicit
+  starting points written before the split; #780 is the sanctioned place to finalize the layout, so this is a
+  resolution, not a relitigation. ADR-0001's "`platform_slug` as an FK" wording is clarified there to mean a logical
+  reference, not a DB constraint.
+- It is **not a one-way door.** Merging back to a mega-table (or splitting a table further) later is an internal
+  numbered migration plus a repository SQL rewrite — not a user-facing breaking change.
 
 ## Alternatives considered
 
-- **Mega-table** (rejected). Fewer tables, one point read for game-detail, and
-  consistent with the literal "one FK" rule. Rejected because it cannot enforce
-  the all-or-nothing groups (many nullable columns; half-set states are
-  representable) and turns `roms` into a wide grab-bag. The integrity cost
-  outweighs a read-speed win that is irrelevant at single-user scale.
-- **Middle-ground hybrid** — keep the light, always-present state (identity,
-  playtime) in `roms` and split out only the bulky/independent `rom_metadata`
-  and `rom_save_states`. Rejected: it has no clean rule ("which fields live
-  where?") and is less legible than the uniform full split.
+- **Mega-table** (rejected). Fewer tables, one point read for game-detail, and consistent with the literal "one FK"
+  rule. Rejected because it cannot enforce the all-or-nothing groups (many nullable columns; half-set states are
+  representable) and turns `roms` into a wide grab-bag. The integrity cost outweighs a read-speed win that is irrelevant
+  at single-user scale.
+- **Middle-ground hybrid** — keep the light, always-present state (identity, playtime) in `roms` and split out only the
+  bulky/independent `rom_metadata` and `rom_save_states`. Rejected: it has no clean rule ("which fields live where?")
+  and is less legible than the uniform full split.

--- a/docs/adr/0003-json-sqlite-persistence-boundary.md
+++ b/docs/adr/0003-json-sqlite-persistence-boundary.md
@@ -6,131 +6,120 @@ Accepted. **Supersedes [ADR-0001](0001-adopt-platform-aggregate.md)** (Platform-
 
 ## Context
 
-Epic [#271](https://github.com/danielcopper/decky-romm-sync/issues/271) migrates
-persistence from JSON files to SQLite. The epic decided that `settings.json`
-"stays JSON", but the recorded rationale is thin — three asserted adjectives in
-the epic's storage-scope table ("small, rarely written; credential security is
-orthogonal"), no ADR, never stress-tested key by key. Every later mention only
-*cites* the epic (`domain/sync_settings.py`, `database-design.md`), never
-re-argues it.
+Epic [#271](https://github.com/danielcopper/decky-romm-sync/issues/271) migrates persistence from JSON files to SQLite.
+The epic decided that `settings.json` "stays JSON", but the recorded rationale is thin — three asserted adjectives in
+the epic's storage-scope table ("small, rarely written; credential security is orthogonal"), no ADR, never stress-tested
+key by key. Every later mention only _cites_ the epic (`domain/sync_settings.py`, `database-design.md`), never re-argues
+it.
 
-In practice the boundary drifted to **by file, not by concept**, and two
-inconsistencies surfaced while scoping the Repository Protocols
-([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)):
+In practice the boundary drifted to **by file, not by concept**, and two inconsistencies surfaced while scoping the
+Repository Protocols ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)):
 
-- **`SyncSettings` is config that landed in the DB.** The save-sync feature
-  toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`,
-  `default_slot`, `autocleanup_limit`) became a SQLite aggregate + `sync_settings`
-  table (#788 / #780). These are pure user-intent toggles — appsettings, not
-  state — yet structurally-identical config in `settings.json` stayed JSON. So
-  "settings stay JSON" was already false at the concept level.
-- **Platform models a sync toggle that lives elsewhere.** ADR-0001 made
-  `Platform` a full aggregate; its `excluded_from_sync` field is the same concept
-  as `enabled_platforms` in `settings.json` (inverted), but `excluded_from_sync`
-  is **dead code** — declared on the aggregate and as a SQL column, read/written
-  nowhere. Platform's other justification fields (`emulation_stack`,
-  `manual_emulator_path`) **do not exist in code**, and its `display_name`
-  caching is already covered: the name resolves live from RomM during sync and,
-  for offline reads, is cached in a single `kv_config` slug→name row — no need
-  for a Platform aggregate.
+- **`SyncSettings` is config that landed in the DB.** The save-sync feature toggles (`save_sync_enabled`,
+  `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) became a SQLite aggregate +
+  `sync_settings` table (#788 / #780). These are pure user-intent toggles — appsettings, not state — yet
+  structurally-identical config in `settings.json` stayed JSON. So "settings stay JSON" was already false at the concept
+  level.
+- **Platform models a sync toggle that lives elsewhere.** ADR-0001 made `Platform` a full aggregate; its
+  `excluded_from_sync` field is the same concept as `enabled_platforms` in `settings.json` (inverted), but
+  `excluded_from_sync` is **dead code** — declared on the aggregate and as a SQL column, read/written nowhere.
+  Platform's other justification fields (`emulation_stack`, `manual_emulator_path`) **do not exist in code**, and its
+  `display_name` caching is already covered: the name resolves live from RomM during sync and, for offline reads, is
+  cached in a single `kv_config` slug→name row — no need for a Platform aggregate.
 
-This forced the underlying question: should `settings.json` move *into* the DB,
-or is the boundary simply mis-drawn? Reviewed from both sides:
+This forced the underlying question: should `settings.json` move _into_ the DB, or is the boundary simply mis-drawn?
+Reviewed from both sides:
 
-- **"Decky convention keeps settings as JSON"** is self-defeating as an argument
-  — by that logic the whole SQLite migration is wrong. Dropped.
-- **"Config can't be recovered after the empty-start cutover"** was overstated —
-  the user *can* re-type it; the real cost is manual re-entry, removable with a
-  one-time importer. Weak on its own.
-- **"settings.json has no `.prev` backup, so a crash truncates it"** (the
-  strongest pro-DB point) is **wrong**: `_locked_write` already writes to a temp
-  file and `os.replace`s it atomically, so a crash leaves the prior file intact.
-  The missing one-deep backup is cheaply addable in JSON, not a migration driver.
+- **"Decky convention keeps settings as JSON"** is self-defeating as an argument — by that logic the whole SQLite
+  migration is wrong. Dropped.
+- **"Config can't be recovered after the empty-start cutover"** was overstated — the user _can_ re-type it; the real
+  cost is manual re-entry, removable with a one-time importer. Weak on its own.
+- **"settings.json has no `.prev` backup, so a crash truncates it"** (the strongest pro-DB point) is **wrong**:
+  `_locked_write` already writes to a temp file and `os.replace`s it atomically, so a crash leaves the prior file
+  intact. The missing one-deep backup is cheaply addable in JSON, not a migration driver.
 
-What *does* hold: flat config has no cross-row invariants or relationships, so
-SQLite's value (aggregates, foreign keys, transactional integrity) buys nothing
-for it — moving it in is the relational-store tax for none of the benefit. The
-fix is therefore not "move settings to the DB" but **draw the boundary by what
-the data *is*, not which file it currently lives in.**
+What _does_ hold: flat config has no cross-row invariants or relationships, so SQLite's value (aggregates, foreign keys,
+transactional integrity) buys nothing for it — moving it in is the relational-store tax for none of the benefit. The fix
+is therefore not "move settings to the DB" but **draw the boundary by what the data _is_, not which file it currently
+lives in.**
 
 ## Decision
 
 Persisted data falls into three buckets, and the bucket decides the store:
 
-1. **User-intent config** — flat, no relationships, the user sets it. → **`settings.json`** (appsettings.json-style flat file).
-2. **Observed / derived-from-an-external-source** — read, not set (e.g. RetroDECK/RetroArch config on the system). → **read live by default.** Persist (in SQLite) **only** with a concrete reason: *cross-run change detection* (store the last-seen value to diff against live) **or** *offline survival of remote data*.
-3. **Synced / derived relational state with real invariants** — per-ROM groups, history, caches of remote data. → **SQLite aggregates.**
+1. **User-intent config** — flat, no relationships, the user sets it. → **`settings.json`** (appsettings.json-style flat
+   file).
+2. **Observed / derived-from-an-external-source** — read, not set (e.g. RetroDECK/RetroArch config on the system). →
+   **read live by default.** Persist (in SQLite) **only** with a concrete reason: _cross-run change detection_ (store
+   the last-seen value to diff against live) **or** _offline survival of remote data_.
+3. **Synced / derived relational state with real invariants** — per-ROM groups, history, caches of remote data. →
+   **SQLite aggregates.**
 
 ### Full mapping
 
-| Data | Today | Bucket | Home | Why |
-| --- | --- | --- | --- | --- |
-| `romm_url`, `romm_user`, `romm_pass`, `steamgriddb_api_key` | settings.json | 1 | **settings.json** | User-set config/secrets. No DB security gain (plaintext either way); not re-derivable, must survive the empty-start cutover. |
-| `steam_input_mode`, `log_level`, `romm_allow_insecure_ssl`, `collection_create_platform_groups` | settings.json | 1 | **settings.json** | Pure scalar toggles. |
-| `enabled_platforms`, `enabled_collections` | settings.json | 1 | **settings.json** | Sync-*selection* = user intent. No relational invariants; the available list comes from RomM, the choice is config. |
-| `save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit` (SyncSettings) | save_sync_state.json → `sync_settings` table | 1 | **settings.json** | Feature toggles = config. The `sync_settings` table is dropped. |
-| `device_name` | save_sync_state.json → `device` table | 1 | **settings.json** | User-set label. |
-| `device_id` (server_device_id) | save_sync_state.json → `device` table | 3 | **`kv_config`** (DB) | Server-issued identity; singleton scalar, no invariants → a kv row, not a table. |
-| `retrodeck_home_path` (+`_previous`), `save_sort_settings` (+`_previous`) | state.json | 2 | **`kv_config`** (DB) | Observed values persisted as last-seen markers for cross-run change detection (`migration.py` diffs live vs stored to trigger path migration). |
-| `shortcut_registry`, `installed_roms`, `downloaded_bios`, sync scalars | state.json | 3 | DB (`roms`, `rom_installs`, `downloaded_bios`, `sync_runs`) | Synced/derived relational state. Unchanged from the epic. |
-| per-ROM saves, playtime | save_sync_state.json | 3 | DB (`rom_save_states`/`rom_save_files`, `rom_playtime`) | Per-ROM state with invariants. Unchanged. |
-| RomM metadata, firmware inventory | metadata_cache.json, firmware_cache.json | 3 | DB (`rom_metadata`, `firmware_cache`) | Offline cache of remote data, per owning table. Unchanged. |
+| Data                                                                                                             | Today                                        | Bucket | Home                                                        | Why                                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `romm_url`, `romm_user`, `romm_pass`, `steamgriddb_api_key`                                                      | settings.json                                | 1      | **settings.json**                                           | User-set config/secrets. No DB security gain (plaintext either way); not re-derivable, must survive the empty-start cutover.                   |
+| `steam_input_mode`, `log_level`, `romm_allow_insecure_ssl`, `collection_create_platform_groups`                  | settings.json                                | 1      | **settings.json**                                           | Pure scalar toggles.                                                                                                                           |
+| `enabled_platforms`, `enabled_collections`                                                                       | settings.json                                | 1      | **settings.json**                                           | Sync-_selection_ = user intent. No relational invariants; the available list comes from RomM, the choice is config.                            |
+| `save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit` (SyncSettings) | save_sync_state.json → `sync_settings` table | 1      | **settings.json**                                           | Feature toggles = config. The `sync_settings` table is dropped.                                                                                |
+| `device_name`                                                                                                    | save_sync_state.json → `device` table        | 1      | **settings.json**                                           | User-set label.                                                                                                                                |
+| `device_id` (server_device_id)                                                                                   | save_sync_state.json → `device` table        | 3      | **`kv_config`** (DB)                                        | Server-issued identity; singleton scalar, no invariants → a kv row, not a table.                                                               |
+| `retrodeck_home_path` (+`_previous`), `save_sort_settings` (+`_previous`)                                        | state.json                                   | 2      | **`kv_config`** (DB)                                        | Observed values persisted as last-seen markers for cross-run change detection (`migration.py` diffs live vs stored to trigger path migration). |
+| `shortcut_registry`, `installed_roms`, `downloaded_bios`, sync scalars                                           | state.json                                   | 3      | DB (`roms`, `rom_installs`, `downloaded_bios`, `sync_runs`) | Synced/derived relational state. Unchanged from the epic.                                                                                      |
+| per-ROM saves, playtime                                                                                          | save_sync_state.json                         | 3      | DB (`rom_save_states`/`rom_save_files`, `rom_playtime`)     | Per-ROM state with invariants. Unchanged.                                                                                                      |
+| RomM metadata, firmware inventory                                                                                | metadata_cache.json, firmware_cache.json     | 3      | DB (`rom_metadata`, `firmware_cache`)                       | Offline cache of remote data, per owning table. Unchanged.                                                                                     |
 
-No generic `romm_cache` catch-all table: remote data is cached in the table that
-owns it (`rom_metadata`, `firmware_cache`); a generic cache table would be an
-untyped dumping ground (the trap `kv_config` itself is fenced against).
+No generic `romm_cache` catch-all table: remote data is cached in the table that owns it (`rom_metadata`,
+`firmware_cache`); a generic cache table would be an untyped dumping ground (the trap `kv_config` itself is fenced
+against).
 
 ## Consequences
 
 **Three tables + aggregates are dropped from the #780 schema:**
 
 - `sync_settings` table + `SyncSettings` aggregate — knobs move to `settings.json`.
-- `platforms` table + `Platform` aggregate — **this supersedes ADR-0001.** Platform reverts to a denormalised `platform_slug` string (ADR-0001's rejected option 1). Sync exclusion stays `enabled_platforms` in settings; the `roms` row stores only `platform_slug`, and the display name is resolved live from RomM during each sync — for offline reads it survives RomM downtime via a single `platform_slug → display_name` blob cached in a `kv_config` row (refreshed every sync), **not** denormalised onto each ROM row; `excluded_from_sync` (dead) is removed. Rebuild a Platform aggregate when a concrete need lands (the standalone-emulator roadmap), not speculatively.
-- `device` table + `Device` aggregate — `device_id` → a `kv_config` row, `device_name` → `settings.json`. The two were unrelated scalars sharing a struct, so the split is honest, not a split aggregate.
+- `platforms` table + `Platform` aggregate — **this supersedes ADR-0001.** Platform reverts to a denormalised
+  `platform_slug` string (ADR-0001's rejected option 1). Sync exclusion stays `enabled_platforms` in settings; the
+  `roms` row stores only `platform_slug`, and the display name is resolved live from RomM during each sync — for offline
+  reads it survives RomM downtime via a single `platform_slug → display_name` blob cached in a `kv_config` row
+  (refreshed every sync), **not** denormalised onto each ROM row; `excluded_from_sync` (dead) is removed. Rebuild a
+  Platform aggregate when a concrete need lands (the standalone-emulator roadmap), not speculatively.
+- `device` table + `Device` aggregate — `device_id` → a `kv_config` row, `device_name` → `settings.json`. The two were
+  unrelated scalars sharing a struct, so the split is honest, not a split aggregate.
 
-**The Repository Protocol set (#782) shrinks 12 → 9:** `Rom`, `RomInstall`,
-`RomMetadata`, `Playtime`, `RomSaveState`, `BiosFile`, `FirmwareCache`,
-`SyncRun`, `KvConfig`. (Dropped: `SyncSettings`, `Platform`, `Device`.)
+**The Repository Protocol set (#782) shrinks 12 → 9:** `Rom`, `RomInstall`, `RomMetadata`, `Playtime`, `RomSaveState`,
+`BiosFile`, `FirmwareCache`, `SyncRun`, `KvConfig`. (Dropped: `SyncSettings`, `Platform`, `Device`.)
 
 **Migration paths** (resolved here, implemented downstream):
 
-- **SyncSettings (5 knobs) + `device_name`: a JSON→JSON move**, independent of
-  SQLite — it can ship anytime, decoupled from the cutover. A settings-schema
-  bump (`migrate_settings`, `_SETTINGS_VERSION` 3 → 4 in
-  `domain/state_migrations.py`) reads the values out of `save_sync_state.json`
-  once and folds them into `settings.json`; services repoint to settings; the
-  keys are dropped from the save-sync state shape. Because these now live in
+- **SyncSettings (5 knobs) + `device_name`: a JSON→JSON move**, independent of SQLite — it can ship anytime, decoupled
+  from the cutover. A settings-schema bump (`migrate_settings`, `_SETTINGS_VERSION` 3 → 4 in
+  `domain/state_migrations.py`) reads the values out of `save_sync_state.json` once and folds them into `settings.json`;
+  services repoint to settings; the keys are dropped from the save-sync state shape. Because these now live in
   `settings.json`, they **survive the empty-start cutover** untouched.
 - **`device_id`: `save_sync_state.json` → `kv_config`**, at the cutover
-  ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) — it is
-  DB-bound, so it moves when the DB becomes the live store.
-- **Schema:** amend `001_initial.sql` to remove the three tables. The DB is
-  created-but-unused pre-cutover (the migration runner from
-  [#781](https://github.com/danielcopper/decky-romm-sync/issues/781) applies the
-  schema, but no service reads it yet), so any existing `romm_sync.db` is
-  disposable — amending the initial schema is correct; no `DROP TABLE` migration
-  is needed for real data that does not exist.
+  ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) — it is DB-bound, so it moves when the DB becomes
+  the live store.
+- **Schema:** amend `001_initial.sql` to remove the three tables. The DB is created-but-unused pre-cutover (the
+  migration runner from [#781](https://github.com/danielcopper/decky-romm-sync/issues/781) applies the schema, but no
+  service reads it yet), so any existing `romm_sync.db` is disposable — amending the initial schema is correct; no
+  `DROP TABLE` migration is needed for real data that does not exist.
 
-**`kv_config` stays** as the home for the change-detection markers and
-`device_id`. It remains reserved for the truly-singleton and miscellaneous —
-not a dumping ground.
+**`kv_config` stays** as the home for the change-detection markers and `device_id`. It remains reserved for the
+truly-singleton and miscellaneous — not a dumping ground.
 
-**Not a one-way door.** If the standalone-emulator work later needs genuinely
-locally-owned per-platform state, a `Platform` aggregate is reintroduced then,
-with real call sites — a numbered migration, not a user-facing break.
+**Not a one-way door.** If the standalone-emulator work later needs genuinely locally-owned per-platform state, a
+`Platform` aggregate is reintroduced then, with real call sites — a numbered migration, not a user-facing break.
 
 ## Alternatives considered
 
-- **Move everything (incl. settings + secrets) into SQLite.** Rejected: flat
-  config has no relational payoff (DB-as-hashmap), and the strongest technical
-  pro-DB argument (no atomic settings write) is factually wrong — `_locked_write`
-  already gives atomicity via temp-file + `os.replace`. A full move buys one
-  migration mechanism at the cost of a one-time importer + a credentials table,
-  for config that has nothing relational to gain.
-- **Keep the status-quo by-file boundary.** Rejected: it is not principled — it
-  leaves config (`SyncSettings`) in the DB and dead config (`excluded_from_sync`)
-  in the schema. The asymmetry is incidental, not designed.
-- **Keep `Platform`/`Device` as forward-looking aggregates.** Rejected on YAGNI:
-  `excluded_from_sync` is dead code, `emulation_stack`/`manual_emulator_path`
-  do not exist, display-name caching is already covered, and `device` is two
+- **Move everything (incl. settings + secrets) into SQLite.** Rejected: flat config has no relational payoff
+  (DB-as-hashmap), and the strongest technical pro-DB argument (no atomic settings write) is factually wrong —
+  `_locked_write` already gives atomicity via temp-file + `os.replace`. A full move buys one migration mechanism at the
+  cost of a one-time importer + a credentials table, for config that has nothing relational to gain.
+- **Keep the status-quo by-file boundary.** Rejected: it is not principled — it leaves config (`SyncSettings`) in the DB
+  and dead config (`excluded_from_sync`) in the schema. The asymmetry is incidental, not designed.
+- **Keep `Platform`/`Device` as forward-looking aggregates.** Rejected on YAGNI: `excluded_from_sync` is dead code,
+  `emulation_stack`/`manual_emulator_path` do not exist, display-name caching is already covered, and `device` is two
   unrelated scalars. Build the aggregate when the need is concrete.

--- a/docs/adr/0004-sync-sqlite-unit-of-work.md
+++ b/docs/adr/0004-sync-sqlite-unit-of-work.md
@@ -3,99 +3,74 @@
 ## Status
 
 Accepted. **Reverses the runtime-UoW connection decision recorded in epic
-[#271](https://github.com/danielcopper/decky-romm-sync/issues/271)** ("fresh
-`aiosqlite.connect()` per UoW … Async chosen over sync+executor"), which was a
-planning-session decision never exercised in code.
+[#271](https://github.com/danielcopper/decky-romm-sync/issues/271)** ("fresh `aiosqlite.connect()` per UoW … Async
+chosen over sync+executor"), which was a planning-session decision never exercised in code.
 
 ## Context
 
-Epic #271 locked the runtime Unit-of-Work on **async `aiosqlite`** (vendored),
-having flipped from an initial sync recommendation during the design session.
-The two recorded drivers were: ~150–250 LOC less service boilerplate (no
-`run_in_executor` shim per DB-touching method) and a uniform
-`async def + async with uow` shape (one indirection step instead of two —
-better traceability). It was explicitly **not** chosen for performance. The
-decision was never implemented — `aiosqlite` was never vendored, and the only
-persistence code that has landed (the [#781](https://github.com/danielcopper/decky-romm-sync/issues/781)
-migration runner) is stdlib `sqlite3`.
+Epic #271 locked the runtime Unit-of-Work on **async `aiosqlite`** (vendored), having flipped from an initial sync
+recommendation during the design session. The two recorded drivers were: ~150–250 LOC less service boilerplate (no
+`run_in_executor` shim per DB-touching method) and a uniform `async def + async with uow` shape (one indirection step
+instead of two — better traceability). It was explicitly **not** chosen for performance. The decision was never
+implemented — `aiosqlite` was never vendored, and the only persistence code that has landed (the
+[#781](https://github.com/danielcopper/decky-romm-sync/issues/781) migration runner) is stdlib `sqlite3`.
 
-Re-examined before implementing
-[#783](https://github.com/danielcopper/decky-romm-sync/issues/783), with three
-findings:
+Re-examined before implementing [#783](https://github.com/danielcopper/decky-romm-sync/issues/783), with three findings:
 
-- **There is no performance or correctness dimension.** `aiosqlite` is itself
-  thread-based — it runs one dedicated worker thread plus a queue and per-call
-  futures *per connection*. It is a friendlier async *surface* over the same
-  blocking `sqlite3`, not async I/O. Both `aiosqlite` and `sqlite3` +
-  `run_in_executor` keep the event loop responsive identically (each offloads
-  the blocking call to a thread). For a single-user, single-writer,
-  microsecond-local-query workload, WAL's reader/writer concurrency — the one
-  structural feature `aiosqlite`'s serialized worker model could expose — has
-  nothing to exploit. The epic already knew this ("not for speed"); confirming
-  it removes any lingering "async is more correct under asyncio" intuition.
-- **A sync precedent now exists in the code.** The merged #781 migration runner
-  is stdlib `sqlite3`. Sync for the runtime UoW is consistent with it; async
-  would split the persistence layer across two paradigms.
-- **`run_in_executor` is the house idiom.** The `do_<verb>` / `_<verb>_io` +
-  `loop.run_in_executor` pattern is used pervasively across services (CLAUDE.md
-  "Async/sync method naming"). It is already reviewed and familiar, and the UoW
-  slots straight into it. `aiosqlite` would introduce a *second* way to do I/O.
+- **There is no performance or correctness dimension.** `aiosqlite` is itself thread-based — it runs one dedicated
+  worker thread plus a queue and per-call futures _per connection_. It is a friendlier async _surface_ over the same
+  blocking `sqlite3`, not async I/O. Both `aiosqlite` and `sqlite3` + `run_in_executor` keep the event loop responsive
+  identically (each offloads the blocking call to a thread). For a single-user, single-writer, microsecond-local-query
+  workload, WAL's reader/writer concurrency — the one structural feature `aiosqlite`'s serialized worker model could
+  expose — has nothing to exploit. The epic already knew this ("not for speed"); confirming it removes any lingering
+  "async is more correct under asyncio" intuition.
+- **A sync precedent now exists in the code.** The merged #781 migration runner is stdlib `sqlite3`. Sync for the
+  runtime UoW is consistent with it; async would split the persistence layer across two paradigms.
+- **`run_in_executor` is the house idiom.** The `do_<verb>` / `_<verb>_io` + `loop.run_in_executor` pattern is used
+  pervasively across services (CLAUDE.md "Async/sync method naming"). It is already reviewed and familiar, and the UoW
+  slots straight into it. `aiosqlite` would introduce a _second_ way to do I/O.
 
 ## Decision
 
-The runtime Unit-of-Work and Repository adapters use **stdlib `sqlite3`
-(synchronous)**. No `aiosqlite`; no new vendored dependency.
+The runtime Unit-of-Work and Repository adapters use **stdlib `sqlite3` (synchronous)**. No `aiosqlite`; no new vendored
+dependency.
 
-- The UoW is a **synchronous context manager** that opens one `sqlite3`
-  connection per operation, applies the runtime PRAGMAs, exposes the nine
-  repositories, and commits / rolls back on exit.
-- Services call it from their `async def` callables via the existing
-  `run_in_executor` idiom — the `with uow_factory() as uow:` block runs inside
-  the synchronous `_<verb>_io` / `do_<verb>` worker.
-- **Thread affinity** (a `sqlite3` connection is single-thread by default,
-  `check_same_thread=True`) is handled by opening and closing the connection
-  *inside* the executor call, so the connection never escapes its worker
-  thread — matching the existing `_..._io` pattern. `check_same_thread` is left
-  at its safe default.
+- The UoW is a **synchronous context manager** that opens one `sqlite3` connection per operation, applies the runtime
+  PRAGMAs, exposes the nine repositories, and commits / rolls back on exit.
+- Services call it from their `async def` callables via the existing `run_in_executor` idiom — the
+  `with uow_factory() as uow:` block runs inside the synchronous `_<verb>_io` / `do_<verb>` worker.
+- **Thread affinity** (a `sqlite3` connection is single-thread by default, `check_same_thread=True`) is handled by
+  opening and closing the connection _inside_ the executor call, so the connection never escapes its worker thread —
+  matching the existing `_..._io` pattern. `check_same_thread` is left at its safe default.
 
-Unchanged from epic #271 (these were never the contested part): connection
-**per UoW**; **service-scoped** UoW lifecycle (thin `main.py` callables don't
-see the factory); **one UoW per platform unit** for library sync (a crash loses
-only the in-flight unit); repositories **return domain aggregates**, not
-TypedDicts. Runtime per-connection PRAGMAs: `foreign_keys=ON`,
-`synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY`,
-`isolation_level=None` (the UoW issues explicit `BEGIN`/`COMMIT`/`ROLLBACK`);
-`journal_mode=WAL` is persistent and already set by the #781 runner.
+Unchanged from epic #271 (these were never the contested part): connection **per UoW**; **service-scoped** UoW lifecycle
+(thin `main.py` callables don't see the factory); **one UoW per platform unit** for library sync (a crash loses only the
+in-flight unit); repositories **return domain aggregates**, not TypedDicts. Runtime per-connection PRAGMAs:
+`foreign_keys=ON`, `synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY`, `isolation_level=None` (the UoW
+issues explicit `BEGIN`/`COMMIT`/`ROLLBACK`); `journal_mode=WAL` is persistent and already set by the #781 runner.
 
 ## Consequences
 
-- The ~150–250 LOC of `run_in_executor` boilerplate the epic sought to avoid is
-  accepted as the cost — but it is the *already-familiar* house idiom, not new
-  cognitive load, and each per-method shim nests into the `_io` worker services
+- The ~150–250 LOC of `run_in_executor` boilerplate the epic sought to avoid is accepted as the cost — but it is the
+  _already-familiar_ house idiom, not new cognitive load, and each per-method shim nests into the `_io` worker services
   already use.
-- No `aiosqlite` under `_vendor/` — one fewer third-party surface to patch and
-  track in a plugin that has no package manager.
-- The epic body's "Connection pattern" bullet is superseded by this ADR.
-  `#783`'s body had drifted the other way (`sqlite3` but `synchronous=FULL` and
-  TypedDict returns); the live values are `synchronous=NORMAL` (the epic and the
-  `001_initial.sql` DDL comment already say NORMAL — `FULL` was a stale
-  copy-error) and aggregate returns.
+- No `aiosqlite` under `_vendor/` — one fewer third-party surface to patch and track in a plugin that has no package
+  manager.
+- The epic body's "Connection pattern" bullet is superseded by this ADR. `#783`'s body had drifted the other way
+  (`sqlite3` but `synchronous=FULL` and TypedDict returns); the live values are `synchronous=NORMAL` (the epic and the
+  `001_initial.sql` DDL comment already say NORMAL — `FULL` was a stale copy-error) and aggregate returns.
 
 ## Not a one-way door
 
-If a second concurrent writer or process is introduced (e.g. a CLI or web
-consumer alongside the plugin — also the chapter-8 domain-events trigger), or a
-long-lived connection held across many awaits becomes the natural design,
-`aiosqlite`'s by-construction thread-affinity safety could pay for itself.
-Revisit then, with real call sites. None of those conditions hold today.
+If a second concurrent writer or process is introduced (e.g. a CLI or web consumer alongside the plugin — also the
+chapter-8 domain-events trigger), or a long-lived connection held across many awaits becomes the natural design,
+`aiosqlite`'s by-construction thread-affinity safety could pay for itself. Revisit then, with real call sites. None of
+those conditions hold today.
 
 ## Alternatives considered
 
-- **Async `aiosqlite` (the epic's locked choice).** Rejected on re-examination:
-  no performance or concurrency gain for this workload (it is thread-based
-  too), it requires vendoring a dependency, and it introduces a second I/O
-  paradigm alongside the established `run_in_executor` idiom and the sync #781
-  runner. Its one genuine advantage — thread-affinity safety by construction —
-  is cheaply matched by connection-per-operation inside the executor. The
-  boilerplate-and-traceability case for it is real but does not outweigh the
-  dependency-plus-paradigm-split cost.
+- **Async `aiosqlite` (the epic's locked choice).** Rejected on re-examination: no performance or concurrency gain for
+  this workload (it is thread-based too), it requires vendoring a dependency, and it introduces a second I/O paradigm
+  alongside the established `run_in_executor` idiom and the sync #781 runner. Its one genuine advantage —
+  thread-affinity safety by construction — is cheaply matched by connection-per-operation inside the executor. The
+  boilerplate-and-traceability case for it is real but does not outweigh the dependency-plus-paradigm-split cost.

--- a/docs/adr/0005-launcher-resolves-path-from-sqlite.md
+++ b/docs/adr/0005-launcher-resolves-path-from-sqlite.md
@@ -2,116 +2,96 @@
 
 ## Status
 
-**Superseded by [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md).**
-The gate this ADR set — #827 proving `SetAppLaunchOptions`-on-existing reliable —
-passed, so the "dumb exec wrapper / path baked into `launch_options`" end state
-(#785) landed and the interim DB-read launcher described below is retired. This
-record is kept for the history of why the interim existed.
+**Superseded by [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md).** The gate this ADR set — #827
+proving `SetAppLaunchOptions`-on-existing reliable — passed, so the "dumb exec wrapper / path baked into
+`launch_options`" end state (#785) landed and the interim DB-read launcher described below is retired. This record is
+kept for the history of why the interim existed.
 
 Originally accepted as the **interim** launcher design shipped with the cutover
-([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)). Revisited
-the "dumb exec wrapper / path baked into `launch_options`" approach locked in
-[#785](https://github.com/danielcopper/decky-romm-sync/issues/785), which was
-**deferred, not rejected** — it stayed the intended end state, gated on the
-hardware test in [#827](https://github.com/danielcopper/decky-romm-sync/issues/827).
+([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)). Revisited the "dumb exec wrapper / path baked into
+`launch_options`" approach locked in [#785](https://github.com/danielcopper/decky-romm-sync/issues/785), which was
+**deferred, not rejected** — it stayed the intended end state, gated on the hardware test in
+[#827](https://github.com/danielcopper/decky-romm-sync/issues/827).
 
 ## Context
 
-`bin/romm-launcher` is the exe Steam runs for every RomM shortcut. Today it
-parses `romm:<rom_id>` from `launch_options`, reads `state.json` via an inline
-`python3` heredoc, looks up `installed_roms[<id>].file_path`, and execs
-`flatpak run net.retrodeck.retrodeck "<path>"`. The path is resolved
-**dynamically at launch time**, not stored in the shortcut.
+`bin/romm-launcher` is the exe Steam runs for every RomM shortcut. Today it parses `romm:<rom_id>` from
+`launch_options`, reads `state.json` via an inline `python3` heredoc, looks up `installed_roms[<id>].file_path`, and
+execs `flatpak run net.retrodeck.retrodeck "<path>"`. The path is resolved **dynamically at launch time**, not stored in
+the shortcut.
 
-The cutover deletes `state.json`. So the launcher must change — it is the one
-**out-of-process** reader of the state being migrated; every in-process reader
-is handled by the service refactor.
+The cutover deletes `state.json`. So the launcher must change — it is the one **out-of-process** reader of the state
+being migrated; every in-process reader is handled by the service refactor.
 
-Issue #785 proposed making the launcher a pure exec wrapper: bake the resolved path
-into `launch_options` at **download-complete** and have the launcher just `exec`
-what it's handed. Two facts, established by investigation, undercut that as the
-*near-term* design:
+Issue #785 proposed making the launcher a pure exec wrapper: bake the resolved path into `launch_options` at
+**download-complete** and have the launcher just `exec` what it's handed. Two facts, established by investigation,
+undercut that as the _near-term_ design:
 
-- **Updating an existing shortcut is documented-unreliable.**
-  `docs/architecture/steam-non-steam-shortcuts.md` and `CLAUDE.md` both state
-  that `Set*` / `SetAppLaunchOptions` on an already-existing shortcut "may not
-  take effect reliably; the workaround is delete + recreate." Shortcuts are
-  created at **sync** time (before download), so writing the path at
-  download-complete is exactly an update-to-existing — the unreliable path. The
-  claim is documented but **never empirically validated** (no hardware test, no
-  Steam version note). #785's own body flags this as the central open risk.
-- **Dynamic resolution gives free path propagation.** A RetroDECK-home
-  migration rewrites install paths and the launcher picks up the new path on the
-  next launch with **zero shortcut updates**. Baking would force a re-resolve
-  pass that rewrites every affected shortcut's `launch_options` — N more
-  unreliable updates, and behaviour the code deliberately does not do today.
+- **Updating an existing shortcut is documented-unreliable.** `docs/architecture/steam-non-steam-shortcuts.md` and
+  `CLAUDE.md` both state that `Set*` / `SetAppLaunchOptions` on an already-existing shortcut "may not take effect
+  reliably; the workaround is delete + recreate." Shortcuts are created at **sync** time (before download), so writing
+  the path at download-complete is exactly an update-to-existing — the unreliable path. The claim is documented but
+  **never empirically validated** (no hardware test, no Steam version note). #785's own body flags this as the central
+  open risk.
+- **Dynamic resolution gives free path propagation.** A RetroDECK-home migration rewrites install paths and the launcher
+  picks up the new path on the next launch with **zero shortcut updates**. Baking would force a re-resolve pass that
+  rewrites every affected shortcut's `launch_options` — N more unreliable updates, and behaviour the code deliberately
+  does not do today.
 
-The dynamic-resolution launcher was a deliberate choice to avoid unreliable
-shortcut mutation. The cutover should preserve that property, not trade it for
-an unvalidated mechanism — while leaving #785's vision reachable if the
+The dynamic-resolution launcher was a deliberate choice to avoid unreliable shortcut mutation. The cutover should
+preserve that property, not trade it for an unvalidated mechanism — while leaving #785's vision reachable if the
 mechanism proves reliable.
 
 ## Decision
 
-The launcher **keeps resolving the path dynamically at launch**, swapping its
-source from `state.json` to the SQLite database:
+The launcher **keeps resolving the path dynamically at launch**, swapping its source from `state.json` to the SQLite
+database:
 
 ```sql
 SELECT file_path FROM rom_installs WHERE rom_id = ?
 ```
 
-opened **read-only** (`file:<db>?mode=ro`) — WAL allows an external reader to
-query the last committed snapshot while the plugin writes, without blocking. The
-launcher locates `<runtime_dir>/romm_sync.db` the same way it locates
-`state.json` today. `launch_options` **keeps carrying `romm:<rom_id>`**, so
-ownership detection (scanning for `romm:`) is unchanged and no shortcut is ever
-updated — at download, at migration, or otherwise.
+opened **read-only** (`file:<db>?mode=ro`) — WAL allows an external reader to query the last committed snapshot while
+the plugin writes, without blocking. The launcher locates `<runtime_dir>/romm_sync.db` the same way it locates
+`state.json` today. `launch_options` **keeps carrying `romm:<rom_id>`**, so ownership detection (scanning for `romm:`)
+is unchanged and no shortcut is ever updated — at download, at migration, or otherwise.
 
-This source-swap ships **inside the cutover (#784)** — the launcher is migrated
-like every other reader of the state being moved. Consequently **#784 no longer
-depends on #785**: the launcher keeps working the moment `state.json` is
+This source-swap ships **inside the cutover (#784)** — the launcher is migrated like every other reader of the state
+being moved. Consequently **#784 no longer depends on #785**: the launcher keeps working the moment `state.json` is
 deleted, with no broken-launch window.
 
 ### Gated end state
 
-The "dumb exec wrapper" (#785) — path baked into `launch_options`, launcher
-resolves nothing — remains the **intended target**, contingent on #827 proving
-`SetAppLaunchOptions`-on-existing reliable on real hardware:
+The "dumb exec wrapper" (#785) — path baked into `launch_options`, launcher resolves nothing — remains the **intended
+target**, contingent on #827 proving `SetAppLaunchOptions`-on-existing reliable on real hardware:
 
-- **Reliable** → #785 proceeds; the interim DB read is removed in favour of the
-  baked path; the launcher becomes resolution-free.
-- **Unreliable / flaky** → the DB-read launcher is the **permanent** design;
-  #785 shrinks to the `bin/rom-launcher` rename plus the #129 groundwork.
+- **Reliable** → #785 proceeds; the interim DB read is removed in favour of the baked path; the launcher becomes
+  resolution-free.
+- **Unreliable / flaky** → the DB-read launcher is the **permanent** design; #785 shrinks to the `bin/rom-launcher`
+  rename plus the #129 groundwork.
 
 ## Consequences
 
-- The launcher is coupled to the `rom_installs` schema (`file_path`, `rom_id`).
-  This is **no worse than today** — it is already coupled to the `state.json`
-  shape (`installed_roms[<id>].file_path`); a boundary reader must read
-  *something*. ADR-0003's decoupling intent was about the *services*, not this
-  external launcher.
-- Free path propagation on RetroDECK-home migration is preserved (migration
-  updates `rom_installs.file_path`; the launcher reads it next launch).
-- The interim launcher code is throwaway-ish if #827 passes and the dumb wrapper
-  lands — accepted as cheap insurance (~a few lines of inline `python3`).
-- **#129 (multi-emulator) directional note:** if the DB-read launcher becomes
-  *permanent* (test fails), emulator selection tends to drift into the launcher
-  alongside path resolution. A hybrid — path from the DB, emulator invocation
-  still passed as data via `launch_options` — keeps selection at the
-  shortcut-build call site. Not a blocker, and only relevant in the test-fails
-  branch.
+- The launcher is coupled to the `rom_installs` schema (`file_path`, `rom_id`). This is **no worse than today** — it is
+  already coupled to the `state.json` shape (`installed_roms[<id>].file_path`); a boundary reader must read _something_.
+  ADR-0003's decoupling intent was about the _services_, not this external launcher.
+- Free path propagation on RetroDECK-home migration is preserved (migration updates `rom_installs.file_path`; the
+  launcher reads it next launch).
+- The interim launcher code is throwaway-ish if #827 passes and the dumb wrapper lands — accepted as cheap insurance (~a
+  few lines of inline `python3`).
+- **#129 (multi-emulator) directional note:** if the DB-read launcher becomes _permanent_ (test fails), emulator
+  selection tends to drift into the launcher alongside path resolution. A hybrid — path from the DB, emulator invocation
+  still passed as data via `launch_options` — keeps selection at the shortcut-build call site. Not a blocker, and only
+  relevant in the test-fails branch.
 
 ## Alternatives considered
 
-- **Bake the resolved path into `launch_options` at download-complete (the #785
-  locked design).** Deferred, not adopted now: it relies on
-  `SetAppLaunchOptions`-on-existing, which is documented-unreliable and
-  unvalidated, and it forces an N-shortcut re-resolve pass on home migration.
-  Revisit after #827. If reliable, it is the cleaner end state (resolution-free
-  launcher, no DB coupling, natural fit for #129).
-- **Hold #784's `state.json` deletion until #785 lands.** Rejected: recreates
-  the #784→#785 dependency and leaves the cutover not self-contained. The
-  source-swap is small and keeps the cutover whole.
+- **Bake the resolved path into `launch_options` at download-complete (the #785 locked design).** Deferred, not adopted
+  now: it relies on `SetAppLaunchOptions`-on-existing, which is documented-unreliable and unvalidated, and it forces an
+  N-shortcut re-resolve pass on home migration. Revisit after #827. If reliable, it is the cleaner end state
+  (resolution-free launcher, no DB coupling, natural fit for #129).
+- **Hold #784's `state.json` deletion until #785 lands.** Rejected: recreates the #784→#785 dependency and leaves the
+  cutover not self-contained. The source-swap is small and keeps the cutover whole.
 
-See also: [ADR-0003](0003-json-sqlite-persistence-boundary.md) (persistence
-boundary), [ADR-0004](0004-sync-sqlite-unit-of-work.md) (sync UoW).
+See also: [ADR-0003](0003-json-sqlite-persistence-boundary.md) (persistence boundary),
+[ADR-0004](0004-sync-sqlite-unit-of-work.md) (sync UoW).

--- a/docs/adr/0006-narrow-unit-of-work-scope.md
+++ b/docs/adr/0006-narrow-unit-of-work-scope.md
@@ -2,65 +2,54 @@
 
 ## Status
 
-Accepted. Refines [ADR-0004](0004-sync-sqlite-unit-of-work.md), which set the
-sync-`sqlite3` + `run_in_executor` UoW but left the transaction *scope* open.
+Accepted. Refines [ADR-0004](0004-sync-sqlite-unit-of-work.md), which set the sync-`sqlite3` + `run_in_executor` UoW but
+left the transaction _scope_ open.
 
 ## Context
 
-SQLite WAL allows many concurrent readers but exactly **one writer for the whole
-database**; `busy_timeout=5000` makes a second writer wait up to 5s and then fail
-with `SQLITE_BUSY`. Every heavy backend operation runs in the default thread
-pool, so two DB-writing operations genuinely overlap on different threads. The
-routine case — established by investigation, not assumed — is a user pressing
-**Play on a game (which fires `pre_launch_sync`, writing save tables) during a
-background library sync** (writing `roms` / `rom_metadata` / `sync_runs`); the
-two are ungated and overlap every session a sync is running.
+SQLite WAL allows many concurrent readers but exactly **one writer for the whole database**; `busy_timeout=5000` makes a
+second writer wait up to 5s and then fail with `SQLITE_BUSY`. Every heavy backend operation runs in the default thread
+pool, so two DB-writing operations genuinely overlap on different threads. The routine case — established by
+investigation, not assumed — is a user pressing **Play on a game (which fires `pre_launch_sync`, writing save tables)
+during a background library sync** (writing `roms` / `rom_metadata` / `sync_runs`); the two are ungated and overlap
+every session a sync is running.
 
-A naïve "open the UoW at the worker's entry, do everything inside, commit at
-exit" would hold the single write transaction across the operation's server
-fetches, multi-second file downloads/uploads, and — for library sync — the
-up-to-60s wait for the frontend to ack a unit. That stalls every other writer
-for the whole I/O duration and turns any >5s hold into a hard `SQLITE_BUSY`
-error on routine concurrency. The existing JSON code already avoids this by
-mutating an in-memory object during the I/O and persisting **once at the end**.
+A naïve "open the UoW at the worker's entry, do everything inside, commit at exit" would hold the single write
+transaction across the operation's server fetches, multi-second file downloads/uploads, and — for library sync — the
+up-to-60s wait for the frontend to ack a unit. That stalls every other writer for the whole I/O duration and turns any
+
+> 5s hold into a hard `SQLITE_BUSY` error on routine concurrency. The existing JSON code already avoids this by mutating
+> an in-memory object during the I/O and persisting **once at the end**.
 
 ## Decision
 
-A Unit of Work wraps **only the database reads and writes — never network I/O,
-file I/O, or a frontend round-trip.** An operation that interleaves I/O opens a
-**short read UoW** (load the aggregates it needs), performs its I/O **outside any
-transaction** (mutating the loaded aggregates in memory), then opens a **short
-write UoW** (persist). A simple mutation with no I/O is one short `with uow:`.
+A Unit of Work wraps **only the database reads and writes — never network I/O, file I/O, or a frontend round-trip.** An
+operation that interleaves I/O opens a **short read UoW** (load the aggregates it needs), performs its I/O **outside any
+transaction** (mutating the loaded aggregates in memory), then opens a **short write UoW** (persist). A simple mutation
+with no I/O is one short `with uow:`.
 
-Cross-operation consistency is provided by the operation's **own serialization**
-— the per-ROM `asyncio.Lock` for saves, the single background task for library
-sync — **not** by holding a UoW open. The per-ROM lock therefore survives the
-cutover unchanged: it is the *logical* serializer (it guards the whole
-read→fetch→transfer→write sequence, which a DB transaction cannot), orthogonal
-to the UoW, which is merely the *atomic DB write*. No single dedicated DB-writer
-thread and no application-level DB locks are introduced.
+Cross-operation consistency is provided by the operation's **own serialization** — the per-ROM `asyncio.Lock` for saves,
+the single background task for library sync — **not** by holding a UoW open. The per-ROM lock therefore survives the
+cutover unchanged: it is the _logical_ serializer (it guards the whole read→fetch→transfer→write sequence, which a DB
+transaction cannot), orthogonal to the UoW, which is merely the _atomic DB write_. No single dedicated DB-writer thread
+and no application-level DB locks are introduced.
 
 ## Consequences
 
-- Some workers open the UoW twice (read, then write) with I/O between. This is
-  the same shape the JSON code already had (load state → do I/O → persist once),
-  not new ceremony.
-- A read-then-write window exists between the two short UoWs; it is closed by the
-  operation's lock / single-task serialization, not by the database. Safe because
-  no other operation mutates the same aggregate concurrently.
-- No write transaction is ever held across slow I/O, so the routine
-  "launch during sync" overlap cannot produce `SQLITE_BUSY` — narrow writes run
-  in tens of milliseconds, and even a bulk per-unit registry commit is
-  sub-second, far under `busy_timeout`.
+- Some workers open the UoW twice (read, then write) with I/O between. This is the same shape the JSON code already had
+  (load state → do I/O → persist once), not new ceremony.
+- A read-then-write window exists between the two short UoWs; it is closed by the operation's lock / single-task
+  serialization, not by the database. Safe because no other operation mutates the same aggregate concurrently.
+- No write transaction is ever held across slow I/O, so the routine "launch during sync" overlap cannot produce
+  `SQLITE_BUSY` — narrow writes run in tens of milliseconds, and even a bulk per-unit registry commit is sub-second, far
+  under `busy_timeout`.
 
 ## Alternatives considered
 
-- **Wide UoW** (one `with uow:` around the whole operation). Rejected: holds the
-  single WAL writer across network/file/ack I/O, stalling all other writers and
-  raising `SQLITE_BUSY` on routine concurrency. Simpler to write, wrong for a
-  single-writer DB shared by overlapping operations.
-- **Single dedicated DB-writer thread** (serialize all DB access through one
-  executor). Rejected: it does not remove the need to keep transactions off slow
-  I/O — a wide transaction on the single thread just queues everyone for the I/O
-  duration — and it adds a second executor hop to every DB call. Unnecessary for
-  a single-user plugin where narrow writes are already ~tens of ms.
+- **Wide UoW** (one `with uow:` around the whole operation). Rejected: holds the single WAL writer across
+  network/file/ack I/O, stalling all other writers and raising `SQLITE_BUSY` on routine concurrency. Simpler to write,
+  wrong for a single-writer DB shared by overlapping operations.
+- **Single dedicated DB-writer thread** (serialize all DB access through one executor). Rejected: it does not remove the
+  need to keep transactions off slow I/O — a wide transaction on the single thread just queues everyone for the I/O
+  duration — and it adds a second executor hop to every DB call. Unnecessary for a single-user plugin where narrow
+  writes are already ~tens of ms.

--- a/docs/adr/0007-rom-retention-identity-anchor.md
+++ b/docs/adr/0007-rom-retention-identity-anchor.md
@@ -2,58 +2,45 @@
 
 ## Status
 
-Accepted. Refines [ADR-0002](0002-per-rom-table-per-aggregate-split.md) (the
-per-ROM table split + cascade FKs) by fixing the *retention* policy #780
-deferred — specifically that the cascade FKs do **not** auto-fire.
+Accepted. Refines [ADR-0002](0002-per-rom-table-per-aggregate-split.md) (the per-ROM table split + cascade FKs) by
+fixing the _retention_ policy #780 deferred — specifically that the cascade FKs do **not** auto-fire.
 
 ## Context
 
-The schema (`db/migrations/001_initial.sql`) gives every per-ROM child table
-(`rom_installs`, `rom_metadata`, `rom_playtime`, `rom_save_states`,
-`rom_save_files`) an `ON DELETE CASCADE` foreign key onto `roms`, with a comment
-that `roms` rows are "deleted ONLY on a deliberate library prune (ROM genuinely
-gone from RomM)." But "genuinely gone from RomM" is exactly what the **automatic**
-library sync detects (its `stale_rom_ids` pass) — so reading the comment
-literally would make the cascade fire automatically and destroy a ROM's local
-**playtime and saves** on any transient server blip, collection-visibility
-change, or reversible RomM edit. The confirmed domain priority is that local
-playtime and save history **survive a ROM leaving RomM**.
+The schema (`db/migrations/001_initial.sql`) gives every per-ROM child table (`rom_installs`, `rom_metadata`,
+`rom_playtime`, `rom_save_states`, `rom_save_files`) an `ON DELETE CASCADE` foreign key onto `roms`, with a comment that
+`roms` rows are "deleted ONLY on a deliberate library prune (ROM genuinely gone from RomM)." But "genuinely gone from
+RomM" is exactly what the **automatic** library sync detects (its `stale_rom_ids` pass) — so reading the comment
+literally would make the cascade fire automatically and destroy a ROM's local **playtime and saves** on any transient
+server blip, collection-visibility change, or reversible RomM edit. The confirmed domain priority is that local playtime
+and save history **survive a ROM leaving RomM**.
 
 ## Decision
 
-- The `roms` row is a permanent **identity anchor**, keyed by RomM's stable
-  `rom_id`. **Transient absence — removing the Steam shortcut, uninstalling
-  files, or the automatic sync finding the ROM no longer on RomM — never deletes
-  the `roms` row.** It *unbinds* (NULLs `shortcut_app_id` via
-  `Rom.unbind_shortcut()`) and/or drops only the directly-affected child row
-  (e.g. `rom_installs` on uninstall). Playtime, saves, and metadata persist.
-- A cascade `DELETE` of a `roms` row (which atomically reaps every per-ROM child
-  via the FKs) is reserved for a **deliberate purge** — an explicit, opt-in user
-  action. That action **does not exist today** and is out of scope for the
-  cutover; the cascade FKs sit dormant until it is built.
-- **No time-based GC.** `roms` grows with every ROM ever seen; rows are tiny
-  (single-digit MB over years even for a heavy curator), and the stable `rom_id`
-  re-links cleanly on re-add. This is accepted over mirroring RomM exactly.
+- The `roms` row is a permanent **identity anchor**, keyed by RomM's stable `rom_id`. **Transient absence — removing the
+  Steam shortcut, uninstalling files, or the automatic sync finding the ROM no longer on RomM — never deletes the `roms`
+  row.** It _unbinds_ (NULLs `shortcut_app_id` via `Rom.unbind_shortcut()`) and/or drops only the directly-affected
+  child row (e.g. `rom_installs` on uninstall). Playtime, saves, and metadata persist.
+- A cascade `DELETE` of a `roms` row (which atomically reaps every per-ROM child via the FKs) is reserved for a
+  **deliberate purge** — an explicit, opt-in user action. That action **does not exist today** and is out of scope for
+  the cutover; the cascade FKs sit dormant until it is built.
+- **No time-based GC.** `roms` grows with every ROM ever seen; rows are tiny (single-digit MB over years even for a
+  heavy curator), and the stable `rom_id` re-links cleanly on re-add. This is accepted over mirroring RomM exactly.
 
 ## Consequences
 
-- The cascade FKs are real and correct but **never auto-fire** — a future reader
-  seeing `ON DELETE CASCADE` with no automatic `DELETE` path should land here.
-- "Playtime survives shortcut removal" generalizes to "local history survives a
-  ROM leaving RomM."
-- The `001_initial.sql` retention comment, ADR-0002, and
-  `docs/architecture/database-design.md` get their wording sharpened
-  (auto-stale = unbind; deliberate purge = delete) in the cutover PR (#784).
-- If `roms` growth ever becomes a genuine concern, the middle ground is an
-  opt-in GC over a precise "fully dead" predicate (no shortcut, not installed,
-  server-stale, **and** no playtime/saves worth keeping) — never coupling
+- The cascade FKs are real and correct but **never auto-fire** — a future reader seeing `ON DELETE CASCADE` with no
+  automatic `DELETE` path should land here.
+- "Playtime survives shortcut removal" generalizes to "local history survives a ROM leaving RomM."
+- The `001_initial.sql` retention comment, ADR-0002, and `docs/architecture/database-design.md` get their wording
+  sharpened (auto-stale = unbind; deliberate purge = delete) in the cutover PR (#784).
+- If `roms` growth ever becomes a genuine concern, the middle ground is an opt-in GC over a precise "fully dead"
+  predicate (no shortcut, not installed, server-stale, **and** no playtime/saves worth keeping) — never coupling
   deletion to the automatic sync.
 
 ## Alternatives considered
 
-- **Auto-delete on sync-stale** (the literal DDL-comment reading). Rejected: an
-  automatic, possibly-transient signal would cascade-destroy playtime/saves; a
-  blip or reversible RomM change is then unrecoverable, and re-add starts fresh.
-- **Pure never-delete** (no purge path at all). Not adopted as a hard rule — the
-  cascade FKs stay so a deliberate purge can be added cheaply later; we simply
-  never auto-fire them.
+- **Auto-delete on sync-stale** (the literal DDL-comment reading). Rejected: an automatic, possibly-transient signal
+  would cascade-destroy playtime/saves; a blip or reversible RomM change is then unrecoverable, and re-add starts fresh.
+- **Pure never-delete** (no purge path at all). Not adopted as a hard rule — the cascade FKs stay so a deliberate purge
+  can be added cheaply later; we simply never auto-fire them.

--- a/docs/adr/0008-rom-install-launch-file-and-rom-dir.md
+++ b/docs/adr/0008-rom-install-launch-file-and-rom-dir.md
@@ -2,129 +2,95 @@
 
 ## Status
 
-Accepted. Refines the `RomInstall` aggregate (introduced for the per-ROM split
-in [ADR-0002](0002-per-rom-table-per-aggregate-split.md), schema in #780) by
-fixing the `install_path` dual-meaning that the JSON→SQLite remodel (#784)
-introduced, and records the **per-file `RomFile[]` model as the committed but
-deferred target**.
+Accepted. Refines the `RomInstall` aggregate (introduced for the per-ROM split in
+[ADR-0002](0002-per-rom-table-per-aggregate-split.md), schema in #780) by fixing the `install_path` dual-meaning that
+the JSON→SQLite remodel (#784) introduced, and records the **per-file `RomFile[]` model as the committed but deferred
+target**.
 
 ## Context
 
-The legacy JSON install record (`InstalledRomEntry`) carried `file_path` always,
-plus `rom_dir: NotRequired[str]` — `rom_dir` was set **only** for ROMs extracted
-from a multi-file archive; a single-file ROM had no `rom_dir` and its containing
-directory was inferred from `file_path`. Presence/absence of `rom_dir` *was* the
-single-vs-multi signal.
+The legacy JSON install record (`InstalledRomEntry`) carried `file_path` always, plus `rom_dir: NotRequired[str]` —
+`rom_dir` was set **only** for ROMs extracted from a multi-file archive; a single-file ROM had no `rom_dir` and its
+containing directory was inferred from `file_path`. Presence/absence of `rom_dir` _was_ the single-vs-multi signal.
 
-The SQLite remodel renamed `rom_dir` → `install_path` and made it `NOT NULL`. To
-keep it always-populated, a single-file install's `install_path` was back-filled
-with `os.path.dirname(file_path)` — i.e. the **shared system directory**
-(`<roms>/<system>/`), the dir that holds *every* ROM of that platform — while a
-multi-file install's `install_path` is its **dedicated extract directory**
-(`<roms>/<system>/<romname>/`). One field, two meanings.
+The SQLite remodel renamed `rom_dir` → `install_path` and made it `NOT NULL`. To keep it always-populated, a single-file
+install's `install_path` was back-filled with `os.path.dirname(file_path)` — i.e. the **shared system directory**
+(`<roms>/<system>/`), the dir that holds _every_ ROM of that platform — while a multi-file install's `install_path` is
+its **dedicated extract directory** (`<roms>/<system>/<romname>/`). One field, two meanings.
 
-That forced every consumer to *re-derive* "is this multi-file?" from path shape:
-migration used `install_path != dirname(file_path)`, removal used
-`is_safe_rom_path`'s segment-depth. The path-shape test is **wrong for the common
-flat multi-file case** — the launch file (often an auto-generated `.m3u`) sits
-directly in the extract dir, so `dirname(file_path) == install_path` exactly as
-for a single-file ROM. A RetroDECK-home migration therefore moved only the launch
-file and orphaned the sibling disc/update/DLC files (the data-loss bug that
-surfaced this decision).
+That forced every consumer to _re-derive_ "is this multi-file?" from path shape: migration used
+`install_path != dirname(file_path)`, removal used `is_safe_rom_path`'s segment-depth. The path-shape test is **wrong
+for the common flat multi-file case** — the launch file (often an auto-generated `.m3u`) sits directly in the extract
+dir, so `dirname(file_path) == install_path` exactly as for a single-file ROM. A RetroDECK-home migration therefore
+moved only the launch file and orphaned the sibling disc/update/DLC files (the data-loss bug that surfaced this
+decision).
 
-Forward context (more multi-file work is coming, and we want the shape right):
-upstream RomM models this domain as `Rom` (the logical game / launch identity) +
-`RomFile[]` (one row per physical file, each tagged with a `category`:
-`game`/`dlc`/`update`/`mod`/`patch`/`manual`/…). Single-vs-multi is **derived**
-from the file rows there, never stored. On disk RomM uses folder-per-game for
-multi-file and a bare file for single-file — exactly this plugin's layout. The
-features that would need the richer model are tracked and **not yet actionable**:
-per-file download/resume + WiiU (#140, currently **blocked** on a version-aware
-RomM API gateway #143) and multi-emulator / standalone Eden (#129), where
-the #837 reporter's "base→`roms/`, updates+DLC→`storage/<game>/`" placement lives.
+Forward context (more multi-file work is coming, and we want the shape right): upstream RomM models this domain as `Rom`
+(the logical game / launch identity) + `RomFile[]` (one row per physical file, each tagged with a `category`:
+`game`/`dlc`/`update`/`mod`/`patch`/`manual`/…). Single-vs-multi is **derived** from the file rows there, never stored.
+On disk RomM uses folder-per-game for multi-file and a bare file for single-file — exactly this plugin's layout. The
+features that would need the richer model are tracked and **not yet actionable**: per-file download/resume + WiiU (#140,
+currently **blocked** on a version-aware RomM API gateway #143) and multi-emulator / standalone Eden (#129), where the
+#837 reporter's "base→`roms/`, updates+DLC→`storage/<game>/`" placement lives.
 
 ## Decision
 
 - **`RomInstall` carries `file_path` (always) and `rom_dir` (nullable).**
-  - `file_path` is the **launch target** — the file baked into the Steam
-    shortcut's `launch_options` (`flatpak run … "<file_path>"`) that the
-    `rom-launcher` exec wrapper is handed and runs (per
-    [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md), which
-    superseded the dynamic SQLite read of
-    [ADR-0005](0005-launcher-resolves-path-from-sqlite.md)); save-path
-    resolution, ES-DE core resolution, and the displayed filename all derive
-    from it. It is load-bearing for every ROM and is never NULL.
-  - `rom_dir` is the **dedicated per-ROM directory**, set only for folder-backed
-    (multi-file) ROMs. It is **NULL for single-file ROMs**, which live as a bare
-    file directly in the shared `<roms>/<system>/` dir and own no folder.
-- **Rename `install_path` → `rom_dir`.** Single-vs-multi is read from `rom_dir`
-  presence — never re-derived from `dirname(file_path)`, never stored as a
-  separate boolean (an `owns_install_dir`-style flag is rejected; the folder's
-  presence *is* the flag).
-- **Consumers branch on `rom_dir` presence.** Migration moves the whole `rom_dir`
-  when set, else just the file. Uninstall `remove_tree`s `rom_dir` when set, else
-  deletes the file; `is_safe_rom_path` stays as the path-containment guard, no
-  longer the single-vs-multi discriminator.
-- **Schema: `rom_dir TEXT` (nullable)** in `001_initial.sql`, renamed from
-  `install_path TEXT NOT NULL`. #784 is the first release that creates the
-  database (DB-init is wired in #784, commit `0122364`), so this is an edit to
-  `001_initial.sql`, **not** a new migration. `NULL` (not `""`) for the
-  single-file "no dedicated folder" case, per the schema's NULL-for-meaningful-
-  absence rule.
-- **The per-file `Rom` + `RomFile[]` + `category` model is the committed target,
-  NOT built in #784.** It is deferred to the feature that needs it (#140;
-  related #129). Keeping `file_path` and `rom_dir` as two **distinct** fields
-  preserves RomM's launch-identity / physical-files seam, so a future
-  `rom_files` 1:N child table (keyed `rom_id`, `ON DELETE CASCADE`, mirroring the
-  existing `rom_save_files` child) is a purely **additive** `002_*.sql` migration
-  plus a re-sync — not a rewrite. `rom_dir` then names the directory those
-  `rom_files` rows live under; `file_path` stays the launch target.
+  - `file_path` is the **launch target** — the file baked into the Steam shortcut's `launch_options`
+    (`flatpak run … "<file_path>"`) that the `rom-launcher` exec wrapper is handed and runs (per
+    [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md), which superseded the dynamic SQLite read of
+    [ADR-0005](0005-launcher-resolves-path-from-sqlite.md)); save-path resolution, ES-DE core resolution, and the
+    displayed filename all derive from it. It is load-bearing for every ROM and is never NULL.
+  - `rom_dir` is the **dedicated per-ROM directory**, set only for folder-backed (multi-file) ROMs. It is **NULL for
+    single-file ROMs**, which live as a bare file directly in the shared `<roms>/<system>/` dir and own no folder.
+- **Rename `install_path` → `rom_dir`.** Single-vs-multi is read from `rom_dir` presence — never re-derived from
+  `dirname(file_path)`, never stored as a separate boolean (an `owns_install_dir`-style flag is rejected; the folder's
+  presence _is_ the flag).
+- **Consumers branch on `rom_dir` presence.** Migration moves the whole `rom_dir` when set, else just the file.
+  Uninstall `remove_tree`s `rom_dir` when set, else deletes the file; `is_safe_rom_path` stays as the path-containment
+  guard, no longer the single-vs-multi discriminator.
+- **Schema: `rom_dir TEXT` (nullable)** in `001_initial.sql`, renamed from `install_path TEXT NOT NULL`. #784 is the
+  first release that creates the database (DB-init is wired in #784, commit `0122364`), so this is an edit to
+  `001_initial.sql`, **not** a new migration. `NULL` (not `""`) for the single-file "no dedicated folder" case, per the
+  schema's NULL-for-meaningful- absence rule.
+- **The per-file `Rom` + `RomFile[]` + `category` model is the committed target, NOT built in #784.** It is deferred to
+  the feature that needs it (#140; related #129). Keeping `file_path` and `rom_dir` as two **distinct** fields preserves
+  RomM's launch-identity / physical-files seam, so a future `rom_files` 1:N child table (keyed `rom_id`,
+  `ON DELETE CASCADE`, mirroring the existing `rom_save_files` child) is a purely **additive** `002_*.sql` migration
+  plus a re-sync — not a rewrite. `rom_dir` then names the directory those `rom_files` rows live under; `file_path`
+  stays the launch target.
 
 ## Consequences
 
-- The migration multi-file data-loss bug is fixed at the **model** level — no
-  path-shape heuristic remains to get wrong.
-- `rom_removal.py` simplifies: a `rom_dir`-presence branch instead of the
-  `is_safe_rom_path` depth trick (which only ever worked because single-file
-  `install_path` happened to be the one-segment shared dir).
-- Single-vs-multi reads off one nullable field — self-documenting; the
-  dual-meaning `install_path` is gone, and so is the redundant shared-dir value
-  stored for single-file ROMs.
-- The richer `RomFile[]` model is **documented and tracked** (this ADR, the #140
-  issue thread, `database-design.md`) so it is not forgotten; it lands additively
-  when #140 unblocks. Until then a multi-file install keeps "one launch file +
-  its folder," which is sufficient for the current single-launch-target behavior
-  (multi-disc via `.m3u`, base game for Switch) — it does **not** yet model
-  per-file categories or multi-destination placement.
-- Vocabulary (`file_path` = launch target, `rom_dir` = dedicated folder) is
-  recorded in `CONTEXT.md`.
-- A separate latent bug — the ES-DE per-game core override writes the gamelist
-  `<path>` as a bare basename, which is already wrong for folder-backed ROMs — is
-  tracked as its own follow-up and is **not** fixed here.
+- The migration multi-file data-loss bug is fixed at the **model** level — no path-shape heuristic remains to get wrong.
+- `rom_removal.py` simplifies: a `rom_dir`-presence branch instead of the `is_safe_rom_path` depth trick (which only
+  ever worked because single-file `install_path` happened to be the one-segment shared dir).
+- Single-vs-multi reads off one nullable field — self-documenting; the dual-meaning `install_path` is gone, and so is
+  the redundant shared-dir value stored for single-file ROMs.
+- The richer `RomFile[]` model is **documented and tracked** (this ADR, the #140 issue thread, `database-design.md`) so
+  it is not forgotten; it lands additively when #140 unblocks. Until then a multi-file install keeps "one launch file +
+  its folder," which is sufficient for the current single-launch-target behavior (multi-disc via `.m3u`, base game for
+  Switch) — it does **not** yet model per-file categories or multi-destination placement.
+- Vocabulary (`file_path` = launch target, `rom_dir` = dedicated folder) is recorded in `CONTEXT.md`.
+- A separate latent bug — the ES-DE per-game core override writes the gamelist `<path>` as a bare basename, which is
+  already wrong for folder-backed ROMs — is tracked as its own follow-up and is **not** fixed here.
 
 ## Alternatives considered
 
-- **`install_path` always populated (the status quo).** Rejected: dual meaning
-  (shared vs dedicated), forces a path-shape multi-file heuristic that is wrong
-  for flat archives (the bug), and the stored value is redundant with
+- **`install_path` always populated (the status quo).** Rejected: dual meaning (shared vs dedicated), forces a
+  path-shape multi-file heuristic that is wrong for flat archives (the bug), and the stored value is redundant with
   `dirname(file_path)` for single-file ROMs.
-- **An `owns_install_dir` boolean flag.** Rejected: re-introduces a stored signal
-  that the optional `rom_dir` already encodes by presence. It sounds right but
-  the folder itself is the signal.
-- **`file_path` optional, present only for multi-file.** Rejected: `file_path` is
-  load-bearing for *every* ROM (the launcher selects it; saves, core resolution,
-  filenames, and the migration relocation anchor all derive from it) — it cannot
-  be NULL for any type.
-- **A dedicated per-ROM folder for *every* ROM (single included), so `rom_dir` is
-  always set.** Technically viable — the launcher is path-explicit and ES-DE
-  scans subfolders recursively — but rejected: it diverges from RomM's and
-  ES-DE's bare-file-for-single convention, adds a folder layer to every game,
-  reworks placement + removal for no current benefit, and the genuine future
-  needs are better served by the additive `RomFile[]` seam than by foldering.
-- **Build `Rom` + `RomFile[]` + `category` now, in #784.** Rejected for this PR:
-  the forcing feature (#140) is blocked on #143; the table's columns (category?
-  per-file destination? download/resume state?) are undefined until #140/#129 are
-  designed; and the `user_version` framework makes it a zero-penalty additive
-  migration later. Building it now would be unread, likely-wrong scaffolding on a
-  near-complete cutover. It is adopted as the documented target instead, so the
+- **An `owns_install_dir` boolean flag.** Rejected: re-introduces a stored signal that the optional `rom_dir` already
+  encodes by presence. It sounds right but the folder itself is the signal.
+- **`file_path` optional, present only for multi-file.** Rejected: `file_path` is load-bearing for _every_ ROM (the
+  launcher selects it; saves, core resolution, filenames, and the migration relocation anchor all derive from it) — it
+  cannot be NULL for any type.
+- **A dedicated per-ROM folder for _every_ ROM (single included), so `rom_dir` is always set.** Technically viable — the
+  launcher is path-explicit and ES-DE scans subfolders recursively — but rejected: it diverges from RomM's and ES-DE's
+  bare-file-for-single convention, adds a folder layer to every game, reworks placement + removal for no current
+  benefit, and the genuine future needs are better served by the additive `RomFile[]` seam than by foldering.
+- **Build `Rom` + `RomFile[]` + `category` now, in #784.** Rejected for this PR: the forcing feature (#140) is blocked
+  on #143; the table's columns (category? per-file destination? download/resume state?) are undefined until #140/#129
+  are designed; and the `user_version` framework makes it a zero-penalty additive migration later. Building it now would
+  be unread, likely-wrong scaffolding on a near-complete cutover. It is adopted as the documented target instead, so the
   decision is recorded without paying for it prematurely.

--- a/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
+++ b/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
@@ -2,140 +2,103 @@
 
 ## Status
 
-Accepted. **Supersedes [ADR-0005](0005-launcher-resolves-path-from-sqlite.md)**,
-the interim DB-read launcher shipped with the cutover. ADR-0005 left the "dumb
-exec wrapper" ([#785](https://github.com/danielcopper/decky-romm-sync/issues/785))
-as the intended end state, **gated on**
-[#827](https://github.com/danielcopper/decky-romm-sync/issues/827) proving
-`SetAppLaunchOptions`-on-existing reliable. #827 passed; this ADR records the
-end state landing.
+Accepted. **Supersedes [ADR-0005](0005-launcher-resolves-path-from-sqlite.md)**, the interim DB-read launcher shipped
+with the cutover. ADR-0005 left the "dumb exec wrapper"
+([#785](https://github.com/danielcopper/decky-romm-sync/issues/785)) as the intended end state, **gated on**
+[#827](https://github.com/danielcopper/decky-romm-sync/issues/827) proving `SetAppLaunchOptions`-on-existing reliable.
+#827 passed; this ADR records the end state landing.
 
 ## Context
 
-ADR-0005 kept the launcher resolving the ROM path **dynamically at launch** —
-parsing `romm:<rom_id>` from `launch_options`, reading
-`SELECT file_path FROM rom_installs WHERE rom_id = ?` from the SQLite database
-opened read-only, then exec-ing RetroDECK. That was a deliberately conservative
-interim: it preserved free path propagation on RetroDECK-home migration and
-avoided mutating existing shortcuts, because the documentation at the time
-claimed `Set*` / `SetAppLaunchOptions` on an already-existing shortcut "may not
-take effect reliably." That claim was **documented but never empirically
-validated** — ADR-0005 flagged it as the central open risk and deferred the
-exec-wrapper design until it could be tested.
+ADR-0005 kept the launcher resolving the ROM path **dynamically at launch** — parsing `romm:<rom_id>` from
+`launch_options`, reading `SELECT file_path FROM rom_installs WHERE rom_id = ?` from the SQLite database opened
+read-only, then exec-ing RetroDECK. That was a deliberately conservative interim: it preserved free path propagation on
+RetroDECK-home migration and avoided mutating existing shortcuts, because the documentation at the time claimed `Set*` /
+`SetAppLaunchOptions` on an already-existing shortcut "may not take effect reliably." That claim was **documented but
+never empirically validated** — ADR-0005 flagged it as the central open risk and deferred the exec-wrapper design until
+it could be tested.
 
-[#827](https://github.com/danielcopper/decky-romm-sync/issues/827) tested it on
-real hardware. `SetAppLaunchOptions` on an existing shortcut proved **reliable**
-across all three scenarios that mattered: in-session (set + read-back in the
-same Steam session), across a Steam restart (the value persists), and under
-removal-churn (re-syncing a library that adds and removes shortcuts in the same
-pass). The one observed hazard is unrelated to the set itself — heavy
-removal-churn can corrupt Steam's in-memory shortcut state, but a Steam restart
-clears it. With the reliability question answered, the interim DB-read launcher
-no longer has a reason to exist.
+[#827](https://github.com/danielcopper/decky-romm-sync/issues/827) tested it on real hardware. `SetAppLaunchOptions` on
+an existing shortcut proved **reliable** across all three scenarios that mattered: in-session (set + read-back in the
+same Steam session), across a Steam restart (the value persists), and under removal-churn (re-syncing a library that
+adds and removes shortcuts in the same pass). The one observed hazard is unrelated to the set itself — heavy
+removal-churn can corrupt Steam's in-memory shortcut state, but a Steam restart clears it. With the reliability question
+answered, the interim DB-read launcher no longer has a reason to exist.
 
-The other ADR-0005 finding — that a Steam shortcut's `appId` is derived from
-`exe + appName` (CRC32) — turns out to **support** the baked design rather than
-threaten it. Because the `appId` is a function of `exe + appName` only,
-mutating `launch_options` (or `startDir`) on an existing shortcut is
-**appId-safe**: the shortcut keeps its identity, its artwork, its collection
-membership, and its `roms.shortcut_app_id` binding. Only changing `exe` or
-`appName` is destructive (it yields a different `appId`, i.e. a different
-shortcut), and the launch command lives entirely in `launch_options` — never in
-`exe` or `appName` — so re-resolving a path never disturbs the binding.
+The other ADR-0005 finding — that a Steam shortcut's `appId` is derived from `exe + appName` (CRC32) — turns out to
+**support** the baked design rather than threaten it. Because the `appId` is a function of `exe + appName` only,
+mutating `launch_options` (or `startDir`) on an existing shortcut is **appId-safe**: the shortcut keeps its identity,
+its artwork, its collection membership, and its `roms.shortcut_app_id` binding. Only changing `exe` or `appName` is
+destructive (it yields a different `appId`, i.e. a different shortcut), and the launch command lives entirely in
+`launch_options` — never in `exe` or `appName` — so re-resolving a path never disturbs the binding.
 
 ## Decision
 
-The launcher becomes a **pure exec wrapper**. `bin/rom-launcher` (renamed from
-`bin/romm-launcher`) is:
+The launcher becomes a **pure exec wrapper**. `bin/rom-launcher` (renamed from `bin/romm-launcher`) is:
 
 ```bash
 exec "$@"
 ```
 
-It owns no state, no path resolution, and no emulator knowledge. Steam hands it
-the full launch command as the shortcut's launch options and it runs exactly
-that.
+It owns no state, no path resolution, and no emulator knowledge. Steam hands it the full launch command as the
+shortcut's launch options and it runs exactly that.
 
-The launch command is **baked into the shortcut's `launch_options`** as
-`<emulator-invocation> "<resolved-rom-path>"`. The emulator invocation is a
-build-time variable (`resolve_emulator_invocation`, returning RetroDECK's
-`flatpak run net.retrodeck.retrodeck` today) — the seam where multi-emulator
-support ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129))
-will branch per ROM. The ROM path is quoted so paths with spaces survive
-`exec "$@"`. `launch_options` carries:
+The launch command is **baked into the shortcut's `launch_options`** as `<emulator-invocation> "<resolved-rom-path>"`.
+The emulator invocation is a build-time variable (`resolve_emulator_invocation`, returning RetroDECK's
+`flatpak run net.retrodeck.retrodeck` today) — the seam where multi-emulator support
+([#129](https://github.com/danielcopper/decky-romm-sync/issues/129)) will branch per ROM. The ROM path is quoted so
+paths with spaces survive `exec "$@"`. `launch_options` carries:
 
-- the **full command** for an installed ROM, written at **sync** (for ROMs
-  already on disk), at **download-complete** (the moment a ROM becomes
-  installed), and **re-resolved on RetroDECK-home migration** (a new
-  `migration_relaunch_options` event rewrites every installed+bound shortcut to
-  the relocated path);
-- the **empty string `""`** (placeholder) for an uninstalled ROM, until it is
-  downloaded.
+- the **full command** for an installed ROM, written at **sync** (for ROMs already on disk), at **download-complete**
+  (the moment a ROM becomes installed), and **re-resolved on RetroDECK-home migration** (a new
+  `migration_relaunch_options` event rewrites every installed+bound shortcut to the relocated path);
+- the **empty string `""`** (placeholder) for an uninstalled ROM, until it is downloaded.
 
-The `romm:<rom_id>` marker is **gone**. Two bindings that previously rode on it
-move off `launch_options`:
+The `romm:<rom_id>` marker is **gone**. Two bindings that previously rode on it move off `launch_options`:
 
-- **Ownership detection** — a RomM-managed shortcut is now identified by its
-  **exe path** ending in `/bin/rom-launcher`, not by scanning `launch_options`
-  for `romm:`.
-- **rom_id ↔ appId** — resolved through the backend's authoritative
-  `get_app_id_rom_id_map()` (the `roms.shortcut_app_id` binding), not parsed
-  from `launch_options`.
+- **Ownership detection** — a RomM-managed shortcut is now identified by its **exe path** ending in `/bin/rom-launcher`,
+  not by scanning `launch_options` for `romm:`.
+- **rom_id ↔ appId** — resolved through the backend's authoritative `get_app_id_rom_id_map()` (the
+  `roms.shortcut_app_id` binding), not parsed from `launch_options`.
 
-A shortcut is treated as RomM-owned only when **both** hold: its exe ends in
-`/bin/rom-launcher` **and** its appId is bound in the backend map. After a DB
-reset the backend map is empty, so our shortcuts are detected by exe but
-unmapped — treated as orphans, and re-sync recreates them.
+A shortcut is treated as RomM-owned only when **both** hold: its exe ends in `/bin/rom-launcher` **and** its appId is
+bound in the backend map. After a DB reset the backend map is empty, so our shortcuts are detected by exe but unmapped —
+treated as orphans, and re-sync recreates them.
 
-Every `SetAppLaunchOptions` on an existing shortcut uses a **fire-then-poll
-confirm**: set the value, then poll `RegisterForAppDetails` until the read-back
-`strLaunchOptions` matches (confirming `""` against an empty read-back is
-valid), or time out. The Set is no longer a fire-and-forget with an assumed
-result.
+Every `SetAppLaunchOptions` on an existing shortcut uses a **fire-then-poll confirm**: set the value, then poll
+`RegisterForAppDetails` until the read-back `strLaunchOptions` matches (confirming `""` against an empty read-back is
+valid), or time out. The Set is no longer a fire-and-forget with an assumed result.
 
 ## Consequences
 
-- The launcher is **resolution-free** — no DB coupling, no inline `python3`, no
-  `rom_installs` schema dependency. The boundary reader that ADR-0005 had to
-  keep is gone.
-- The launch path is **data** in `launch_options`, computed at the shortcut-build
-  call site. This is the natural home for emulator selection too, so
-  [#129](https://github.com/danielcopper/decky-romm-sync/issues/129)
-  (multi-emulator) and
-  [#865](https://github.com/danielcopper/decky-romm-sync/issues/865)
-  (disc-switch) are **non-breaking**: they change only the `launch_options` data
-  and the build-time invocation resolver, never the launcher binary or the
-  shortcut identity.
-- Free path propagation on RetroDECK-home migration is **no longer automatic** —
-  the migration now re-resolves and rewrites each installed+bound shortcut's
-  `launch_options` (the `migration_relaunch_options` event). This is the
-  N-shortcut update pass ADR-0005 wanted to avoid; #827 proved it reliable, so
-  it is now an acceptable cost, and the per-shortcut confirm makes a silently
-  dropped write observable.
-- **Breaking for existing shortcuts: a re-sync is required.** Shortcuts created
-  under the `romm:<rom_id>` model carry the old marker and no baked command;
-  they are detected by exe but recreated by re-sync to pick up the baked
+- The launcher is **resolution-free** — no DB coupling, no inline `python3`, no `rom_installs` schema dependency. The
+  boundary reader that ADR-0005 had to keep is gone.
+- The launch path is **data** in `launch_options`, computed at the shortcut-build call site. This is the natural home
+  for emulator selection too, so [#129](https://github.com/danielcopper/decky-romm-sync/issues/129) (multi-emulator) and
+  [#865](https://github.com/danielcopper/decky-romm-sync/issues/865) (disc-switch) are **non-breaking**: they change
+  only the `launch_options` data and the build-time invocation resolver, never the launcher binary or the shortcut
+  identity.
+- Free path propagation on RetroDECK-home migration is **no longer automatic** — the migration now re-resolves and
+  rewrites each installed+bound shortcut's `launch_options` (the `migration_relaunch_options` event). This is the
+  N-shortcut update pass ADR-0005 wanted to avoid; #827 proved it reliable, so it is now an acceptable cost, and the
+  per-shortcut confirm makes a silently dropped write observable.
+- **Breaking for existing shortcuts: a re-sync is required.** Shortcuts created under the `romm:<rom_id>` model carry
+  the old marker and no baked command; they are detected by exe but recreated by re-sync to pick up the baked
   `launch_options`. Accepted as a **pre-release** breaking change.
-- This **supersedes ADR-0005**. The interim DB-read launcher and the
-  `romm:<rom_id>` marker are retired; ADR-0005 is kept as the record of why the
-  interim existed and what gate (#827) had to clear before this design could
-  land.
+- This **supersedes ADR-0005**. The interim DB-read launcher and the `romm:<rom_id>` marker are retired; ADR-0005 is
+  kept as the record of why the interim existed and what gate (#827) had to clear before this design could land.
 
 ## Alternatives considered
 
-- **Keep the DB-read launcher permanently** (the ADR-0005 test-fails branch).
-  Rejected: #827 proved `SetAppLaunchOptions`-on-existing reliable, so the
-  conservatism that justified the interim no longer applies. The DB-read
-  launcher keeps the launcher coupled to the `rom_installs` schema and tends to
-  pull emulator selection into the launcher alongside path resolution — the
-  opposite of where #129 wants that decision to live.
-- **Bake the path but keep the `romm:<rom_id>` marker for ownership.** Rejected:
-  the marker and the baked command would both occupy `launch_options`, and the
-  exe path already uniquely identifies our shortcuts. Ownership-by-exe plus the
-  backend `get_app_id_rom_id_map()` binding is the cleaner split — the exe says
-  "ours," the backend map says "which ROM."
+- **Keep the DB-read launcher permanently** (the ADR-0005 test-fails branch). Rejected: #827 proved
+  `SetAppLaunchOptions`-on-existing reliable, so the conservatism that justified the interim no longer applies. The
+  DB-read launcher keeps the launcher coupled to the `rom_installs` schema and tends to pull emulator selection into the
+  launcher alongside path resolution — the opposite of where #129 wants that decision to live.
+- **Bake the path but keep the `romm:<rom_id>` marker for ownership.** Rejected: the marker and the baked command would
+  both occupy `launch_options`, and the exe path already uniquely identifies our shortcuts. Ownership-by-exe plus the
+  backend `get_app_id_rom_id_map()` binding is the cleaner split — the exe says "ours," the backend map says "which
+  ROM."
 
-See also: [ADR-0005](0005-launcher-resolves-path-from-sqlite.md) (superseded
-interim), [ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) (`RomInstall`
-launch `file_path` — the path baked into the command),
-[ADR-0003](0003-json-sqlite-persistence-boundary.md) (persistence boundary).
+See also: [ADR-0005](0005-launcher-resolves-path-from-sqlite.md) (superseded interim),
+[ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) (`RomInstall` launch `file_path` — the path baked into the
+command), [ADR-0003](0003-json-sqlite-persistence-boundary.md) (persistence boundary).

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-The Python backend follows **Cosmic Python** ("Architecture Patterns with Python") adapted for a single-user Decky plugin. Code is split into four layers with a strictly enforced dependency direction:
+The Python backend follows **Cosmic Python** ("Architecture Patterns with Python") adapted for a single-user Decky
+plugin. Code is split into four layers with a strictly enforced dependency direction:
 
 - **`services/`** — orchestration. Business logic and the public callable surface.
 - **`adapters/`** — I/O. Everything that touches the network, the filesystem, the clock, or Steam.
@@ -10,7 +11,9 @@ The Python backend follows **Cosmic Python** ("Architecture Patterns with Python
 - **`lib/`** — cross-cutting utilities independent of every other layer.
 - **`models/`** — data shapes (TypedDicts, dataclasses) independent of every other layer.
 
-Services depend on **Protocols** (defined in `services/protocols/`), never on concrete adapter classes. Adapters implement those Protocols. `bootstrap.py` is the composition root — the only place where concrete adapters meet services. `main.py` owns the Decky lifecycle and the callable surface; it holds no business logic.
+Services depend on **Protocols** (defined in `services/protocols/`), never on concrete adapter classes. Adapters
+implement those Protocols. `bootstrap.py` is the composition root — the only place where concrete adapters meet
+services. `main.py` owns the Decky lifecycle and the callable surface; it holds no business logic.
 
 ```python
 class Plugin:
@@ -69,7 +72,9 @@ Arrow direction: depends-on (A -> B means A uses B).
 
 ## The `XxxServiceConfig` constructor pattern
 
-Every service takes a **single** `config` keyword argument — a frozen dataclass named `<ServiceName>Config`. All dependencies live in the config: Protocol-typed adapters, infrastructure seams (event loop, logger, `Clock`, `UuidGen`, `Sleeper`), persistence callbacks, and settings-derived values. There are no bare-param or mixed constructors.
+Every service takes a **single** `config` keyword argument — a frozen dataclass named `<ServiceName>Config`. All
+dependencies live in the config: Protocol-typed adapters, infrastructure seams (event loop, logger, `Clock`, `UuidGen`,
+`Sleeper`), persistence callbacks, and settings-derived values. There are no bare-param or mixed constructors.
 
 ```python
 sync_service = LibraryService(
@@ -86,68 +91,103 @@ sync_service = LibraryService(
 )
 ```
 
-Outer services keep the `Service` token in both names (`SteamGridService` + `SteamGridServiceConfig`). Sub-services may use role-based names without the token when it reads more naturally (`SyncEngine` + `SyncEngineConfig`, `SyncOrchestrator` + `SyncOrchestratorConfig`).
+Outer services keep the `Service` token in both names (`SteamGridService` + `SteamGridServiceConfig`). Sub-services may
+use role-based names without the token when it reads more naturally (`SyncEngine` + `SyncEngineConfig`,
+`SyncOrchestrator` + `SyncOrchestratorConfig`).
 
 ## Module Responsibilities
 
 ### Services (`py_modules/services/`)
 
-Two services are large enough to be decomposed into sub-service packages (`services/library/` and `services/saves/`); the rest are single modules. A service over ~700 LOC is the decomposition signal.
+Two services are large enough to be decomposed into sub-service packages (`services/library/` and `services/saves/`);
+the rest are single modules. A service over ~700 LOC is the decomposition signal.
 
-| Module | Domain |
-| --- | --- |
-| `library/` | LibraryService façade — fetch ROMs, preview/apply sync, per-unit shortcut delivery, `roms`/`SyncRun` writes + queries (decomposed; see below) |
-| `saves/` | SaveService aggregate — `.srm` upload/download, conflict detection, slots, versions (decomposed; see below) |
-| `downloads.py` | DownloadService — ZIP extraction, M3U, fcntl-locked queue, progress |
-| `firmware.py` | FirmwareService — BIOS registry, downloads, per-core filtering |
-| `session_lifecycle.py` | SessionLifecycleService — post-exit orchestration (playtime + post-exit save sync + achievement sync + migration refresh) |
-| `migration.py` | MigrationService — RetroDECK path-change detection + file migration, save-sort change detection + conflict resolution |
-| `steamgrid.py` | SteamGridService — SteamGridDB fetch, cache, icons |
-| `artwork.py` | ArtworkService — cover art download, staging, cleanup |
-| `game_detail.py` | GameDetailService — game detail page data aggregation |
-| `playtime.py` | PlaytimeService — session recording into `rom_playtime`, RomM-note reconciliation |
-| `achievements.py` | AchievementsService — progress, caching, RA username |
-| `settings.py` | SettingsService — settings reads/writes, Steam Input config |
-| `rom_removal.py` | RomRemovalService — ROM file deletion + `rom_installs` cleanup via the UoW; keeps the `roms` row, playtime, and saves per ADR-0007 |
-| `cores.py` | CoreService — active-core lookup, core switching, gamelist edits |
-| `shortcut_removal.py` | ShortcutRemovalService — shortcut removal; unbinds the ROM in `roms` (keeps the row per ADR-0007) |
-| `metadata.py` | MetadataService — ROM metadata reads from `rom_metadata` (7-day TTL), app_id mapping |
-| `launch_gate.py` | LaunchGateService — pre-launch gate (rom lookup, install check, save status) |
-| `startup_healing.py` | StartupHealingService — prunes stale `rom_installs` rows against disk on load (via the UoW) + reconciles orphaned `running` SyncRuns (a hard crash leaves a `running` row → marked errored) |
-| `connection.py` | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials) |
-| `protocols/` | Protocol interfaces grouped by concern (see [Protocol Interfaces](#protocol-interfaces)) |
+| Module                 | Domain                                                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `library/`             | LibraryService façade — fetch ROMs, preview/apply sync, per-unit shortcut delivery, `roms`/`SyncRun` writes + queries (decomposed; see below)                                               |
+| `saves/`               | SaveService aggregate — `.srm` upload/download, conflict detection, slots, versions (decomposed; see below)                                                                                 |
+| `downloads.py`         | DownloadService — ZIP extraction, M3U, fcntl-locked queue, progress                                                                                                                         |
+| `firmware.py`          | FirmwareService — BIOS registry, downloads, per-core filtering                                                                                                                              |
+| `session_lifecycle.py` | SessionLifecycleService — post-exit orchestration (playtime + post-exit save sync + achievement sync + migration refresh)                                                                   |
+| `migration.py`         | MigrationService — RetroDECK path-change detection + file migration, save-sort change detection + conflict resolution                                                                       |
+| `steamgrid.py`         | SteamGridService — SteamGridDB fetch, cache, icons                                                                                                                                          |
+| `artwork.py`           | ArtworkService — cover art download, staging, cleanup                                                                                                                                       |
+| `game_detail.py`       | GameDetailService — game detail page data aggregation                                                                                                                                       |
+| `playtime.py`          | PlaytimeService — session recording into `rom_playtime`, RomM-note reconciliation                                                                                                           |
+| `achievements.py`      | AchievementsService — progress, caching, RA username                                                                                                                                        |
+| `settings.py`          | SettingsService — settings reads/writes, Steam Input config                                                                                                                                 |
+| `rom_removal.py`       | RomRemovalService — ROM file deletion + `rom_installs` cleanup via the UoW; keeps the `roms` row, playtime, and saves per ADR-0007                                                          |
+| `cores.py`             | CoreService — active-core lookup, core switching, gamelist edits                                                                                                                            |
+| `shortcut_removal.py`  | ShortcutRemovalService — shortcut removal; unbinds the ROM in `roms` (keeps the row per ADR-0007)                                                                                           |
+| `metadata.py`          | MetadataService — ROM metadata reads from `rom_metadata` (7-day TTL), app_id mapping                                                                                                        |
+| `launch_gate.py`       | LaunchGateService — pre-launch gate (rom lookup, install check, save status)                                                                                                                |
+| `startup_healing.py`   | StartupHealingService — prunes stale `rom_installs` rows against disk on load (via the UoW) + reconciles orphaned `running` SyncRuns (a hard crash leaves a `running` row → marked errored) |
+| `connection.py`        | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials)                                                               |
+| `protocols/`           | Protocol interfaces grouped by concern (see [Protocol Interfaces](#protocol-interfaces))                                                                                                    |
 
 #### LibraryService decomposition (`services/library/`)
 
 The library sync subsystem is a façade over three sub-services that coordinate through a shared `LibrarySyncStateBox`:
 
-| Module | Role |
-| --- | --- |
-| `service.py` | `LibraryService` façade — public callable surface; wires the sub-services and delegates |
-| `fetcher.py` | `LibraryFetcher` — read-only RomM roundtrips: list platforms/collections, the incremental/full pagination loop, per-unit work-queue construction |
-| `sync_orchestrator.py` | `SyncOrchestrator` — preview (read-only), the per-unit apply pipeline, cancel, the heartbeat clock, progress emission |
-| `reporter.py` | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries |
-| `_state.py` | `LibrarySyncStateBox` — shared mutable in-flight sync state; the single source of truth threaded through every sub-service |
+| Module                 | Role                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `service.py`           | `LibraryService` façade — public callable surface; wires the sub-services and delegates                                                          |
+| `fetcher.py`           | `LibraryFetcher` — read-only RomM roundtrips: list platforms/collections, the incremental/full pagination loop, per-unit work-queue construction |
+| `sync_orchestrator.py` | `SyncOrchestrator` — preview (read-only), the per-unit apply pipeline, cancel, the heartbeat clock, progress emission                            |
+| `reporter.py`          | `SyncReporter` — post-apply finalisation (artwork filenames, per-unit `roms` upsert + `SyncRun` lifecycle) and the `roms`-derived queries        |
+| `_state.py`            | `LibrarySyncStateBox` — shared mutable in-flight sync state; the single source of truth threaded through every sub-service                       |
 
-The pipeline is split **fetch (read-only) / apply (owns persistence)**: the fetcher never mutates the `roms` registry or `rom_metadata`, and the reporter's per-unit commit upserts each acked ROM's `roms` row and stamps its cached `rom_metadata` in the same write Unit of Work (Rom row first, then metadata — FK-safe). So a preview never mutates state, and an interrupted apply leaves only the units it already committed — incremental, per-unit delivery.
+The pipeline is split **fetch (read-only) / apply (owns persistence)**: the fetcher never mutates the `roms` registry or
+`rom_metadata`, and the reporter's per-unit commit upserts each acked ROM's `roms` row and stamps its cached
+`rom_metadata` in the same write Unit of Work (Rom row first, then metadata — FK-safe). So a preview never mutates
+state, and an interrupted apply leaves only the units it already committed — incremental, per-unit delivery.
 
-**Where the synced-ROM state lives.** The registry of synced ROMs, the last-sync timestamp, and the sync stats are SQLite, not JSON. The reporter upserts each acked ROM into the `roms` table via `Rom.synced(...)` / `update_cover_path` / `assign_sgdb_id` (artwork and steamgrid patch `cover_path` / `sgdb_id` on the same aggregate during the per-unit commit) and, in the same write UoW, stamps the ROM's cached `rom_metadata` (`build_rom_metadata` maps the live RomM `metadatum` — Rom row saved first so the `rom_id` FK holds); the orchestrator drives the `SyncRun` lifecycle (`start` at apply-dispatch, `complete` / `mark_cancelled` / `mark_errored` at finalize). `sync_stats.roms` is a registry-derived bound-shortcut count computed at read time (the ROMs still bound to a shortcut in `roms`, i.e. `shortcut_app_id` not NULL), not a stored scalar. The old JSON `shortcut_registry` / `last_sync` / `sync_stats` are gone from this path; all writes go through the `roms` / `sync_runs` Repository Protocols behind a narrow Unit of Work (per [ADR-0006](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0006-narrow-unit-of-work-scope.md) the UoW spans only the DB write, never the up-to-60s frontend ack). The platform `slug → display_name` map resolves live from RomM each sync and is cached in a `kv_config` row for offline reads. Removing a shortcut **unbinds** the ROM (`Rom.unbind_shortcut()` NULLs `shortcut_app_id`, keeping the row and its per-ROM children) rather than deleting it, per [ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md). The full schema and aggregate model are in [Database Design](database-design.md).
+**Where the synced-ROM state lives.** The registry of synced ROMs, the last-sync timestamp, and the sync stats are
+SQLite, not JSON. The reporter upserts each acked ROM into the `roms` table via `Rom.synced(...)` / `update_cover_path`
+/ `assign_sgdb_id` (artwork and steamgrid patch `cover_path` / `sgdb_id` on the same aggregate during the per-unit
+commit) and, in the same write UoW, stamps the ROM's cached `rom_metadata` (`build_rom_metadata` maps the live RomM
+`metadatum` — Rom row saved first so the `rom_id` FK holds); the orchestrator drives the `SyncRun` lifecycle (`start` at
+apply-dispatch, `complete` / `mark_cancelled` / `mark_errored` at finalize). `sync_stats.roms` is a registry-derived
+bound-shortcut count computed at read time (the ROMs still bound to a shortcut in `roms`, i.e. `shortcut_app_id` not
+NULL), not a stored scalar. The old JSON `shortcut_registry` / `last_sync` / `sync_stats` are gone from this path; all
+writes go through the `roms` / `sync_runs` Repository Protocols behind a narrow Unit of Work (per
+[ADR-0006](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0006-narrow-unit-of-work-scope.md) the UoW
+spans only the DB write, never the up-to-60s frontend ack). The platform `slug → display_name` map resolves live from
+RomM each sync and is cached in a `kv_config` row for offline reads. Removing a shortcut **unbinds** the ROM
+(`Rom.unbind_shortcut()` NULLs `shortcut_app_id`, keeping the row and its per-ROM children) rather than deleting it, per
+[ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md).
+The full schema and aggregate model are in [Database Design](database-design.md).
 
 #### DownloadService notes
 
-RomM exposes three mutually exclusive file-layout flags on every ROM detail. They control how the server stores files and how the API serves them. The plugin maps each layout to a local on-disk path:
+RomM exposes three mutually exclusive file-layout flags on every ROM detail. They control how the server stores files
+and how the API serves them. The plugin maps each layout to a local on-disk path:
 
-| RomM flag | RomM server layout | What `fs_name` is | Plugin local layout |
-| --- | --- | --- | --- |
-| `has_simple_single_file` | `roms/<platform>/<file>` — one file, flat | the filename | flat in platform folder: `roms/<platform>/<file>` |
-| `has_nested_single_file` | `roms/<platform>/<folder>/<file>` — one file in a per-game folder | the **folder** name | flat in platform folder: `roms/<platform>/<file>` |
-| `has_multiple_files` | per-game folder with multiple files (multi-disc, BIN+CUE, etc.) | the ZIP/folder name | extracted into per-game subfolder: `roms/<platform>/<fs_name_no_ext>/...` |
+| RomM flag                | RomM server layout                                                | What `fs_name` is   | Plugin local layout                                                       |
+| ------------------------ | ----------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------- |
+| `has_simple_single_file` | `roms/<platform>/<file>` — one file, flat                         | the filename        | flat in platform folder: `roms/<platform>/<file>`                         |
+| `has_nested_single_file` | `roms/<platform>/<folder>/<file>` — one file in a per-game folder | the **folder** name | flat in platform folder: `roms/<platform>/<file>`                         |
+| `has_multiple_files`     | per-game folder with multiple files (multi-disc, BIN+CUE, etc.)   | the ZIP/folder name | extracted into per-game subfolder: `roms/<platform>/<fs_name_no_ext>/...` |
 
-**`has_nested_single_file` quirk**: `fs_name` is the parent folder name, not the filename. The actual filename with extension lives in `files[0].file_name`. The plugin reads from `files[0].file_name` so the downloaded ROM lands with the correct extension (e.g. `Game.chd`, not the extension-less folder name `Game`). A defensive helper falls back to `fs_name` and warns if `files` is empty or missing.
+**`has_nested_single_file` quirk**: `fs_name` is the parent folder name, not the filename. The actual filename with
+extension lives in `files[0].file_name`. The plugin reads from `files[0].file_name` so the downloaded ROM lands with the
+correct extension (e.g. `Game.chd`, not the extension-less folder name `Game`). A defensive helper falls back to
+`fs_name` and warns if `files` is empty or missing.
 
-**Why nested-single is flattened locally**: a nested-single-file ROM has no sidecars by definition — RomM would mark it `has_multiple_files` if any companion files existed. The parent folder adds no value at the local layer, so the plugin drops it and stores the ROM directly in the platform folder, matching the simple-single-file layout. Multi-file ROMs keep their per-game subfolder because they contain multiple related files that belong together.
+**Why nested-single is flattened locally**: a nested-single-file ROM has no sidecars by definition — RomM would mark it
+`has_multiple_files` if any companion files existed. The parent folder adds no value at the local layer, so the plugin
+drops it and stores the ROM directly in the platform folder, matching the simple-single-file layout. Multi-file ROMs
+keep their per-game subfolder because they contain multiple related files that belong together.
 
-**Extract-vs-flat gate keys on `len(files) > 1`, not on `has_multiple_files`**: the plugin decides ZIP-extract vs single-file download with the `is_multi_file_download` helper (`domain/rom_files.py`), which returns `len(files) > 1 OR has_multiple_files`. This mirrors RomM's own download gate, which zips whenever the **total** file count is not exactly 1. RomM computes `has_multiple_files` from **top-level** files only, so the two counts disagree for a nested layout: a canonical Switch game (base file at the root plus `update/` and `dlc/` in subfolders) has exactly one top-level file (`has_multiple_files=False`, `has_nested_single_file=True`) yet more than one total file, so RomM serves a ZIP. Keying on `has_multiple_files` alone would take the single-file path and write the ZIP bytes verbatim into one unreadable `.nsp`. The boolean is kept as a defensive fallback for payloads that omit `files`; a genuine nested-single ROM has `len(files) == 1` and correctly stays on the flat single-file path.
+**Extract-vs-flat gate keys on `len(files) > 1`, not on `has_multiple_files`**: the plugin decides ZIP-extract vs
+single-file download with the `is_multi_file_download` helper (`domain/rom_files.py`), which returns
+`len(files) > 1 OR has_multiple_files`. This mirrors RomM's own download gate, which zips whenever the **total** file
+count is not exactly 1. RomM computes `has_multiple_files` from **top-level** files only, so the two counts disagree for
+a nested layout: a canonical Switch game (base file at the root plus `update/` and `dlc/` in subfolders) has exactly one
+top-level file (`has_multiple_files=False`, `has_nested_single_file=True`) yet more than one total file, so RomM serves
+a ZIP. Keying on `has_multiple_files` alone would take the single-file path and write the ZIP bytes verbatim into one
+unreadable `.nsp`. The boolean is kept as a defensive fallback for payloads that omit `files`; a genuine nested-single
+ROM has `len(files) == 1` and correctly stays on the flat single-file path.
 
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
 
@@ -155,104 +195,134 @@ Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip p
 
 Adapters own all I/O and implement the Protocols defined in `services/protocols/`. Selected adapters:
 
-| Module | Role |
-| --- | --- |
-| `romm/http.py` | `RommHttpAdapter` — HTTP transport: auth, SSL, retry, User-Agent, platform map |
-| `romm/romm_api.py` | `RommApiAdapter` — RomM REST surface (saves, ROMs, platforms, firmware, devices, notes) over the HTTP transport |
-| `steam_config.py` | `SteamConfigAdapter` — Steam VDF read/write, grid dir, shortcut icon write, Steam Input config |
-| `steamgriddb.py` | `SteamGridDbAdapter` — SteamGridDB REST client |
-| `sgdb_artwork_cache.py` | `SgdbArtworkCacheAdapter` — on-disk SGDB artwork cache |
-| `cover_art_file_store.py` | `CoverArtFileStoreAdapter` — RomM cover art staging on disk |
-| `persistence.py` | `PersistenceAdapter` + per-domain persister adapters — settings/state/cache/save-sync JSON I/O |
-| `repositories/` | `SqliteUnitOfWork` + per-aggregate repository adapters — SQLite I/O (the live persistence path; see [Database Design](database-design.md)) |
-| `sqlite_migrations.py` | `apply_migrations` — schema migration runner (`db/migrations/NNN_*.sql`, `PRAGMA user_version`) |
-| `registry_store.py` | `RegistryStoreAdapter` — JSON shortcut-registry reads/writes; no longer wired (the library slice moved to `roms`), kept until teardown for the not-yet-migrated readers |
-| `metadata_cache_store.py` | `MetadataCacheStoreAdapter` — metadata cache reads/writes |
-| `download_file.py` | `DownloadFileAdapter` — download filesystem |
-| `firmware_file.py` / `migration_file.py` / `rom_files.py` / `save_file.py` | per-subtree filesystem adapters (BIOS, RetroDECK migration, ROM removal, local saves) |
-| `retrodeck_paths.py` | `RetroDeckPathsAdapter` — reads `retrodeck.json` for ROMs/saves/BIOS/home paths |
-| `retroarch_config.py` | `RetroArchConfigAdapter` — reads `retroarch.cfg` save-sort flags |
-| `retroarch_core_info.py` | `RetroArchCoreInfoAdapter` — reads RetroArch `.info` files (`corename`, metadata) |
-| `es_de_config.py` | `CoreResolver` + `GamelistXmlEditorAdapter` — ES-DE `es_systems.xml` / `gamelist.xml` |
-| `system_clock.py` / `system_uuid_gen.py` / `asyncio_sleeper.py` | concrete `Clock` / `UuidGen` / `Sleeper` seams |
-| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, path-exists probe, `package.json` version reader, settings-aware debug logger |
+| Module                                                                     | Role                                                                                                                                                                    |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `romm/http.py`                                                             | `RommHttpAdapter` — HTTP transport: auth, SSL, retry, User-Agent, platform map                                                                                          |
+| `romm/romm_api.py`                                                         | `RommApiAdapter` — RomM REST surface (saves, ROMs, platforms, firmware, devices, notes) over the HTTP transport                                                         |
+| `steam_config.py`                                                          | `SteamConfigAdapter` — Steam VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                          |
+| `steamgriddb.py`                                                           | `SteamGridDbAdapter` — SteamGridDB REST client                                                                                                                          |
+| `sgdb_artwork_cache.py`                                                    | `SgdbArtworkCacheAdapter` — on-disk SGDB artwork cache                                                                                                                  |
+| `cover_art_file_store.py`                                                  | `CoverArtFileStoreAdapter` — RomM cover art staging on disk                                                                                                             |
+| `persistence.py`                                                           | `PersistenceAdapter` + per-domain persister adapters — settings/state/cache/save-sync JSON I/O                                                                          |
+| `repositories/`                                                            | `SqliteUnitOfWork` + per-aggregate repository adapters — SQLite I/O (the live persistence path; see [Database Design](database-design.md))                              |
+| `sqlite_migrations.py`                                                     | `apply_migrations` — schema migration runner (`db/migrations/NNN_*.sql`, `PRAGMA user_version`)                                                                         |
+| `registry_store.py`                                                        | `RegistryStoreAdapter` — JSON shortcut-registry reads/writes; no longer wired (the library slice moved to `roms`), kept until teardown for the not-yet-migrated readers |
+| `metadata_cache_store.py`                                                  | `MetadataCacheStoreAdapter` — metadata cache reads/writes                                                                                                               |
+| `download_file.py`                                                         | `DownloadFileAdapter` — download filesystem                                                                                                                             |
+| `firmware_file.py` / `migration_file.py` / `rom_files.py` / `save_file.py` | per-subtree filesystem adapters (BIOS, RetroDECK migration, ROM removal, local saves)                                                                                   |
+| `retrodeck_paths.py`                                                       | `RetroDeckPathsAdapter` — reads `retrodeck.json` for ROMs/saves/BIOS/home paths                                                                                         |
+| `retroarch_config.py`                                                      | `RetroArchConfigAdapter` — reads `retroarch.cfg` save-sort flags                                                                                                        |
+| `retroarch_core_info.py`                                                   | `RetroArchCoreInfoAdapter` — reads RetroArch `.info` files (`corename`, metadata)                                                                                       |
+| `es_de_config.py`                                                          | `CoreResolver` + `GamelistXmlEditorAdapter` — ES-DE `es_systems.xml` / `gamelist.xml`                                                                                   |
+| `system_clock.py` / `system_uuid_gen.py` / `asyncio_sleeper.py`            | concrete `Clock` / `UuidGen` / `Sleeper` seams                                                                                                                          |
+| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, path-exists probe, `package.json` version reader, settings-aware debug logger                                                                                 |
 
 #### PersistenceAdapter notes
 
-- **File locking**: write methods acquire an exclusive `fcntl.flock` before touching the file, preventing concurrent writes from corrupting state.
-- **Schema versioning**: every state file written includes a `version` field. On read, a mismatch causes the file to be treated as absent (cache discarded, state reset to defaults) rather than loading incompatible data.
-- **Atomic writes**: data is written to a temporary file in the same directory, then renamed into place with `os.replace()`, so a crash mid-write never leaves a partial file.
+- **File locking**: write methods acquire an exclusive `fcntl.flock` before touching the file, preventing concurrent
+  writes from corrupting state.
+- **Schema versioning**: every state file written includes a `version` field. On read, a mismatch causes the file to be
+  treated as absent (cache discarded, state reset to defaults) rather than loading incompatible data.
+- **Atomic writes**: data is written to a temporary file in the same directory, then renamed into place with
+  `os.replace()`, so a crash mid-write never leaves a partial file.
 
 ### Domain (`py_modules/domain/`)
 
-Domain modules contain pure logic with no I/O and no Decky imports. They take inputs and return outputs; anything stateless and I/O-free that would otherwise sit in a service lives here. Domain is stdlib + self only — it imports no other internal layer (`lib` and `models` included). Aggregate roots and the enforcement that keeps them honest are documented in [Database Design](database-design.md). Selected modules:
+Domain modules contain pure logic with no I/O and no Decky imports. They take inputs and return outputs; anything
+stateless and I/O-free that would otherwise sit in a service lives here. Domain is stdlib + self only — it imports no
+other internal layer (`lib` and `models` included). Aggregate roots and the enforcement that keeps them honest are
+documented in [Database Design](database-design.md). Selected modules:
 
-| Module | Role |
-| --- | --- |
-| `sync_action.py` | `compute_sync_action` — the save-sync decision algorithm. Returns `SyncAction` union (`Skip` / `Upload` / `Download` / `Conflict`). See [Save File Sync Architecture](save-file-sync-architecture.md). |
-| `sync_diff.py` | ROM classification and platform/collection diff computation for the sync preview |
-| `preview_delta.py` | `PreviewDelta` shape for the sync preview |
-| `work_unit.py` | `WorkUnit` — the per-unit sync work item |
-| `save_state.py` | `SaveSyncState` aggregate + `from_dict`/`to_dict` (schema migrations live here) |
-| `save_path.py` / `save_attribution.py` / `save_status*.py` / `save_extensions.py` | save path resolution, uploader attribution, status DTO building |
-| `firmware_paths.py` / `bios.py` | BIOS path computation and status formatting; `bios.py` also holds the BIOS status dataclasses (`AvailableCore`, `BiosFileEntry`, `BiosStatus`) |
-| `iso_time.py` | `parse_iso` / `parse_iso_to_epoch` — ISO-8601 timestamp parsing (stdlib only) |
-| `achievements.py` | achievement progress computation |
-| `shortcut_data.py` | shortcut data building (registry entries, shortcut dicts) |
-| `steam_categories.py` | Steam collection name computation |
-| `sgdb_artwork.py` | SGDB asset-type/endpoint maps and `to_signed_app_id` |
-| `installed_roms.py` / `rom_files.py` | installed-ROM detection, M3U generation, launch-file detection |
-| `retroarch_core_info.py` | `parse_core_info` — pure parser for RetroArch `.info` files |
-| `state_migrations.py` | `migrate_settings` / `migrate_state` for the main state files |
-| `sync_state.py` | `SyncState` enum (idle, running, cancelling) |
-| `emulator_tag.py` / `version.py` | emulator-tag formatting, version parsing, core-change detection |
+| Module                                                                            | Role                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sync_action.py`                                                                  | `compute_sync_action` — the save-sync decision algorithm. Returns `SyncAction` union (`Skip` / `Upload` / `Download` / `Conflict`). See [Save File Sync Architecture](save-file-sync-architecture.md). |
+| `sync_diff.py`                                                                    | ROM classification and platform/collection diff computation for the sync preview                                                                                                                       |
+| `preview_delta.py`                                                                | `PreviewDelta` shape for the sync preview                                                                                                                                                              |
+| `work_unit.py`                                                                    | `WorkUnit` — the per-unit sync work item                                                                                                                                                               |
+| `save_state.py`                                                                   | `SaveSyncState` aggregate + `from_dict`/`to_dict` (schema migrations live here)                                                                                                                        |
+| `save_path.py` / `save_attribution.py` / `save_status*.py` / `save_extensions.py` | save path resolution, uploader attribution, status DTO building                                                                                                                                        |
+| `firmware_paths.py` / `bios.py`                                                   | BIOS path computation and status formatting; `bios.py` also holds the BIOS status dataclasses (`AvailableCore`, `BiosFileEntry`, `BiosStatus`)                                                         |
+| `iso_time.py`                                                                     | `parse_iso` / `parse_iso_to_epoch` — ISO-8601 timestamp parsing (stdlib only)                                                                                                                          |
+| `achievements.py`                                                                 | achievement progress computation                                                                                                                                                                       |
+| `shortcut_data.py`                                                                | shortcut data building (registry entries, shortcut dicts)                                                                                                                                              |
+| `steam_categories.py`                                                             | Steam collection name computation                                                                                                                                                                      |
+| `sgdb_artwork.py`                                                                 | SGDB asset-type/endpoint maps and `to_signed_app_id`                                                                                                                                                   |
+| `installed_roms.py` / `rom_files.py`                                              | installed-ROM detection, M3U generation, launch-file detection                                                                                                                                         |
+| `retroarch_core_info.py`                                                          | `parse_core_info` — pure parser for RetroArch `.info` files                                                                                                                                            |
+| `state_migrations.py`                                                             | `migrate_settings` / `migrate_state` for the main state files                                                                                                                                          |
+| `sync_state.py`                                                                   | `SyncState` enum (idle, running, cancelling)                                                                                                                                                           |
+| `emulator_tag.py` / `version.py`                                                  | emulator-tag formatting, version parsing, core-change detection                                                                                                                                        |
 
-**Config-source parsers** follow a dedicated domain+adapter template (pure parse in domain, I/O in adapter, callback Protocol into services). The full pattern, source catalog, and decisions log are on the [Config Source Parsers](config-source-parsers.md) page.
+**Config-source parsers** follow a dedicated domain+adapter template (pure parse in domain, I/O in adapter, callback
+Protocol into services). The full pattern, source catalog, and decisions log are on the
+[Config Source Parsers](config-source-parsers.md) page.
 
 ### Models (`py_modules/models/`)
 
-TypedDicts and dataclasses describing on-disk and in-flight data shapes (`state.py`, `metadata.py`, `metadata_patches.py`, `registry_patches.py`). Models import nothing from the other layers.
+TypedDicts and dataclasses describing on-disk and in-flight data shapes (`state.py`, `metadata.py`,
+`metadata_patches.py`, `registry_patches.py`). Models import nothing from the other layers.
 
 ### Other
 
-| File | Role |
-| --- | --- |
-| `main.py` | Plugin class — Decky lifecycle (`_main`/`_unload`) and the callable surface (one `async def` per `@callable`) |
-| `bootstrap.py` | Composition root — `bootstrap()` builds adapters, `wire_services()` builds services |
-| `lib/errors.py` | Exception hierarchy (`RommApiError`, `classify_error`) |
-| `lib/list_result.py` | `ErrorCode` and the canonical callable failure shape |
+| File                 | Role                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `main.py`            | Plugin class — Decky lifecycle (`_main`/`_unload`) and the callable surface (one `async def` per `@callable`) |
+| `bootstrap.py`       | Composition root — `bootstrap()` builds adapters, `wire_services()` builds services                           |
+| `lib/errors.py`      | Exception hierarchy (`RommApiError`, `classify_error`)                                                        |
+| `lib/list_result.py` | `ErrorCode` and the canonical callable failure shape                                                          |
 
 ## Composition Root (`bootstrap.py`)
 
 The composition root has two functions:
 
-1. **`bootstrap()`** — builds every adapter and loads + migrates settings, plugin state, and the metadata cache so the persister adapters bind the live mutable dicts at construction. Returns a typed `BootstrapResult` carrying four bundles (`adapters`, `stores`, `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only outputs.
+1. **`bootstrap()`** — builds every adapter and loads + migrates settings, plugin state, and the metadata cache so the
+   persister adapters bind the live mutable dicts at construction. Returns a typed `BootstrapResult` carrying four
+   bundles (`adapters`, `stores`, `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only
+   outputs.
 
-2. **`wire_services()`** — takes a `WiringConfig` (the four bundles plus `min_required_version`) and constructs every service, injecting each one's `*ServiceConfig`. Returns a dict of named service instances.
+2. **`wire_services()`** — takes a `WiringConfig` (the four bundles plus `min_required_version`) and constructs every
+   service, injecting each one's `*ServiceConfig`. Returns a dict of named service instances.
 
-The two-phase split exists because adapter instantiation and state loading happen first (`bootstrap()`), then `main.py` composes the runtime bundle (event loop, `decky.emit`) and calls `wire_services()` so services receive references to the fully-populated state dicts. Some services are constructed before others to satisfy ordering constraints (e.g. `MigrationService` before `SaveService` so save sync observes fresh save-sort state). Forward references between peers are threaded via `LateBinding`.
+The two-phase split exists because adapter instantiation and state loading happen first (`bootstrap()`), then `main.py`
+composes the runtime bundle (event loop, `decky.emit`) and calls `wire_services()` so services receive references to the
+fully-populated state dicts. Some services are constructed before others to satisfy ordering constraints (e.g.
+`MigrationService` before `SaveService` so save sync observes fresh save-sort state). Forward references between peers
+are threaded via `LateBinding`.
 
-Per the process-boundary rule, adapter instantiation never happens in `main.py`, and no service wiring happens in `bootstrap.py`'s caller other than via `wire_services()`.
+Per the process-boundary rule, adapter instantiation never happens in `main.py`, and no service wiring happens in
+`bootstrap.py`'s caller other than via `wire_services()`.
 
 ## Protocol Interfaces
 
-Services depend on Protocols, never on concrete adapter implementations. The Protocols live in the `services/protocols/` package, organised topically (consumers always deep-import `from services.protocols import X`):
+Services depend on Protocols, never on concrete adapter implementations. The Protocols live in the `services/protocols/`
+package, organised topically (consumers always deep-import `from services.protocols import X`):
 
-- **`transport`** — external system clients: `RommApi` (and its narrowed facets `RommSaveApi`, `RommRomReader`, `RommDeviceApi`, `RommFirmwareApi`, `RommPlaytimeApi`, `RommLibraryApi`, `RommConnectionApi`, `RommPlatformReader`, `RommAchievementsApi`, `RommSyncApi`, `RommVersion`), `SteamConfigStore`, `SteamGridDbApi`.
+- **`transport`** — external system clients: `RommApi` (and its narrowed facets `RommSaveApi`, `RommRomReader`,
+  `RommDeviceApi`, `RommFirmwareApi`, `RommPlaytimeApi`, `RommLibraryApi`, `RommConnectionApi`, `RommPlatformReader`,
+  `RommAchievementsApi`, `RommSyncApi`, `RommVersion`), `SteamConfigStore`, `SteamGridDbApi`.
 - **`determinism`** — `Clock` / `UuidGen` / `Sleeper` test seams.
-- **`persistence`** — `StatePersister`, `SettingsPersister`, `MetadataCachePersister`, `MetadataCacheStore`, `FirmwareCachePersister`, `SaveSyncStatePersister`, `ShortcutRegistryStore`, `PluginMetadataReader`.
-- **`paths`** — `RetroDeckPaths`, `SystemResolver`, `CoreInfoProvider`, `CoreResolverFn`, `CoreNameProviderFn`, `RetroArchConfigReader`, `RetroArchCoreInfoReader`, `RetroArchSaveSortingProvider`, `GamelistXmlEditor`.
-- **`infra`** — cross-cutting callable seams: `EventEmitter`, `DebugLogger`, `PathExistsReader`, `HostnameReader`, `PendingSyncReader`, `DownloadQueueCleanup`.
-- **`files`** — filesystem seams: `CoverArtFileStore`, `DownloadFileStore`, `FirmwareFileStore`, `MigrationFileStore`, `RomFileStore`, `SaveFileStore`, `SgdbArtworkCache`.
-- **`cross_service`** — narrowly-typed multi-method seams one service exposes to another so services stay independent: `BiosChecker`, `AchievementsReader`, `ArtworkManager`, `ArtworkRemover`, `RetryStrategy`, `MigrationPendingFn`, `SaveSortChangeFn`, the `LaunchGate*` and `Session*` seams.
+- **`persistence`** — `StatePersister`, `SettingsPersister`, `MetadataCachePersister`, `MetadataCacheStore`,
+  `FirmwareCachePersister`, `SaveSyncStatePersister`, `ShortcutRegistryStore`, `PluginMetadataReader`.
+- **`paths`** — `RetroDeckPaths`, `SystemResolver`, `CoreInfoProvider`, `CoreResolverFn`, `CoreNameProviderFn`,
+  `RetroArchConfigReader`, `RetroArchCoreInfoReader`, `RetroArchSaveSortingProvider`, `GamelistXmlEditor`.
+- **`infra`** — cross-cutting callable seams: `EventEmitter`, `DebugLogger`, `PathExistsReader`, `HostnameReader`,
+  `PendingSyncReader`, `DownloadQueueCleanup`.
+- **`files`** — filesystem seams: `CoverArtFileStore`, `DownloadFileStore`, `FirmwareFileStore`, `MigrationFileStore`,
+  `RomFileStore`, `SaveFileStore`, `SgdbArtworkCache`.
+- **`cross_service`** — narrowly-typed multi-method seams one service exposes to another so services stay independent:
+  `BiosChecker`, `AchievementsReader`, `ArtworkManager`, `ArtworkRemover`, `RetryStrategy`, `MigrationPendingFn`,
+  `SaveSortChangeFn`, the `LaunchGate*` and `Session*` seams.
 
-Protocol names carry a suffix that signals shape (`…Reader`, `…Provider`/`…Fn`, `…Store`, `…Cache`, `…Persister`; bare names for pervasive primitives like `Clock`).
+Protocol names carry a suffix that signals shape (`…Reader`, `…Provider`/`…Fn`, `…Store`, `…Cache`, `…Persister`; bare
+names for pervasive primitives like `Clock`).
 
 `RommApiAdapter` implements `RommApi` over `RommHttpAdapter`, targeting RomM 4.8.1+ endpoints.
 
 ## Boundary Enforcement
 
-Four CI-gated layers keep the dependency direction and the call-site rules from drifting. Aggregate-specific enforcement (the `@cosmic_aggregate` decorator and the field-assignment check) is documented in [Database Design](database-design.md).
+Four CI-gated layers keep the dependency direction and the call-site rules from drifting. Aggregate-specific enforcement
+(the `@cosmic_aggregate` decorator and the field-assignment check) is documented in
+[Database Design](database-design.md).
 
 ### 1. import-linter (CI-enforced)
 
@@ -311,39 +381,56 @@ Run with `PYTHONPATH=py_modules lint-imports` (or `mise run lint`). CI gates on 
 
 ### 2. Cosmic Python call bans
 
-`scripts/check_cosmic_call_bans.sh` (also bundled into `mise run lint`) complements the import-level guardrail at the call site: services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` / `random.*` directly — they inject the corresponding `Clock` / `Sleeper` / `UuidGen` Protocol instead.
+`scripts/check_cosmic_call_bans.sh` (also bundled into `mise run lint`) complements the import-level guardrail at the
+call site: services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` /
+`uuid.uuid4()` / `random.*` directly — they inject the corresponding `Clock` / `Sleeper` / `UuidGen` Protocol instead.
 
 ### 3. Aggregate field-assignment check
 
-`scripts/check_aggregate_field_assignment.py` (also bundled into `mise run lint`) is a small custom AST linter that enforces the **mutation-only-via-methods** rule for aggregates — a rule no type checker can express directly. It collects the class names decorated with `@cosmic_aggregate` in `domain/`, then scans `services/` for `<aggregate>.<field> = ...` assignments and fails CI on any it finds. The escape hatch is a trailing `# pragma: no aggregate-check` on the offending line. It is a no-op until aggregate roots exist (the decorator set is empty today) and activates automatically as they land. Full detail in [Database Design](database-design.md).
+`scripts/check_aggregate_field_assignment.py` (also bundled into `mise run lint`) is a small custom AST linter that
+enforces the **mutation-only-via-methods** rule for aggregates — a rule no type checker can express directly. It
+collects the class names decorated with `@cosmic_aggregate` in `domain/`, then scans `services/` for
+`<aggregate>.<field> = ...` assignments and fails CI on any it finds. The escape hatch is a trailing
+`# pragma: no aggregate-check` on the offending line. It is a no-op until aggregate roots exist (the decorator set is
+empty today) and activates automatically as they land. Full detail in [Database Design](database-design.md).
 
 ### 4. Enforced: underscore prefix
 
-All internal methods use a `_` prefix; public callables (exposed to the frontend via `callable()`) have none. `main.py` callable methods delegate directly to the corresponding service method. Even synchronous callable bodies are `async def` — Decky's callable framework requires it.
+All internal methods use a `_` prefix; public callables (exposed to the frontend via `callable()`) have none. `main.py`
+callable methods delegate directly to the corresponding service method. Even synchronous callable bodies are `async def`
+— Decky's callable framework requires it.
 
-This is no longer just a convention — basedpyright enforces it with `reportPrivateUsage = "error"`, so accessing a `_`-prefixed name from outside its owning class is a hard type error. Tests are exempt via an `executionEnvironments` override (white-box testing — inspecting and rebinding a system-under-test's private state — is an accepted pattern). One corollary: a method one sub-service calls on a peer is part of that peer's **public** surface and carries no underscore, which keeps `reportPrivateUsage` coherent with the saves-style peer-injection carve-out.
+This is no longer just a convention — basedpyright enforces it with `reportPrivateUsage = "error"`, so accessing a
+`_`-prefixed name from outside its owning class is a hard type error. Tests are exempt via an `executionEnvironments`
+override (white-box testing — inspecting and rebinding a system-under-test's private state — is an accepted pattern).
+One corollary: a method one sub-service calls on a peer is part of that peer's **public** surface and carries no
+underscore, which keeps `reportPrivateUsage` coherent with the saves-style peer-injection carve-out.
 
 ## Service Dependency Summary
 
-Every service receives its dependencies through a single `*ServiceConfig` dataclass. Cross-service dependencies are Protocol-typed (services never import each other's concrete classes). Selected wiring:
+Every service receives its dependencies through a single `*ServiceConfig` dataclass. Cross-service dependencies are
+Protocol-typed (services never import each other's concrete classes). Selected wiring:
 
-| Service | Key injected dependencies |
-| --- | --- |
-| **LibraryService** | `RommLibraryApi`, `SteamConfigStore`, `ArtworkManager`, `Clock`/`UuidGen`/`Sleeper`, `SettingsPersister`, `UnitOfWorkFactory` (roms / sync_runs / kv_config / rom_metadata) |
-| **MetadataService** | `UnitOfWorkFactory` (reads `rom_metadata` / `roms`) |
-| **SaveService** | `RommApi`, `RetryStrategy`, `SaveFileStore`, `SaveSyncStatePersister`, `Clock`, `RetroDeckPaths`, core-name/active-core providers, migration-detect callbacks |
-| **DownloadService** | `RommApi`, `DownloadFileStore`, `RetroDeckPaths`, `Clock`/`Sleeper` |
-| **FirmwareService** | `RommApi`, `FirmwareFileStore`, `FirmwareCachePersister`, `CoreInfoProvider`, `RetroDeckPaths` |
-| **SteamGridService** | `SteamGridDbApi`, `RommApi`, `SteamConfigStore`, `SgdbArtworkCache`, `UnitOfWorkFactory` (sgdb_id on `roms`), `PendingSyncReader` |
-| **MigrationService** | `MigrationFileStore`, `RetroDeckPaths`, save-sort/active-core/core-name providers, BIOS-index callback |
-| **GameDetailService** | `BiosChecker`, `AchievementsReader` (cross-service), `Clock`, `UnitOfWorkFactory` (one read UoW over `roms` / `rom_installs` / `rom_save_states` / `rom_metadata` / `kv_config`) |
-| **AchievementsService** | `RommAchievementsApi`, `Clock`, `DebugLogger`, `UnitOfWorkFactory` (reads `ra_id` from `roms`) |
-| **SettingsService** | `SteamConfigStore`, `SettingsPersister`, `UnitOfWorkFactory` (reads bound `shortcut_app_id`s from `roms`) |
-| **PlaytimeService** | `RommPlaytimeApi`, `RetryStrategy`, `Clock`, `UnitOfWorkFactory` (reads/writes `rom_playtime`) |
-| **RomRemovalService** | `RomFileStore`, `RetroDeckPaths`, `DownloadQueueCleanup` peer, `UnitOfWorkFactory` (reads/deletes `rom_installs`) |
-| **ShortcutRemovalService** | `SteamConfigStore`, `ArtworkRemover` peer, `UnitOfWorkFactory` (unbinds via `roms`, offline name via `kv_config`) |
-| **SessionLifecycleService** | `Session*` cross-service seams (playtime / post-exit sync / achievement sync / migration reader) |
-| **LaunchGateService** | `LaunchGateRomLookup`, `LaunchGateInstalledChecker`, `LaunchGateSaveStatusReader` cross-service seams |
-| **ConnectionService** | `RommConnectionApi`, `SettingsPersister`, `min_required_version` |
+| Service                     | Key injected dependencies                                                                                                                                                        |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LibraryService**          | `RommLibraryApi`, `SteamConfigStore`, `ArtworkManager`, `Clock`/`UuidGen`/`Sleeper`, `SettingsPersister`, `UnitOfWorkFactory` (roms / sync_runs / kv_config / rom_metadata)      |
+| **MetadataService**         | `UnitOfWorkFactory` (reads `rom_metadata` / `roms`)                                                                                                                              |
+| **SaveService**             | `RommApi`, `RetryStrategy`, `SaveFileStore`, `SaveSyncStatePersister`, `Clock`, `RetroDeckPaths`, core-name/active-core providers, migration-detect callbacks                    |
+| **DownloadService**         | `RommApi`, `DownloadFileStore`, `RetroDeckPaths`, `Clock`/`Sleeper`                                                                                                              |
+| **FirmwareService**         | `RommApi`, `FirmwareFileStore`, `FirmwareCachePersister`, `CoreInfoProvider`, `RetroDeckPaths`                                                                                   |
+| **SteamGridService**        | `SteamGridDbApi`, `RommApi`, `SteamConfigStore`, `SgdbArtworkCache`, `UnitOfWorkFactory` (sgdb_id on `roms`), `PendingSyncReader`                                                |
+| **MigrationService**        | `MigrationFileStore`, `RetroDeckPaths`, save-sort/active-core/core-name providers, BIOS-index callback                                                                           |
+| **GameDetailService**       | `BiosChecker`, `AchievementsReader` (cross-service), `Clock`, `UnitOfWorkFactory` (one read UoW over `roms` / `rom_installs` / `rom_save_states` / `rom_metadata` / `kv_config`) |
+| **AchievementsService**     | `RommAchievementsApi`, `Clock`, `DebugLogger`, `UnitOfWorkFactory` (reads `ra_id` from `roms`)                                                                                   |
+| **SettingsService**         | `SteamConfigStore`, `SettingsPersister`, `UnitOfWorkFactory` (reads bound `shortcut_app_id`s from `roms`)                                                                        |
+| **PlaytimeService**         | `RommPlaytimeApi`, `RetryStrategy`, `Clock`, `UnitOfWorkFactory` (reads/writes `rom_playtime`)                                                                                   |
+| **RomRemovalService**       | `RomFileStore`, `RetroDeckPaths`, `DownloadQueueCleanup` peer, `UnitOfWorkFactory` (reads/deletes `rom_installs`)                                                                |
+| **ShortcutRemovalService**  | `SteamConfigStore`, `ArtworkRemover` peer, `UnitOfWorkFactory` (unbinds via `roms`, offline name via `kv_config`)                                                                |
+| **SessionLifecycleService** | `Session*` cross-service seams (playtime / post-exit sync / achievement sync / migration reader)                                                                                 |
+| **LaunchGateService**       | `LaunchGateRomLookup`, `LaunchGateInstalledChecker`, `LaunchGateSaveStatusReader` cross-service seams                                                                            |
+| **ConnectionService**       | `RommConnectionApi`, `SettingsPersister`, `min_required_version`                                                                                                                 |
 
-Most services also receive shared state (`state`, `settings`, `metadata_cache`, `save_sync_state`), the event loop, the logger, and the `DebugLogger` Protocol through their config. As the SQLite cutover proceeds, services that no longer read the in-memory dicts drop them: `GameDetailService`/`AchievementsService` no longer take `state`, and `SettingsService` reads bound shortcuts from `roms` rather than the in-memory `shortcut_registry`.
+Most services also receive shared state (`state`, `settings`, `metadata_cache`, `save_sync_state`), the event loop, the
+logger, and the `DebugLogger` Protocol through their config. As the SQLite cutover proceeds, services that no longer
+read the in-memory dicts drop them: `GameDetailService`/`AchievementsService` no longer take `state`, and
+`SettingsService` reads bound shortcuts from `roms` rather than the in-memory `shortcut_registry`.

--- a/docs/architecture/config-source-parsers.md
+++ b/docs/architecture/config-source-parsers.md
@@ -2,75 +2,117 @@
 
 ## Overview
 
-The plugin reads configuration and metadata from multiple local files — ES-DE XML, RetroArch `.info` files, `retrodeck.json`, `retroarch.cfg`, gamelist XML, a bundled `core_defaults.json`, and more. Each source has its own format, its own update cycle, and its own authoritative domain. None of them is redundant with another, even when they describe overlapping concepts like "core name" or "supported extensions".
+The plugin reads configuration and metadata from multiple local files — ES-DE XML, RetroArch `.info` files,
+`retrodeck.json`, `retroarch.cfg`, gamelist XML, a bundled `core_defaults.json`, and more. Each source has its own
+format, its own update cycle, and its own authoritative domain. None of them is redundant with another, even when they
+describe overlapping concepts like "core name" or "supported extensions".
 
-This page catalogs the sources, the rules for parsing them, and the mapping of questions to sources. It is the reference that new parsers should follow and the justification for why existing parsers are shaped the way they are.
+This page catalogs the sources, the rules for parsing them, and the mapping of questions to sources. It is the reference
+that new parsers should follow and the justification for why existing parsers are shaped the way they are.
 
-**Not covered on this page:** HTTP API clients (RomM, SteamGridDB, RetroAchievements). Those are handled as network-facing adapter clients, not as config-source parsers. The same layering principles apply but the mechanics (auth, retries, rate limiting) are different enough that they belong in their own documents.
+**Not covered on this page:** HTTP API clients (RomM, SteamGridDB, RetroAchievements). Those are handled as
+network-facing adapter clients, not as config-source parsers. The same layering principles apply but the mechanics
+(auth, retries, rate limiting) are different enough that they belong in their own documents.
 
 ## Why multiple sources?
 
-RetroDECK is a stack of independent components — ES-DE as the frontend, RetroArch as the runtime, a glue config layer on top, plus bundled tooling. Each component owns its own metadata in its own format:
+RetroDECK is a stack of independent components — ES-DE as the frontend, RetroArch as the runtime, a glue config layer on
+top, plus bundled tooling. Each component owns its own metadata in its own format:
 
-- **ES-DE** keeps its system definitions in `es_systems.xml`, its per-game overrides in `gamelist.xml`, and display-oriented labels it chose to include. It decides which core runs a ROM.
-- **RetroArch** keeps per-core metadata in `.info` files shipped alongside each `.so` — `corename`, `display_name`, `supported_extensions`, `firmware_*`, `database`, and more. It decides how saves are organized on disk, which firmware to require, and what extensions each core accepts.
-- **RetroDECK glue** keeps user-facing configuration in `retrodeck.json` (paths for ROMs, saves, BIOS, state) and forwards RetroArch's own `retroarch.cfg` (sort settings, core directories, and everything else RetroArch reads at startup).
+- **ES-DE** keeps its system definitions in `es_systems.xml`, its per-game overrides in `gamelist.xml`, and
+  display-oriented labels it chose to include. It decides which core runs a ROM.
+- **RetroArch** keeps per-core metadata in `.info` files shipped alongside each `.so` — `corename`, `display_name`,
+  `supported_extensions`, `firmware_*`, `database`, and more. It decides how saves are organized on disk, which firmware
+  to require, and what extensions each core accepts.
+- **RetroDECK glue** keeps user-facing configuration in `retrodeck.json` (paths for ROMs, saves, BIOS, state) and
+  forwards RetroArch's own `retroarch.cfg` (sort settings, core directories, and everything else RetroArch reads at
+  startup).
 
-There is no unified source. The upstream components are developed independently, updated on independent schedules, and have no mechanism to consolidate their metadata. The plugin must read each source individually.
+There is no unified source. The upstream components are developed independently, updated on independent schedules, and
+have no mechanism to consolidate their metadata. The plugin must read each source individually.
 
-Attempting to "normalize" these into a single internal model would fight against upstream — every time ES-DE renames a label or RetroArch ships a new core, the normalization table would drift. The sustainable approach is the opposite: keep each source as its own parser, keep the parsers ignorant of each other, and let services choose the right parser per flow.
+Attempting to "normalize" these into a single internal model would fight against upstream — every time ES-DE renames a
+label or RetroArch ships a new core, the normalization table would drift. The sustainable approach is the opposite: keep
+each source as its own parser, keep the parsers ignorant of each other, and let services choose the right parser per
+flow.
 
 ## Principle: one parser per source, no cross-contamination
 
-Each external source gets exactly one parser. Parsers do not fall back to each other. Services are responsible for picking the right parser for each business flow.
+Each external source gets exactly one parser. Parsers do not fall back to each other. Services are responsible for
+picking the right parser for each business flow.
 
 The principle has three parts:
 
-1. **One parser per source.** Adding a second reader for the same file creates drift — sooner or later the two readers disagree and the bug lives in the newer one. `retrodeck.json` has one parser. `es_systems.xml` has one parser. Every new source follows suit.
+1. **One parser per source.** Adding a second reader for the same file creates drift — sooner or later the two readers
+   disagree and the bug lives in the newer one. `retrodeck.json` has one parser. `es_systems.xml` has one parser. Every
+   new source follows suit.
 
-2. **No cross-contamination.** When a parser cannot answer a question — the file is missing, a field is absent, the value is malformed — the parser returns `None` (or raises), it does **not** defer to another parser. Cross-parser fallbacks are how ES-DE's display label ended up being used as a RetroArch save directory name (the underlying bug of [#208](https://github.com/danielcopper/decky-romm-sync/issues/208)). Each source owns its own answer or admits it has none.
+2. **No cross-contamination.** When a parser cannot answer a question — the file is missing, a field is absent, the
+   value is malformed — the parser returns `None` (or raises), it does **not** defer to another parser. Cross-parser
+   fallbacks are how ES-DE's display label ended up being used as a RetroArch save directory name (the underlying bug of
+   [#208](https://github.com/danielcopper/decky-romm-sync/issues/208)). Each source owns its own answer or admits it has
+   none.
 
-3. **Services choose the parser per flow.** "Which core is active for this ROM?" is an ES-DE question. "What does RetroArch call that core in its own subsystem?" is a RetroArch question. Both questions may appear inside the same service method, and the service is responsible for asking each one at the right parser. Do not invent a parser-of-parsers to hide the choice.
+3. **Services choose the parser per flow.** "Which core is active for this ROM?" is an ES-DE question. "What does
+   RetroArch call that core in its own subsystem?" is a RetroArch question. Both questions may appear inside the same
+   service method, and the service is responsible for asking each one at the right parser. Do not invent a
+   parser-of-parsers to hide the choice.
 
 ### Worked example: ES-DE label vs RetroArch corename
 
-The concrete case that motivated this principle, and the bug in [#208](https://github.com/danielcopper/decky-romm-sync/issues/208):
+The concrete case that motivated this principle, and the bug in
+[#208](https://github.com/danielcopper/decky-romm-sync/issues/208):
 
-- `CoreResolver` (parses ES-DE) returns a tuple `(core_so, label)` for "which core is active?". `label` is ES-DE's **display string** — e.g. `"Snes9x - Current"`. It is a UI-level name, chosen by the ES-DE/RetroDECK team to disambiguate in the core picker UI.
-- RetroArch, when `sort_savefiles_enable = true`, writes saves into subdirectories named by the **`corename`** field of the core's `.info` file — e.g. `"Snes9x"`. It is RetroArch's canonical internal name, set by the core's maintainer, baked into RetroArch's runtime path logic.
+- `CoreResolver` (parses ES-DE) returns a tuple `(core_so, label)` for "which core is active?". `label` is ES-DE's
+  **display string** — e.g. `"Snes9x - Current"`. It is a UI-level name, chosen by the ES-DE/RetroDECK team to
+  disambiguate in the core picker UI.
+- RetroArch, when `sort_savefiles_enable = true`, writes saves into subdirectories named by the **`corename`** field of
+  the core's `.info` file — e.g. `"Snes9x"`. It is RetroArch's canonical internal name, set by the core's maintainer,
+  baked into RetroArch's runtime path logic.
 
-These two values **are not redundant representations of the same thing**. They answer different questions at different layers:
+These two values **are not redundant representations of the same thing**. They answer different questions at different
+layers:
 
-| Core | ES-DE label | RetroArch `corename` |
-| --- | --- | --- |
-| Snes9x | `Snes9x - Current` | `Snes9x` |
-| mGBA | `mGBA` | `mGBA` |
-| Beetle PSX HW | `Beetle PSX HW` | `Beetle PSX HW` |
-| SwanStation | `SwanStation` | `SwanStation` |
-| Genesis Plus GX | `Genesis Plus GX` | `Genesis Plus GX` |
+| Core            | ES-DE label        | RetroArch `corename` |
+| --------------- | ------------------ | -------------------- |
+| Snes9x          | `Snes9x - Current` | `Snes9x`             |
+| mGBA            | `mGBA`             | `mGBA`               |
+| Beetle PSX HW   | `Beetle PSX HW`    | `Beetle PSX HW`      |
+| SwanStation     | `SwanStation`      | `SwanStation`        |
+| Genesis Plus GX | `Genesis Plus GX`  | `Genesis Plus GX`    |
 
-Four out of five happen to match textually. Snes9x does not — ES-DE added `" - Current"` to disambiguate from the older `Snes9x 2010` variant. The match is **incidental**, not structural. Future cores, future ES-DE redesigns, and future RetroDECK re-labelings will introduce new mismatches.
+Four out of five happen to match textually. Snes9x does not — ES-DE added `" - Current"` to disambiguate from the older
+`Snes9x 2010` variant. The match is **incidental**, not structural. Future cores, future ES-DE redesigns, and future
+RetroDECK re-labelings will introduce new mismatches.
 
-Reconciling by whitelist — a table of "ES-DE label → RetroArch corename" mappings — would be a perpetual maintenance burden. Every new core, every label change, every RetroDECK release shifts the table. The correct answer is to not reconcile at all: when you need the save directory name, ask RetroArch; when you need the UI label, ask ES-DE. The lookup is O(1) per source, caching is local, and drift is impossible because neither parser pretends to speak for the other.
+Reconciling by whitelist — a table of "ES-DE label → RetroArch corename" mappings — would be a perpetual maintenance
+burden. Every new core, every label change, every RetroDECK release shifts the table. The correct answer is to not
+reconcile at all: when you need the save directory name, ask RetroArch; when you need the UI label, ask ES-DE. The
+lookup is O(1) per source, caching is local, and drift is impossible because neither parser pretends to speak for the
+other.
 
 ## Question-to-source mapping
 
-| Question | Authoritative source | Why |
-| --- | --- | --- |
-| Which core is active for system X / ROM Y? | ES-DE (`es_systems.xml` + `gamelist.xml`) | ES-DE **decides** this — defaults, per-system overrides, per-game overrides. |
-| What's the ES-DE display label for a core? | ES-DE | Label is an ES-DE/RetroDECK UI concern, chosen at the ES-DE config level. |
-| What subdirectory does RetroArch use for this core's saves (sort-by-core)? | RetroArch `.info` `corename` field | RetroArch creates the directory using `corename`; `.info` is the only place that canonical name lives. |
-| What ROM extensions does a core support? | RetroArch `.info` `supported_extensions` field | libretro-maintainer-authoritative, updated with every core release. |
-| What firmware files does a core need? | RetroArch `.info` `firmware_count` + `firmwareN_*` fields | libretro-maintainer-authoritative; optional flags included. |
-| What datfile database matches a core's ROMs? | RetroArch `.info` `database` field | libretro-maintainer-authoritative. |
-| Where does RetroDECK put ROMs, saves, BIOS, states, and its home directory? | `retrodeck.json` | RetroDECK owns path configuration; it's the file users edit via the RetroDECK configurator. |
-| Is RetroArch's save-sorting by content or by core enabled? | `retroarch.cfg` `sort_savefiles_*` | RetroArch owns its runtime config; the cfg is its canonical input. |
+| Question                                                                    | Authoritative source                                      | Why                                                                                                    |
+| --------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Which core is active for system X / ROM Y?                                  | ES-DE (`es_systems.xml` + `gamelist.xml`)                 | ES-DE **decides** this — defaults, per-system overrides, per-game overrides.                           |
+| What's the ES-DE display label for a core?                                  | ES-DE                                                     | Label is an ES-DE/RetroDECK UI concern, chosen at the ES-DE config level.                              |
+| What subdirectory does RetroArch use for this core's saves (sort-by-core)?  | RetroArch `.info` `corename` field                        | RetroArch creates the directory using `corename`; `.info` is the only place that canonical name lives. |
+| What ROM extensions does a core support?                                    | RetroArch `.info` `supported_extensions` field            | libretro-maintainer-authoritative, updated with every core release.                                    |
+| What firmware files does a core need?                                       | RetroArch `.info` `firmware_count` + `firmwareN_*` fields | libretro-maintainer-authoritative; optional flags included.                                            |
+| What datfile database matches a core's ROMs?                                | RetroArch `.info` `database` field                        | libretro-maintainer-authoritative.                                                                     |
+| Where does RetroDECK put ROMs, saves, BIOS, states, and its home directory? | `retrodeck.json`                                          | RetroDECK owns path configuration; it's the file users edit via the RetroDECK configurator.            |
+| Is RetroArch's save-sorting by content or by core enabled?                  | `retroarch.cfg` `sort_savefiles_*`                        | RetroArch owns its runtime config; the cfg is its canonical input.                                     |
 
-If a new question appears, the first step is to figure out which source authoritatively owns it. The mapping above grows as new questions are added — treat this table as part of the contract, not a passive catalog.
+If a new question appears, the first step is to figure out which source authoritatively owns it. The mapping above grows
+as new questions are added — treat this table as part of the contract, not a passive catalog.
 
 ## Parser layout template
 
-New parsers follow a strict domain-plus-adapter split, matching the broader service/adapter architecture documented in [Backend Architecture](backend-architecture.md): a pure parse function in `domain/`, all I/O in an `adapters/` class, and a callback Protocol that services depend on. The `.info` parser below (`domain/retroarch_core_info.py` + `adapters/retroarch_core_info.py`) is the reference shape.
+New parsers follow a strict domain-plus-adapter split, matching the broader service/adapter architecture documented in
+[Backend Architecture](backend-architecture.md): a pure parse function in `domain/`, all I/O in an `adapters/` class,
+and a callback Protocol that services depend on. The `.info` parser below (`domain/retroarch_core_info.py` +
+`adapters/retroarch_core_info.py`) is the reference shape.
 
 ```text
 ┌──────────────────────────────────────┐
@@ -96,7 +138,8 @@ New parsers follow a strict domain-plus-adapter split, matching the broader serv
 
 ### 1. Pure parser in `py_modules/domain/<source>.py`
 
-A module of pure functions. No I/O, no logging, no filesystem access. Takes text (or already-loaded data) as input and returns a structured representation.
+A module of pure functions. No I/O, no logging, no filesystem access. Takes text (or already-loaded data) as input and
+returns a structured representation.
 
 ```python
 # domain/retroarch_core_info.py
@@ -111,11 +154,14 @@ def parse_core_info(text: str) -> dict[str, str]:
     ...
 ```
 
-Why in domain: parsing is pure logic. It's exhaustively testable with inline text fixtures — no tmp_path, no mocks, no subprocess. This is the cleanest possible unit under test, and it's where format-level edge cases belong (comments, blank lines, unquoted values, escaped characters, line-continuation quirks, etc.).
+Why in domain: parsing is pure logic. It's exhaustively testable with inline text fixtures — no tmp_path, no mocks, no
+subprocess. This is the cleanest possible unit under test, and it's where format-level edge cases belong (comments,
+blank lines, unquoted values, escaped characters, line-continuation quirks, etc.).
 
 ### 2. I/O-owning adapter in `py_modules/adapters/<source>.py`
 
-A class with a single responsibility: resolve the right file path(s), read bytes, delegate parsing to the domain module, cache the result, handle I/O errors.
+A class with a single responsibility: resolve the right file path(s), read bytes, delegate parsing to the domain module,
+cache the result, handle I/O errors.
 
 ```python
 # adapters/retroarch_core_info.py
@@ -133,18 +179,25 @@ class RetroArchCoreInfoAdapter:
         """Convenience accessor for the corename field."""
 ```
 
-Why in adapter: anything that touches the filesystem (open, read, stat, glob) is I/O and belongs in the adapter layer per the plugin's layering rules. Adapters are allowed to import domain modules — the reverse is not allowed (enforced by import-linter).
+Why in adapter: anything that touches the filesystem (open, read, stat, glob) is I/O and belongs in the adapter layer
+per the plugin's layering rules. Adapters are allowed to import domain modules — the reverse is not allowed (enforced by
+import-linter).
 
 ### 3. Protocol(s) in `py_modules/services/protocols/`
 
-Services never import concrete adapters. They depend on callable protocols defined in the `services/protocols/` package (config-source parsers live in `paths.py`), and the concrete adapter method is wired up by `bootstrap.py`.
+Services never import concrete adapters. They depend on callable protocols defined in the `services/protocols/` package
+(config-source parsers live in `paths.py`), and the concrete adapter method is wired up by `bootstrap.py`.
 
 ```python
 class CoreNameProviderFn(Protocol):
     def __call__(self, core_so: str) -> str | None: ...
 ```
 
-One protocol per capability, not one protocol per adapter. This matches the existing pattern of individual callback protocols (`SavesPathProvider`, `RomsPathProvider`, `BiosPathProvider`, etc.) introduced by the #196 refactor. When the same adapter exposes multiple capabilities (`get_corename`, `get_supported_extensions`, `get_firmware_requirements`, …), each gets its own protocol so services can depend on only what they actually use — and a test double only needs to stub the callables a given test exercises.
+One protocol per capability, not one protocol per adapter. This matches the existing pattern of individual callback
+protocols (`SavesPathProvider`, `RomsPathProvider`, `BiosPathProvider`, etc.) introduced by the #196 refactor. When the
+same adapter exposes multiple capabilities (`get_corename`, `get_supported_extensions`, `get_firmware_requirements`, …),
+each gets its own protocol so services can depend on only what they actually use — and a test double only needs to stub
+the callables a given test exercises.
 
 ### 4. Wiring in `py_modules/bootstrap.py`
 
@@ -163,119 +216,204 @@ migration_service = MigrationService(
 )
 ```
 
-The service receives callbacks, not an adapter. It has no knowledge of which file or format they come from — which keeps services independent of any single parser and makes them straightforward to test with fake callables.
+The service receives callbacks, not an adapter. It has no knowledge of which file or format they come from — which keeps
+services independent of any single parser and makes them straightforward to test with fake callables.
 
 ### 5. Tests at each layer
 
-- **`tests/domain/test_<source>.py`** — pure-parse tests with inline string fixtures. Edge cases, malformed input, Unicode, whitespace variations, missing fields. No tmp_path, no mocks.
-- **`tests/adapters/test_<source>.py`** — adapter tests with `tmp_path`. Happy path, file missing, `OSError`, cache hits, candidate-path fallback. This is the only layer that touches real files.
-- **`tests/services/test_<service>.py`** — service tests with the callback mocked (`MagicMock`). Flow tests: what happens on `None`, what happens on success, what happens when the callback is not injected at all.
+- **`tests/domain/test_<source>.py`** — pure-parse tests with inline string fixtures. Edge cases, malformed input,
+  Unicode, whitespace variations, missing fields. No tmp_path, no mocks.
+- **`tests/adapters/test_<source>.py`** — adapter tests with `tmp_path`. Happy path, file missing, `OSError`, cache
+  hits, candidate-path fallback. This is the only layer that touches real files.
+- **`tests/services/test_<service>.py`** — service tests with the callback mocked (`MagicMock`). Flow tests: what
+  happens on `None`, what happens on success, what happens when the callback is not injected at all.
 
 ## Current parsers
 
-| Source | Format | Parser location | Layer status | What it answers |
-| --- | --- | --- | --- | --- |
-| `retrodeck.json` | JSON | `adapters/retrodeck_paths.py` — `RetroDeckPathsAdapter` | ✅ adapter (correct layering) | Where RetroDECK puts saves, ROMs, BIOS, and its home directory. |
-| `retroarch.cfg` | INI-ish `key = "value"` | `adapters/retroarch_config.py` — `RetroArchConfigAdapter` | ✅ adapter (correct layering) | Save-sorting flags (`sort_savefiles_by_content_enable`, `sort_savefiles_enable`); room to grow as more cfg fields are needed. |
-| `es_systems.xml` | XML | `adapters/es_de_config.py` — `CoreResolver` | ✅ adapter (correct layering) | Which core is ES-DE's default for a system; list of available cores with labels. |
-| `gamelist.xml` | XML | `adapters/es_de_config.py` — `CoreResolver` + `GamelistXmlEditorAdapter` | ✅ adapter (correct layering) | Per-system and per-game `altemulator` overrides; metadata reads and writes. |
-| `core_defaults.json` (bundled) | JSON | `adapters/es_de_config.py` — `CoreResolver` | ✅ adapter (correct layering) | Static fallback for core defaults when live `es_systems.xml` is unavailable. |
-| RetroArch `.info` | INI-ish `key = "value"` | `adapters/retroarch_core_info.py` + `domain/retroarch_core_info.py` | ✅ adapter + pure-domain parse (correct layering) | `corename` (authoritative save subdir name), plus the full metadata dict for future use. |
+| Source                         | Format                  | Parser location                                                          | Layer status                                      | What it answers                                                                                                               |
+| ------------------------------ | ----------------------- | ------------------------------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `retrodeck.json`               | JSON                    | `adapters/retrodeck_paths.py` — `RetroDeckPathsAdapter`                  | ✅ adapter (correct layering)                     | Where RetroDECK puts saves, ROMs, BIOS, and its home directory.                                                               |
+| `retroarch.cfg`                | INI-ish `key = "value"` | `adapters/retroarch_config.py` — `RetroArchConfigAdapter`                | ✅ adapter (correct layering)                     | Save-sorting flags (`sort_savefiles_by_content_enable`, `sort_savefiles_enable`); room to grow as more cfg fields are needed. |
+| `es_systems.xml`               | XML                     | `adapters/es_de_config.py` — `CoreResolver`                              | ✅ adapter (correct layering)                     | Which core is ES-DE's default for a system; list of available cores with labels.                                              |
+| `gamelist.xml`                 | XML                     | `adapters/es_de_config.py` — `CoreResolver` + `GamelistXmlEditorAdapter` | ✅ adapter (correct layering)                     | Per-system and per-game `altemulator` overrides; metadata reads and writes.                                                   |
+| `core_defaults.json` (bundled) | JSON                    | `adapters/es_de_config.py` — `CoreResolver`                              | ✅ adapter (correct layering)                     | Static fallback for core defaults when live `es_systems.xml` is unavailable.                                                  |
+| RetroArch `.info`              | INI-ish `key = "value"` | `adapters/retroarch_core_info.py` + `domain/retroarch_core_info.py`      | ✅ adapter + pure-domain parse (correct layering) | `corename` (authoritative save subdir name), plus the full metadata dict for future use.                                      |
 
-The ES-DE parsers (`CoreResolver`, `GamelistXmlEditorAdapter`) keep their XML parsing inline rather than in a separate pure-domain module; that is acceptable because the adapter owns its I/O. New `.info`-style sources that warrant a pure-parse split should follow the [parser layout template](#parser-layout-template) above (pure parse in `domain/`, I/O in `adapters/`).
+The ES-DE parsers (`CoreResolver`, `GamelistXmlEditorAdapter`) keep their XML parsing inline rather than in a separate
+pure-domain module; that is acceptable because the adapter owns its I/O. New `.info`-style sources that warrant a
+pure-parse split should follow the [parser layout template](#parser-layout-template) above (pure parse in `domain/`, I/O
+in `adapters/`).
 
 ## Known consumer gaps
 
 One-parser-per-source compliance has two sides, and this page historically only covered one of them:
 
-1. **Parser inventory (covered above).** Does each source have exactly one parser? Does that parser live in the right layer? Does it refuse to cross-contaminate?
-2. **Consumer compliance (this section).** Does every service method that asks a question route it through the right parser? It is possible — and has happened in practice — for every parser to be individually correct while a consumer still builds the wrong answer by calling the wrong parser or by forgetting to call a parser at all.
+1. **Parser inventory (covered above).** Does each source have exactly one parser? Does that parser live in the right
+   layer? Does it refuse to cross-contaminate?
+2. **Consumer compliance (this section).** Does every service method that asks a question route it through the right
+   parser? It is possible — and has happened in practice — for every parser to be individually correct while a consumer
+   still builds the wrong answer by calling the wrong parser or by forgetting to call a parser at all.
 
 The gap below is the consumer-side cautionary tale that motivated adding this section.
 
 ### Case study: SaveService missed the RetroArch corename after #208
 
-[#208](https://github.com/danielcopper/decky-romm-sync/issues/208) introduced the `RetroArchCoreInfoAdapter` precisely to fix the "ES-DE label leaks into RetroArch save path" bug described in the [Worked example](#worked-example-es-de-label-vs-retroarch-corename) above. That PR correctly updated `MigrationService` to ask ES-DE which core is active and then ask the RetroArch `.info` parser for the canonical `corename`. The parser was written, the protocol was defined, and the migration flow was fixed.
+[#208](https://github.com/danielcopper/decky-romm-sync/issues/208) introduced the `RetroArchCoreInfoAdapter` precisely
+to fix the "ES-DE label leaks into RetroArch save path" bug described in the
+[Worked example](#worked-example-es-de-label-vs-retroarch-corename) above. That PR correctly updated `MigrationService`
+to ask ES-DE which core is active and then ask the RetroArch `.info` parser for the canonical `corename`. The parser was
+written, the protocol was defined, and the migration flow was fixed.
 
-It was not until PR #227 had already merged, during live-testing on a real Steam Deck, that the second shoe dropped: `SaveService._get_rom_save_info` — which every save-sync flow on every game launch routes through — was still calling `domain.save_path.resolve_save_dir(..., sort_by_core=True)` **without** the resolved `core_name` argument. The domain function's guard `if sort_by_core and core_name:` silently skipped the core subdir branch, so every save path fell back to `{saves_base}/{system}/` instead of `{saves_base}/{system}/{corename}/`.
+It was not until PR #227 had already merged, during live-testing on a real Steam Deck, that the second shoe dropped:
+`SaveService._get_rom_save_info` — which every save-sync flow on every game launch routes through — was still calling
+`domain.save_path.resolve_save_dir(..., sort_by_core=True)` **without** the resolved `core_name` argument. The domain
+function's guard `if sort_by_core and core_name:` silently skipped the core subdir branch, so every save path fell back
+to `{saves_base}/{system}/` instead of `{saves_base}/{system}/{corename}/`.
 
-The live reproduction: a user restored a Mario Golf save from the game detail page. RetroArch had `sort_savefiles_enable = "true"`, so the migrated save lived at `saves/gba/mGBA/Mario Golf - Advance Tour (USA).srm`. The restore wrote to `saves/gba/Mario Golf - Advance Tour (USA).srm` — the parent directory. RetroArch at launch read from the core subdir, so the restored save was invisible to the game.
+The live reproduction: a user restored a Mario Golf save from the game detail page. RetroArch had
+`sort_savefiles_enable = "true"`, so the migrated save lived at `saves/gba/mGBA/Mario Golf - Advance Tour (USA).srm`.
+The restore wrote to `saves/gba/Mario Golf - Advance Tour (USA).srm` — the parent directory. RetroArch at launch read
+from the core subdir, so the restored save was invisible to the game.
 
-The parsers were fine. The migration consumer was fine. The save-sync consumer was not, because during the #208 fix the author only updated the consumer that the issue explicitly named and did not audit other call sites for the same mistake. That omission is exactly what the "one parser per source" principle is supposed to prevent — but the principle had been documented only as parser-side guidance and never applied as an audit criterion against the existing codebase.
+The parsers were fine. The migration consumer was fine. The save-sync consumer was not, because during the #208 fix the
+author only updated the consumer that the issue explicitly named and did not audit other call sites for the same
+mistake. That omission is exactly what the "one parser per source" principle is supposed to prevent — but the principle
+had been documented only as parser-side guidance and never applied as an audit criterion against the existing codebase.
 
-[#232](https://github.com/danielcopper/decky-romm-sync/issues/232) closed the SaveService gap and added this section to make the consumer-compliance dimension explicit.
+[#232](https://github.com/danielcopper/decky-romm-sync/issues/232) closed the SaveService gap and added this section to
+make the consumer-compliance dimension explicit.
 
 ### Consumer checklist for reviewers
 
-When reviewing a PR that touches save-path resolution, core resolution, firmware requirements, or any other capability in the question-to-source mapping table, walk each call site with these questions:
+When reviewing a PR that touches save-path resolution, core resolution, firmware requirements, or any other capability
+in the question-to-source mapping table, walk each call site with these questions:
 
-1. **Is the right parser being called at all?** The answer to "what subdirectory does RetroArch use for this core's saves?" is always the RetroArch `.info` `corename` field. The answer to "which core runs this ROM?" is always ES-DE. A consumer that asks ES-DE for a save-directory name, or asks RetroArch which core is active, has skipped a source boundary.
-2. **Are all inputs to the parser resolved from their own authoritative parsers?** `resolve_save_dir` takes `core_name` as an input — not because the domain function can compute it, but because the caller is responsible for asking the right parser first. A call that passes `core_name=None` with `sort_by_core=True` is a silent bug, because the domain guard drops the core subdir without error.
-3. **Does the `None` case fail loudly?** When a required parser returns `None`, the consumer must either (a) skip the operation with a warning (MigrationService's choice — one-shot flow, acceptable to halt), or (b) log a warning and fall back to a documented behavior (SaveService's choice — continuous critical path, acceptable to degrade). **Silent fallback with no diagnostic is never acceptable** — that is what produced #232.
-4. **Does the same call pattern appear elsewhere?** If you are fixing one consumer, grep the whole codebase for the same function name and audit every call site. A `resolve_retroarch_corename` helper exists on both `MigrationService` (`services/migration.py`) and the saves `RomInfoService` (`services/saves/rom_info.py`) — future save-path consumers should follow the same pattern or reuse a helper rather than inlining the two-step resolution.
-5. **Is the new consumer covered by regression tests?** Every consumer should have unit tests for: the happy path, the `None` path (parser unresolvable), and the "callback not injected at all" path. The `TestGetRomSaveInfo` class in `tests/services/saves/test_rom_info.py` is the reference shape.
+1. **Is the right parser being called at all?** The answer to "what subdirectory does RetroArch use for this core's
+   saves?" is always the RetroArch `.info` `corename` field. The answer to "which core runs this ROM?" is always ES-DE.
+   A consumer that asks ES-DE for a save-directory name, or asks RetroArch which core is active, has skipped a source
+   boundary.
+2. **Are all inputs to the parser resolved from their own authoritative parsers?** `resolve_save_dir` takes `core_name`
+   as an input — not because the domain function can compute it, but because the caller is responsible for asking the
+   right parser first. A call that passes `core_name=None` with `sort_by_core=True` is a silent bug, because the domain
+   guard drops the core subdir without error.
+3. **Does the `None` case fail loudly?** When a required parser returns `None`, the consumer must either (a) skip the
+   operation with a warning (MigrationService's choice — one-shot flow, acceptable to halt), or (b) log a warning and
+   fall back to a documented behavior (SaveService's choice — continuous critical path, acceptable to degrade). **Silent
+   fallback with no diagnostic is never acceptable** — that is what produced #232.
+4. **Does the same call pattern appear elsewhere?** If you are fixing one consumer, grep the whole codebase for the same
+   function name and audit every call site. A `resolve_retroarch_corename` helper exists on both `MigrationService`
+   (`services/migration.py`) and the saves `RomInfoService` (`services/saves/rom_info.py`) — future save-path consumers
+   should follow the same pattern or reuse a helper rather than inlining the two-step resolution.
+5. **Is the new consumer covered by regression tests?** Every consumer should have unit tests for: the happy path, the
+   `None` path (parser unresolvable), and the "callback not injected at all" path. The `TestGetRomSaveInfo` class in
+   `tests/services/saves/test_rom_info.py` is the reference shape.
 
 ### Historical examples
 
-| Issue | Parser state | Consumer state | Resolution |
-| --- | --- | --- | --- |
-| [#208](https://github.com/danielcopper/decky-romm-sync/issues/208) | `.info` parser did not exist; ES-DE label was the only core name source | `MigrationService` used the ES-DE label as the RetroArch save subdir name | Add `RetroArchCoreInfoAdapter`, resolve corename from `.info`, wire into migration |
-| [#232](https://github.com/danielcopper/decky-romm-sync/issues/232) | `.info` parser correct (from #208) | `SaveService._get_rom_save_info` still called `resolve_save_dir` with `core_name=None`, so `sort_by_core` was a silent no-op for every save flow | Thread `get_core_name` into `SaveService`, extract `_resolve_retroarch_corename` helper mirroring `MigrationService`, warn+fallback when unresolvable |
+| Issue                                                              | Parser state                                                            | Consumer state                                                                                                                                   | Resolution                                                                                                                                            |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#208](https://github.com/danielcopper/decky-romm-sync/issues/208) | `.info` parser did not exist; ES-DE label was the only core name source | `MigrationService` used the ES-DE label as the RetroArch save subdir name                                                                        | Add `RetroArchCoreInfoAdapter`, resolve corename from `.info`, wire into migration                                                                    |
+| [#232](https://github.com/danielcopper/decky-romm-sync/issues/232) | `.info` parser correct (from #208)                                      | `SaveService._get_rom_save_info` still called `resolve_save_dir` with `core_name=None`, so `sort_by_core` was a silent no-op for every save flow | Thread `get_core_name` into `SaveService`, extract `_resolve_retroarch_corename` helper mirroring `MigrationService`, warn+fallback when unresolvable |
 
-Both issues are parser-side fine in the sense that the parser itself returned the right answer for the question asked. They are consumer-side bugs: the consumer either asked the wrong parser or forgot to ask the right one. The checklist above exists to catch the second shoe before it drops in production.
+Both issues are parser-side fine in the sense that the parser itself returned the right answer for the question asked.
+They are consumer-side bugs: the consumer either asked the wrong parser or forgot to ask the right one. The checklist
+above exists to catch the second shoe before it drops in production.
 
 ## Planned / future unlocks
 
-The RetroArch `.info` parser, introduced by #208, ships with only the `corename` field hooked up — the minimum needed to fix the save-sort migration bug. But `.info` files contain much more, and the parser returns the full dict internally. The following unlocks are natural follow-ups; each should land in its own issue and its own PR so we can pace them against real need rather than speculatively building ahead.
+The RetroArch `.info` parser, introduced by #208, ships with only the `corename` field hooked up — the minimum needed to
+fix the save-sort migration bug. But `.info` files contain much more, and the parser returns the full dict internally.
+The following unlocks are natural follow-ups; each should land in its own issue and its own PR so we can pace them
+against real need rather than speculatively building ahead.
 
-| Capability | `.info` field(s) | Replaces today's | Value |
-| --- | --- | --- | --- |
-| Per-core supported extensions | `supported_extensions` | Hardcoded lists in `defaults/config.json` | Self-updating via Flatpak releases; fewer drift bugs when cores add formats. |
-| Per-core firmware requirements | `firmware_count`, `firmware<N>_desc`, `firmware<N>_path`, `firmware<N>_opt` | Manual BIOS registry in `FirmwareService` | Authoritative list per active core; highlights what's truly needed vs optional. |
-| Core switching validation | `supported_extensions` | (no check today) | Prevent assigning a core to a system whose ROM extensions it can't load. |
-| DAT/database identification | `database` | (no use today) | Match ROM headers against the right datfile for integrity checks. |
-| Core display names | `display_name` | ES-DE label only | Secondary source when an ES-DE label is unavailable (rare); never used to override ES-DE. |
+| Capability                     | `.info` field(s)                                                            | Replaces today's                          | Value                                                                                     |
+| ------------------------------ | --------------------------------------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Per-core supported extensions  | `supported_extensions`                                                      | Hardcoded lists in `defaults/config.json` | Self-updating via Flatpak releases; fewer drift bugs when cores add formats.              |
+| Per-core firmware requirements | `firmware_count`, `firmware<N>_desc`, `firmware<N>_path`, `firmware<N>_opt` | Manual BIOS registry in `FirmwareService` | Authoritative list per active core; highlights what's truly needed vs optional.           |
+| Core switching validation      | `supported_extensions`                                                      | (no check today)                          | Prevent assigning a core to a system whose ROM extensions it can't load.                  |
+| DAT/database identification    | `database`                                                                  | (no use today)                            | Match ROM headers against the right datfile for integrity checks.                         |
+| Core display names             | `display_name`                                                              | ES-DE label only                          | Secondary source when an ES-DE label is unavailable (rare); never used to override ES-DE. |
 
 None of these are in scope for #208. They are listed here so that, when the time comes, contributors know:
 
 - The parser already exists — no new adapter needed.
-- The right way to extend it is a new callback protocol in `services/protocols/` (the `paths.py` module) plus a new accessor method on the adapter (e.g. `get_supported_extensions(core_so)`).
-- The underlying `get_core_info` already returns the full dict, so each new accessor is a few lines wrapping `info.get(field)`.
+- The right way to extend it is a new callback protocol in `services/protocols/` (the `paths.py` module) plus a new
+  accessor method on the adapter (e.g. `get_supported_extensions(core_so)`).
+- The underlying `get_core_info` already returns the full dict, so each new accessor is a few lines wrapping
+  `info.get(field)`.
 - The new accessor gets wired into bootstrap.py the same way `get_corename` is.
 
 ## How to add a new source
 
 When the plugin needs to read a new external config/metadata source, the checklist is:
 
-1. **Identify the source and its authoritative domain.** Add a row to the **Question-to-source mapping** table above. If the new source overlaps with an existing one, explicitly decide which parser owns which question — do not merge them.
-2. **Write the pure parser** in `py_modules/domain/<source>.py`. Start with the smallest function that answers the immediate need; grow the API later. Tests first.
-3. **Write the adapter** in `py_modules/adapters/<source>.py`. Path resolution, file read, parsing delegation, caching. Tests with `tmp_path`.
-4. **Add callback protocol(s)** in `py_modules/services/protocols/`. One protocol per capability, in the existing `*Fn` Call-protocol style.
-5. **Wire in `bootstrap.py`.** Instantiate the adapter in the composition root; thread its method(s) into services that need them.
-6. **Consume in services.** Services depend on the protocol, not on the adapter. Handle the `None` / failure case at the service layer — no cross-parser fallbacks.
-7. **Add a row to Current parsers** above and update the decisions log below if there's a non-obvious design choice worth recording.
-8. **Update `.importlinter`** if the new adapter needs a contract line to stay independent of services or sibling adapters.
+1. **Identify the source and its authoritative domain.** Add a row to the **Question-to-source mapping** table above. If
+   the new source overlaps with an existing one, explicitly decide which parser owns which question — do not merge them.
+2. **Write the pure parser** in `py_modules/domain/<source>.py`. Start with the smallest function that answers the
+   immediate need; grow the API later. Tests first.
+3. **Write the adapter** in `py_modules/adapters/<source>.py`. Path resolution, file read, parsing delegation, caching.
+   Tests with `tmp_path`.
+4. **Add callback protocol(s)** in `py_modules/services/protocols/`. One protocol per capability, in the existing `*Fn`
+   Call-protocol style.
+5. **Wire in `bootstrap.py`.** Instantiate the adapter in the composition root; thread its method(s) into services that
+   need them.
+6. **Consume in services.** Services depend on the protocol, not on the adapter. Handle the `None` / failure case at the
+   service layer — no cross-parser fallbacks.
+7. **Add a row to Current parsers** above and update the decisions log below if there's a non-obvious design choice
+   worth recording.
+8. **Update `.importlinter`** if the new adapter needs a contract line to stay independent of services or sibling
+   adapters.
 
 ## Decisions log
 
 Non-obvious design choices worth preserving:
 
-- **Three sibling adapters for RetroDECK/RetroArch-side config, not one bundle.** The plugin has `RetroDeckPathsAdapter` (reads `retrodeck.json`), `RetroArchConfigAdapter` (reads `retroarch.cfg`), and `RetroArchCoreInfoAdapter` (reads `.info` files) as three independent adapters. A single combined "RetroDECK/RetroArch config" adapter would conflate three different owners (RetroDECK team vs RetroArch team vs libretro core maintainers), three different change triggers (user configurator edits vs runtime cfg writes vs Flatpak core releases), and three different file layouts (user home for `retrodeck.json`, RetroDECK config directory for `retroarch.cfg`, Flatpak install tree for `.info`). Bundling them would produce a class with too many reasons to change; splitting them keeps each adapter small, testable, and cleanly scoped to one source. This is the applied form of the "one parser per source" principle for the RetroDECK/RetroArch-side of the codebase.
+- **Three sibling adapters for RetroDECK/RetroArch-side config, not one bundle.** The plugin has `RetroDeckPathsAdapter`
+  (reads `retrodeck.json`), `RetroArchConfigAdapter` (reads `retroarch.cfg`), and `RetroArchCoreInfoAdapter` (reads
+  `.info` files) as three independent adapters. A single combined "RetroDECK/RetroArch config" adapter would conflate
+  three different owners (RetroDECK team vs RetroArch team vs libretro core maintainers), three different change
+  triggers (user configurator edits vs runtime cfg writes vs Flatpak core releases), and three different file layouts
+  (user home for `retrodeck.json`, RetroDECK config directory for `retroarch.cfg`, Flatpak install tree for `.info`).
+  Bundling them would produce a class with too many reasons to change; splitting them keeps each adapter small,
+  testable, and cleanly scoped to one source. This is the applied form of the "one parser per source" principle for the
+  RetroDECK/RetroArch-side of the codebase.
 
-- **No TTL cache for `.info` reads.** `RetroDeckPathsAdapter` uses a 30-second TTL cache for `retrodeck.json` because that file can be edited by the user at runtime via RetroDECK's configurator. `.info` files live inside a read-only Flatpak install and only change when the Flatpak is updated, which in practice tears down the plugin process anyway. A simple per-instance dict cache (keyed by `core_so`, no expiry) is sufficient — plugin restart picks up any real change. `RetroArchConfigAdapter` currently reads `retroarch.cfg` uncached on every call; that's fine for today's low call frequency and can grow a cache later if needed.
+- **No TTL cache for `.info` reads.** `RetroDeckPathsAdapter` uses a 30-second TTL cache for `retrodeck.json` because
+  that file can be edited by the user at runtime via RetroDECK's configurator. `.info` files live inside a read-only
+  Flatpak install and only change when the Flatpak is updated, which in practice tears down the plugin process anyway. A
+  simple per-instance dict cache (keyed by `core_so`, no expiry) is sufficient — plugin restart picks up any real
+  change. `RetroArchConfigAdapter` currently reads `retroarch.cfg` uncached on every call; that's fine for today's low
+  call frequency and can grow a cache later if needed.
 
-- **No fallback from RetroArch parser to ES-DE label.** When `.info` lookup returns `None`, `MigrationService` returns `None` for the core name and the save-sort migration logs a warning and skips the affected files. This is deliberately stricter than the previous behavior (which returned the ES-DE label and silently built wrong paths for any core where label ≠ corename). Fail-loud beats silent corruption; real-world `.info`-missing cases can be diagnosed from the warning and addressed by adding candidate paths or a bundled fallback.
+- **No fallback from RetroArch parser to ES-DE label.** When `.info` lookup returns `None`, `MigrationService` returns
+  `None` for the core name and the save-sort migration logs a warning and skips the affected files. This is deliberately
+  stricter than the previous behavior (which returned the ES-DE label and silently built wrong paths for any core where
+  label ≠ corename). Fail-loud beats silent corruption; real-world `.info`-missing cases can be diagnosed from the
+  warning and addressed by adding candidate paths or a bundled fallback.
 
-- **`core_so` is the full `.so` basename including `_libretro`.** `CoreResolver.get_active_core` returns `(core_so, label)` where `core_so` is e.g. `"snes9x_libretro"`, not `"snes9x"`. This is set by the regex `[\w-]+_libretro` when parsing `es_systems.xml`'s `<command>` elements. The `.info` filename is therefore `{core_so}.info` (e.g. `snes9x_libretro.info`), not `{core_so}_libretro.info`. This is a subtle naming quirk documented here so future parser users don't double the suffix.
+- **`core_so` is the full `.so` basename including `_libretro`.** `CoreResolver.get_active_core` returns
+  `(core_so, label)` where `core_so` is e.g. `"snes9x_libretro"`, not `"snes9x"`. This is set by the regex
+  `[\w-]+_libretro` when parsing `es_systems.xml`'s `<command>` elements. The `.info` filename is therefore
+  `{core_so}.info` (e.g. `snes9x_libretro.info`), not `{core_so}_libretro.info`. This is a subtle naming quirk
+  documented here so future parser users don't double the suffix.
 
-- **RetroDECK-only path resolution, standalone RetroArch out of scope.** The `.info` adapter only looks under `net.retrodeck.retrodeck` Flatpak paths (system-wide `/var/lib/flatpak/...` and per-user `~/.local/share/flatpak/...`). Support for `org.libretro.RetroArch` Flatpak, native RetroArch installs, and other launchers is deferred — a separate long-term issue tracks broadening the plugin's launcher support beyond RetroDECK, and this parser will be extended alongside that work.
+- **RetroDECK-only path resolution, standalone RetroArch out of scope.** The `.info` adapter only looks under
+  `net.retrodeck.retrodeck` Flatpak paths (system-wide `/var/lib/flatpak/...` and per-user
+  `~/.local/share/flatpak/...`). Support for `org.libretro.RetroArch` Flatpak, native RetroArch installs, and other
+  launchers is deferred — a separate long-term issue tracks broadening the plugin's launcher support beyond RetroDECK,
+  and this parser will be extended alongside that work.
 
-- **Candidate paths use the `current/active` Flatpak symlinks.** Both candidate paths for `.info` files (system and per-user) route through `current/active`, which is Flatpak's stable symlink to the installed commit. This means the adapter does not need to know the specific Flatpak commit hash, and Flatpak updates do not break path resolution.
+- **Candidate paths use the `current/active` Flatpak symlinks.** Both candidate paths for `.info` files (system and
+  per-user) route through `current/active`, which is Flatpak's stable symlink to the installed commit. This means the
+  adapter does not need to know the specific Flatpak commit hash, and Flatpak updates do not break path resolution.
 
 ---
 
 **Related pages:**
 
-- [Backend Architecture](backend-architecture.md) — service/adapter architecture, dependency diagram, boundary enforcement
-- [Save File Sync Architecture](save-file-sync-architecture.md) — save sync details, conflict detection, sort-by-core migration flow
-- [RetroDECK Path Migration](../user-guide/retrodeck-path-migration.md) — user-facing guide for moving a RetroDECK install between storage locations
+- [Backend Architecture](backend-architecture.md) — service/adapter architecture, dependency diagram, boundary
+  enforcement
+- [Save File Sync Architecture](save-file-sync-architecture.md) — save sync details, conflict detection, sort-by-core
+  migration flow
+- [RetroDECK Path Migration](../user-guide/retrodeck-path-migration.md) — user-facing guide for moving a RetroDECK
+  install between storage locations

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -2,37 +2,87 @@
 
 ## Overview
 
-This page is the canonical home for the **aggregate domain model** behind the SQLite persistence migration (epic [#271](https://github.com/danielcopper/decky-romm-sync/issues/271)). The migration replaces the current JSON state files with a SQLite database whose tables back a set of Cosmic Python aggregates.
+This page is the canonical home for the **aggregate domain model** behind the SQLite persistence migration (epic
+[#271](https://github.com/danielcopper/decky-romm-sync/issues/271)). The migration replaces the current JSON state files
+with a SQLite database whose tables back a set of Cosmic Python aggregates.
 
-The migration is phased. The **enforcement infrastructure** (the decorator, the linters, and the type-check rule that keep aggregates honest, [#788](https://github.com/danielcopper/decky-romm-sync/issues/788)), the full **aggregate set** (the 8 aggregate roots, their fields, and their mutation methods), the **SQLite schema** (the migration framework + `001_initial.sql`, [#780](https://github.com/danielcopper/decky-romm-sync/issues/780)/[#781](https://github.com/danielcopper/decky-romm-sync/issues/781)), the per-aggregate **Repository Protocols** ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)), and the runtime **Unit of Work** + concrete `sqlite3` repository adapters ([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)) are all in place — documented below. The service cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) is in flight, vertical by vertical.
+The migration is phased. The **enforcement infrastructure** (the decorator, the linters, and the type-check rule that
+keep aggregates honest, [#788](https://github.com/danielcopper/decky-romm-sync/issues/788)), the full **aggregate set**
+(the 8 aggregate roots, their fields, and their mutation methods), the **SQLite schema** (the migration framework +
+`001_initial.sql`,
+[#780](https://github.com/danielcopper/decky-romm-sync/issues/780)/[#781](https://github.com/danielcopper/decky-romm-sync/issues/781)),
+the per-aggregate **Repository Protocols** ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)), and the
+runtime **Unit of Work** + concrete `sqlite3` repository adapters
+([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)) are all in place — documented below. The service
+cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) is in flight, vertical by vertical.
 
-The cutover is a **hard cut** — SQLite starts empty, the JSON state is not migrated into it, and each JSON-era state class is deleted once its last consumer moves over. The **library/roms slice has landed**: the live sync path now writes `roms` (the synced-ROM registry), `sync_runs` (the start→complete/cancel/error lifecycle that replaces the JSON `last_sync`/`sync_stats` scalars), and the `kv_config` `platform_slug → display_name` cache row, all through Repository Protocols + the Unit of Work. The **metadata slice has landed**: `rom_metadata` is now written by the reporter's per-unit commit — the same write Unit of Work as the `roms` upsert (Rom row first, then metadata, so the `rom_id` FK is satisfied at commit and a ROM and its cached metadata land atomically) — and `MetadataService`/`GameDetailService` read it back from SQLite (the JSON `metadata_cache` is no longer read by either). The **playtime slice has landed**: `PlaytimeService` now records sessions and reconciles RomM-note totals through the `rom_playtime` aggregate (session-end folds the duration in a short write UoW, then pushes to RomM outside the transaction). The **rom-removal + startup-healing slice has landed**: `RomRemovalService.remove_rom`/`uninstall_all_roms` and `StartupHealingService.prune_stale_installed_roms` now read and delete `rom_installs` through the Unit of Work instead of the JSON `installed_roms` dict — an uninstall (or stale prune) deletes only the on-disk files and the `rom_installs` row, never the `roms` identity row, playtime, saves, or metadata ([ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md)). The **read-consumers slice has landed**: the last in-memory `shortcut_registry` readers moved to SQLite — `GameDetailService` resolves the ROM, install record, cached save state, cached metadata, and platform-name cache in one read Unit of Work (the has-saves badge now reads `rom_save_states`, the platform display name the `kv_config` cache, both degrading gracefully when absent); `AchievementsService` reads each ROM's `ra_id` from `roms`; `SettingsService.apply_steam_input_setting` reads the bound `shortcut_app_id`s from `roms` (skipping unbound NULL rows). With that, the in-memory `shortcut_registry` dict has **no live service reader**, and `SaveSyncState` is **fully dead** — both `.playtime` (already dropped) and `.saves` (GameDetailService was the last reader) now have no live reader. Those JSON-era state classes — `SaveSyncState`, the in-memory `shortcut_registry` dict — and the now-dead JSON `metadata_cache` store are deleted in the teardown stream.
+The cutover is a **hard cut** — SQLite starts empty, the JSON state is not migrated into it, and each JSON-era state
+class is deleted once its last consumer moves over. The **library/roms slice has landed**: the live sync path now writes
+`roms` (the synced-ROM registry), `sync_runs` (the start→complete/cancel/error lifecycle that replaces the JSON
+`last_sync`/`sync_stats` scalars), and the `kv_config` `platform_slug → display_name` cache row, all through Repository
+Protocols + the Unit of Work. The **metadata slice has landed**: `rom_metadata` is now written by the reporter's
+per-unit commit — the same write Unit of Work as the `roms` upsert (Rom row first, then metadata, so the `rom_id` FK is
+satisfied at commit and a ROM and its cached metadata land atomically) — and `MetadataService`/`GameDetailService` read
+it back from SQLite (the JSON `metadata_cache` is no longer read by either). The **playtime slice has landed**:
+`PlaytimeService` now records sessions and reconciles RomM-note totals through the `rom_playtime` aggregate (session-end
+folds the duration in a short write UoW, then pushes to RomM outside the transaction). The **rom-removal +
+startup-healing slice has landed**: `RomRemovalService.remove_rom`/`uninstall_all_roms` and
+`StartupHealingService.prune_stale_installed_roms` now read and delete `rom_installs` through the Unit of Work instead
+of the JSON `installed_roms` dict — an uninstall (or stale prune) deletes only the on-disk files and the `rom_installs`
+row, never the `roms` identity row, playtime, saves, or metadata
+([ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md)).
+The **read-consumers slice has landed**: the last in-memory `shortcut_registry` readers moved to SQLite —
+`GameDetailService` resolves the ROM, install record, cached save state, cached metadata, and platform-name cache in one
+read Unit of Work (the has-saves badge now reads `rom_save_states`, the platform display name the `kv_config` cache,
+both degrading gracefully when absent); `AchievementsService` reads each ROM's `ra_id` from `roms`;
+`SettingsService.apply_steam_input_setting` reads the bound `shortcut_app_id`s from `roms` (skipping unbound NULL rows).
+With that, the in-memory `shortcut_registry` dict has **no live service reader**, and `SaveSyncState` is **fully dead**
+— both `.playtime` (already dropped) and `.saves` (GameDetailService was the last reader) now have no live reader. Those
+JSON-era state classes — `SaveSyncState`, the in-memory `shortcut_registry` dict — and the now-dead JSON
+`metadata_cache` store are deleted in the teardown stream.
 
 ## What an aggregate is here
 
-An **aggregate** is a cluster of domain objects treated as a single unit for data consistency, with one root entity that owns all invariants and is the only external entry point. The full definition — root, identity, transaction boundary, by-id references, mutation-via-methods — lives in the [`Aggregate` glossary entry in `CONTEXT.md`](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md). This page uses that vocabulary; it does not re-derive the Cosmic Python theory.
+An **aggregate** is a cluster of domain objects treated as a single unit for data consistency, with one root entity that
+owns all invariants and is the only external entry point. The full definition — root, identity, transaction boundary,
+by-id references, mutation-via-methods — lives in the
+[`Aggregate` glossary entry in `CONTEXT.md`](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md). This
+page uses that vocabulary; it does not re-derive the Cosmic Python theory.
 
-Aggregate boundaries are **invariant boundaries, not storage boundaries** — one aggregate may be backed by several tables, and table layout is a downstream decision. The first concrete aggregate-boundary decision, adopting `Platform` as a full aggregate rather than a denormalized string, was recorded in [ADR-0001](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0001-adopt-platform-aggregate.md) — now **superseded by [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)**, which reverts `Platform` to a denormalized `platform_slug` string.
+Aggregate boundaries are **invariant boundaries, not storage boundaries** — one aggregate may be backed by several
+tables, and table layout is a downstream decision. The first concrete aggregate-boundary decision, adopting `Platform`
+as a full aggregate rather than a denormalized string, was recorded in
+[ADR-0001](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0001-adopt-platform-aggregate.md) — now
+**superseded by
+[ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)**,
+which reverts `Platform` to a denormalized `platform_slug` string.
 
 ## Standards shared across all aggregates
 
 Every aggregate in this codebase follows the same rules, so the enforcement layers below can be uniform:
 
-- **Declared via the `@cosmic_aggregate` decorator.** This is the canonical form — not a transitional flag. The decorator marks the class as an aggregate root and is the marker the field-assignment check looks for.
-- **Mutation only via verb-named methods on the root.** No external field assignment (`aggregate.field = value`) from services. Methods are named after the domain event that occurred (`adopt_baseline(...)`, `mark_installed(...)`, `confirm_slot(...)`) — per-field verbs even when slightly forced (`set_autocleanup_limit(10)`), consistency over expressiveness. Field access for reads is fine.
-- **Cross-aggregate references by id only** — never by holding a Python reference to another aggregate's internals. `RomInstall` carries `rom_id: int`, not `rom: Rom`.
-- **No `extra: dict[str, Any]` forward-compat hedge.** Schema migrations carry the model forward; aggregates do not hold an open-ended JSON dict against future change.
+- **Declared via the `@cosmic_aggregate` decorator.** This is the canonical form — not a transitional flag. The
+  decorator marks the class as an aggregate root and is the marker the field-assignment check looks for.
+- **Mutation only via verb-named methods on the root.** No external field assignment (`aggregate.field = value`) from
+  services. Methods are named after the domain event that occurred (`adopt_baseline(...)`, `mark_installed(...)`,
+  `confirm_slot(...)`) — per-field verbs even when slightly forced (`set_autocleanup_limit(10)`), consistency over
+  expressiveness. Field access for reads is fine.
+- **Cross-aggregate references by id only** — never by holding a Python reference to another aggregate's internals.
+  `RomInstall` carries `rom_id: int`, not `rom: Rom`.
+- **No `extra: dict[str, Any]` forward-compat hedge.** Schema migrations carry the model forward; aggregates do not hold
+  an open-ended JSON dict against future change.
 
 ## CP enforcement layers
 
-Four mechanisms keep the aggregate rules from drifting. They are layered — each catches a different class of violation, and together they make "mutate an aggregate's fields from a service" fail before it merges.
+Four mechanisms keep the aggregate rules from drifting. They are layered — each catches a different class of violation,
+and together they make "mutate an aggregate's fields from a service" fail before it merges.
 
-| Layer | Mechanism | What it catches |
-| --- | --- | --- |
-| 1 | `@cosmic_aggregate` decorator | Declares the root; gives it `__slots__` so unknown fields can't be set |
-| 2 | AST field-assignment check | `aggregate.field = value` in `services/` |
-| 3 | import-linter domain contracts | Non-stdlib / non-self imports into `domain/` |
-| 4 | basedpyright `reportPrivateUsage` | Access to `_`-prefixed internals from production code |
+| Layer | Mechanism                         | What it catches                                                        |
+| ----- | --------------------------------- | ---------------------------------------------------------------------- |
+| 1     | `@cosmic_aggregate` decorator     | Declares the root; gives it `__slots__` so unknown fields can't be set |
+| 2     | AST field-assignment check        | `aggregate.field = value` in `services/`                               |
+| 3     | import-linter domain contracts    | Non-stdlib / non-self imports into `domain/`                           |
+| 4     | basedpyright `reportPrivateUsage` | Access to `_`-prefixed internals from production code                  |
 
 ### 1. The `@cosmic_aggregate` decorator
 
@@ -48,26 +98,40 @@ class Rom:
     # ...
 ```
 
-The decorator applies `@dataclass(slots=True)`, so the root gets `__init__`, `__repr__`, `__eq__`, and `__slots__` for free. `__slots__` matters for enforcement: a slotted dataclass rejects assignment to any attribute not declared as a field, so typos and ad-hoc field additions fail at runtime, not silently. It is also the marker the AST check (layer 2) scans for — `@cosmic_aggregate` is how a class opts into the mutation-via-methods rule.
+The decorator applies `@dataclass(slots=True)`, so the root gets `__init__`, `__repr__`, `__eq__`, and `__slots__` for
+free. `__slots__` matters for enforcement: a slotted dataclass rejects assignment to any attribute not declared as a
+field, so typos and ad-hoc field additions fail at runtime, not silently. It is also the marker the AST check (layer 2)
+scans for — `@cosmic_aggregate` is how a class opts into the mutation-via-methods rule.
 
-**Value Objects do not use this decorator.** Immutable members of an aggregate (e.g. `FileSyncState`, `BiosFileEntry`) use a plain `@dataclass(frozen=True, slots=True)` — they are immutable by construction and have no mutation surface to police, so they need neither the marker nor the verb-method discipline. The decorator is for roots only.
+**Value Objects do not use this decorator.** Immutable members of an aggregate (e.g. `FileSyncState`, `BiosFileEntry`)
+use a plain `@dataclass(frozen=True, slots=True)` — they are immutable by construction and have no mutation surface to
+police, so they need neither the marker nor the verb-method discipline. The decorator is for roots only.
 
 ### 2. AST field-assignment check
 
-`scripts/check_aggregate_field_assignment.py` is a small custom linter, wired into CI alongside the cosmic call bans. It enforces the **mutation-only-via-methods** rule that a type checker cannot express directly.
+`scripts/check_aggregate_field_assignment.py` is a small custom linter, wired into CI alongside the cosmic call bans. It
+enforces the **mutation-only-via-methods** rule that a type checker cannot express directly.
 
 How it works:
 
 1. It walks `py_modules/domain/`, parses every file, and collects the class names decorated with `@cosmic_aggregate`.
-2. It walks `py_modules/services/` and flags every assignment whose target is `<receiver>.<field> = ...` where the receiver's variable name matches an aggregate class name (exact snake_case identifier match — variable `rom` matches aggregate `Rom`, `rom_state` does not). It skips `self.x = ...` (method-body internals) and subscript receivers (`d["k"].x = ...`).
+2. It walks `py_modules/services/` and flags every assignment whose target is `<receiver>.<field> = ...` where the
+   receiver's variable name matches an aggregate class name (exact snake_case identifier match — variable `rom` matches
+   aggregate `Rom`, `rom_state` does not). It skips `self.x = ...` (method-body internals) and subscript receivers
+   (`d["k"].x = ...`).
 
-The heuristic is conservative by design — a guardrail, not a prover. It can false-positive (a variable named `rom` holding something else) and false-negative (assignment through a complex expression). The escape hatch is a trailing comment on the offending line:
+The heuristic is conservative by design — a guardrail, not a prover. It can false-positive (a variable named `rom`
+holding something else) and false-negative (assignment through a complex expression). The escape hatch is a trailing
+comment on the offending line:
 
 ```python
 rom.cover_path = path  # pragma: no aggregate-check
 ```
 
-**It is a no-op until aggregates exist.** No class carries `@cosmic_aggregate` yet, so the aggregate-name set is empty and the check finds nothing. It activates automatically as the aggregate roots land in later PRs — the moment a `@cosmic_aggregate` class appears, any `aggregate.field = ...` in a service starts failing CI. Old JSON-era containers (e.g. `SaveSyncState`) don't carry the decorator, so they keep working until the cutover wave replaces them.
+**It is a no-op until aggregates exist.** No class carries `@cosmic_aggregate` yet, so the aggregate-name set is empty
+and the check finds nothing. It activates automatically as the aggregate roots land in later PRs — the moment a
+`@cosmic_aggregate` class appears, any `aggregate.field = ...` in a service starts failing CI. Old JSON-era containers
+(e.g. `SaveSyncState`) don't carry the decorator, so they keep working until the cutover wave replaces them.
 
 ### 3. import-linter — domain is stdlib + self only
 
@@ -94,13 +158,20 @@ forbidden_modules =
     _vendor
 ```
 
-Together these say: **domain = stdlib + self only.** `domain-independence` forbids every sibling first-party layer (note `lib` and `models` are now in the forbidden list — domain depends on no other internal layer); `domain-stdlib-only` forbids the `_vendor` namespace, which is the codebase's only entry point for non-stdlib runtime code. This is the CP doctrine that the domain model has no external runtime dependencies, mechanically enforced.
+Together these say: **domain = stdlib + self only.** `domain-independence` forbids every sibling first-party layer (note
+`lib` and `models` are now in the forbidden list — domain depends on no other internal layer); `domain-stdlib-only`
+forbids the `_vendor` namespace, which is the codebase's only entry point for non-stdlib runtime code. This is the CP
+doctrine that the domain model has no external runtime dependencies, mechanically enforced.
 
-A consequence of `lib` being forbidden: anything domain needs from "shared utilities" lives inside `domain` itself. ISO-8601 timestamp parsing (`parse_iso` / `parse_iso_to_epoch`) moved from `lib/iso_time.py` to `domain/iso_time.py` for exactly this reason.
+A consequence of `lib` being forbidden: anything domain needs from "shared utilities" lives inside `domain` itself.
+ISO-8601 timestamp parsing (`parse_iso` / `parse_iso_to_epoch`) moved from `lib/iso_time.py` to `domain/iso_time.py` for
+exactly this reason.
 
 ### 4. basedpyright `reportPrivateUsage = "error"`
 
-`pyproject.toml` sets `reportPrivateUsage = "error"`, so accessing a `_`-prefixed name from outside its owning class is a hard type error, not a convention nobody enforces. This makes the underscore-prefix convention real: production code cannot reach into an aggregate's (or any class's) internals.
+`pyproject.toml` sets `reportPrivateUsage = "error"`, so accessing a `_`-prefixed name from outside its owning class is
+a hard type error, not a convention nobody enforces. This makes the underscore-prefix convention real: production code
+cannot reach into an aggregate's (or any class's) internals.
 
 Tests are exempt via an execution-environment override:
 
@@ -111,115 +182,267 @@ extraPaths = ["py_modules"]
 reportPrivateUsage = "none"
 ```
 
-White-box testing — inspecting and rebinding the private state of the system under test — is a deliberate, accepted pattern here. The guardrail targets production encapsulation, not test setup.
+White-box testing — inspecting and rebinding the private state of the system under test — is a deliberate, accepted
+pattern here. The guardrail targets production encapsulation, not test setup.
 
-One corollary worth stating: a method that one sub-service calls on a peer is part of that peer's **public** surface and carries **no** leading underscore. The `_` prefix is reserved for genuinely class-internal helpers, which keeps `reportPrivateUsage` coherent with the saves-style peer-injection carve-out — peers call public methods, never private ones.
+One corollary worth stating: a method that one sub-service calls on a peer is part of that peer's **public** surface and
+carries **no** leading underscore. The `_` prefix is reserved for genuinely class-internal helpers, which keeps
+`reportPrivateUsage` coherent with the saves-style peer-injection carve-out — peers call public methods, never private
+ones.
 
 ## The aggregate set
 
-Eight aggregate roots model the persisted domain. Each lives in its own `domain/<name>.py` module, is declared with `@cosmic_aggregate`, and mutates only through verb-named methods. Per [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md) the former `SyncSettings` knobs and `device_name` move to `settings.json` ([#822](https://github.com/danielcopper/decky-romm-sync/issues/822)) and `device_id` becomes a `kv_config` row ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) — they were config and a singleton scalar, not relational state with invariants. The **Carries** column reflects the fields as actually implemented (`?` marks a nullable/optional field); where the shipped shape is intentionally leaner than the original #788 plan, the **Why** column says so. Cross-aggregate references are by id/slug only — the per-ROM aggregates (`RomMetadata`, `RomSaveState`, `Playtime`) are keyed by `rom_id` externally rather than carrying it as a field; only `RomInstall` carries `rom_id` as a field rather than keying on it externally, and it also denormalizes `platform_slug`/`system` so migration and save-sort can read installs without a join.
+Eight aggregate roots model the persisted domain. Each lives in its own `domain/<name>.py` module, is declared with
+`@cosmic_aggregate`, and mutates only through verb-named methods. Per
+[ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)
+the former `SyncSettings` knobs and `device_name` move to `settings.json`
+([#822](https://github.com/danielcopper/decky-romm-sync/issues/822)) and `device_id` becomes a `kv_config` row
+([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) — they were config and a singleton scalar, not
+relational state with invariants. The **Carries** column reflects the fields as actually implemented (`?` marks a
+nullable/optional field); where the shipped shape is intentionally leaner than the original #788 plan, the **Why**
+column says so. Cross-aggregate references are by id/slug only — the per-ROM aggregates (`RomMetadata`, `RomSaveState`,
+`Playtime`) are keyed by `rom_id` externally rather than carrying it as a field; only `RomInstall` carries `rom_id` as a
+field rather than keying on it externally, and it also denormalizes `platform_slug`/`system` so migration and save-sort
+can read installs without a join.
 
-| Aggregate root | Carries | Why a separate aggregate |
-| --- | --- | --- |
-| `Rom` (`domain/rom.py`) | `rom_id` (identity), `platform_slug`, `name`, `fs_name`, `shortcut_app_id?`, `last_synced_at`, `cover_path?`, `igdb_id?`, `sgdb_id?`, `ra_id?` | Created/updated atomically when a ROM is synced from RomM; `shortcut_app_id` is NULL when the ROM is unbound (shortcut removed / gone from RomM) but the row is retained per [ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md). The platform display name is **not** modeled as a local aggregate; `platform_slug` is a denormalized RomM slug and the display name is resolved live from RomM (per [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)), cached for offline reads in the `kv_config` `platform_names` row. |
-| `RomInstall` (`domain/rom_install.py`) | `rom_id`, `file_path`, `rom_dir?`, `platform_slug`, `system`, `installed_at` | Exists only while a ROM is downloaded — created on download-complete, removed on uninstall. References `Rom` by `rom_id`. `file_path` is the launch target (always present); `rom_dir` is the dedicated per-ROM directory and is **NULL for single-file ROMs** (which live as a bare file in the shared `<roms>/<system>/` dir) — single-vs-multi is read from `rom_dir` presence, not re-derived from the path ([ADR-0008](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0008-rom-install-launch-file-and-rom-dir.md)). Denormalized `platform_slug` / `system` let migration + save-sort read installs without joining the registry. A per-file `RomFile[]` child (`category`: game/dlc/update/…) is the documented future model, deferred to #140/#129 and additive when it lands (ADR-0008). |
-| `RomMetadata` (`domain/rom_metadata.py`) | `summary`, `genres`, `companies`, `first_release_date?`, `average_rating?`, `game_modes`, `player_count`, `cached_at`, `steam_categories` | 7-day staleness signal (`cached_at`), regenerated independently of library sync — staleness, not a schedule, prompts a refresh. Per-ROM, keyed by `rom_id`. |
-| `RomSaveState` (`domain/rom_save_state.py`) | `active_slot?`, `slot_confirmed`, `emulator`, `system`, `last_synced_core?`, `own_upload_ids?`, `slots{}`, `files{}` (a `FileSyncState` value object per filename), `last_sync_check_at?` | Per-ROM saves aggregate. Matrix invariants hold inside: a file baseline always carries a non-empty `last_sync_hash`, while `tracked_save_id` is present only for server-anchored baselines (the `adopt_baseline` path) and NULL for hash-only baselines (the `update_baseline_hash` skip-adopt path); a non-legacy `active_slot` always has its `slots` key. Per-ROM, keyed by `rom_id`. |
-| `Playtime` (`domain/playtime.py`) | `total_seconds`, `session_count`, `last_session_start?`, `last_session_duration_sec?`, `note_id?` | Per-ROM, owned by PlaytimeService. Independent lifecycle from saves (`session_lifecycle.py` already treats them as separate concerns). Keyed by `rom_id`. |
-| `BiosFile` (`domain/bios_file.py`) | `(platform_slug, file_name)` (composite identity), `file_path`, `downloaded_at`, `firmware_id?` | Per downloaded BIOS file. Composite key — a bare filename is unsafe (two platforms can ship same-named BIOS). `firmware_id` is nullable metadata, not identity. |
-| `FirmwareCacheEntry` (`domain/firmware_cache.py`) | `id?`, `name`, `platform_slug`, `file_size_bytes`, `cached_at` | Per cached firmware item from RomM. TTL-cached server inventory; the cache is replaced wholesale on refresh and the TTL check lives in the service, so the aggregate stays a thin record. |
-| `SyncRun` (`domain/sync_run.py`) | `id`, `started_at`, `status`, `platforms_planned`, `roms_planned`, `finished_at?`, `platforms_completed?`, `collections_completed?`, `error?` | Models sync-as-operation — a `running` → `completed`/`cancelled`/`errored` state machine that terminates exactly once. Replaces scattered scalars (`last_sync`, `sync_stats`, `last_synced_platforms`, `last_synced_collections`). `sync_stats.roms` is not a field — it's a registry-derived count computed at read time. |
+| Aggregate root                                    | Carries                                                                                                                                                                                   | Why a separate aggregate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Rom` (`domain/rom.py`)                           | `rom_id` (identity), `platform_slug`, `name`, `fs_name`, `shortcut_app_id?`, `last_synced_at`, `cover_path?`, `igdb_id?`, `sgdb_id?`, `ra_id?`                                            | Created/updated atomically when a ROM is synced from RomM; `shortcut_app_id` is NULL when the ROM is unbound (shortcut removed / gone from RomM) but the row is retained per [ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md). The platform display name is **not** modeled as a local aggregate; `platform_slug` is a denormalized RomM slug and the display name is resolved live from RomM (per [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)), cached for offline reads in the `kv_config` `platform_names` row.                                                                                                                                                    |
+| `RomInstall` (`domain/rom_install.py`)            | `rom_id`, `file_path`, `rom_dir?`, `platform_slug`, `system`, `installed_at`                                                                                                              | Exists only while a ROM is downloaded — created on download-complete, removed on uninstall. References `Rom` by `rom_id`. `file_path` is the launch target (always present); `rom_dir` is the dedicated per-ROM directory and is **NULL for single-file ROMs** (which live as a bare file in the shared `<roms>/<system>/` dir) — single-vs-multi is read from `rom_dir` presence, not re-derived from the path ([ADR-0008](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0008-rom-install-launch-file-and-rom-dir.md)). Denormalized `platform_slug` / `system` let migration + save-sort read installs without joining the registry. A per-file `RomFile[]` child (`category`: game/dlc/update/…) is the documented future model, deferred to #140/#129 and additive when it lands (ADR-0008). |
+| `RomMetadata` (`domain/rom_metadata.py`)          | `summary`, `genres`, `companies`, `first_release_date?`, `average_rating?`, `game_modes`, `player_count`, `cached_at`, `steam_categories`                                                 | 7-day staleness signal (`cached_at`), regenerated independently of library sync — staleness, not a schedule, prompts a refresh. Per-ROM, keyed by `rom_id`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `RomSaveState` (`domain/rom_save_state.py`)       | `active_slot?`, `slot_confirmed`, `emulator`, `system`, `last_synced_core?`, `own_upload_ids?`, `slots{}`, `files{}` (a `FileSyncState` value object per filename), `last_sync_check_at?` | Per-ROM saves aggregate. Matrix invariants hold inside: a file baseline always carries a non-empty `last_sync_hash`, while `tracked_save_id` is present only for server-anchored baselines (the `adopt_baseline` path) and NULL for hash-only baselines (the `update_baseline_hash` skip-adopt path); a non-legacy `active_slot` always has its `slots` key. Per-ROM, keyed by `rom_id`.                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `Playtime` (`domain/playtime.py`)                 | `total_seconds`, `session_count`, `last_session_start?`, `last_session_duration_sec?`, `note_id?`                                                                                         | Per-ROM, owned by PlaytimeService. Independent lifecycle from saves (`session_lifecycle.py` already treats them as separate concerns). Keyed by `rom_id`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `BiosFile` (`domain/bios_file.py`)                | `(platform_slug, file_name)` (composite identity), `file_path`, `downloaded_at`, `firmware_id?`                                                                                           | Per downloaded BIOS file. Composite key — a bare filename is unsafe (two platforms can ship same-named BIOS). `firmware_id` is nullable metadata, not identity.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `FirmwareCacheEntry` (`domain/firmware_cache.py`) | `id?`, `name`, `platform_slug`, `file_size_bytes`, `cached_at`                                                                                                                            | Per cached firmware item from RomM. TTL-cached server inventory; the cache is replaced wholesale on refresh and the TTL check lives in the service, so the aggregate stays a thin record.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `SyncRun` (`domain/sync_run.py`)                  | `id`, `started_at`, `status`, `platforms_planned`, `roms_planned`, `finished_at?`, `platforms_completed?`, `collections_completed?`, `error?`                                             | Models sync-as-operation — a `running` → `completed`/`cancelled`/`errored` state machine that terminates exactly once. Replaces scattered scalars (`last_sync`, `sync_stats`, `last_synced_platforms`, `last_synced_collections`). `sync_stats.roms` is not a field — it's a registry-derived count computed at read time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
-`FileSyncState` (inside `RomSaveState`) is a **value object**, not an aggregate: a frozen `@dataclass(frozen=True, slots=True)` built whole by `adopt_baseline(...)`, with no mutation surface of its own.
+`FileSyncState` (inside `RomSaveState`) is a **value object**, not an aggregate: a frozen
+`@dataclass(frozen=True, slots=True)` built whole by `adopt_baseline(...)`, with no mutation surface of its own.
 
 ## The SQLite schema
 
-The tables that back the aggregates, designed in [#780](https://github.com/danielcopper/decky-romm-sync/issues/780). The authoritative DDL — every column type, default, constraint, and the full decision rationale inline — is [`py_modules/db/migrations/001_initial.sql`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/db/migrations/001_initial.sql). This section is the map, not a re-derivation.
+The tables that back the aggregates, designed in [#780](https://github.com/danielcopper/decky-romm-sync/issues/780). The
+authoritative DDL — every column type, default, constraint, and the full decision rationale inline — is
+[`py_modules/db/migrations/001_initial.sql`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/db/migrations/001_initial.sql).
+This section is the map, not a re-derivation.
 
 ### One table per aggregate
 
-Each aggregate gets its own table — the per-ROM cluster is **not** a single wide `roms` mega-table. The epic floated a mega-table as a starting proposal; #780 owns the final layout and split it. The deciding factor was integrity, not speed (read performance is a non-issue at single-user scale): the per-ROM aggregates are **all-or-nothing groups** — an install is either fully present or absent, metadata is cached or not — and separate tables let "state absent" mean "no row" rather than a wide row of NULLs the schema cannot keep internally consistent. The rejected mega-table alternative is recorded in [ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md). One Repository per aggregate (the [CONTEXT.md](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md) rule) maps 1:1 onto these tables.
+Each aggregate gets its own table — the per-ROM cluster is **not** a single wide `roms` mega-table. The epic floated a
+mega-table as a starting proposal; #780 owns the final layout and split it. The deciding factor was integrity, not speed
+(read performance is a non-issue at single-user scale): the per-ROM aggregates are **all-or-nothing groups** — an
+install is either fully present or absent, metadata is cached or not — and separate tables let "state absent" mean "no
+row" rather than a wide row of NULLs the schema cannot keep internally consistent. The rejected mega-table alternative
+is recorded in
+[ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md).
+One Repository per aggregate (the [CONTEXT.md](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md)
+rule) maps 1:1 onto these tables.
 
-| Table | Backs | Key | Row present when |
-| --- | --- | --- | --- |
-| `roms` | `Rom` (identity + shortcut) | `rom_id` | ROM is synced from RomM |
-| `rom_installs` | `RomInstall` | `rom_id` | ROM is downloaded |
-| `rom_metadata` | `RomMetadata` | `rom_id` | metadata has been cached |
-| `rom_playtime` | `Playtime` | `rom_id` | ROM has been played |
-| `rom_save_states` | `RomSaveState` (scalars) | `rom_id` | save tracking exists |
-| `rom_save_files` | `FileSyncState` (1:N child) | `(rom_id, filename)` | a file baseline is tracked |
-| `downloaded_bios` | `BiosFile` | `(platform_slug, file_name)` | a BIOS file is downloaded |
-| `firmware_cache` | `FirmwareCacheEntry` | `(platform_slug, name)` | firmware inventory is cached |
-| `sync_runs` | `SyncRun` | `id` | one row per sync run (history) |
-| `kv_config` | misc singleton scalars | `key` | per key |
+| Table             | Backs                       | Key                          | Row present when               |
+| ----------------- | --------------------------- | ---------------------------- | ------------------------------ |
+| `roms`            | `Rom` (identity + shortcut) | `rom_id`                     | ROM is synced from RomM        |
+| `rom_installs`    | `RomInstall`                | `rom_id`                     | ROM is downloaded              |
+| `rom_metadata`    | `RomMetadata`               | `rom_id`                     | metadata has been cached       |
+| `rom_playtime`    | `Playtime`                  | `rom_id`                     | ROM has been played            |
+| `rom_save_states` | `RomSaveState` (scalars)    | `rom_id`                     | save tracking exists           |
+| `rom_save_files`  | `FileSyncState` (1:N child) | `(rom_id, filename)`         | a file baseline is tracked     |
+| `downloaded_bios` | `BiosFile`                  | `(platform_slug, file_name)` | a BIOS file is downloaded      |
+| `firmware_cache`  | `FirmwareCacheEntry`        | `(platform_slug, name)`      | firmware inventory is cached   |
+| `sync_runs`       | `SyncRun`                   | `id`                         | one row per sync run (history) |
+| `kv_config`       | misc singleton scalars      | `key`                        | per key                        |
 
-`SyncRun` carries its own invariants, so per CONTEXT.md it gets a typed table rather than untyped `kv_config` rows. `kv_config` is reserved for the truly miscellaneous: `retrodeck_home_path` (+ its pending-migration `_previous`), `save_sort_settings` (+ `_previous`), and the `platform_names` cache — a single `platform_slug → display_name` JSON blob the library sync refreshes every run so offline reads (the DangerZone label, the game-detail platform name) show "Nintendo 64" rather than the bare `n64` slug when RomM is unreachable. The schema version is **not** a `kv_config` key — it is tracked in `PRAGMA user_version` by the [migration runner](#the-migration-framework) ([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)).
+`SyncRun` carries its own invariants, so per CONTEXT.md it gets a typed table rather than untyped `kv_config` rows.
+`kv_config` is reserved for the truly miscellaneous: `retrodeck_home_path` (+ its pending-migration `_previous`),
+`save_sort_settings` (+ `_previous`), and the `platform_names` cache — a single `platform_slug → display_name` JSON blob
+the library sync refreshes every run so offline reads (the DangerZone label, the game-detail platform name) show
+"Nintendo 64" rather than the bare `n64` slug when RomM is unreachable. The schema version is **not** a `kv_config` key
+— it is tracked in `PRAGMA user_version` by the [migration runner](#the-migration-framework)
+([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)).
 
-`SyncRun` is a **history** table, not a single "last run" row: a 1-row table would let a newly-started run (`status='running'`, no stats yet) erase the last completed run's displayable stats. "Last successful sync" is the newest row with `status='completed'`; "is a sync running" is any row with `status='running'`.
+`SyncRun` is a **history** table, not a single "last run" row: a 1-row table would let a newly-started run
+(`status='running'`, no stats yet) erase the last completed run's displayable stats. "Last successful sync" is the
+newest row with `status='completed'`; "is a sync running" is any row with `status='running'`.
 
 ### Foreign keys
 
-Most relationships are *not* parent-child (`startup_healing` prunes against disk truth; playtime survives shortcut removal), so foreign keys are deliberately sparse:
+Most relationships are _not_ parent-child (`startup_healing` prunes against disk truth; playtime survives shortcut
+removal), so foreign keys are deliberately sparse:
 
-- **Per-ROM tables → `roms`, `ON DELETE CASCADE`** (`rom_installs`, `rom_metadata`, `rom_playtime`, `rom_save_states`, `rom_save_files`). Per-ROM state is genuinely owned by the ROM, so a `DELETE FROM roms WHERE …` cascades it all away in one statement. Per [ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md) this cascade is **dormant**: a `roms` row is a permanent identity anchor keyed by RomM's stable `rom_id`. **Auto-stale = unbind** — when the automatic sync finds a ROM gone from RomM (or its shortcut is removed), the row is *unbound* (`Rom.unbind_shortcut()` NULLs `shortcut_app_id`, the row and its per-ROM children stay) so local playtime/saves/metadata survive. **Only a deliberate purge = delete** — an explicit, opt-in user action (which does not exist today) `DELETE`s the row and lets the cascade reap the children. The automatic sync never `DELETE`s a `roms` row.
-  - **Caveat — writes to a cascade parent (`roms`) MUST UPSERT, never `INSERT OR REPLACE`/`REPLACE`.** In SQLite `REPLACE` resolves a PK conflict by *delete-then-insert* of the parent row, and that DELETE fires the `ON DELETE CASCADE` above — silently wiping every per-ROM child on a re-save (a normal library re-sync, where the `roms` row already exists). `SqliteRomRepository.save()` therefore uses `INSERT … ON CONFLICT(rom_id) DO UPDATE SET …`, which updates the parent in place and never triggers the cascade ([#887](https://github.com/danielcopper/decky-romm-sync/issues/887)). Leaf tables with no cascade children may keep `INSERT OR REPLACE`.
-- **`platform_slug` → no FK.** Carried on `roms` / `rom_installs` / `downloaded_bios` / `firmware_cache` as a plain denormalized RomM platform slug. There is no `platforms` table to reference — [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md) dropped the `Platform` aggregate — so it is just a string. The platform *display name* is not stored on the row: it resolves live from RomM during each sync and is cached for offline reads in a single `kv_config` `platform_slug → display_name` blob (refreshed every sync), degrading to the bare slug only when RomM is unreachable and the cache is empty.
+- **Per-ROM tables → `roms`, `ON DELETE CASCADE`** (`rom_installs`, `rom_metadata`, `rom_playtime`, `rom_save_states`,
+  `rom_save_files`). Per-ROM state is genuinely owned by the ROM, so a `DELETE FROM roms WHERE …` cascades it all away
+  in one statement. Per
+  [ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md)
+  this cascade is **dormant**: a `roms` row is a permanent identity anchor keyed by RomM's stable `rom_id`. **Auto-stale
+  = unbind** — when the automatic sync finds a ROM gone from RomM (or its shortcut is removed), the row is _unbound_
+  (`Rom.unbind_shortcut()` NULLs `shortcut_app_id`, the row and its per-ROM children stay) so local
+  playtime/saves/metadata survive. **Only a deliberate purge = delete** — an explicit, opt-in user action (which does
+  not exist today) `DELETE`s the row and lets the cascade reap the children. The automatic sync never `DELETE`s a `roms`
+  row.
+  - **Caveat — writes to a cascade parent (`roms`) MUST UPSERT, never `INSERT OR REPLACE`/`REPLACE`.** In SQLite
+    `REPLACE` resolves a PK conflict by _delete-then-insert_ of the parent row, and that DELETE fires the
+    `ON DELETE CASCADE` above — silently wiping every per-ROM child on a re-save (a normal library re-sync, where the
+    `roms` row already exists). `SqliteRomRepository.save()` therefore uses
+    `INSERT … ON CONFLICT(rom_id) DO UPDATE SET …`, which updates the parent in place and never triggers the cascade
+    ([#887](https://github.com/danielcopper/decky-romm-sync/issues/887)). Leaf tables with no cascade children may keep
+    `INSERT OR REPLACE`.
+- **`platform_slug` → no FK.** Carried on `roms` / `rom_installs` / `downloaded_bios` / `firmware_cache` as a plain
+  denormalized RomM platform slug. There is no `platforms` table to reference —
+  [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)
+  dropped the `Platform` aggregate — so it is just a string. The platform _display name_ is not stored on the row: it
+  resolves live from RomM during each sync and is cached for offline reads in a single `kv_config`
+  `platform_slug → display_name` blob (refreshed every sync), degrading to the bare slug only when RomM is unreachable
+  and the cache is empty.
 
-The split moved the FK policy from the epic's "one FK only" (written for the mega-table world) to "CASCADE for the per-ROM ownership relationships the split introduced; no FK for cross-aggregate references" — same intent, applied to the new tables. See [ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md).
+The split moved the FK policy from the epic's "one FK only" (written for the mega-table world) to "CASCADE for the
+per-ROM ownership relationships the split introduced; no FK for cross-aggregate references" — same intent, applied to
+the new tables. See
+[ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md).
 
 ### Type conventions
 
-All tables are `STRICT` (SQLite ≥ 3.37; the Deck ships 3.50). STRICT allows only `INTEGER` / `REAL` / `TEXT` / `BLOB` / `ANY`, so:
+All tables are `STRICT` (SQLite ≥ 3.37; the Deck ships 3.50). STRICT allows only `INTEGER` / `REAL` / `TEXT` / `BLOB` /
+`ANY`, so:
 
 - **Booleans** are `INTEGER` 0/1, guarded by `CHECK (col IN (0, 1))`.
-- **Event timestamps** are `TEXT` ISO-8601 (sortable, human-readable); **cache/TTL timestamps** are `REAL` Unix-epoch seconds (cheap age math). The split is aggregate-driven — only the caches do age arithmetic.
-- **JSON** arrays/objects are `TEXT` guarded by `CHECK (json_valid(col))`. They are display/read-model data, never queried by element, so normalization buys nothing.
-- `rom_save_states.own_upload_ids` is nullable `TEXT` where **`NULL` ≠ `'[]'`**: `NULL` means attribution unknown/legacy, `'[]'` means we uploaded nothing — both meaningful.
+- **Event timestamps** are `TEXT` ISO-8601 (sortable, human-readable); **cache/TTL timestamps** are `REAL` Unix-epoch
+  seconds (cheap age math). The split is aggregate-driven — only the caches do age arithmetic.
+- **JSON** arrays/objects are `TEXT` guarded by `CHECK (json_valid(col))`. They are display/read-model data, never
+  queried by element, so normalization buys nothing.
+- `rom_save_states.own_upload_ids` is nullable `TEXT` where **`NULL` ≠ `'[]'`**: `NULL` means attribution
+  unknown/legacy, `'[]'` means we uploaded nothing — both meaningful.
 
-No blanket `created_at`/`updated_at` audit columns (the aggregates already model the timestamps that matter), no `systems` lookup table (`system` stays `TEXT`), and no secondary indexes yet (every lookup and cascade rides a primary key; further indexing is deferred until profiling justifies it, per the epic).
+No blanket `created_at`/`updated_at` audit columns (the aggregates already model the timestamps that matter), no
+`systems` lookup table (`system` stays `TEXT`), and no secondary indexes yet (every lookup and cascade rides a primary
+key; further indexing is deferred until profiling justifies it, per the epic).
 
 ## The migration framework
 
-The schema above is not loaded as a special case — it is migration `001`, applied by the same runner that applies every future schema change. The runner lives in [`py_modules/adapters/sqlite_migrations.py`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/adapters/sqlite_migrations.py) ([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)) — it does file + database I/O, so it is an adapter — and is invoked from `bootstrap()` at plugin startup, before any service is wired. stdlib `sqlite3` only; no Alembic or other third-party migration tooling.
+The schema above is not loaded as a special case — it is migration `001`, applied by the same runner that applies every
+future schema change. The runner lives in
+[`py_modules/adapters/sqlite_migrations.py`](https://github.com/danielcopper/decky-romm-sync/blob/main/py_modules/adapters/sqlite_migrations.py)
+([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)) — it does file + database I/O, so it is an adapter
+— and is invoked from `bootstrap()` at plugin startup, before any service is wired. stdlib `sqlite3` only; no Alembic or
+other third-party migration tooling.
 
-**Versioning — `PRAGMA user_version`.** SQLite keeps a single integer in the database header, readable and writable via `PRAGMA user_version`. The runner uses it as the applied-schema marker: a fresh database reports `0`; after migration `NNN` is applied the runner stamps `user_version = NNN`. There is no separate `schema_migrations` table — `user_version` is the whole mechanism (the same lean approach SDH-PlayTime and Junk-Store use). This is why the schema version is deliberately **not** a `kv_config` key.
+**Versioning — `PRAGMA user_version`.** SQLite keeps a single integer in the database header, readable and writable via
+`PRAGMA user_version`. The runner uses it as the applied-schema marker: a fresh database reports `0`; after migration
+`NNN` is applied the runner stamps `user_version = NNN`. There is no separate `schema_migrations` table — `user_version`
+is the whole mechanism (the same lean approach SDH-PlayTime and Junk-Store use). This is why the schema version is
+deliberately **not** a `kv_config` key.
 
-**Discovery — `NNN_descriptive_name.sql`.** Migrations are plain `.sql` files under `py_modules/db/migrations/`, named with a leading integer (`001_initial.sql`). At startup the runner scans that directory, parses the integer prefix off each filename, sorts ascending **numerically** (so `10` follows `2`, not lexically), and applies only the files whose number is greater than the database's current `user_version`. Files that don't match `NNN_*.sql` are ignored.
+**Discovery — `NNN_descriptive_name.sql`.** Migrations are plain `.sql` files under `py_modules/db/migrations/`, named
+with a leading integer (`001_initial.sql`). At startup the runner scans that directory, parses the integer prefix off
+each filename, sorts ascending **numerically** (so `10` follows `2`, not lexically), and applies only the files whose
+number is greater than the database's current `user_version`. Files that don't match `NNN_*.sql` are ignored.
 
-**Atomic per migration.** Each migration runs inside its own transaction: `BEGIN` → the migration's DDL → `PRAGMA user_version = NNN` → `COMMIT`. The version bump rides the same transaction as the DDL, so a migration is all-or-nothing: if any statement fails, the transaction rolls back (DDL **and** version bump both undone) and the runner re-raises, leaving the database at the last successfully-applied version. Migration files therefore contain transaction-safe DDL only and must **not** carry their own `BEGIN`/`COMMIT` — the runner supplies the transaction.
+**Atomic per migration.** Each migration runs inside its own transaction: `BEGIN` → the migration's DDL →
+`PRAGMA user_version = NNN` → `COMMIT`. The version bump rides the same transaction as the DDL, so a migration is
+all-or-nothing: if any statement fails, the transaction rolls back (DDL **and** version bump both undone) and the runner
+re-raises, leaving the database at the last successfully-applied version. Migration files therefore contain
+transaction-safe DDL only and must **not** carry their own `BEGIN`/`COMMIT` — the runner supplies the transaction.
 
-**Connection PRAGMAs.** The runner sets `journal_mode=WAL` (persistent — recorded in the database file, so it carries over to runtime connections) and `foreign_keys=ON` (so `CASCADE`-bearing DDL behaves here as it will at runtime). The full per-connection PRAGMA set for runtime Unit-of-Work connections is applied by the UoW itself (see [The runtime Unit of Work](#the-runtime-unit-of-work) below): `foreign_keys=ON`, `synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY`, with `isolation_level=None` so the UoW drives `BEGIN`/`COMMIT`/`ROLLBACK` explicitly.
+**Connection PRAGMAs.** The runner sets `journal_mode=WAL` (persistent — recorded in the database file, so it carries
+over to runtime connections) and `foreign_keys=ON` (so `CASCADE`-bearing DDL behaves here as it will at runtime). The
+full per-connection PRAGMA set for runtime Unit-of-Work connections is applied by the UoW itself (see
+[The runtime Unit of Work](#the-runtime-unit-of-work) below): `foreign_keys=ON`, `synchronous=NORMAL`,
+`busy_timeout=5000`, `temp_store=MEMORY`, with `isolation_level=None` so the UoW drives `BEGIN`/`COMMIT`/`ROLLBACK`
+explicitly.
 
-**Database location.** The database is `romm_sync.db` in the plugin runtime directory (`decky.DECKY_PLUGIN_RUNTIME_DIR`), alongside today's JSON state files. With the cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) under way the live path now reads and writes it; DB-init is hard-failing (a migration failure aborts startup rather than degrading silently) so a corrupt or unmigratable database never serves stale reads.
+**Database location.** The database is `romm_sync.db` in the plugin runtime directory
+(`decky.DECKY_PLUGIN_RUNTIME_DIR`), alongside today's JSON state files. With the cutover
+([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) under way the live path now reads and writes it;
+DB-init is hard-failing (a migration failure aborts startup rather than degrading silently) so a corrupt or unmigratable
+database never serves stale reads.
 
 ### How to add a v2 migration
 
-Drop a new file `002_descriptive_name.sql` into `py_modules/db/migrations/` containing the schema change (e.g. `ALTER TABLE roms ADD COLUMN …;` or a fresh `CREATE TABLE …;`) as transaction-safe DDL with no `BEGIN`/`COMMIT`. That's the whole change — on the next startup the runner sees `002 > user_version`, applies it inside its own transaction, and bumps `user_version` to `2`. Existing databases receive only the new migration; fresh databases receive `001` then `002` in order. No code change is needed to register the file.
+Drop a new file `002_descriptive_name.sql` into `py_modules/db/migrations/` containing the schema change (e.g.
+`ALTER TABLE roms ADD COLUMN …;` or a fresh `CREATE TABLE …;`) as transaction-safe DDL with no `BEGIN`/`COMMIT`. That's
+the whole change — on the next startup the runner sees `002 > user_version`, applies it inside its own transaction, and
+bumps `user_version` to `2`. Existing databases receive only the new migration; fresh databases receive `001` then `002`
+in order. No code change is needed to register the file.
 
 ## The runtime Unit of Work
 
-The schema is read and written at runtime through a **Unit of Work** (UoW) — the atomic transaction boundary one operation works inside. The concrete UoW and the nine `sqlite3` repository adapters that back it live in [`py_modules/adapters/repositories/`](https://github.com/danielcopper/decky-romm-sync/tree/main/py_modules/adapters/repositories) ([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)). The `UnitOfWork` / `UnitOfWorkFactory` Protocols services depend on live in `py_modules/services/protocols/uow.py`; the per-aggregate Repository Protocols in `py_modules/services/protocols/repositories.py` ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)).
+The schema is read and written at runtime through a **Unit of Work** (UoW) — the atomic transaction boundary one
+operation works inside. The concrete UoW and the nine `sqlite3` repository adapters that back it live in
+[`py_modules/adapters/repositories/`](https://github.com/danielcopper/decky-romm-sync/tree/main/py_modules/adapters/repositories)
+([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)). The `UnitOfWork` / `UnitOfWorkFactory` Protocols
+services depend on live in `py_modules/services/protocols/uow.py`; the per-aggregate Repository Protocols in
+`py_modules/services/protocols/repositories.py` ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)).
 
-**Synchronous `sqlite3`, not `aiosqlite`.** Per [ADR-0004](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0004-sync-sqlite-unit-of-work.md) the runtime UoW uses stdlib `sqlite3` (synchronous), reversing the epic's earlier `aiosqlite` plan: `aiosqlite` is itself thread-based with no concurrency win for this single-writer workload, it would add a vendored dependency, and it would introduce a second I/O paradigm alongside the established `run_in_executor` idiom and the sync [#781](https://github.com/danielcopper/decky-romm-sync/issues/781) migration runner. No new vendored dependency.
+**Synchronous `sqlite3`, not `aiosqlite`.** Per
+[ADR-0004](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0004-sync-sqlite-unit-of-work.md) the
+runtime UoW uses stdlib `sqlite3` (synchronous), reversing the epic's earlier `aiosqlite` plan: `aiosqlite` is itself
+thread-based with no concurrency win for this single-writer workload, it would add a vendored dependency, and it would
+introduce a second I/O paradigm alongside the established `run_in_executor` idiom and the sync
+[#781](https://github.com/danielcopper/decky-romm-sync/issues/781) migration runner. No new vendored dependency.
 
-**Shape.** `SqliteUnitOfWork(db_path)` is a synchronous context manager. `__enter__` opens one connection (`isolation_level=None`, `row_factory = sqlite3.Row`), applies the per-connection PRAGMAs (`foreign_keys=ON`, `synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY` — `journal_mode=WAL` is already persistent from the runner), issues an explicit `BEGIN`, builds the nine repositories over that shared connection, and returns itself. `__exit__` commits on a clean exit, rolls back on an exception (then re-raises), and always closes the connection. One UoW therefore equals one transaction; writes across several repositories commit or roll back together.
+**Shape.** `SqliteUnitOfWork(db_path)` is a synchronous context manager. `__enter__` opens one connection
+(`isolation_level=None`, `row_factory = sqlite3.Row`), applies the per-connection PRAGMAs (`foreign_keys=ON`,
+`synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY` — `journal_mode=WAL` is already persistent from the
+runner), issues an explicit `BEGIN`, builds the nine repositories over that shared connection, and returns itself.
+`__exit__` commits on a clean exit, rolls back on an exception (then re-raises), and always closes the connection. One
+UoW therefore equals one transaction; writes across several repositories commit or roll back together.
 
-**Thread affinity.** A `sqlite3` connection is single-thread by default (`check_same_thread=True`, left at its safe default). Services run the whole `with uow_factory() as uow:` block inside their synchronous `run_in_executor` worker (the house `do_<verb>` / `_<verb>_io` idiom), so the connection is created, used, and closed entirely on one worker thread and never escapes it.
+**Thread affinity.** A `sqlite3` connection is single-thread by default (`check_same_thread=True`, left at its safe
+default). Services run the whole `with uow_factory() as uow:` block inside their synchronous `run_in_executor` worker
+(the house `do_<verb>` / `_<verb>_io` idiom), so the connection is created, used, and closed entirely on one worker
+thread and never escapes it.
 
-**Repositories.** Each `SqliteXxxRepository` holds the UoW's open connection and maps rows ↔ domain aggregates: STRICT booleans round-trip through `int(bool)` / `bool(int)`, JSON-array/object columns through `json.dumps` / `json.loads`. `RomSaveStateRepository` spans two tables (`rom_save_states` + `rom_save_files`) — `save` writes the scalar row then replaces the child file rows inside the same transaction. The adapters import only `sqlite3`, `json`, and `domain.*` (never `services`), and structurally satisfy the Repository Protocols; the UoW structurally satisfies `UnitOfWork`, keeping the `adapters ↛ services` boundary intact. The factory (`functools.partial(SqliteUnitOfWork, db_path)`) is wired in `bootstrap()` and threaded into every migrated service's `*ServiceConfig` as `uow_factory`; per [ADR-0006](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0006-narrow-unit-of-work-scope.md) a service opens the UoW only around its DB reads/writes, never across the server/file I/O or the frontend ack.
+**Repositories.** Each `SqliteXxxRepository` holds the UoW's open connection and maps rows ↔ domain aggregates: STRICT
+booleans round-trip through `int(bool)` / `bool(int)`, JSON-array/object columns through `json.dumps` / `json.loads`.
+`RomSaveStateRepository` spans two tables (`rom_save_states` + `rom_save_files`) — `save` writes the scalar row then
+replaces the child file rows inside the same transaction. The adapters import only `sqlite3`, `json`, and `domain.*`
+(never `services`), and structurally satisfy the Repository Protocols; the UoW structurally satisfies `UnitOfWork`,
+keeping the `adapters ↛ services` boundary intact. The factory (`functools.partial(SqliteUnitOfWork, db_path)`) is wired
+in `bootstrap()` and threaded into every migrated service's `*ServiceConfig` as `uow_factory`; per
+[ADR-0006](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0006-narrow-unit-of-work-scope.md) a
+service opens the UoW only around its DB reads/writes, never across the server/file I/O or the frontend ack.
 
 ## Coming in later PRs
 
-With the aggregate set, the schema, the Repository Protocols, and the runtime UoW in place, the service cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) lands vertical by vertical. Already migrated: firmware, downloads + the launcher read path (the latter since removed — the launcher no longer reads SQLite at all; the launch command is baked into the shortcut's `launch_options` and the `rom-launcher` exec wrapper just runs it, per [ADR-0009](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md)), the saves vertical, the library/roms slice (registry → `roms`, sync lifecycle → `sync_runs`, the platform-name cache → `kv_config`), the metadata slice (`rom_metadata` written by the reporter's per-unit commit; `MetadataService`/`GameDetailService` read it from SQLite), the playtime slice (`PlaytimeService` records sessions and reconciles RomM-note totals through `rom_playtime`), the rom-removal + startup-healing slice (`RomRemovalService` and `StartupHealingService.prune_stale_installed_roms` read/delete `rom_installs` through the UoW; the JSON `installed_roms` dict is no longer read by either), the read-consumers slice (`GameDetailService`/`AchievementsService`/`SettingsService` read the synced-shortcut registry, install record, save state, and `ra_id` from SQLite — the in-memory `shortcut_registry` dict has no live service reader and `SaveSyncState` is fully dead), and the migration slice. After the migration slice, `MigrationService` reads the RetroDECK-home and save-sort change-detection markers from `kv_config` (Bucket 2 per [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)) and relocates installed-ROM file paths through `uow.rom_installs.relocate`; `SyncReporter.get_rom_by_steam_app_id` tests installed-ness via `uow.rom_installs.get`; and the two interim readers of the same markers moved with it — `StartupHealingService.prune_stale_installed_roms` reads the pending-migration home from `kv_config`, and `RomInfoService` reads the save-sort markers from `kv_config`. The `retrodeck_home_path*` and `save_sort_settings*` markers have no live JSON-state reader and are dropped from `PluginState`. Still downstream:
+With the aggregate set, the schema, the Repository Protocols, and the runtime UoW in place, the service cutover
+([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) lands vertical by vertical. Already migrated:
+firmware, downloads + the launcher read path (the latter since removed — the launcher no longer reads SQLite at all; the
+launch command is baked into the shortcut's `launch_options` and the `rom-launcher` exec wrapper just runs it, per
+[ADR-0009](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md)),
+the saves vertical, the library/roms slice (registry → `roms`, sync lifecycle → `sync_runs`, the platform-name cache →
+`kv_config`), the metadata slice (`rom_metadata` written by the reporter's per-unit commit;
+`MetadataService`/`GameDetailService` read it from SQLite), the playtime slice (`PlaytimeService` records sessions and
+reconciles RomM-note totals through `rom_playtime`), the rom-removal + startup-healing slice (`RomRemovalService` and
+`StartupHealingService.prune_stale_installed_roms` read/delete `rom_installs` through the UoW; the JSON `installed_roms`
+dict is no longer read by either), the read-consumers slice (`GameDetailService`/`AchievementsService`/`SettingsService`
+read the synced-shortcut registry, install record, save state, and `ra_id` from SQLite — the in-memory
+`shortcut_registry` dict has no live service reader and `SaveSyncState` is fully dead), and the migration slice. After
+the migration slice, `MigrationService` reads the RetroDECK-home and save-sort change-detection markers from `kv_config`
+(Bucket 2 per
+[ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md))
+and relocates installed-ROM file paths through `uow.rom_installs.relocate`; `SyncReporter.get_rom_by_steam_app_id` tests
+installed-ness via `uow.rom_installs.get`; and the two interim readers of the same markers moved with it —
+`StartupHealingService.prune_stale_installed_roms` reads the pending-migration home from `kv_config`, and
+`RomInfoService` reads the save-sort markers from `kv_config`. The `retrodeck_home_path*` and `save_sort_settings*`
+markers have no live JSON-state reader and are dropped from `PluginState`. Still downstream:
 
-- **Teardown** — with `SaveSyncState` (`.playtime` and `.saves`) and the in-memory `shortcut_registry` dict now reader-free, the dead persisters, the `RegistryStoreAdapter`/`MetadataCacheStoreAdapter` JSON stores, `domain/save_state.py`, and the in-memory state dict are deleted. (`installed_roms` is no longer read by any service, but it stays on `PluginState`/the JSON state dict until the teardown stream removes the test seeding that still populates it.)
+- **Teardown** — with `SaveSyncState` (`.playtime` and `.saves`) and the in-memory `shortcut_registry` dict now
+  reader-free, the dead persisters, the `RegistryStoreAdapter`/`MetadataCacheStoreAdapter` JSON stores,
+  `domain/save_state.py`, and the in-memory state dict are deleted. (`installed_roms` is no longer read by any service,
+  but it stays on `PluginState`/the JSON state dict until the teardown stream removes the test seeding that still
+  populates it.)
 
-Chapter 8+ of the Cosmic Python book (domain events + message bus) is explicitly out of scope for this epic; the triggers for revisiting that scope are recorded in `CLAUDE.md`.
+Chapter 8+ of the Cosmic Python book (domain events + message bus) is explicitly out of scope for this epic; the
+triggers for revisiting that scope are recorded in `CLAUDE.md`.
 
 ## See also
 
-- [Backend Architecture](backend-architecture.md) — the four-layer split, the `XxxServiceConfig` pattern, and the boundary-enforcement layers that aggregates build on.
-- [`CONTEXT.md`](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md) — the `Aggregate`, `kv_config`, and `Rom`/`ROM`/`RomM` glossary entries.
-- [ADR-0001](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0001-adopt-platform-aggregate.md) — the decision to adopt `Platform` as a full aggregate (**superseded by ADR-0003**).
-- [ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md) — the per-ROM table-per-aggregate split and the per-ROM CASCADE foreign keys.
-- [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md) — the JSON/SQLite persistence boundary; drops the `Platform`, `Device`, and `SyncSettings` aggregates and reverts `Platform` to a denormalized `platform_slug` string.
+- [Backend Architecture](backend-architecture.md) — the four-layer split, the `XxxServiceConfig` pattern, and the
+  boundary-enforcement layers that aggregates build on.
+- [`CONTEXT.md`](https://github.com/danielcopper/decky-romm-sync/blob/main/CONTEXT.md) — the `Aggregate`, `kv_config`,
+  and `Rom`/`ROM`/`RomM` glossary entries.
+- [ADR-0001](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0001-adopt-platform-aggregate.md) — the
+  decision to adopt `Platform` as a full aggregate (**superseded by ADR-0003**).
+- [ADR-0002](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0002-per-rom-table-per-aggregate-split.md)
+  — the per-ROM table-per-aggregate split and the per-ROM CASCADE foreign keys.
+- [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md)
+  — the JSON/SQLite persistence boundary; drops the `Platform`, `Device`, and `SyncSettings` aggregates and reverts
+  `Platform` to a denormalized `platform_slug` string.

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -2,25 +2,28 @@
 
 ## Overview
 
-decky-romm-sync provides bidirectional save file synchronization between RetroDECK and a self-hosted RomM server. Saves are uploaded after play sessions and downloaded before game launch, enabling seamless multi-device play.
+decky-romm-sync provides bidirectional save file synchronization between RetroDECK and a self-hosted RomM server. Saves
+are uploaded after play sessions and downloaded before game launch, enabling seamless multi-device play.
 
-The initial implementation covers **RetroArch per-game `.srm` saves only**. This includes all systems that use RetroArch cores via RetroDECK (NES, SNES, GB, GBC, GBA, Genesis, N64, PSX via RetroArch cores, Saturn, Dreamcast, PC Engine, and more). Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, etc.) are deferred to Phase 7.
+The initial implementation covers **RetroArch per-game `.srm` saves only**. This includes all systems that use RetroArch
+cores via RetroDECK (NES, SNES, GB, GBC, GBA, Genesis, N64, PSX via RetroArch cores, Saturn, Dreamcast, PC Engine, and
+more). Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, etc.) are deferred to Phase 7.
 
 ## RomM Save API
 
 Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `error_code: "version_error"`.
 
-| Endpoint | Method | Notes |
-| --- | --- | --- |
-| `/api/saves?rom_id={id}` | GET | Returns array. Each item now includes `slot`, `file_name_no_tags`, `file_extension`, `content_hash`, and `device_syncs` array. |
-| `/api/saves/{id}` | GET | Single save metadata with v4.7 fields |
-| `/api/saves?rom_id={id}&emulator={emulator}&slot={slot}` | POST | Creates a new save entry. Slot-aware: `slot=default` causes RomM to append a timestamp to the filename (e.g. `Game.srm` becomes `Game [2026-03-24_15-18-50].srm`). Same filename + same slot = upsert. Different slot = new entry. |
-| `/api/saves/{id}` | PUT | Updates file content only. No metadata changes, no new entry created. |
-| `/api/saves/{id}/content` | GET | Binary download by save ID (new in v4.7) |
-| `/api/devices` | GET | List all registered devices for the authenticated user. Returns array of `{id, name, platform, client, client_version, last_seen, created_at, ...}`. |
-| `/api/devices` | POST | Register a device. Accepts hostname, platform, client info. Returns `device_id` (UUID). |
-| `/api/devices/{id}` | DELETE | Remove a device registration. Returns 204 No Content. PATCH (rename) is not supported (405). |
-| `/api/saves/delete` | POST | Bulk delete saves by ID. Body: `{"saves": [id1, id2, ...]}`. Returns result dict. |
+| Endpoint                                                 | Method | Notes                                                                                                                                                                                                                              |
+| -------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/saves?rom_id={id}`                                 | GET    | Returns array. Each item now includes `slot`, `file_name_no_tags`, `file_extension`, `content_hash`, and `device_syncs` array.                                                                                                     |
+| `/api/saves/{id}`                                        | GET    | Single save metadata with v4.7 fields                                                                                                                                                                                              |
+| `/api/saves?rom_id={id}&emulator={emulator}&slot={slot}` | POST   | Creates a new save entry. Slot-aware: `slot=default` causes RomM to append a timestamp to the filename (e.g. `Game.srm` becomes `Game [2026-03-24_15-18-50].srm`). Same filename + same slot = upsert. Different slot = new entry. |
+| `/api/saves/{id}`                                        | PUT    | Updates file content only. No metadata changes, no new entry created.                                                                                                                                                              |
+| `/api/saves/{id}/content`                                | GET    | Binary download by save ID (new in v4.7)                                                                                                                                                                                           |
+| `/api/devices`                                           | GET    | List all registered devices for the authenticated user. Returns array of `{id, name, platform, client, client_version, last_seen, created_at, ...}`.                                                                               |
+| `/api/devices`                                           | POST   | Register a device. Accepts hostname, platform, client info. Returns `device_id` (UUID).                                                                                                                                            |
+| `/api/devices/{id}`                                      | DELETE | Remove a device registration. Returns 204 No Content. PATCH (rename) is not supported (405).                                                                                                                                       |
+| `/api/saves/delete`                                      | POST   | Bulk delete saves by ID. Body: `{"saves": [id1, id2, ...]}`. Returns result dict.                                                                                                                                                  |
 
 **New parameters on POST:**
 
@@ -38,13 +41,15 @@ Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `error_code:
 
 ## Save Slots
 
-RomM v4.7 introduces **save slots** — named containers for save files. This enables multi-save workflows (e.g., different save states per device).
+RomM v4.7 introduces **save slots** — named containers for save files. This enables multi-save workflows (e.g.,
+different save states per device).
 
 ### How slots work
 
 - Each save on RomM belongs to a slot (or has `slot=null` for legacy pre-slot saves)
 - Save identity on RomM: `(user_id, rom_id, filename)` **within a slot**
-- `POST /api/saves` with `slot=default` causes RomM to append a timestamp to the filename: `Game.srm` becomes `Game [2026-03-24_15-18-50].srm`
+- `POST /api/saves` with `slot=default` causes RomM to append a timestamp to the filename: `Game.srm` becomes
+  `Game [2026-03-24_15-18-50].srm`
 - Same filename + same slot = overwrites (upsert). Different slot = new save entry.
 - `PUT /api/saves/{id}` updates file content only, no metadata changes. No new entry created.
 - `autocleanup_limit` parameter controls how many stacked versions are retained per slot
@@ -70,142 +75,196 @@ RomM v4.7 introduces **save slots** — named containers for save files. This en
 
 ## Device Registration
 
-Each machine running the plugin registers as a device with the RomM server. This allows RomM to track which device uploaded each save.
+Each machine running the plugin registers as a device with the RomM server. This allows RomM to track which device
+uploaded each save.
 
-1. On first use with save sync enabled, the plugin calls `POST /api/devices` with the friendly device label (`name`), platform, client info, and the contents of `/etc/machine-id` as the `hostname` fingerprint
+1. On first use with save sync enabled, the plugin calls `POST /api/devices` with the friendly device label (`name`),
+   platform, client info, and the contents of `/etc/machine-id` as the `hostname` fingerprint
 2. Server returns a `device_id` (UUID) stored as `server_device_id` in state
-3. This ID is passed to `list_saves` (populates `device_syncs` per save) and `upload_save` / `download_save_content` (tracks sync status)
-4. `device_syncs` array on each save shows per-device sync status: `device_id`, `device_name`, `is_current`, `last_synced_at`
+3. This ID is passed to `list_saves` (populates `device_syncs` per save) and `upload_save` / `download_save_content`
+   (tracks sync status)
+4. `device_syncs` array on each save shows per-device sync status: `device_id`, `device_name`, `is_current`,
+   `last_synced_at`
 5. `is_current = false` means another device uploaded since our last sync
 6. Server returns HTTP 409 on POST when device has stale sync record (additional safety net)
 
 ### Why `/etc/machine-id` is the fingerprint
 
-RomM ≥4.8.1 dedupes devices by fingerprint — `mac_address`, OR `hostname` + `platform` — and returns the existing device instead of minting a duplicate (`allow_existing` defaults true). The `name` field is **not** fingerprinted, so without a stable fingerprint every local-state wipe (the SQLite reinstall path) would create a fresh duplicate device on each reinstall.
+RomM ≥4.8.1 dedupes devices by fingerprint — `mac_address`, OR `hostname` + `platform` — and returns the existing device
+instead of minting a duplicate (`allow_existing` defaults true). The `name` field is **not** fingerprinted, so without a
+stable fingerprint every local-state wipe (the SQLite reinstall path) would create a fresh duplicate device on each
+reinstall.
 
-The plugin sends `/etc/machine-id` as the RomM `hostname`: it is machine-derived (survives a reinstall), unique per device (two Steam Decks stay distinct), and stable. The real OS hostname is deliberately **not** sent — two stock Steam Decks both report `steamdeck`, so a `hostname` + `platform` fingerprint built from the OS hostname would collide them into one server device. The friendly OS hostname remains the display-only `name`. When `/etc/machine-id` is unreadable the `hostname` field is omitted entirely, degrading to the pre-4.8.1 no-fingerprint behaviour rather than sending a colliding value.
+The plugin sends `/etc/machine-id` as the RomM `hostname`: it is machine-derived (survives a reinstall), unique per
+device (two Steam Decks stay distinct), and stable. The real OS hostname is deliberately **not** sent — two stock Steam
+Decks both report `steamdeck`, so a `hostname` + `platform` fingerprint built from the OS hostname would collide them
+into one server device. The friendly OS hostname remains the display-only `name`. When `/etc/machine-id` is unreadable
+the `hostname` field is omitted entirely, degrading to the pre-4.8.1 no-fingerprint behaviour rather than sending a
+colliding value.
 
 ### RomM account requirement
 
-Save games in RomM are tied to the authenticated user account. Users must use their own RomM account (not a shared/generic one) so saves are correctly attributed per user, per device.
+Save games in RomM are tied to the authenticated user account. Users must use their own RomM account (not a
+shared/generic one) so saves are correctly attributed per user, per device.
 
 ## Emulator Tags
 
-The `emulator` parameter on RomM save uploads determines the server-side folder path: `saves/{system}/{rom_id}/{emulator}/`
+The `emulator` parameter on RomM save uploads determines the server-side folder path:
+`saves/{system}/{rom_id}/{emulator}/`
 
 **Format:** `retroarch-{core}` where core is the libretro core name without `_libretro` suffix, lowercased.
 
 - Examples: `retroarch-mgba`, `retroarch-snes9x`, `retroarch-swanstation`
 - Fallback: `retroarch` if core resolution fails (e.g., ES-DE config parse error)
 
-**Important:** Emulator tag is **immutable** on RomM — set on creation, cannot be changed later. This means saves created before v2 have `emulator=retroarch` and will keep that tag. New saves created with slots get the correct `retroarch-{core}` tag.
+**Important:** Emulator tag is **immutable** on RomM — set on creation, cannot be changed later. This means saves
+created before v2 have `emulator=retroarch` and will keep that tag. New saves created with slots get the correct
+`retroarch-{core}` tag.
 
 For future standalone emulator support (Phase 9): just the emulator name, e.g. `duckstation`.
 
 ## Sync Decision Algorithm
 
-Each sync run picks one action per save file: `Skip`, `Upload`, `Download`, or `Conflict`. The decision is computed by a pure function — no I/O, no service or adapter imports — so behaviour is fully driven by inputs and is exhaustively unit-tested.
+Each sync run picks one action per save file: `Skip`, `Upload`, `Download`, or `Conflict`. The decision is computed by a
+pure function — no I/O, no service or adapter imports — so behaviour is fully driven by inputs and is exhaustively
+unit-tested.
 
 ### Inputs
 
-- **`local_file`** — `{filename, path, size, mtime}` for a file on disk, or `None` if no local file exists for this filename.
+- **`local_file`** — `{filename, path, size, mtime}` for a file on disk, or `None` if no local file exists for this
+  filename.
 - **`server_saves_in_slot`** — RomM save dicts already filtered to the active slot.
-- **`files_state`** — the per-filename slice of `save_sync_state.json` (may be empty for a never-synced file). Carries `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`, `last_sync_local_mtime`, etc.
+- **`files_state`** — the per-filename slice of `save_sync_state.json` (may be empty for a never-synced file). Carries
+  `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`, `last_sync_local_mtime`, etc.
 - **`device_id`** — this device's RomM-server ID (used to find our entry in `server_save.device_syncs`).
 - **`local_hash`** — pre-computed MD5 of `local_file`, or `None`.
 
 ### Pick rule and discriminators
 
-Within `server_saves_in_slot`, the algorithm picks the **newest by `updated_at`** as the canonical save and decides against that one. Other saves in the slot are ignored — no foreign-save surfacing, no per-save dismiss state.
+Within `server_saves_in_slot`, the algorithm picks the **newest by `updated_at`** as the canonical save and decides
+against that one. Other saves in the slot are ignored — no foreign-save surfacing, no per-save dismiss state.
 
 Two discriminators drive the branch:
 
-1. **Our device's entry on the picked save**: `server.device_syncs[me]` may be missing (we never touched this save), `is_current=true` (server claims our last write/read is current), or `is_current=false` (someone else has moved this save forward since we last touched it).
-2. **Hash divergence vs. baseline**: `local_hash != files_state["last_sync_hash"]` means the local file has been edited since the last successful sync. Without a baseline (`last_sync_hash` is missing) we cannot claim divergence.
+1. **Our device's entry on the picked save**: `server.device_syncs[me]` may be missing (we never touched this save),
+   `is_current=true` (server claims our last write/read is current), or `is_current=false` (someone else has moved this
+   save forward since we last touched it).
+2. **Hash divergence vs. baseline**: `local_hash != files_state["last_sync_hash"]` means the local file has been edited
+   since the last successful sync. Without a baseline (`last_sync_hash` is missing) we cannot claim divergence.
 
-`is_current` is **computed server-side**, not stored — see [RomM Save Sync API Behaviour](#romm-save-sync-api-behaviour) below.
+`is_current` is **computed server-side**, not stored — see [RomM Save Sync API Behaviour](#romm-save-sync-api-behaviour)
+below.
 
 ### Outcomes
 
-| Variant | Service behaviour |
-| --- | --- |
-| `Skip(reason)` | No I/O. Optional `adopt_baseline=True` flag: dispatcher writes `last_sync_hash := local_hash` (state mutation only, no network). |
-| `Upload(target_save_id=None)` | POST a new save to the slot. Server assigns an ID; we record it in state. |
-| `Upload(target_save_id=int)` | PUT to the existing save id (re-upload). Used when our offline edits need to land on the existing server save. |
-| `Download(server_save)` | GET save content, overwrite local file, update sync state. |
-| `Conflict(server_save)` | Surface a `SyncConflict` to the frontend. The user resolves via `resolve_sync_conflict(rom_id, filename, server_save_id, action)`. |
+| Variant                       | Service behaviour                                                                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `Skip(reason)`                | No I/O. Optional `adopt_baseline=True` flag: dispatcher writes `last_sync_hash := local_hash` (state mutation only, no network).   |
+| `Upload(target_save_id=None)` | POST a new save to the slot. Server assigns an ID; we record it in state.                                                          |
+| `Upload(target_save_id=int)`  | PUT to the existing save id (re-upload). Used when our offline edits need to land on the existing server save.                     |
+| `Download(server_save)`       | GET save content, overwrite local file, update sync state.                                                                         |
+| `Conflict(server_save)`       | Surface a `SyncConflict` to the frontend. The user resolves via `resolve_sync_conflict(rom_id, filename, server_save_id, action)`. |
 
-`Skip(adopt_baseline=True)` is recorded both from the mutating sync path (`SyncEngine._sync_rom_saves`) and the read-only status path (`StatusService._get_save_status_io`). The alternative — only writing the baseline from the mutating path — would leave state incomplete forever for users who only ever open the game-detail panel.
+`Skip(adopt_baseline=True)` is recorded both from the mutating sync path (`SyncEngine._sync_rom_saves`) and the
+read-only status path (`StatusService._get_save_status_io`). The alternative — only writing the baseline from the
+mutating path — would leave state incomplete forever for users who only ever open the game-detail panel.
 
 ### Implementation
 
-The algorithm is `compute_sync_action` in `py_modules/domain/sync_action.py`. The `SaveService` aggregate (`py_modules/services/saves/`) calls it from two sub-services:
+The algorithm is `compute_sync_action` in `py_modules/domain/sync_action.py`. The `SaveService` aggregate
+(`py_modules/services/saves/`) calls it from two sub-services:
 
-- `SyncEngine._sync_rom_saves` (`services/saves/sync_engine/`) iterates local files and server-only-in-slot groups, dispatching each action via the matrix executor's `_dispatch_sync_action` (POST/PUT/GET + state update).
-- `StatusService._get_save_status_io` (`services/saves/status/`) runs the same decisions read-only and folds them into the `SaveStatus.files[*].status` strings the frontend renders. The only allowed mutation is recording an adopted baseline hash — pure state hygiene with no network traffic.
+- `SyncEngine._sync_rom_saves` (`services/saves/sync_engine/`) iterates local files and server-only-in-slot groups,
+  dispatching each action via the matrix executor's `_dispatch_sync_action` (POST/PUT/GET + state update).
+- `StatusService._get_save_status_io` (`services/saves/status/`) runs the same decisions read-only and folds them into
+  the `SaveStatus.files[*].status` strings the frontend renders. The only allowed mutation is recording an adopted
+  baseline hash — pure state hygiene with no network traffic.
 
-Server-only saves (no matching local file) are grouped by their target local filename (`rom_name.<ext>`) before being passed to `compute_sync_action`. The algorithm picks the newest in the group, so older stacked versions in the same slot are not separately surfaced.
+Server-only saves (no matching local file) are grouped by their target local filename (`rom_name.<ext>`) before being
+passed to `compute_sync_action`. The algorithm picks the newest in the group, so older stacked versions in the same slot
+are not separately surfaced.
 
 ## Decision Matrix
 
-The matrix below enumerates every input combination `compute_sync_action` handles. Rows are derived from the algorithm and exhaustively cover the cross-product of dimensions. Tests in `tests/domain/test_sync_action.py` map 1:1 to these rows.
+The matrix below enumerates every input combination `compute_sync_action` handles. Rows are derived from the algorithm
+and exhaustively cover the cross-product of dimensions. Tests in `tests/domain/test_sync_action.py` map 1:1 to these
+rows.
 
 Dimensions:
 
 - **Local file** — does a `.srm` exist on disk?
 - **Server saves in slot** — none, or at least one (algorithm picks newest).
-- **Our device entry on picked save** — *never touched* (no `device_syncs` entry for our id), *current=true*, or *current=false*.
-- **Local vs `last_sync_hash`** — *unchanged*, *changed*, or *no baseline* (key missing in state).
-- **Local mtime vs server `updated_at`** — only consulted in the `never touched` branch where the algorithm has no other ordering signal.
+- **Our device entry on picked save** — _never touched_ (no `device_syncs` entry for our id), _current=true_, or
+  _current=false_.
+- **Local vs `last_sync_hash`** — _unchanged_, _changed_, or _no baseline_ (key missing in state).
+- **Local mtime vs server `updated_at`** — only consulted in the `never touched` branch where the algorithm has no other
+  ordering signal.
 
-| # | local file | server in slot | our entry | local vs baseline | mtime vs server | decision | reason |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | no | none | n/a | n/a | n/a | `Skip(nothing_to_sync)` | nothing local, nothing server |
-| 2 | yes | none | n/a | n/a | n/a | `Upload(POST)` | first push for this save (or recovery after server-side wipe) |
-| 3 | no | ≥1 | never touched | n/a | n/a | `Download(picked)` | no relation, pull newest |
-| 4 | no | ≥1 | current=true | n/a | n/a | `Download(picked)` | recovery — server still tracks our last version, local is gone |
-| 5 | no | ≥1 | current=false | n/a | n/a | `Download(picked)` | server moved forward, nothing local to protect |
-| 6a | yes | ≥1 | never touched | no baseline | local mtime ≥ server | `Upload(POST)` | post our local as a new save in the slot — no overwrite risk |
-| 6b | yes | ≥1 | never touched | no baseline | local mtime < server | `Download(picked)` | server is newer than our untracked local |
-| 7 | yes | ≥1 | current=true | unchanged | n/a | `Skip(synced)` | steady state |
-| 8 | yes | ≥1 | current=true | no baseline | n/a | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected |
-| 9 | yes | ≥1 | current=true | changed | n/a | `Upload(PUT to picked.id)` | offline edit — push our changes back onto the save the server still considers ours |
-| 10 | yes | ≥1 | current=false | unchanged | n/a | `Download(picked)` | another device synced; we did nothing — adopt their version |
-| 11 | yes | ≥1 | current=false | no baseline | n/a | `Download(picked)` | no baseline → cannot prove our local is newer; server wins |
-| 12 | yes | ≥1 | current=false | changed | n/a | **`Conflict(picked)`** | both sides changed independently — only true conflict |
+| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                 |
+| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                          |
+| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                          |
+| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                               |
+| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                         |
+| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                         |
+| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                           |
+| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                               |
+| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                           |
+| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected |
+| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                     |
+| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                            |
+| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                             |
+| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                  |
 
 Conflict happens in exactly one row (#12). Every other row resolves silently to a Skip, Upload, or Download.
 
 ### Why row 6a posts instead of overwriting
 
-Row 6a fires when a local file exists, a server save also exists in the slot, but our device has never touched the picked server save and our local mtime is at-or-after the server's `updated_at`. There is no baseline (`last_sync_hash`), so we cannot prove drift either way; we also have no claim on the picked save (no `device_syncs` entry for our id). POSTing a brand-new save preserves both files: the original picked save stays intact, and our local content lands as a separate entry that becomes the new newest. Subsequent syncs pick our save naturally.
+Row 6a fires when a local file exists, a server save also exists in the slot, but our device has never touched the
+picked server save and our local mtime is at-or-after the server's `updated_at`. There is no baseline
+(`last_sync_hash`), so we cannot prove drift either way; we also have no claim on the picked save (no `device_syncs`
+entry for our id). POSTing a brand-new save preserves both files: the original picked save stays intact, and our local
+content lands as a separate entry that becomes the new newest. Subsequent syncs pick our save naturally.
 
 ### Why row 11 downloads instead of uploading
 
-Row 11 looks superficially symmetrical to row 6a — local file exists, mtime is whatever, no baseline. The difference is that our device **does** have an entry on the picked save (we touched it before) and the entry says `is_current=false`. Some other device has PUT to that save since our last interaction, so its content is foreign to us. Without a baseline, we cannot prove our local has edits that postdate the foreign PUT. mtime is unreliable (filesystem touches, migrations, clock skew). Pushing a PUT here would overwrite the foreign content blindly. We download instead, accepting the trade-off that a state-corrupted-but-genuinely-newer local file gets overwritten — that scenario is rare and a silent overwrite of another device's work would be worse.
+Row 11 looks superficially symmetrical to row 6a — local file exists, mtime is whatever, no baseline. The difference is
+that our device **does** have an entry on the picked save (we touched it before) and the entry says `is_current=false`.
+Some other device has PUT to that save since our last interaction, so its content is foreign to us. Without a baseline,
+we cannot prove our local has edits that postdate the foreign PUT. mtime is unreliable (filesystem touches, migrations,
+clock skew). Pushing a PUT here would overwrite the foreign content blindly. We download instead, accepting the
+trade-off that a state-corrupted-but-genuinely-newer local file gets overwritten — that scenario is rare and a silent
+overwrite of another device's work would be worse.
 
 ### Why is there no foreign-save modal anymore
 
-Earlier versions surfaced every server save in the slot the user had not authored as a "newer-in-slot" prompt. The pragmatic newest-wins model used by the official RomM clients (Argosy, Grout) treats the slot as a single timeline: whichever save has the highest `updated_at` wins, regardless of which device PUT it. We adopted that model in v0.16 because it eliminates ~1500 lines of foreign-tracking code and aligns with the wider RomM ecosystem. Cross-device uploads are silently adopted unless local edits diverge from baseline (row 12). This is documented behaviour, not a regression.
+Earlier versions surfaced every server save in the slot the user had not authored as a "newer-in-slot" prompt. The
+pragmatic newest-wins model used by the official RomM clients (Argosy, Grout) treats the slot as a single timeline:
+whichever save has the highest `updated_at` wins, regardless of which device PUT it. We adopted that model in v0.16
+because it eliminates ~1500 lines of foreign-tracking code and aligns with the wider RomM ecosystem. Cross-device
+uploads are silently adopted unless local edits diverge from baseline (row 12). This is documented behaviour, not a
+regression.
 
 ## Slot Setup Wizard
 
-Before save sync can operate for a game, the user must choose which slot to track. This is managed by the `slot_confirmed` flag in per-game state.
+Before save sync can operate for a game, the user must choose which slot to track. This is managed by the
+`slot_confirmed` flag in per-game state.
 
 ### Scenarios on first use
 
-| Scenario | Local | Server | Behavior |
-| --- | --- | --- | --- |
-| A | No saves | Has saves | Wizard: choose which server slot to track |
-| B | Has saves | No saves | Auto-configure with default slot (no prompt) |
-| C | Has saves | Has saves (other slots) | Wizard: upload to default or track server slot |
-| D | -- | -- | Manual slot switch in game detail |
-| E | Has saves | Has saves in default slot | Wizard: track default or use different slot |
+| Scenario | Local     | Server                    | Behavior                                       |
+| -------- | --------- | ------------------------- | ---------------------------------------------- |
+| A        | No saves  | Has saves                 | Wizard: choose which server slot to track      |
+| B        | Has saves | No saves                  | Auto-configure with default slot (no prompt)   |
+| C        | Has saves | Has saves (other slots)   | Wizard: upload to default or track server slot |
+| D        | --        | --                        | Manual slot switch in game detail              |
+| E        | Has saves | Has saves in default slot | Wizard: track default or use different slot    |
 
 ### Where the check happens
 
 - **Game detail page (SAVES tab):** shows wizard instead of save list when `slot_confirmed=false`
-- **Play button:** checks before launch. If not configured and server has saves, redirects to SAVES tab. If no server saves, auto-configures with default.
+- **Play button:** checks before launch. If not configured and server has saves, redirects to SAVES tab. If no server
+  saves, auto-configures with default.
 
 ## Save File Discovery
 
@@ -224,9 +283,14 @@ This path varies depending on where RetroDECK was installed:
 - **Internal SSD**: `/home/deck/retrodeck/saves/`
 - **SD card**: `/run/media/deck/Emulation/retrodeck/saves/`
 
-The backend reads `retrodeck.json` → `paths.saves_path` as the source of truth (`py_modules/adapters/retrodeck_paths.py`). When that file is unreadable — e.g. a fresh install with no RetroDECK configured yet — it falls back to the hardcoded RetroDECK default `~/retrodeck/saves`.
+The backend reads `retrodeck.json` → `paths.saves_path` as the source of truth
+(`py_modules/adapters/retrodeck_paths.py`). When that file is unreadable — e.g. a fresh install with no RetroDECK
+configured yet — it falls back to the hardcoded RetroDECK default `~/retrodeck/saves`.
 
-The plugin deliberately does **not** read `savefile_directory` from `retroarch.cfg`. RetroDECK re-derives `savefile_directory = saves_path` on every launch/reset/move (its `component_prepare.sh` rewrites the key, and the "move data" flow updates `retrodeck.json` and `retroarch.cfg` in lockstep), so `retrodeck.json` is the single source of truth and reading the cfg key would only track a value RetroDECK is about to overwrite.
+The plugin deliberately does **not** read `savefile_directory` from `retroarch.cfg`. RetroDECK re-derives
+`savefile_directory = saves_path` on every launch/reset/move (its `component_prepare.sh` rewrites the key, and the "move
+data" flow updates `retrodeck.json` and `retroarch.cfg` in lockstep), so `retrodeck.json` is the single source of truth
+and reading the cfg key would only track a value RetroDECK is about to overwrite.
 
 ### RetroArch .srm pattern
 
@@ -239,14 +303,24 @@ All RetroArch cores save in a consistent location:
 Where:
 
 - `<saves_path>` is the base path from `retrodeck.json` → `paths.saves_path`
-- `{system}` is the RetroDECK ROM directory name (e.g. `gba`, `snes`, `n64`, `psx`) — this matches the ROM folder under `roms/`
+- `{system}` is the RetroDECK ROM directory name (e.g. `gba`, `snes`, `n64`, `psx`) — this matches the ROM folder under
+  `roms/`
 - `{rom_name}` is the ROM filename without extension
 
-**Sort by content directory**: RetroDECK's default RetroArch config sets `sort_savefiles_by_content_enable = true`. This means save subdirectories match the ROM's parent folder name (the platform slug like `gba`), **not** the RetroArch core name (like `mGBA`). The separate `sort_savefiles_enable` setting (sort by core name) is `false` by default.
+**Sort by content directory**: RetroDECK's default RetroArch config sets `sort_savefiles_by_content_enable = true`. This
+means save subdirectories match the ROM's parent folder name (the platform slug like `gba`), **not** the RetroArch core
+name (like `mGBA`). The separate `sort_savefiles_enable` setting (sort by core name) is `false` by default.
 
-**Sort by core name (optional)**: When a user enables `sort_savefiles_enable`, RetroArch organizes saves by the core's canonical name instead — e.g. `<saves_path>/Snes9x/game.srm` rather than `<saves_path>/snes/game.srm`. The canonical core name comes from the `corename` field of RetroArch's `.info` file for the active core, which is **not** the same as the ES-DE display label for that core (e.g. ES-DE labels the core `Snes9x - Current` while RetroArch calls it `Snes9x`). The plugin resolves this by asking two different parsers — ES-DE for "which core is active", then the RetroArch `.info` parser for "what does RetroArch call that core". The rationale and architecture are documented on the [Config Source Parsers](config-source-parsers.md) page.
+**Sort by core name (optional)**: When a user enables `sort_savefiles_enable`, RetroArch organizes saves by the core's
+canonical name instead — e.g. `<saves_path>/Snes9x/game.srm` rather than `<saves_path>/snes/game.srm`. The canonical
+core name comes from the `corename` field of RetroArch's `.info` file for the active core, which is **not** the same as
+the ES-DE display label for that core (e.g. ES-DE labels the core `Snes9x - Current` while RetroArch calls it `Snes9x`).
+The plugin resolves this by asking two different parsers — ES-DE for "which core is active", then the RetroArch `.info`
+parser for "what does RetroArch call that core". The rationale and architecture are documented on the
+[Config Source Parsers](config-source-parsers.md) page.
 
-The backend resolves save paths by looking up the ROM's system slug in the platform config and constructing the expected `.srm` path. The file is checked for existence and its hash/mtime are read for comparison.
+The backend resolves save paths by looking up the ROM's system slug in the platform config and constructing the expected
+`.srm` path. The file is checked for existence and its hash/mtime are read for comparison.
 
 ### Unsupported: `savefiles_in_content_dir` (Write Saves to Content Directory)
 
@@ -254,19 +328,31 @@ RetroArch has a third save-related layout setting that **the plugin does not sup
 
 - `savefiles_in_content_dir` — RetroArch UI label: **"Write Saves to Content Directory"**
 
-When this setting is **enabled** (RetroDECK default is `false`), RetroArch writes save files into the **same directory as the ROM file** (e.g. `roms/gba/Game/Game.srm`) instead of the configured `savefile_directory`. The two `sort_savefiles_*` settings discussed above become irrelevant in that case because saves no longer live in the savefile directory at all.
+When this setting is **enabled** (RetroDECK default is `false`), RetroArch writes save files into the **same directory
+as the ROM file** (e.g. `roms/gba/Game/Game.srm`) instead of the configured `savefile_directory`. The two
+`sort_savefiles_*` settings discussed above become irrelevant in that case because saves no longer live in the savefile
+directory at all.
 
-**The plugin does not handle this configuration.** `adapters/retroarch_config.py` reads only `sort_savefiles_by_content_enable` and `sort_savefiles_enable` — it does not read or react to `savefiles_in_content_dir`. If a user enables it, the plugin's save sync, conflict detection, and save-sort migration will silently miss every save because they only look inside `savefile_directory`.
+**The plugin does not handle this configuration.** `adapters/retroarch_config.py` reads only
+`sort_savefiles_by_content_enable` and `sort_savefiles_enable` — it does not read or react to
+`savefiles_in_content_dir`. If a user enables it, the plugin's save sync, conflict detection, and save-sort migration
+will silently miss every save because they only look inside `savefile_directory`.
 
-**Why this is easy to confuse**: the RetroArch UI labels are deliberately similar. "Write Saves to **Content Directory**" controls the **destination** (next to the ROM vs the saves directory), while "Sort Saves **Into Folders by Content Directory**" controls the **layout within** the saves directory. They sound nearly identical but mean very different things.
+**Why this is easy to confuse**: the RetroArch UI labels are deliberately similar. "Write Saves to **Content
+Directory**" controls the **destination** (next to the ROM vs the saves directory), while "Sort Saves **Into Folders by
+Content Directory**" controls the **layout within** the saves directory. They sound nearly identical but mean very
+different things.
 
-| RetroArch UI label | cfg key | What it controls |
-| --- | --- | --- |
-| Write Saves to Content Directory | `savefiles_in_content_dir` | **Destination** — next to ROM (true) vs `savefile_directory` (false). Plugin does **not** handle `true`. |
-| Sort Saves Into Folders by Content Directory | `sort_savefiles_by_content_enable` | **Layout inside `savefile_directory`** — group by ROM parent folder name. Plugin handles both values. |
-| Sort Saves Into Folders by Core Name | `sort_savefiles_enable` | **Layout inside `savefile_directory`** — further group by RetroArch core name. Plugin handles both values. |
+| RetroArch UI label                           | cfg key                            | What it controls                                                                                           |
+| -------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Write Saves to Content Directory             | `savefiles_in_content_dir`         | **Destination** — next to ROM (true) vs `savefile_directory` (false). Plugin does **not** handle `true`.   |
+| Sort Saves Into Folders by Content Directory | `sort_savefiles_by_content_enable` | **Layout inside `savefile_directory`** — group by ROM parent folder name. Plugin handles both values.      |
+| Sort Saves Into Folders by Core Name         | `sort_savefiles_enable`            | **Layout inside `savefile_directory`** — further group by RetroArch core name. Plugin handles both values. |
 
-**Status**: tracked as an enhancement in [#239](https://github.com/danielcopper/decky-romm-sync/issues/239). Minimum scope there is detect-and-warn (read the key, surface a banner explaining save sync is disabled, skip all save operations). Full support — resolving save paths relative to the ROM's actual on-disk location — is a larger refactor deferred to multi-emulator work.
+**Status**: tracked as an enhancement in [#239](https://github.com/danielcopper/decky-romm-sync/issues/239). Minimum
+scope there is detect-and-warn (read the key, surface a banner explaining save sync is disabled, skip all save
+operations). Full support — resolving save paths relative to the ROM's actual on-disk location — is a larger refactor
+deferred to multi-emulator work.
 
 ## Save-Sort Migration: Automatic Detection and Conflict Resolution
 
@@ -277,256 +363,406 @@ RetroArch save sorting is controlled by two keys in `retroarch.cfg`:
 - `sort_savefiles_by_content_enable` — group saves under the ROM's platform folder (e.g. `gba/`)
 - `sort_savefiles_enable` — group saves under the core's canonical name folder (e.g. `mGBA/`)
 
-When a user changes either setting — most commonly via the RetroArch Quick Menu **while a game is running** — RetroArch does not migrate existing `.srm` files. It silently begins writing future saves to the new layout. The result is a split state: older saves sit at the old path, newer in-session saves go to the new path, with no signal from RetroArch that anything changed.
+When a user changes either setting — most commonly via the RetroArch Quick Menu **while a game is running** — RetroArch
+does not migrate existing `.srm` files. It silently begins writing future saves to the new layout. The result is a split
+state: older saves sit at the old path, newer in-session saves go to the new path, with no signal from RetroArch that
+anything changed.
 
-The plugin must detect this layout change and offer a one-click migration to consolidate files under the new path. Because the most common trigger is mid-game configuration (Quick Menu → Settings → Directory), detection cannot be deferred to plugin startup alone. It must also run at the points that bracket gameplay.
+The plugin must detect this layout change and offer a one-click migration to consolidate files under the new path.
+Because the most common trigger is mid-game configuration (Quick Menu → Settings → Directory), detection cannot be
+deferred to plugin startup alone. It must also run at the points that bracket gameplay.
 
 ### Detection trigger points
 
-All five trigger points call the `refresh_migration_state` callable and share the same idempotent backend methods. Running on every trigger is cheap: `detect_retrodeck_path_change()` and `detect_save_sort_change()` both have early-return guards that exit immediately when no config change has occurred since the last call.
+All five trigger points call the `refresh_migration_state` callable and share the same idempotent backend methods.
+Running on every trigger is cheap: `detect_retrodeck_path_change()` and `detect_save_sort_change()` both have
+early-return guards that exit immediately when no config change has occurred since the last call.
 
-| When | Where (code location) | Why |
-| --- | --- | --- |
-| Plugin load | `main.py` Phase 6 in `_main()` | Catches changes that occurred between plugin sessions |
-| QAM open | `MainPage.tsx` mount `useEffect` | User navigating via QAM sees current state when Settings is one tap away |
-| Game-detail open | `RomMGameInfoPanel.tsx` `useEffect([appId])` | Per-game navigation refreshes state when the user browses without launching |
-| Pre-game-launch | `launchInterceptor.ts` | Catches setting changes made by external tooling between sessions |
-| Post-game-exit | `sessionManager.ts` (after save-sync) | **Primary trigger for the main real-world scenario** — user changed settings via Quick Menu mid-game |
+| When             | Where (code location)                        | Why                                                                                                  |
+| ---------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Plugin load      | `main.py` Phase 6 in `_main()`               | Catches changes that occurred between plugin sessions                                                |
+| QAM open         | `MainPage.tsx` mount `useEffect`             | User navigating via QAM sees current state when Settings is one tap away                             |
+| Game-detail open | `RomMGameInfoPanel.tsx` `useEffect([appId])` | Per-game navigation refreshes state when the user browses without launching                          |
+| Pre-game-launch  | `launchInterceptor.ts`                       | Catches setting changes made by external tooling between sessions                                    |
+| Post-game-exit   | `sessionManager.ts` (after save-sync)        | **Primary trigger for the main real-world scenario** — user changed settings via Quick Menu mid-game |
 
 ### Post-game ordering and the detect-first invariant (#238)
 
-In `sessionManager.ts` `handleGameStop`, save-sync runs first, then migration refresh runs unconditionally. However, the ordering within `handleGameStop` is **not load-bearing** — save-sync is order-independent with respect to detect triggers because of three structural guards introduced in #238:
+In `sessionManager.ts` `handleGameStop`, save-sync runs first, then migration refresh runs unconditionally. However, the
+ordering within `handleGameStop` is **not load-bearing** — save-sync is order-independent with respect to detect
+triggers because of three structural guards introduced in #238:
 
-**The race problem (pre-#238):** When the user changes RetroArch sort settings mid-game, `refreshMigrationState` from `RomMGameInfoPanel` remount could update state to the new layout before `postExitSync` read it. Save-sync would then look in the wrong directory, download stale server content, and the newest-wins resolver would pick the fresh-but-stale download over the real user progress.
+**The race problem (pre-#238):** When the user changes RetroArch sort settings mid-game, `refreshMigrationState` from
+`RomMGameInfoPanel` remount could update state to the new layout before `postExitSync` read it. Save-sync would then
+look in the wrong directory, download stale server content, and the newest-wins resolver would pick the fresh-but-stale
+download over the real user progress.
 
 **Three structural guards:**
 
-1. **Rule 1 — Read previous layout during pending migration.** `RomInfoService.get_rom_save_info` (`services/saves/rom_info.py`) reads `save_sort_settings_previous` (the layout RetroArch was writing to during the session) in preference to `save_sort_settings` (the new layout). This ensures save-sync always looks where RetroArch actually wrote.
+1. **Rule 1 — Read previous layout during pending migration.** `RomInfoService.get_rom_save_info`
+   (`services/saves/rom_info.py`) reads `save_sort_settings_previous` (the layout RetroArch was writing to during the
+   session) in preference to `save_sort_settings` (the new layout). This ensures save-sync always looks where RetroArch
+   actually wrote.
 
-2. **Rule 2 — Upload-only mode during pending migration.** `SyncEngine._sync_rom_saves` skips `server_only` matches (no downloads) when a save-sort migration is pending. This prevents stale server content from being written to disk with `mtime=now`, which the mtime-naive migration resolver could then mispick.
+2. **Rule 2 — Upload-only mode during pending migration.** `SyncEngine._sync_rom_saves` skips `server_only` matches (no
+   downloads) when a save-sort migration is pending. This prevents stale server content from being written to disk with
+   `mtime=now`, which the mtime-naive migration resolver could then mispick.
 
-3. **Detect-first invariant.** `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, and `sync_all_saves` all call `detect_save_sort_change` (via an injected callback from `MigrationService`) before reading state. This closes the race where `post_exit_sync` reaches the backend before any frontend detect trigger fires — ensuring `save_sort_settings_previous` is always set before save-sync reads it.
+3. **Detect-first invariant.** `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, and `sync_all_saves` all call
+   `detect_save_sort_change` (via an injected callback from `MigrationService`) before reading state. This closes the
+   race where `post_exit_sync` reaches the backend before any frontend detect trigger fires — ensuring
+   `save_sort_settings_previous` is always set before save-sync reads it.
 
-Combined, these three guards close all four race sub-scenarios (mid-session change with detect winning or post_exit winning the race, and NEW-from-start with detect winning or post_exit winning).
+Combined, these three guards close all four race sub-scenarios (mid-session change with detect winning or post_exit
+winning the race, and NEW-from-start with detect winning or post_exit winning).
 
-Migration refresh still runs unconditionally regardless of connectivity because `refresh_migration_state` only reads config files and local state — it does not touch user save files. The actual migration runs only when the user explicitly clicks the migrate button in Settings.
+Migration refresh still runs unconditionally regardless of connectivity because `refresh_migration_state` only reads
+config files and local state — it does not touch user save files. The actual migration runs only when the user
+explicitly clicks the migrate button in Settings.
 
 ### Newest-wins conflict resolution
 
 Implemented in `_resolve_save_sort_conflict` in `py_modules/services/migration.py`.
 
-**The scenario**: the user enables `sort_savefiles_enable` mid-game and saves in-game. RetroArch writes fresh progress to the new layout — e.g. `saves/gba/mGBA/Mario Golf.srm`. The old file at the original layout — e.g. `saves/gba/Mario Golf.srm` — still exists with pre-change content. When migration runs, both files are present and the migration logic treats this as a conflict.
+**The scenario**: the user enables `sort_savefiles_enable` mid-game and saves in-game. RetroArch writes fresh progress
+to the new layout — e.g. `saves/gba/mGBA/Mario Golf.srm`. The old file at the original layout — e.g.
+`saves/gba/Mario Golf.srm` — still exists with pre-change content. When migration runs, both files are present and the
+migration logic treats this as a conflict.
 
 **Resolution rule**: the file with the newer `mtime` wins.
 
-| Case | Condition | Action |
-| --- | --- | --- |
-| Destination newer (typical) | In-game save wrote to the new layout during the session | Remove the orphan at the old path via `os.remove`, keep the destination, count as migrated |
-| Source newer (rare) | Source `mtime` exceeds destination; possible if the user reverted settings without playing | Atomically overwrite the destination via `os.replace`, count as migrated |
-| Tie (equal mtime) | `mtime` values identical at filesystem granularity | Bias toward destination (no-op keep) |
+| Case                        | Condition                                                                                  | Action                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Destination newer (typical) | In-game save wrote to the new layout during the session                                    | Remove the orphan at the old path via `os.remove`, keep the destination, count as migrated |
+| Source newer (rare)         | Source `mtime` exceeds destination; possible if the user reverted settings without playing | Atomically overwrite the destination via `os.replace`, count as migrated                   |
+| Tie (equal mtime)           | `mtime` values identical at filesystem granularity                                         | Bias toward destination (no-op keep)                                                       |
 
-On any `OSError` during `mtime` reads or file operations, the error is appended to the errors list and processing continues with the next item. The migration never leaves state partially inconsistent — each file is either fully resolved or skipped with an error recorded.
+On any `OSError` during `mtime` reads or file operations, the error is appended to the errors list and processing
+continues with the next item. The migration never leaves state partially inconsistent — each file is either fully
+resolved or skipped with an error recorded.
 
 ### Why newest-wins is safe
 
-- If the user played game G during the setting change, the in-game save at the new path contains all progress up to that save point. The old file at the old path contains only pre-change progress — a strict subset. Deleting the old file loses nothing.
-- If the user did **not** play game G during the setting change, only the old file exists (no destination file, no conflict) and migration is a simple move to the new path.
-- Save-sync has already uploaded the new-path version to RomM before migration runs (see post-game ordering above). Even a catastrophic local migration failure leaves the latest version on the server.
+- If the user played game G during the setting change, the in-game save at the new path contains all progress up to that
+  save point. The old file at the old path contains only pre-change progress — a strict subset. Deleting the old file
+  loses nothing.
+- If the user did **not** play game G during the setting change, only the old file exists (no destination file, no
+  conflict) and migration is a simple move to the new path.
+- Save-sync has already uploaded the new-path version to RomM before migration runs (see post-game ordering above). Even
+  a catastrophic local migration failure leaves the latest version on the server.
 
-**Mtime-naive limitation:** The resolver compares pure `os.path.getmtime` timestamps. A freshly-downloaded file has `mtime=now` regardless of how old its content actually is. This is structurally prevented by #238 Rule 2 (upload-only mode during pending migration prevents downloads that would create stale files with misleading mtimes). If Rule 2 is ever removed, the resolver would need to be made hash-aware.
+**Mtime-naive limitation:** The resolver compares pure `os.path.getmtime` timestamps. A freshly-downloaded file has
+`mtime=now` regardless of how old its content actually is. This is structurally prevented by #238 Rule 2 (upload-only
+mode during pending migration prevents downloads that would create stale files with misleading mtimes). If Rule 2 is
+ever removed, the resolver would need to be made hash-aware.
 
 ### Relationship to `retrodeck_path_migration`
 
-The RetroDECK **path** migration — `_migrate_retrodeck_files_io` in `migration.py`, triggered when the RetroDECK home directory moves between the internal SSD and an SD card — uses a different conflict-resolution approach: a user-driven bulk strategy modal (overwrite / skip / cancel). That is intentional. ROMs and BIOS files are not progress files, and `mtime`-based resolution is not semantically meaningful for them. See [RetroDECK Path Migration](../user-guide/retrodeck-path-migration.md) for the user-facing side.
+The RetroDECK **path** migration — `_migrate_retrodeck_files_io` in `migration.py`, triggered when the RetroDECK home
+directory moves between the internal SSD and an SD card — uses a different conflict-resolution approach: a user-driven
+bulk strategy modal (overwrite / skip / cancel). That is intentional. ROMs and BIOS files are not progress files, and
+`mtime`-based resolution is not semantically meaningful for them. See
+[RetroDECK Path Migration](../user-guide/retrodeck-path-migration.md) for the user-facing side.
 
 ### Supported systems
 
 All paths below are relative to `<saves_path>` from `retrodeck.json`.
 
-| System | Save Path Example | Extension |
-| --- | --- | --- |
-| NES | `saves/nes/game.srm` | `.srm` |
-| SNES | `saves/snes/game.srm` | `.srm` |
-| Game Boy | `saves/gb/game.srm` | `.srm` |
-| Game Boy Color | `saves/gbc/game.srm` | `.srm` |
-| Game Boy Advance | `saves/gba/game.srm` | `.srm` |
-| Genesis / Mega Drive | `saves/genesis/game.srm` | `.srm` |
-| Master System | `saves/mastersystem/game.srm` | `.srm` |
-| Nintendo 64 | `saves/n64/game.srm` | `.srm` |
-| PlayStation (RetroArch) | `saves/psx/game.srm` | `.srm` |
-| Saturn | `saves/saturn/game.srm` | `.srm` |
-| Dreamcast | `saves/dreamcast/game.srm` | `.srm` |
-| PC Engine / TurboGrafx-16 | `saves/pcengine/game.srm` | `.srm` |
-| Neo Geo Pocket | `saves/ngp/game.srm` | `.srm` |
-| WonderSwan | `saves/wonderswan/game.srm` | `.srm` |
-| Atari Lynx | `saves/atarilynx/game.srm` | `.srm` |
+| System                    | Save Path Example             | Extension |
+| ------------------------- | ----------------------------- | --------- |
+| NES                       | `saves/nes/game.srm`          | `.srm`    |
+| SNES                      | `saves/snes/game.srm`         | `.srm`    |
+| Game Boy                  | `saves/gb/game.srm`           | `.srm`    |
+| Game Boy Color            | `saves/gbc/game.srm`          | `.srm`    |
+| Game Boy Advance          | `saves/gba/game.srm`          | `.srm`    |
+| Genesis / Mega Drive      | `saves/genesis/game.srm`      | `.srm`    |
+| Master System             | `saves/mastersystem/game.srm` | `.srm`    |
+| Nintendo 64               | `saves/n64/game.srm`          | `.srm`    |
+| PlayStation (RetroArch)   | `saves/psx/game.srm`          | `.srm`    |
+| Saturn                    | `saves/saturn/game.srm`       | `.srm`    |
+| Dreamcast                 | `saves/dreamcast/game.srm`    | `.srm`    |
+| PC Engine / TurboGrafx-16 | `saves/pcengine/game.srm`     | `.srm`    |
+| Neo Geo Pocket            | `saves/ngp/game.srm`          | `.srm`    |
+| WonderSwan                | `saves/wonderswan/game.srm`   | `.srm`    |
+| Atari Lynx                | `saves/atarilynx/game.srm`    | `.srm`    |
 
 ## Slot Deletion
 
-Users can delete save slots from the game detail SAVES tab. Deletion removes the slot from local state and bulk-deletes all server saves in the slot.
+Users can delete save slots from the game detail SAVES tab. Deletion removes the slot from local state and bulk-deletes
+all server saves in the slot.
 
 ### How it works
 
-1. **Get delete info**: `get_slot_delete_info(rom_id, slot)` returns metadata for the confirmation modal — server save count, tracked file count, slot source (server/local), and whether the slot is active.
-2. **Confirmation modal**: Always shown (both local-only and server-backed slots). Shows exact save count and whether saves will be deleted from the server.
-3. **Perform deletion**: `delete_slot(rom_id, slot)` bulk-deletes server saves via `POST /api/saves/delete`, removes the slot from the `slots` dict, and cleans up `files` entries whose `tracked_save_id` matches a deleted save.
+1. **Get delete info**: `get_slot_delete_info(rom_id, slot)` returns metadata for the confirmation modal — server save
+   count, tracked file count, slot source (server/local), and whether the slot is active.
+2. **Confirmation modal**: Always shown (both local-only and server-backed slots). Shows exact save count and whether
+   saves will be deleted from the server.
+3. **Perform deletion**: `delete_slot(rom_id, slot)` bulk-deletes server saves via `POST /api/saves/delete`, removes the
+   slot from the `slots` dict, and cleans up `files` entries whose `tracked_save_id` matches a deleted save.
 
 ### Safety invariants
 
-- **Active slot cannot be deleted.** The user must switch to a different slot first. This implicitly prevents deleting the last remaining slot — the last slot is always active (there's nothing to switch to), so it can never be deleted.
-- **Server errors leave state intact.** If `delete_server_saves` fails (network error), the slot is NOT removed from local state. The user can retry.
+- **Active slot cannot be deleted.** The user must switch to a different slot first. This implicitly prevents deleting
+  the last remaining slot — the last slot is always active (there's nothing to switch to), so it can never be deleted.
+- **Server errors leave state intact.** If `delete_server_saves` fails (network error), the slot is NOT removed from
+  local state. The user can retry.
 - **Local-only slots** (`source: "local"`) skip server calls entirely — always deletable.
 
 ### Frontend
 
-The delete button appears in inactive slot bodies alongside "Activate Slot". It is hidden on the active slot. Gamepad navigation between the buttons uses `Focusable` with `flow-children="right"` for proper DPad left/right traversal.
+The delete button appears in inactive slot bodies alongside "Activate Slot". It is hidden on the active slot. Gamepad
+navigation between the buttons uses `Focusable` with `flow-children="right"` for proper DPad left/right traversal.
 
 ## Server Capabilities
 
-The capabilities system (`get_server_capabilities` callable) has been removed. Since the plugin now requires RomM >= 4.8.1, all features (device sync, version history, slot deletion, device management) are unconditionally available. The frontend no longer fetches or checks capability flags.
+The capabilities system (`get_server_capabilities` callable) has been removed. Since the plugin now requires RomM >=
+4.8.1, all features (device sync, version history, slot deletion, device management) are unconditionally available. The
+frontend no longer fetches or checks capability flags.
 
 ## Conflict Resolution
 
-A `Conflict` outcome from `compute_sync_action` (matrix row 12) is the only surface that shows a modal. It fires when the server has moved forward (`device_syncs[me].is_current=false`) and the local file has diverged from the recorded baseline (`local_hash != last_sync_hash`) — both sides have unsynced changes that cannot be silently merged.
+A `Conflict` outcome from `compute_sync_action` (matrix row 12) is the only surface that shows a modal. It fires when
+the server has moved forward (`device_syncs[me].is_current=false`) and the local file has diverged from the recorded
+baseline (`local_hash != last_sync_hash`) — both sides have unsynced changes that cannot be silently merged.
 
 ### The modal
 
-`SyncConflictModal` (`src/components/SyncConflictModal.tsx`) shows the local-save row and the picked server-save row side by side, each with size and timestamp. Three actions:
+`SyncConflictModal` (`src/components/SyncConflictModal.tsx`) shows the local-save row and the picked server-save row
+side by side, each with size and timestamp. Three actions:
 
-- **Keep Local** → `resolveSyncConflict(rom_id, filename, "keep_local")` → backend PUTs local content onto the picked server save.
-- **Use Server** → `resolveSyncConflict(rom_id, filename, "use_server")` → backend downloads the picked server save and overwrites local.
-- **Cancel** → pure UI close, no callable, no state mutation. The conflict re-fires on the next sync as long as the underlying state still produces matrix row 12.
+- **Keep Local** → `resolveSyncConflict(rom_id, filename, "keep_local")` → backend PUTs local content onto the picked
+  server save.
+- **Use Server** → `resolveSyncConflict(rom_id, filename, "use_server")` → backend downloads the picked server save and
+  overwrites local.
+- **Cancel** → pure UI close, no callable, no state mutation. The conflict re-fires on the next sync as long as the
+  underlying state still produces matrix row 12.
 
-The modal is shown by `CustomPlayButton` during pre-launch sync, and by `VersionHistoryPanel.handleRestore` (in `SavesTab`) when a version-restore pre-flight returns `conflict_blocked`. Both call `showSyncConflictModal(conflict)` which returns a Promise resolving to `"keep_local" | "use_server" | "cancel"`. After post-exit sync, `sessionManager` only fires a toast — the conflict re-surfaces in the modal at the next pre-launch.
+The modal is shown by `CustomPlayButton` during pre-launch sync, and by `VersionHistoryPanel.handleRestore` (in
+`SavesTab`) when a version-restore pre-flight returns `conflict_blocked`. Both call `showSyncConflictModal(conflict)`
+which returns a Promise resolving to `"keep_local" | "use_server" | "cancel"`. After post-exit sync, `sessionManager`
+only fires a toast — the conflict re-surfaces in the modal at the next pre-launch.
 
 ### resolve_sync_conflict callable
 
-`SaveService.resolve_sync_conflict(rom_id, filename, server_save_id, action)` — the async callable wired in `main.py`. The façade delegates to `SyncEngine.resolve_sync_conflict`, whose rollback sub-module (`services/saves/sync_engine/rollback.py`) runs the resolution:
+`SaveService.resolve_sync_conflict(rom_id, filename, server_save_id, action)` — the async callable wired in `main.py`.
+The façade delegates to `SyncEngine.resolve_sync_conflict`, whose rollback sub-module
+(`services/saves/sync_engine/rollback.py`) runs the resolution:
 
 1. Acquires the per-rom asyncio.Lock so no other sync operation for this rom can race.
 2. Fetches a fresh server-saves list and re-picks the newest in the active slot.
-3. **Round-trips `server_save_id`**: the caller passes the id the user was shown in the modal. If the freshly-picked head's id doesn't match, a third device has uploaded a newer save into the slot between the modal opening and the click. The backend returns `{success: False, error_code: "stale_conflict", message: ...}` instead of dispatching — silently PUTting local content over the third device's work would be a write-loss. The frontend surfaces an error and the user cancels + retries; the next sync re-evaluates the matrix with the fresh head.
+3. **Round-trips `server_save_id`**: the caller passes the id the user was shown in the modal. If the freshly-picked
+   head's id doesn't match, a third device has uploaded a newer save into the slot between the modal opening and the
+   click. The backend returns `{success: False, error_code: "stale_conflict", message: ...}` instead of dispatching —
+   silently PUTting local content over the third device's work would be a write-loss. The frontend surfaces an error and
+   the user cancels + retries; the next sync re-evaluates the matrix with the fresh head.
 4. Dispatches:
-   - `keep_local` → `_resolve_conflict_keep_local` reads the server save's content hash. If it matches local (rare, but possible — both devices ended up at the same content via different paths), the server's id is adopted into state without re-uploading. Otherwise the local file is PUT to the picked save id, then `confirm_download` registers our device as `is_current=true`.
+   - `keep_local` → `_resolve_conflict_keep_local` reads the server save's content hash. If it matches local (rare, but
+     possible — both devices ended up at the same content via different paths), the server's id is adopted into state
+     without re-uploading. Otherwise the local file is PUT to the picked save id, then `confirm_download` registers our
+     device as `is_current=true`.
    - `use_server` → `_resolve_conflict_use_server` downloads the picked save and writes it to the local path.
 
-The modal only accepts `keep_local` or `use_server`; `cancel` never reaches the backend. A wrong action string is rejected before the lock is acquired.
+The modal only accepts `keep_local` or `use_server`; `cancel` never reaches the backend. A wrong action string is
+rejected before the lock is acquired.
 
 ### Why no defer state
 
-Earlier drafts persisted a `deferred` field in per-file state to suppress the modal on subsequent syncs until the server state changed. This was removed before merge: the conflict is already surface-on-demand (only shown during a user-initiated launch), and re-firing on the next launch is the desired behaviour — the user has just reopened the game and is in a position to decide. Self-healing is automatic: if another device pushes in the meantime, the picked server save changes and the matrix may produce Skip or Download instead of Conflict, dissolving the conflict without user input.
+Earlier drafts persisted a `deferred` field in per-file state to suppress the modal on subsequent syncs until the server
+state changed. This was removed before merge: the conflict is already surface-on-demand (only shown during a
+user-initiated launch), and re-firing on the next launch is the desired behaviour — the user has just reopened the game
+and is in a position to decide. Self-healing is automatic: if another device pushes in the meantime, the picked server
+save changes and the matrix may produce Skip or Download instead of Conflict, dissolving the conflict without user
+input.
 
 ### Per-rom asyncio.Lock
 
-`SyncEngine._rom_sync_locks: dict[int, asyncio.Lock]` (`services/saves/sync_engine/engine.py`) serializes `pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`, and `resolve_sync_conflict` for the same `rom_id`. `StatusService.get_save_status` also takes the lock — not for the read, but for its one write: the executor body adopts a baseline hash (`Skip(adopt_baseline=True)`) and persists it through a `rom_save_states` read-modify-write, which would otherwise race a concurrent sync and clobber that sync's update. The lock-free server-saves network fetch stays outside the lock; only the local RMW is the critical section. Different rom_ids have independent locks, so cross-game concurrency (e.g. Sync All Saves running concurrently with a resolve on one specific rom) is unaffected. The lock is created lazily on first access (`SyncEngine.rom_lock(rom_id)`).
+`SyncEngine._rom_sync_locks: dict[int, asyncio.Lock]` (`services/saves/sync_engine/engine.py`) serializes
+`pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`, and `resolve_sync_conflict` for the same
+`rom_id`. `StatusService.get_save_status` also takes the lock — not for the read, but for its one write: the executor
+body adopts a baseline hash (`Skip(adopt_baseline=True)`) and persists it through a `rom_save_states` read-modify-write,
+which would otherwise race a concurrent sync and clobber that sync's update. The lock-free server-saves network fetch
+stays outside the lock; only the local RMW is the critical section. Different rom_ids have independent locks, so
+cross-game concurrency (e.g. Sync All Saves running concurrently with a resolve on one specific rom) is unaffected. The
+lock is created lazily on first access (`SyncEngine.rom_lock(rom_id)`).
 
-The realistic race the lock prevents: user clicks Keep Local → executor runs PUT + state mutation → in parallel, `post_exit_sync` for a game that just stopped runs and mutates the same per-file state → last-writer-wins on the `rom_save_states` aggregate, dropping one set of fields. The same lost-update window applies to `get_save_status`'s baseline-adopt write versus a concurrent pre-launch / post-exit / manual sync. The lock makes each read-modify-write-and-persist sequence atomic relative to the others.
+The realistic race the lock prevents: user clicks Keep Local → executor runs PUT + state mutation → in parallel,
+`post_exit_sync` for a game that just stopped runs and mutates the same per-file state → last-writer-wins on the
+`rom_save_states` aggregate, dropping one set of fields. The same lost-update window applies to `get_save_status`'s
+baseline-adopt write versus a concurrent pre-launch / post-exit / manual sync. The lock makes each
+read-modify-write-and-persist sequence atomic relative to the others.
 
 ## Local Save File Naming
 
-Every download path — pre-launch / post-exit / manual sync, conflict-resolve "Use Server", rollback / version switch, slot switch — writes content to a path of the form:
+Every download path — pre-launch / post-exit / manual sync, conflict-resolve "Use Server", rollback / version switch,
+slot switch — writes content to a path of the form:
 
 ```text
 <saves_dir>/<rom_basename>.<server_save.file_extension>
 ```
 
-`<rom_basename>` is the ROM file's name without extension (e.g. `Mario Golf - Advance Tour (USA)` from `Mario Golf - Advance Tour (USA).gba`); `<server_save.file_extension>` is the `file_extension` field on the chosen RomM save (e.g. `srm`).
+`<rom_basename>` is the ROM file's name without extension (e.g. `Mario Golf - Advance Tour (USA)` from
+`Mario Golf - Advance Tour (USA).gba`); `<server_save.file_extension>` is the `file_extension` field on the chosen RomM
+save (e.g. `srm`).
 
-This is the **only** path used for local writes. The server's stored `file_name` (which may carry a timestamp tag like `[2026-03-24_15-18-50]` or come from a different client with an unrelated naming convention) and the server's `file_name_no_tags` are **not** consulted. RetroArch identifies SRAM purely by `<rom_basename>.<ext>` filename match — content is opaque bytes — so writing to anything else would leave the save invisible to the emulator.
+This is the **only** path used for local writes. The server's stored `file_name` (which may carry a timestamp tag like
+`[2026-03-24_15-18-50]` or come from a different client with an unrelated naming convention) and the server's
+`file_name_no_tags` are **not** consulted. RetroArch identifies SRAM purely by `<rom_basename>.<ext>` filename match —
+content is opaque bytes — so writing to anything else would leave the save invisible to the emulator.
 
-The shared helper is `_local_save_target(server_save, rom_name)` in `py_modules/services/saves/_helpers.py` (wrapping `domain.save_path.compute_local_save_target`). It requires a non-None `rom_name`; there is no fallback to server-derived names. If a ROM is not installed (`RomInfoService.get_rom_save_info` returns `None`) the saves tab shows no entry for it and sync is a no-op for that ROM — by design, rather than guessing a path that may or may not match what RetroArch uses.
+The shared helper is `_local_save_target(server_save, rom_name)` in `py_modules/services/saves/_helpers.py` (wrapping
+`domain.save_path.compute_local_save_target`). It requires a non-None `rom_name`; there is no fallback to server-derived
+names. If a ROM is not installed (`RomInfoService.get_rom_save_info` returns `None`) the saves tab shows no entry for it
+and sync is a no-op for that ROM — by design, rather than guessing a path that may or may not match what RetroArch uses.
 
-This matches the convention used by the official RomM clients [Argosy](https://github.com/rommapp/argosy-launcher) and [Grout](https://github.com/rommapp/grout).
+This matches the convention used by the official RomM clients [Argosy](https://github.com/rommapp/argosy-launcher) and
+[Grout](https://github.com/rommapp/grout).
 
-The version-history UI (`list_file_versions`) reflects the same principle: it returns every save in the active slot except the currently-tracked one, with no filename filter. A user can switch to any save in the slot — even ones uploaded by another client with a different name — and the destructive switch lands the content at the canonical local path.
+The version-history UI (`list_file_versions`) reflects the same principle: it returns every save in the active slot
+except the currently-tracked one, with no filename filter. A user can switch to any save in the slot — even ones
+uploaded by another client with a different name — and the destructive switch lands the content at the canonical local
+path.
 
 ## Version Switch Flow (rollback)
 
-Users can switch the active save to a chosen older version via the Previous Versions dropdown in the SAVES tab. The flow is more involved than a simple download because it must:
+Users can switch the active save to a chosen older version via the Previous Versions dropdown in the SAVES tab. The flow
+is more involved than a simple download because it must:
 
 1. Capture any local changes server-side first (otherwise the destructive overwrite would lose them).
-2. Make the chosen save authoritative cross-device — other devices that already have the latest save tracked must end up downloading the chosen version on their next sync.
+2. Make the chosen save authoritative cross-device — other devices that already have the latest save tracked must end up
+   downloading the chosen version on their next sync.
 
 ### Why a switch cannot be a download-only
 
-A pure download to local would only update *our* device. On the next sync from any other device, RomM's newest-by-`updated_at` rule would still pick the original (newer) save and propagate it back to us. The switch would silently undo itself.
+A pure download to local would only update _our_ device. On the next sync from any other device, RomM's
+newest-by-`updated_at` rule would still pick the original (newer) save and propagate it back to us. The switch would
+silently undo itself.
 
-To make the switch authoritative cross-device, the chosen older save's `updated_at` must become NOW so it beats every other save in the slot.
+To make the switch authoritative cross-device, the chosen older save's `updated_at` must become NOW so it beats every
+other save in the slot.
 
 ### Matrix pre-flight
 
-Before the destructive switch starts, `rollback_to_version` runs a full `compute_sync_action` pre-flight on the currently-tracked save (via `_sync_rom_saves`):
+Before the destructive switch starts, `rollback_to_version` runs a full `compute_sync_action` pre-flight on the
+currently-tracked save (via `_sync_rom_saves`):
 
-| Pre-flight outcome | What happens |
-| --- | --- |
-| `Skip(synced)` / `Skip(adopt_baseline=True)` | No I/O. Switch proceeds. |
-| `Upload(POST/PUT)` | Local changes are silently pushed to the server first. Switch proceeds. |
-| `Download(server)` | The newer server save is silently adopted. Switch then proceeds (the user's chosen target is still in the slot). |
-| `Conflict(...)` | Switch aborts with `{"status": "conflict_blocked", "conflicts": [...]}`. The frontend opens the standard `SyncConflictModal`; the user must resolve via Keep Local / Use Server before retrying the switch. |
-| Non-conflict error | Switch aborts with `{"status": "preflight_failed", "errors": [...]}`. |
+| Pre-flight outcome                           | What happens                                                                                                                                                                                                |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Skip(synced)` / `Skip(adopt_baseline=True)` | No I/O. Switch proceeds.                                                                                                                                                                                    |
+| `Upload(POST/PUT)`                           | Local changes are silently pushed to the server first. Switch proceeds.                                                                                                                                     |
+| `Download(server)`                           | The newer server save is silently adopted. Switch then proceeds (the user's chosen target is still in the slot).                                                                                            |
+| `Conflict(...)`                              | Switch aborts with `{"status": "conflict_blocked", "conflicts": [...]}`. The frontend opens the standard `SyncConflictModal`; the user must resolve via Keep Local / Use Server before retrying the switch. |
+| Non-conflict error                           | Switch aborts with `{"status": "preflight_failed", "errors": [...]}`.                                                                                                                                       |
 
-The pre-flight replaces the dedicated "unsynced local changes" / "tracked save missing" warnings the previous design used — those were workarounds for not running the matrix. With the matrix in front of every switch, local data is always captured (or the user is forced to resolve a real conflict) before the local file is overwritten.
+The pre-flight replaces the dedicated "unsynced local changes" / "tracked save missing" warnings the previous design
+used — those were workarounds for not running the matrix. With the matrix in front of every switch, local data is always
+captured (or the user is forced to resolve a real conflict) before the local file is overwritten.
 
 ### The four-step destructive switch
 
-After the pre-flight clears, `VersionsService._rollback_to_version_io` (`services/saves/versions.py`) runs the switch — the actual file/server writes go through `SyncEngine`:
+After the pre-flight clears, `VersionsService._rollback_to_version_io` (`services/saves/versions.py`) runs the switch —
+the actual file/server writes go through `SyncEngine`:
 
-1. **Download target**: GET the chosen older save's content and overwrite local. `_do_download_save` updates `tracked_save_id` and `last_sync_hash` to the target version, so even if step 2 fails the local view is consistent with the target.
-2. **PUT to bump `updated_at`**: re-upload local content via `_do_upload_save(server_save=target_save)`. This issues a PUT against the target save id with byte-identical content. RomM v4.8.1 fires the SQLAlchemy `onupdate=utc_now` hook on every PUT regardless of whether the content changed, so `save.updated_at` becomes NOW. The target save is now newest in the slot.
-3. **Confirm download**: `_do_upload_save` also calls `confirm_download(target_save_id, device_id)`. RomM v4.8.1's PUT does **not** auto-upsert the calling device's `device_save_sync` row, so without this call our `is_current` would evaluate `false` immediately after our own PUT. The dedicated `/api/saves/{id}/downloaded` endpoint upserts `last_synced_at = save.updated_at` so the computed `is_current` flips back to `true` for us.
-4. **Update local state**: `_do_upload_save` records `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`, and friends from the post-PUT response, leaving local state consistent with the now-newest server save.
+1. **Download target**: GET the chosen older save's content and overwrite local. `_do_download_save` updates
+   `tracked_save_id` and `last_sync_hash` to the target version, so even if step 2 fails the local view is consistent
+   with the target.
+2. **PUT to bump `updated_at`**: re-upload local content via `_do_upload_save(server_save=target_save)`. This issues a
+   PUT against the target save id with byte-identical content. RomM v4.8.1 fires the SQLAlchemy `onupdate=utc_now` hook
+   on every PUT regardless of whether the content changed, so `save.updated_at` becomes NOW. The target save is now
+   newest in the slot.
+3. **Confirm download**: `_do_upload_save` also calls `confirm_download(target_save_id, device_id)`. RomM v4.8.1's PUT
+   does **not** auto-upsert the calling device's `device_save_sync` row, so without this call our `is_current` would
+   evaluate `false` immediately after our own PUT. The dedicated `/api/saves/{id}/downloaded` endpoint upserts
+   `last_synced_at = save.updated_at` so the computed `is_current` flips back to `true` for us.
+4. **Update local state**: `_do_upload_save` records `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`,
+   and friends from the post-PUT response, leaving local state consistent with the now-newest server save.
 
-After this, the next `compute_sync_action` for our device picks `target_save` (now newest), our `is_current=true`, hash matches the baseline → `Skip(synced)`. Other devices on their next sync see `target_save` as newest with their own `is_current=false` → matrix row 5 (`Download`) → adopt our switch. Cross-device propagation works without a dedicated rollback API.
+After this, the next `compute_sync_action` for our device picks `target_save` (now newest), our `is_current=true`, hash
+matches the baseline → `Skip(synced)`. Other devices on their next sync see `target_save` as newest with their own
+`is_current=false` → matrix row 5 (`Download`) → adopt our switch. Cross-device propagation works without a dedicated
+rollback API.
 
 ### Failure handling
 
 - **Pre-flight `Conflict`**: switch never runs. Status: `conflict_blocked`. Local file untouched.
 - **Pre-flight non-conflict error**: switch never runs. Status: `preflight_failed`. Local file untouched.
 - **Step 1 (download) fails**: state is not mutated. Status: `not_found` (or surfaced error). Local file unchanged.
-- **Step 1 (download) succeeds, step 2 (PUT) fails**: state mutation from the download is persisted. Status: `put_failed`. Local file and local state both point at the target. Cross-device propagation is incomplete — other devices still see the original newest save. Calling `rollback_to_version` again is safe and idempotent: step 1 is already done, step 2 retries the PUT.
+- **Step 1 (download) succeeds, step 2 (PUT) fails**: state mutation from the download is persisted. Status:
+  `put_failed`. Local file and local state both point at the target. Cross-device propagation is incomplete — other
+  devices still see the original newest save. Calling `rollback_to_version` again is safe and idempotent: step 1 is
+  already done, step 2 retries the PUT.
 
 ## RomM Save Sync API Behaviour
 
-The plugin depends on several RomM v4.8.1 behaviours that are not obvious from the OpenAPI schema and were discovered while implementing the rewrite. They drive design decisions throughout the sync layer.
+The plugin depends on several RomM v4.8.1 behaviours that are not obvious from the OpenAPI schema and were discovered
+while implementing the rewrite. They drive design decisions throughout the sync layer.
 
 ### `is_current` is computed, not stored
 
-RomM's `device_save_sync` table stores `last_synced_at` and `is_untracked` per device per save. The `is_current` field surfaced on each `device_syncs[]` entry of a `GET /api/saves` response is **derived at read time** as `sync.last_synced_at > save.updated_at` (strict greater-than — equality counts as not-current). There is no column to set; you can only push the components.
+RomM's `device_save_sync` table stores `last_synced_at` and `is_untracked` per device per save. The `is_current` field
+surfaced on each `device_syncs[]` entry of a `GET /api/saves` response is **derived at read time** as
+`sync.last_synced_at > save.updated_at` (strict greater-than — equality counts as not-current). There is no column to
+set; you can only push the components.
 
 ### `GET /api/saves` upserts `device_syncs` for the queried device
 
-Hardware-verified on RomM 4.8.1: `GET /api/saves?rom_id=X&device_id=Y` upserts a `device_save_sync` row for device Y on every save returned that did not already have one. The `optimistic` query flag does not appear to prevent the upsert. The upserted row has `last_synced_at = save.updated_at`, which under the strict-`>` formula evaluates to `is_current = false` — i.e. the row is created in a "not current yet" state.
+Hardware-verified on RomM 4.8.1: `GET /api/saves?rom_id=X&device_id=Y` upserts a `device_save_sync` row for device Y on
+every save returned that did not already have one. The `optimistic` query flag does not appear to prevent the upsert.
+The upserted row has `last_synced_at = save.updated_at`, which under the strict-`>` formula evaluates to
+`is_current = false` — i.e. the row is created in a "not current yet" state.
 
-This has a concrete consequence for the sync algorithm: the "no entry for our device on the picked save" branch of `compute_sync_action` (matrix rows 6a/6b) is unreachable in real plugin operation, because `SyncEngine._sync_rom_saves` always calls `list_saves` (which triggers the upsert) before passing the data to the algorithm. By the time the algorithm runs, our device entry exists on every server save. The branch is retained as defensive code and is exercised by unit tests in `tests/domain/test_sync_action.py`.
+This has a concrete consequence for the sync algorithm: the "no entry for our device on the picked save" branch of
+`compute_sync_action` (matrix rows 6a/6b) is unreachable in real plugin operation, because `SyncEngine._sync_rom_saves`
+always calls `list_saves` (which triggers the upsert) before passing the data to the algorithm. By the time the
+algorithm runs, our device entry exists on every server save. The branch is retained as defensive code and is exercised
+by unit tests in `tests/domain/test_sync_action.py`.
 
 ### PUT bumps `updated_at`, not the calling device's sync row
 
-`PUT /api/saves/{id}` triggers SQLAlchemy's `onupdate=utc_now` hook on every PUT, so `save.updated_at` becomes the server's NOW even if the content is byte-identical. **It does not** upsert the calling device's `device_save_sync.last_synced_at`. The computed `is_current` flag therefore flips to `false` for the calling device immediately after the PUT response is observed (because `save.updated_at > sync.last_synced_at` for everyone, including us).
+`PUT /api/saves/{id}` triggers SQLAlchemy's `onupdate=utc_now` hook on every PUT, so `save.updated_at` becomes the
+server's NOW even if the content is byte-identical. **It does not** upsert the calling device's
+`device_save_sync.last_synced_at`. The computed `is_current` flag therefore flips to `false` for the calling device
+immediately after the PUT response is observed (because `save.updated_at > sync.last_synced_at` for everyone, including
+us).
 
-To restore `is_current=true` for our device after a PUT, we must explicitly call `POST /api/saves/{id}/downloaded`, which upserts `last_synced_at = save.updated_at`. `_do_upload_save` does this unconditionally after every successful POST or PUT (best-effort — failures are logged at debug and don't fail the upload).
+To restore `is_current=true` for our device after a PUT, we must explicitly call `POST /api/saves/{id}/downloaded`,
+which upserts `last_synced_at = save.updated_at`. `_do_upload_save` does this unconditionally after every successful
+POST or PUT (best-effort — failures are logged at debug and don't fail the upload).
 
 ### GET `/content?optimistic=true` auto-upserts the sync row
 
-`GET /api/saves/{id}/content?device_id=X&optimistic=true` (default `true`) is the canonical download endpoint. It auto-upserts `device_save_sync` for the calling device with `last_synced_at = save.updated_at`. After a successful download our `is_current` evaluates `true` without an extra round-trip.
+`GET /api/saves/{id}/content?device_id=X&optimistic=true` (default `true`) is the canonical download endpoint. It
+auto-upserts `device_save_sync` for the calling device with `last_synced_at = save.updated_at`. After a successful
+download our `is_current` evaluates `true` without an extra round-trip.
 
-`download_save_content` in `adapters/romm/romm_api.py` always passes `device_id` and `optimistic=true`. The non-optimistic legacy `download_save(save_id, dest_path)` is retained for use cases that must not touch sync state but is not used by the sync flow.
+`download_save_content` in `adapters/romm/romm_api.py` always passes `device_id` and `optimistic=true`. The
+non-optimistic legacy `download_save(save_id, dest_path)` is retained for use cases that must not touch sync state but
+is not used by the sync flow.
 
 ### Implication for the sync algorithm
 
-Because `is_current` is computed and the only ways to make it `true` are PUT/POST followed by `confirm_download`, or a `GET /content?optimistic=true`, the algorithm can trust `is_current` as authoritative without further hashing. Row 8 in the matrix (no baseline yet, `is_current=true`, local exists) is the canonical adopt-baseline case: we believe the server's claim and write `last_sync_hash := local_hash` so future runs can detect drift.
+Because `is_current` is computed and the only ways to make it `true` are PUT/POST followed by `confirm_download`, or a
+`GET /content?optimistic=true`, the algorithm can trust `is_current` as authoritative without further hashing. Row 8 in
+the matrix (no baseline yet, `is_current=true`, local exists) is the canonical adopt-baseline case: we believe the
+server's claim and write `last_sync_hash := local_hash` so future runs can detect drift.
 
 ## Sync Flows
 
-All four sync entry points share a single decision primitive — `compute_sync_action` — and a single dispatch path — `_dispatch_sync_action`. The flows differ only in *when* they fire and how they surface results.
+All four sync entry points share a single decision primitive — `compute_sync_action` — and a single dispatch path —
+`_dispatch_sync_action`. The flows differ only in _when_ they fire and how they surface results.
 
 ### Pre-launch sync
 
-Triggered from the game detail page when the user clicks the Play button (if `sync_before_launch` is enabled). This is **not** triggered automatically via `RegisterForAppLifetimeNotifications` — pre-launch sync runs explicitly from `CustomPlayButton.handlePlay()`.
+Triggered from the game detail page when the user clicks the Play button (if `sync_before_launch` is enabled). This is
+**not** triggered automatically via `RegisterForAppLifetimeNotifications` — pre-launch sync runs explicitly from
+`CustomPlayButton.handlePlay()`.
 
 1. User clicks Play on the game detail page.
 2. `CustomPlayButton` calls `preLaunchSync(romId)` on the backend (15s timeout).
-3. Backend fetches server saves, runs `_sync_rom_saves` which iterates files and dispatches every `compute_sync_action` outcome.
-4. If a `Conflict` was returned for any file, the result includes a `conflicts` list. `CustomPlayButton` shows `SyncConflictModal` for the first conflict, awaits the user's choice, then either re-runs sync (Keep Local / Use Server) or falls through (Cancel).
+3. Backend fetches server saves, runs `_sync_rom_saves` which iterates files and dispatches every `compute_sync_action`
+   outcome.
+4. If a `Conflict` was returned for any file, the result includes a `conflicts` list. `CustomPlayButton` shows
+   `SyncConflictModal` for the first conflict, awaits the user's choice, then either re-runs sync (Keep Local / Use
+   Server) or falls through (Cancel).
 5. Game launches. Sync failures and timeouts do not block launch.
 6. Toast notification shown on sync result.
 
@@ -536,8 +772,10 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 
 1. `RegisterForAppLifetimeNotifications` fires with `bRunning: false`.
 2. `sessionManager` calls `recordSessionEnd(romId)` for playtime, then `postExitSync(romId)`.
-3. Backend runs `_sync_rom_saves`. For most rows the local file's hash will differ from `last_sync_hash` (the user just played), so the typical action is `Upload(PUT to picked.id)` — matrix row 9.
-4. If a `Conflict` is returned, a toast notifies the user. The modal is **not** opened post-exit — the conflict re-fires at the next pre-launch sync, where the user resolves it via Keep Local / Use Server before launch.
+3. Backend runs `_sync_rom_saves`. For most rows the local file's hash will differ from `last_sync_hash` (the user just
+   played), so the typical action is `Upload(PUT to picked.id)` — matrix row 9.
+4. If a `Conflict` is returned, a toast notifies the user. The modal is **not** opened post-exit — the conflict re-fires
+   at the next pre-launch sync, where the user resolves it via Keep Local / Use Server before launch.
 5. Toast notification shown on success or conflict.
 
 ### Manual sync all
@@ -547,11 +785,15 @@ User-initiated from the "Sync All Saves Now" button in Save Sync settings.
 1. Iterates all installed ROMs from the backend registry.
 2. For each ROM with sync state: runs `_sync_rom_saves`.
 3. Per-rom asyncio.Lock prevents collision with concurrent pre-launch / post-exit syncs.
-4. Reports total synced count and number of pending conflicts. Conflicts surface via the modal individually at each game's next pre-launch sync.
+4. Reports total synced count and number of pending conflicts. Conflicts surface via the modal individually at each
+   game's next pre-launch sync.
 
 ### Get save status (read-only)
 
-Triggered by the game-detail panel and SAVES tab via `getSaveStatus(romId)`. Runs `_get_save_status_io` — a read-only counterpart of `_sync_rom_saves` that returns the same `compute_sync_action` decisions but performs no upload/download I/O. The only mutation it allows is recording `last_sync_hash` for `Skip(adopt_baseline=True)` rows so future drift detection works.
+Triggered by the game-detail panel and SAVES tab via `getSaveStatus(romId)`. Runs `_get_save_status_io` — a read-only
+counterpart of `_sync_rom_saves` that returns the same `compute_sync_action` decisions but performs no upload/download
+I/O. The only mutation it allows is recording `last_sync_hash` for `Skip(adopt_baseline=True)` rows so future drift
+detection works.
 
 ### Offline queue drain
 
@@ -559,36 +801,55 @@ If the RomM server is unreachable when a sync runs:
 
 1. `compute_sync_action` is never reached — `list_saves` raises and the rom-level sync returns an error string.
 2. The local save file is untouched. State is untouched.
-3. On the next successful server contact (next sync attempt, manual sync, or pre-launch), the algorithm runs against current server state and produces the same outcome it would have produced earlier — typically Upload (post-play) or Skip.
-4. No data is lost. There is no separate retry queue because the algorithm is idempotent: re-running it after a transient failure converges on the same end state.
+3. On the next successful server contact (next sync attempt, manual sync, or pre-launch), the algorithm runs against
+   current server state and produces the same outcome it would have produced earlier — typically Upload (post-play) or
+   Skip.
+4. No data is lost. There is no separate retry queue because the algorithm is idempotent: re-running it after a
+   transient failure converges on the same end state.
 
 ## Playtime Tracking
 
 ### Local delta-based accumulation
 
-Playtime is tracked per-ROM in the SQLite `rom_playtime` table (the `Playtime` aggregate), independent of the `saves` lifecycle. (The legacy `save_sync_state.json` `playtime.<rom_id>` section is no longer written by `PlaytimeService` and no longer read by anyone — uninstalling a ROM now deletes only its files and `rom_installs` row, leaving playtime and saves intact per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md). The dormant JSON section is dropped in the JSON-state teardown stream.)
+Playtime is tracked per-ROM in the SQLite `rom_playtime` table (the `Playtime` aggregate), independent of the `saves`
+lifecycle. (The legacy `save_sync_state.json` `playtime.<rom_id>` section is no longer written by `PlaytimeService` and
+no longer read by anyone — uninstalling a ROM now deletes only its files and `rom_installs` row, leaving playtime and
+saves intact per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md). The dormant JSON section is dropped in the
+JSON-state teardown stream.)
 
 Session tracking:
 
-1. `recordSessionStart(romId)`: backend opens the session marker (`last_session_start`) on the ROM's `rom_playtime` row in a short write Unit of Work
-2. During play, device suspend/resume events pause the timer (via `RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend`)
-3. `recordSessionEnd(romId)`: in an executor worker, a short write UoW folds the closed session into the aggregate (`record_session` clamps elapsed to 0–24h, increments `total_seconds` and `session_count`, records `last_session_duration_sec`); then, outside the transaction, the merged total is pushed to RomM via user notes (best-effort)
+1. `recordSessionStart(romId)`: backend opens the session marker (`last_session_start`) on the ROM's `rom_playtime` row
+   in a short write Unit of Work
+2. During play, device suspend/resume events pause the timer (via `RegisterForOnSuspendRequest` /
+   `RegisterForOnResumeFromSuspend`)
+3. `recordSessionEnd(romId)`: in an executor worker, a short write UoW folds the closed session into the aggregate
+   (`record_session` clamps elapsed to 0–24h, increments `total_seconds` and `session_count`, records
+   `last_session_duration_sec`); then, outside the transaction, the merged total is pushed to RomM via user notes
+   (best-effort)
 
 ### Steam display
 
-Steam natively tracks playtime for non-Steam shortcuts. No additional work is needed — Steam's built-in tracking handles the display in the library.
+Steam natively tracks playtime for non-Steam shortcuts. No additional work is needed — Steam's built-in tracking handles
+the display in the library.
 
 ### RomM last_played
 
-After each play session, the backend updates the ROM's `last_played` timestamp on the RomM server. This keeps the RomM library sorted correctly by recent activity. When a RomM playtime API becomes available in the future, the locally accumulated `playtime_seconds` can be synced to RomM as well.
+After each play session, the backend updates the ROM's `last_played` timestamp on the RomM server. This keeps the RomM
+library sorted correctly by recent activity. When a RomM playtime API becomes available in the future, the locally
+accumulated `playtime_seconds` can be synced to RomM as well.
 
 ## State Schema — save_sync_state.json
 
-Save sync state is stored in a separate file from the main `state.json` to avoid bloating the core state with per-ROM sync metadata.
+Save sync state is stored in a separate file from the main `state.json` to avoid bloating the core state with per-ROM
+sync metadata.
 
 Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
 
-The save-sync **feature toggles** (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) and the **device label** (`device_name`) live in `settings.json`, not here — they are user-intent config, not synced relational state (ADR-0003). `StateService` reads and writes them through the live settings dict; only `device_id` / `server_device_id` (server-issued identity) remain on this file.
+The save-sync **feature toggles** (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
+`autocleanup_limit`) and the **device label** (`device_name`) live in `settings.json`, not here — they are user-intent
+config, not synced relational state (ADR-0003). `StateService` reads and writes them through the live settings dict;
+only `device_id` / `server_device_id` (server-issued identity) remain on this file.
 
 ```json
 {
@@ -631,51 +892,72 @@ The save-sync **feature toggles** (`save_sync_enabled`, `sync_before_launch`, `s
 
 ### Field reference
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `version` | integer | State schema version (currently 1) |
-| `device_id` | string (UUID v4) | Unique identifier for this machine, generated on first use |
-| `server_device_id` | string / null | RomM server device UUID. Null until first device registration. |
-| `saves` | object | Per-ROM sync metadata, keyed by `rom_id` (string) |
-| `saves.<id>.system` | string | RetroDECK system slug (e.g. `"gba"`, `"snes"`) |
-| `saves.<id>.active_slot` | string | Which RomM slot this game syncs to (e.g. `"default"`) |
-| `saves.<id>.slot_confirmed` | boolean | Whether user has explicitly chosen their slot (see "Slot Setup Wizard") |
-| `saves.<id>.last_synced_core` | string / null | RetroArch core used at last sync (for core change detection, e.g. `"mgba_libretro"`) |
-| `saves.<id>.own_upload_ids` | array of integer | Save ids this device originally POSTed. Drives the `uploaded_by_us` indicator on the SAVES tab. |
-| `saves.<id>.last_sync_check_at` | ISO-8601 string / null | Timestamp of the most recent `_sync_rom_saves` run for this rom (regardless of whether files transferred). |
-| `saves.<id>.files` | object | Per-file sync state, keyed by filename (e.g. `"game.srm"`) |
-| `saves.<id>.files.<fn>.tracked_save_id` | integer / null | Most recent RomM save id this device tracked. Used to exclude the active save from the Previous Versions dropdown and as an uploader-attribution hint; **not** consulted by `compute_sync_action` (the algorithm picks newest by `updated_at`). |
-| `saves.<id>.files.<fn>.last_sync_hash` | MD5 hex string | Hash of the save file at last sync. Drift baseline used by matrix rows 7/8/9/10/11/12. |
-| `saves.<id>.files.<fn>.last_sync_at` | ISO-8601 string | Timestamp of last successful sync. |
-| `saves.<id>.files.<fn>.last_sync_server_updated_at` | ISO-8601 string | Server's `updated_at` at last sync. |
-| `saves.<id>.files.<fn>.last_sync_server_save_id` | integer | RomM save id for the most recently synced server save. |
-| `saves.<id>.files.<fn>.last_sync_server_size` | integer | Server file size at last sync. |
-| `saves.<id>.files.<fn>.last_sync_local_mtime` | float | Local file mtime (epoch seconds) at last sync. |
-| `saves.<id>.files.<fn>.last_sync_local_size` | integer | Local file size (bytes) at last sync. |
-| `playtime` | object | **Legacy / dormant — no live reader.** Per-ROM playtime now lives in the SQLite `rom_playtime` table (the `Playtime` aggregate); `PlaytimeService` no longer writes this JSON section and `RomRemovalService` no longer reads it (uninstall keeps playtime per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md)). It is dropped in the JSON-state teardown stream. The same fields below (`total_seconds`, `session_count`, `last_session_start`, `last_session_duration_sec`, `note_id`) back the SQLite aggregate. |
-| `playtime.<id>.total_seconds` | integer | Accumulated playtime in seconds. |
-| `playtime.<id>.session_count` | integer | Number of completed play sessions. |
-| `playtime.<id>.last_session_start` | ISO-8601 / null | Start time of current session (null when not playing). |
-| `playtime.<id>.last_session_duration_sec` | integer / null | Duration of last completed session. |
-| `playtime.<id>.note_id` | integer / null | Cached RomM note ID for playtime storage (avoids ROM detail fetch). |
+| Field                                               | Type                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                                           | integer                | State schema version (currently 1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `device_id`                                         | string (UUID v4)       | Unique identifier for this machine, generated on first use                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `server_device_id`                                  | string / null          | RomM server device UUID. Null until first device registration.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `saves`                                             | object                 | Per-ROM sync metadata, keyed by `rom_id` (string)                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `saves.<id>.system`                                 | string                 | RetroDECK system slug (e.g. `"gba"`, `"snes"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `saves.<id>.active_slot`                            | string                 | Which RomM slot this game syncs to (e.g. `"default"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `saves.<id>.slot_confirmed`                         | boolean                | Whether user has explicitly chosen their slot (see "Slot Setup Wizard")                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `saves.<id>.last_synced_core`                       | string / null          | RetroArch core used at last sync (for core change detection, e.g. `"mgba_libretro"`)                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `saves.<id>.own_upload_ids`                         | array of integer       | Save ids this device originally POSTed. Drives the `uploaded_by_us` indicator on the SAVES tab.                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `saves.<id>.last_sync_check_at`                     | ISO-8601 string / null | Timestamp of the most recent `_sync_rom_saves` run for this rom (regardless of whether files transferred).                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `saves.<id>.files`                                  | object                 | Per-file sync state, keyed by filename (e.g. `"game.srm"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `saves.<id>.files.<fn>.tracked_save_id`             | integer / null         | Most recent RomM save id this device tracked. Used to exclude the active save from the Previous Versions dropdown and as an uploader-attribution hint; **not** consulted by `compute_sync_action` (the algorithm picks newest by `updated_at`).                                                                                                                                                                                                                                                                              |
+| `saves.<id>.files.<fn>.last_sync_hash`              | MD5 hex string         | Hash of the save file at last sync. Drift baseline used by matrix rows 7/8/9/10/11/12.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `saves.<id>.files.<fn>.last_sync_at`                | ISO-8601 string        | Timestamp of last successful sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `saves.<id>.files.<fn>.last_sync_server_updated_at` | ISO-8601 string        | Server's `updated_at` at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `saves.<id>.files.<fn>.last_sync_server_save_id`    | integer                | RomM save id for the most recently synced server save.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `saves.<id>.files.<fn>.last_sync_server_size`       | integer                | Server file size at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `saves.<id>.files.<fn>.last_sync_local_mtime`       | float                  | Local file mtime (epoch seconds) at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `saves.<id>.files.<fn>.last_sync_local_size`        | integer                | Local file size (bytes) at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `playtime`                                          | object                 | **Legacy / dormant — no live reader.** Per-ROM playtime now lives in the SQLite `rom_playtime` table (the `Playtime` aggregate); `PlaytimeService` no longer writes this JSON section and `RomRemovalService` no longer reads it (uninstall keeps playtime per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md)). It is dropped in the JSON-state teardown stream. The same fields below (`total_seconds`, `session_count`, `last_session_start`, `last_session_duration_sec`, `note_id`) back the SQLite aggregate. |
+| `playtime.<id>.total_seconds`                       | integer                | Accumulated playtime in seconds.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `playtime.<id>.session_count`                       | integer                | Number of completed play sessions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `playtime.<id>.last_session_start`                  | ISO-8601 / null        | Start time of current session (null when not playing).                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `playtime.<id>.last_session_duration_sec`           | integer / null         | Duration of last completed session.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `playtime.<id>.note_id`                             | integer / null         | Cached RomM note ID for playtime storage (avoids ROM detail fetch).                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`, `autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this file. `save_sync_enabled` is the master feature toggle; `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs; `default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on the server (10).
+The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
+`autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this file.
+`save_sync_enabled` is the master feature toggle; `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch
+/ post-exit syncs; `default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save
+versions per slot on the server (10).
 
-Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom_saves` and `_get_save_status_io` and surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the next sync as long as the underlying state still produces matrix row 12.
+Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom_saves` and `_get_save_status_io` and
+surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the
+next sync as long as the underlying state still produces matrix row 12.
 
 ### Legacy field migration
 
-`SaveSyncState.from_dict` (`py_modules/domain/save_state.py`) performs idempotent schema migrations every time the plugin loads — the typed aggregate is rebuilt from the on-disk JSON, legacy keys are dropped at construction, and the next `to_dict`/persist produces a clean file. Each strip below disappears from disk on the next state write:
+`SaveSyncState.from_dict` (`py_modules/domain/save_state.py`) performs idempotent schema migrations every time the
+plugin loads — the typed aggregate is rebuilt from the on-disk JSON, legacy keys are dropped at construction, and the
+next `to_dict`/persist produces a clean file. Each strip below disappears from disk on the next state write:
 
-- **`saves.<id>.active_core`** → renamed to `saves.<id>.last_synced_core` (per-game; `last_synced_core` wins if both are present).
-- **`saves.<id>.files.<fn>.dismissed_newer_save_id`** → dropped. Was used by the removed newer-in-slot detection. Users upgrading from v0.15.x and earlier may have this field; it's silently removed.
-- **`settings` block + `device_name`** → no longer parsed from or written to this file. The save-sync feature toggles and the device label moved to `settings.json` (ADR-0003); a one-time `settings.json` schema bump (v3 → v4) reads the legacy values out of `save_sync_state.json` and folds them in. On the next state write they disappear from this file. The legacy `settings.conflict_mode` / `settings.clock_skew_tolerance_sec` keys (dropped in earlier releases) are not carried over.
+- **`saves.<id>.active_core`** → renamed to `saves.<id>.last_synced_core` (per-game; `last_synced_core` wins if both are
+  present).
+- **`saves.<id>.files.<fn>.dismissed_newer_save_id`** → dropped. Was used by the removed newer-in-slot detection. Users
+  upgrading from v0.15.x and earlier may have this field; it's silently removed.
+- **`settings` block + `device_name`** → no longer parsed from or written to this file. The save-sync feature toggles
+  and the device label moved to `settings.json` (ADR-0003); a one-time `settings.json` schema bump (v3 → v4) reads the
+  legacy values out of `save_sync_state.json` and folds them in. On the next state write they disappear from this file.
+  The legacy `settings.conflict_mode` / `settings.clock_skew_tolerance_sec` keys (dropped in earlier releases) are not
+  carried over.
 
-The dropped `pending_conflicts`, `dismissed_saves_state`, and other obsolete sync-state fields are simply not loaded. They never appear in the rebuilt aggregate, and the next state write produces a clean file.
+The dropped `pending_conflicts`, `dismissed_saves_state`, and other obsolete sync-state fields are simply not loaded.
+They never appear in the rebuilt aggregate, and the next state write produces a clean file.
 
 ### SaveSyncState SQLite cutover status
 
-The game-detail panel's cached has-saves badge (`get_cached_game_detail`) no longer reads the in-memory `SaveSyncState.saves` dict — it reads the `rom_save_states` aggregate through the Unit of Work (the per-file `last_sync_hash` → the `synced`/`unknown` status the badge renders), the lightweight counterpart to the live `getSaveStatus` flow above. With that and the playtime cutover, the legacy `SaveSyncState` container has **no live reader** and is fully dead pending teardown; the live save-sync engine still persists through `save_sync_state.json` (the SaveService SQLite migration is a separate cutover stream). `domain/save_state.py` is removed in the teardown stream, not here.
+The game-detail panel's cached has-saves badge (`get_cached_game_detail`) no longer reads the in-memory
+`SaveSyncState.saves` dict — it reads the `rom_save_states` aggregate through the Unit of Work (the per-file
+`last_sync_hash` → the `synced`/`unknown` status the badge renders), the lightweight counterpart to the live
+`getSaveStatus` flow above. With that and the playtime cutover, the legacy `SaveSyncState` container has **no live
+reader** and is fully dead pending teardown; the live save-sync engine still persists through `save_sync_state.json`
+(the SaveService SQLite migration is a separate cutover stream). `domain/save_state.py` is removed in the teardown
+stream, not here.
 
 ## Session Detection
 
@@ -683,7 +965,8 @@ Game start and stop events are detected using Steam's frontend APIs, not by poll
 
 ### RegisterForAppLifetimeNotifications
 
-The primary mechanism. `SteamClient.GameSessions.RegisterForAppLifetimeNotifications` fires a callback whenever any app (including non-Steam shortcuts) starts or stops.
+The primary mechanism. `SteamClient.GameSessions.RegisterForAppLifetimeNotifications` fires a callback whenever any app
+(including non-Steam shortcuts) starts or stops.
 
 The callback receives:
 
@@ -692,11 +975,14 @@ The callback receives:
 
 ### Router.MainRunningApp
 
-After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms and then reads `Router.MainRunningApp` for a reliable `appid` and `display_name`. Falls back to `unAppID` from the notification if `MainRunningApp` is null.
+After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms
+and then reads `Router.MainRunningApp` for a reliable `appid` and `display_name`. Falls back to `unAppID` from the
+notification if `MainRunningApp` is null.
 
 ### App ID to ROM ID mapping
 
-The session manager maintains a cached `appId -> romId` map loaded from the backend's synced-ROM registry (the `roms` SQLite table, via `get_app_id_rom_id_map`). This map is refreshed:
+The session manager maintains a cached `appId -> romId` map loaded from the backend's synced-ROM registry (the `roms`
+SQLite table, via `get_app_id_rom_id_map`). This map is refreshed:
 
 - On session manager initialization (plugin load)
 - Before each game start event (in case a sync added new shortcuts)
@@ -712,17 +998,22 @@ To exclude sleep time from playtime tracking:
 
 ## RomM Notes API Bug and Workaround
 
-> **Historical context:** This bug affects RomM 4.6.1. RomM 4.7.0+ fixes the underlying issue. The workaround is retained because the `all_user_notes` approach remains the plugin's primary read path regardless.
+> **Historical context:** This bug affects RomM 4.6.1. RomM 4.7.0+ fixes the underlying issue. The workaround is
+> retained because the `all_user_notes` approach remains the plugin's primary read path regardless.
 
 ### The bug
 
-`GET /api/roms/{id}/notes` returns HTTP 500 Internal Server Error in RomM 4.6.1 whenever any note exists for a ROM. POST (create), PUT (update), and DELETE all work correctly — only the GET list endpoint is broken.
+`GET /api/roms/{id}/notes` returns HTTP 500 Internal Server Error in RomM 4.6.1 whenever any note exists for a ROM. POST
+(create), PUT (update), and DELETE all work correctly — only the GET list endpoint is broken.
 
-This bug is in the `get_rom_notes()` handler in RomM's `backend/endpoints/rom.py`. The function calls `db_rom_handler.get_rom_notes()` which uses `json_array_contains_value()` for tag filtering — this utility appears to fail depending on the database driver or JSON column format.
+This bug is in the `get_rom_notes()` handler in RomM's `backend/endpoints/rom.py`. The function calls
+`db_rom_handler.get_rom_notes()` which uses `json_array_contains_value()` for tag filtering — this utility appears to
+fail depending on the database driver or JSON column format.
 
 ### The workaround
 
-`GET /api/roms/{id}` (the ROM detail endpoint) returns the full `DetailedRomSchema` which includes an `all_user_notes` array of `UserNoteSchema` objects. This completely bypasses the broken notes list endpoint.
+`GET /api/roms/{id}` (the ROM detail endpoint) returns the full `DetailedRomSchema` which includes an `all_user_notes`
+array of `UserNoteSchema` objects. This completely bypasses the broken notes list endpoint.
 
 Each note in `all_user_notes` contains:
 
@@ -739,34 +1030,39 @@ Each note in `all_user_notes` contains:
 The plugin stores playtime data in RomM notes (since RomM has no dedicated playtime API). The workflow:
 
 1. **Read**: Fetch `GET /api/roms/{id}`, filter `all_user_notes` for notes with `title == "romm-sync:playtime"`
-2. **Create**: `POST /api/roms/{id}/notes` with `title: "romm-sync:playtime"`, JSON content, `is_public: false`. Do **not** send `tags` — it contributes to the GET bug.
+2. **Create**: `POST /api/roms/{id}/notes` with `title: "romm-sync:playtime"`, JSON content, `is_public: false`. Do
+   **not** send `tags` — it contributes to the GET bug.
 3. **Update**: `PUT /api/roms/{id}/notes/{note_id}` with updated playtime JSON
 4. **Delete**: `DELETE /api/roms/{id}/notes/{note_id}` if needed
 
-The note `id` is cached locally on the `rom_playtime` row (`note_id`) to avoid fetching the full ROM detail on every session end. If the local row is lost, the plugin recovers by reading `all_user_notes` from the ROM detail and finding existing notes by `title == "romm-sync:playtime"`.
+The note `id` is cached locally on the `rom_playtime` row (`note_id`) to avoid fetching the full ROM detail on every
+session end. If the local row is lost, the plugin recovers by reading `all_user_notes` from the ROM detail and finding
+existing notes by `title == "romm-sync:playtime"`.
 
 ### Future: RomM playtime API
 
-**Feature request #1225** (dedicated playtime API) is still open. Until it ships, playtime continues to use notes-based storage.
+**Feature request #1225** (dedicated playtime API) is still open. Until it ships, playtime continues to use notes-based
+storage.
 
 ## Known Limitations
 
 ### Standalone emulators not supported
 
-Phase 5 only covers RetroArch `.srm` saves. Standalone emulators store saves under `<saves_path>/<platform>/<emulator_name>/` with emulator-specific formats:
+Phase 5 only covers RetroArch `.srm` saves. Standalone emulators store saves under
+`<saves_path>/<platform>/<emulator_name>/` with emulator-specific formats:
 
-| Platform | Emulator | Save Path | Format |
-| --- | --- | --- | --- |
-| psx | DuckStation | `psx/duckstation/memcards/` | `.mcd` shared memory cards |
-| ps2 | PCSX2 | `ps2/pcsx2/memcards/` | `.ps2` shared memory cards |
-| gc | Dolphin | `gc/dolphin/{US,EU,JP}/` | Per-region memory card files |
-| wii | Dolphin | `wii/dolphin/` | Wii save data + virtual SD card |
-| nds | melonDS | `nds/melonds/` | Per-game `.sav` files |
-| n3ds | Azahar | `n3ds/azahar/` | NAND/SDMC title ID structure |
-| PSP | PPSSPP | `PSP/PPSSPP-SA/` | Title ID directories |
-| wiiu | Cemu | `wiiu/cemu/` | mlc01 title ID structure |
-| switch | Ryubing | `switch/ryubing/` | User profile-based save data |
-| xbox | Xemu | `xbox/xemu/` | Xbox HDD image saves |
+| Platform | Emulator    | Save Path                   | Format                          |
+| -------- | ----------- | --------------------------- | ------------------------------- |
+| psx      | DuckStation | `psx/duckstation/memcards/` | `.mcd` shared memory cards      |
+| ps2      | PCSX2       | `ps2/pcsx2/memcards/`       | `.ps2` shared memory cards      |
+| gc       | Dolphin     | `gc/dolphin/{US,EU,JP}/`    | Per-region memory card files    |
+| wii      | Dolphin     | `wii/dolphin/`              | Wii save data + virtual SD card |
+| nds      | melonDS     | `nds/melonds/`              | Per-game `.sav` files           |
+| n3ds     | Azahar      | `n3ds/azahar/`              | NAND/SDMC title ID structure    |
+| PSP      | PPSSPP      | `PSP/PPSSPP-SA/`            | Title ID directories            |
+| wiiu     | Cemu        | `wiiu/cemu/`                | mlc01 title ID structure        |
+| switch   | Ryubing     | `switch/ryubing/`           | User profile-based save data    |
+| xbox     | Xemu        | `xbox/xemu/`                | Xbox HDD image saves            |
 
 Key challenges:
 
@@ -778,20 +1074,30 @@ Standalone emulator support is tracked on the [GitHub Projects board](https://gi
 
 ### Shared memory cards deferred
 
-PS1 and PS2 games using RetroArch cores that save to shared memory cards (rather than per-game `.srm`) are not handled. Syncing a shared memory card affects all games on the card, requiring system-level tracking rather than per-game tracking. Deferred to Phase 7.
+PS1 and PS2 games using RetroArch cores that save to shared memory cards (rather than per-game `.srm`) are not handled.
+Syncing a shared memory card affects all games on the card, requiring system-level tracking rather than per-game
+tracking. Deferred to Phase 7.
 
 ### No RomM playtime API
 
-RomM currently supports `last_played` timestamps but does not have a dedicated playtime tracking API (feature request #1225 is open). The plugin stores playtime in RomM user notes (see "RomM Notes API Bug and Workaround" above) and updates `last_played` on the server after each session. When a RomM playtime API becomes available, the plugin can migrate from notes-based storage to the native API.
+RomM currently supports `last_played` timestamps but does not have a dedicated playtime tracking API (feature request
+#1225 is open). The plugin stores playtime in RomM user notes (see "RomM Notes API Bug and Workaround" above) and
+updates `last_played` on the server after each session. When a RomM playtime API becomes available, the plugin can
+migrate from notes-based storage to the native API.
 
 ### Emulator save states not synced
 
-RetroArch save states (`<states_path>/{system}/`, where `<states_path>` comes from `retrodeck.json` → `paths.states_path`) are not synced. Only SRAM saves (`.srm`) are handled. Save states are large, emulator-version-specific, and not portable between different RetroArch core versions.
+RetroArch save states (`<states_path>/{system}/`, where `<states_path>` comes from `retrodeck.json` →
+`paths.states_path`) are not synced. Only SRAM saves (`.srm`) are handled. Save states are large,
+emulator-version-specific, and not portable between different RetroArch core versions.
 
 ### Save slot migration between slots not yet implemented
 
-Moving saves between slots (copy from slot A to slot B) is not supported. Users can delete slots (which removes all saves in the slot from the server) and create new ones, but there is no "move saves from slot X to slot Y" operation.
+Moving saves between slots (copy from slot A to slot B) is not supported. Users can delete slots (which removes all
+saves in the slot from the server) and create new ones, but there is no "move saves from slot X to slot Y" operation.
 
 ### Cross-device save browsing limited
 
-While `device_syncs` per save shows which devices have synced, the plugin cannot filter or browse saves by a specific other device. This is an API limitation — `GET /api/saves?device_id=X` only populates `device_syncs` for device X, not for arbitrary devices.
+While `device_syncs` per save shows which devices have synced, the plugin cannot filter or browse saves by a specific
+other device. This is an API limitation — `GET /api/saves?device_id=X` only populates `device_syncs` for device X, not
+for arbitrary devices.

--- a/docs/architecture/save-sync-coverage.md
+++ b/docs/architecture/save-sync-coverage.md
@@ -1,0 +1,82 @@
+# Save Sync Coverage
+
+Why some saves sync and others don't. The mechanics live in
+[Save File Sync Architecture](save-file-sync-architecture.md); this page explains the **coverage envelope** — which save
+files the per-game model can and cannot reach — and the strategy for the gaps. The user-facing result is the
+[Save sync support matrix](../user-guide/save-sync-support-matrix.md).
+
+## The per-game discovery model
+
+Save discovery is **exact-name probing**, not a directory scan. For an installed ROM whose file stem is `rom_name`, the
+sync looks for exactly `<saves_dir>/<rom_name><ext>` for each extension in a fixed list, and uploads the ones that
+exist. There is no glob, no `listdir`, no pattern match.
+
+This is a deliberate bijection: **one ROM → one set of `<rom_name>.<ext>` files in the save folder.** It maps perfectly
+onto libretro's own SRAM convention, where the save file mirrors the ROM name. Everything that doesn't fit that shape is
+invisible to the sync.
+
+Two hard properties follow, and they define the entire coverage envelope:
+
+1. **The filename must be the ROM stem.** A file named anything else — a fixed card name (`pcsx-card2.mcd`,
+   `vmu_save_A1.bin`), or a name with a slot/unit infix (`game.1.mcr`) — is never probed.
+2. **The file must live in the save folder.** A save in RetroArch's _system_ directory (Flycast VMUs), in a per-emulator
+   subdirectory (`mame/nvram/`), or next to the ROM (`savefiles_in_content_dir`) is never seen.
+
+The extension list is a small static map: a default of `.srm` / `.rtc` / `.sav`, plus per-platform overrides (today only
+`nds` → `.dsv` and `segacd` → `.brm`).
+
+## How RomM stores saves
+
+RomM treats a save as a file blob keyed by `(rom_id, slot)`, with an `emulator` tag (which becomes a storage
+subdirectory) and an MD5 `content_hash`. It stores the bytes the client sends and leaves their meaning to the client —
+there is no `save_type` or memory-card concept, and each save belongs to a single ROM. This format-agnostic design keeps
+the server simple and works for any client; RomM's own in-browser player (EmulatorJS) uses the same path, uploading one
+save blob per `(game, core)`.
+
+Because both the server and our discovery are organised **per game**, two things follow. Supporting a new _per-game_
+save format is a client-side change — the server already accepts the file as-is. And a _shared_ card has no per-game
+identity to map onto a `(rom_id, slot)` record, so any shared-card handling is a client-side modelling decision (see
+below), not something the server provides or prevents.
+
+## The three coverage classes
+
+Every core's save behavior falls into one of these (plus "no save"):
+
+| Class   | Shape                                                                                  | What it needs                                                                                                                 |
+| ------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **(a)** | Per-game, single-token `<rom>.<ext>`, save folder                                      | Just add `<ext>` to the override map. No architecture change.                                                                 |
+| **(b)** | Per-game, but a **slot/unit infix** (`<rom>.1.mcr`, `<rom>.A1.bin`)                    | Infix-aware discovery **and** download-target derivation (the current code drops the infix), plus multi-file-per-ROM support. |
+| **(c)** | **Shared** card (one file, many games), **fixed** name, or **outside** the save folder | Breaks the per-game model. Not solvable by an extension — see strategy below.                                                 |
+
+Class (a) is pure upside. Class (b) is bounded engineering that stays inside the per-game model. Class (c) is the
+genuinely hard one.
+
+## Strategy for class (c)
+
+The emulation ecosystem has already converged on the answer, and it aligns with this project's "no assumptions, the user
+decides on ambiguity" stance:
+
+- **No tool merges binary card images.** Block-level merge of a shared `.mcr`/`.ps2`/`.raw` is a confirmed dead end. The
+  only options are _isolate_ (per-game) or _pick-one_ (whole-file).
+- **Prefer per-game mode.** Modern emulators default to it (DuckStation per-game cards; Beetle PSX / PCSX ReARMed slot
+  0; PCSX2 Folder Memory Cards; Dolphin GCI folders). Where the launch core supports per-game cards, that path collapses
+  class (c) into class (a)/(b) and maps cleanly onto per-game sync.
+- **For an unavoidable shared card, treat it as one device-global blob:** whole-file, last-writer-wins, with conflict
+  **detection that warns instead of clobbering** (the Ludusavi model), and rely on the existing version history as the
+  recovery net. Never present it as per-game; never merge.
+- **Sync SRAM, not save states.** Save states are core- and version-coupled and not portable across devices; in-game
+  saves are.
+- **The per-game card format is emulator-specific.** A per-game card written by the RetroArch PCSX2 core is not
+  byte-compatible with standalone PCSX2. The sync key/format must match the core the user actually launches with — which
+  is exactly what RomM's `emulator` subdirectory captures.
+
+## Roadmap mapping
+
+- **(a)** — extension-map additions, candidate for incremental delivery; research/verification tracked in
+  [#237](https://github.com/danielcopper/decky-romm-sync/issues/237).
+- **(b)** — infix-aware per-game discovery (PS1 multi-card, Flycast per-game VMU); research in
+  [#237](https://github.com/danielcopper/decky-romm-sync/issues/237), implementation under the save-format epic
+  [#255](https://github.com/danielcopper/decky-romm-sync/issues/255).
+- **(c)** — shared/system-dir handling under [#255](https://github.com/danielcopper/decky-romm-sync/issues/255) (save
+  formats), [#151](https://github.com/danielcopper/decky-romm-sync/issues/151) (Dreamcast VMU), and
+  [#129](https://github.com/danielcopper/decky-romm-sync/issues/129) (standalone emulators) — all v2.0.

--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -1,6 +1,7 @@
 # Steam Non-Steam Shortcuts
 
-Technical reference for how decky-romm-sync creates, manages, and launches non-Steam shortcuts. This covers the `SteamClient.Apps.AddShortcut` API, VDF format details, and app ID handling.
+Technical reference for how decky-romm-sync creates, manages, and launches non-Steam shortcuts. This covers the
+`SteamClient.Apps.AddShortcut` API, VDF format details, and app ID handling.
 
 ## AddShortcut API Behavior
 
@@ -14,7 +15,8 @@ Returns the new shortcut's `appId` (a number), or `0`/`null` on failure.
 
 ### What it actually does
 
-Despite accepting four parameters, `AddShortcut` **ignores `startDir` and `launchOptions`**. This was confirmed by the [MoonDeck plugin](https://github.com/FrogTheFrog/moondeck) developers. Only `name` and `exe` are used during creation.
+Despite accepting four parameters, `AddShortcut` **ignores `startDir` and `launchOptions`**. This was confirmed by the
+[MoonDeck plugin](https://github.com/FrogTheFrog/moondeck) developers. Only `name` and `exe` are used during creation.
 
 To set all shortcut properties reliably, call the `Set*` methods **after a 500ms delay**:
 
@@ -28,11 +30,13 @@ SteamClient.Apps.SetShortcutStartDir(appId, startDir);
 SteamClient.Apps.SetAppLaunchOptions(appId, launchOptions);
 ```
 
-The 500ms delay is critical. Without it, the `Set*` calls may silently fail because Steam has not finished registering the new app internally.
+The 500ms delay is critical. Without it, the `Set*` calls may silently fail because Steam has not finished registering
+the new app internally.
 
 ### Exe quoting
 
-**Do NOT pass quoted exe paths to `AddShortcut` or `SetShortcutExe`.** The API handles quoting internally. Passing `"\"path/to/exe\""` (pre-quoted) results in double-quoting, which causes launches to fail with "file not found."
+**Do NOT pass quoted exe paths to `AddShortcut` or `SetShortcutExe`.** The API handles quoting internally. Passing
+`"\"path/to/exe\""` (pre-quoted) results in double-quoting, which causes launches to fail with "file not found."
 
 Pass the raw path:
 
@@ -44,28 +48,46 @@ SteamClient.Apps.SetShortcutExe(appId, "/home/deck/homebrew/plugins/decky-romm-s
 
 A shortcut's `appId` is derived from `exe + appName` (CRC32). Two consequences follow:
 
-- **`launchOptions` and `startDir` are appId-safe.** Changing either on an existing shortcut keeps the same `appId`, so the shortcut's identity, artwork, collection membership, and `roms.shortcut_app_id` binding all survive. `SetAppLaunchOptions` on an existing shortcut is **reliable** — confirmed on hardware in [#827](https://github.com/danielcopper/decky-romm-sync/issues/827) across in-session writes, a Steam restart, and removal-churn re-syncs. The plugin uses it directly to bake the launch command in at download-complete and to re-resolve paths after a RetroDECK-home migration.
-- **`exe` and `appName` are destructive.** Changing either yields a *different* `appId` — effectively a new shortcut. A launch-config change that touches `exe` or the name therefore requires delete + recreate (re-sync); a `launchOptions`-only change does not.
+- **`launchOptions` and `startDir` are appId-safe.** Changing either on an existing shortcut keeps the same `appId`, so
+  the shortcut's identity, artwork, collection membership, and `roms.shortcut_app_id` binding all survive.
+  `SetAppLaunchOptions` on an existing shortcut is **reliable** — confirmed on hardware in
+  [#827](https://github.com/danielcopper/decky-romm-sync/issues/827) across in-session writes, a Steam restart, and
+  removal-churn re-syncs. The plugin uses it directly to bake the launch command in at download-complete and to
+  re-resolve paths after a RetroDECK-home migration.
+- **`exe` and `appName` are destructive.** Changing either yields a _different_ `appId` — effectively a new shortcut. A
+  launch-config change that touches `exe` or the name therefore requires delete + recreate (re-sync); a
+  `launchOptions`-only change does not.
 
-Because `SetAppLaunchOptions` returns `void` with no success signal, the plugin **fires the set then polls** `RegisterForAppDetails` until the read-back `strLaunchOptions` matches (`setLaunchOptionsConfirmed`). Setting `""` — the placeholder an uninstalled ROM carries until it is downloaded — is valid and confirms against an empty read-back.
+Because `SetAppLaunchOptions` returns `void` with no success signal, the plugin **fires the set then polls**
+`RegisterForAppDetails` until the read-back `strLaunchOptions` matches (`setLaunchOptionsConfirmed`). Setting `""` — the
+placeholder an uninstalled ROM carries until it is downloaded — is valid and confirms against an empty read-back.
 
-The real hazard is not the set: heavy removal-churn can corrupt Steam's in-memory shortcut state. A Steam restart clears it. The sync engine processes removals before additions to minimise churn.
+The real hazard is not the set: heavy removal-churn can corrupt Steam's in-memory shortcut state. A Steam restart clears
+it. The sync engine processes removals before additions to minimise churn.
 
 See: `src/utils/steamShortcuts.ts`
 
 ## BIsModOrShortcut
 
-Non-Steam shortcuts return `BIsModOrShortcut() = true` by default. This is their natural state — Steam uses this flag to determine how to render and launch an app.
+Non-Steam shortcuts return `BIsModOrShortcut() = true` by default. This is their natural state — Steam uses this flag to
+determine how to render and launch an app.
 
-An earlier version of the plugin used a "bypass counter" pattern (inspired by MetaDeck) to temporarily return `false` from `BIsModOrShortcut()` so that Steam would render metadata sections (description, developer, etc.) on the game detail page. This approach was **dropped in Phase 5.6** because it caused launch failures — Steam skips the shortcut launch path when `BIsModOrShortcut()` returns `false`.
+An earlier version of the plugin used a "bypass counter" pattern (inspired by MetaDeck) to temporarily return `false`
+from `BIsModOrShortcut()` so that Steam would render metadata sections (description, developer, etc.) on the game detail
+page. This approach was **dropped in Phase 5.6** because it caused launch failures — Steam skips the shortcut launch
+path when `BIsModOrShortcut()` returns `false`.
 
-The current approach owns the entire game detail UI via custom React components (`RomMPlaySection`, `RomMGameInfoPanel`, `CustomPlayButton`) injected through route patching. This avoids fighting Steam's internal rendering logic.
+The current approach owns the entire game detail UI via custom React components (`RomMPlaySection`, `RomMGameInfoPanel`,
+`CustomPlayButton`) injected through route patching. This avoids fighting Steam's internal rendering logic.
 
 See: `src/patches/gameDetailPatch.tsx`, `src/components/RomMPlaySection.tsx`
 
 ## VDF Format Notes
 
-Shortcut creation goes through the frontend `SteamClient.Apps.AddShortcut()` API — `AddShortcut` returns the real `appId` directly, so the plugin never computes app IDs itself for shortcut creation. VDF read/write support remains in the backend `SteamConfigAdapter` (`adapters/steam_config.py`) for reading the existing shortcut set and writing shortcut icons into the grid directory.
+Shortcut creation goes through the frontend `SteamClient.Apps.AddShortcut()` API — `AddShortcut` returns the real
+`appId` directly, so the plugin never computes app IDs itself for shortcut creation. VDF read/write support remains in
+the backend `SteamConfigAdapter` (`adapters/steam_config.py`) for reading the existing shortcut set and writing shortcut
+icons into the grid directory.
 
 ### shortcuts.vdf structure
 
@@ -77,19 +99,20 @@ Steam stores non-Steam shortcuts in a binary VDF file at:
 
 Each entry has these key fields:
 
-| VDF Field | Format | Notes |
-| --- | --- | --- |
-| `AppName` | string | Display name |
-| `Exe` | string | **Quoted** path: `"/path/to/exe"` |
-| `StartDir` | string | **Quoted** path: `"/path/to/dir"` |
-| `LaunchOptions` | string | The full launch command the `bin/rom-launcher` exec wrapper runs, e.g. `flatpak run net.retrodeck.retrodeck "/path/to/game.iso"` — or `""` (placeholder) for an uninstalled ROM. No `romm:<id>` marker; ownership is detected by the exe path instead |
-| `appid` | signed int32 | Assigned by Steam when `AddShortcut` runs; stored as the signed int32 form (`to_signed_app_id`) |
-| `icon` | string | Icon path or hash |
-| `tags` | object | Steam collection tags. The plugin manages collections via `collectionStore` (machine-scoped names like `RomM: N64 (steamdeck)`), not by writing this VDF field. |
+| VDF Field       | Format       | Notes                                                                                                                                                                                                                                                 |
+| --------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AppName`       | string       | Display name                                                                                                                                                                                                                                          |
+| `Exe`           | string       | **Quoted** path: `"/path/to/exe"`                                                                                                                                                                                                                     |
+| `StartDir`      | string       | **Quoted** path: `"/path/to/dir"`                                                                                                                                                                                                                     |
+| `LaunchOptions` | string       | The full launch command the `bin/rom-launcher` exec wrapper runs, e.g. `flatpak run net.retrodeck.retrodeck "/path/to/game.iso"` — or `""` (placeholder) for an uninstalled ROM. No `romm:<id>` marker; ownership is detected by the exe path instead |
+| `appid`         | signed int32 | Assigned by Steam when `AddShortcut` runs; stored as the signed int32 form (`to_signed_app_id`)                                                                                                                                                       |
+| `icon`          | string       | Icon path or hash                                                                                                                                                                                                                                     |
+| `tags`          | object       | Steam collection tags. The plugin manages collections via `collectionStore` (machine-scoped names like `RomM: N64 (steamdeck)`), not by writing this VDF field.                                                                                       |
 
 ### AddShortcut vs VDF quoting
 
-When the backend `SteamConfigAdapter` writes directly to `shortcuts.vdf`, the `Exe` and `StartDir` fields **must** be wrapped in double quotes:
+When the backend `SteamConfigAdapter` writes directly to `shortcuts.vdf`, the `Exe` and `StartDir` fields **must** be
+wrapped in double quotes:
 
 ```python
 entry = {
@@ -98,58 +121,80 @@ entry = {
 }
 ```
 
-When using `SteamClient.Apps.AddShortcut()` (the path shortcut creation goes through), **do NOT quote** — the API adds quotes internally.
+When using `SteamClient.Apps.AddShortcut()` (the path shortcut creation goes through), **do NOT quote** — the API adds
+quotes internally.
 
 See: `py_modules/adapters/steam_config.py`
 
 ## App IDs and Artwork
 
-`SteamClient.Apps.AddShortcut()` returns the real `appId`, so the plugin does **not** compute shortcut app IDs itself — there is no CRC32 app-ID generator in the codebase. Steam derives the `appId` from `exe + appName` (CRC32), which is why mutating `launchOptions` or `startDir` keeps the same `appId` (see [Updating existing shortcuts](#updating-existing-shortcuts)) while changing `exe`/name produces a different one. The frontend stores the returned `appId` and the backend persists it as `shortcut_app_id` on the ROM's `roms` row (the synced-ROM registry; reverse-lookupable by `shortcut_app_id`). The frontend resolves rom_id ↔ appId through the backend's `get_app_id_rom_id_map()` callable, which reads that binding.
+`SteamClient.Apps.AddShortcut()` returns the real `appId`, so the plugin does **not** compute shortcut app IDs itself —
+there is no CRC32 app-ID generator in the codebase. Steam derives the `appId` from `exe + appName` (CRC32), which is why
+mutating `launchOptions` or `startDir` keeps the same `appId` (see
+[Updating existing shortcuts](#updating-existing-shortcuts)) while changing `exe`/name produces a different one. The
+frontend stores the returned `appId` and the backend persists it as `shortcut_app_id` on the ROM's `roms` row (the
+synced-ROM registry; reverse-lookupable by `shortcut_app_id`). The frontend resolves rom_id ↔ appId through the
+backend's `get_app_id_rom_id_map()` callable, which reads that binding.
 
-The only app-ID math the backend does is converting an unsigned Steam app ID to its signed int32 form for `shortcuts.vdf` records — `to_signed_app_id(app_id)` in `py_modules/domain/sgdb_artwork.py`. SGDB endpoint/asset-type maps live in the same module.
+The only app-ID math the backend does is converting an unsigned Steam app ID to its signed int32 form for
+`shortcuts.vdf` records — `to_signed_app_id(app_id)` in `py_modules/domain/sgdb_artwork.py`. SGDB endpoint/asset-type
+maps live in the same module.
 
 ### Artwork file naming
 
 Grid artwork is stored at `userdata/<user_id>/config/grid/`, keyed by the shortcut's real `appId`:
 
-| Suffix | Artwork Type |
-| --- | --- |
-| `<appId>p.png` | Portrait grid (cover) |
-| `<appId>_hero.png` | Hero banner |
-| `<appId>_logo.png` | Logo overlay |
-| `<appId>.png` | Wide grid / horizontal |
-| `<appId>_icon.png` | Icon |
+| Suffix             | Artwork Type           |
+| ------------------ | ---------------------- |
+| `<appId>p.png`     | Portrait grid (cover)  |
+| `<appId>_hero.png` | Hero banner            |
+| `<appId>_logo.png` | Logo overlay           |
+| `<appId>.png`      | Wide grid / horizontal |
+| `<appId>_icon.png` | Icon                   |
 
-`ArtworkService` (cover staging/finalisation, renaming the staged cover to `{app_id}p.png`) and `SteamGridService` (SGDB hero/logo/grid/icon, writing the icon into the grid dir) own the artwork flow. Icon writes go through `SteamConfigAdapter.write_shortcut_icon`.
+`ArtworkService` (cover staging/finalisation, renaming the staged cover to `{app_id}p.png`) and `SteamGridService` (SGDB
+hero/logo/grid/icon, writing the icon into the grid dir) own the artwork flow. Icon writes go through
+`SteamConfigAdapter.write_shortcut_icon`.
 
 ## Key Files
 
-| File | Purpose |
-| --- | --- |
-| `src/utils/steamShortcuts.ts` | `addShortcut()`, `removeShortcut()`, `getExistingRomMShortcuts()` — frontend shortcut CRUD |
-| `src/utils/syncManager.ts` | Listens for sync events, orchestrates shortcut creation/removal, artwork application, collection management |
-| `src/utils/collections.ts` | Machine-scoped Steam collection management |
-| `src/patches/gameDetailPatch.tsx` | Route patch for `/library/app/:appid` — injects RomMPlaySection for custom game detail UI |
-| `src/patches/metadataPatches.ts` | Store patches for description, associations, categories, release date display |
-| `py_modules/adapters/steam_config.py` | `SteamConfigAdapter` — VDF read/write, grid dir, shortcut icon write, Steam Input config |
-| `py_modules/services/library/` | LibraryService — builds shortcut data, drives per-unit sync apply |
-| `py_modules/domain/sgdb_artwork.py` | `to_signed_app_id`, SGDB asset-type/endpoint maps |
-| `bin/rom-launcher` | Pure `exec "$@"` wrapper invoked by Steam — runs the full launch command baked into the shortcut's launch options; owns no state, no path resolution, no emulator knowledge |
+| File                                  | Purpose                                                                                                                                                                     |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/steamShortcuts.ts`         | `addShortcut()`, `removeShortcut()`, `getExistingRomMShortcuts()` — frontend shortcut CRUD                                                                                  |
+| `src/utils/syncManager.ts`            | Listens for sync events, orchestrates shortcut creation/removal, artwork application, collection management                                                                 |
+| `src/utils/collections.ts`            | Machine-scoped Steam collection management                                                                                                                                  |
+| `src/patches/gameDetailPatch.tsx`     | Route patch for `/library/app/:appid` — injects RomMPlaySection for custom game detail UI                                                                                   |
+| `src/patches/metadataPatches.ts`      | Store patches for description, associations, categories, release date display                                                                                               |
+| `py_modules/adapters/steam_config.py` | `SteamConfigAdapter` — VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                                    |
+| `py_modules/services/library/`        | LibraryService — builds shortcut data, drives per-unit sync apply                                                                                                           |
+| `py_modules/domain/sgdb_artwork.py`   | `to_signed_app_id`, SGDB asset-type/endpoint maps                                                                                                                           |
+| `bin/rom-launcher`                    | Pure `exec "$@"` wrapper invoked by Steam — runs the full launch command baked into the shortcut's launch options; owns no state, no path resolution, no emulator knowledge |
 
 ## Common Pitfalls
 
 ### Quoting exe breaks launches
 
-Pre-quoting the exe path in `AddShortcut` or `SetShortcutExe` causes double-quoting. Steam tries to execute `""/path/to/exe""` and fails with "file not found." Always pass raw paths through the SteamClient API.
+Pre-quoting the exe path in `AddShortcut` or `SetShortcutExe` causes double-quoting. Steam tries to execute
+`""/path/to/exe""` and fails with "file not found." Always pass raw paths through the SteamClient API.
 
 ### Empty Set* params after AddShortcut
 
-Calling `Set*` methods too quickly after `AddShortcut` (before the 500ms delay) results in the properties not being saved. The shortcut appears in the library but with wrong or missing exe/startDir/launchOptions. Launches fail or open the wrong thing.
+Calling `Set*` methods too quickly after `AddShortcut` (before the 500ms delay) results in the properties not being
+saved. The shortcut appears in the library but with wrong or missing exe/startDir/launchOptions. Launches fail or open
+the wrong thing.
 
 ### Removal-churn can corrupt shortcut state
 
-`SetAppLaunchOptions` on an existing shortcut is reliable (validated in [#827](https://github.com/danielcopper/decky-romm-sync/issues/827); see [Updating existing shortcuts](#updating-existing-shortcuts)) — the historical "property updates may not persist" warning has been narrowed. The remaining hazard is **removal-churn**: adding and removing many shortcuts in one pass can corrupt Steam's in-memory shortcut state. A Steam restart clears it. The sync engine processes removals before additions to keep churn down, and every launch-options write uses the fire-then-poll `setLaunchOptionsConfirmed` so a silently dropped write is observable rather than assumed. Only `exe`/name changes still need delete + recreate, because those change the `appId`.
+`SetAppLaunchOptions` on an existing shortcut is reliable (validated in
+[#827](https://github.com/danielcopper/decky-romm-sync/issues/827); see
+[Updating existing shortcuts](#updating-existing-shortcuts)) — the historical "property updates may not persist" warning
+has been narrowed. The remaining hazard is **removal-churn**: adding and removing many shortcuts in one pass can corrupt
+Steam's in-memory shortcut state. A Steam restart clears it. The sync engine processes removals before additions to keep
+churn down, and every launch-options write uses the fire-then-poll `setLaunchOptionsConfirmed` so a silently dropped
+write is observable rather than assumed. Only `exe`/name changes still need delete + recreate, because those change the
+`appId`.
 
 ### AddShortcut timing between shortcuts
 
-When creating multiple shortcuts in a loop, a 50ms delay between each `addShortcut()` call prevents corrupting Steam's internal shortcut state. Without this delay, some shortcuts may silently fail to register.
+When creating multiple shortcuts in a loop, a 50ms delay between each `addShortcut()` call prevents corrupting Steam's
+internal shortcut state. Without this delay, some shortcuts may silently fail to register.

--- a/docs/architecture/steam-remote-play.md
+++ b/docs/architecture/steam-remote-play.md
@@ -2,24 +2,31 @@
 
 ## What Users See
 
-When a user runs the plugin on one machine (e.g. Steam Deck) and has another machine logged into the same Steam account on the same LAN (e.g. Bazzite HTPC), they may notice:
+When a user runs the plugin on one machine (e.g. Steam Deck) and has another machine logged into the same Steam account
+on the same LAN (e.g. Bazzite HTPC), they may notice:
 
-1. **Shortcuts appearing on other devices** — all non-Steam shortcuts from the source machine show up on the remote client
+1. **Shortcuts appearing on other devices** — all non-Steam shortcuts from the source machine show up on the remote
+   client
 2. **Missing artwork** — remote shortcuts appear without grid, hero, or logo images
-3. **Disappearing shortcuts** — when the source machine goes offline (sleep, shutdown, network loss), the shortcuts vanish from the remote client
-4. **No "Stream" vs "Play" confusion** — sometimes remote shortcuts show only a "Stream" button instead of the expected "Play"
+3. **Disappearing shortcuts** — when the source machine goes offline (sleep, shutdown, network loss), the shortcuts
+   vanish from the remote client
+4. **No "Stream" vs "Play" confusion** — sometimes remote shortcuts show only a "Stream" button instead of the expected
+   "Play"
 
 ## Root Cause: Steam In-Home Streaming Discovery Protocol
 
-This is **NOT** Steam Cloud syncing `shortcuts.vdf`. The `shortcuts.vdf` file is strictly local and never leaves the machine via Steam Cloud. Collections, on the other hand, do sync via Steam Cloud.
+This is **NOT** Steam Cloud syncing `shortcuts.vdf`. The `shortcuts.vdf` file is strictly local and never leaves the
+machine via Steam Cloud. Collections, on the other hand, do sync via Steam Cloud.
 
-What users observe is Steam's **In-Home Streaming / Remote Play discovery protocol** — a LAN-based mechanism for advertising available games to other Steam clients.
+What users observe is Steam's **In-Home Streaming / Remote Play discovery protocol** — a LAN-based mechanism for
+advertising available games to other Steam clients.
 
 ## Protocol Details
 
 ### Discovery Phase (UDP 27036)
 
-Steam clients periodically broadcast UDP packets on port 27036 to discover other Steam instances on the local network. When two clients running under the same Steam account find each other, they negotiate a TCP control connection.
+Steam clients periodically broadcast UDP packets on port 27036 to discover other Steam instances on the local network.
+When two clients running under the same Steam account find each other, they negotiate a TCP control connection.
 
 The discovery broadcast uses `CMsgRemoteClientBroadcastStatus` protobuf messages containing:
 
@@ -29,7 +36,8 @@ The discovery broadcast uses `CMsgRemoteClientBroadcastStatus` protobuf messages
 
 ### Control Connection (TCP)
 
-After discovery, the two clients establish a persistent TCP connection. Over this connection, the source client sends `CMsgRemoteClientAppStatus` messages that contain a `ShortcutInfo` submessage for each non-Steam shortcut.
+After discovery, the two clients establish a persistent TCP connection. Over this connection, the source client sends
+`CMsgRemoteClientAppStatus` messages that contain a `ShortcutInfo` submessage for each non-Steam shortcut.
 
 ### ShortcutInfo — What Gets Transmitted
 
@@ -45,13 +53,17 @@ The `ShortcutInfo` protobuf message (from `steammessages_remoteclient.proto`) in
 
 ### What Is NOT Transmitted
 
-- **Artwork files** — Grid (portrait), hero, logo, and wide grid images are stored as local files in `userdata/<id>/config/grid/`. These paths are not shared over the protocol. This is why remote shortcuts appear with placeholder/missing artwork.
+- **Artwork files** — Grid (portrait), hero, logo, and wide grid images are stored as local files in
+  `userdata/<id>/config/grid/`. These paths are not shared over the protocol. This is why remote shortcuts appear with
+  placeholder/missing artwork.
 - **Detailed metadata** — No description, genres, developer info, or other store-patched metadata transfers.
-- **Install state** — The remote client has no way to know if the game's ROM is actually downloaded on the source machine.
+- **Install state** — The remote client has no way to know if the game's ROM is actually downloaded on the source
+  machine.
 
 ### Ephemeral Nature
 
-The remote shortcuts exist only as long as the TCP control connection is alive. They are **not persisted** to the remote machine's `shortcuts.vdf`. When the source machine:
+The remote shortcuts exist only as long as the TCP control connection is alive. They are **not persisted** to the remote
+machine's `shortcuts.vdf`. When the source machine:
 
 - Goes to sleep
 - Shuts down
@@ -79,7 +91,8 @@ The plugin can distinguish local shortcuts from remote phantom shortcuts using t
 
 ### `collectionStore.localGamesCollection`
 
-This collection contains only shortcuts created on the local machine. Remote streaming phantoms are excluded. Use this to filter DangerZone removal operations to local-only shortcuts.
+This collection contains only shortcuts created on the local machine. Remote streaming phantoms are excluded. Use this
+to filter DangerZone removal operations to local-only shortcuts.
 
 ```typescript
 const localApps = collectionStore.localGamesCollection.apps;
@@ -88,7 +101,8 @@ const localApps = collectionStore.localGamesCollection.apps;
 
 ### `SteamAppOverview.per_client_data`
 
-Each `SteamAppOverview` object has a `per_client_data` array containing entries for each client that has advertised the app:
+Each `SteamAppOverview` object has a `per_client_data` array containing entries for each client that has advertised the
+app:
 
 ```typescript
 interface PerClientData {
@@ -103,33 +117,46 @@ A shortcut from a remote machine will have a `per_client_data` entry with a diff
 
 ### `SteamAppOverview.local_per_client_data`
 
-Returns only the local machine's `per_client_data` entry. If this is `undefined` or empty for a shortcut, it likely originates from a remote client.
+Returns only the local machine's `per_client_data` entry. If this is `undefined` or empty for a shortcut, it likely
+originates from a remote client.
 
 ## What the Plugin Does
 
 ### Machine-Scoped Collections
 
-Collections are named with the machine hostname, e.g. `"RomM: Nintendo 64 (steamdeck)"`. Since Steam Cloud syncs collections across devices, this prevents collection name collisions between machines. Each machine's collections are clearly attributed.
+Collections are named with the machine hostname, e.g. `"RomM: Nintendo 64 (steamdeck)"`. Since Steam Cloud syncs
+collections across devices, this prevents collection name collisions between machines. Each machine's collections are
+clearly attributed.
 
 ### What We Tried and Removed
 
 We investigated two approaches for programmatic detection of remote phantoms:
 
-1. **`collectionStore.localGamesCollection`** — Was supposed to contain only locally-created shortcuts, allowing us to filter out remote phantoms in DangerZone and label them in the game detail panel. **In practice, this was unreliable** — it incorrectly marked local shortcuts as remote.
+1. **`collectionStore.localGamesCollection`** — Was supposed to contain only locally-created shortcuts, allowing us to
+   filter out remote phantoms in DangerZone and label them in the game detail panel. **In practice, this was
+   unreliable** — it incorrectly marked local shortcuts as remote.
 
-2. **`SteamAppOverview.per_client_data`** — Was supposed to provide per-device metadata for each shortcut, allowing us to show which device a game came from. **This field is never populated for Non-Steam Shortcuts** — it only works for real Steam store games.
+2. **`SteamAppOverview.per_client_data`** — Was supposed to provide per-device metadata for each shortcut, allowing us
+   to show which device a game came from. **This field is never populated for Non-Steam Shortcuts** — it only works for
+   real Steam store games.
 
-Both approaches were removed. **Steam's native UI already handles this well**: remote phantom shortcuts show a "Stream" button instead of "Play", which clearly communicates that the game is available from another device.
+Both approaches were removed. **Steam's native UI already handles this well**: remote phantom shortcuts show a "Stream"
+button instead of "Play", which clearly communicates that the game is available from another device.
 
 ### DangerZone and Remote Phantoms
 
-DangerZone removal operations ("Remove All RomM Shortcuts", "Remove by Platform") use the **synced-ROM registry (the `roms` SQLite table)**, which is local-only. These operations can only affect shortcuts created by the plugin on the current machine. Remote streaming phantoms cannot be removed this way — and even if they could, they would reappear immediately since they're ephemeral entries from the live TCP connection.
+DangerZone removal operations ("Remove All RomM Shortcuts", "Remove by Platform") use the **synced-ROM registry (the
+`roms` SQLite table)**, which is local-only. These operations can only affect shortcuts created by the plugin on the
+current machine. Remote streaming phantoms cannot be removed this way — and even if they could, they would reappear
+immediately since they're ephemeral entries from the live TCP connection.
 
-The "Remove Non-Steam Games" section shows all non-Steam apps visible to the current client, including remote phantoms. Removing a phantom has no lasting effect — it reappears as long as the source device is online.
+The "Remove Non-Steam Games" section shows all non-Steam apps visible to the current client, including remote phantoms.
+Removing a phantom has no lasting effect — it reappears as long as the source device is online.
 
 ## What Can't Be Controlled
 
-- **No per-shortcut streaming opt-out** — all non-Steam shortcuts are advertised; there is no API to exclude specific ones
+- **No per-shortcut streaming opt-out** — all non-Steam shortcuts are advertised; there is no API to exclude specific
+  ones
 - **No artwork transfer** — artwork must be set locally on each machine; the streaming protocol doesn't carry it
 - **No persistence** — remote shortcuts are ephemeral and cannot be "saved" on the remote client
 
@@ -137,15 +164,21 @@ The "Remove Non-Steam Games" section shows all non-Steam apps visible to the cur
 
 ### Issue #8791: Name Collision
 
-When both the source and remote machine have a non-Steam shortcut with the same name, Steam may display incorrect metadata (mixing fields from both entries). This can occur when both machines run the plugin and sync the same RomM library.
+When both the source and remote machine have a non-Steam shortcut with the same name, Steam may display incorrect
+metadata (mixing fields from both entries). This can occur when both machines run the plugin and sync the same RomM
+library.
 
 ### Issue #12315: "Stream" Button Regression
 
-A regression in certain Steam client versions causes remote non-Steam shortcuts to only show a "Stream" button instead of allowing direct local launch. This affects users who have the same game installed locally but also see it advertised from a remote client.
+A regression in certain Steam client versions causes remote non-Steam shortcuts to only show a "Stream" button instead
+of allowing direct local launch. This affects users who have the same game installed locally but also see it advertised
+from a remote client.
 
 ## References
 
-- [SteamDatabase/Protobufs](https://github.com/SteamDatabase/Protobufs) — Decompiled Steam protobuf definitions including `steammessages_remoteclient.proto`
-- [Coding Range: Steam In-Home Streaming Discovery Protocol](https://codingrange.com/coding/2015/09/05/steam-in-home-streaming-discovery-protocol.html) — Detailed protocol analysis
+- [SteamDatabase/Protobufs](https://github.com/SteamDatabase/Protobufs) — Decompiled Steam protobuf definitions
+  including `steammessages_remoteclient.proto`
+- [Coding Range: Steam In-Home Streaming Discovery Protocol](https://codingrange.com/coding/2015/09/05/steam-in-home-streaming-discovery-protocol.html)
+  — Detailed protocol analysis
 - [IHSlib](https://github.com/nicfit/ihslib) — Python library implementing the Steam In-Home Streaming protocol
 - [steam-discover](https://github.com/nicfit/steam-discover) — CLI tool for discovering Steam clients on the network

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -17,7 +17,8 @@ mise install          # installs Node LTS, pnpm, Python
 mise run setup        # installs JS + Python dependencies
 ```
 
-This creates a Python virtual environment (auto-activated by mise via `_.python.venv` in `mise.toml`) and installs all npm packages.
+This creates a Python virtual environment (auto-activated by mise via `_.python.venv` in `mise.toml`) and installs all
+npm packages.
 
 ## Building
 
@@ -40,9 +41,12 @@ To run with coverage:
 python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch
 ```
 
-Tests mirror the source layout (`tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`), with each test file mapping 1:1 to a source module. Shared mocks live in `tests/conftest.py`, which also provides a mock `decky` module so tests run without Decky Loader.
+Tests mirror the source layout (`tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`),
+with each test file mapping 1:1 to a source module. Shared mocks live in `tests/conftest.py`, which also provides a mock
+`decky` module so tests run without Decky Loader.
 
-Frontend component tests run with `mise run test:frontend` (`pnpm test`); see the CLAUDE.md "Frontend component tests" section for the `@decky/api` event harness.
+Frontend component tests run with `mise run test:frontend` (`pnpm test`); see the CLAUDE.md "Frontend component tests"
+section for the `@decky/api` event harness.
 
 Every backend feature or callable where testing makes sense should have unit tests covering:
 
@@ -56,7 +60,8 @@ Every backend feature or callable where testing makes sense should have unit tes
 mise run dev          # builds frontend + restarts plugin_loader
 ```
 
-This runs `pnpm build` and then `sudo systemctl restart plugin_loader` to pick up changes. For backend-only changes, restarting the plugin loader is sufficient without rebuilding.
+This runs `pnpm build` and then `sudo systemctl restart plugin_loader` to pick up changes. For backend-only changes,
+restarting the plugin loader is sufficient without rebuilding.
 
 ## Deploying to Device
 
@@ -83,17 +88,22 @@ The `.importlinter` config enforces the layer boundary contracts:
 - Utilities (`lib/`) must not import services, adapters, or domain
 - Domain must not import services or adapters (`lib` is allowed)
 - Models must not import services, adapters, domain, or lib
-- Services must not import stdlib I/O / non-deterministic primitives (`time`, `uuid`, `random`, `subprocess`, `threading`, `requests`)
+- Services must not import stdlib I/O / non-deterministic primitives (`time`, `uuid`, `random`, `subprocess`,
+  `threading`, `requests`)
 - Services must be independent of each other (no cross-service imports)
 
-`mise run lint` also runs `scripts/check_cosmic_call_bans.sh`, which complements the import rules at the call site: services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` / `random.*` directly — they inject the `Clock` / `Sleeper` / `UuidGen` Protocol instead.
+`mise run lint` also runs `scripts/check_cosmic_call_bans.sh`, which complements the import rules at the call site:
+services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` /
+`random.*` directly — they inject the `Clock` / `Sleeper` / `UuidGen` Protocol instead.
 
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality
 
-- **SonarCloud** — CI-based analysis on every PR and push to main. Quality Gate enforces 80% coverage on new code, 0 bugs, 0 vulnerabilities.
-- **Ruff** — Python linting in CI. Expanded ruleset includes B (bugbear), SIM (simplify), UP (pyupgrade), RUF (ruff-specific), and ARG (unused arguments) in addition to the base E/F rules.
+- **SonarCloud** — CI-based analysis on every PR and push to main. Quality Gate enforces 80% coverage on new code, 0
+  bugs, 0 vulnerabilities.
+- **Ruff** — Python linting in CI. Expanded ruleset includes B (bugbear), SIM (simplify), UP (pyupgrade), RUF
+  (ruff-specific), and ARG (unused arguments) in addition to the base E/F rules.
 - **basedpyright** — Type checking in CI. Checks all source files including the test suite (tests/ is not excluded).
 - **import-linter** — Layer boundary enforcement in CI (see Linting section above).
 - **pytest-cov** — Branch coverage reported to SonarCloud.
@@ -147,4 +157,5 @@ defaults/config.json                 # platform_map: 149 platform slug -> RetroD
 tests/                               # Backend unit tests, mirroring py_modules/ layout
 ```
 
-See [Backend Architecture](../architecture/backend-architecture.md) for the service/adapter design, dependency diagram, and layer enforcement rules.
+See [Backend Architecture](../architecture/backend-architecture.md) for the service/adapter design, dependency diagram,
+and layer enforcement rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,8 @@
 
 # decky-romm-sync
 
-A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](https://github.com/rommapp/romm) ROM library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](https://retrodeck.net/).
+A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](https://github.com/rommapp/romm) ROM
+library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](https://retrodeck.net/).
 
 - Browse your entire RomM library directly from Steam's Gaming Mode
 - Download ROMs on-demand with cover art, hero banners, logos, and metadata
@@ -14,11 +15,15 @@ A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](h
 ## User Guide
 
 1. **[Getting Started](user-guide/getting-started.md)** — Prerequisites, installation, and first-time setup
-2. **[Configuration](user-guide/configuration.md)** — Connection settings, SteamGridDB API key, Steam Input, debug options
-3. **[Syncing Your Library](user-guide/syncing-your-library.md)** — How sync works, per-platform toggles, collections, artwork
-4. **[Managing Games](user-guide/managing-games.md)** — Game detail panel, downloading ROMs, uninstalling, refreshing metadata
+2. **[Configuration](user-guide/configuration.md)** — Connection settings, SteamGridDB API key, Steam Input, debug
+   options
+3. **[Syncing Your Library](user-guide/syncing-your-library.md)** — How sync works, per-platform toggles, collections,
+   artwork
+4. **[Managing Games](user-guide/managing-games.md)** — Game detail panel, downloading ROMs, uninstalling, refreshing
+   metadata
 5. **[BIOS Management](user-guide/bios-management.md)** — What BIOS files are, checking status, downloading per-platform
-6. **[RetroDECK Path Migration](user-guide/retrodeck-path-migration.md)** — Moving your RetroDECK installation between storage locations
+6. **[RetroDECK Path Migration](user-guide/retrodeck-path-migration.md)** — Moving your RetroDECK installation between
+   storage locations
 7. **[Save Sync](user-guide/save-sync.md)** — Auto-sync, conflict resolution modes, manual sync, failed sync retries
 8. **[Troubleshooting](user-guide/troubleshooting.md)** — Common issues, fixes, Danger Zone explained
 
@@ -26,9 +31,14 @@ A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](h
 
 Developer-oriented documentation for contributors and those interested in the internals.
 
-- **[Steam Non-Steam Shortcuts](architecture/steam-non-steam-shortcuts.md)** — AddShortcut API, VDF format, app ID generation
-- **[Backend Architecture](architecture/backend-architecture.md)** — Service/adapter architecture, dependency diagram, boundary enforcement
-- **[Config Source Parsers](architecture/config-source-parsers.md)** — One-parser-per-source principle, source catalog, parser layout template for local config/metadata files
+- **[Steam Non-Steam Shortcuts](architecture/steam-non-steam-shortcuts.md)** — AddShortcut API, VDF format, app ID
+  generation
+- **[Backend Architecture](architecture/backend-architecture.md)** — Service/adapter architecture, dependency diagram,
+  boundary enforcement
+- **[Config Source Parsers](architecture/config-source-parsers.md)** — One-parser-per-source principle, source catalog,
+  parser layout template for local config/metadata files
 - **[Development](contributing/development.md)** — Developer setup, building, testing, dev reload
-- **[Save File Sync Architecture](architecture/save-file-sync-architecture.md)** — Three-way conflict detection, session tracking, state schema, device registration
-- **[Steam Remote Play and Cross-Device Shortcuts](architecture/steam-remote-play.md)** — Remote Play discovery protocol, phantom shortcuts, detection APIs
+- **[Save File Sync Architecture](architecture/save-file-sync-architecture.md)** — Three-way conflict detection, session
+  tracking, state schema, device registration
+- **[Steam Remote Play and Cross-Device Shortcuts](architecture/steam-remote-play.md)** — Remote Play discovery
+  protocol, phantom shortcuts, detection APIs

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -1,10 +1,12 @@
 # BIOS Management
 
-Some emulated systems require BIOS files to run games. Without the correct BIOS files, games for those systems will fail to launch. The plugin can download BIOS files directly from your RomM server.
+Some emulated systems require BIOS files to run games. Without the correct BIOS files, games for those systems will fail
+to launch. The plugin can download BIOS files directly from your RomM server.
 
 ## What Are BIOS Files?
 
-BIOS (Basic Input/Output System) files are firmware dumps from original hardware. Emulators need them to accurately simulate the console's boot process. Common examples:
+BIOS (Basic Input/Output System) files are firmware dumps from original hardware. Emulators need them to accurately
+simulate the console's boot process. Common examples:
 
 - **PlayStation** — `scph5501.bin` (and other regional variants)
 - **Dreamcast** — `dc_boot.bin`, `dc_flash.bin`
@@ -14,7 +16,8 @@ Not all systems need BIOS files. Cartridge-based systems like Game Boy, SNES, an
 
 ## BIOS Status on the Game Detail Page
 
-When you open a game that belongs to a platform with BIOS files on your RomM server, the game detail panel shows a BIOS status indicator:
+When you open a game that belongs to a platform with BIOS files on your RomM server, the game detail panel shows a BIOS
+status indicator:
 
 - **Green** — "BIOS ready (X files)" — all BIOS files are downloaded
 - **Orange** — "BIOS required — X/Y downloaded" — some files are missing
@@ -37,62 +40,82 @@ The dedicated BIOS management page shows all platforms that have firmware files 
 
 <!-- Screenshot: BIOS Manager page showing platforms with download counts and Download All buttons -->
 
-BIOS files are downloaded to your RetroDECK bios directory (e.g. `~/retrodeck/bios/`). Some platforms use subdirectories — for example, Dreamcast BIOS goes into `bios/dc/` and PS2 BIOS goes into `bios/pcsx2/bios/`. The plugin handles the correct placement automatically.
+BIOS files are downloaded to your RetroDECK bios directory (e.g. `~/retrodeck/bios/`). Some platforms use subdirectories
+— for example, Dreamcast BIOS goes into `bios/dc/` and PS2 BIOS goes into `bios/pcsx2/bios/`. The plugin handles the
+correct placement automatically.
 
 ## Which Systems Need BIOS?
 
-This depends on what's uploaded to your RomM server. Common systems that require BIOS files include PlayStation, PS2, Saturn, Dreamcast, and some arcade systems. The plugin only shows BIOS status for platforms that have firmware files in your RomM library.
+This depends on what's uploaded to your RomM server. Common systems that require BIOS files include PlayStation, PS2,
+Saturn, Dreamcast, and some arcade systems. The plugin only shows BIOS status for platforms that have firmware files in
+your RomM library.
 
 ## Per-Platform BIOS Filtering
 
-The plugin only shows BIOS files that belong to the platform you're looking at. For example, a GBA game page shows `gba_bios.bin` only — not Game Boy or Game Boy Color BIOS files, even though the emulator core (mGBA) supports all three systems. This filtering is built into the BIOS registry and works automatically.
+The plugin only shows BIOS files that belong to the platform you're looking at. For example, a GBA game page shows
+`gba_bios.bin` only — not Game Boy or Game Boy Color BIOS files, even though the emulator core (mGBA) supports all three
+systems. This filtering is built into the BIOS registry and works automatically.
 
 ## Active Core Detection
 
-Different emulator cores can have different BIOS requirements for the same platform. The plugin detects which core RetroDECK is actually configured to use and filters the BIOS list accordingly, so you only see the files that matter for your setup.
+Different emulator cores can have different BIOS requirements for the same platform. The plugin detects which core
+RetroDECK is actually configured to use and filters the BIOS list accordingly, so you only see the files that matter for
+your setup.
 
 ### Example: Game Boy Advance
 
-- With **mGBA** (RetroDECK's default), `gba_bios.bin` is shown as *optional* — mGBA has a built-in high-level BIOS replacement
-- With **gpSP**, `gba_bios.bin` is shown as *required* — gpSP cannot run without it
+- With **mGBA** (RetroDECK's default), `gba_bios.bin` is shown as _optional_ — mGBA has a built-in high-level BIOS
+  replacement
+- With **gpSP**, `gba_bios.bin` is shown as _required_ — gpSP cannot run without it
 
-The active core name appears as a badge in both the game detail page BIOS indicator and the BIOS Manager. This tells you at a glance which core the plugin is filtering for.
+The active core name appears as a badge in both the game detail page BIOS indicator and the BIOS Manager. This tells you
+at a glance which core the plugin is filtering for.
 
 **How the core is determined:**
 
 1. If a per-game override exists in ES-DE's `gamelist.xml` (via `<altemulator>`), the plugin uses that first
 2. If no per-game override, the plugin checks for a per-system override in `gamelist.xml` (via `<alternativeEmulator>`)
-3. The plugin reads RetroDECK's ES-DE configuration (`es_systems.xml`) from the flatpak installation to find the default emulator for each platform — the first listed RetroArch core is treated as the default
-4. If the live configuration can't be read, the plugin falls back to a shipped `core_defaults.json` with RetroDECK's known defaults
+3. The plugin reads RetroDECK's ES-DE configuration (`es_systems.xml`) from the flatpak installation to find the default
+   emulator for each platform — the first listed RetroArch core is treated as the default
+4. If the live configuration can't be read, the plugin falls back to a shipped `core_defaults.json` with RetroDECK's
+   known defaults
 5. If all detection fails, all BIOS files for the platform are shown — the safe default
 
-The detection chain ensures BIOS filtering works even when RetroDECK's configuration files aren't accessible (e.g. after an update changes paths). You'll see a "Core: mGBA" badge when detection is working, or no badge when falling back to showing all files.
+The detection chain ensures BIOS filtering works even when RetroDECK's configuration files aren't accessible (e.g. after
+an update changes paths). You'll see a "Core: mGBA" badge when detection is working, or no badge when falling back to
+showing all files.
 
 ## Changing the Active Core
 
-You can change the active emulator core directly from the plugin, without leaving Game Mode. Changes are written to ES-DE's `gamelist.xml` so they persist across sessions and are picked up by both the plugin and ES-DE.
+You can change the active emulator core directly from the plugin, without leaving Game Mode. Changes are written to
+ES-DE's `gamelist.xml` so they persist across sessions and are picked up by both the plugin and ES-DE.
 
 ### Per-Platform (BIOS Manager)
 
-In the BIOS Manager, platforms with multiple available cores show an **Active Core** dropdown. Changing this sets the default core for all games on that platform.
+In the BIOS Manager, platforms with multiple available cores show an **Active Core** dropdown. Changing this sets the
+default core for all games on that platform.
 
 1. Open the BIOS Manager from the main QAM page
 2. Find the platform you want to change
 3. Use the **Active Core** dropdown to select a different core
 4. The BIOS file list updates immediately to show files relevant to the new core
 
-This writes a system-wide override to ES-DE's `gamelist.xml`. ES-DE will pick up the change on next launch. The BIOS Manager works even when your RomM server is offline — core switching and BIOS status are available, only download buttons are disabled.
+This writes a system-wide override to ES-DE's `gamelist.xml`. ES-DE will pick up the change on next launch. The BIOS
+Manager works even when your RomM server is offline — core switching and BIOS status are available, only download
+buttons are disabled.
 
 ### Per-Game (Game Detail Page)
 
-On the game detail page, a **CPU button** (microchip icon) appears between the RomM and Steam gear buttons when multiple cores are available for the game's platform.
+On the game detail page, a **CPU button** (microchip icon) appears between the RomM and Steam gear buttons when multiple
+cores are available for the game's platform.
 
 1. Open a game's detail page
 2. Tap the **CPU button** (microchip icon)
 3. Pick a core from the menu — the current core is marked with a checkmark
 4. The BIOS status, core badge, and game info panel update immediately
 
-A per-game override takes priority over the platform default. To reset back to the platform default, select the default core (marked with "(default)") from the menu — this clears the per-game override.
+A per-game override takes priority over the platform default. To reset back to the platform default, select the default
+core (marked with "(default)") from the menu — this clears the per-game override.
 
 ### Non-Default Core Indicator
 
@@ -101,7 +124,8 @@ The CPU button changes color to indicate the active core status:
 - **Gray** — the default core is active (no overrides)
 - **Yellow** — a non-default core is active (per-game or per-platform override)
 
-The game detail info panel shows the active core in a dedicated "Emulator" column alongside the BIOS status, using a two-column layout.
+The game detail info panel shows the active core in a dedicated "Emulator" column alongside the BIOS status, using a
+two-column layout.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,6 +1,7 @@
 # Configuration
 
-All settings are accessible from the plugin's QAM panel. Open the Quick Access Menu (**...** button) and navigate to the decky-romm-sync plugin.
+All settings are accessible from the plugin's QAM panel. Open the Quick Access Menu (**...** button) and navigate to the
+decky-romm-sync plugin.
 
 ## Connection Settings
 
@@ -8,14 +9,22 @@ The Connection Settings page manages your RomM server connection.
 
 <!-- Screenshot: Connection Settings page -->
 
-- **RomM URL** — the full URL of your RomM server, including port if needed (e.g. `http://192.168.1.100:8080`). Tap **Edit** to change it; the URL saves automatically.
-- **RomM Account** — shows **Connected** once a token is stored, or **Not connected** otherwise. Tap **Connect** to open a one-time prompt for your RomM username and password. The plugin exchanges them for a RomM Client API Token and stores only the token; your password is discarded after the token is minted and never saved. The username and password are write-only — they are never pre-filled or shown back to you. If your account cannot create API tokens, the status reports that.
-- **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN only).
+- **RomM URL** — the full URL of your RomM server, including port if needed (e.g. `http://192.168.1.100:8080`). Tap
+  **Edit** to change it; the URL saves automatically.
+- **RomM Account** — shows **Connected** once a token is stored, or **Not connected** otherwise. Tap **Connect** to open
+  a one-time prompt for your RomM username and password. The plugin exchanges them for a RomM Client API Token and
+  stores only the token; your password is discarded after the token is minted and never saved. The username and password
+  are write-only — they are never pre-filled or shown back to you. If your account cannot create API tokens, the status
+  reports that.
+- **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
+  only).
 - **Test Connection** — verifies the plugin can reach and authenticate with your RomM server using the stored token.
 
 ## SteamGridDB API Key
 
-The plugin uses [SteamGridDB](https://www.steamgriddb.com/) to fetch additional artwork for your games — hero banners, logos, and wide grid images. RomM provides cover art, but SteamGridDB fills in the rest so your games look like first-class Steam titles.
+The plugin uses [SteamGridDB](https://www.steamgriddb.com/) to fetch additional artwork for your games — hero banners,
+logos, and wide grid images. RomM provides cover art, but SteamGridDB fills in the rest so your games look like
+first-class Steam titles.
 
 To set this up:
 
@@ -26,17 +35,19 @@ To set this up:
 
 <!-- Screenshot: SteamGridDB API Key section with Edit and Verify buttons -->
 
-Without an API key, games will still have cover art from RomM but the hero banner, logo overlay, and wide grid image will be missing.
+Without an API key, games will still have cover art from RomM but the hero banner, logo overlay, and wide grid image
+will be missing.
 
 ## Steam Input Mode
 
-Controls how Steam handles controller input for ROM shortcuts. Found under the **Controller** section in Connection Settings.
+Controls how Steam handles controller input for ROM shortcuts. Found under the **Controller** section in Connection
+Settings.
 
-| Mode | Description |
-| --- | --- |
-| **Default** (Recommended) | Uses your global Steam Input settings. Works well with RetroDECK's default configuration. |
-| **Force On** | Explicitly enables Steam Input wrapping. Normalizes the controller as standard XInput, which RetroArch autoconfig expects. |
-| **Force Off** | Raw HID passthrough. Only for advanced users — may break RetroArch menu navigation. |
+| Mode                      | Description                                                                                                                |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Default** (Recommended) | Uses your global Steam Input settings. Works well with RetroDECK's default configuration.                                  |
+| **Force On**              | Explicitly enables Steam Input wrapping. Normalizes the controller as standard XInput, which RetroArch autoconfig expects. |
+| **Force Off**             | Raw HID passthrough. Only for advanced users — may break RetroArch menu navigation.                                        |
 
 After changing the mode, tap **Apply to All Shortcuts** to update all existing ROM shortcuts.
 
@@ -46,18 +57,21 @@ After changing the mode, tap **Apply to All Shortcuts** to update all existing R
 
 A dropdown in the **Advanced** section on the main page. Controls how much detail the plugin logs.
 
-| Level | Description |
-| --- | --- |
-| **Error** | Only errors — minimal output |
-| **Warn** (default) | Errors and warnings |
-| **Info** | General operational messages |
-| **Debug** | Verbose output for troubleshooting |
+| Level              | Description                        |
+| ------------------ | ---------------------------------- |
+| **Error**          | Only errors — minimal output       |
+| **Warn** (default) | Errors and warnings                |
+| **Info**           | General operational messages       |
+| **Debug**          | Verbose output for troubleshooting |
 
-Leave this at **Warn** unless you're investigating an issue. Switch to **Debug** when reporting bugs or diagnosing problems.
+Leave this at **Warn** unless you're investigating an issue. Switch to **Debug** when reporting bugs or diagnosing
+problems.
 
 ## RetroArch Input Driver Fix
 
-If the plugin detects that RetroArch is using the `x` input driver (which causes controller issues in menus on Wayland systems), a warning appears on the main page with a **Change to sdl2** button. This modifies your RetroArch config to use `sdl2` instead, which fixes controller navigation in RetroArch menus.
+If the plugin detects that RetroArch is using the `x` input driver (which causes controller issues in menus on Wayland
+systems), a warning appears on the main page with a **Change to sdl2** button. This modifies your RetroArch config to
+use `sdl2` instead, which fixes controller navigation in RetroArch menus.
 
 <!-- Screenshot: RetroArch input_driver warning with fix button -->
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -2,17 +2,25 @@
 
 ## What is decky-romm-sync?
 
-decky-romm-sync is a [Decky Loader](https://decky.xyz/) plugin that connects your self-hosted [RomM](https://github.com/rommapp/romm) ROM library to Steam. Every game in your RomM library appears as a Non-Steam shortcut in the Steam Library, complete with cover art, metadata, and collections. Games launch through [RetroDECK](https://retrodeck.net/).
+decky-romm-sync is a [Decky Loader](https://decky.xyz/) plugin that connects your self-hosted
+[RomM](https://github.com/rommapp/romm) ROM library to Steam. Every game in your RomM library appears as a Non-Steam
+shortcut in the Steam Library, complete with cover art, metadata, and collections. Games launch through
+[RetroDECK](https://retrodeck.net/).
 
 ## Prerequisites
 
 Before installing the plugin, you need:
 
-1. **A RomM server** — a running RomM instance with your ROM library. You'll need the server URL plus a username and password to connect the first time. The plugin exchanges those credentials for a RomM Client API Token and stores only the token — your password is never saved. Each user should have their own RomM account (see [Save Sync](save-sync.md) for why this matters).
+1. **A RomM server** — a running RomM instance with your ROM library. You'll need the server URL plus a username and
+   password to connect the first time. The plugin exchanges those credentials for a RomM Client API Token and stores
+   only the token — your password is never saved. Each user should have their own RomM account (see
+   [Save Sync](save-sync.md) for why this matters).
 
-2. **RetroDECK** — installed on your Steam Deck or Linux PC. RetroDECK handles the actual emulation. The plugin creates shortcuts that launch games through RetroDECK.
+2. **RetroDECK** — installed on your Steam Deck or Linux PC. RetroDECK handles the actual emulation. The plugin creates
+   shortcuts that launch games through RetroDECK.
 
-3. **Decky Loader** — the plugin framework for Steam's Gaming Mode. Install it from [decky.xyz](https://decky.xyz/) if you haven't already.
+3. **Decky Loader** — the plugin framework for Steam's Gaming Mode. Install it from [decky.xyz](https://decky.xyz/) if
+   you haven't already.
 
 4. **A personal RomM account** — save sync ties saves to the authenticated user. Use your own account, not a shared one.
 
@@ -40,9 +48,12 @@ Before installing the plugin, you need:
 
 6. Decky downloads and installs the plugin automatically — no restart needed
 
-**Tip:** You can also open the [releases page](https://github.com/danielcopper/decky-romm-sync/releases) in Steam's built-in browser (Gaming Mode → long-press the Steam button → Web Browser), long-press the zip download link, and copy the URL from there.
+**Tip:** You can also open the [releases page](https://github.com/danielcopper/decky-romm-sync/releases) in Steam's
+built-in browser (Gaming Mode → long-press the Steam button → Web Browser), long-press the zip download link, and copy
+the URL from there.
 
-Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc.) as long as it points to a valid `.zip` containing the plugin.
+Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc.) as long as it points to a valid
+`.zip` containing the plugin.
 
 ### Manual installation (alternative)
 
@@ -61,11 +72,15 @@ After installation, you need to connect the plugin to your RomM server:
 4. Tap **Connect**, enter your RomM username and password once, and confirm
 5. The **RomM Account** row shows **Connected** on success. Tap **Test Connection** to re-verify at any time
 
-The plugin mints a RomM Client API Token from the credentials you enter and discards the password — it is never stored. The same applies if the plugin auto-migrates an older install that still had a saved password: the password is discarded as soon as a token is minted. If your RomM account is not allowed to create API tokens, the Connect step reports that and you'll need an account with token permissions.
+The plugin mints a RomM Client API Token from the credentials you enter and discards the password — it is never stored.
+The same applies if the plugin auto-migrates an older install that still had a saved password: the password is discarded
+as soon as a token is minted. If your RomM account is not allowed to create API tokens, the Connect step reports that
+and you'll need an account with token permissions.
 
 <!-- Screenshot: Connection Settings page with URL field, Connect button, and token status -->
 
-Once connected, you're ready to sync your library. See [Configuration](configuration.md) for additional settings, or jump straight to [Syncing Your Library](syncing-your-library.md).
+Once connected, you're ready to sync your library. See [Configuration](configuration.md) for additional settings, or
+jump straight to [Syncing Your Library](syncing-your-library.md).
 
 ---
 

--- a/docs/user-guide/managing-games.md
+++ b/docs/user-guide/managing-games.md
@@ -1,10 +1,12 @@
 # Managing Games
 
-After syncing, each game in your Steam Library that came from RomM has an injected **RomM Sync** panel on its detail page. This panel handles downloads, artwork, BIOS status, save sync, and more.
+After syncing, each game in your Steam Library that came from RomM has an injected **RomM Sync** panel on its detail
+page. This panel handles downloads, artwork, BIOS status, save sync, and more.
 
 ## The Game Detail Panel
 
-When you open a RomM game in the Steam Library, you'll see the RomM Sync panel below the standard Steam content. It shows:
+When you open a RomM game in the Steam Library, you'll see the RomM Sync panel below the standard Steam content. It
+shows:
 
 - **Status badge** — "Installed", "Downloading", or "Not Installed"
 - **Platform name** — which system the game belongs to (e.g. "Game Boy Advance")
@@ -31,7 +33,8 @@ Downloaded ROMs are stored in your RetroDECK roms directory (e.g. `~/retrodeck/r
 
 ### Multi-Disc Games
 
-Multi-disc games (e.g. multi-disc PS1 titles) are downloaded as a single ZIP from RomM, extracted automatically, and an M3U playlist file is used for disc switching. This is handled transparently — just download and play.
+Multi-disc games (e.g. multi-disc PS1 titles) are downloaded as a single ZIP from RomM, extracted automatically, and an
+M3U playlist file is used for disc switching. This is handled transparently — just download and play.
 
 ## Uninstalling ROMs
 
@@ -52,11 +55,20 @@ Tap **Refresh Metadata** in the game detail panel to:
 - Re-fetch game metadata (description, developer, genres, release date) from RomM
 - Update the native Steam display with the latest information
 
-This is useful if artwork was missing on first sync (SteamGridDB may have added new images since) or if metadata has changed on your RomM server.
+This is useful if artwork was missing on first sync (SteamGridDB may have added new images since) or if metadata has
+changed on your RomM server.
 
-When you tap **Refresh Artwork**, the plugin asks your RomM server which SteamGridDB game the ROM maps to and applies the hero banner, logo, wide grid, and icon for that game. **RomM is the source of truth**: whenever your server has a SteamGridDB id for a game, that id wins — on both sync and refresh. If RomM has no id, the plugin tries to derive one from the game's IGDB id. Only when neither resolves a SteamGridDB game does a picker open, where you search SteamGridDB by name and choose from the results (with thumbnails). A name pick is applied immediately but is **not permanent** — once your RomM server has a SteamGridDB id for that game, that id takes over. Because a manual pick isn't stored as the resolved id, you can change it any time: just tap **Refresh Artwork** again and the picker reopens. To pin a specific match for good, set the SteamGridDB id on the game in RomM.
+When you tap **Refresh Artwork**, the plugin asks your RomM server which SteamGridDB game the ROM maps to and applies
+the hero banner, logo, wide grid, and icon for that game. **RomM is the source of truth**: whenever your server has a
+SteamGridDB id for a game, that id wins — on both sync and refresh. If RomM has no id, the plugin tries to derive one
+from the game's IGDB id. Only when neither resolves a SteamGridDB game does a picker open, where you search SteamGridDB
+by name and choose from the results (with thumbnails). A name pick is applied immediately but is **not permanent** —
+once your RomM server has a SteamGridDB id for that game, that id takes over. Because a manual pick isn't stored as the
+resolved id, you can change it any time: just tap **Refresh Artwork** again and the picker reopens. To pin a specific
+match for good, set the SteamGridDB id on the game in RomM.
 
-The full set of per-game actions — refresh artwork, refresh metadata, sync save files, download BIOS, and uninstall — is available from the RomM Actions menu in the game detail panel.
+The full set of per-game actions — refresh artwork, refresh metadata, sync save files, download BIOS, and uninstall — is
+available from the RomM Actions menu in the game detail panel.
 
 ![RomM Actions context menu with Refresh Artwork, Sync Save Files, Download BIOS, and Uninstall entries](../assets/screenshot-actions.jpg)
 
@@ -78,7 +90,8 @@ Select any installed game in the Steam Library and press **Play**. The plugin's 
 2. Launches RetroDECK with the correct ROM
 3. RetroDECK auto-detects the system from the ROM's directory path and uses the appropriate emulator
 
-If the ROM is not downloaded, the launcher will request a download — you'll get a toast notification and can play once the download completes.
+If the ROM is not downloaded, the launcher will request a download — you'll get a toast notification and can play once
+the download completes.
 
 ---
 

--- a/docs/user-guide/retrodeck-path-migration.md
+++ b/docs/user-guide/retrodeck-path-migration.md
@@ -1,12 +1,16 @@
 # RetroDECK Path Migration
 
-If you move your RetroDECK installation to a different location — for example, from internal storage to an SD card, or vice versa — the plugin detects the change and helps you migrate your downloaded files so everything keeps working.
+If you move your RetroDECK installation to a different location — for example, from internal storage to an SD card, or
+vice versa — the plugin detects the change and helps you migrate your downloaded files so everything keeps working.
 
 ## How It Works
 
-Every time the plugin starts, it compares the current RetroDECK home path with the path it had stored from your last session. If the paths differ, the plugin flags a migration. This typically happens after you use RetroDECK's built-in move tool or manually relocate your `retrodeck/` directory.
+Every time the plugin starts, it compares the current RetroDECK home path with the path it had stored from your last
+session. If the paths differ, the plugin flags a migration. This typically happens after you use RetroDECK's built-in
+move tool or manually relocate your `retrodeck/` directory.
 
-The plugin does not move your RetroDECK files — RetroDECK handles that. What the plugin migrates are the files *it* manages: downloaded ROMs, BIOS files, and save files that it tracks for sync purposes.
+The plugin does not move your RetroDECK files — RetroDECK handles that. What the plugin migrates are the files _it_
+manages: downloaded ROMs, BIOS files, and save files that it tracks for sync purposes.
 
 ## Warning Banners
 
@@ -30,10 +34,12 @@ The plugin updates its internal tracking to point to the new paths and moves any
 
 ## Conflict Handling
 
-If files already exist at the destination (for example, you copied some files manually before migrating), a popup appears with three choices:
+If files already exist at the destination (for example, you copied some files manually before migrating), a popup
+appears with three choices:
 
 - **Overwrite** — Replace the existing files at the destination with the ones being migrated
-- **Skip** — Keep the existing files at the destination and just update the plugin's internal path references to point to them
+- **Skip** — Keep the existing files at the destination and just update the plugin's internal path references to point
+  to them
 - **Cancel** — Abort the migration entirely; no files are moved and no paths are updated
 
 ## What Gets Migrated
@@ -41,10 +47,12 @@ If files already exist at the destination (for example, you copied some files ma
 The migration covers three categories of files:
 
 - **ROMs** — All ROMs tracked in the plugin's state (previously downloaded through the plugin)
-- **BIOS files** — Both files the plugin downloaded and untracked files that match known entries in the BIOS registry (e.g. files you placed manually that the plugin recognizes)
+- **BIOS files** — Both files the plugin downloaded and untracked files that match known entries in the BIOS registry
+  (e.g. files you placed manually that the plugin recognizes)
 - **Save files** — Recursively scanned from the save directories, excluding hidden directories (like `.git` or `.tmp`)
 
-Files that the plugin doesn't know about — ROMs you added outside the plugin, for instance — are not affected. RetroDECK's own move tool handles those.
+Files that the plugin doesn't know about — ROMs you added outside the plugin, for instance — are not affected.
+RetroDECK's own move tool handles those.
 
 ---
 

--- a/docs/user-guide/save-file-extensions.md
+++ b/docs/user-guide/save-file-extensions.md
@@ -3,6 +3,16 @@
 Research results for which save file extensions RetroDECK cores produce, and what our plugin needs to support. This
 informs the implementation of [#196](https://github.com/danielcopper/decky-romm-sync/issues/196).
 
+!!! note "Superseded in part by the full audit"
+
+    A later core-by-core audit of all 155 RetroDECK cores is captured in the
+    [Save sync support matrix](save-sync-support-matrix.md), with the rationale in
+    [Save sync coverage](../architecture/save-sync-coverage.md). It **revisits some assumptions on this page** —
+    notably that Saturn (Beetle Saturn writes `.bkr`/`.bcr`/`.smpc`, not `.srm`), Neo Geo Pocket (`.flash`/`.ngf`),
+    and Pokémon Mini (`.eep`) are _not_ standard `.srm`. Those rows are documented by libretro but still await
+    on-device confirmation ([#237](https://github.com/danielcopper/decky-romm-sync/issues/237)). Treat the matrix as
+    the broader, current view; this page remains the record of the original `.srm`/`.dsv`/`.brm` decision.
+
 ## How RetroArch Save Extensions Work
 
 RetroArch has two save mechanisms:

--- a/docs/user-guide/save-file-extensions.md
+++ b/docs/user-guide/save-file-extensions.md
@@ -1,14 +1,19 @@
 # Save File Extensions
 
-Research results for which save file extensions RetroDECK cores produce, and what our plugin needs to support. This informs the implementation of [#196](https://github.com/danielcopper/decky-romm-sync/issues/196).
+Research results for which save file extensions RetroDECK cores produce, and what our plugin needs to support. This
+informs the implementation of [#196](https://github.com/danielcopper/decky-romm-sync/issues/196).
 
 ## How RetroArch Save Extensions Work
 
 RetroArch has two save mechanisms:
 
-1. **Standard libretro saves** (`libretro_saves = "true"` in core info): RetroArch handles all file I/O. The extension is **hardcoded to `.srm`** (SRAM) and **`.rtc`** (real-time clock). The core exposes memory via `RETRO_MEMORY_SAVE_RAM` / `RETRO_MEMORY_RTC`, and RetroArch writes the files. Every core using this mechanism produces identical extensions.
+1. **Standard libretro saves** (`libretro_saves = "true"` in core info): RetroArch handles all file I/O. The extension
+   is **hardcoded to `.srm`** (SRAM) and **`.rtc`** (real-time clock). The core exposes memory via
+   `RETRO_MEMORY_SAVE_RAM` / `RETRO_MEMORY_RTC`, and RetroArch writes the files. Every core using this mechanism
+   produces identical extensions.
 
-2. **Core-managed saves** (`libretro_saves = "false"` or absent): The core handles its own file I/O, writing to RetroArch's save directory with custom extensions. RetroArch has no control over these filenames.
+2. **Core-managed saves** (`libretro_saves = "false"` or absent): The core handles its own file I/O, writing to
+   RetroArch's save directory with custom extensions. RetroArch has no control over these filenames.
 
 This means `.srm`/`.rtc` covers the vast majority of cores. Only a handful of cores use custom extensions.
 
@@ -20,32 +25,33 @@ Checked against RetroDECK's installed cores (March 2026). Only cores relevant to
 
 These cores all produce `.srm` (and optionally `.rtc`). No additional extensions needed.
 
-| Platform | Cores | Notes |
-| --- | --- | --- |
-| **GB/GBC** | gambatte, sameboy, gearboy, tgbdual, fixgb, DoubleCherryGB | `.rtc` used by Pokemon Crystal/Gold/Silver etc. |
-| **GBA** | mgba, vbam, vba_next, skyemu | All GBA save types (EEPROM, SRAM, Flash) packed into single `.srm` |
-| **NES** | fceumm, nestopia, mesen | Battery-backed saves |
-| **SNES** | snes9x (all variants), bsnes (all variants), supafaust, mednafen_snes, mesen-s | Standard SRAM |
-| **N64** | mupen64plus_next, parallel_n64 | **Packed format**: EEPROM + 4 Memory Paks + SRAM + FlashRAM all in one `.srm` (290KB) |
-| **Genesis/MD** | genesis_plus_gx, genesis_plus_gx_wide, picodrive, blastem, clownmdemu | Cartridge backup |
-| **PSX** | mednafen_psx_hw, mednafen_psx, pcsx_rearmed, swanstation | Memory card 0 as raw 128KB `.srm` |
-| **Saturn** | mednafen_saturn, kronos, yabasanshiro, yabause | Standard save |
-| **DS** | desmume, desmume2015, melondsds, melonds | See DeSmuME special case below |
-| **PC Engine** | mednafen_pce_fast, mednafen_pce, mednafen_supergrafx | Standard save |
-| **Lynx** | handy | Standard save |
-| **NGP/NGPC** | mednafen_ngp, race | Standard save |
-| **Virtual Boy** | mednafen_vb | Standard save |
-| **WonderSwan** | mednafen_wswan | Standard save |
-| **3DO** | opera | NVRAM |
-| **Jaguar** | virtualjaguar | Standard save |
-| **Pokemon Mini** | pokemini | Standard save |
+| Platform         | Cores                                                                          | Notes                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| **GB/GBC**       | gambatte, sameboy, gearboy, tgbdual, fixgb, DoubleCherryGB                     | `.rtc` used by Pokemon Crystal/Gold/Silver etc.                                       |
+| **GBA**          | mgba, vbam, vba_next, skyemu                                                   | All GBA save types (EEPROM, SRAM, Flash) packed into single `.srm`                    |
+| **NES**          | fceumm, nestopia, mesen                                                        | Battery-backed saves                                                                  |
+| **SNES**         | snes9x (all variants), bsnes (all variants), supafaust, mednafen_snes, mesen-s | Standard SRAM                                                                         |
+| **N64**          | mupen64plus_next, parallel_n64                                                 | **Packed format**: EEPROM + 4 Memory Paks + SRAM + FlashRAM all in one `.srm` (290KB) |
+| **Genesis/MD**   | genesis_plus_gx, genesis_plus_gx_wide, picodrive, blastem, clownmdemu          | Cartridge backup                                                                      |
+| **PSX**          | mednafen_psx_hw, mednafen_psx, pcsx_rearmed, swanstation                       | Memory card 0 as raw 128KB `.srm`                                                     |
+| **Saturn**       | mednafen_saturn, kronos, yabasanshiro, yabause                                 | Standard save                                                                         |
+| **DS**           | desmume, desmume2015, melondsds, melonds                                       | See DeSmuME special case below                                                        |
+| **PC Engine**    | mednafen_pce_fast, mednafen_pce, mednafen_supergrafx                           | Standard save                                                                         |
+| **Lynx**         | handy                                                                          | Standard save                                                                         |
+| **NGP/NGPC**     | mednafen_ngp, race                                                             | Standard save                                                                         |
+| **Virtual Boy**  | mednafen_vb                                                                    | Standard save                                                                         |
+| **WonderSwan**   | mednafen_wswan                                                                 | Standard save                                                                         |
+| **3DO**          | opera                                                                          | NVRAM                                                                                 |
+| **Jaguar**       | virtualjaguar                                                                  | Standard save                                                                         |
+| **Pokemon Mini** | pokemini                                                                       | Standard save                                                                         |
 
 ### Cores With Special Extension Behavior
 
 #### DeSmuME (DS) -- `.dsv`
 
 - `libretro_saves = "true"`, so **default is `.srm`**
-- However, DeSmuME has a dual-mode: its `BackupDevice` class can write `.dsv` (DeSmuME's native format) when configured in Mednafen-compatibility mode
+- However, DeSmuME has a dual-mode: its `BackupDevice` class can write `.dsv` (DeSmuME's native format) when configured
+  in Mednafen-compatibility mode
 - The core will also fall back to loading `.sav` files if `.dsv` is not found
 - **Action**: Add `.dsv` as platform override for DS, so we pick up saves from users who switched modes
 
@@ -53,7 +59,8 @@ These cores all produce `.srm` (and optionally `.rtc`). No additional extensions
 
 - `libretro_saves = "true"` for **cartridge SRAM** (standard `.srm`)
 - But Sega CD **BRAM** (backup RAM) is managed by the core separately as `.brm` files
-- These include: `cart.brm` (cartridge backup RAM) and region-specific system BRAM (`scd_U.brm`, `scd_E.brm`, `scd_J.brm`)
+- These include: `cart.brm` (cartridge backup RAM) and region-specific system BRAM (`scd_U.brm`, `scd_E.brm`,
+  `scd_J.brm`)
 - The per-game BRAM uses the standard rom-name `.brm` pattern
 - **Action**: Add `.brm` as platform override for Sega CD
 
@@ -62,7 +69,8 @@ These cores all produce `.srm` (and optionally `.rtc`). No additional extensions
 - No `libretro_saves` field in core info -- uses its own VMU format
 - Produces `vmu_save_{A1-D1}.bin` files and `dc_nvmem.bin`
 - Multi-slot VMU support (games can produce multiple `.bin` files)
-- **Action**: Tracked separately in [#151](https://github.com/danielcopper/decky-romm-sync/issues/151). Not included in extension expansion.
+- **Action**: Tracked separately in [#151](https://github.com/danielcopper/decky-romm-sync/issues/151). Not included in
+  extension expansion.
 
 #### MAME / FBNeo (Arcade) -- `.nv`
 
@@ -96,20 +104,21 @@ Uses a **flat global allowlist** of 11 extensions with no per-platform mapping:
 .srm, .sav, .dsv, .mcr, .mcd, .brm, .eep, .sra, .fla, .mpk, .nv
 ```
 
-This is intentionally broad -- Grout targets multiple CFWs (muOS, NextUI, MinUI) where standalone emulators produce these formats. For RetroArch-only setups like RetroDECK, most of these are unnecessary.
+This is intentionally broad -- Grout targets multiple CFWs (muOS, NextUI, MinUI) where standalone emulators produce
+these formats. For RetroArch-only setups like RetroDECK, most of these are unnecessary.
 
 ### Argosy (Android client)
 
 Uses a **per-emulator** mapping:
 
-| Emulator | Extensions |
-| --- | --- |
-| RetroArch | `.srm`, `.sav` |
+| Emulator                    | Extensions                     |
+| --------------------------- | ------------------------------ |
+| RetroArch                   | `.srm`, `.sav`                 |
 | Mupen64Plus FZ (standalone) | `.sra`, `.eep`, `.fla`, `.mpk` |
-| DraStic (standalone DS) | `.dsv`, `.sav` |
-| melonDS (standalone) | `.sav` |
-| DuckStation (standalone) | `.mcd` |
-| MAME | `.nv` |
+| DraStic (standalone DS)     | `.dsv`, `.sav`                 |
+| melonDS (standalone)        | `.sav`                         |
+| DuckStation (standalone)    | `.mcd`                         |
+| MAME                        | `.nv`                          |
 
 Again, standalone emulator formats that don't apply to RetroDECK's RetroArch-based setup.
 
@@ -117,17 +126,17 @@ Again, standalone emulator formats that don't apply to RetroDECK's RetroArch-bas
 
 For decky-romm-sync (RetroDECK-only):
 
-| Extension | Include? | Reason |
-| --- | --- | --- |
-| `.srm` | **Yes** (already supported) | Standard RetroArch SRAM |
-| `.rtc` | **Yes** (already supported) | Standard RetroArch RTC |
-| `.dsv` | **Yes** (add as DS override) | DeSmuME native format |
-| `.brm` | **Yes** (add as Sega CD override) | Genesis Plus GX Sega CD BRAM |
-| `.sav` | **Yes** (add to defaults) | gpsp fallback, DeSmuME fallback, defensive |
-| `.bin` | **No** (separate ticket #151) | Flycast Dreamcast VMU -- needs special handling |
-| `.eep`, `.sra`, `.fla`, `.mpk` | **No** | N64 standalone formats, Mupen64Plus packs into `.srm` |
-| `.mcr`, `.mcd` | **No** | PSX Mednafen/DuckStation formats, RetroArch cores use `.srm` |
-| `.nv` | **No** | MAME NVRAM, completely different directory structure |
+| Extension                      | Include?                          | Reason                                                       |
+| ------------------------------ | --------------------------------- | ------------------------------------------------------------ |
+| `.srm`                         | **Yes** (already supported)       | Standard RetroArch SRAM                                      |
+| `.rtc`                         | **Yes** (already supported)       | Standard RetroArch RTC                                       |
+| `.dsv`                         | **Yes** (add as DS override)      | DeSmuME native format                                        |
+| `.brm`                         | **Yes** (add as Sega CD override) | Genesis Plus GX Sega CD BRAM                                 |
+| `.sav`                         | **Yes** (add to defaults)         | gpsp fallback, DeSmuME fallback, defensive                   |
+| `.bin`                         | **No** (separate ticket #151)     | Flycast Dreamcast VMU -- needs special handling              |
+| `.eep`, `.sra`, `.fla`, `.mpk` | **No**                            | N64 standalone formats, Mupen64Plus packs into `.srm`        |
+| `.mcr`, `.mcd`                 | **No**                            | PSX Mednafen/DuckStation formats, RetroArch cores use `.srm` |
+| `.nv`                          | **No**                            | MAME NVRAM, completely different directory structure         |
 
 ### Platform Override Map
 
@@ -140,4 +149,5 @@ _PLATFORM_OVERRIDES = {
 }
 ```
 
-Adding `.sav` to defaults is conservative but safe -- it ensures we pick up saves from any core that uses `.sav` as an alternative SRAM format, without false-matching on non-save files.
+Adding `.sav` to defaults is conservative but safe -- it ensures we pick up saves from any core that uses `.sav` as an
+alternative SRAM format, without false-matching on non-save files.

--- a/docs/user-guide/save-sync-support-matrix.md
+++ b/docs/user-guide/save-sync-support-matrix.md
@@ -1,0 +1,218 @@
+# Save sync support by platform
+
+Save sync works **per game**: when a game is installed, its save is uploaded to RomM and pulled back before launch, so
+you can carry on across devices. Standard cartridge saves work automatically. A few consoles store saves differently —
+this page shows what syncs for each system today, and what's planned.
+
+## Categories
+
+|    | Meaning                                                                                                                                                                    |
+| -- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ | **Synced today.** Your saves for this system carry across devices automatically.                                                                                           |
+| 🔜 | **Planned.** This save type isn't synced yet, but it fits the model and is on the way in a future release.                                                                 |
+| ❌ | **Not synced.** This system uses a _shared_ memory card (one card for many games) or stores saves outside the per-game save folder, so it doesn't fit per-game sync today. |
+| ⚪ | **No save data.** This system's emulator has no in-game save to sync (you can still use save states locally).                                                              |
+
+## What syncs today ✅
+
+Standard per-game cartridge saves sync automatically. That covers the large majority of systems — Nintendo (NES, SNES,
+Game Boy / Color / Advance, N64, DS), Sega (Master System, Game Gear, Genesis / Mega Drive, Sega CD), PC Engine /
+TurboGrafx, WonderSwan, Atari Lynx, Virtual Boy, and more.
+
+## Coming soon 🔜
+
+Per-game saves for these systems fit the sync model and are planned for a future release:
+
+| System                                  | Notes |
+| --------------------------------------- | ----- |
+| Sega Saturn — per-game backup-RAM saves |       |
+| PlayStation — memory-card saves         |       |
+| Neo Geo Pocket / Color                  |       |
+| Pokémon Mini                            |       |
+| Commodore Amiga                         |       |
+
+A few less-common systems (some DOS, PICO-8, ST-V) may also gain support pending confirmation.
+
+## Not synced yet ❌
+
+These consoles use a **shared memory card** — a single card file holds the saves for _all_ your games — or keep saves
+outside the per-game save folder. A shared card can't be split per game without risking other games' saves, so it
+doesn't fit per-game sync today. We're looking at safe ways to handle these in a future release.
+
+| System                                                     |
+| ---------------------------------------------------------- |
+| Dreamcast — shared VMU card                                |
+| PlayStation 2 — shared memory card                         |
+| GameCube — shared memory card                              |
+| Neo Geo CD — shared save                                   |
+| Nintendo 3DS — saves kept in a separate location           |
+| PSP — saves kept in per-game folders, not single files     |
+| Arcade (MAME) — NVRAM is stored separately by the emulator |
+
+## No save data ⚪
+
+Many computer, arcade, and homebrew systems have no in-game battery save at all — there's simply nothing to sync (save
+states still work locally). See the full table for specifics.
+
+## Full platform list
+
+??? note "Every platform (149)"
+
+    Status of each platform's default emulator core. Some platforms offer alternative cores that may behave differently.
+
+    | Platform | Status | Notes |
+    | --- | --- | --- |
+    | `amstradcpc` | ❌ | Not synced |
+    | `apple2` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `apple2gs` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `arcade` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `arcadia` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `astrocde` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `atomiswave` | ❌ | Not synced |
+    | `consolearcade` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `cps` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `cps1` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `cps2` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `cps3` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `crvision` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `daphne` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `doom` | ❌ | Not synced |
+    | `dreamcast` | ❌ | Not synced |
+    | `easyrpg` | ❌ | Not synced |
+    | `fmtowns` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `gamate` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `gameandwatch` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `gamecom` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `gc` | ❌ | Not synced |
+    | `gmaster` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `gx4000` | ❌ | Not synced |
+    | `laserdisc` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `lcdgames` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `mame` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `mess` | ❌ | Not synced |
+    | `model2` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `n3ds` | ❌ | Not synced |
+    | `naomi` | ❌ | Not synced |
+    | `naomi2` | ❌ | Not synced |
+    | `naomigd` | ❌ | Not synced |
+    | `neogeocd` | ❌ | Not synced |
+    | `neogeocdjp` | ❌ | Not synced |
+    | `ps2` | ❌ | Not synced |
+    | `psp` | ❌ | Not synced |
+    | `pv1000` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `scummvm` | ❌ | Not synced |
+    | `scv` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `supracan` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `vsmile` | ❌ | Saves are stored separately by the emulator (MAME) |
+    | `wii` | ❌ | Not synced |
+    | `x68000` | ❌ | Not synced |
+    | `amiga` | 🔜 | Planned |
+    | `amiga1200` | 🔜 | Planned |
+    | `amiga600` | 🔜 | Planned |
+    | `amigacd32` | 🔜 | Planned |
+    | `atarijaguar` | 🔜 | Planned |
+    | `cdimono1` | 🔜 | Under review |
+    | `cdtv` | 🔜 | Planned |
+    | `dos` | 🔜 | Planned |
+    | `ngp` | 🔜 | Planned |
+    | `ngpc` | 🔜 | Planned |
+    | `pc` | 🔜 | Planned |
+    | `pico8` | 🔜 | Planned |
+    | `pokemini` | 🔜 | Planned |
+    | `psx` | 🔜 | Planned |
+    | `quake` | 🔜 | Planned |
+    | `saturn` | 🔜 | Planned |
+    | `saturnjp` | 🔜 | Planned |
+    | `stv` | 🔜 | Planned |
+    | `wasm4` | 🔜 | Under review |
+    | `windows3x` | 🔜 | Planned |
+    | `windows9x` | 🔜 | Planned |
+    | `3do` | ✅ | Synced |
+    | `atari2600` | ✅ | Synced |
+    | `c64` | ✅ | Synced |
+    | `famicom` | ✅ | Synced |
+    | `fbneo` | ✅ | Synced |
+    | `fds` | ✅ | Synced |
+    | `gamegear` | ✅ | Synced |
+    | `gb` | ✅ | Synced |
+    | `gba` | ✅ | Synced |
+    | `gbc` | ✅ | Synced |
+    | `genesis` | ✅ | Synced |
+    | `mark3` | ✅ | Synced |
+    | `mastersystem` | ✅ | Synced |
+    | `megacd` | ✅ | Synced |
+    | `megacdjp` | ✅ | Synced |
+    | `megadrive` | ✅ | Synced |
+    | `megadrivejp` | ✅ | Synced |
+    | `megaduck` | ✅ | Synced |
+    | `multivision` | ✅ | Synced |
+    | `n64` | ✅ | Synced |
+    | `n64dd` | ✅ | Synced |
+    | `nds` | ✅ | Synced |
+    | `neogeo` | ✅ | Synced |
+    | `nes` | ✅ | Synced |
+    | `pc88` | ✅ | Synced |
+    | `pcengine` | ✅ | Synced |
+    | `pcenginecd` | ✅ | Synced |
+    | `pcfx` | ✅ | Synced |
+    | `plus4` | ✅ | Synced |
+    | `satellaview` | ✅ | Synced |
+    | `sega32x` | ✅ | Synced |
+    | `sega32xjp` | ✅ | Synced |
+    | `sega32xna` | ✅ | Synced |
+    | `segacd` | ✅ | Synced |
+    | `sfc` | ✅ | Synced |
+    | `sg-1000` | ✅ | Synced |
+    | `sgb` | ✅ | Synced |
+    | `snes` | ✅ | Synced |
+    | `snesna` | ✅ | Synced |
+    | `sufami` | ✅ | Synced |
+    | `supergrafx` | ✅ | Synced |
+    | `supervision` | ✅ | Synced |
+    | `tg-cd` | ✅ | Synced |
+    | `tg16` | ✅ | Synced |
+    | `tic80` | ✅ | Synced |
+    | `vic20` | ✅ | Synced |
+    | `virtualboy` | ✅ | Synced |
+    | `wonderswan` | ✅ | Synced |
+    | `wonderswancolor` | ✅ | Synced |
+    | `arduboy` | ⚪ | No save data |
+    | `atari5200` | ⚪ | No save data |
+    | `atari7800` | ⚪ | No save data |
+    | `atari800` | ⚪ | No save data |
+    | `atarilynx` | ⚪ | No save data |
+    | `atarist` | ⚪ | No save data |
+    | `atarixe` | ⚪ | No save data |
+    | `bbcmicro` | ⚪ | No save data |
+    | `chailove` | ⚪ | No save data |
+    | `channelf` | ⚪ | No save data |
+    | `colecovision` | ⚪ | No save data |
+    | `fba` | ⚪ | No save data |
+    | `intellivision` | ⚪ | No save data |
+    | `j2me` | ⚪ | No save data |
+    | `lowresnx` | ⚪ | No save data |
+    | `lutro` | ⚪ | No save data |
+    | `moto` | ⚪ | No save data |
+    | `msx` | ⚪ | No save data |
+    | `msx1` | ⚪ | No save data |
+    | `msx2` | ⚪ | No save data |
+    | `msxturbor` | ⚪ | No save data |
+    | `odyssey2` | ⚪ | No save data |
+    | `palm` | ⚪ | No save data |
+    | `pc98` | ⚪ | No save data |
+    | `ports` | ⚪ | No save data |
+    | `spectravideo` | ⚪ | No save data |
+    | `to8` | ⚪ | No save data |
+    | `uzebox` | ⚪ | No save data |
+    | `vectrex` | ⚪ | No save data |
+    | `videopac` | ⚪ | No save data |
+    | `vircon32` | ⚪ | No save data |
+    | `x1` | ⚪ | No save data |
+    | `zmachine` | ⚪ | No save data |
+    | `zx81` | ⚪ | No save data |
+    | `zxspectrum` | ⚪ | No save data |
+
+---
+
+_Coverage is reviewed against the emulator cores RetroDECK ships. Some 🔜 entries are awaiting on-device confirmation.
+Last reviewed 2026-06-04._

--- a/docs/user-guide/save-sync-support-matrix.md
+++ b/docs/user-guide/save-sync-support-matrix.md
@@ -6,12 +6,12 @@ this page shows what syncs for each system today, and what's planned.
 
 ## Categories
 
-|    | Meaning                                                                                                                                                                    |
-| -- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ | **Synced today.** Your saves for this system carry across devices automatically.                                                                                           |
-| 🔜 | **Planned.** This save type isn't synced yet, but it fits the model and is on the way in a future release.                                                                 |
-| ❌ | **Not synced.** This system uses a _shared_ memory card (one card for many games) or stores saves outside the per-game save folder, so it doesn't fit per-game sync today. |
-| ⚪ | **No save data.** This system's emulator has no in-game save to sync (you can still use save states locally).                                                              |
+|    | Meaning                                                                                                                                                                                                                                           |
+| -- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ | **Synced today.** Your saves for this system carry across devices automatically.                                                                                                                                                                  |
+| 🔜 | **Planned.** This save type isn't synced yet, but it fits the model and is on the way in a future release.                                                                                                                                        |
+| ❌ | **Not synced yet.** This system uses a _shared_ memory card (one card for many games) or stores saves outside the per-game save folder, so it doesn't fit per-game sync today — **planned for a later release**, handled differently (see below). |
+| ⚪ | **No save data.** This system's emulator has no in-game save to sync (you can still use save states locally).                                                                                                                                     |
 
 ## What syncs today ✅
 

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -1,30 +1,42 @@
 # Save Sync
 
-Save sync keeps your game saves in sync between multiple devices through your RomM server. Play a game on your Steam Deck, then continue where you left off on your HTPC — your saves travel with you.
+Save sync keeps your game saves in sync between multiple devices through your RomM server. Play a game on your Steam
+Deck, then continue where you left off on your HTPC — your saves travel with you.
 
 ## How It Works
 
-The plugin uploads and downloads RetroArch save files (`.srm`) to and from your RomM server. When you start a game, the plugin checks if the server has a newer save and downloads it. When you stop playing, it uploads your updated save.
+The plugin uploads and downloads RetroArch save files (`.srm`) to and from your RomM server. When you start a game, the
+plugin checks if the server has a newer save and downloads it. When you stop playing, it uploads your updated save.
 
-> **Important:** Save sync (pre-launch download, post-exit upload, conflict detection) only runs when you launch games from the **game detail page** using the plugin's Play button. Launching from context menus, search results, or the recent games shelf bypasses the sync flow. Always open the game page and use the Play button to ensure your saves stay in sync.
+> **Important:** Save sync (pre-launch download, post-exit upload, conflict detection) only runs when you launch games
+> from the **game detail page** using the plugin's Play button. Launching from context menus, search results, or the
+> recent games shelf bypasses the sync flow. Always open the game page and use the Play button to ensure your saves stay
+> in sync.
 
 Sync uses a **newest-wins** model with a hash-divergence guard:
 
-- The plugin asks the RomM server for the saves in your active slot for the game and picks the newest (highest `updated_at`).
-- If the server tracks your device as up-to-date and your local file matches the recorded baseline, there's nothing to do.
+- The plugin asks the RomM server for the saves in your active slot for the game and picks the newest (highest
+  `updated_at`).
+- If the server tracks your device as up-to-date and your local file matches the recorded baseline, there's nothing to
+  do.
 - If another device pushed a newer save and your local file is unchanged, the new server save is downloaded silently.
 - If you played offline and your local file changed, your save is pushed back to the server.
-- A conflict modal only appears if **both sides changed** since the last sync — the plugin won't silently overwrite either version.
+- A conflict modal only appears if **both sides changed** since the last sync — the plugin won't silently overwrite
+  either version.
 
-This is the same model used by the official RomM clients (Argosy and Grout). It keeps cross-device save sync simple: one timeline per slot, newest wins.
+This is the same model used by the official RomM clients (Argosy and Grout). It keeps cross-device save sync simple: one
+timeline per slot, newest wins.
 
 ## Important: Use Your Own RomM Account
 
-Save files in RomM are tied to the authenticated user account. If multiple people share the same RomM account, their saves will overwrite each other. Each person should have their own RomM account with their own credentials configured in the plugin.
+Save files in RomM are tied to the authenticated user account. If multiple people share the same RomM account, their
+saves will overwrite each other. Each person should have their own RomM account with their own credentials configured in
+the plugin.
 
 ## Supported Systems
 
-Save sync currently supports **RetroArch per-game `.srm` saves only**. This covers all systems that use RetroArch cores through RetroDECK:
+Save sync currently supports **RetroArch per-game `.srm` saves only**. This covers all systems that use RetroArch cores
+through RetroDECK:
 
 - NES, SNES, Game Boy, Game Boy Color, Game Boy Advance
 - Genesis / Mega Drive, Master System, Nintendo 64
@@ -32,7 +44,8 @@ Save sync currently supports **RetroArch per-game `.srm` saves only**. This cove
 - Saturn, Dreamcast, PC Engine / TurboGrafx-16
 - Neo Geo Pocket, WonderSwan, Atari Lynx
 
-Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, etc.) are **not yet supported** and are planned for a future update.
+Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, etc.) are **not yet supported** and are planned
+for a future update.
 
 ## Settings
 
@@ -42,15 +55,18 @@ Open **Save Sync** from the main QAM page to configure sync behavior.
 
 ### Auto Sync
 
-- **Sync before launch** (default: on) — runs sync from the game detail page when you tap Play. If the server is unreachable, the game launches with whatever local save exists.
+- **Sync before launch** (default: on) — runs sync from the game detail page when you tap Play. If the server is
+  unreachable, the game launches with whatever local save exists.
 - **Sync after exit** (default: on) — runs sync after closing a game. Shows a toast notification on success.
 
 ### When saves conflict
 
 The plugin uses a single, automatic resolution policy:
 
-- **Newest server save in your slot wins** by default. If your local save hasn't changed since the last successful sync, the server version is downloaded silently.
-- **Your local edits push automatically** when the server still considers your device up-to-date — for example, you played offline and no other device synced in the meantime.
+- **Newest server save in your slot wins** by default. If your local save hasn't changed since the last successful sync,
+  the server version is downloaded silently.
+- **Your local edits push automatically** when the server still considers your device up-to-date — for example, you
+  played offline and no other device synced in the meantime.
 - **A conflict modal appears only when both sides changed** since the last sync. You pick which version to keep.
 
 Tap **Sync All Saves Now** to sync saves for all installed ROMs at once. This is useful for:
@@ -74,13 +90,19 @@ Three actions:
 
 - **Keep Local** — uploads your local save to the server, overwriting the server version.
 - **Use Server** — downloads the server save and overwrites your local file.
-- **Cancel** — dismisses the modal without changing anything. The conflict will reappear on the next sync as long as both sides still differ. If another device pushes an update in the meantime, the situation may resolve automatically (your unchanged local file gets the new version) and the modal won't reappear.
+- **Cancel** — dismisses the modal without changing anything. The conflict will reappear on the next sync as long as
+  both sides still differ. If another device pushes an update in the meantime, the situation may resolve automatically
+  (your unchanged local file gets the new version) and the modal won't reappear.
 
-The modal blocks the Play action until you choose. If a post-exit sync detects a conflict you'll see a toast — the modal opens the next time you tap Play, where it blocks launch until resolved. There is no longer a separate "pending conflicts" list on the settings page.
+The modal blocks the Play action until you choose. If a post-exit sync detects a conflict you'll see a toast — the modal
+opens the next time you tap Play, where it blocks launch until resolved. There is no longer a separate "pending
+conflicts" list on the settings page.
 
 ## Core Switch Warning
 
-When you switch the emulator core for a game (e.g., from mGBA to gpSP for GBA), the plugin detects the change and shows a warning before launching. This is because some cores use incompatible save formats — launching with a different core may overwrite your existing save with data the previous core can't read.
+When you switch the emulator core for a game (e.g., from mGBA to gpSP for GBA), the plugin detects the change and shows
+a warning before launching. This is because some cores use incompatible save formats — launching with a different core
+may overwrite your existing save with data the previous core can't read.
 
 The warning shows which core you're switching from and to. You can:
 
@@ -89,24 +111,32 @@ The warning shows which core you're switching from and to. You can:
 
 ### Per-game override warning (temporary)
 
-You may see a second warning box in the same dialog titled **Per-Game Core Switch Not Working**. This is a temporary notice about a RetroDECK bug (tracked in [#210](https://github.com/danielcopper/decky-romm-sync/issues/210)): per-game core overrides are currently ignored for ROMs whose filenames contain special characters like parentheses (`()`), brackets (`[]`), or other punctuation. For those ROMs, switching the core per-game has no effect — RetroDECK silently falls back to the system-wide core.
+You may see a second warning box in the same dialog titled **Per-Game Core Switch Not Working**. This is a temporary
+notice about a RetroDECK bug (tracked in [#210](https://github.com/danielcopper/decky-romm-sync/issues/210)): per-game
+core overrides are currently ignored for ROMs whose filenames contain special characters like parentheses (`()`),
+brackets (`[]`), or other punctuation. For those ROMs, switching the core per-game has no effect — RetroDECK silently
+falls back to the system-wide core.
 
-**Workaround**: switch the core **system-wide** via the QAM panel (Core Switching) rather than per-game. This second warning will disappear from the dialog once RetroDECK fixes the underlying issue.
+**Workaround**: switch the core **system-wide** via the QAM panel (Core Switching) rather than per-game. This second
+warning will disappear from the dialog once RetroDECK fixes the underlying issue.
 
 ### Which cores are compatible?
 
-Most cores for the same system produce compatible `.srm` saves because the save format is defined by the original hardware, not the emulator. However, there are exceptions:
+Most cores for the same system produce compatible `.srm` saves because the save format is defined by the original
+hardware, not the emulator. However, there are exceptions:
 
-| System | Cores | Compatible? | Notes |
-| --- | --- | --- | --- |
-| SNES | Snes9x, Supafaust, bsnes | Yes | All dump raw cartridge SRAM identically |
-| PSX | Beetle PSX, PCSX ReARMed | Generally yes | Both use RetroArch's `.srm` memory card convention, but verify after switching — historical edge cases exist with memory card handling |
-| N64 | Mupen64Plus, ParaLLEl | Generally yes | ParaLLEl-N64 is based on Mupen64Plus-next and shares save logic; save-type auto-detection can occasionally mismatch between cores |
-| GBA | mGBA, VBA-M | Generally yes | Minor edge cases with save type detection |
-| **GBA** | **mGBA ↔ gpSP** | **No** | **gpSP uses different save type detection; may corrupt saves** |
-| **NDS** | **MelonDS ↔ DeSmuME** | **No** | **Completely different save formats** |
+| System  | Cores                    | Compatible?   | Notes                                                                                                                                  |
+| ------- | ------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| SNES    | Snes9x, Supafaust, bsnes | Yes           | All dump raw cartridge SRAM identically                                                                                                |
+| PSX     | Beetle PSX, PCSX ReARMed | Generally yes | Both use RetroArch's `.srm` memory card convention, but verify after switching — historical edge cases exist with memory card handling |
+| N64     | Mupen64Plus, ParaLLEl    | Generally yes | ParaLLEl-N64 is based on Mupen64Plus-next and shares save logic; save-type auto-detection can occasionally mismatch between cores      |
+| GBA     | mGBA, VBA-M              | Generally yes | Minor edge cases with save type detection                                                                                              |
+| **GBA** | **mGBA ↔ gpSP**          | **No**        | **gpSP uses different save type detection; may corrupt saves**                                                                         |
+| **NDS** | **MelonDS ↔ DeSmuME**    | **No**        | **Completely different save formats**                                                                                                  |
 
-> **If in doubt, don't switch cores mid-playthrough.** Before switching, back up your `.srm` file — copy it somewhere safe (e.g. a `saves-backup/` folder). If the new core loads your save correctly, you can delete the backup. If it doesn't, you can restore the backup and switch the core back.
+> **If in doubt, don't switch cores mid-playthrough.** Before switching, back up your `.srm` file — copy it somewhere
+> safe (e.g. a `saves-backup/` folder). If the new core loads your save correctly, you can delete the backup. If it
+> doesn't, you can restore the backup and switch the core back.
 
 <!-- TODO: Expand this section with more tested core combinations as user reports come in -->
 
@@ -115,62 +145,75 @@ Most cores for the same system produce compatible `.srm` saves because the save 
 If the RomM server is unreachable when a sync is attempted:
 
 - **Before launch**: the game starts normally with your local save (a toast notification informs you).
-- **After exit**: the upload is skipped. Your local save is untouched, and the next sync attempt produces the same outcome — typically pushing your changes once the server is reachable again.
+- **After exit**: the upload is skipped. Your local save is untouched, and the next sync attempt produces the same
+  outcome — typically pushing your changes once the server is reachable again.
 - No save data is ever lost due to a failed sync.
 
 ## Playtime Tracking
 
-The plugin tracks playtime per game. Session start and end times are recorded, and device suspend/resume is accounted for (sleep time is excluded). Playtime is displayed on the game detail page next to the save sync status.
+The plugin tracks playtime per game. Session start and end times are recorded, and device suspend/resume is accounted
+for (sleep time is excluded). Playtime is displayed on the game detail page next to the save sync status.
 
 Steam also tracks playtime natively for non-Steam shortcuts, so you'll see playtime in the standard Steam UI as well.
 
 ## Save File Location
 
-Save files are stored in your RetroDECK saves directory. The exact path is read from RetroDECK's configuration at runtime — typically:
+Save files are stored in your RetroDECK saves directory. The exact path is read from RetroDECK's configuration at
+runtime — typically:
 
 - **Internal SSD**: `~/retrodeck/saves/{system}/{rom_name}.srm`
 - **SD card**: `/run/media/deck/Emulation/retrodeck/saves/{system}/{rom_name}.srm`
 
 ## RetroArch Save Sorting Requirement
 
-Save sync expects save files to be organized as `{saves_dir}/{system}/{rom_name}.srm`. This matches the **RetroDECK default** RetroArch configuration:
+Save sync expects save files to be organized as `{saves_dir}/{system}/{rom_name}.srm`. This matches the **RetroDECK
+default** RetroArch configuration:
 
-| RetroArch Setting | Required Value | RetroDECK Default |
-| --- | --- | --- |
-| Sort Saves into Folders by Content Directory | **ON** | ON |
-| Sort Saves into Folders by Core Name | **OFF** | OFF |
+| RetroArch Setting                            | Required Value | RetroDECK Default |
+| -------------------------------------------- | -------------- | ----------------- |
+| Sort Saves into Folders by Content Directory | **ON**         | ON                |
+| Sort Saves into Folders by Core Name         | **OFF**        | OFF               |
 
-> **If you changed these settings in RetroArch, save sync will silently fail to find your save files.** No error is shown — saves simply won't sync.
+> **If you changed these settings in RetroArch, save sync will silently fail to find your save files.** No error is
+> shown — saves simply won't sync.
 
 ### What happens with other configurations
 
 RetroArch has four possible save sorting combinations. Only the first one is supported:
 
-| Content Directory | Core Name | Save path | Supported? |
-| --- | --- | --- | --- |
-| ON | OFF | `saves/gba/game.srm` | Yes |
-| OFF | ON | `saves/mGBA/game.srm` | No |
-| ON | ON | `saves/gba/mGBA/game.srm` | No |
-| OFF | OFF | `saves/game.srm` (flat) | No |
+| Content Directory | Core Name | Save path                 | Supported? |
+| ----------------- | --------- | ------------------------- | ---------- |
+| ON                | OFF       | `saves/gba/game.srm`      | Yes        |
+| OFF               | ON        | `saves/mGBA/game.srm`     | No         |
+| ON                | ON        | `saves/gba/mGBA/game.srm` | No         |
+| OFF               | OFF       | `saves/game.srm` (flat)   | No         |
 
-If you use "Sort by Core Name" (alone or combined with Content Directory), your saves end up in a subfolder named after the core (e.g., `mGBA`, `duckstation`, `Mesen`). The plugin does not search these subfolders.
+If you use "Sort by Core Name" (alone or combined with Content Directory), your saves end up in a subfolder named after
+the core (e.g., `mGBA`, `duckstation`, `Mesen`). The plugin does not search these subfolders.
 
 ### How to check your settings
 
-In RetroArch: **Settings > Saving**. Look for the two "Sort Saves into Folders" toggles. On a fresh RetroDECK install, they are already set correctly.
+In RetroArch: **Settings > Saving**. Look for the two "Sort Saves into Folders" toggles. On a fresh RetroDECK install,
+they are already set correctly.
 
 ### If your saves are already in core-name folders
 
-If you previously played with "Sort by Core Name" enabled, your existing `.srm` files are inside core-named subfolders. You have two options:
+If you previously played with "Sort by Core Name" enabled, your existing `.srm` files are inside core-named subfolders.
+You have two options:
 
 1. **Move the files** back to the parent system directory (e.g., move `saves/gba/mGBA/*.srm` to `saves/gba/`)
-2. **Change the RetroArch setting** back to Content Directory only (RetroArch will create new save files in the correct location on next launch — but your old saves stay in the core folder)
+2. **Change the RetroArch setting** back to Content Directory only (RetroArch will create new save files in the correct
+   location on next launch — but your old saves stay in the core folder)
 
 ## RomM Version Compatibility
 
-The plugin requires **RomM >= 4.8.1**. Servers below 4.8.1 are rejected at connection time with a full error page in both the QAM panel and the game detail view. The plugin uses v4.7+ features including server-side device tracking, content hashing, save slots, and `device_syncs` for conflict detection. The 4.8.1 minimum is set because that is the version the plugin has been tested against.
+The plugin requires **RomM >= 4.8.1**. Servers below 4.8.1 are rejected at connection time with a full error page in
+both the QAM panel and the game detail view. The plugin uses v4.7+ features including server-side device tracking,
+content hashing, save slots, and `device_syncs` for conflict detection. The 4.8.1 minimum is set because that is the
+version the plugin has been tested against.
 
-For technical details on how save sync works internally (three-way conflict detection, state schema, session detection), see the [Save File Sync Architecture](../architecture/save-file-sync-architecture.md) technical reference.
+For technical details on how save sync works internally (three-way conflict detection, state schema, session detection),
+see the [Save File Sync Architecture](../architecture/save-file-sync-architecture.md) technical reference.
 
 ---
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -1,6 +1,7 @@
 # Syncing Your Library
 
-Syncing fetches your RomM game library and creates Non-Steam shortcuts in Steam for every game. After syncing, your games appear in the Steam Library with cover art, metadata, and organized into collections.
+Syncing fetches your RomM game library and creates Non-Steam shortcuts in Steam for every game. After syncing, your
+games appear in the Steam Library with cover art, metadata, and organized into collections.
 
 ## How Sync Works
 
@@ -8,7 +9,8 @@ Syncing fetches your RomM game library and creates Non-Steam shortcuts in Steam 
 2. For each ROM, a Non-Steam shortcut is created in Steam via the SteamClient API — no restart required
 3. Cover art from RomM is applied as the portrait grid image
 4. If you have a SteamGridDB API key configured, hero banners, logos, and wide grid images are also fetched
-5. Metadata (description, developer, genres, release date) is cached and displayed in the plugin's custom game detail panel
+5. Metadata (description, developer, genres, release date) is cached and displayed in the plugin's custom game detail
+   panel
 6. Steam collections are created per platform (e.g. "RomM: Game Boy Advance (steamdeck)")
 
 ## Starting a Sync
@@ -26,7 +28,8 @@ You can tap **Cancel Sync** to stop mid-sync. Games already added will remain.
 
 ## Per-Platform Toggles
 
-Not every platform in your RomM library needs to be synced to Steam. Use the **Platforms** page to enable or disable individual platforms.
+Not every platform in your RomM library needs to be synced to Steam. Use the **Platforms** page to enable or disable
+individual platforms.
 
 1. From the main page, tap **Platforms**
 2. Each platform shows its name and ROM count
@@ -38,7 +41,8 @@ Not every platform in your RomM library needs to be synced to Steam. Use the **P
 
 ## Collections
 
-The plugin automatically creates Steam collections for each synced platform. Collection names include your machine's hostname to avoid conflicts if you run the plugin on multiple devices:
+The plugin automatically creates Steam collections for each synced platform. Collection names include your machine's
+hostname to avoid conflicts if you run the plugin on multiple devices:
 
 - `RomM: Nintendo 64 (steamdeck)`
 - `RomM: Game Boy Advance (steamdeck)`
@@ -50,36 +54,46 @@ Collections appear in Steam's library sidebar and can be used to browse games by
 
 The **Collections** page splits collections into three sub-tabs plus a dedicated top-level toggle for RomM favorites:
 
-- **Sync RomM favorites** (top-level toggle) — the user collection RomM auto-manages as your favorites. Always exactly one per account, so it sits above the sub-tabs as a single switch.
+- **Sync RomM favorites** (top-level toggle) — the user collection RomM auto-manages as your favorites. Always exactly
+  one per account, so it sits above the sub-tabs as a single switch.
 - **My** sub-tab — your other user-created collections
-- **Smart** sub-tab — filter-based collections that resolve membership at query time, so syncing always picks up the current matches
+- **Smart** sub-tab — filter-based collections that resolve membership at query time, so syncing always picks up the
+  current matches
 - **Franchise** sub-tab — auto-generated franchise groupings (IGDB)
 
-Each sub-tab shows its visible count in the section header (e.g. `MY COLLECTIONS (4)`) and lets you toggle individual collections, or use the paired **Enable All** / **Disable All** buttons to bulk-toggle just that sub-tab. The global **Show collection games in platform groups** toggle controls whether games pulled in via a collection also get added to their platform's Steam group.
+Each sub-tab shows its visible count in the section header (e.g. `MY COLLECTIONS (4)`) and lets you toggle individual
+collections, or use the paired **Enable All** / **Disable All** buttons to bulk-toggle just that sub-tab. The global
+**Show collection games in platform groups** toggle controls whether games pulled in via a collection also get added to
+their platform's Steam group.
 
 ## Artwork
 
 Each synced game gets up to five types of artwork:
 
-| Type | Source | Where It Appears |
-| --- | --- | --- |
-| Portrait Grid (cover) | RomM | Library grid tiles, collections |
-| Hero Banner | SteamGridDB | Game detail page background |
-| Logo | SteamGridDB | Title overlay on hero banner |
-| Wide Grid | SteamGridDB | Recent games shelf, list view |
-| Icon | SteamGridDB | Taskbar, small UI elements |
+| Type                  | Source      | Where It Appears                |
+| --------------------- | ----------- | ------------------------------- |
+| Portrait Grid (cover) | RomM        | Library grid tiles, collections |
+| Hero Banner           | SteamGridDB | Game detail page background     |
+| Logo                  | SteamGridDB | Title overlay on hero banner    |
+| Wide Grid             | SteamGridDB | Recent games shelf, list view   |
+| Icon                  | SteamGridDB | Taskbar, small UI elements      |
 
-Cover art is always applied from RomM. The other four types require a [SteamGridDB API key](configuration.md#steamgriddb-api-key). Games without a SteamGridDB match will show Steam's default placeholders for those slots.
+Cover art is always applied from RomM. The other four types require a
+[SteamGridDB API key](configuration.md#steamgriddb-api-key). Games without a SteamGridDB match will show Steam's default
+placeholders for those slots.
 
-You can refresh artwork for any individual game from its [game detail page](managing-games.md#refreshing-artwork-and-metadata).
+You can refresh artwork for any individual game from its
+[game detail page](managing-games.md#refreshing-artwork-and-metadata).
 
 ## Re-Syncing
 
-Running sync again updates your library with any changes from RomM (new ROMs, removed platforms, etc.). Existing shortcuts are updated rather than duplicated.
+Running sync again updates your library with any changes from RomM (new ROMs, removed platforms, etc.). Existing
+shortcuts are updated rather than duplicated.
 
 ## Removing Shortcuts
 
-To remove synced games, use the **Danger Zone** page. See [Troubleshooting — Danger Zone](troubleshooting.md#danger-zone) for details on the available removal options.
+To remove synced games, use the **Danger Zone** page. See
+[Troubleshooting — Danger Zone](troubleshooting.md#danger-zone) for details on the available removal options.
 
 ---
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -6,23 +6,30 @@ Common issues and how to fix them.
 
 ### BIOS files missing
 
-**Symptom**: A game for a system that requires BIOS files (PlayStation, Saturn, Dreamcast, etc.) fails to launch or shows a black screen.
+**Symptom**: A game for a system that requires BIOS files (PlayStation, Saturn, Dreamcast, etc.) fails to launch or
+shows a black screen.
 
-**Fix**: Check the game's detail page — if the BIOS indicator is orange, you're missing required BIOS files. Go to **BIOS Files** in the QAM and tap **Download All** for the relevant platform. See [BIOS Management](bios-management.md) for details.
+**Fix**: Check the game's detail page — if the BIOS indicator is orange, you're missing required BIOS files. Go to
+**BIOS Files** in the QAM and tap **Download All** for the relevant platform. See [BIOS Management](bios-management.md)
+for details.
 
 ### ROM not downloaded
 
 **Symptom**: Pressing Play does nothing, or you get a toast saying the ROM needs to be downloaded.
 
-**Fix**: Open the game's detail page and tap **Download** in the RomM Sync panel. The game will be playable once the download completes.
+**Fix**: Open the game's detail page and tap **Download** in the RomM Sync panel. The game will be playable once the
+download completes.
 
 ### Controller doesn't work in RetroArch menus
 
-**Symptom**: The game plays fine, but the RetroArch Quick Menu (L3+R3) can't be navigated with the controller — only mouse/touch works.
+**Symptom**: The game plays fine, but the RetroArch Quick Menu (L3+R3) can't be navigated with the controller — only
+mouse/touch works.
 
-**Fix**: This is caused by RetroArch using the `x` input driver on a Wayland system. If the plugin detects this, a warning appears on the main QAM page with a **Change to sdl2** button. Tap it to fix the issue.
+**Fix**: This is caused by RetroArch using the `x` input driver on a Wayland system. If the plugin detects this, a
+warning appears on the main QAM page with a **Change to sdl2** button. Tap it to fix the issue.
 
-If the warning doesn't appear, you can manually change `input_driver = "x"` to `input_driver = "sdl2"` in your RetroArch config file.
+If the warning doesn't appear, you can manually change `input_driver = "x"` to `input_driver = "sdl2"` in your RetroArch
+config file.
 
 ## Saves Not Syncing
 
@@ -34,13 +41,15 @@ If the warning doesn't appear, you can manually change `input_driver = "x"` to `
 
 **Symptom**: Toast notifications say "RomM unreachable" or sync operations show in the Failed Syncs list.
 
-**Fix**: Check your network connection and verify the RomM server is running. Go to **Connection Settings** and tap **Test Connection**. Failed syncs are queued and retried automatically when the server is reachable again.
+**Fix**: Check your network connection and verify the RomM server is running. Go to **Connection Settings** and tap
+**Test Connection**. Failed syncs are queued and retried automatically when the server is reachable again.
 
 ### Save file not found
 
 **Symptom**: The game detail page shows save status but no save file is being synced.
 
-**Fix**: Save sync only works for RetroArch `.srm` save files. If you're using a standalone emulator (PCSX2, DuckStation, Dolphin, etc.), saves for those systems are not yet supported.
+**Fix**: Save sync only works for RetroArch `.srm` save files. If you're using a standalone emulator (PCSX2,
+DuckStation, Dolphin, etc.), saves for those systems are not yet supported.
 
 Also verify the game actually creates a `.srm` file — some games use in-game passwords instead of battery saves.
 
@@ -48,7 +57,8 @@ Also verify the game actually creates a `.srm` file — some games use in-game p
 
 **Symptom**: Your save keeps reverting to an older version after syncing.
 
-**Fix**: Check your conflict resolution mode in **Save Sync** settings. If set to "Always Download", the server version always overwrites your local save. Switch to "Newest Wins" or "Ask Me" if you play on multiple devices.
+**Fix**: Check your conflict resolution mode in **Save Sync** settings. If set to "Always Download", the server version
+always overwrites your local save. Switch to "Newest Wins" or "Ask Me" if you play on multiple devices.
 
 Also make sure each person using RomM has their own account — shared accounts cause saves to overwrite each other.
 
@@ -58,25 +68,37 @@ Also make sure each person using RomM has their own account — shared accounts 
 
 **Symptom**: Games have cover art but no hero banner, logo, or wide grid image. The detail page background is blank.
 
-**Fix**: Configure a SteamGridDB API key in [Connection Settings](configuration.md#steamgriddb-api-key). It's free — create an account at steamgriddb.com and copy your API key.
+**Fix**: Configure a SteamGridDB API key in [Connection Settings](configuration.md#steamgriddb-api-key). It's free —
+create an account at steamgriddb.com and copy your API key.
 
 ### Game not found on SteamGridDB
 
 **Symptom**: Some games have full artwork while others are missing hero/logo/wide grid even with an API key configured.
 
-**Explanation**: Automatic matching links your ROM to a SteamGridDB game via its IGDB id, and that cross-reference is sometimes missing — especially for obscure ports and regional releases — even when SteamGridDB *does* have artwork under a differently-linked entry.
+**Explanation**: Automatic matching links your ROM to a SteamGridDB game via its IGDB id, and that cross-reference is
+sometimes missing — especially for obscure ports and regional releases — even when SteamGridDB _does_ have artwork under
+a differently-linked entry.
 
-**Fix**: The durable fix is on your RomM server — set the correct SteamGridDB id on the game (or enable the SteamGridDB metadata source and rescan). RomM is the source of truth for artwork matching, so the plugin picks up the corrected id on the next sync or **Refresh Artwork**. When RomM *and* the IGDB cross-reference both come up empty, **Refresh Artwork** opens a picker where you can search SteamGridDB by name and apply a match on the spot — but that pick is temporary and is replaced once RomM provides an id for the game. If a game genuinely has no artwork uploaded to SteamGridDB, those slots fall back to Steam's defaults — you can contribute artwork there to help the community.
+**Fix**: The durable fix is on your RomM server — set the correct SteamGridDB id on the game (or enable the SteamGridDB
+metadata source and rescan). RomM is the source of truth for artwork matching, so the plugin picks up the corrected id
+on the next sync or **Refresh Artwork**. When RomM _and_ the IGDB cross-reference both come up empty, **Refresh
+Artwork** opens a picker where you can search SteamGridDB by name and apply a match on the spot — but that pick is
+temporary and is replaced once RomM provides an id for the game. If a game genuinely has no artwork uploaded to
+SteamGridDB, those slots fall back to Steam's defaults — you can contribute artwork there to help the community.
 
 ### Artwork not appearing after sync
 
-**Fix**: Open the game's detail page and tap **Refresh Metadata** in the RomM Sync panel. This re-fetches all artwork and metadata.
+**Fix**: Open the game's detail page and tap **Refresh Metadata** in the RomM Sync panel. This re-fetches all artwork
+and metadata.
 
 ## Shortcuts Appear on Other Devices
 
-**Symptom**: Games synced on your Steam Deck also appear on your HTPC (or vice versa), but without artwork. They disappear when the source device goes offline.
+**Symptom**: Games synced on your Steam Deck also appear on your HTPC (or vice versa), but without artwork. They
+disappear when the source device goes offline.
 
-**Explanation**: This is Steam's Remote Play discovery protocol, not a plugin bug. Steam automatically advertises all non-Steam shortcuts to other Steam clients on the same network. These "phantom" shortcuts are ephemeral — they only exist while both devices are online.
+**Explanation**: This is Steam's Remote Play discovery protocol, not a plugin bug. Steam automatically advertises all
+non-Steam shortcuts to other Steam clients on the same network. These "phantom" shortcuts are ephemeral — they only
+exist while both devices are online.
 
 The plugin cannot prevent this. Your options are:
 
@@ -89,27 +111,34 @@ For technical details, see [Steam Remote Play and Cross-Device Shortcuts](../arc
 
 ### Download shows no progress
 
-**Fix**: Check your connection to the RomM server (Connection Settings > Test Connection). If the server is reachable, try cancelling and restarting the download from the game detail page.
+**Fix**: Check your connection to the RomM server (Connection Settings > Test Connection). If the server is reachable,
+try cancelling and restarting the download from the game detail page.
 
 ### Download failed
 
-**Fix**: Open the **Downloads** page from the QAM to see error details. Common causes include insufficient disk space, network interruption, or the ROM being unavailable on the server. Failed downloads can be retried from the game detail page.
+**Fix**: Open the **Downloads** page from the QAM to see error details. Common causes include insufficient disk space,
+network interruption, or the ROM being unavailable on the server. Failed downloads can be retried from the game detail
+page.
 
 ## Danger Zone
 
-The **Danger Zone** page provides options for removing shortcuts, ROM files, save files, and BIOS files. All destructive actions require confirmation (tap once to see the prompt, tap again to confirm).
+The **Danger Zone** page provides options for removing shortcuts, ROM files, save files, and BIOS files. All destructive
+actions require confirmation (tap once to see the prompt, tap again to confirm).
 
 ### Remove by Platform
 
-Removes all shortcuts for a specific platform (e.g. all Game Boy Advance games). The associated Steam collection is also cleaned up.
+Removes all shortcuts for a specific platform (e.g. all Game Boy Advance games). The associated Steam collection is also
+cleaned up.
 
 ### Remove All RomM Shortcuts
 
-Removes every shortcut that was created by the plugin, across all platforms. Collections are cleaned up. Does not delete downloaded ROM files.
+Removes every shortcut that was created by the plugin, across all platforms. Collections are cleaned up. Does not delete
+downloaded ROM files.
 
 ### Uninstall All Installed ROMs
 
-Deletes all downloaded ROM files from disk. Shortcuts remain in your library so you can re-download later. Use this to reclaim disk space.
+Deletes all downloaded ROM files from disk. Shortcuts remain in your library so you can re-download later. Use this to
+reclaim disk space.
 
 ### Remove Non-Steam Games
 
@@ -126,11 +155,13 @@ The plugin shows extra warnings if RetroDECK is not whitelisted, since removing 
 
 ### Delete Save Files
 
-Deletes local `.srm` save files for a specific platform. Shows each platform that has synced games, with the number of games affected. This only removes local save files — saves already uploaded to your RomM server are not affected.
+Deletes local `.srm` save files for a specific platform. Shows each platform that has synced games, with the number of
+games affected. This only removes local save files — saves already uploaded to your RomM server are not affected.
 
 ### Delete BIOS Files
 
-Deletes downloaded BIOS files for a specific platform. Shows each platform that has BIOS files present locally. You can re-download them later from the BIOS Manager.
+Deletes downloaded BIOS files for a specific platform. Shows each platform that has BIOS files present locally. You can
+re-download them later from the BIOS Manager.
 
 <!-- Screenshot: Danger Zone page showing removal options and whitelist -->
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,12 +63,14 @@ nav:
       - BIOS Management: user-guide/bios-management.md
       - Save Sync: user-guide/save-sync.md
       - Save File Extensions: user-guide/save-file-extensions.md
+      - Save Sync Support Matrix: user-guide/save-sync-support-matrix.md
       - RetroDECK Path Migration: user-guide/retrodeck-path-migration.md
       - Troubleshooting: user-guide/troubleshooting.md
   - Architecture:
       - Backend Architecture: architecture/backend-architecture.md
       - Database Design: architecture/database-design.md
       - Save File Sync Architecture: architecture/save-file-sync-architecture.md
+      - Save Sync Coverage: architecture/save-sync-coverage.md
       - Config Source Parsers: architecture/config-source-parsers.md
       - Steam Non-Steam Shortcuts: architecture/steam-non-steam-shortcuts.md
       - Steam Remote Play & Cross-Device: architecture/steam-remote-play.md


### PR DESCRIPTION
## What

- **Save sync support by platform** (user guide) — a matrix of every reachable platform and its default core: what syncs today, what's planned, and what isn't, with plain-language reasons.
- **Save sync coverage** (architecture) — the per-game discovery model, how RomM stores saves, the per-format coverage classes, and the strategy for shared memory cards.
- Reconciles the older **Save File Extensions** page, where the full core audit revises a few of its assumptions (Saturn, Neo Geo Pocket, Pokémon Mini).

## Tooling (separate first commit)

- Adopt `deno fmt` for Markdown (`deno.json`: proseWrap always, lineWidth 120) plus a `markdown-format` CI check, and reformat all existing Markdown to match.

Built from a core-by-core audit of the 155 RetroArch cores RetroDECK can launch. The non-`.srm` rows are documented by libretro but still need on-device confirmation.

Refs #237