### PR TITLE
fix(cores): normalize RomM slug → RetroDECK system before core/gamelist seams

### DIFF
--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -64,14 +64,24 @@ class RommHttpAdapter:
     # ------------------------------------------------------------------
 
     def load_platform_map(self) -> dict[str, str]:
-        """Load the platform slug -> RetroDECK system mapping from config.json."""
+        """Load the platform slug -> RetroDECK system mapping from config.json.
+
+        Degrades to an empty map on a missing or corrupt config.json (matching the
+        es_de_config loaders) so ``resolve_system`` falls back to its verbatim
+        pass-through (ADR-0010 §5) instead of raising into callers — several of
+        which (the synchronous game-detail builder) have no surrounding guard.
+        """
         # Check plugin root first (Decky CLI moves defaults/ contents to root),
         # then defaults/ subdirectory (dev deploys via mise run deploy)
         root_path = os.path.join(self._plugin_dir, "config.json")
         dev_path = os.path.join(self._plugin_dir, "defaults", "config.json")
         config_path = root_path if os.path.exists(root_path) else dev_path
-        with open(config_path) as f:
-            config = json.load(f)
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            self._logger.warning("Failed to load platform_map from config.json: %s", e)
+            return {}
         return config.get("platform_map", {})
 
     def resolve_system(self, platform_slug: str, platform_fs_slug: str | None = None) -> str:

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -539,6 +539,7 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
             firmware_file_store=cfg.adapters.firmware_file_store,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             core_info=cfg.adapters.core_info_provider,
+            resolve_system=cfg.adapters.http_adapter.resolve_system,
             uow_factory=cfg.callbacks.uow_factory,
         ),
     )
@@ -601,6 +602,7 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
             logger=cfg.runtime.logger,
             core_info=cfg.adapters.core_info_provider,
             gamelist_editor=cfg.adapters.gamelist_editor,
+            resolve_system=cfg.adapters.http_adapter.resolve_system,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             bios_checker=firmware_service,
         ),

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         CoreInfoProvider,
         GamelistXmlEditor,
         RetroDeckPaths,
+        SystemResolver,
     )
 
 
@@ -33,15 +34,17 @@ class CoreServiceConfig:
     """Frozen wiring bundle handed to ``CoreService.__init__``.
 
     Carries the runtime infrastructure (event loop, logger), the
-    ES-DE read/write seams, the bundled RetroDECK paths provider,
-    and the cross-service BIOS checker. Bundled here so the ctor
-    stays within the S107 parameter budget.
+    ES-DE read/write seams, the platform-slug-to-system resolver, the
+    bundled RetroDECK paths provider, and the cross-service BIOS
+    checker. Bundled here so the ctor stays within the S107 parameter
+    budget.
     """
 
     loop: asyncio.AbstractEventLoop
     logger: logging.Logger
     core_info: CoreInfoProvider
     gamelist_editor: GamelistXmlEditor
+    resolve_system: SystemResolver
     retrodeck_paths: RetroDeckPaths
     bios_checker: BiosChecker
 
@@ -54,13 +57,15 @@ class CoreService:
         self._logger = config.logger
         self._core_info = config.core_info
         self._gamelist_editor = config.gamelist_editor
+        self._resolve_system = config.resolve_system
         self._retrodeck_paths = config.retrodeck_paths
         self._bios_checker = config.bios_checker
 
     async def get_available_cores(self, platform_slug: str) -> dict[str, Any]:
         """Return available cores for a platform along with the active selection."""
-        cores = self._core_info.get_available_cores(platform_slug)
-        active_so, active_label = self._core_info.get_active_core(platform_slug)
+        system = self._resolve_system(platform_slug)
+        cores = self._core_info.get_available_cores(system)
+        active_so, active_label = self._core_info.get_active_core(system)
         return {
             "cores": cores,
             "active_core": active_so,
@@ -70,10 +75,10 @@ class CoreService:
     def _set_system_core_io(
         self,
         retrodeck_home: str,
-        platform_slug: str,
+        system: str,
         core_label: str,
     ) -> None:
-        self._gamelist_editor.set_system_override(retrodeck_home, platform_slug, core_label or None)
+        self._gamelist_editor.set_system_override(retrodeck_home, system, core_label or None)
         self._core_info.reset_cache()
 
     async def set_system_core(self, platform_slug: str, core_label: str) -> dict[str, Any]:
@@ -89,12 +94,13 @@ class CoreService:
         retrodeck_home = self._retrodeck_paths.retrodeck_home()
         if not retrodeck_home:
             return {"success": False, "message": "RetroDECK home not found"}
+        system = self._resolve_system(platform_slug)
         try:
             await self._loop.run_in_executor(
                 None,
                 self._set_system_core_io,
                 retrodeck_home,
-                platform_slug,
+                system,
                 core_label,
             )
             bios = await self._bios_checker.check_platform_bios(platform_slug)
@@ -106,11 +112,11 @@ class CoreService:
     def _set_game_core_io(
         self,
         retrodeck_home: str,
-        platform_slug: str,
+        system: str,
         rom_path: str,
         core_label: str,
     ) -> None:
-        self._gamelist_editor.set_game_override(retrodeck_home, platform_slug, rom_path, core_label or None)
+        self._gamelist_editor.set_game_override(retrodeck_home, system, rom_path, core_label or None)
         self._core_info.reset_cache()
 
     async def set_game_core(self, platform_slug: str, rom_path: str, core_label: str) -> dict[str, Any]:
@@ -125,12 +131,13 @@ class CoreService:
         retrodeck_home = self._retrodeck_paths.retrodeck_home()
         if not retrodeck_home:
             return {"success": False, "message": "RetroDECK home not found"}
+        system = self._resolve_system(platform_slug)
         try:
             await self._loop.run_in_executor(
                 None,
                 self._set_game_core_io,
                 retrodeck_home,
-                platform_slug,
+                system,
                 rom_path,
                 core_label,
             )

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         FirmwareFileStore,
         RetroDeckPaths,
         RommFirmwareApi,
+        SystemResolver,
         UnitOfWorkFactory,
     )
 
@@ -57,6 +58,7 @@ class FirmwareServiceConfig:
     firmware_file_store: FirmwareFileStore
     retrodeck_paths: RetroDeckPaths
     core_info: CoreInfoProvider
+    resolve_system: SystemResolver
     uow_factory: UnitOfWorkFactory
 
 
@@ -76,6 +78,7 @@ class FirmwareService:
         self._firmware_file_store = config.firmware_file_store
         self._retrodeck_paths = config.retrodeck_paths
         self._core_info = config.core_info
+        self._resolve_system = config.resolve_system
         self._uow_factory = config.uow_factory
         self._bios_registry: dict[str, Any] = {}
         self._bios_files_index: dict[str, dict[str, Any]] | None = None
@@ -263,8 +266,9 @@ class FirmwareService:
         if self._firmware_cache is None:
             return None
 
+        system = self._resolve_system(platform_slug)
         fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
-        active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
+        active_core_so, active_core_label = self._core_info.get_active_core(system, rom_filename=rom_filename)
 
         registry_platform = {}
         for slug in fw_slugs:
@@ -300,7 +304,7 @@ class FirmwareService:
             "files": [asdict(f) for f in files],
             "active_core": active_core_so,
             "active_core_label": active_core_label,
-            "available_cores": self._core_info.get_available_cores(platform_slug),
+            "available_cores": self._core_info.get_available_cores(system),
             "cached_at": self._firmware_cache_epoch,
         }
 
@@ -352,13 +356,20 @@ class FirmwareService:
             return {rom.platform_slug for rom in uow.roms.iter_all() if rom.platform_slug}
 
     def _enrich_platform_map(self, platforms_map, installed_slugs):
-        """Add core info and game-installed flags to each platform entry."""
+        """Add core info and game-installed flags to each platform entry.
+
+        The core read seams key by the resolved RetroDECK ``system`` (ADR-0010
+        §2), so each entry's raw RomM/BIOS-folder slug is normalized before the
+        ``get_active_core`` / ``get_available_cores`` calls; ``has_games`` and the
+        BIOS-folder file lookups stay on the raw slug (their own vocabulary).
+        """
         for plat in platforms_map.values():
             slug = plat["platform_slug"]
-            core_so, core_label = self._core_info.get_active_core(slug)
+            system = self._resolve_system(slug)
+            core_so, core_label = self._core_info.get_active_core(system)
             plat["active_core"] = core_so
             plat["active_core_label"] = core_label
-            plat["available_cores"] = self._core_info.get_available_cores(slug)
+            plat["available_cores"] = self._core_info.get_available_cores(system)
             plat["files"] = [self._enrich_firmware_file(f, core_so=core_so) for f in plat["files"]]
             plat["has_games"] = slug in installed_slugs
             plat["all_downloaded"] = all(f["downloaded"] for f in plat["files"])
@@ -529,8 +540,9 @@ class FirmwareService:
             resp["downloaded"] = 0
             return resp
 
+        system = self._resolve_system(platform_slug)
         fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
-        core_so, _ = self._core_info.get_active_core(platform_slug)
+        core_so, _ = self._core_info.get_active_core(system)
 
         platform_firmware = [
             fw
@@ -548,8 +560,9 @@ class FirmwareService:
 
     async def check_platform_bios(self, platform_slug, rom_filename=None):
         """Check if RomM has firmware for this platform and whether it's downloaded."""
+        system = self._resolve_system(platform_slug)
         fw_slugs = firmware_paths.resolve_firmware_slugs(platform_slug)
-        active_core_so, active_core_label = self._core_info.get_active_core(platform_slug, rom_filename=rom_filename)
+        active_core_so, active_core_label = self._core_info.get_active_core(system, rom_filename=rom_filename)
 
         # Build combined registry entries for this platform from all mapped slugs
         registry_platform = {}
@@ -605,7 +618,7 @@ class FirmwareService:
             "files": [asdict(f) for f in files],
             "active_core": active_core_so,
             "active_core_label": active_core_label,
-            "available_cores": self._core_info.get_available_cores(platform_slug),
+            "available_cores": self._core_info.get_available_cores(system),
         }
 
     def _delete_platform_bios_io(self, platform_slug, files):

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -442,6 +442,28 @@ class TestPlatformMap:
         assert "snes" in pm
         assert len(pm) > 50  # Should have many entries
 
+    def test_missing_config_returns_empty_map(self, tmp_path):
+        """A plugin_dir with no config.json degrades to an empty map, not an error.
+
+        ``resolve_system`` then falls back to its verbatim pass-through (ADR-0010
+        §5) rather than raising into the synchronous game-detail builder.
+        """
+        import logging
+
+        adapter = RommHttpAdapter({}, str(tmp_path), logging.getLogger("test"), "decky-romm-sync/9.9.9")
+        assert adapter.load_platform_map() == {}
+        # resolve_system survives the empty map and passes the slug through unchanged.
+        assert adapter.resolve_system("dc") == "dc"
+
+    def test_corrupt_config_returns_empty_map(self, tmp_path):
+        """A corrupt (non-JSON) config.json degrades to an empty map, not an error."""
+        import logging
+
+        (tmp_path / "config.json").write_text("{ this is not valid json")
+        adapter = RommHttpAdapter({}, str(tmp_path), logging.getLogger("test"), "decky-romm-sync/9.9.9")
+        assert adapter.load_platform_map() == {}
+        assert adapter.resolve_system("dc") == "dc"
+
 
 # ============================================================================
 # _translate_http_error

--- a/tests/fakes/fake_core_info_provider.py
+++ b/tests/fakes/fake_core_info_provider.py
@@ -12,7 +12,10 @@ class FakeCoreInfoProvider:
     Both attributes are mutable so tests can set them directly on the
     instance before exercising the code under test. ``reset_cache``
     increments ``reset_cache_count`` so writers can assert the cache
-    was invalidated after a write.
+    was invalidated after a write. ``active_core_calls`` and
+    ``available_cores_calls`` record the ``system_name`` each seam was
+    invoked with so callers can assert a normalized system (not the raw
+    platform slug) reached the read seam.
     """
 
     def __init__(
@@ -24,15 +27,19 @@ class FakeCoreInfoProvider:
         self.active_core = active_core
         self.available_cores: list[dict[str, Any]] = available_cores if available_cores is not None else []
         self.reset_cache_count = 0
+        self.active_core_calls: list[tuple[str, str | None]] = []
+        self.available_cores_calls: list[str] = []
 
     def get_active_core(
         self,
         system_name: str,
         rom_filename: str | None = None,
     ) -> tuple[str | None, str | None]:
+        self.active_core_calls.append((system_name, rom_filename))
         return self.active_core
 
     def get_available_cores(self, system_name: str) -> list[dict[str, Any]]:
+        self.available_cores_calls.append(system_name)
         return self.available_cores
 
     def reset_cache(self) -> None:

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -41,6 +41,23 @@ class FakeGamelistEditor:
         return True
 
 
+class FakeSystemResolver:
+    """In-memory ``SystemResolver`` for tests.
+
+    Maps known RomM platform slugs to RetroDECK systems and records each
+    call so tests can assert resolution happened. Unknown slugs fall
+    through unchanged, mirroring the real resolver's pass-through.
+    """
+
+    def __init__(self, mapping: dict[str, str] | None = None) -> None:
+        self.mapping = mapping if mapping is not None else {}
+        self.calls: list[tuple[str, str | None]] = []
+
+    def __call__(self, platform_slug: str, platform_fs_slug: str | None = None) -> str:
+        self.calls.append((platform_slug, platform_fs_slug))
+        return self.mapping.get(platform_slug, platform_slug)
+
+
 class FakeBiosChecker:
     """In-memory ``BiosChecker`` for tests (only implements the async entry CoreService uses)."""
 
@@ -82,6 +99,17 @@ def gamelist_editor() -> FakeGamelistEditor:
 
 
 @pytest.fixture
+def resolve_system() -> FakeSystemResolver:
+    return FakeSystemResolver(
+        mapping={
+            "dc": "dreamcast",
+            "sms": "mastersystem",
+            "neo-geo-pocket": "ngp",
+        }
+    )
+
+
+@pytest.fixture
 def bios_checker() -> FakeBiosChecker:
     return FakeBiosChecker()
 
@@ -92,13 +120,22 @@ def retrodeck_paths() -> FakeRetroDeckPaths:
 
 
 @pytest.fixture
-def service(event_loop, logger, core_info, gamelist_editor, bios_checker, retrodeck_paths) -> CoreService:
+def service(
+    event_loop,
+    logger,
+    core_info,
+    gamelist_editor,
+    resolve_system,
+    bios_checker,
+    retrodeck_paths,
+) -> CoreService:
     return CoreService(
         config=CoreServiceConfig(
             loop=event_loop,
             logger=logger,
             core_info=core_info,
             gamelist_editor=gamelist_editor,
+            resolve_system=resolve_system,
             retrodeck_paths=retrodeck_paths,
             bios_checker=bios_checker,
         ),
@@ -252,3 +289,65 @@ class TestSetGameCore:
         assert gamelist_editor.game_calls == [
             ("/home/deck/retrodeck", "n64", "n64/zelda.z64", "Mupen64Plus"),
         ]
+
+
+# ── slug → system normalization ────────────────────────────────────────
+#
+# The raw RomM platform_slug (dc, sms, neo-geo-pocket) must be resolved to
+# the RetroDECK system (dreamcast, mastersystem, ngp) BEFORE it reaches the
+# ES-DE core read/write seams. The BIOS recheck, by contrast, stays on the
+# RAW slug — that is BIOS space, owned by FirmwareService.
+
+
+class TestSlugNormalization:
+    @pytest.mark.parametrize(
+        ("slug", "system"),
+        [
+            ("dc", "dreamcast"),
+            ("sms", "mastersystem"),
+            ("neo-geo-pocket", "ngp"),
+            ("snes", "snes"),  # identity: slug already equals system
+        ],
+    )
+    def test_get_available_cores_resolves_system(self, event_loop, service, core_info, resolve_system, slug, system):
+        event_loop.run_until_complete(service.get_available_cores(slug))
+        # Both read seams receive the NORMALIZED system, not the raw slug.
+        assert core_info.available_cores_calls == [system]
+        assert core_info.active_core_calls == [(system, None)]
+        assert resolve_system.calls == [(slug, None)]
+
+    @pytest.mark.parametrize(
+        ("slug", "system"),
+        [
+            ("dc", "dreamcast"),
+            ("sms", "mastersystem"),
+            ("neo-geo-pocket", "ngp"),
+            ("snes", "snes"),
+        ],
+    )
+    def test_set_system_core_resolves_system_keeps_raw_bios(
+        self, event_loop, service, gamelist_editor, bios_checker, slug, system
+    ):
+        event_loop.run_until_complete(service.set_system_core(slug, "Core"))
+        # ES-DE write seam receives the NORMALIZED system.
+        assert gamelist_editor.system_calls == [("/home/deck/retrodeck", system, "Core")]
+        # BIOS recheck receives the RAW slug.
+        assert bios_checker.calls == [(slug, None)]
+
+    @pytest.mark.parametrize(
+        ("slug", "system"),
+        [
+            ("dc", "dreamcast"),
+            ("sms", "mastersystem"),
+            ("neo-geo-pocket", "ngp"),
+            ("snes", "snes"),
+        ],
+    )
+    def test_set_game_core_resolves_system_keeps_raw_bios(
+        self, event_loop, service, gamelist_editor, bios_checker, slug, system
+    ):
+        event_loop.run_until_complete(service.set_game_core(slug, f"{slug}/game.rom", "Core"))
+        # ES-DE write seam receives the NORMALIZED system; rom_path is verbatim.
+        assert gamelist_editor.game_calls == [("/home/deck/retrodeck", system, f"{slug}/game.rom", "Core")]
+        # BIOS recheck receives the RAW slug (filename derived from rom_path).
+        assert bios_checker.calls == [(slug, f"{slug}/game.rom")]

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -24,6 +24,24 @@ from services.firmware import FirmwareService, FirmwareServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
 
 
+class FakeSystemResolver:
+    """In-memory ``SystemResolver`` for tests.
+
+    Maps known RomM platform slugs to RetroDECK systems and records each
+    call. Unknown slugs fall through unchanged, mirroring the real
+    resolver's pass-through. Used to assert the core read seams receive a
+    normalized system while BIOS-folder lookups stay on the raw slug.
+    """
+
+    def __init__(self, mapping: dict[str, str] | None = None) -> None:
+        self.mapping = mapping if mapping is not None else {}
+        self.calls: list[tuple[str, str | None]] = []
+
+    def __call__(self, platform_slug: str, platform_fs_slug: str | None = None) -> str:
+        self.calls.append((platform_slug, platform_fs_slug))
+        return self.mapping.get(platform_slug, platform_slug)
+
+
 def _make_clock() -> FakeClock:
     """Return a fresh FakeClock pinned to a synthetic instant."""
     return FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
@@ -57,6 +75,7 @@ def _make_firmware_service(
     firmware_file_store=None,
     retrodeck_paths: FakeRetroDeckPaths | None = None,
     core_info: FakeCoreInfoProvider | None = None,
+    resolve_system: FakeSystemResolver | None = None,
     logger=None,
     load_registry: bool = True,
 ) -> FirmwareService:
@@ -78,6 +97,7 @@ def _make_firmware_service(
             firmware_file_store=firmware_file_store if firmware_file_store is not None else FirmwareFileAdapter(),
             retrodeck_paths=retrodeck_paths if retrodeck_paths is not None else FakeRetroDeckPaths(),
             core_info=core_info if core_info is not None else FakeCoreInfoProvider(),
+            resolve_system=resolve_system if resolve_system is not None else FakeSystemResolver(),
             uow_factory=uow_factory if uow_factory is not None else FakeUnitOfWorkFactory(),
         ),
     )
@@ -243,6 +263,49 @@ class TestGetFirmwareStatus:
         dc_plat = next(p for p in result["platforms"] if p["platform_slug"] == "dc")
         assert len(dc_plat["files"]) == 2
         assert all(not f["downloaded"] for f in dc_plat["files"])  # get_firmware_status files are dicts
+
+    @pytest.mark.asyncio
+    async def test_enrich_resolves_system_for_cores_keeps_raw_slug_for_platform(self, tmp_path):
+        """Per-platform core reads get the NORMALIZED system; entry slug stays raw.
+
+        ``_enrich_platform_map`` keys ``platform_slug`` / ``has_games`` /
+        BIOS-folder file lookups on the raw RomM/BIOS-folder slug (ADR-0010 §4)
+        but must feed the resolved RetroDECK system to the ``get_active_core`` /
+        ``get_available_cores`` seams (ADR-0010 §2).
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        core_info = FakeCoreInfoProvider(
+            active_core=("flycast_libretro.so", "Flycast"),
+            available_cores=[{"label": "Flycast", "so": "flycast_libretro.so"}],
+        )
+        resolver = FakeSystemResolver(mapping={"dc": "dreamcast"})
+        fw = _make_firmware_service(core_info=core_info, resolve_system=resolver)
+
+        firmware_list = [
+            {
+                "id": 1,
+                "file_name": "bios_dc.bin",
+                "file_path": "bios/dc/bios_dc.bin",
+                "file_size_bytes": 100,
+                "md5_hash": "",
+            },
+        ]
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
+
+        result = await fw.get_firmware_status()
+
+        dc_plat = next(p for p in result["platforms"] if p["platform_slug"] == "dc")
+        # Entry identity stays on the RAW slug.
+        assert dc_plat["platform_slug"] == "dc"
+        # Active-core data resolved under the NORMALIZED system surfaces on the entry.
+        assert dc_plat["active_core"] == "flycast_libretro.so"
+        assert dc_plat["available_cores"] == [{"label": "Flycast", "so": "flycast_libretro.so"}]
+        # Both core read seams received the NORMALIZED system, not the raw slug.
+        assert core_info.active_core_calls == [("dreamcast", None)]
+        assert core_info.available_cores_calls == ["dreamcast"]
+        assert resolver.calls == [("dc", None)]
 
     @pytest.mark.asyncio
     async def test_has_games_reflects_synced_roms(self, plugin, fw):
@@ -915,6 +978,60 @@ class TestCheckPlatformBiosRequired:
         assert classifications["alien.bin"] == "unknown"
 
 
+class TestCheckPlatformBiosSlugNormalization:
+    """check_platform_bios resolves slug→system for cores, keeps raw slug for BIOS.
+
+    The firmware ``file_path`` and bios registry are keyed on the raw RomM
+    platform slug (BIOS-folder vocabulary, ADR-0010 §4). The active-core /
+    available-cores reads must instead receive the resolved RetroDECK system.
+    """
+
+    @pytest.mark.parametrize(
+        ("slug", "system"),
+        [
+            ("dc", "dreamcast"),
+            ("sms", "mastersystem"),
+            ("neo-geo-pocket", "ngp"),
+            ("gba", "gba"),  # identity: slug already equals system
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_resolves_system_for_cores_keeps_raw_slug_for_bios(self, slug, system):
+        from unittest.mock import AsyncMock, MagicMock
+
+        core_info = FakeCoreInfoProvider(
+            active_core=("flycast_libretro.so", "Flycast"),
+            available_cores=[{"label": "Flycast", "so": "flycast_libretro.so"}],
+        )
+        resolver = FakeSystemResolver(mapping={"dc": "dreamcast", "sms": "mastersystem", "neo-geo-pocket": "ngp"})
+        fw = _make_firmware_service(core_info=core_info, resolve_system=resolver)
+
+        firmware_list = [
+            {
+                "id": 1,
+                "file_name": "boot.bin",
+                "file_path": f"bios/{slug}/boot.bin",
+                "file_size_bytes": 512,
+                "md5_hash": "",
+            },
+        ]
+        fw._bios_registry = {"platforms": {slug: {"boot.bin": {"description": "Boot", "required": True, "md5": ""}}}}
+        fw._bios_files_index = {"boot.bin": {"description": "Boot", "required": True, "md5": "", "platform": slug}}
+
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
+
+        result = await fw.check_platform_bios(slug)
+
+        # RAW slug matched the firmware file_path + registry, so a file is found.
+        assert result["needs_bios"] is True
+        assert result["server_count"] == 1
+        # Both core read seams received the NORMALIZED system.
+        assert core_info.active_core_calls == [(system, None)]
+        assert core_info.available_cores_calls == [system]
+        assert resolver.calls == [(slug, None)]
+
+
 class TestDownloadRequiredFirmware:
     @pytest.mark.asyncio
     async def test_downloads_required_only(self, plugin, fw, tmp_path):
@@ -968,6 +1085,62 @@ class TestDownloadRequiredFirmware:
         assert result["downloaded"] == 1
         assert 1 in download_called_ids
         assert 2 not in download_called_ids
+
+    @pytest.mark.asyncio
+    async def test_resolves_system_for_active_core_keeps_raw_slug_for_filter(self):
+        """Active-core read gets the NORMALIZED system; the firmware filter stays raw.
+
+        ``download_required_firmware`` keys the firmware-slug filter on the raw
+        RomM/BIOS-folder slug (ADR-0010 §4) but must resolve the slug to a
+        RetroDECK system before the ``get_active_core`` read (ADR-0010 §2) so the
+        per-core required flags use the correct active core.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        core_info = FakeCoreInfoProvider(active_core=("flycast_libretro.so", "Flycast"))
+        resolver = FakeSystemResolver(mapping={"dc": "dreamcast"})
+        fw = _make_firmware_service(core_info=core_info, resolve_system=resolver)
+
+        firmware_list = [
+            {
+                "id": 1,
+                "file_name": "boot.bin",
+                "file_path": "bios/dc/boot.bin",
+                "file_size_bytes": 100,
+                "md5_hash": "",
+            },
+        ]
+        # Per-core required flag keyed on the active-core .so resolved via the system.
+        fw._bios_files_index = {
+            "boot.bin": {
+                "description": "Boot",
+                "required": False,
+                "cores": {"flycast_libretro.so": {"required": True}},
+                "platform": "dc",
+            },
+        }
+        # run_in_executor returns the firmware list (the only executor call before
+        # the batch); download_firmware is awaited directly and is patched below.
+        fw._loop = MagicMock()
+        fw._loop.run_in_executor = AsyncMock(return_value=firmware_list)
+
+        download_called_ids: list[int] = []
+
+        async def fake_download_firmware(fw_id):
+            download_called_ids.append(fw_id)
+            return {"success": True}
+
+        with patch.object(fw, "download_firmware", side_effect=fake_download_firmware):
+            result = await fw.download_required_firmware("dc")
+
+        # RAW slug matched the firmware file_path filter, so the file is considered.
+        # The per-core required flag (keyed on the active core from the NORMALIZED
+        # system) marked it required, so it was downloaded.
+        assert result["downloaded"] == 1
+        assert download_called_ids == [1]
+        # get_active_core received the NORMALIZED system, not the raw slug.
+        assert core_info.active_core_calls == [("dreamcast", None)]
+        assert resolver.calls == [("dc", None)]
 
     @pytest.mark.asyncio
     async def test_skips_already_downloaded_required(self, plugin, fw, tmp_path):
@@ -1824,6 +1997,7 @@ class TestCheckPlatformBiosCached:
         firmware_cache=None,
         firmware_cache_epoch: float = 0,
         bios_registry=None,
+        resolve_system=None,
     ) -> tuple[FirmwareService, FakeCoreInfoProvider]:
         import logging
 
@@ -1832,6 +2006,7 @@ class TestCheckPlatformBiosCached:
             plugin_dir="/fake",
             logger=logging.getLogger("test"),
             core_info=core_info,
+            resolve_system=resolve_system,
         )
         fw._firmware_cache = firmware_cache
         fw._firmware_cache_epoch = firmware_cache_epoch
@@ -1911,6 +2086,52 @@ class TestCheckPlatformBiosCached:
 
         api.list_firmware.assert_not_called()
         api.get_firmware.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("slug", "system"),
+        [
+            ("dc", "dreamcast"),
+            ("sms", "mastersystem"),
+            ("neo-geo-pocket", "ngp"),
+            ("gba", "gba"),  # identity: slug already equals system
+        ],
+    )
+    def test_resolves_system_for_cores_keeps_raw_slug_for_bios(self, tmp_path, slug, system):
+        """Core read seams get the NORMALIZED system; BIOS folder lookup uses RAW slug.
+
+        The firmware cache ``file_path`` and the registry are keyed on the raw
+        platform slug (BIOS-folder vocabulary). The active-core / available-cores
+        reads must instead receive the resolved RetroDECK system.
+        """
+        resolver = FakeSystemResolver(mapping={"dc": "dreamcast", "sms": "mastersystem", "neo-geo-pocket": "ngp"})
+        fw, core_info = self._make_service(
+            firmware_cache=[
+                {
+                    "file_path": f"bios/{slug}/boot.bin",
+                    "file_name": "boot.bin",
+                    "file_size_bytes": 512,
+                    "md5_hash": "abc",
+                    "id": 1,
+                },
+            ],
+            firmware_cache_epoch=7.0,
+            bios_registry={"platforms": {slug: {"boot.bin": {"required": True, "md5": "abc"}}}},
+            resolve_system=resolver,
+        )
+        core_info.active_core = ("flycast_libretro.so", "Flycast")
+        core_info.available_cores = [{"label": "Flycast", "so": "flycast_libretro.so"}]
+
+        with patch.object(fw, "_retrodeck_paths", FakeRetroDeckPaths(bios=str(tmp_path))):
+            result = fw.check_platform_bios_cached(slug)
+
+        assert result is not None
+        # The RAW slug matched the cache + registry, so a file is found.
+        assert result["needs_bios"] is True
+        assert result["server_count"] == 1
+        # Both core read seams received the NORMALIZED system.
+        assert core_info.active_core_calls == [(system, None)]
+        assert core_info.available_cores_calls == [system]
+        assert resolver.calls == [(slug, None)]
 
 
 class TestFirmwareCachePersistence:

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -137,6 +137,7 @@ def plugin(tmp_path):
             firmware_file_store=FirmwareFileAdapter(),
             retrodeck_paths=FakeRetroDeckPaths(),
             core_info=FakeCoreInfoProvider(),
+            resolve_system=lambda platform_slug, platform_fs_slug=None: platform_slug,
             uow_factory=FakeUnitOfWorkFactory(),
         ),
     )

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -71,6 +71,7 @@ def plugin(tmp_path, fake_romm_api):
             firmware_file_store=FirmwareFileAdapter(),
             retrodeck_paths=FakeRetroDeckPaths(),
             core_info=FakeCoreInfoProvider(),
+            resolve_system=lambda platform_slug, platform_fs_slug=None: platform_slug,
             uow_factory=FakeUnitOfWorkFactory(),
         ),
     )


### PR DESCRIPTION
Closes #906.

## Problem

`CoreService` and `FirmwareService` fed the raw RomM `platform_slug` into the ES-DE system-keyed seams (`get_active_core` / `get_available_cores` / `set_system_override` / `set_game_override`, whose params are named `system_name`). For platforms where `slug != system` (`dc`/`dreamcast`, `sms`/`mastersystem`, `neo-geo-pocket`/`ngp`, …) the per-game `<altemulator>` override was written to `ES-DE/gamelists/<slug>/` while RetroDECK's launcher reads `ES-DE/gamelists/<system>/` — so the core switch was **silently lost** and the game launched with the default core. The wrong active core also drove BIOS-required filtering in the game-detail panel.

## Fix

Inject the existing `SystemResolver` Protocol into both services and normalize `slug → system` **before** every core/gamelist seam:

- `cores.py`: `get_available_cores` / `get_active_core` / `set_system_override` / `set_game_override`.
- `firmware.py`: `check_platform_bios`, `check_platform_bios_cached`, `download_required_firmware`, and the `get_firmware_status` all-platforms view (`_enrich_platform_map`).

BIOS-folder lookups (`resolve_firmware_slugs` / `parse_firmware_slug` / `bios/<slug>/` paths) deliberately **stay on the raw slug** — that is a separate vocabulary (ADR-0010 §4); normalizing it would break BIOS resolution. `game_detail` is covered transitively (it only calls `check_platform_bios(_cached)`).

Also wrapped `load_platform_map`'s file read in graceful degradation (`OSError`/`JSONDecodeError` → `{}`), since this change makes it newly reachable from the resilient game-detail render path.

## Verification

- `ruff check` + `ruff format`: clean
- `basedpyright` (py_modules + tests + main): 0 errors, 0 warnings, 0 notes
- `pytest`: 2959 passed
- cosmic call bans / aggregate-field ban / import-linter (8 contracts): all green
- New tests cover `slug != system` (`dc→dreamcast`, `sms→mastersystem`, `neo-geo-pocket→ngp`) and identity, asserting core seams get the normalized system while BIOS lookups keep the raw slug; plus config.json missing/corrupt degradation.

## On-device verification — pending (merge gate)

Unit tests prove the wiring; the runtime behavior must be confirmed on a Steam Deck with RetroDECK:

- [x] Switch the per-game core for a `slug != system` title (e.g. Dreamcast / Master System / Neo Geo Pocket) and confirm the `<altemulator>` now lands in `ES-DE/gamelists/<system>/gamelist.xml`.
- [x] Launch that game and confirm it runs with the switched core (not the default).
- [x] Confirm the BIOS-required panel reflects the correct active core for a `slug != system` platform.

docs: N/A — internal slug→system resolution fix; no user-visible flow or architecture change (ADR-0010 already prescribed this follow-up).
