### PR TITLE
feat(ui): add per-platform BIOS delete to the System page

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -49,12 +49,30 @@ first, then the BIOS files that core needs.
 4. Below the core, each platform shows how many BIOS files are downloaded vs. available (e.g. "3 / 5 files")
 5. Tap **Show Files** to see the individual file list for a platform
 6. Tap **Download All** to download all missing BIOS files for a platform
+7. Tap **Delete BIOS** to remove that platform's downloaded BIOS files (see below)
 
 <!-- Screenshot: System page showing per-platform Emulator Core dropdown above BIOS download counts -->
 
 BIOS files are downloaded to your RetroDECK bios directory (e.g. `~/retrodeck/bios/`). Some platforms use subdirectories
 — for example, Dreamcast BIOS goes into `bios/dc/` and PS2 BIOS goes into `bios/pcsx2/bios/`. The plugin handles the
 correct placement automatically.
+
+### Deleting BIOS Files
+
+You can remove a platform's downloaded BIOS files directly from the **System** page. The **Delete BIOS** button appears
+only when the platform has at least one downloaded file — its label shows the count (e.g. "Delete BIOS (3)"). Because
+deletion is local, the button works even when your RomM server is offline.
+
+1. On the **System** page, find the platform whose BIOS files you want to remove
+2. Tap **Delete BIOS**
+3. Confirm the action in the dialog that appears
+
+This is a destructive action, so a confirmation dialog asks you to confirm before anything is deleted. Once confirmed,
+the plugin removes every downloaded BIOS file for that system from your RetroDECK bios directory and reports the result.
+Games that need those files won't launch until you download them again with **Download All** or **Download Required**.
+
+The same per-platform delete is also available from the **Data Management** page (under per-platform actions) for
+bulk-cleanup workflows.
 
 ## Which Systems Need BIOS?
 

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -10,10 +10,13 @@
 //   - refreshSystem failure branch → setBiosError(result.message || fallback)
 //   - handleDownloadAll catch → setBiosStatus(`Download failed: ${e}`)
 //   - handleDownloadRequired catch → setBiosStatus(`Download failed: ${e}`)
+//   - handleDeleteBios catch → setBiosStatus(`Failed to delete BIOS files: ${e}`)
 //   - setSystemCore onChange catch → debugLog(`setSystemCore: error: ${e}`)
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
+import { showModal } from "@decky/ui";
+import type { ReactElement } from "react";
 import { SystemPage } from "./SystemPage";
 import * as backend from "../api/backend";
 import type { FirmwarePlatformExt } from "../types";
@@ -67,8 +70,28 @@ vi.mock("@decky/ui", async () => {
       );
     },
     Spinner: () => ce("div", { "data-testid": "spinner" }),
+    // ConfirmModal is passed to showModal as a created element; the test reads
+    // its props (strTitle / onOK) off the captured showModal call rather than
+    // rendering it, mirroring DangerZone.test.tsx.
+    ConfirmModal: passthrough("div"),
+    showModal: vi.fn(),
   };
 });
+
+// Props of the ConfirmModal element handed to the most recent showModal() call.
+interface ConfirmModalProps {
+  strTitle?: string;
+  strDescription?: string;
+  strOKButtonText?: string;
+  strCancelButtonText?: string;
+  onOK?: () => void;
+}
+function lastConfirmModalProps(): ConfirmModalProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<ConfirmModalProps> | undefined;
+  return el?.props ?? null;
+}
 
 // Flush mount-time + chained promise resolutions.
 const flushAsync = () =>
@@ -99,6 +122,11 @@ describe("SystemPage", () => {
     vi.mocked(backend.downloadAllFirmware).mockResolvedValue({ success: true });
     vi.mocked(backend.downloadRequiredFirmware).mockResolvedValue({
       success: true,
+    });
+    vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+      success: true,
+      deleted_count: 0,
+      message: "",
     });
     vi.mocked(backend.setSystemCore).mockResolvedValue({ success: true });
   });
@@ -990,6 +1018,154 @@ describe("SystemPage", () => {
       // No dropdown rendered, but the "Emulator Core" Field is.
       expect(capturedDropdowns.length).toBe(0);
       expect(container.textContent).toContain("snes9x");
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // N2. Delete BIOS (#933) — per-platform destructive action
+  // ------------------------------------------------------------------
+  describe("handleDeleteBios", () => {
+    function biosPlatformWithDownloaded(): FirmwarePlatformExt {
+      return makeBiosPlatform({
+        platform_slug: "ps1",
+        files: [
+          {
+            id: 1,
+            file_name: "scph5501.bin",
+            size: 100,
+            md5: "x",
+            downloaded: true,
+            required: true,
+            description: "PS1 BIOS",
+            hash_valid: true,
+            classification: "required",
+          },
+        ],
+      });
+    }
+
+    function biosPlatformNothingDownloaded(): FirmwarePlatformExt {
+      return makeBiosPlatform({
+        platform_slug: "ps1",
+        files: [
+          {
+            id: 1,
+            file_name: "scph5501.bin",
+            size: 100,
+            md5: "x",
+            downloaded: false,
+            required: true,
+            description: "PS1 BIOS",
+            hash_valid: null,
+            classification: "required",
+          },
+        ],
+      });
+    }
+
+    it("hides the Delete BIOS button when no files are downloaded", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformNothingDownloaded()],
+      });
+      const { queryByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(queryByText(/Delete BIOS/)).toBeNull();
+    });
+
+    it("shows the Delete BIOS button with the downloaded count when at least one file is downloaded", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(getByText("Delete BIOS (1)")).toBeTruthy();
+    });
+
+    it("opens a ConfirmModal (does NOT call deletePlatformBios) when the Delete BIOS button is clicked", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      // Confirmation gates the destructive call — nothing deleted yet.
+      expect(vi.mocked(backend.deletePlatformBios)).not.toHaveBeenCalled();
+      const props = lastConfirmModalProps();
+      expect(props?.strTitle).toBe("Delete BIOS files for ps1?");
+      expect(props?.strOKButtonText).toBe("Delete BIOS Files");
+      expect(props?.strCancelButtonText).toBe("Cancel");
+    });
+
+    it("calls deletePlatformBios(slug), surfaces the message, and refreshes on confirm + success", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: true,
+        deleted_count: 1,
+        message: "Deleted 1 BIOS file",
+      });
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      await act(async () => {
+        lastConfirmModalProps()?.onOK?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.deletePlatformBios)).toHaveBeenCalledWith("ps1");
+      // refreshSystem: once on mount + once after a successful delete.
+      expect(vi.mocked(backend.getFirmwareStatus)).toHaveBeenCalledTimes(2);
+      expect(container.textContent).toContain("Deleted 1 BIOS file");
+    });
+
+    it("surfaces the failure message and does NOT refresh when deletePlatformBios reports success=false", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: false,
+        deleted_count: 0,
+        message: "Nothing to delete",
+      });
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      await act(async () => {
+        lastConfirmModalProps()?.onOK?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.deletePlatformBios)).toHaveBeenCalledWith("ps1");
+      // Only the mount-time refresh — no second refresh on failure.
+      expect(vi.mocked(backend.getFirmwareStatus)).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Nothing to delete");
+    });
+
+    it("sets biosStatus='Failed to delete BIOS files: <e>' when deletePlatformBios throws", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      vi.mocked(backend.deletePlatformBios).mockRejectedValue(new Error("io"));
+      const { getByText, container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      await act(async () => {
+        lastConfirmModalProps()?.onOK?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // CATCH-REJECTION assert: status string rendered.
+      expect(container.textContent).toContain("Failed to delete BIOS files: Error: io");
     });
   });
 

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -1,9 +1,19 @@
-import { useState, useEffect, FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, Field, Focusable, DropdownItem } from "@decky/ui";
+import { useState, useEffect, FC, createElement } from "react";
+import {
+  PanelSection,
+  PanelSectionRow,
+  ButtonItem,
+  Field,
+  Focusable,
+  DropdownItem,
+  ConfirmModal,
+  showModal,
+} from "@decky/ui";
 import {
   getFirmwareStatus,
   downloadAllFirmware,
   downloadRequiredFirmware,
+  deletePlatformBios,
   setSystemCore,
   debugLog,
 } from "../api/backend";
@@ -120,6 +130,38 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
       setBiosStatus(`Download failed: ${e}`);
     }
     setDownloading(null);
+  };
+
+  // Destructive action — deletes the platform's downloaded BIOS files. Mirrors
+  // the DangerZone confirm UX (ConfirmModal via showModal). Kept flat at the
+  // component-body level (like handleDownloadAll) so the modal's onOK is a
+  // single named-handler call rather than a deeply-nested async closure (S2004).
+  const handleDeleteBios = async (platformSlug: string) => {
+    setBiosStatus("");
+    try {
+      const result = await deletePlatformBios(platformSlug);
+      setBiosStatus(result.message);
+      if (result.success) {
+        await refreshSystem();
+      }
+    } catch (e) {
+      setBiosStatus(`Failed to delete BIOS files: ${e}`);
+    }
+  };
+
+  const confirmDeleteBios = (platformSlug: string) => {
+    showModal(
+      createElement(ConfirmModal, {
+        strTitle: `Delete BIOS files for ${platformSlug}?`,
+        strDescription:
+          "This deletes every downloaded BIOS file for this system from your RetroDECK bios directory. Games that need these files won't launch until you download them again.",
+        strOKButtonText: "Delete BIOS Files",
+        strCancelButtonText: "Cancel",
+        onOK: () => {
+          detach(handleDeleteBios(platformSlug));
+        },
+      }),
+    );
   };
 
   const handleSystemCoreChange = async (platform: FirmwarePlatformExt, optionData: string) => {
@@ -299,6 +341,19 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
               disabled={isDownloading}
             >
               {isDownloading ? "Downloading..." : "Download All"}
+            </ButtonItem>
+          </PanelSectionRow>
+        )}
+        {/* Delete is local-only (no server needed) and shown only when there is
+            at least one downloaded file to delete. Destructive → ConfirmModal. */}
+        {done > 0 && (
+          <PanelSectionRow>
+            <ButtonItem
+              layout="below"
+              onClick={() => confirmDeleteBios(platform.platform_slug)}
+              disabled={isDownloading}
+            >
+              {`Delete BIOS (${done})`}
             </ButtonItem>
           </PanelSectionRow>
         )}


### PR DESCRIPTION
Closes #933.

## What

The System QAM page already shows per-platform BIOS status + downloads, but had no way to delete a platform's downloaded BIOS files — that lived only in Data Management. This adds a per-platform **Delete BIOS** action to the System page.

- Renders only when the platform has ≥1 downloaded BIOS file (label shows the count); works while the RomM server is offline (deletion is local).
- Destructive → guarded by a `ConfirmModal`, mirroring the Data Management delete flow. On success it refreshes the System view and surfaces the result message.
- Reuses the existing `deletePlatformBios` callable (fixed in #750). The Data Management delete entry point is left as-is — purely additive.

## Tests & docs

Six SystemPage tests (hidden when nothing downloaded, shown with count, confirm-gate, success+refresh, failure-no-refresh, throw-catch) with non-vacuous assertions (three mutation-checked). `bios-management.md` (System page doc) documents the delete action, its visibility/offline behaviour, and the Data Management cross-reference.
