### PR TITLE
ci: gate sonarcloud required check so dependabot PRs don't deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,26 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  # Branch-protection shim: the `sonarcloud` job is skipped on Dependabot PRs
+  # (no SONAR_TOKEN access), and a skipped required check never reports success,
+  # which would deadlock every Dependabot PR. This gate always reports, passing
+  # when SonarCloud succeeded or was skipped and failing only when it failed.
+  # Make THIS job the required status check instead of `sonarcloud`.
+  sonar-gate:
+    runs-on: ubuntu-latest
+    needs: [sonarcloud]
+    if: always()
+    steps:
+      - name: Require SonarCloud to pass (skipped on Dependabot PRs)
+        env:
+          SONAR_RESULT: ${{ needs.sonarcloud.result }}
+        run: |
+          echo "SonarCloud job result: $SONAR_RESULT"
+          if [ "$SONAR_RESULT" = "failure" ] || [ "$SONAR_RESULT" = "cancelled" ]; then
+            echo "::error::SonarCloud did not pass"
+            exit 1
+          fi
+
   markdownlint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -100,8 +100,10 @@ See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality
 
-- **SonarCloud** — CI-based analysis on every PR and push to main. Quality Gate enforces 80% coverage on new code, 0
-  bugs, 0 vulnerabilities.
+- **SonarCloud** — CI-based analysis on every human PR and push to main. Quality Gate enforces 80% coverage on new code,
+  0 bugs, 0 vulnerabilities. The scan is skipped on Dependabot PRs (no `SONAR_TOKEN` access in that restricted context);
+  the required status check is the `sonar-gate` job, which passes when SonarCloud succeeded or was skipped and fails
+  only when it failed — so dependency PRs aren't deadlocked on a check that can never run for them.
 - **Ruff** — Python linting in CI. Expanded ruleset includes B (bugbear), SIM (simplify), UP (pyupgrade), RUF
   (ruff-specific), and ARG (unused arguments) in addition to the base E/F rules.
 - **basedpyright** — Type checking in CI. Checks all source files including the test suite (tests/ is not excluded).


### PR DESCRIPTION
## Problem

Dependabot PRs never auto-merge — they sit permanently `BLOCKED` even with every other check green. Root cause: `sonarcloud` is a required status check, but the `sonarcloud` job is skipped on Dependabot PRs (`if: github.actor != 'dependabot[bot]'`, since the restricted Dependabot context has no `SONAR_TOKEN`). A skipped required check never reports success, so branch protection blocks the PR forever. I've been clearing the backlog by merging them manually.

## Fix

Add a `sonar-gate` job that always runs (`if: always()`, `needs: [sonarcloud]`) and translates SonarCloud's outcome into a check that can actually go green for Dependabot:

- sonarcloud `success` or `skipped` → gate passes
- sonarcloud `failure` / `cancelled` → gate fails

The required status check is then swapped from `sonarcloud` to `sonar-gate` in branch protection (after merge — see below).

### Why this doesn't weaken the gate for human PRs

| Scenario | sonarcloud | sonar-gate | Merge |
| --- | --- | --- | --- |
| Dependabot PR | skipped | ✅ | unblocked |
| Human PR, Sonar passes | success | ✅ | allowed |
| Human PR, Sonar quality gate fails | failure | ❌ | blocked |
| Human PR, tests fail (Sonar skipped via `needs`) | skipped | ✅, but `test` is separately required & red | blocked |

Nobody can masquerade as `dependabot[bot]`, and if tests are red the separately-required `test`/`frontend-test` checks block the PR — so the SonarCloud requirement stays sharp for real code. I considered giving Dependabot a `SONAR_TOKEN` via Dependabot secrets instead, but that re-exposes the token to code running in the PR context (e.g. a malicious dependency's postinstall) for an analysis that's a no-op on lockfile-only changes.

## Follow-up: branch-protection swap (manual, after merge)

This has to land on `main` first so GitHub registers the `sonar-gate` context; then the required checks are updated — drop `sonarcloud`, add `sonar-gate` (other contexts unchanged).

## Docs

Updated `docs/contributing/development.md` — the SonarCloud bullet now notes the Dependabot skip and the `sonar-gate` required check.
