### PR TITLE
fix(ui): show the per-game core-switch warning only when the filename triggers it

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -130,6 +130,26 @@ cores are available for the game's platform.
 A per-game override takes priority over the platform default. To reset back to the platform default, select the default
 core (marked with "(default)") from the menu — this clears the per-game override.
 
+### Per-game core switching limitation
+
+A per-game core override works for most ROMs, but **not** when the ROM filename contains certain special characters.
+This is an upstream RetroDECK bug, not a plugin limitation: RetroDECK matches the gamelist entry by treating the
+filename as an awk regular expression, so any regex metacharacter in the name breaks the match and the per-game
+`<altemulator>` override is silently ignored. RetroDECK then falls back to the system-wide core.
+
+The breaking characters are: `(` `)` `[` `]` `{` `}` `+` `*` `?` `|` `^` `$` `\`. A plain dot (`.`) is fine — it is a
+common part of filenames (e.g. `Tetris.gb`) and matches the literal dot. So:
+
+- `Tetris.gb` — per-game core switching works.
+- `Mario Golf - Advance Tour (USA).zip` — the parentheses break the match; the per-game override is ignored.
+
+When you switch the core per-game for a ROM whose filename contains one of these characters, the core-change dialog on
+the game detail page shows a "Per-Game Core Switch May Be Ignored" note. For clean filenames the note does not appear.
+
+**Workaround**: set the core **system-wide** for that platform instead, using the
+[Emulator Core dropdown on this System page](#per-platform-system-page). A system-wide override does not depend on the
+filename, so it always applies. This limitation will go away on its own once RetroDECK fixes the upstream match.
+
 ### Non-Default Core Indicator
 
 The CPU button changes color to indicate the active core status:

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -109,16 +109,9 @@ The warning shows which core you're switching from and to. You can:
 - **Continue** — launch with the new core (your save may be overwritten)
 - **Cancel** — go back and switch the core back before launching
 
-### Per-game override warning (temporary)
-
-You may see a second warning box in the same dialog titled **Per-Game Core Switch Not Working**. This is a temporary
-notice about a RetroDECK bug (tracked in [#210](https://github.com/danielcopper/decky-romm-sync/issues/210)): per-game
-core overrides are currently ignored for ROMs whose filenames contain special characters like parentheses (`()`),
-brackets (`[]`), or other punctuation. For those ROMs, switching the core per-game has no effect — RetroDECK silently
-falls back to the system-wide core.
-
-**Workaround**: switch the core **system-wide** via the QAM panel (Core Switching) rather than per-game. This second
-warning will disappear from the dialog once RetroDECK fixes the underlying issue.
+For ROMs whose filenames contain special characters, the warning also notes that the per-game core override may be
+ignored by RetroDECK. See [Per-game core switching limitation](bios-management.md#per-game-core-switching-limitation) on
+the System page for what that means and how to work around it.
 
 ### Which cores are compatible?
 

--- a/src/components/CoreChangeModal.test.tsx
+++ b/src/components/CoreChangeModal.test.tsx
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { cloneElement, createElement, type ReactElement } from "react";
-import { showModal } from "@decky/ui";
+import { showModal, Navigation } from "@decky/ui";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { detach } from "../utils/detach";
+
+// A filename whose parentheses trip RetroDECK's awk-regex match, so the
+// per-game core-switch warning box must render. Mirrors the #210 break case.
+const RISKY_FILE = "Mario Golf - Advance Tour (USA).zip";
+// A clean filename — no regex metacharacters, so the override works and the
+// red box must stay hidden.
+const CLEAN_FILE = "Tetris.gb";
 
 // Per-file mock for @decky/ui. The global stub renders ModalRoot as a
 // pass-through <div> but discards its `closeModal` prop. Here we capture
@@ -22,6 +29,7 @@ vi.mock("@decky/ui", () => {
     DialogButton: ({ children, onClick, disabled }: AnyProps & { disabled?: boolean }) =>
       createElement("button", { onClick, disabled }, children as never),
     showModal: vi.fn(),
+    Navigation: { NavigateToExternalWeb: vi.fn() },
   };
 });
 
@@ -38,6 +46,7 @@ function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
 interface CoreChangeContentProps {
   oldLabel: string;
   newLabel: string;
+  launchFileName?: string;
   closeModal?: () => void;
   onDone: (proceed: boolean) => void;
 }
@@ -101,15 +110,55 @@ describe("CoreChangeModal", () => {
   });
 
   describe("CoreChangeModalContent — rendering", () => {
-    it("renders title, label arrow, and both warning blocks", () => {
+    it("always renders title, label arrow, and the Save Compatibility Warning", () => {
       // Drive via showCoreChangeModal so we don't depend on the non-exported FC.
-      detach(showCoreChangeModal("CoreA", "CoreB"));
+      detach(showCoreChangeModal("CoreA", "CoreB", CLEAN_FILE));
       const { container } = render(lastShownElement());
 
       expect(container.textContent).toContain("Emulator Core Changed");
       expect(container.textContent).toContain("CoreA → CoreB");
       expect(container.textContent).toContain("Save Compatibility Warning");
-      expect(container.textContent).toContain("Per-Game Core Switch Not Working");
+    });
+
+    it("hides the per-game core-switch box for a clean filename", () => {
+      detach(showCoreChangeModal("CoreA", "CoreB", CLEAN_FILE));
+      const { container, queryByText } = render(lastShownElement());
+
+      // The always-on Save Compatibility Warning is unaffected by the filename.
+      expect(container.textContent).toContain("Save Compatibility Warning");
+      // The conditional red box and its Learn more button are absent.
+      expect(container.textContent).not.toContain("Per-Game Core Switch May Be Ignored");
+      expect(queryByText("Learn more")).toBeNull();
+    });
+
+    it("hides the per-game core-switch box when no filename is provided", () => {
+      detach(showCoreChangeModal("CoreA", "CoreB"));
+      const { container, queryByText } = render(lastShownElement());
+
+      expect(container.textContent).toContain("Save Compatibility Warning");
+      expect(container.textContent).not.toContain("Per-Game Core Switch May Be Ignored");
+      expect(queryByText("Learn more")).toBeNull();
+    });
+
+    it("shows the per-game core-switch box for a filename with special characters", () => {
+      detach(showCoreChangeModal("CoreA", "CoreB", RISKY_FILE));
+      const { container, queryByText } = render(lastShownElement());
+
+      expect(container.textContent).toContain("Save Compatibility Warning");
+      expect(container.textContent).toContain("Per-Game Core Switch May Be Ignored");
+      expect(container.textContent).toContain("special characters");
+      expect(container.textContent).toContain("System page");
+      expect(queryByText("Learn more")).not.toBeNull();
+    });
+
+    it("opens the published docs anchor when Learn more is clicked", () => {
+      detach(showCoreChangeModal("CoreA", "CoreB", RISKY_FILE));
+      const { container } = render(lastShownElement());
+
+      fireEvent.click(buttonByText(container, "Learn more"));
+      expect(Navigation.NavigateToExternalWeb).toHaveBeenCalledWith(
+        "https://danielcopper.github.io/decky-romm-sync/user-guide/bios-management/#per-game-core-switching-limitation",
+      );
     });
   });
 

--- a/src/components/CoreChangeModal.tsx
+++ b/src/components/CoreChangeModal.tsx
@@ -1,18 +1,36 @@
 import { FC } from "react";
-import { ModalRoot, DialogButton, showModal } from "@decky/ui";
+import { ModalRoot, DialogButton, showModal, Navigation } from "@decky/ui";
+import { coreSwitchMayBeIgnored } from "../utils/coreSwitch";
+
+// Published docs anchor for the per-game core-switch limitation (System page).
+// Heading slug derived from "### Per-game core switching limitation".
+const CORE_SWITCH_DOCS_URL =
+  "https://danielcopper.github.io/decky-romm-sync/user-guide/bios-management/#per-game-core-switching-limitation";
 
 interface CoreChangeModalProps {
   oldLabel: string;
   newLabel: string;
+  // ROM launch filename (basename) RetroDECK awk-matches against gamelist.xml
+  // <path>. When it carries regex metacharacters the per-game override may be
+  // silently ignored — see coreSwitchMayBeIgnored / issue #210.
+  launchFileName?: string | undefined;
   closeModal?: () => void;
   onDone: (proceed: boolean) => void;
 }
 
-const CoreChangeModalContent: FC<CoreChangeModalProps> = ({ oldLabel, newLabel, closeModal, onDone }) => {
+const CoreChangeModalContent: FC<CoreChangeModalProps> = ({
+  oldLabel,
+  newLabel,
+  launchFileName,
+  closeModal,
+  onDone,
+}) => {
   const handleChoice = (proceed: boolean) => {
     closeModal?.();
     onDone(proceed);
   };
+
+  const mayBeIgnored = launchFileName !== undefined && coreSwitchMayBeIgnored(launchFileName);
 
   return (
     <ModalRoot
@@ -60,23 +78,32 @@ const CoreChangeModalContent: FC<CoreChangeModalProps> = ({ oldLabel, newLabel, 
           </div>
         </div>
 
-        <div
-          style={{
-            padding: "10px",
-            background: "rgba(244, 67, 54, 0.15)",
-            borderRadius: "4px",
-            border: "1px solid rgba(244, 67, 54, 0.3)",
-            marginBottom: "16px",
-          }}
-        >
-          <div style={{ fontSize: "12px", color: "#ef9a9a", marginBottom: "6px", fontWeight: "bold" }}>
-            Per-Game Core Switch Not Working
+        {mayBeIgnored && (
+          <div
+            style={{
+              padding: "10px",
+              background: "rgba(244, 67, 54, 0.15)",
+              borderRadius: "4px",
+              border: "1px solid rgba(244, 67, 54, 0.3)",
+              marginBottom: "16px",
+            }}
+          >
+            <div style={{ fontSize: "12px", color: "#ef9a9a", marginBottom: "6px", fontWeight: "bold" }}>
+              Per-Game Core Switch May Be Ignored
+            </div>
+            <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", lineHeight: "1.4" }}>
+              This ROM&rsquo;s filename contains special characters (e.g. parentheses). A known RetroDECK bug can cause
+              per-game core overrides to be ignored for such names. If the core does not change in-game, set it
+              system-wide on the System page instead.
+            </div>
+            <DialogButton
+              onClick={() => Navigation.NavigateToExternalWeb(CORE_SWITCH_DOCS_URL)}
+              style={{ marginTop: "8px", fontSize: "12px", minWidth: "0", width: "auto", padding: "4px 12px" }}
+            >
+              Learn more
+            </DialogButton>
           </div>
-          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.7)", lineHeight: "1.4" }}>
-            Due to a RetroDECK bug, per-game core overrides are currently ignored for ROMs with special characters in
-            the filename (e.g. parentheses). To actually use a different core, switch it system-wide via the QAM panel.
-          </div>
-        </div>
+        )}
 
         <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
           <DialogButton onClick={() => handleChoice(true)}>Continue</DialogButton>
@@ -89,8 +116,15 @@ const CoreChangeModalContent: FC<CoreChangeModalProps> = ({ oldLabel, newLabel, 
   );
 };
 
-export function showCoreChangeModal(oldLabel: string, newLabel: string): Promise<boolean> {
+export function showCoreChangeModal(oldLabel: string, newLabel: string, launchFileName?: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    showModal(<CoreChangeModalContent oldLabel={oldLabel} newLabel={newLabel} onDone={resolve} />);
+    showModal(
+      <CoreChangeModalContent
+        oldLabel={oldLabel}
+        newLabel={newLabel}
+        launchFileName={launchFileName}
+        onDone={resolve}
+      />,
+    );
   });
 }

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -116,6 +116,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const [dlProgress, setDlProgress] = useState<DownloadProgress | null>(null);
   const [isOffline, setIsOffline] = useState(getRommConnectionState() === "offline");
   const romIdRef = useRef<number | null>(null);
+  const romFileRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const transitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -153,6 +154,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         const rid = cached.rom_id!;
         setRomId(rid);
         romIdRef.current = rid;
+        romFileRef.current = cached.rom_file ?? null;
         if (cached.rom_name) setRomName(cached.rom_name);
 
         if (cached.installed) {
@@ -333,6 +335,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     return showCoreChangeModal(
       coreCheck.old_label ?? coreCheck.old_core ?? "Unknown",
       coreCheck.new_label ?? coreCheck.new_core ?? "Unknown",
+      romFileRef.current ?? undefined,
     );
   };
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -140,6 +140,7 @@ vi.mock("@decky/ui", () => {
     Menu: passthrough("div"),
     MenuItem: ({ children, onClick }: AnyProps) => createElement("button", { onClick }, children as never),
     Router: { CloseSideMenus: vi.fn(), Navigate: vi.fn() },
+    Navigation: { NavigateToExternalWeb: vi.fn(), Navigate: vi.fn() },
     // findSP locates Steam's <SteamRoot> iframe document for stylesheet
     // injection. Tests run in happy-dom — no Steam, no iframe — so the
     // safe stub returns undefined and the consumer's `!sp?.window?.document`

--- a/src/utils/coreSwitch.test.ts
+++ b/src/utils/coreSwitch.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { coreSwitchMayBeIgnored } from "./coreSwitch";
+
+describe("coreSwitchMayBeIgnored", () => {
+  it("returns false for a clean filename", () => {
+    expect(coreSwitchMayBeIgnored("Tetris.gb")).toBe(false);
+  });
+
+  it("returns false for a clean filename with spaces and dashes", () => {
+    expect(coreSwitchMayBeIgnored("Mario Golf - Advance Tour.zip")).toBe(false);
+  });
+
+  it("returns true for a filename with parentheses", () => {
+    expect(coreSwitchMayBeIgnored("Mario Golf - Advance Tour (USA).zip")).toBe(true);
+  });
+
+  it("returns true for a filename with square brackets", () => {
+    expect(coreSwitchMayBeIgnored("Sonic [!].md")).toBe(true);
+  });
+
+  it.each([
+    ["paren open", "Game (.gb"],
+    ["paren close", "Game ).gb"],
+    ["bracket open", "Game [.gb"],
+    ["bracket close", "Game ].gb"],
+    ["brace open", "Game {.gb"],
+    ["brace close", "Game }.gb"],
+    ["plus", "Game+.gb"],
+    ["star", "Game*.gb"],
+    ["question", "Game?.gb"],
+    ["pipe", "Game|.gb"],
+    ["caret", "Game^.gb"],
+    ["dollar", "Game$.gb"],
+    ["backslash", "Game\\.gb"],
+  ])("returns true for a filename containing a %s metacharacter", (_label, name) => {
+    expect(coreSwitchMayBeIgnored(name)).toBe(true);
+  });
+
+  it("returns false when only a dot is present (regex dot matches literal dot)", () => {
+    expect(coreSwitchMayBeIgnored("Pokemon.Red.gba")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(coreSwitchMayBeIgnored("")).toBe(false);
+  });
+});

--- a/src/utils/coreSwitch.ts
+++ b/src/utils/coreSwitch.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-game core-switch reliability check.
+ *
+ * RetroDECK matches a gamelist.xml `<path>` against the ROM filename with an
+ * awk *regex*, so the per-game `<altemulator>` core override is silently
+ * ignored when the filename contains regex metacharacters. Clean names work;
+ * names with `( ) [ ] { } + * ? | ^ $ \` do not. The dot `.` is intentionally
+ * excluded — a regex dot matches the literal dot in `Tetris.gb`, so it is
+ * harmless. This mirrors the upstream RetroDECK break condition tracked in
+ * issue #210; we only surface it honestly.
+ */
+
+// Regex metacharacters that break RetroDECK's awk filename match. The dot is
+// deliberately absent — it matches the literal dot and is harmless.
+const CORE_SWITCH_BREAKING_CHARS = "()[]{}+*?|^$\\";
+
+/**
+ * Returns true iff `launchFileName` contains a character that breaks
+ * RetroDECK's awk-regex filename match, meaning a per-game core override may be
+ * silently ignored for this ROM.
+ *
+ * @param launchFileName - The ROM launch filename (basename) matched against
+ *   the gamelist.xml `<path>` entry.
+ */
+export function coreSwitchMayBeIgnored(launchFileName: string): boolean {
+  for (const ch of launchFileName) {
+    if (CORE_SWITCH_BREAKING_CHARS.includes(ch)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Refs #210 — honest-surfacing of the upstream RetroDECK awk-regex bug (the underlying bug is upstream and unfixed; this only makes our warning accurate). Stacked on #923 (#929): the limitation docs land in #923's reworked System-page doc, so GitHub retargets to `main` once #923 merges.

## What

The per-game core-switch dialog always showed an absolute red **"Per-Game Core Switch Not Working"** box. That's wrong — RetroDECK's awk-regex gamelist match only drops the per-game `<altemulator>` override for filenames containing regex metacharacters (`( ) [ ] { } + * ? | ^ $ \`); clean names like `Tetris.gb` switch fine.

- The red box now renders **only** when the ROM's launch filename actually contains one of those characters (`coreSwitchMayBeIgnored`). Clean filenames get no warning.
- Softened copy: **"Per-Game Core Switch May Be Ignored"** + a **Learn more** link to the docs.
- The always-correct **Save Compatibility Warning** is unchanged.

## Docs

Moved the limitation out of `save-sync.md` (mis-placed and absolutely worded) into the System-page doc (`bios-management.md`), correctly scoped to special-character filenames, with the system-wide workaround. The modal's *Learn more* opens that published section.

## Tests

`coreSwitch.test.ts` — per-metacharacter table, dot excluded, clean → false. `CoreChangeModal.test.tsx` — red box hidden for clean / absent filename, shown for a parenthesized name, *Learn more* opens the exact published URL.
