### PR TITLE
feat(saves): single-token memory-card extensions, keyed by RetroDECK system

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,9 +5,9 @@
 # this hook fast (<2s) so commits don't become friction; CI + branch protection
 # is where correctness is enforced.
 #
-# Two independent sections — Python (ruff) and frontend (prettier). A no-op or
-# missing tool in one section must NOT skip the other, so each section guards
-# itself rather than exiting the whole hook.
+# Three independent sections — Python (ruff), frontend (prettier), and
+# Markdown (deno fmt). A no-op or missing tool in one section must NOT skip the
+# others, so each section guards itself rather than exiting the whole hook.
 
 # --- Python: format + lint staged files with ruff -------------------------
 # Find ruff — prefer Mason binary, fall back to PATH
@@ -56,6 +56,30 @@ else
         $PRETTIER --write $STAGED_FE
 
         for file in $STAGED_FE; do
+            if [ -f "$file" ]; then
+                git add "$file"
+            fi
+        done
+    fi
+fi
+
+# --- Markdown: format staged Markdown with deno fmt -----------------------
+# Find deno — prefer the mise-managed binary, fall back to PATH
+DENO="$(mise which deno 2>/dev/null)"
+if [ -z "$DENO" ]; then
+    DENO="$(command -v deno 2>/dev/null)"
+fi
+if [ -z "$DENO" ]; then
+    echo "pre-commit: deno not found (run 'mise run setup'), skipping Markdown format"
+else
+    # Get staged Markdown files, minus the paths deno.json excludes. Skip if none.
+    STAGED_MD=$(git diff --cached --name-only --diff-filter=ACM -- '*.md' \
+        | grep -vE '^(CHANGELOG\.md$|site/|node_modules/|\.worktrees/)')
+    if [ -n "$STAGED_MD" ]; then
+        # Format staged files (deno.json: proseWrap=always, lineWidth=120), then re-stage
+        $DENO fmt $STAGED_MD
+
+        for file in $STAGED_MD; do
             if [ -f "$file" ]; then
                 git add "$file"
             fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,10 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Tooling**: mise manages node, pnpm, python, uv. Venv auto-creates at `.venv` (via `_.python.venv` in mise.toml)
   using uv as the underlying tool; `mise run setup` installs Python deps via `uv pip install` (uv is the canonical
   Python package manager in this project).
-- **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): runs `ruff format` +
-  `ruff check` on staged Python files. Stays fast (<2s) so commits don't become friction — heavy validation
-  (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR push, never in the commit hook. CI + branch
-  protection enforces correctness; don't re-introduce heavy checks here.
+- **Pre-commit hook** (`.githooks/pre-commit`, wired by `mise run setup` via `core.hooksPath`): formats staged files —
+  `ruff format` + `ruff check` (Python), `prettier --write` (TS/TSX), and `deno fmt` (Markdown). Stays fast (<2s) so
+  commits don't become friction — heavy validation (basedpyright, lint-imports, cosmic bans, pytest) is CI-only on PR
+  push, never in the commit hook. CI + branch protection enforces correctness; don't re-introduce heavy checks here.
 
 ## Code Quality
 

--- a/docs/adr/0010-normalize-romm-slug-to-retrodeck-system.md
+++ b/docs/adr/0010-normalize-romm-slug-to-retrodeck-system.md
@@ -1,0 +1,98 @@
+# Platform identity is normalized to a RetroDECK `system` at the RomM seam; local resolution keys by `system`, never by the raw RomM slug
+
+## Status
+
+Accepted. Implemented incrementally: the save-extension keying lands with this ADR
+([#899](https://github.com/danielcopper/decky-romm-sync/issues/899)); the core / firmware / game-detail normalization is
+a follow-up (the slug→system leak issue). The full multi-vocabulary reference table under `docs/architecture/` is
+completed after the naming research (ES-DE / RetroArch / standalone-emulator naming for
+[#129](https://github.com/danielcopper/decky-romm-sync/issues/129)).
+
+## Context
+
+The plugin ingests games from RomM and then resolves, **locally**, where each game's saves live, which file extensions
+to probe for them, which emulator core launches the game, and which BIOS it needs. Every one of those is a decision
+about the **local RetroDECK / RetroArch environment**, not about RomM.
+
+A platform is named by **different vocabularies at different layers**, and they do not always agree:
+
+| Vocabulary | Example (Dreamcast / NGP) | Source | Used for |
+| --- | --- | --- | --- |
+| RomM `slug` | `dc` / `neo-geo-pocket` | RomM API (canonical) | **input only** — must be normalized |
+| RomM `fs_slug` | `dc` | RomM library scanner (igir `{romm}` token produces it) | RomM's on-disk folder name |
+| RomM `igdb_slug` | `dreamcast` | RomM metadata | BIOS (`known_bios_files.json`) |
+| RetroDECK / ES-DE `system` | `dreamcast` / `ngp` | `platform_map` value, `es_systems.xml`, `core_defaults.json` | **all local decisions** (saves, cores, gamelists) |
+| RetroArch `corename` / `core_so` | `Flycast` / `flycast_libretro.so` | core `.info` / `.so` | active core, sort-by-core save subdirs |
+| BIOS-folder slug | `pcsx2/bios` → `ps2` | RetroArch cores | BIOS placement (its own space) |
+
+RomM holds `slug`, `fs_slug` and `igdb_slug` as **independent** fields that may diverge, and RomM **changed its slug
+scheme over versions** (PR #1674 / migration 0046 standardized short "Universal Platform Slugs" — `dreamcast → dc`,
+`playstation → psx` — while other platforms keep long IGDB-style slugs such as `neo-geo-pocket`, `pokemon-mini`,
+`commodore-cdtv`) yet still accepts the old folder names for its scanner. So **`slug == system` cannot be assumed**.
+
+The plugin already normalizes RomM `slug` / `fs_slug` → RetroDECK `system` in exactly one place: `resolve_system`
+(`adapters/romm/http.py`) backed by `platform_map` (`defaults/config.json`), at download time. The resolved `system` is
+stored on the install (`rom_installs.system`) alongside the raw `platform_slug`.
+
+The bug that surfaced this (during #899): `get_save_extensions` was keyed by the **raw RomM `platform_slug`**, while the
+save **directory** in the very same function (`resolve_save_dir`) was keyed by the normalized `system`. Because
+`slug != system` for many platforms (`dc != dreamcast`), the override silently missed and core-specific saves
+(`.bkr`, `.dsv`, …) were never probed → silent save loss. The **same raw-slug leak** exists in core / firmware /
+game-detail resolution: the system-keyed seam in `es_de_config.py` (parameters literally named `system_name`) is fed the
+raw slug, so e.g. a core override is written to `ES-DE/gamelists/dc/` while RetroDECK's launcher reads
+`ES-DE/gamelists/dreamcast/` — the core choice is silently lost.
+
+## Decision
+
+1. **RomM's platform identity (`slug` / `fs_slug`) is input only.** It is normalized to a RetroDECK `system`
+   **exactly once**, at the RomM seam (`resolve_system` / `platform_map`); the resolved `system` is the identity carried
+   downstream and stored on the install.
+2. **Every local decision keys by the normalized `system`** — save directory, save extension, core selection,
+   gamelist / `<altemulator>` writes — **never** by the raw RomM slug. Where a value is genuinely **core-specific**, it
+   keys by the **active core on top of `system`** (see §5 of the save-sync-coverage doc), not by the platform alone.
+3. **The save-extension override map (`_PLATFORM_OVERRIDES`) is keyed by `system`.** Keys are RetroDECK system names, not
+   RomM slugs. (Implemented in #899.)
+4. **BIOS / firmware resolution is a separate vocabulary** (the RomM / BIOS-folder slug space — `known_bios_files.json`
+   IGDB slugs, folder overrides like `pcsx2/bios → ps2`) and is **deliberately NOT** normalized to `system`. Those
+   lookups are correct in their own slug space; normalizing them to `system` would break BIOS resolution. When a service
+   does both a core lookup (system space) and a BIOS lookup (BIOS space) on the same slug, only the core lookup is
+   normalized.
+5. **`resolve_system` keeps its verbatim fallback** (unknown slug → returned as-is); it is **not** changed to
+   normalize-or-fail. An unmapped / new platform must still launch with default behavior. Robustness is therefore
+   bounded by `platform_map` coverage, which is maintained as a standing concern (map-coverage audit follow-up).
+
+## Consequences
+
+- Save-extension lookup is now consistent with the save directory and **robust to RomM slug variants**: short and long
+  forms collapse to one `system` through `platform_map` (`ngp ← {ngp, neo-geo-pocket}`, `saturn ← {saturn, sega-saturn}`,
+  …). Lands in #899.
+- Override keys that no RomM slug can ever resolve to (`saturnjp`, `amiga1200`, `amiga600`, `cdtv`) are **unreachable**
+  under system-keying and were dropped: a JP-Saturn / Amiga-600/1200 ROM resolves to `saturn` / `amiga` and is covered by
+  those keys; `cdtv` needs a `platform_map` entry first (`commodore-cdtv → cdtv`) before its `.nvr` override can return —
+  deferred to the map-coverage audit.
+- The **same decision must be applied to core / firmware / game-detail resolution** (the live slug→system leak). Done as
+  a separate follow-up: inject a `SystemResolver`, normalize the raw slug before the system-keyed seams
+  (`get_active_core` / `get_available_cores` / `set_*_override`), and **leave the BIOS-folder lookups untouched**.
+  Uninstalled ROMs (game-detail) have no `installed.system`, so those services call `resolve_system(rom.platform_slug, …)`
+  themselves.
+- A `system` value not present in `platform_map` (e.g. `commodore-cdtv` today) degrades to the same safe default as
+  before (no regression) but cannot reach a system-keyed override until mapped.
+- The vocabulary boundaries above become the **foundation for multi-emulator support** (#129): each standalone emulator
+  carries its own save-path / naming convention, layered on top of `system` + active core. The full reference table
+  (including the ES-DE / RetroArch / standalone specifics still being researched) lives under `docs/architecture/`.
+
+## Alternatives considered
+
+- **Keep keying by the raw RomM slug; add long-form aliases to the override map.** Rejected: incomplete (which aliases,
+  per platform, unbounded as RomM evolves) and it duplicates the normalization `platform_map` already performs.
+  System-keying reuses the single existing seam.
+- **Normalize everything, including BIOS lookups, to `system`.** Rejected: BIOS resolution is correct in the RomM /
+  BIOS-folder slug space; normalizing it to `system` would break it. The vocabularies are genuinely distinct and must
+  not be conflated — a blanket `platform_slug → system` rename in `firmware.py` is a bug, not a fix.
+- **Make `resolve_system` fail on an unknown slug (normalize-or-die).** Rejected: an unmapped / new platform must still
+  launch with default behavior; failing would break it. Verbatim fallback plus active map-coverage maintenance is the
+  safer posture.
+
+See also: [ADR-0003](0003-json-sqlite-persistence-boundary.md) (persistence boundary),
+[ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) (`RomInstall` fields incl. `system`),
+[#129](https://github.com/danielcopper/decky-romm-sync/issues/129) (multi-emulator seam).

--- a/docs/adr/0010-normalize-romm-slug-to-retrodeck-system.md
+++ b/docs/adr/0010-normalize-romm-slug-to-retrodeck-system.md
@@ -16,14 +16,14 @@ about the **local RetroDECK / RetroArch environment**, not about RomM.
 
 A platform is named by **different vocabularies at different layers**, and they do not always agree:
 
-| Vocabulary | Example (Dreamcast / NGP) | Source | Used for |
-| --- | --- | --- | --- |
-| RomM `slug` | `dc` / `neo-geo-pocket` | RomM API (canonical) | **input only** — must be normalized |
-| RomM `fs_slug` | `dc` | RomM library scanner (igir `{romm}` token produces it) | RomM's on-disk folder name |
-| RomM `igdb_slug` | `dreamcast` | RomM metadata | BIOS (`known_bios_files.json`) |
-| RetroDECK / ES-DE `system` | `dreamcast` / `ngp` | `platform_map` value, `es_systems.xml`, `core_defaults.json` | **all local decisions** (saves, cores, gamelists) |
-| RetroArch `corename` / `core_so` | `Flycast` / `flycast_libretro.so` | core `.info` / `.so` | active core, sort-by-core save subdirs |
-| BIOS-folder slug | `pcsx2/bios` → `ps2` | RetroArch cores | BIOS placement (its own space) |
+| Vocabulary                       | Example (Dreamcast / NGP)         | Source                                                       | Used for                                          |
+| -------------------------------- | --------------------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| RomM `slug`                      | `dc` / `neo-geo-pocket`           | RomM API (canonical)                                         | **input only** — must be normalized               |
+| RomM `fs_slug`                   | `dc`                              | RomM library scanner (igir `{romm}` token produces it)       | RomM's on-disk folder name                        |
+| RomM `igdb_slug`                 | `dreamcast`                       | RomM metadata                                                | BIOS (`known_bios_files.json`)                    |
+| RetroDECK / ES-DE `system`       | `dreamcast` / `ngp`               | `platform_map` value, `es_systems.xml`, `core_defaults.json` | **all local decisions** (saves, cores, gamelists) |
+| RetroArch `corename` / `core_so` | `Flycast` / `flycast_libretro.so` | core `.info` / `.so`                                         | active core, sort-by-core save subdirs            |
+| BIOS-folder slug                 | `pcsx2/bios` → `ps2`              | RetroArch cores                                              | BIOS placement (its own space)                    |
 
 RomM holds `slug`, `fs_slug` and `igdb_slug` as **independent** fields that may diverge, and RomM **changed its slug
 scheme over versions** (PR #1674 / migration 0046 standardized short "Universal Platform Slugs" — `dreamcast → dc`,
@@ -36,22 +36,22 @@ stored on the install (`rom_installs.system`) alongside the raw `platform_slug`.
 
 The bug that surfaced this (during #899): `get_save_extensions` was keyed by the **raw RomM `platform_slug`**, while the
 save **directory** in the very same function (`resolve_save_dir`) was keyed by the normalized `system`. Because
-`slug != system` for many platforms (`dc != dreamcast`), the override silently missed and core-specific saves
-(`.bkr`, `.dsv`, …) were never probed → silent save loss. The **same raw-slug leak** exists in core / firmware /
-game-detail resolution: the system-keyed seam in `es_de_config.py` (parameters literally named `system_name`) is fed the
-raw slug, so e.g. a core override is written to `ES-DE/gamelists/dc/` while RetroDECK's launcher reads
+`slug != system` for many platforms (`dc != dreamcast`), the override silently missed and core-specific saves (`.bkr`,
+`.dsv`, …) were never probed → silent save loss. The **same raw-slug leak** exists in core / firmware / game-detail
+resolution: the system-keyed seam in `es_de_config.py` (parameters literally named `system_name`) is fed the raw slug,
+so e.g. a core override is written to `ES-DE/gamelists/dc/` while RetroDECK's launcher reads
 `ES-DE/gamelists/dreamcast/` — the core choice is silently lost.
 
 ## Decision
 
-1. **RomM's platform identity (`slug` / `fs_slug`) is input only.** It is normalized to a RetroDECK `system`
-   **exactly once**, at the RomM seam (`resolve_system` / `platform_map`); the resolved `system` is the identity carried
+1. **RomM's platform identity (`slug` / `fs_slug`) is input only.** It is normalized to a RetroDECK `system` **exactly
+   once**, at the RomM seam (`resolve_system` / `platform_map`); the resolved `system` is the identity carried
    downstream and stored on the install.
-2. **Every local decision keys by the normalized `system`** — save directory, save extension, core selection,
-   gamelist / `<altemulator>` writes — **never** by the raw RomM slug. Where a value is genuinely **core-specific**, it
-   keys by the **active core on top of `system`** (see §5 of the save-sync-coverage doc), not by the platform alone.
-3. **The save-extension override map (`_PLATFORM_OVERRIDES`) is keyed by `system`.** Keys are RetroDECK system names, not
-   RomM slugs. (Implemented in #899.)
+2. **Every local decision keys by the normalized `system`** — save directory, save extension, core selection, gamelist /
+   `<altemulator>` writes — **never** by the raw RomM slug. Where a value is genuinely **core-specific**, it keys by the
+   **active core on top of `system`** (see §5 of the save-sync-coverage doc), not by the platform alone.
+3. **The save-extension override map (`_PLATFORM_OVERRIDES`) is keyed by `system`.** Keys are RetroDECK system names,
+   not RomM slugs. (Implemented in #899.)
 4. **BIOS / firmware resolution is a separate vocabulary** (the RomM / BIOS-folder slug space — `known_bios_files.json`
    IGDB slugs, folder overrides like `pcsx2/bios → ps2`) and is **deliberately NOT** normalized to `system`. Those
    lookups are correct in their own slug space; normalizing them to `system` would break BIOS resolution. When a service
@@ -64,17 +64,17 @@ raw slug, so e.g. a core override is written to `ES-DE/gamelists/dc/` while Retr
 ## Consequences
 
 - Save-extension lookup is now consistent with the save directory and **robust to RomM slug variants**: short and long
-  forms collapse to one `system` through `platform_map` (`ngp ← {ngp, neo-geo-pocket}`, `saturn ← {saturn, sega-saturn}`,
-  …). Lands in #899.
+  forms collapse to one `system` through `platform_map` (`ngp ← {ngp, neo-geo-pocket}`,
+  `saturn ← {saturn, sega-saturn}`, …). Lands in #899.
 - Override keys that no RomM slug can ever resolve to (`saturnjp`, `amiga1200`, `amiga600`, `cdtv`) are **unreachable**
-  under system-keying and were dropped: a JP-Saturn / Amiga-600/1200 ROM resolves to `saturn` / `amiga` and is covered by
-  those keys; `cdtv` needs a `platform_map` entry first (`commodore-cdtv → cdtv`) before its `.nvr` override can return —
-  deferred to the map-coverage audit.
+  under system-keying and were dropped: a JP-Saturn / Amiga-600/1200 ROM resolves to `saturn` / `amiga` and is covered
+  by those keys; `cdtv` needs a `platform_map` entry first (`commodore-cdtv → cdtv`) before its `.nvr` override can
+  return — deferred to the map-coverage audit.
 - The **same decision must be applied to core / firmware / game-detail resolution** (the live slug→system leak). Done as
   a separate follow-up: inject a `SystemResolver`, normalize the raw slug before the system-keyed seams
   (`get_active_core` / `get_available_cores` / `set_*_override`), and **leave the BIOS-folder lookups untouched**.
-  Uninstalled ROMs (game-detail) have no `installed.system`, so those services call `resolve_system(rom.platform_slug, …)`
-  themselves.
+  Uninstalled ROMs (game-detail) have no `installed.system`, so those services call
+  `resolve_system(rom.platform_slug, …)` themselves.
 - A `system` value not present in `platform_map` (e.g. `commodore-cdtv` today) degrades to the same safe default as
   before (no regression) but cannot reach a system-keyed override until mapped.
 - The vocabulary boundaries above become the **foundation for multi-emulator support** (#129): each standalone emulator

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -631,6 +631,31 @@ is more involved than a simple download because it must:
 2. Make the chosen save authoritative cross-device — other devices that already have the latest save tracked must end up
    downloading the chosen version on their next sync.
 
+### Multi-file saves: version history suppressed (interim #908 guard)
+
+Some systems store one game state across **several files with distinct extensions** — e.g. a Sega Saturn cartridge save
+is `<rom>.bkr` + `<rom>.bcr` + `<rom>.smpc` (three files = one state). RomM stores each filename as an **independent
+save record with its own version stack**, so the slot's "current save" is really an N-file _set_, not a single file with
+a version history. Per-file rollback would revert one component and leave the siblings on their current version — an
+incoherent save.
+
+Until grouped save-states with atomic set rollback land
+([#908](https://github.com/danielcopper/decky-romm-sync/issues/908)), the plugin **detects multi-file slots and
+suppresses version history + rollback** for them:
+
+- `get_save_status` carries `multi_file: bool`, `component_files: list[str]` (the N filenames, sorted), and
+  `rollback_supported: bool`. Detection counts the distinct canonical target filenames the active slot resolves to
+  (across the matrix outcomes); more than one ⇒ multi-file.
+- The SAVES tab replaces the Previous-Versions dropdown for a multi-file slot with a read-only **"Files in this save
+  (N)"** component list plus a short note that per-version rollback isn't available yet.
+- `list_file_versions` short-circuits to `{"status": "multi_file_unsupported", "versions": []}` and
+  `rollback_to_version` refuses with `{"status": "unsupported"}` before any preflight or destructive I/O. Both backstops
+  detect multi-file from the **local** save files on disk (a rollback target is always installed), so they add no extra
+  network round-trip.
+
+Single-file slots — including a single file with genuine prior versions — are unaffected and keep the full
+version-history + rollback flow described below.
+
 ### Why a switch cannot be a download-only
 
 A pure download to local would only update _our_ device. On the next sync from any other device, RomM's

--- a/docs/architecture/save-sync-coverage.md
+++ b/docs/architecture/save-sync-coverage.md
@@ -22,9 +22,11 @@ Two hard properties follow, and they define the entire coverage envelope:
 2. **The file must live in the save folder.** A save in RetroArch's _system_ directory (Flycast VMUs), in a per-emulator
    subdirectory (`mame/nvram/`), or next to the ROM (`savefiles_in_content_dir`) is never seen.
 
-The extension list is a small static map: a default of `.srm` / `.rtc` / `.sav`, plus per-platform overrides (`nds` →
-`.dsv`, `segacd` → `.brm`, `saturn`/`saturnjp` → `.bkr`/`.bcr`/`.smpc`, `ngp`/`ngpc` → `.flash`/`.ngf`, `pokemini` →
-`.eep`, and the `amiga` family → `.nvr`).
+The extension list is a small static map keyed by the **RetroDECK system** (the normalized value from
+`resolve_system` / `platform_map`, not the raw RomM platform slug — keying by system keeps the lookup aligned with the
+save directory, cores, and gamelists, which are all system-keyed): a default of `.srm` / `.rtc` / `.sav`, plus
+per-system overrides (`nds` → `.dsv`, `segacd` → `.brm`, `saturn` → `.bkr`/`.bcr`/`.smpc`, `ngp`/`ngpc` →
+`.flash`/`.ngf`, `pokemini` → `.eep`, and `amiga`/`amigacd32` → `.nvr`).
 
 ## How RomM stores saves
 

--- a/docs/architecture/save-sync-coverage.md
+++ b/docs/architecture/save-sync-coverage.md
@@ -22,8 +22,9 @@ Two hard properties follow, and they define the entire coverage envelope:
 2. **The file must live in the save folder.** A save in RetroArch's _system_ directory (Flycast VMUs), in a per-emulator
    subdirectory (`mame/nvram/`), or next to the ROM (`savefiles_in_content_dir`) is never seen.
 
-The extension list is a small static map: a default of `.srm` / `.rtc` / `.sav`, plus per-platform overrides (today only
-`nds` → `.dsv` and `segacd` → `.brm`).
+The extension list is a small static map: a default of `.srm` / `.rtc` / `.sav`, plus per-platform overrides (`nds` →
+`.dsv`, `segacd` → `.brm`, `saturn`/`saturnjp` → `.bkr`/`.bcr`/`.smpc`, `ngp`/`ngpc` → `.flash`/`.ngf`, `pokemini` →
+`.eep`, and the `amiga` family → `.nvr`).
 
 ## How RomM stores saves
 
@@ -127,13 +128,7 @@ no battery save · `❓` unverified. Non-`.srm` rows are libretro-documented and
     | `virtualjaguar_libretro` | 🟠 (b) | `.srm`, `.cdrom.srm` | infix / saves | atarijaguar |
     | `dosbox_pure_libretro` | 🟡 (a) | `.pure.zip`, `.save.zip` | single_token_nonstandard / saves | dos, pc, windows3x, windows9x |
     | `kronos_libretro` | 🟡 (a) | `.ram` | single_token_nonstandard / saves | arcade, consolearcade, mame, saturn, saturnjp +1 |
-    | `mednafen_ngp_libretro` | 🟡 (a) | `.flash` | single_token_nonstandard / saves | ngp, ngpc |
-    | `mednafen_saturn_libretro` | 🟡 (a) | `.bkr`, `.bcr`, `.smpc` | single_token_nonstandard / saves | saturn, saturnjp |
     | `nxengine_libretro` | 🟡 (a) | `.dat` | single_token_nonstandard / saves | ports |
-    | `pokemini_libretro` | 🟡 (a) | `.eep` | single_token_nonstandard / saves | pokemini |
-    | `puae2021_libretro` | 🟡 (a) | `.nvr` | single_token_nonstandard / saves | amiga, amiga1200, amiga600, amigacd32, cdtv |
-    | `puae_libretro` | 🟡 (a) | `.nvr` | single_token_nonstandard / saves | amiga, amiga1200, amiga600, amigacd32, cdtv |
-    | `race_libretro` | 🟡 (a) | `.ngf` | single_token_nonstandard / saves | ngp, ngpc |
     | `retro8_libretro` | 🟡 (a) | `.p8d.txt` | single_token_nonstandard / saves | pico8 |
     | `ardens_libretro` | ❓ | — | unknown / unknown | arduboy |
     | `panda3ds_libretro` | ❓ | — | unknown / unknown | n3ds |
@@ -159,9 +154,11 @@ no battery save · `❓` unverified. Non-`.srm` rows are libretro-documented and
     | `genesis_plus_gx_wide_libretro` | ✅ | `.srm`, `.brm` | single_token_default / saves | gamegear, genesis, mark3, mastersystem, megacd +5 |
     | `geolith_libretro` | ✅ | `.srm`, `.nv`, `.mcr` | single_token_default / saves | arcade, mame, neogeo |
     | `gpsp_libretro` | ✅ | `.srm` | single_token_default / saves | gba |
+    | `mednafen_ngp_libretro` | ✅ | `.flash` | single_token_default / saves | ngp, ngpc |
     | `mednafen_pce_fast_libretro` | ✅ | `.srm` | single_token_default / saves | pcengine, pcenginecd, tg16, tg-cd |
     | `mednafen_pce_libretro` | ✅ | `.srm` | single_token_default / saves | pcengine, pcenginecd, supergrafx, tg16, tg-cd |
     | `mednafen_pcfx_libretro` | ✅ | `.srm` | single_token_default / saves | pcfx |
+    | `mednafen_saturn_libretro` | ✅ | `.bkr`, `.bcr`, `.smpc` | single_token_default / saves | saturn, saturnjp |
     | `mednafen_supafaust_libretro` | ✅ | `.srm` | single_token_default / saves | sfc, snes, snesna |
     | `mednafen_supergrafx_libretro` | ✅ | `.srm` | single_token_default / saves | supergrafx, tg16 |
     | `mednafen_vb_libretro` | ✅ | `.srm` | single_token_default / saves | virtualboy |
@@ -177,9 +174,13 @@ no battery save · `❓` unverified. Non-`.srm` rows are libretro-documented and
     | `opera_libretro` | ✅ | `.srm` | single_token_default / saves | 3do |
     | `parallel_n64_libretro` | ✅ | `.srm` | single_token_default / saves | n64, n64dd |
     | `picodrive_libretro` | ✅ | `.srm` | single_token_default / saves | gamegear, genesis, mark3, mastersystem, megacd +7 |
+    | `pokemini_libretro` | ✅ | `.eep` | single_token_default / saves | pokemini |
     | `potator_libretro` | ✅ | `.srm` | single_token_default / saves | supervision |
+    | `puae2021_libretro` | ✅ | `.nvr` | single_token_default / saves | amiga, amiga1200, amiga600, amigacd32, cdtv |
+    | `puae_libretro` | ✅ | `.nvr` | single_token_default / saves | amiga, amiga1200, amiga600, amigacd32, cdtv |
     | `quasi88_libretro` | ✅ | `.srm` | single_token_default / saves | pc88 |
     | `quicknes_libretro` | ✅ | `.srm` | single_token_default / saves | famicom, nes |
+    | `race_libretro` | ✅ | `.ngf` | single_token_default / saves | ngp, ngpc |
     | `sameboy_libretro` | ✅ | `.srm`, `.rtc` | single_token_default / saves | gb, gbc, sgb |
     | `sameduck_libretro` | ✅ | `.srm`, `.rtc` | single_token_default / saves | megaduck |
     | `smsplus_libretro` | ✅ | `.srm` | single_token_default / saves | gamegear, mark3, mastersystem |

--- a/docs/architecture/save-sync-coverage.md
+++ b/docs/architecture/save-sync-coverage.md
@@ -22,11 +22,11 @@ Two hard properties follow, and they define the entire coverage envelope:
 2. **The file must live in the save folder.** A save in RetroArch's _system_ directory (Flycast VMUs), in a per-emulator
    subdirectory (`mame/nvram/`), or next to the ROM (`savefiles_in_content_dir`) is never seen.
 
-The extension list is a small static map keyed by the **RetroDECK system** (the normalized value from
-`resolve_system` / `platform_map`, not the raw RomM platform slug — keying by system keeps the lookup aligned with the
-save directory, cores, and gamelists, which are all system-keyed): a default of `.srm` / `.rtc` / `.sav`, plus
-per-system overrides (`nds` → `.dsv`, `segacd` → `.brm`, `saturn` → `.bkr`/`.bcr`/`.smpc`, `ngp`/`ngpc` →
-`.flash`/`.ngf`, `pokemini` → `.eep`, and `amiga`/`amigacd32` → `.nvr`).
+The extension list is a small static map keyed by the **RetroDECK system** (the normalized value from `resolve_system` /
+`platform_map`, not the raw RomM platform slug — keying by system keeps the lookup aligned with the save directory,
+cores, and gamelists, which are all system-keyed): a default of `.srm` / `.rtc` / `.sav`, plus per-system overrides
+(`nds` → `.dsv`, `segacd` → `.brm`, `saturn` → `.bkr`/`.bcr`/`.smpc`, `ngp`/`ngpc` → `.flash`/`.ngf`, `pokemini` →
+`.eep`, and `amiga`/`amigacd32` → `.nvr`).
 
 ## How RomM stores saves
 

--- a/docs/user-guide/save-file-extensions.md
+++ b/docs/user-guide/save-file-extensions.md
@@ -150,9 +150,9 @@ For decky-romm-sync (RetroDECK-only):
 
 ### System Override Map
 
-Override keys are RetroDECK **system** names (the normalized value from `resolve_system` / `platform_map`), not raw
-RomM platform slugs — this keeps the extension lookup aligned with the save directory, cores, and gamelists, which are
-all system-keyed.
+Override keys are RetroDECK **system** names (the normalized value from `resolve_system` / `platform_map`), not raw RomM
+platform slugs — this keeps the extension lookup aligned with the save directory, cores, and gamelists, which are all
+system-keyed.
 
 ```python
 _DEFAULT_EXTENSIONS = (".srm", ".rtc", ".sav")

--- a/docs/user-guide/save-file-extensions.md
+++ b/docs/user-guide/save-file-extensions.md
@@ -148,7 +148,11 @@ For decky-romm-sync (RetroDECK-only):
 | `.mcr`, `.mcd`                 | **No**                            | PSX Mednafen/DuckStation formats, RetroArch cores use `.srm` |
 | `.nv`                          | **No**                            | MAME NVRAM, completely different directory structure         |
 
-### Platform Override Map
+### System Override Map
+
+Override keys are RetroDECK **system** names (the normalized value from `resolve_system` / `platform_map`), not raw
+RomM platform slugs — this keeps the extension lookup aligned with the save directory, cores, and gamelists, which are
+all system-keyed.
 
 ```python
 _DEFAULT_EXTENSIONS = (".srm", ".rtc", ".sav")

--- a/docs/user-guide/save-sync-support-matrix.md
+++ b/docs/user-guide/save-sync-support-matrix.md
@@ -23,13 +23,9 @@ TurboGrafx, WonderSwan, Atari Lynx, Virtual Boy, and more.
 
 Per-game saves for these systems fit the sync model and are planned for a future release:
 
-| System                                  | Notes |
-| --------------------------------------- | ----- |
-| Sega Saturn — per-game backup-RAM saves |       |
-| PlayStation — memory-card saves         |       |
-| Neo Geo Pocket / Color                  |       |
-| Pokémon Mini                            |       |
-| Commodore Amiga                         |       |
+| System                          | Notes |
+| ------------------------------- | ----- |
+| PlayStation — memory-card saves |       |
 
 A few less-common systems (some DOS, PICO-8, ST-V) may also gain support pending confirmation.
 
@@ -106,28 +102,24 @@ states still work locally). See the full table for specifics.
     | `vsmile` | ❌ | Saves are stored separately by the emulator (MAME) |
     | `wii` | ❌ | Not synced |
     | `x68000` | ❌ | Not synced |
-    | `amiga` | 🔜 | Planned |
     | `amiga1200` | 🔜 | Planned |
     | `amiga600` | 🔜 | Planned |
-    | `amigacd32` | 🔜 | Planned |
     | `atarijaguar` | 🔜 | Planned |
     | `cdimono1` | 🔜 | Under review |
-    | `cdtv` | 🔜 | Planned |
+    | `cdtv` | 🔜 | Planned — pending platform mapping (#907) |
     | `dos` | 🔜 | Planned |
-    | `ngp` | 🔜 | Planned |
-    | `ngpc` | 🔜 | Planned |
     | `pc` | 🔜 | Planned |
     | `pico8` | 🔜 | Planned |
-    | `pokemini` | 🔜 | Planned |
     | `psx` | 🔜 | Planned |
     | `quake` | 🔜 | Planned |
-    | `saturn` | 🔜 | Planned |
     | `saturnjp` | 🔜 | Planned |
     | `stv` | 🔜 | Planned |
     | `wasm4` | 🔜 | Under review |
     | `windows3x` | 🔜 | Planned |
     | `windows9x` | 🔜 | Planned |
     | `3do` | ✅ | Synced |
+    | `amiga` | ✅ | Synced |
+    | `amigacd32` | ✅ | Synced |
     | `atari2600` | ✅ | Synced |
     | `c64` | ✅ | Synced |
     | `famicom` | ✅ | Synced |
@@ -151,12 +143,16 @@ states still work locally). See the full table for specifics.
     | `nds` | ✅ | Synced |
     | `neogeo` | ✅ | Synced |
     | `nes` | ✅ | Synced |
+    | `ngp` | ✅ | Synced |
+    | `ngpc` | ✅ | Synced |
     | `pc88` | ✅ | Synced |
     | `pcengine` | ✅ | Synced |
     | `pcenginecd` | ✅ | Synced |
     | `pcfx` | ✅ | Synced |
     | `plus4` | ✅ | Synced |
+    | `pokemini` | ✅ | Synced |
     | `satellaview` | ✅ | Synced |
+    | `saturn` | ✅ | Synced |
     | `sega32x` | ✅ | Synced |
     | `sega32xjp` | ✅ | Synced |
     | `sega32xna` | ✅ | Synced |
@@ -215,4 +211,4 @@ states still work locally). See the full table for specifics.
 ---
 
 _Coverage is reviewed against the emulator cores RetroDECK ships. Some 🔜 entries are awaiting on-device confirmation.
-Last reviewed 2026-06-04._
+Last reviewed 2026-06-05._

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ node = "lts"
 pnpm = "latest"
 python = "3.11"  # match Decky Loader's embedded Python (libpython3.11)
 uv = "latest"    # mise creates venvs via uv internally; expose it so the setup task can install deps without bootstrapping pip
+deno = "2"       # markdown formatter (deno fmt) — pre-commit hook + CI markdown-format check; matches CI's v2.x
 
 [env]
 _.python.venv = { path = ".venv", create = true }

--- a/py_modules/domain/save_extensions.py
+++ b/py_modules/domain/save_extensions.py
@@ -1,8 +1,12 @@
-"""Per-platform save file extension configuration.
+"""Per-system save file extension configuration.
 
 Provides the list of save file extensions to look for when syncing saves.
 The default covers RetroArch's standard .srm and .rtc extensions.
-Platform-specific overrides can expand or replace this list.
+Per-system overrides can expand or replace this list. Override keys are
+RetroDECK *system* names (the normalized value from resolve_system /
+platform_map), NOT raw RomM platform slugs — keying by system keeps the
+extension lookup aligned with the rest of the local flow (save directory,
+cores, gamelists), which is also system-keyed.
 
 Extension mapping based on RetroDECK core audit — see wiki/Save-File-Extensions.
 
@@ -13,39 +17,42 @@ from __future__ import annotations
 
 _DEFAULT_EXTENSIONS: tuple[str, ...] = (".srm", ".rtc", ".sav")
 
-# Platform-specific overrides. Keys are RomM platform slugs.
-# Values completely replace the default list for that platform.
+# Platform-specific overrides. Keys are RetroDECK *system* names — the
+# normalized value produced by resolve_system / platform_map, NOT raw RomM
+# platform slugs. Values completely replace the default list for that system.
 # See wiki/Save-File-Extensions for the research behind these mappings.
+# CDTV (.nvr) is deferred: RomM's slug ``commodore-cdtv`` is not yet in
+# platform_map, so no install can reach a ``cdtv`` system today — re-add a
+# ``cdtv`` key once platform_map maps ``commodore-cdtv -> cdtv`` (tracked
+# separately).
 _PLATFORM_OVERRIDES: dict[str, tuple[str, ...]] = {
     "nds": (".srm", ".rtc", ".sav", ".dsv"),  # DeSmuME native format
     "segacd": (".srm", ".rtc", ".sav", ".brm"),  # Genesis Plus GX Sega CD BRAM
     "saturn": (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc"),  # Beetle Saturn / yabasanshiro backup RAM
-    "saturnjp": (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc"),
     "ngp": (".srm", ".rtc", ".sav", ".flash", ".ngf"),  # Beetle NeoPop (.flash) / RACE (.ngf)
     "ngpc": (".srm", ".rtc", ".sav", ".flash", ".ngf"),
     "pokemini": (".srm", ".rtc", ".sav", ".eep"),  # PokeMini EEPROM
     "amiga": (".srm", ".rtc", ".sav", ".nvr"),  # PUAE non-volatile RAM
-    "amiga1200": (".srm", ".rtc", ".sav", ".nvr"),
-    "amiga600": (".srm", ".rtc", ".sav", ".nvr"),
     "amigacd32": (".srm", ".rtc", ".sav", ".nvr"),
-    "cdtv": (".srm", ".rtc", ".sav", ".nvr"),
 }
 
 
-def get_save_extensions(platform_slug: str | None = None) -> tuple[str, ...]:
-    """Return the save file extensions to search for a given platform.
+def get_save_extensions(system: str | None = None) -> tuple[str, ...]:
+    """Return the save file extensions to search for a given system.
 
     Parameters
     ----------
-    platform_slug:
-        RomM platform slug (e.g. "gba", "n64", "psx").
-        If None or not in overrides, returns the default extensions.
+    system:
+        RetroDECK *system* name — the normalized value from
+        resolve_system / platform_map (e.g. "gba", "saturn", "amiga"), NOT
+        the raw RomM platform slug. If None or not in overrides, returns the
+        default extensions.
 
     Returns
     -------
     tuple[str, ...]
         Tuple of file extensions including the leading dot (e.g. (".srm", ".rtc")).
     """
-    if platform_slug is not None and platform_slug in _PLATFORM_OVERRIDES:
-        return _PLATFORM_OVERRIDES[platform_slug]
+    if system is not None and system in _PLATFORM_OVERRIDES:
+        return _PLATFORM_OVERRIDES[system]
     return _DEFAULT_EXTENSIONS

--- a/py_modules/domain/save_extensions.py
+++ b/py_modules/domain/save_extensions.py
@@ -19,6 +19,16 @@ _DEFAULT_EXTENSIONS: tuple[str, ...] = (".srm", ".rtc", ".sav")
 _PLATFORM_OVERRIDES: dict[str, tuple[str, ...]] = {
     "nds": (".srm", ".rtc", ".sav", ".dsv"),  # DeSmuME native format
     "segacd": (".srm", ".rtc", ".sav", ".brm"),  # Genesis Plus GX Sega CD BRAM
+    "saturn": (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc"),  # Beetle Saturn / yabasanshiro backup RAM
+    "saturnjp": (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc"),
+    "ngp": (".srm", ".rtc", ".sav", ".flash", ".ngf"),  # Beetle NeoPop (.flash) / RACE (.ngf)
+    "ngpc": (".srm", ".rtc", ".sav", ".flash", ".ngf"),
+    "pokemini": (".srm", ".rtc", ".sav", ".eep"),  # PokeMini EEPROM
+    "amiga": (".srm", ".rtc", ".sav", ".nvr"),  # PUAE non-volatile RAM
+    "amiga1200": (".srm", ".rtc", ".sav", ".nvr"),
+    "amiga600": (".srm", ".rtc", ".sav", ".nvr"),
+    "amigacd32": (".srm", ".rtc", ".sav", ".nvr"),
+    "cdtv": (".srm", ".rtc", ".sav", ".nvr"),
 }
 
 

--- a/py_modules/domain/save_status.py
+++ b/py_modules/domain/save_status.py
@@ -29,6 +29,40 @@ class SaveSyncDisplay:
     last_sync_check_at: str | None
 
 
+@dataclass(frozen=True)
+class MultiFileSlot:
+    """Whether the active slot's current save spans more than one file.
+
+    A single game state on RetroArch can be stored as several files with
+    distinct extensions (e.g. Sega Saturn cartridge saves: ``.bkr`` +
+    ``.bcr`` + ``.smpc``). RomM stores each of those as an independent save
+    record with its own version stack, so the slot's "current save" is
+    really an N-file *set*, not a single file with a version history.
+
+    ``is_multi_file`` is True when the slot resolves to more than one
+    distinct local target filename. ``component_files`` is the sorted set
+    of those filenames (the N files that together make up the current
+    save); it always reflects every distinct filename in the slot, even
+    for the single-file case (one entry).
+    """
+
+    is_multi_file: bool
+    component_files: list[str]
+
+
+def compute_multi_file_slot(filenames: list[str]) -> MultiFileSlot:
+    """Classify an active slot as single- or multi-file from its target filenames.
+
+    *filenames* is the set of canonical local target filenames the active
+    slot resolves to — one per distinct save record / extension, gathered
+    from the matrix outcomes. More than one distinct filename means the
+    slot's current save is a multi-file set (the sibling files are
+    components of one game state, not prior versions of each other).
+    """
+    distinct = sorted(set(filenames))
+    return MultiFileSlot(is_multi_file=len(distinct) > 1, component_files=distinct)
+
+
 def compute_save_sync_display(
     files: list[dict[str, Any]] | None,
     last_sync_check_at: str | None,

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -746,7 +746,6 @@ class MigrationService:
         """Collect migration items for a single ROM's save files."""
         system = install.system
         file_path = install.file_path
-        platform_slug = install.platform_slug
         if not system or not file_path:
             return
         core_name: str | None = None
@@ -786,7 +785,7 @@ class MigrationService:
         if old_dir == new_dir:
             return
         rom_name = os.path.splitext(os.path.basename(file_path))[0]
-        for ext in get_save_extensions(platform_slug):
+        for ext in get_save_extensions(system):
             filename = rom_name + ext
             old_file = os.path.join(old_dir, filename)
             new_file = os.path.join(new_dir, filename)

--- a/py_modules/services/saves/rom_info.py
+++ b/py_modules/services/saves/rom_info.py
@@ -188,11 +188,11 @@ class RomInfoService:
             return []
         rom_name = info["rom_name"]
         saves_dir = info["saves_dir"]
-        platform_slug = info["platform_slug"]
+        system = info["system"]
         if not self._save_file_store.is_dir(saves_dir):
             return []
         results = []
-        for ext in get_save_extensions(platform_slug):
+        for ext in get_save_extensions(system):
             save_path = os.path.join(saves_dir, rom_name + ext)
             if self._save_file_store.is_file(save_path):
                 results.append({"path": save_path, "filename": rom_name + ext})

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -8,7 +8,7 @@ from domain.emulator_tag import detect_core_change
 from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_attribution import compute_uploaded_by_us
-from domain.save_status import compute_save_sync_display
+from domain.save_status import compute_multi_file_slot, compute_save_sync_display
 from domain.save_status_builders import (
     build_file_status,
     resolve_chosen_server,
@@ -122,23 +122,28 @@ class StatusService:
         device_id: str | None,
         server_in_slot: list[dict[str, Any]],
         info: dict[str, Any],
-    ) -> tuple[MatrixOutcome | None, list[MatrixOutcome], bool]:
+    ) -> tuple[MatrixOutcome | None, list[MatrixOutcome], bool, list[str]]:
         """Iterate matrix outcomes for the active slot, splitting them into local/server-only buckets.
 
         Side effect: when an outcome is ``Skip(adopt_baseline=True)`` with
         a local hash, records that hash as the new sync baseline on
         *save_state* (in memory) and flags that a write is needed.
 
-        Returns ``(first_local_outcome, server_only_outcomes, baseline_adopted)``.
-        The local bucket is the first outcome with a local file present —
-        matching the active-slot single-entry view this status flow surfaces.
+        Returns ``(first_local_outcome, server_only_outcomes, baseline_adopted,
+        all_filenames)``. The local bucket is the first outcome with a local
+        file present — matching the active-slot single-entry view this status
+        flow surfaces. ``all_filenames`` is every distinct canonical target
+        filename the slot resolves to (one per outcome), used to detect a
+        multi-file save (#908 guard).
         """
         local_outcome: MatrixOutcome | None = None
         server_only_outcomes: list[MatrixOutcome] = []
         baseline_adopted = False
+        all_filenames: list[str] = []
         for outcome in self._sync_engine.iter_matrix_outcomes(
             rom_id, server_in_slot, save_state=save_state, device_id=device_id, info=info
         ):
+            all_filenames.append(outcome.filename)
             if isinstance(outcome.action, Skip) and outcome.action.adopt_baseline and outcome.local_hash:
                 self._sync_engine.adopt_baseline_hash(save_state, outcome.filename, outcome.local_hash)
                 baseline_adopted = True
@@ -146,7 +151,7 @@ class StatusService:
                 server_only_outcomes.append(outcome)
             elif local_outcome is None:
                 local_outcome = outcome
-        return local_outcome, server_only_outcomes, baseline_adopted
+        return local_outcome, server_only_outcomes, baseline_adopted, all_filenames
 
     def _get_save_status_io(
         self,
@@ -201,14 +206,16 @@ class StatusService:
 
         file_statuses: list[dict[str, Any]] = []
         conflicts: list[dict[str, Any]] = []
+        multi_file = compute_multi_file_slot([])
 
         if info is not None:
             # The baseline-adopt path mutates a working copy; an absent aggregate
             # starts from a fresh default so the matrix can evaluate against it.
             working_state = save_state if save_state is not None else RomSaveState()
-            local_outcome, server_only_outcomes, baseline_adopted = self._partition_outcomes(
+            local_outcome, server_only_outcomes, baseline_adopted, all_filenames = self._partition_outcomes(
                 rom_id, working_state, device_id, server_in_slot, info
             )
+            multi_file = compute_multi_file_slot(all_filenames)
             if baseline_adopted:
                 with self._uow_factory() as uow:
                     uow.rom_save_states.save(rom_id, working_state)
@@ -252,6 +259,15 @@ class StatusService:
                 )
             ),
             "server_query_failed": server_query_failed,
+            # Interim #908 guard: a slot whose current save spans >1 distinct
+            # file (e.g. Saturn .bkr/.bcr/.smpc) is an N-file *set*, not a
+            # single file with a version history. Per-version rollback would
+            # revert one component and leave the others — an incoherent save —
+            # so version history + rollback are suppressed for multi-file slots
+            # until grouped save-states land (#908).
+            "multi_file": multi_file.is_multi_file,
+            "component_files": multi_file.component_files,
+            "rollback_supported": not multi_file.is_multi_file,
         }
 
     # ------------------------------------------------------------------

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
+from domain.save_status import compute_multi_file_slot
 from services.saves._helpers import local_save_target
 from services.saves._settings import resolve_default_slot
 
@@ -89,6 +90,19 @@ class VersionsService:
         with self._uow_factory() as uow:
             uow.rom_save_states.save(rom_id, save_state)
 
+    def _local_component_filenames(self, rom_id: int) -> list[str]:
+        """Distinct local save filenames on disk for the ROM (one per extension).
+
+        Used to detect a multi-file save — more than one distinct filename
+        means the slot's current save is an N-file set (e.g. Saturn
+        ``.bkr``/``.bcr``/``.smpc``), not a single file with a version
+        history (#908 interim guard). Reads only the local saves directory,
+        no network: a rollback target is always an *installed* ROM, so its
+        component files are present on disk. Returns an empty list when the
+        ROM is not installed.
+        """
+        return [lf["filename"] for lf in self._rom_info.find_save_files(rom_id)]
+
     # ------------------------------------------------------------------
     # Version History API
     # ------------------------------------------------------------------
@@ -111,6 +125,14 @@ class VersionsService:
           contains: id, file_name, emulator, updated_at, file_size_bytes,
           device_syncs, uploaded_by_us. ``versions`` may be empty — the
           server answered, nothing matched.
+        - ``{"status": "multi_file_unsupported", "versions": []}`` when the
+          slot's current save spans more than one distinct file (e.g.
+          Saturn ``.bkr``/``.bcr``/``.smpc``). The sibling records are
+          components of one game state, not prior versions, so listing them
+          as history would be misleading and rolling back would corrupt the
+          set. Interim #908 guard — the frontend already hides the panel via
+          ``get_save_status``'s ``multi_file`` flag; this is the defensive
+          backstop for any direct caller.
         - ``{"status": "server_unreachable", "message": ...}`` if the
           ``list_saves`` call failed (network, server, auth, etc.). The
           frontend distinguishes this from an empty list so it can show a
@@ -118,6 +140,11 @@ class VersionsService:
         """
         rom_id = int(rom_id)
         save_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
+
+        component_files = await self._loop.run_in_executor(None, self._local_component_filenames, rom_id)
+        if compute_multi_file_slot(component_files).is_multi_file:
+            self._log_debug(f"list_file_versions: multi-file slot for rom {rom_id} ({component_files}); suppressing")
+            return {"status": "multi_file_unsupported", "versions": []}
 
         try:
             server_saves = await self._loop.run_in_executor(
@@ -264,6 +291,11 @@ class VersionsService:
           ``version_deleted`` so it can prompt the user to reinstall the
           ROM rather than telling them the version is gone from the
           server.
+        - ``{"status": "unsupported"}`` if the slot's current save spans
+          more than one distinct file (e.g. Saturn ``.bkr``/``.bcr``/
+          ``.smpc``). Per-version rollback would revert one component and
+          leave the others — an incoherent save — so it is refused.
+          Interim #908 guard; grouped atomic-set rollback is tracked there.
         - ``{"status": "version_deleted"}`` if the chosen save id is no
           longer on the server (genuinely deleted — the ``list_saves``
           call succeeded and the id was absent).
@@ -291,6 +323,17 @@ class VersionsService:
             info = self._rom_info.get_rom_save_info(rom_id)
             if not info:
                 return {"status": "rom_not_installed"}
+
+            # Interim #908 guard: refuse per-version rollback on a multi-file
+            # slot (e.g. Saturn .bkr/.bcr/.smpc) before any destructive or
+            # preflight I/O runs — rolling one component back would leave the
+            # others, producing an incoherent save. Local-only (no network):
+            # a rollback target is always installed, so its component files
+            # are on disk.
+            component_files = await self._loop.run_in_executor(None, self._local_component_filenames, rom_id)
+            if compute_multi_file_slot(component_files).is_multi_file:
+                self._log_debug(f"rollback_to_version: multi-file slot for rom {rom_id} ({component_files}); refusing")
+                return {"status": "unsupported"}
 
             save_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
             core_so = await self._loop.run_in_executor(None, self._resolve_core, rom_id)

--- a/src/components/saves/SlotPanel.test.tsx
+++ b/src/components/saves/SlotPanel.test.tsx
@@ -221,6 +221,49 @@ describe("SlotPanel", () => {
       expect(queryByTestId("vhp-b.srm")).not.toBeNull();
     });
 
+    it("multi-file slot: shows component list + #908 note and NO VersionHistoryPanel", () => {
+      const status = makeStatus({
+        files: [
+          {
+            filename: "rally.bkr",
+            local_path: "/data/rally.bkr",
+            local_hash: "h",
+            local_mtime: "2025-06-15T10:00:00Z",
+            local_size: 100,
+            server_save_id: 1,
+            server_file_name: null,
+            server_emulator: null,
+            server_updated_at: null,
+            server_size: null,
+            last_sync_at: null,
+            status: "synced",
+          },
+        ],
+        multi_file: true,
+        component_files: ["rally.bcr", "rally.bkr", "rally.smpc"],
+        rollback_supported: false,
+      });
+      const { container, queryByTestId } = render(
+        <SlotPanel
+          {...defaultProps({
+            isActive: true,
+            defaultExpanded: true,
+            saveStatus: status,
+          })}
+        />,
+      );
+      // The component file list is shown.
+      expect(container.textContent).toContain("Files in this save (3)");
+      expect(container.textContent).toContain("rally.bcr");
+      expect(container.textContent).toContain("rally.smpc");
+      // The calm #908 note replaces Previous Versions / rollback.
+      expect(container.textContent).toContain(
+        "This save spans 3 files. Per-version rollback isn't available for multi-file saves yet.",
+      );
+      // No version-history / rollback control is rendered for the file.
+      expect(queryByTestId("vhp-rally.bkr")).toBeNull();
+    });
+
     it("shows 'No save files tracked yet' when active slot has no files", () => {
       const { container } = render(
         <SlotPanel

--- a/src/components/saves/SlotPanel.tsx
+++ b/src/components/saves/SlotPanel.tsx
@@ -23,6 +23,48 @@ import { InactiveSlotBody } from "./InactiveSlotBody";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import { detach } from "../../utils/detach";
 
+/**
+ * Multi-file note (#908 interim guard) — replaces the Previous-Versions /
+ * rollback UI for a save that spans more than one file. Lists the N component
+ * filenames and explains that per-version rollback isn't available yet.
+ */
+function renderMultiFileNote(componentFiles: string[]): ReturnType<typeof createElement> {
+  const n = componentFiles.length;
+  return createElement(
+    "div",
+    {
+      key: "multi-file-note",
+      style: { marginTop: "6px", marginLeft: "8px" },
+    },
+    createElement(
+      "div",
+      { style: { fontSize: "11px", color: "#8f98a0", fontWeight: 600 } },
+      `Files in this save (${n})`,
+    ),
+    ...componentFiles.map((fn) =>
+      createElement(
+        "div",
+        {
+          key: `comp-${fn}`,
+          style: {
+            fontSize: "11px",
+            color: "#8f98a0",
+            fontFamily: "monospace",
+            wordBreak: "break-all" as const,
+            marginTop: "1px",
+          },
+        },
+        fn,
+      ),
+    ),
+    createElement(
+      "div",
+      { style: { fontSize: "11px", color: MUTED_COLOR, fontStyle: "italic" as const, marginTop: "4px" } },
+      `This save spans ${n} files. Per-version rollback isn't available for multi-file saves yet.`,
+    ),
+  );
+}
+
 function renderActiveSlotBody(
   saveStatus: SaveStatus | null,
   conflicts: SyncConflict[],
@@ -32,6 +74,24 @@ function renderActiveSlotBody(
   onVersionRestored: () => void,
 ): (ReturnType<typeof createElement> | null)[] {
   if (saveStatus && saveStatus.files.length > 0) {
+    // Multi-file save (#908 guard): the slot's current save is one game state
+    // spread across N files. The siblings are components, not prior versions,
+    // so suppress the per-file VersionHistoryPanel/rollback and show the
+    // component list + a calm note instead.
+    if (saveStatus.multi_file) {
+      const componentFiles = saveStatus.component_files ?? [];
+      return [
+        ...saveStatus.files.map((f) => {
+          const conflict = conflicts.find((c) => c.filename === f.filename);
+          return createElement(
+            "div",
+            { key: f.filename },
+            renderSaveFileRow(f, conflict, saveStatus.last_sync_check_at),
+          );
+        }),
+        renderMultiFileNote(componentFiles),
+      ];
+    }
     return saveStatus.files.map((f) => {
       const conflict = conflicts.find((c) => c.filename === f.filename);
       return createElement(

--- a/src/components/saves/VersionHistoryPanel.tsx
+++ b/src/components/saves/VersionHistoryPanel.tsx
@@ -35,7 +35,10 @@ export const VersionHistoryPanel: FC<VersionHistoryPanelProps> = ({ romId, slot,
     setLoadError(null);
     try {
       const result: ListFileVersionsResult = await savesListFileVersions(romId, slot, filename);
-      if (result.status === "ok") {
+      if (result.status === "ok" || result.status === "multi_file_unsupported") {
+        // multi_file_unsupported carries an empty list — a multi-file slot's
+        // siblings are components, not prior versions (#908). The panel is
+        // hidden for multi-file slots anyway; this is the defensive backstop.
         setVersions(result.versions);
       } else {
         detach(debugLog(`VersionHistoryPanel: server unreachable for ${filename}: ${result.message}`));

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -84,6 +84,18 @@ export interface SaveStatus {
    *  and surface a misleading uploads-pending indicator on what is in
    *  fact a connectivity blip. */
   server_query_failed?: boolean;
+  /** True when the active slot's current save spans more than one distinct
+   *  file (e.g. Sega Saturn `.bkr`/`.bcr`/`.smpc`). Those siblings are
+   *  components of one game state, not prior versions — so the frontend
+   *  suppresses per-file version history + rollback and shows the component
+   *  list instead. Interim #908 guard. */
+  multi_file?: boolean;
+  /** The N filenames that together make up the current save (sorted). Set
+   *  alongside `multi_file`; one entry for a single-file slot. */
+  component_files?: string[];
+  /** False when per-version rollback is unavailable for the slot — currently
+   *  only for multi-file saves (mirrors `!multi_file`). */
+  rollback_supported?: boolean;
 }
 
 export interface SaveSlotSummary {
@@ -192,4 +204,5 @@ export type RollbackStatus =
 
 export type ListFileVersionsResult =
   | { status: "ok"; versions: SaveVersionEntry[] }
+  | { status: "multi_file_unsupported"; versions: SaveVersionEntry[] }
   | { status: "server_unreachable"; message: string };

--- a/tests/domain/test_save_extensions.py
+++ b/tests/domain/test_save_extensions.py
@@ -31,17 +31,17 @@ class TestGetSaveExtensionsDefault:
 
 
 class TestGetSaveExtensionsWithOverride:
-    """get_save_extensions respects platform-specific overrides."""
+    """get_save_extensions respects per-system overrides (keys are RetroDECK systems)."""
 
     def test_nds_override_includes_dsv(self):
-        """NDS platform returns DeSmuME .dsv extension."""
+        """NDS system returns DeSmuME .dsv extension."""
         result = get_save_extensions("nds")
         assert ".dsv" in result
         assert ".srm" in result
         assert ".sav" in result
 
     def test_segacd_override_includes_brm(self):
-        """Sega CD platform returns Genesis Plus GX .brm extension."""
+        """Sega CD system returns Genesis Plus GX .brm extension."""
         result = get_save_extensions("segacd")
         assert ".brm" in result
         assert ".srm" in result
@@ -51,17 +51,13 @@ class TestGetSaveExtensionsWithOverride:
         result = get_save_extensions("saturn")
         assert result == (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc")
 
-    def test_saturnjp_matches_saturn(self):
-        """The saturnjp alias slug returns the same tuple as saturn."""
-        assert get_save_extensions("saturnjp") == get_save_extensions("saturn")
-
     def test_ngp_override_appends_flash_and_ngf(self):
         """NGP returns Beetle NeoPop (.flash) and RACE (.ngf) extensions, defaults retained."""
         result = get_save_extensions("ngp")
         assert result == (".srm", ".rtc", ".sav", ".flash", ".ngf")
 
     def test_ngpc_matches_ngp(self):
-        """The ngpc alias slug returns the same tuple as ngp."""
+        """The ngpc system returns the same tuple as ngp."""
         assert get_save_extensions("ngpc") == get_save_extensions("ngp")
 
     def test_pokemini_override_appends_eep(self):
@@ -74,11 +70,22 @@ class TestGetSaveExtensionsWithOverride:
         result = get_save_extensions("amiga")
         assert result == (".srm", ".rtc", ".sav", ".nvr")
 
-    def test_amiga_family_slugs_match(self):
-        """All amiga-family slugs return identical tuples."""
-        expected = get_save_extensions("amiga")
-        for slug in ("amiga1200", "amiga600", "amigacd32", "cdtv"):
-            assert get_save_extensions(slug) == expected
+    def test_amigacd32_override_appends_nvr(self):
+        """AmigaCD32 returns the PUAE .nvr extension, defaults retained."""
+        result = get_save_extensions("amigacd32")
+        assert result == (".srm", ".rtc", ".sav", ".nvr")
+
+    def test_dropped_keys_now_return_default(self):
+        """Keys unreachable under system-keying are dropped → they return defaults.
+
+        ``saturnjp`` normalizes to system ``saturn``, ``amiga1200``/``amiga600``
+        to system ``amiga``, and ``commodore-cdtv`` is not yet in platform_map
+        (so no ``cdtv`` system can arrive). None of these strings is a system
+        name any install produces, so they are no longer override keys and fall
+        through to the defaults.
+        """
+        for dropped in ("saturnjp", "amiga1200", "amiga600", "cdtv"):
+            assert get_save_extensions(dropped) == _DEFAULTS
 
     def test_non_override_platform_still_returns_default(self):
         """Platforms without overrides get defaults."""

--- a/tests/domain/test_save_extensions.py
+++ b/tests/domain/test_save_extensions.py
@@ -46,12 +46,48 @@ class TestGetSaveExtensionsWithOverride:
         assert ".brm" in result
         assert ".srm" in result
 
+    def test_saturn_override_appends_backup_ram_extensions(self):
+        """Saturn returns Beetle Saturn / yabasanshiro backup RAM extensions, defaults retained."""
+        result = get_save_extensions("saturn")
+        assert result == (".srm", ".rtc", ".sav", ".bkr", ".bcr", ".smpc")
+
+    def test_saturnjp_matches_saturn(self):
+        """The saturnjp alias slug returns the same tuple as saturn."""
+        assert get_save_extensions("saturnjp") == get_save_extensions("saturn")
+
+    def test_ngp_override_appends_flash_and_ngf(self):
+        """NGP returns Beetle NeoPop (.flash) and RACE (.ngf) extensions, defaults retained."""
+        result = get_save_extensions("ngp")
+        assert result == (".srm", ".rtc", ".sav", ".flash", ".ngf")
+
+    def test_ngpc_matches_ngp(self):
+        """The ngpc alias slug returns the same tuple as ngp."""
+        assert get_save_extensions("ngpc") == get_save_extensions("ngp")
+
+    def test_pokemini_override_appends_eep(self):
+        """PokeMini returns the EEPROM .eep extension, defaults retained."""
+        result = get_save_extensions("pokemini")
+        assert result == (".srm", ".rtc", ".sav", ".eep")
+
+    def test_amiga_override_appends_nvr(self):
+        """Amiga returns the PUAE .nvr extension, defaults retained."""
+        result = get_save_extensions("amiga")
+        assert result == (".srm", ".rtc", ".sav", ".nvr")
+
+    def test_amiga_family_slugs_match(self):
+        """All amiga-family slugs return identical tuples."""
+        expected = get_save_extensions("amiga")
+        for slug in ("amiga1200", "amiga600", "amigacd32", "cdtv"):
+            assert get_save_extensions(slug) == expected
+
     def test_non_override_platform_still_returns_default(self):
         """Platforms without overrides get defaults."""
         result = get_save_extensions("gba")
         assert result == _DEFAULTS
         assert ".dsv" not in result
         assert ".brm" not in result
+        assert ".nvr" not in result
+        assert ".flash" not in result
 
     def test_patched_override_replaces_defaults(self):
         """A patched override completely replaces the default list."""

--- a/tests/domain/test_save_status.py
+++ b/tests/domain/test_save_status.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from domain.save_status import SaveSyncDisplay, compute_save_sync_display
+from domain.save_status import (
+    MultiFileSlot,
+    SaveSyncDisplay,
+    compute_multi_file_slot,
+    compute_save_sync_display,
+)
 
 
 class TestComputeSaveSyncDisplay:
@@ -75,3 +80,33 @@ class TestComputeSaveSyncDisplay:
         """Default value (False) preserves the pre-fix behavior."""
         result = compute_save_sync_display(None, None)
         assert result == SaveSyncDisplay(status="none", label="No saves", last_sync_check_at=None)
+
+
+class TestComputeMultiFileSlot:
+    """compute_multi_file_slot — single vs. multi-file detection from target filenames."""
+
+    def test_empty_is_single_file(self):
+        """No files (e.g. ROM not installed / empty slot) is not multi-file."""
+        result = compute_multi_file_slot([])
+        assert result == MultiFileSlot(is_multi_file=False, component_files=[])
+
+    def test_single_file_is_not_multi_file(self):
+        result = compute_multi_file_slot(["pokemon.srm"])
+        assert result == MultiFileSlot(is_multi_file=False, component_files=["pokemon.srm"])
+
+    def test_multiple_distinct_files_is_multi_file(self):
+        """Saturn cartridge save: .bkr + .bcr + .smpc = one game state across three files."""
+        result = compute_multi_file_slot(["rally.bkr", "rally.bcr", "rally.smpc"])
+        assert result.is_multi_file is True
+        # Sorted set of the component filenames.
+        assert result.component_files == ["rally.bcr", "rally.bkr", "rally.smpc"]
+
+    def test_duplicate_filenames_collapse_to_single(self):
+        """Repeated identical filenames are one distinct file, not multi-file."""
+        result = compute_multi_file_slot(["pokemon.srm", "pokemon.srm"])
+        assert result == MultiFileSlot(is_multi_file=False, component_files=["pokemon.srm"])
+
+    def test_component_files_are_deduped_and_sorted(self):
+        result = compute_multi_file_slot(["b.sav", "a.srm", "b.sav", "a.srm"])
+        assert result.is_multi_file is True
+        assert result.component_files == ["a.srm", "b.sav"]

--- a/tests/services/saves/test_rom_info.py
+++ b/tests/services/saves/test_rom_info.py
@@ -79,6 +79,36 @@ class TestFindSaveFiles:
 
         assert result == []
 
+    def test_probes_system_extensions_when_slug_differs_from_system(self, tmp_path):
+        """find_save_files keys save extensions by the normalized system, not the raw RomM slug (#899).
+
+        Regression for the call-site leak: ``get_save_extensions`` was called
+        with the raw RomM ``platform_slug`` (``sega-saturn``), which has no
+        override and falls back to defaults — so a Saturn backup-RAM ``.bkr``
+        save was never probed. The fix keys the lookup by the normalized
+        ``system`` (``saturn``), whose override includes ``.bkr``. Reverting the
+        rom_info.py change (passing ``platform_slug`` again) makes this fail:
+        ``sega-saturn`` is not in ``_PLATFORM_OVERRIDES`` so ``.bkr`` is not in
+        the probed extension list and the save is missed.
+        """
+        svc, _ = make_service(tmp_path)
+        _seed_install(
+            svc,
+            70,
+            file_path=str(tmp_path / "retrodeck" / "roms" / "saturn" / "Panzer Dragoon.cue"),
+            system="saturn",
+            platform_slug="sega-saturn",
+        )
+        # sort_by_content=True (RetroDECK default, no sort settings seeded) →
+        # saves land in saves_base/{content_dir}, content_dir = "saturn".
+        saves_dir = tmp_path / "saves" / "saturn"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        (saves_dir / "Panzer Dragoon.bkr").write_bytes(b"\x00" * 256)
+
+        result = svc._rom_info.find_save_files(70)
+
+        assert [f["filename"] for f in result] == ["Panzer Dragoon.bkr"]
+
 
 class TestGetRomSaveInfo:
     """Tests for get_rom_save_info."""

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -263,6 +263,62 @@ class TestGetSaveStatusComputeAction:
         assert result["conflicts"] == []
 
 
+class TestMultiFileSlotGuard:
+    """get_save_status flags a multi-file slot and marks rollback unsupported (#908 interim guard).
+
+    A multi-file save (e.g. Saturn ``.bkr``/``.bcr``/``.smpc``) is one game
+    state spread across several files, each stored on RomM as an independent
+    record. Listing the siblings as "previous versions" and rolling one back
+    would corrupt the set, so the status response signals the frontend to
+    suppress version history + rollback until grouped save-states land.
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_file_slot_flags_and_disables_rollback(self, tmp_path):
+        """Two distinct local extensions for the same rom → multi_file=True, rollback unsupported."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path, system="saturn", file_name="rally.cue")
+        # Two component files of one Saturn cartridge save.
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bkr")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bcr")
+
+        result = await svc.get_save_status(42)
+
+        assert result["multi_file"] is True
+        assert result["rollback_supported"] is False
+        # Component filenames are the sorted set of the slot's files.
+        assert result["component_files"] == ["rally.bcr", "rally.bkr"]
+
+    @pytest.mark.asyncio
+    async def test_single_file_slot_is_not_multi_file(self, tmp_path):
+        """A single-extension slot keeps multi_file=False and rollback supported."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[100] = _server_save()
+
+        result = await svc.get_save_status(42)
+
+        assert result["multi_file"] is False
+        assert result["rollback_supported"] is True
+        assert result["component_files"] == ["pokemon.srm"]
+
+    @pytest.mark.asyncio
+    async def test_no_local_files_is_not_multi_file(self, tmp_path):
+        """ROM installed but no local saves → not multi-file, rollback supported."""
+        svc, _ = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+
+        result = await svc.get_save_status(42)
+
+        assert result["multi_file"] is False
+        assert result["rollback_supported"] is True
+        assert result["component_files"] == []
+
+
 class TestSaveSyncDisplayEnrichment:
     """get_save_status ships a pre-computed save_sync_display alongside files/conflicts."""
 

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -266,6 +266,44 @@ class TestListFileVersions:
         assert len(versions) == 1
         assert versions[0]["uploaded_by_us"] is None
 
+    @pytest.mark.asyncio
+    async def test_multi_file_slot_suppresses_versions(self, tmp_path):
+        """A multi-file slot (e.g. Saturn .bkr/.bcr) returns multi_file_unsupported
+        with an empty version list — the sibling records are components of one
+        game state, not prior versions (#908 interim guard)."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path, system="saturn", file_name="rally.cue")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bkr")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bcr")
+        # Server saves exist, but they must NOT be surfaced as "previous versions".
+        fake.saves[100] = _server_save(
+            save_id=100, rom_id=42, slot="default", filename="rally.bkr", updated_at="2026-03-10T10:00:00Z"
+        )
+        fake.saves[50] = _server_save(
+            save_id=50, rom_id=42, slot="default", filename="rally.bcr", updated_at="2026-03-01T10:00:00Z"
+        )
+
+        result = await svc.list_file_versions(42, "default", "rally.bkr")
+
+        assert result == {"status": "multi_file_unsupported", "versions": []}
+
+    @pytest.mark.asyncio
+    async def test_single_file_slot_still_lists_versions(self, tmp_path):
+        """A single-extension slot is unaffected by the multi-file guard."""
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[100] = _server_save(save_id=100, rom_id=42, slot="default", updated_at="2026-03-10T10:00:00Z")
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-03-01T10:00:00Z")
+        self._setup_state(svc, tracked_id=100)
+
+        result = await svc.list_file_versions(42, "default", "pokemon.srm")
+
+        assert result["status"] == "ok"
+        assert [v["id"] for v in result["versions"]] == [50]
+
 
 class TestRollbackToVersion:
     """Tests for SaveService.rollback_to_version — the core rollback flow."""
@@ -553,6 +591,46 @@ class TestRollbackToVersion:
         assert "error" not in result
         # Critical: must NOT collide with the "genuinely deleted" case.
         assert result["status"] != "version_deleted"
+
+    @pytest.mark.asyncio
+    async def test_multi_file_slot_refuses_rollback(self, tmp_path):
+        """A multi-file slot refuses per-version rollback (#908 interim guard).
+
+        Rolling one component (e.g. Saturn .bkr) back to an older version
+        would leave the siblings (.bcr/.smpc) on the current version,
+        producing an incoherent save — so the rollback is refused before any
+        preflight or destructive I/O runs.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path, system="saturn", file_name="rally.cue")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bkr")
+        _create_save(tmp_path, system="saturn", rom_name="rally", ext=".bcr")
+        fake.saves[50] = _server_save(
+            save_id=50, rom_id=42, slot="default", filename="rally.bkr", updated_at="2026-02-01T10:00:00Z"
+        )
+
+        result = await svc.rollback_to_version(42, "default", 50)
+
+        assert result == {"status": "unsupported"}
+        # No destructive I/O ran: the target was never downloaded.
+        download_ids = [c[1][0] for c in fake.call_log if c[0] == "download_save_content"]
+        assert 50 not in download_ids
+
+    @pytest.mark.asyncio
+    async def test_single_file_slot_rollback_unaffected(self, tmp_path):
+        """A single-extension slot rolls back normally — the guard does not fire."""
+        svc, fake = make_service(tmp_path)
+
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        self._setup_state(svc, tmp_path, tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = self._tracked_save(100)
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.rollback_to_version(42, "default", 50)
+
+        assert result["status"] == "ok"
 
     # ------------------------------------------------------------------
     # Cross-device propagation: rollback re-PUTs target so it becomes


### PR DESCRIPTION
Closes #899

## What this does

1. **Single-token memory-card extensions.** Adds `_PLATFORM_OVERRIDES` rows for Saturn (`.bkr`/`.bcr`/`.smpc`), NGP/NGPC (`.flash`/`.ngf`), Pokémon Mini (`.eep`), and Amiga / AmigaCD32 (`.nvr`) so the per-game probe finds these non-`.srm` battery saves.
2. **Keys the extension lookup by the normalized RetroDECK `system`, not the raw RomM slug.** The save directory in the same flow was already system-keyed; the extension lookup wasn't, so for any platform where `slug != system` the override silently missed → core-specific saves were never probed. Decision recorded in **[ADR-0010](docs/adr/0010-normalize-romm-slug-to-retrodeck-system.md)**.
3. **Interim guard for multi-file version history & rollback** ([#908](https://github.com/danielcopper/decky-romm-sync/issues/908)). A multi-file save (e.g. Saturn = 3 files = one state) is N independent RomM records; the UI mislabeled the sibling files as "Previous Versions" and rollback acted per-file (incoherent). The Saves tab now shows them as save components and disables rollback for multi-file slots, with backend backstops.
4. Tooling: `deno fmt` for Markdown added to the pre-commit hook (+ `deno` pinned in `mise.toml`).

## On-device validation (hardware, against a real RomM ≥ 4.8.1)

- **Upload:** Saturn `.bkr`+`.bcr`+`.smpc`, NGPC `.flash`, PokéMini `.eep` all discovered + uploaded (Saturn multi-file `synced=3`, others `synced=1`).
- **`slug != system` proven live:** the test RomM returned `neo-geo-pocket-color` (NGPC) and `pokemon-mini` (PokéMini) — the long IGDB slugs. Both saves were found **only** because the lookup keys by the normalized `system`; the old raw-slug lookup would have silently missed them.
- **Round-trip:** local deleted → re-synced → every file downloaded back **byte-identical** (sha256), Saturn pulling all 3.
- **Real launch:** a Beetle Saturn launch confirmed pre-launch sync (`Skip` when in-sync, `synced=0`) and post-exit sync (`Upload`, `synced=3`, `errors=0`).
- Extensions are source-verified per libretro core (Beetle Saturn / Beetle NeoPop / RACE / PokeMini / PUAE).

## Scope / limitations

- Shared-card toggles (`shared_intmemory`, `opt_shared_nvram`) and PUAE M3U multi-disc write a shared card → not per-game, won't sync (documented).
- `cdtv` `.nvr` is deferred until `platform_map` maps `commodore-cdtv` ([#907](https://github.com/danielcopper/decky-romm-sync/issues/907)). Coherent multi-file rollback is tracked in [#908](https://github.com/danielcopper/decky-romm-sync/issues/908).

## Before merge

- [x] On-device: saves land as `<rom>.<ext>` and round-trip byte-identical (validated for Saturn / NGPC / PokéMini)
- [x] Flip the support-matrix rows 🔜 → ✅ (Saturn, NGP, NGPC, Pokémon Mini, Amiga, AmigaCD32; d9eda40)
- [x] Follow-up issues filed: [#906](https://github.com/danielcopper/decky-romm-sync/issues/906) (slug→system leak), [#907](https://github.com/danielcopper/decky-romm-sync/issues/907) (platform_map coverage), [#908](https://github.com/danielcopper/decky-romm-sync/issues/908) (multi-file rollback)
