### PR TITLE
docs(persistence): reconcile docs with landed SQLite persistence layer

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,7 +55,7 @@ opens one connection, exposes the repositories, and commits on clean exit / roll
 database reads/writes, never network/file I/O or a frontend round-trip; cross-operation consistency comes from the
 operation's own serialization (the per-ROM save lock, the single library-sync task), not from holding a UoW open.
 
-### Persistence boundary (settings.json / save_sync_state.json / SQLite)
+### Persistence boundary (settings.json / SQLite)
 
 Where a piece of persisted state lives is a deliberate decision driven by what the data _is_, not which file it
 historically lived in. Per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md), three buckets, and the bucket
@@ -71,28 +71,27 @@ picks the store:
 3. **Synced / derived relational state with real invariants** — per-ROM groups, history, caches of remote data →
    **SQLite aggregates**.
 
-`save_sync_state.json` is the _legacy_ JSON home for bucket-3 save state and for `device_id`; it is replaced by SQLite
-at the cutover. As of #822 it no longer holds the save-sync toggles or `device_name` (those moved to `settings.json`,
-settings schema v4) — only `device_id` remains until the cutover folds it into `kv_config`.
+`device_id` now lives in the `kv_config` table; bucket-3 save state lives in SQLite aggregates. `save_sync_state.json`
+is a dead store — never written, read exactly once at bootstrap for the one-time legacy settings fold. As of #822 it no
+longer held the save-sync toggles or `device_name` (those moved to `settings.json`, settings schema v4).
 
 ### Cutover
 
-The hard cut from JSON state files to SQLite ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)).
-"Hard" means **SQLite starts empty** — the JSON state is not migrated into it, and the JSON-era domain classes are
-deleted in the same wave. Bucket-1 config (`settings.json`) and the change-detection markers are unaffected by the
-cutover; only the relational save/library/playtime state is re-derived from scratch (re-synced from RomM, re-pruned
-against disk). The JSON→JSON moves that _precede_ the cutover (e.g. #822) are explicitly **not** cutover work — they
-ship independently because they touch no SQLite.
+The hard cut from JSON state files to SQLite ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) has
+landed. "Hard" means **SQLite started empty** — the JSON state was not migrated into it, and the JSON-era domain classes
+(`SaveSyncState`, `PluginState`) and `domain/save_state.py` were deleted in the same wave. Bucket-1 config
+(`settings.json`) and the change-detection markers were unaffected; only the relational save/library/playtime state was
+re-derived from scratch (re-synced from RomM, re-pruned against disk).
 
 ### kv_config
 
 A key-value table for small singleton configuration values that don't justify their own aggregate or table. One row per
 key.
 
-Intended residents (per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md); the table is created-but-unused
-until the cutover): the RetroDECK home path marker (`retrodeck_home_path` + its pending-migration `_previous`), the
-save-sort settings markers (`save_sort_settings` + `_previous`), and `device_id` (server-issued identity, folded in at
-the cutover). The schema version is **not** a `kv_config` key — it lives in `PRAGMA user_version`.
+Residents (per [ADR-0003](docs/adr/0003-json-sqlite-persistence-boundary.md)): the RetroDECK home path marker
+(`retrodeck_home_path` + its pending-migration `_previous`), the save-sort settings markers (`save_sort_settings` +
+`_previous`), `device_id` (server-issued identity), and `platform_names` (platform_slug → display_name cache). The
+schema version is **not** a `kv_config` key — it lives in `PRAGMA user_version`.
 
 **Not** a dumping ground: anything with its own lifecycle, invariants, or repeat-row potential gets its own aggregate.
 `kv_config` is for the truly small, the truly singleton, and the truly miscellaneous.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -36,7 +36,6 @@ bootstrap.py (composition root: bootstrap() builds adapters, wire_services() bui
 │   SteamGridDbAdapter / SgdbArtworkCacheAdapter — SGDB   │
 │   PersistenceAdapter (+ persister adapters) — JSON I/O  │
 │   SqliteUnitOfWork (+ repository adapters) — SQLite I/O │
-│   MetadataCacheStoreAdapter                             │
 │   CoverArtFileStore / DownloadFile                      │
 │   FirmwareFile / MigrationFile / RomFile / SaveFile     │
 │   RetroDeckPaths / RetroArchConfig / RetroArchCoreInfo  │
@@ -195,27 +194,25 @@ Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip p
 
 Adapters own all I/O and implement the Protocols defined in `services/protocols/`. Selected adapters:
 
-| Module                                                                     | Role                                                                                                                                                                    |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `romm/http.py`                                                             | `RommHttpAdapter` — HTTP transport: auth, SSL, retry, User-Agent, platform map                                                                                          |
-| `romm/romm_api.py`                                                         | `RommApiAdapter` — RomM REST surface (saves, ROMs, platforms, firmware, devices, notes) over the HTTP transport                                                         |
-| `steam_config.py`                                                          | `SteamConfigAdapter` — Steam VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                          |
-| `steamgriddb.py`                                                           | `SteamGridDbAdapter` — SteamGridDB REST client                                                                                                                          |
-| `sgdb_artwork_cache.py`                                                    | `SgdbArtworkCacheAdapter` — on-disk SGDB artwork cache                                                                                                                  |
-| `cover_art_file_store.py`                                                  | `CoverArtFileStoreAdapter` — RomM cover art staging on disk                                                                                                             |
-| `persistence.py`                                                           | `PersistenceAdapter` + per-domain persister adapters — settings/state/cache/save-sync JSON I/O                                                                          |
-| `repositories/`                                                            | `SqliteUnitOfWork` + per-aggregate repository adapters — SQLite I/O (the live persistence path; see [Database Design](database-design.md))                              |
-| `sqlite_migrations.py`                                                     | `apply_migrations` — schema migration runner (`db/migrations/NNN_*.sql`, `PRAGMA user_version`)                                                                         |
-| `registry_store.py`                                                        | `RegistryStoreAdapter` — JSON shortcut-registry reads/writes; no longer wired (the library slice moved to `roms`), kept until teardown for the not-yet-migrated readers |
-| `metadata_cache_store.py`                                                  | `MetadataCacheStoreAdapter` — metadata cache reads/writes                                                                                                               |
-| `download_file.py`                                                         | `DownloadFileAdapter` — download filesystem                                                                                                                             |
-| `firmware_file.py` / `migration_file.py` / `rom_files.py` / `save_file.py` | per-subtree filesystem adapters (BIOS, RetroDECK migration, ROM removal, local saves)                                                                                   |
-| `retrodeck_paths.py`                                                       | `RetroDeckPathsAdapter` — reads `retrodeck.json` for ROMs/saves/BIOS/home paths                                                                                         |
-| `retroarch_config.py`                                                      | `RetroArchConfigAdapter` — reads `retroarch.cfg` save-sort flags                                                                                                        |
-| `retroarch_core_info.py`                                                   | `RetroArchCoreInfoAdapter` — reads RetroArch `.info` files (`corename`, metadata)                                                                                       |
-| `es_de_config.py`                                                          | `CoreResolver` + `GamelistXmlEditorAdapter` — ES-DE `es_systems.xml` / `gamelist.xml`                                                                                   |
-| `system_clock.py` / `system_uuid_gen.py` / `asyncio_sleeper.py`            | concrete `Clock` / `UuidGen` / `Sleeper` seams                                                                                                                          |
-| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, path-exists probe, `package.json` version reader, settings-aware debug logger                                                                                 |
+| Module                                                                     | Role                                                                                                                                                                          |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `romm/http.py`                                                             | `RommHttpAdapter` — HTTP transport: auth, SSL, retry, User-Agent, platform map                                                                                                |
+| `romm/romm_api.py`                                                         | `RommApiAdapter` — RomM REST surface (saves, ROMs, platforms, firmware, devices, notes) over the HTTP transport                                                               |
+| `steam_config.py`                                                          | `SteamConfigAdapter` — Steam VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                                |
+| `steamgriddb.py`                                                           | `SteamGridDbAdapter` — SteamGridDB REST client                                                                                                                                |
+| `sgdb_artwork_cache.py`                                                    | `SgdbArtworkCacheAdapter` — on-disk SGDB artwork cache                                                                                                                        |
+| `cover_art_file_store.py`                                                  | `CoverArtFileStoreAdapter` — RomM cover art staging on disk                                                                                                                   |
+| `persistence.py`                                                           | `PersistenceAdapter` + per-domain persister adapters — `settings.json` read/write plus the one-time legacy `save_sync_state.json` read that feeds the bootstrap settings fold |
+| `repositories/`                                                            | `SqliteUnitOfWork` + per-aggregate repository adapters — SQLite I/O (the live persistence path; see [Database Design](database-design.md))                                    |
+| `sqlite_migrations.py`                                                     | `apply_migrations` — schema migration runner (`db/migrations/NNN_*.sql`, `PRAGMA user_version`)                                                                               |
+| `download_file.py`                                                         | `DownloadFileAdapter` — download filesystem                                                                                                                                   |
+| `firmware_file.py` / `migration_file.py` / `rom_files.py` / `save_file.py` | per-subtree filesystem adapters (BIOS, RetroDECK migration, ROM removal, local saves)                                                                                         |
+| `retrodeck_paths.py`                                                       | `RetroDeckPathsAdapter` — reads `retrodeck.json` for ROMs/saves/BIOS/home paths                                                                                               |
+| `retroarch_config.py`                                                      | `RetroArchConfigAdapter` — reads `retroarch.cfg` save-sort flags                                                                                                              |
+| `retroarch_core_info.py`                                                   | `RetroArchCoreInfoAdapter` — reads RetroArch `.info` files (`corename`, metadata)                                                                                             |
+| `es_de_config.py`                                                          | `CoreResolver` + `GamelistXmlEditorAdapter` — ES-DE `es_systems.xml` / `gamelist.xml`                                                                                         |
+| `system_clock.py` / `system_uuid_gen.py` / `asyncio_sleeper.py`            | concrete `Clock` / `UuidGen` / `Sleeper` seams                                                                                                                                |
+| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, path-exists probe, `package.json` version reader, settings-aware debug logger                                                                                       |
 
 #### PersistenceAdapter notes
 
@@ -239,7 +236,7 @@ documented in [Database Design](database-design.md). Selected modules:
 | `sync_diff.py`                                                                    | ROM classification and platform/collection diff computation for the sync preview                                                                                                                       |
 | `preview_delta.py`                                                                | `PreviewDelta` shape for the sync preview                                                                                                                                                              |
 | `work_unit.py`                                                                    | `WorkUnit` — the per-unit sync work item                                                                                                                                                               |
-| `save_state.py`                                                                   | `SaveSyncState` aggregate + `from_dict`/`to_dict` (schema migrations live here)                                                                                                                        |
+| `rom_save_state.py`                                                               | `RomSaveState` aggregate + `FileSyncState` value object — per-ROM save-sync state, backed by `rom_save_states` + `rom_save_files`                                                                      |
 | `save_path.py` / `save_attribution.py` / `save_status*.py` / `save_extensions.py` | save path resolution, uploader attribution, status DTO building                                                                                                                                        |
 | `firmware_paths.py` / `bios.py`                                                   | BIOS path computation and status formatting; `bios.py` also holds the BIOS status dataclasses (`AvailableCore`, `BiosFileEntry`, `BiosStatus`)                                                         |
 | `iso_time.py`                                                                     | `parse_iso` / `parse_iso_to_epoch` — ISO-8601 timestamp parsing (stdlib only)                                                                                                                          |
@@ -249,7 +246,7 @@ documented in [Database Design](database-design.md). Selected modules:
 | `sgdb_artwork.py`                                                                 | SGDB asset-type/endpoint maps and `to_signed_app_id`                                                                                                                                                   |
 | `installed_roms.py` / `rom_files.py`                                              | installed-ROM detection, M3U generation, launch-file detection                                                                                                                                         |
 | `retroarch_core_info.py`                                                          | `parse_core_info` — pure parser for RetroArch `.info` files                                                                                                                                            |
-| `state_migrations.py`                                                             | `migrate_settings` / `migrate_state` for the main state files                                                                                                                                          |
+| `state_migrations.py`                                                             | `migrate_settings` (`settings.json`) + `fold_legacy_save_sync_settings` (one-time legacy `save_sync_state.json` fold); `migrate_state` is a vestigial v1 no-op kept as future-migration scaffolding    |
 | `sync_state.py`                                                                   | `SyncState` enum (idle, running, cancelling)                                                                                                                                                           |
 | `emulator_tag.py` / `version.py`                                                  | emulator-tag formatting, version parsing, core-change detection                                                                                                                                        |
 
@@ -259,8 +256,8 @@ Protocol into services). The full pattern, source catalog, and decisions log are
 
 ### Models (`py_modules/models/`)
 
-TypedDicts and dataclasses describing on-disk and in-flight data shapes (`state.py`, `metadata.py`,
-`metadata_patches.py`, `registry_patches.py`). Models import nothing from the other layers.
+TypedDicts and dataclasses describing on-disk and in-flight data shapes (`state.py`, `metadata.py`). Models import
+nothing from the other layers.
 
 ### Other
 
@@ -275,19 +272,20 @@ TypedDicts and dataclasses describing on-disk and in-flight data shapes (`state.
 
 The composition root has two functions:
 
-1. **`bootstrap()`** — builds every adapter and loads + migrates settings, plugin state, and the metadata cache so the
-   persister adapters bind the live mutable dicts at construction. Returns a typed `BootstrapResult` carrying four
-   bundles (`adapters`, `stores`, `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only
-   outputs.
+1. **`bootstrap()`** — builds every adapter, applies the SQLite schema migrations, and loads + migrates `settings.json`
+   (folding in the one-time legacy `save_sync_state.json` settings) so the settings persister binds the live mutable
+   `settings` dict at construction. Returns a typed `BootstrapResult` carrying four bundles (`adapters`, `stores`,
+   `callbacks`, `runtime_adapters`) plus a small `handles` struct for Plugin-only outputs.
 
 2. **`wire_services()`** — takes a `WiringConfig` (the four bundles plus `min_required_version`) and constructs every
    service, injecting each one's `*ServiceConfig`. Returns a dict of named service instances.
 
 The two-phase split exists because adapter instantiation and state loading happen first (`bootstrap()`), then `main.py`
-composes the runtime bundle (event loop, `decky.emit`) and calls `wire_services()` so services receive references to the
-fully-populated state dicts. Some services are constructed before others to satisfy ordering constraints (e.g.
-`MigrationService` before `SaveService` so save sync observes fresh save-sort state). Forward references between peers
-are threaded via `LateBinding`.
+composes the runtime bundle (event loop, `decky.emit`) and calls `wire_services()`. Services receive the `settings` dict
+(the only field on `StateBundle`) plus the SQLite Unit-of-Work factory / repository handles for all relational state —
+no plural in-memory state dicts remain. Some services are constructed before others to satisfy ordering constraints
+(e.g. `MigrationService` before `SaveService` so save sync observes fresh save-sort state). Forward references between
+peers are threaded via `LateBinding`.
 
 Per the process-boundary rule, adapter instantiation never happens in `main.py`, and no service wiring happens in
 `bootstrap.py`'s caller other than via `wire_services()`.
@@ -301,8 +299,7 @@ package, organised topically (consumers always deep-import `from services.protoc
   `RommDeviceApi`, `RommFirmwareApi`, `RommPlaytimeApi`, `RommLibraryApi`, `RommConnectionApi`, `RommPlatformReader`,
   `RommAchievementsApi`, `RommSyncApi`, `RommVersion`), `SteamConfigStore`, `SteamGridDbApi`.
 - **`determinism`** — `Clock` / `UuidGen` / `Sleeper` test seams.
-- **`persistence`** — `StatePersister`, `SettingsPersister`, `MetadataCachePersister`, `MetadataCacheStore`,
-  `FirmwareCachePersister`, `SaveSyncStatePersister`, `ShortcutRegistryStore`, `PluginMetadataReader`.
+- **`persistence`** — `SettingsPersister`, `PluginMetadataReader`.
 - **`paths`** — `RetroDeckPaths`, `SystemResolver`, `CoreInfoProvider`, `CoreResolverFn`, `CoreNameProviderFn`,
   `RetroArchConfigReader`, `RetroArchCoreInfoReader`, `RetroArchSaveSortingProvider`, `GamelistXmlEditor`.
 - **`infra`** — cross-cutting callable seams: `EventEmitter`, `DebugLogger`, `PathExistsReader`, `HostnameReader`,
@@ -389,10 +386,9 @@ call site: services may not call `datetime.now()` / `asyncio.sleep()` / `time.ti
 
 `scripts/check_aggregate_field_assignment.py` (also bundled into `mise run lint`) is a small custom AST linter that
 enforces the **mutation-only-via-methods** rule for aggregates — a rule no type checker can express directly. It
-collects the class names decorated with `@cosmic_aggregate` in `domain/`, then scans `services/` for
-`<aggregate>.<field> = ...` assignments and fails CI on any it finds. The escape hatch is a trailing
-`# pragma: no aggregate-check` on the offending line. It is a no-op until aggregate roots exist (the decorator set is
-empty today) and activates automatically as they land. Full detail in [Database Design](database-design.md).
+collects the class names decorated with `@cosmic_aggregate` in `domain/` (currently the 8 aggregate roots), then scans
+`services/` for `<aggregate>.<field> = ...` assignments and fails CI on any it finds. The escape hatch is a trailing
+`# pragma: no aggregate-check` on the offending line. Full detail in [Database Design](database-design.md).
 
 ### 4. Enforced: underscore prefix
 
@@ -411,26 +407,26 @@ underscore, which keeps `reportPrivateUsage` coherent with the saves-style peer-
 Every service receives its dependencies through a single `*ServiceConfig` dataclass. Cross-service dependencies are
 Protocol-typed (services never import each other's concrete classes). Selected wiring:
 
-| Service                     | Key injected dependencies                                                                                                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **LibraryService**          | `RommLibraryApi`, `SteamConfigStore`, `ArtworkManager`, `Clock`/`UuidGen`/`Sleeper`, `SettingsPersister`, `UnitOfWorkFactory` (roms / sync_runs / kv_config / rom_metadata)      |
-| **MetadataService**         | `UnitOfWorkFactory` (reads `rom_metadata` / `roms`)                                                                                                                              |
-| **SaveService**             | `RommApi`, `RetryStrategy`, `SaveFileStore`, `SaveSyncStatePersister`, `Clock`, `RetroDeckPaths`, core-name/active-core providers, migration-detect callbacks                    |
-| **DownloadService**         | `RommApi`, `DownloadFileStore`, `RetroDeckPaths`, `Clock`/`Sleeper`                                                                                                              |
-| **FirmwareService**         | `RommApi`, `FirmwareFileStore`, `FirmwareCachePersister`, `CoreInfoProvider`, `RetroDeckPaths`                                                                                   |
-| **SteamGridService**        | `SteamGridDbApi`, `RommApi`, `SteamConfigStore`, `SgdbArtworkCache`, `UnitOfWorkFactory` (sgdb_id on `roms`), `PendingSyncReader`                                                |
-| **MigrationService**        | `MigrationFileStore`, `RetroDeckPaths`, save-sort/active-core/core-name providers, BIOS-index callback                                                                           |
-| **GameDetailService**       | `BiosChecker`, `AchievementsReader` (cross-service), `Clock`, `UnitOfWorkFactory` (one read UoW over `roms` / `rom_installs` / `rom_save_states` / `rom_metadata` / `kv_config`) |
-| **AchievementsService**     | `RommAchievementsApi`, `Clock`, `DebugLogger`, `UnitOfWorkFactory` (reads `ra_id` from `roms`)                                                                                   |
-| **SettingsService**         | `SteamConfigStore`, `SettingsPersister`, `UnitOfWorkFactory` (reads bound `shortcut_app_id`s from `roms`)                                                                        |
-| **PlaytimeService**         | `RommPlaytimeApi`, `RetryStrategy`, `Clock`, `UnitOfWorkFactory` (reads/writes `rom_playtime`)                                                                                   |
-| **RomRemovalService**       | `RomFileStore`, `RetroDeckPaths`, `DownloadQueueCleanup` peer, `UnitOfWorkFactory` (reads/deletes `rom_installs`)                                                                |
-| **ShortcutRemovalService**  | `SteamConfigStore`, `ArtworkRemover` peer, `UnitOfWorkFactory` (unbinds via `roms`, offline name via `kv_config`)                                                                |
-| **SessionLifecycleService** | `Session*` cross-service seams (playtime / post-exit sync / achievement sync / migration reader)                                                                                 |
-| **LaunchGateService**       | `LaunchGateRomLookup`, `LaunchGateInstalledChecker`, `LaunchGateSaveStatusReader` cross-service seams                                                                            |
-| **ConnectionService**       | `RommConnectionApi`, `SettingsPersister`, `min_required_version`                                                                                                                 |
+| Service                     | Key injected dependencies                                                                                                                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LibraryService**          | `RommLibraryApi`, `SteamConfigStore`, `ArtworkManager`, `Clock`/`UuidGen`/`Sleeper`, `SettingsPersister`, `UnitOfWorkFactory` (roms / sync_runs / kv_config / rom_metadata)                     |
+| **MetadataService**         | `UnitOfWorkFactory` (reads `rom_metadata` / `roms`)                                                                                                                                             |
+| **SaveService**             | `RommApi`, `RetryStrategy`, `SaveFileStore`, `UnitOfWorkFactory` (`rom_save_states` / `rom_save_files`), `Clock`, `RetroDeckPaths`, core-name/active-core providers, migration-detect callbacks |
+| **DownloadService**         | `RommApi`, `DownloadFileStore`, `RetroDeckPaths`, `Clock`/`Sleeper`                                                                                                                             |
+| **FirmwareService**         | `RommApi`, `FirmwareFileStore`, `CoreInfoProvider`, `RetroDeckPaths`, `UnitOfWorkFactory` (`firmware_cache`)                                                                                    |
+| **SteamGridService**        | `SteamGridDbApi`, `RommApi`, `SteamConfigStore`, `SgdbArtworkCache`, `UnitOfWorkFactory` (sgdb_id on `roms`), `PendingSyncReader`                                                               |
+| **MigrationService**        | `MigrationFileStore`, `RetroDeckPaths`, save-sort/active-core/core-name providers, BIOS-index callback                                                                                          |
+| **GameDetailService**       | `BiosChecker`, `AchievementsReader` (cross-service), `Clock`, `UnitOfWorkFactory` (one read UoW over `roms` / `rom_installs` / `rom_save_states` / `rom_metadata` / `kv_config`)                |
+| **AchievementsService**     | `RommAchievementsApi`, `Clock`, `DebugLogger`, `UnitOfWorkFactory` (reads `ra_id` from `roms`)                                                                                                  |
+| **SettingsService**         | `SteamConfigStore`, `SettingsPersister`, `UnitOfWorkFactory` (reads bound `shortcut_app_id`s from `roms`)                                                                                       |
+| **PlaytimeService**         | `RommPlaytimeApi`, `RetryStrategy`, `Clock`, `UnitOfWorkFactory` (reads/writes `rom_playtime`)                                                                                                  |
+| **RomRemovalService**       | `RomFileStore`, `RetroDeckPaths`, `DownloadQueueCleanup` peer, `UnitOfWorkFactory` (reads/deletes `rom_installs`)                                                                               |
+| **ShortcutRemovalService**  | `SteamConfigStore`, `ArtworkRemover` peer, `UnitOfWorkFactory` (unbinds via `roms`, offline name via `kv_config`)                                                                               |
+| **SessionLifecycleService** | `Session*` cross-service seams (playtime / post-exit sync / achievement sync / migration reader)                                                                                                |
+| **LaunchGateService**       | `LaunchGateRomLookup`, `LaunchGateInstalledChecker`, `LaunchGateSaveStatusReader` cross-service seams                                                                                           |
+| **ConnectionService**       | `RommConnectionApi`, `SettingsPersister`, `min_required_version`                                                                                                                                |
 
-Most services also receive shared state (`state`, `settings`, `metadata_cache`, `save_sync_state`), the event loop, the
-logger, and the `DebugLogger` Protocol through their config. As the SQLite cutover proceeds, services that no longer
-read the in-memory dicts drop them: `GameDetailService`/`AchievementsService` no longer take `state`, and
-`SettingsService` reads bound shortcuts from `roms` rather than the in-memory `shortcut_registry`.
+Most services also receive the `settings` dict (`StateBundle`'s only field), the runtime infrastructure (event loop,
+logger, the `DebugLogger` Protocol), and the `UnitOfWorkFactory` for relational state through their config. The old
+in-memory `state` / `metadata_cache` / `save_sync_state` / `shortcut_registry` dicts are gone — every relational
+read/write goes through the Unit of Work.

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -3,44 +3,49 @@
 ## Overview
 
 This page is the canonical home for the **aggregate domain model** behind the SQLite persistence migration (epic
-[#271](https://github.com/danielcopper/decky-romm-sync/issues/271)). The migration replaces the current JSON state files
-with a SQLite database whose tables back a set of Cosmic Python aggregates.
+[#271](https://github.com/danielcopper/decky-romm-sync/issues/271)). The migration replaced the JSON state files with a
+SQLite database whose tables back a set of Cosmic Python aggregates.
 
-The migration is phased. The **enforcement infrastructure** (the decorator, the linters, and the type-check rule that
-keep aggregates honest, [#788](https://github.com/danielcopper/decky-romm-sync/issues/788)), the full **aggregate set**
-(the 8 aggregate roots, their fields, and their mutation methods), the **SQLite schema** (the migration framework +
-`001_initial.sql`,
+The migration **and its teardown are complete**. The **enforcement infrastructure** (the decorator, the linters, and the
+type-check rule that keep aggregates honest, [#788](https://github.com/danielcopper/decky-romm-sync/issues/788)), the
+full **aggregate set** (the 8 aggregate roots, their fields, and their mutation methods), the **SQLite schema** (the
+migration framework + `001_initial.sql`,
 [#780](https://github.com/danielcopper/decky-romm-sync/issues/780)/[#781](https://github.com/danielcopper/decky-romm-sync/issues/781)),
 the per-aggregate **Repository Protocols** ([#782](https://github.com/danielcopper/decky-romm-sync/issues/782)), and the
 runtime **Unit of Work** + concrete `sqlite3` repository adapters
-([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)) are all in place — documented below. The service
-cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) is in flight, vertical by vertical.
+([#783](https://github.com/danielcopper/decky-romm-sync/issues/783)) are all in place — documented below. SQLite,
+reached through the Unit of Work, is the **sole live persistence path for relational state**; the only remaining live
+JSON file is `settings.json`.
 
-The cutover is a **hard cut** — SQLite starts empty, the JSON state is not migrated into it, and each JSON-era state
-class is deleted once its last consumer moves over. The **library/roms slice has landed**: the live sync path now writes
-`roms` (the synced-ROM registry), `sync_runs` (the start→complete/cancel/error lifecycle that replaces the JSON
-`last_sync`/`sync_stats` scalars), and the `kv_config` `platform_slug → display_name` cache row, all through Repository
-Protocols + the Unit of Work. The **metadata slice has landed**: `rom_metadata` is now written by the reporter's
-per-unit commit — the same write Unit of Work as the `roms` upsert (Rom row first, then metadata, so the `rom_id` FK is
-satisfied at commit and a ROM and its cached metadata land atomically) — and `MetadataService`/`GameDetailService` read
-it back from SQLite (the JSON `metadata_cache` is no longer read by either). The **playtime slice has landed**:
-`PlaytimeService` now records sessions and reconciles RomM-note totals through the `rom_playtime` aggregate (session-end
-folds the duration in a short write UoW, then pushes to RomM outside the transaction; opening a game's detail page
-triggers a pull-only reconcile that reads the RomM note and folds its total into `rom_playtime` via `reconcile_total` —
-total-only, never writing a note). The **rom-removal + startup-healing slice has landed**:
-`RomRemovalService.remove_rom`/`uninstall_all_roms` and `StartupHealingService.prune_stale_installed_roms` now read and
-delete `rom_installs` through the Unit of Work instead of the JSON `installed_roms` dict — an uninstall (or stale prune)
-deletes only the on-disk files and the `rom_installs` row, never the `roms` identity row, playtime, saves, or metadata
-([ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md)).
-The **read-consumers slice has landed**: the last in-memory `shortcut_registry` readers moved to SQLite —
-`GameDetailService` resolves the ROM, install record, cached save state, cached metadata, and platform-name cache in one
-read Unit of Work (the has-saves badge now reads `rom_save_states`, the platform display name the `kv_config` cache,
-both degrading gracefully when absent); `AchievementsService` reads each ROM's `ra_id` from `roms`;
-`SettingsService.apply_steam_input_setting` reads the bound `shortcut_app_id`s from `roms` (skipping unbound NULL rows).
-With that, the in-memory `shortcut_registry` dict has **no live service reader**, and `SaveSyncState` is **fully dead**
-— both `.playtime` (already dropped) and `.saves` (GameDetailService was the last reader) now have no live reader. Those
-JSON-era state classes — `SaveSyncState`, the in-memory `shortcut_registry` dict — and the now-dead JSON
-`metadata_cache` store are deleted in the teardown stream.
+The cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) was a **hard cut** — SQLite started
+empty, the JSON state was not migrated into it, and each JSON-era state class was deleted once its last consumer moved
+over. Each vertical landed in turn:
+
+- **library/roms** — the live sync path writes `roms` (the synced-ROM registry), `sync_runs` (the
+  start→complete/cancel/error lifecycle that replaced the JSON `last_sync`/`sync_stats` scalars), and the `kv_config`
+  `platform_slug → display_name` cache row, all through Repository Protocols + the Unit of Work.
+- **metadata** — `rom_metadata` is written by the reporter's per-unit commit, the same write Unit of Work as the `roms`
+  upsert (Rom row first, then metadata, so the `rom_id` FK is satisfied at commit and a ROM and its cached metadata land
+  atomically); `MetadataService`/`GameDetailService` read it back from SQLite.
+- **playtime** — `PlaytimeService` records sessions and reconciles RomM-note totals through the `rom_playtime` aggregate
+  (session-end folds the duration in a short write UoW, then pushes to RomM outside the transaction; opening a game's
+  detail page triggers a pull-only reconcile that folds the RomM note's total into `rom_playtime` via `reconcile_total`
+  — total-only, never writing a note).
+- **rom-removal + startup-healing** — `RomRemovalService.remove_rom`/`uninstall_all_roms` and
+  `StartupHealingService.prune_stale_installed_roms` read and delete `rom_installs` through the Unit of Work; an
+  uninstall (or stale prune) deletes only the on-disk files and the `rom_installs` row, never the `roms` identity row,
+  playtime, saves, or metadata
+  ([ADR-0007](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0007-rom-retention-identity-anchor.md)).
+- **read-consumers** — `GameDetailService` resolves the ROM, install record, cached save state, cached metadata, and
+  platform-name cache in one read Unit of Work (the has-saves badge reads `rom_save_states`, the platform display name
+  the `kv_config` cache, both degrading gracefully when absent); `AchievementsService` reads each ROM's `ra_id` from
+  `roms`; `SettingsService.apply_steam_input_setting` reads the bound `shortcut_app_id`s from `roms` (skipping unbound
+  NULL rows).
+
+With every consumer moved over, the teardown completed: the JSON-era state class `SaveSyncState`
+(`domain/save_state.py`), the dead JSON stores (`RegistryStoreAdapter`, `MetadataCacheStoreAdapter`), the dead
+persisters, and the in-memory state dicts (`shortcut_registry`, `metadata_cache`, and the catch-all `state` dict) are
+all **deleted**.
 
 ## What an aggregate is here
 
@@ -129,10 +134,8 @@ comment on the offending line:
 rom.cover_path = path  # pragma: no aggregate-check
 ```
 
-**It is a no-op until aggregates exist.** No class carries `@cosmic_aggregate` yet, so the aggregate-name set is empty
-and the check finds nothing. It activates automatically as the aggregate roots land in later PRs — the moment a
-`@cosmic_aggregate` class appears, any `aggregate.field = ...` in a service starts failing CI. Old JSON-era containers
-(e.g. `SaveSyncState`) don't carry the decorator, so they keep working until the cutover wave replaces them.
+**The check is active.** The 8 aggregate roots all carry `@cosmic_aggregate`, so the aggregate-name set is populated and
+any `aggregate.field = ...` assignment in a service fails CI. The escape hatch above is the only way past it.
 
 ### 3. import-linter — domain is stdlib + self only
 
@@ -252,12 +255,13 @@ rule) maps 1:1 onto these tables.
 | `sync_runs`       | `SyncRun`                   | `id`                         | one row per sync run (history) |
 | `kv_config`       | misc singleton scalars      | `key`                        | per key                        |
 
-`SyncRun` carries its own invariants, so per CONTEXT.md it gets a typed table rather than untyped `kv_config` rows.
-`kv_config` is reserved for the truly miscellaneous: `retrodeck_home_path` (+ its pending-migration `_previous`),
-`save_sort_settings` (+ `_previous`), and the `platform_names` cache — a single `platform_slug → display_name` JSON blob
-the library sync refreshes every run so offline reads (the DangerZone label, the game-detail platform name) show
-"Nintendo 64" rather than the bare `n64` slug when RomM is unreachable. The schema version is **not** a `kv_config` key
-— it is tracked in `PRAGMA user_version` by the [migration runner](#the-migration-framework)
+`SyncRun` carries its own invariants, so per CONTEXT.md it gets a typed table rather than untyped `kv_config` rows. The
+full live `kv_config` key set is `device_id` (the server-issued device identity), `platform_names` (the JSON-encoded
+`platform_slug → display_name` cache), `retrodeck_home_path` (+ its pending-migration `_previous`), and
+`save_sort_settings` (+ `_previous`) — the truly miscellaneous singleton scalars. The `platform_names` cache is a single
+JSON blob the library sync refreshes every run so offline reads (the DangerZone label, the game-detail platform name)
+show "Nintendo 64" rather than the bare `n64` slug when RomM is unreachable. The schema version is **not** a `kv_config`
+key — it is tracked in `PRAGMA user_version` by the [migration runner](#the-migration-framework)
 ([#781](https://github.com/danielcopper/decky-romm-sync/issues/781)).
 
 `SyncRun` is a **history** table, not a single "last run" row: a 1-row table would let a newly-started run
@@ -350,10 +354,8 @@ full per-connection PRAGMA set for runtime Unit-of-Work connections is applied b
 explicitly.
 
 **Database location.** The database is `romm_sync.db` in the plugin runtime directory
-(`decky.DECKY_PLUGIN_RUNTIME_DIR`), alongside today's JSON state files. With the cutover
-([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) under way the live path now reads and writes it;
-DB-init is hard-failing (a migration failure aborts startup rather than degrading silently) so a corrupt or unmigratable
-database never serves stale reads.
+(`decky.DECKY_PLUGIN_RUNTIME_DIR`). The live path reads and writes it; DB-init is hard-failing (a migration failure
+aborts startup rather than degrading silently) so a corrupt or unmigratable database never serves stale reads.
 
 ### How to add a v2 migration
 
@@ -401,35 +403,35 @@ in `bootstrap()` and threaded into every migrated service's `*ServiceConfig` as 
 [ADR-0006](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0006-narrow-unit-of-work-scope.md) a
 service opens the UoW only around its DB reads/writes, never across the server/file I/O or the frontend ack.
 
-## Coming in later PRs
+## Cutover status
 
-With the aggregate set, the schema, the Repository Protocols, and the runtime UoW in place, the service cutover
-([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) lands vertical by vertical. Already migrated:
-firmware, downloads + the launcher read path (the latter since removed — the launcher no longer reads SQLite at all; the
-launch command is baked into the shortcut's `launch_options` and the `rom-launcher` exec wrapper just runs it, per
-[ADR-0009](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md)),
-the saves vertical, the library/roms slice (registry → `roms`, sync lifecycle → `sync_runs`, the platform-name cache →
-`kv_config`), the metadata slice (`rom_metadata` written by the reporter's per-unit commit;
-`MetadataService`/`GameDetailService` read it from SQLite), the playtime slice (`PlaytimeService` records sessions and
-reconciles RomM-note totals through `rom_playtime` — at session-end and pull-only on detail-page view), the
-rom-removal + startup-healing slice (`RomRemovalService` and `StartupHealingService.prune_stale_installed_roms`
-read/delete `rom_installs` through the UoW; the JSON `installed_roms` dict is no longer read by either), the
-read-consumers slice (`GameDetailService`/`AchievementsService`/`SettingsService` read the synced-shortcut registry,
-install record, save state, and `ra_id` from SQLite — the in-memory `shortcut_registry` dict has no live service reader
-and `SaveSyncState` is fully dead), and the migration slice. After the migration slice, `MigrationService` reads the
-RetroDECK-home and save-sort change-detection markers from `kv_config` (Bucket 2 per
-[ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md))
-and relocates installed-ROM file paths through `uow.rom_installs.relocate`; `SyncReporter.get_rom_by_steam_app_id` tests
-installed-ness via `uow.rom_installs.get`; and the two interim readers of the same markers moved with it —
-`StartupHealingService.prune_stale_installed_roms` reads the pending-migration home from `kv_config`, and
-`RomInfoService` reads the save-sort markers from `kv_config`. The `retrodeck_home_path*` and `save_sort_settings*`
-markers have no live JSON-state reader and are dropped from `PluginState`. Still downstream:
+The service cutover ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) landed vertical by vertical and
+is complete. Every slice migrated:
 
-- **Teardown** — with `SaveSyncState` (`.playtime` and `.saves`) and the in-memory `shortcut_registry` dict now
-  reader-free, the dead persisters, the `RegistryStoreAdapter`/`MetadataCacheStoreAdapter` JSON stores,
-  `domain/save_state.py`, and the in-memory state dict are deleted. (`installed_roms` is no longer read by any service,
-  but it stays on `PluginState`/the JSON state dict until the teardown stream removes the test seeding that still
-  populates it.)
+- **firmware** and **downloads** (the launcher's old SQLite read path was since removed — the launcher no longer reads
+  SQLite at all; the launch command is baked into the shortcut's `launch_options` and the `rom-launcher` exec wrapper
+  just runs it, per
+  [ADR-0009](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md)).
+- the **saves** vertical.
+- the **library/roms** slice (registry → `roms`, sync lifecycle → `sync_runs`, the platform-name cache → `kv_config`).
+- the **metadata** slice (`rom_metadata` written by the reporter's per-unit commit;
+  `MetadataService`/`GameDetailService` read it from SQLite).
+- the **playtime** slice (`PlaytimeService` records sessions and reconciles RomM-note totals through `rom_playtime` —
+  session-end push + pull-only reconcile-on-view).
+- the **rom-removal + startup-healing** slice (`RomRemovalService` and
+  `StartupHealingService.prune_stale_installed_roms` read/delete `rom_installs` through the UoW).
+- the **read-consumers** slice (`GameDetailService`/`AchievementsService`/`SettingsService` read the synced-shortcut
+  registry, install record, save state, and `ra_id` from SQLite).
+- the **migration** slice — `MigrationService` reads the RetroDECK-home and save-sort change-detection markers from
+  `kv_config` (Bucket 2 per
+  [ADR-0003](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0003-json-sqlite-persistence-boundary.md))
+  and relocates installed-ROM file paths through `uow.rom_installs.relocate`; `SyncReporter.get_rom_by_steam_app_id`
+  tests installed-ness via `uow.rom_installs.get`; `StartupHealingService.prune_stale_installed_roms` reads the
+  pending-migration home from `kv_config`; and `RomInfoService` reads the save-sort markers from `kv_config`.
+
+With every consumer moved over, the teardown completed: the dead persisters, the `RegistryStoreAdapter` /
+`MetadataCacheStoreAdapter` JSON stores, `domain/save_state.py` (`SaveSyncState`), and the in-memory state dicts
+(`shortcut_registry`, `metadata_cache`, `installed_roms`, and the catch-all `state` dict) are all deleted.
 
 Chapter 8+ of the Cosmic Python book (domain events + message bus) is explicitly out of scope for this epic; the
 triggers for revisiting that scope are recorded in `CLAUDE.md`.

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -134,7 +134,8 @@ unit-tested.
 - **`local_file`** — `{filename, path, size, mtime}` for a file on disk, or `None` if no local file exists for this
   filename.
 - **`server_saves_in_slot`** — RomM save dicts already filtered to the active slot.
-- **`files_state`** — the per-filename slice of `save_sync_state.json` (may be empty for a never-synced file). Carries
+- **`files_state`** — the per-filename baseline from the ROM's save state — the `FileSyncState` value object on the
+  `RomSaveState` aggregate (persisted in the `rom_save_files` table), may be empty for a never-synced file. Carries
   `tracked_save_id`, `last_sync_hash`, `last_sync_server_updated_at`, `last_sync_local_mtime`, etc.
 - **`device_id`** — this device's RomM-server ID (used to find our entry in `server_save.device_syncs`).
 - **`local_hash`** — pre-computed MD5 of `local_file`, or `None`.
@@ -837,10 +838,8 @@ If the RomM server is unreachable when a sync runs:
 ### Local delta-based accumulation
 
 Playtime is tracked per-ROM in the SQLite `rom_playtime` table (the `Playtime` aggregate), independent of the `saves`
-lifecycle. (The legacy `save_sync_state.json` `playtime.<rom_id>` section is no longer written by `PlaytimeService` and
-no longer read by anyone — uninstalling a ROM now deletes only its files and `rom_installs` row, leaving playtime and
-saves intact per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md). The dormant JSON section is dropped in the
-JSON-state teardown stream.)
+lifecycle. Uninstalling a ROM deletes only its files and `rom_installs` row, leaving playtime and saves intact per
+[ADR-0007](../adr/0007-rom-retention-identity-anchor.md).
 
 Session tracking:
 
@@ -864,89 +863,89 @@ After each play session, the backend updates the ROM's `last_played` timestamp o
 library sorted correctly by recent activity. When a RomM playtime API becomes available in the future, the locally
 accumulated `playtime_seconds` can be synced to RomM as well.
 
-## State Schema — save_sync_state.json
+## Save-Sync State — the `RomSaveState` aggregate
 
-Save sync state is stored in a separate file from the main `state.json` to avoid bloating the core state with per-ROM
-sync metadata.
+Per-ROM save-sync state lives in SQLite — there is no JSON file. The per-ROM scalars are the `RomSaveState` aggregate
+(`domain/rom_save_state.py`), backed by the `rom_save_states` table; the per-file baselines are `FileSyncState` value
+objects (one per filename), backed by the `rom_save_files` table. Both are reached through the Unit of Work as
+`uow.rom_save_states`, which spans the two tables (sync sqlite3 run via `run_in_executor`, per
+[ADR-0004](../adr/0004-sync-sqlite-unit-of-work.md)).
 
-Location: `~/homebrew/data/decky-romm-sync/save_sync_state.json`
+The canonical source for the table DDL, columns, and aggregate invariants is [database-design.md](database-design.md).
+This page describes the state conceptually; the field reference below maps each logical field to its column.
 
 The save-sync **feature toggles** (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
-`autocleanup_limit`) and the **device label** (`device_name`) live in `settings.json`, not here — they are user-intent
-config, not synced relational state (ADR-0003). `StateService` reads and writes them through the live settings dict;
-only `device_id` / `server_device_id` (server-issued identity) remain on this file.
+`autocleanup_limit`) and the **device label** (`device_name`) live in `settings.json`, not in this aggregate — they are
+user-intent config, not synced relational state (ADR-0003). Device identity is `kv_config['device_id']` (see the
+[Device Registration](#device-registration) section above), not a field on the per-ROM aggregate.
+
+The logical shape of a single ROM's save state — the scalars as a `rom_save_states` row plus its child `rom_save_files`
+rows — looks like this:
 
 ```json
 {
-  "version": 1,
-  "device_id": "550e8400-e29b-41d4-a716-446655440000",
-  "server_device_id": "81445610-e5a1-46b5-9389-9d159f99c21c",
-  "saves": {
-    "42": {
-      "system": "gba",
-      "active_slot": "default",
-      "slot_confirmed": true,
-      "last_synced_core": "mgba_libretro",
-      "own_upload_ids": [18],
-      "last_sync_check_at": "2026-02-17T10:31:00+00:00",
-      "files": {
-        "game.srm": {
-          "tracked_save_id": 18,
-          "last_sync_hash": "d41d8cd98f00b204e9800998ecf8427e",
-          "last_sync_at": "2026-02-17T10:30:00+00:00",
-          "last_sync_server_updated_at": "2026-02-17T10:30:00+00:00",
-          "last_sync_server_save_id": 18,
-          "last_sync_server_size": 32768,
-          "last_sync_local_mtime": 1739789395.0,
-          "last_sync_local_size": 32768
-        }
+  "42": {
+    "system": "gba",
+    "active_slot": "default",
+    "slot_confirmed": true,
+    "last_synced_core": "mgba_libretro",
+    "own_upload_ids": [18],
+    "last_sync_check_at": "2026-02-17T10:31:00+00:00",
+    "files": {
+      "game.srm": {
+        "tracked_save_id": 18,
+        "last_sync_hash": "d41d8cd98f00b204e9800998ecf8427e",
+        "last_sync_at": "2026-02-17T10:30:00+00:00",
+        "last_sync_server_updated_at": "2026-02-17T10:30:00+00:00",
+        "last_sync_server_save_id": 18,
+        "last_sync_server_size": 32768,
+        "last_sync_local_mtime": 1739789395.0,
+        "last_sync_local_size": 32768
       }
-    }
-  },
-  "playtime": {
-    "42": {
-      "total_seconds": 7200,
-      "session_count": 3,
-      "last_session_start": null,
-      "last_session_duration_sec": 1800,
-      "note_id": 456
     }
   }
 }
 ```
 
+Per-ROM playtime is a separate aggregate (`Playtime`, `rom_playtime` table) — see
+[Playtime Tracking](#playtime-tracking) above.
+
 ### Field reference
 
-| Field                                               | Type                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`                                           | integer                | State schema version (currently 1)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `device_id`                                         | string (UUID v4)       | Unique identifier for this machine, generated on first use                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `server_device_id`                                  | string / null          | RomM server device UUID. Null until first device registration.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `saves`                                             | object                 | Per-ROM sync metadata, keyed by `rom_id` (string)                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `saves.<id>.system`                                 | string                 | RetroDECK system slug (e.g. `"gba"`, `"snes"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `saves.<id>.active_slot`                            | string                 | Which RomM slot this game syncs to (e.g. `"default"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `saves.<id>.slot_confirmed`                         | boolean                | Whether user has explicitly chosen their slot (see "Slot Setup Wizard")                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `saves.<id>.last_synced_core`                       | string / null          | RetroArch core used at last sync (for core change detection, e.g. `"mgba_libretro"`)                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `saves.<id>.own_upload_ids`                         | array of integer       | Save ids this device originally POSTed. Drives the `uploaded_by_us` indicator on the SAVES tab.                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `saves.<id>.last_sync_check_at`                     | ISO-8601 string / null | Timestamp of the most recent `_sync_rom_saves` run for this rom (regardless of whether files transferred).                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `saves.<id>.files`                                  | object                 | Per-file sync state, keyed by filename (e.g. `"game.srm"`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `saves.<id>.files.<fn>.tracked_save_id`             | integer / null         | Most recent RomM save id this device tracked. Used to exclude the active save from the Previous Versions dropdown and as an uploader-attribution hint; **not** consulted by `compute_sync_action` (the algorithm picks newest by `updated_at`).                                                                                                                                                                                                                                                                              |
-| `saves.<id>.files.<fn>.last_sync_hash`              | MD5 hex string         | Hash of the save file at last sync. Drift baseline used by matrix rows 7/8/9/10/11/12.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `saves.<id>.files.<fn>.last_sync_at`                | ISO-8601 string        | Timestamp of last successful sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `saves.<id>.files.<fn>.last_sync_server_updated_at` | ISO-8601 string        | Server's `updated_at` at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `saves.<id>.files.<fn>.last_sync_server_save_id`    | integer                | RomM save id for the most recently synced server save.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `saves.<id>.files.<fn>.last_sync_server_size`       | integer                | Server file size at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `saves.<id>.files.<fn>.last_sync_local_mtime`       | float                  | Local file mtime (epoch seconds) at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `saves.<id>.files.<fn>.last_sync_local_size`        | integer                | Local file size (bytes) at last sync.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `playtime`                                          | object                 | **Legacy / dormant — no live reader.** Per-ROM playtime now lives in the SQLite `rom_playtime` table (the `Playtime` aggregate); `PlaytimeService` no longer writes this JSON section and `RomRemovalService` no longer reads it (uninstall keeps playtime per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md)). It is dropped in the JSON-state teardown stream. The same fields below (`total_seconds`, `session_count`, `last_session_start`, `last_session_duration_sec`, `note_id`) back the SQLite aggregate. |
-| `playtime.<id>.total_seconds`                       | integer                | Accumulated playtime in seconds.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `playtime.<id>.session_count`                       | integer                | Number of completed play sessions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `playtime.<id>.last_session_start`                  | ISO-8601 / null        | Start time of current session (null when not playing).                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `playtime.<id>.last_session_duration_sec`           | integer / null         | Duration of last completed session.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `playtime.<id>.note_id`                             | integer / null         | Cached RomM note ID for playtime storage (avoids ROM detail fetch).                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+The `saves.<id>.*` fields are columns on the `rom_save_states` table (one row per ROM); the `saves.<id>.files.<fn>.*`
+fields are columns on the `rom_save_files` table (one row per `(rom_id, filename)`). The `saves.<id>` / `files.<fn>`
+notation here mirrors the logical shape above — see [database-design.md](database-design.md) for the physical column
+names and constraints.
+
+| Field                                               | Type                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `saves`                                             | object                 | Per-ROM sync metadata, keyed by `rom_id` (string)                                                                                                                                                                                                                                                                                                                                                                                       |
+| `saves.<id>.system`                                 | string                 | RetroDECK system slug (e.g. `"gba"`, `"snes"`)                                                                                                                                                                                                                                                                                                                                                                                          |
+| `saves.<id>.emulator`                               | string                 | Emulator tag (default `"retroarch"`); forms the RomM save-folder path `saves/{system}/{rom_id}/{emulator}/`.                                                                                                                                                                                                                                                                                                                            |
+| `saves.<id>.active_slot`                            | string                 | Which RomM slot this game syncs to (e.g. `"default"`)                                                                                                                                                                                                                                                                                                                                                                                   |
+| `saves.<id>.slot_confirmed`                         | boolean                | Whether user has explicitly chosen their slot (see "Slot Setup Wizard")                                                                                                                                                                                                                                                                                                                                                                 |
+| `saves.<id>.last_synced_core`                       | string / null          | RetroArch core used at last sync (for core change detection, e.g. `"mgba_libretro"`)                                                                                                                                                                                                                                                                                                                                                    |
+| `saves.<id>.own_upload_ids`                         | array of integer       | Save ids this device originally POSTed. Drives the `uploaded_by_us` indicator on the SAVES tab.                                                                                                                                                                                                                                                                                                                                         |
+| `saves.<id>.slots`                                  | object                 | Merged slot listing (read-model cache): per slot, its `source` / `count` / latest `updated_at`.                                                                                                                                                                                                                                                                                                                                         |
+| `saves.<id>.last_sync_check_at`                     | ISO-8601 string / null | Timestamp of the most recent `_sync_rom_saves` run for this rom (regardless of whether files transferred).                                                                                                                                                                                                                                                                                                                              |
+| `saves.<id>.files`                                  | object                 | Per-file sync state, keyed by filename (e.g. `"game.srm"`)                                                                                                                                                                                                                                                                                                                                                                              |
+| `saves.<id>.files.<fn>.tracked_save_id`             | integer / null         | Most recent RomM save id this device tracked. Used to exclude the active save from the Previous Versions dropdown and as an uploader-attribution hint; **not** consulted by `compute_sync_action` (the algorithm picks newest by `updated_at`).                                                                                                                                                                                         |
+| `saves.<id>.files.<fn>.last_sync_hash`              | MD5 hex string         | Hash of the save file at last sync. Drift baseline used by matrix rows 7/8/9/10/11/12.                                                                                                                                                                                                                                                                                                                                                  |
+| `saves.<id>.files.<fn>.last_sync_at`                | ISO-8601 string        | Timestamp of last successful sync.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `saves.<id>.files.<fn>.last_sync_server_updated_at` | ISO-8601 string        | Server's `updated_at` at last sync.                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `saves.<id>.files.<fn>.last_sync_server_save_id`    | integer                | RomM save id for the most recently synced server save.                                                                                                                                                                                                                                                                                                                                                                                  |
+| `saves.<id>.files.<fn>.last_sync_server_size`       | integer                | Server file size at last sync.                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `saves.<id>.files.<fn>.last_sync_local_mtime`       | float                  | Local file mtime (epoch seconds) at last sync.                                                                                                                                                                                                                                                                                                                                                                                          |
+| `saves.<id>.files.<fn>.last_sync_local_size`        | integer                | Local file size (bytes) at last sync.                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `playtime`                                          | object                 | Per-ROM playtime lives in the `rom_playtime` table (the `Playtime` aggregate), a separate aggregate from saves — `RomRemovalService` keeps playtime on uninstall per [ADR-0007](../adr/0007-rom-retention-identity-anchor.md). The fields below (`total_seconds`, `session_count`, `last_session_start`, `last_session_duration_sec`, `note_id`) are its columns, keyed by `rom_id`. See [Playtime Tracking](#playtime-tracking) above. |
+| `playtime.<id>.total_seconds`                       | integer                | Accumulated playtime in seconds.                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `playtime.<id>.session_count`                       | integer                | Number of completed play sessions.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `playtime.<id>.last_session_start`                  | ISO-8601 / null        | Start time of current session (null when not playing).                                                                                                                                                                                                                                                                                                                                                                                  |
+| `playtime.<id>.last_session_duration_sec`           | integer / null         | Duration of last completed session.                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `playtime.<id>.note_id`                             | integer / null         | Cached RomM note ID for playtime storage (avoids ROM detail fetch).                                                                                                                                                                                                                                                                                                                                                                     |
 
 The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
-`autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this file.
+`autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this aggregate.
 `save_sync_enabled` is the master feature toggle; `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch
 / post-exit syncs; `default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save
 versions per slot on the server (10).
@@ -957,32 +956,15 @@ next sync as long as the underlying state still produces matrix row 12.
 
 ### Legacy field migration
 
-`SaveSyncState.from_dict` (`py_modules/domain/save_state.py`) performs idempotent schema migrations every time the
-plugin loads — the typed aggregate is rebuilt from the on-disk JSON, legacy keys are dropped at construction, and the
-next `to_dict`/persist produces a clean file. Each strip below disappears from disk on the next state write:
+The per-file schema migrations that the old JSON aggregate ran at load time are moot: SQLite starts empty and no JSON
+state is imported into it (this is a beta plugin — the library re-syncs from RomM). There is no on-disk aggregate to
+rebuild, so the old `active_core` → `last_synced_core` rename and the `dismissed_newer_save_id` strip no longer happen.
 
-- **`saves.<id>.active_core`** → renamed to `saves.<id>.last_synced_core` (per-game; `last_synced_core` wins if both are
-  present).
-- **`saves.<id>.files.<fn>.dismissed_newer_save_id`** → dropped. Was used by the removed newer-in-slot detection. Users
-  upgrading from v0.15.x and earlier may have this field; it's silently removed.
-- **`settings` block + `device_name`** → no longer parsed from or written to this file. The save-sync feature toggles
-  and the device label moved to `settings.json` (ADR-0003); a one-time `settings.json` schema bump (v3 → v4) reads the
-  legacy values out of `save_sync_state.json` and folds them in. On the next state write they disappear from this file.
-  The legacy `settings.conflict_mode` / `settings.clock_skew_tolerance_sec` keys (dropped in earlier releases) are not
-  carried over.
-
-The dropped `pending_conflicts`, `dismissed_saves_state`, and other obsolete sync-state fields are simply not loaded.
-They never appear in the rebuilt aggregate, and the next state write produces a clean file.
-
-### SaveSyncState SQLite cutover status
-
-The game-detail panel's cached has-saves badge (`get_cached_game_detail`) no longer reads the in-memory
-`SaveSyncState.saves` dict — it reads the `rom_save_states` aggregate through the Unit of Work (the per-file
-`last_sync_hash` → the `synced`/`unknown` status the badge renders), the lightweight counterpart to the live
-`getSaveStatus` flow above. With that and the playtime cutover, the legacy `SaveSyncState` container has **no live
-reader** and is fully dead pending teardown; the live save-sync engine still persists through `save_sync_state.json`
-(the SaveService SQLite migration is a separate cutover stream). `domain/save_state.py` is removed in the teardown
-stream, not here.
+The one surviving legacy read is a single one-time settings fold at bootstrap. `fold_legacy_save_sync_settings`
+(`py_modules/domain/state_migrations.py`) lifts the old `settings` block (the save-sync feature toggles) plus
+`device_name` out of any pre-existing `save_sync_state.json` and folds them into `settings.json` — the `settings.json`
+v3 → v4 schema bump. After that fold, `save_sync_state.json` is never read or written again; the file is not a
+persistence store anymore.
 
 ## Session Detection
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -131,13 +131,22 @@ py_modules/
   adapters/                          # I/O boundaries — implement Protocols
     romm/{http,romm_api}.py          # RomM HTTP transport + REST adapter
     steam_config.py / steamgriddb.py / sgdb_artwork_cache.py / cover_art_file_store.py
-    persistence.py / registry_store.py / metadata_cache_store.py
+    persistence.py                   # settings.json read/write + one-time legacy save_sync_state fold
+    repositories/                    # SqliteUnitOfWork (unit_of_work.py) + 9 repos (8 aggregate + kv_config)
+                                     #   (rom, rom_install, rom_metadata, playtime, rom_save_state,
+                                     #    bios_file, firmware_cache, sync_run, kv_config)
+    sqlite_migrations.py / machine_id.py  # schema migration runner (PRAGMA user_version) + machine-id reader
     download_file.py / firmware_file.py / migration_file.py / rom_files.py / save_file.py
     retrodeck_paths.py / retroarch_config.py / retroarch_core_info.py / es_de_config.py
     system_clock.py / system_uuid_gen.py / asyncio_sleeper.py / hostname.py / path_probe.py / plugin_metadata.py / debug_logger.py
+  db/
+    migrations/001_initial.sql       # SQLite schema DDL
   domain/                            # Pure compute — no I/O, no service/adapter imports
+    _aggregate.py                    # the @cosmic_aggregate decorator
+    rom.py / rom_install.py / rom_metadata.py / rom_metadata_mapping.py / playtime.py
+    rom_save_state.py / bios_file.py / firmware_cache.py / sync_run.py
     sync_action.py / sync_diff.py / preview_delta.py / work_unit.py
-    save_state.py / save_path.py / save_status*.py / save_attribution.py / save_extensions.py
+    save_path.py / save_status*.py / save_attribution.py / save_extensions.py
     firmware_paths.py / bios.py / achievements.py / shortcut_data.py / steam_categories.py
     sgdb_artwork.py / installed_roms.py / rom_files.py / retroarch_core_info.py
     state_migrations.py / sync_state.py / emulator_tag.py / version.py

--- a/py_modules/db/migrations/001_initial.sql
+++ b/py_modules/db/migrations/001_initial.sql
@@ -284,6 +284,8 @@ CREATE TABLE sync_runs (
 --   retrodeck_home_path_previous  pending-migration previous home (TEXT)
 --   save_sort_settings            {sort_by_content, sort_by_core} (JSON)
 --   save_sort_settings_previous   pending save-sort change (JSON)
+--   device_id                     server-issued device identity (TEXT)
+--   platform_names                platform_slug -> display_name cache (JSON)
 -- Schema version is NOT a kv_config key — it is tracked in PRAGMA user_version
 -- by the migration runner (adapters/sqlite_migrations.py, #781).
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #786.

The JSON→SQLite migration (#271) and its teardown have fully landed, but the architecture docs still described the JSON-era persistence as live and framed the cutover/teardown as future work. This reconciles them with the implemented SQLite layer.

## What changed

- **backend-architecture.md** — drop the deleted adapters (`registry_store`, `metadata_cache_store`) and Protocols (`StatePersister`, `MetadataCachePersister`, `MetadataCacheStore`, `SaveSyncStatePersister`, `ShortcutRegistryStore`); `SaveService` now lists the `UnitOfWorkFactory`; the aggregate field-assignment check is documented as active (8 roots); the shared-state paragraph reflects `StateBundle` holding only `settings`.
- **database-design.md** — overview and cutover-status sections moved to past tense (migration + teardown complete); `kv_config` known-keys gains `device_id` and `platform_names`.
- **save-file-sync-architecture.md** — the per-ROM save-state section is rewritten onto the `RomSaveState` aggregate (`rom_save_states` + `rom_save_files`, reached via the UoW) instead of the deleted `save_sync_state.json`; the field reference is updated (`device_id` is now a `kv_config` row, not a save-state field).
- **CONTEXT.md** — persistence-boundary, Cutover, and `kv_config` glossary entries updated to the landed state.
- **development.md** — project-structure tree adds `repositories/`, `sqlite_migrations.py`, `machine_id.py`, `db/migrations/`, and the new aggregate domain modules; drops the deleted JSON-store adapters.
- **001_initial.sql** — `device_id` and `platform_names` added to the `kv_config` known-keys comment.

## Notes

- `mkdocs build --strict` passes.
- A follow-up `chore` PR removes the dead JSON-era code this surfaced (the unconsumed `firmware_cache.json` persister chain, `_locked_write`'s `rotate_to` rotation, the orphaned `migrate_state`, and two stale docstrings) — kept separate so this stays docs-only.
