### PR TITLE
fix(ui): thread rom_filename so the game-detail reads the per-game active core

### DIFF
--- a/main.py
+++ b/main.py
@@ -198,8 +198,8 @@ class Plugin:
     async def set_game_core(self, platform_slug, rom_path, core_label):
         return await self._core_service.set_game_core(platform_slug, rom_path, core_label)
 
-    async def get_platform_core_info(self, platform_slug):
-        return await self._core_service.get_available_cores(platform_slug)
+    async def get_platform_core_info(self, platform_slug, rom_filename=None):
+        return await self._core_service.get_available_cores(platform_slug, rom_filename=rom_filename)
 
     # ── Firmware delegation to FirmwareService ──────────────
 

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -61,11 +61,17 @@ class CoreService:
         self._retrodeck_paths = config.retrodeck_paths
         self._bios_checker = config.bios_checker
 
-    async def get_available_cores(self, platform_slug: str) -> dict[str, Any]:
-        """Return available cores for a platform along with the active selection."""
+    async def get_available_cores(self, platform_slug: str, rom_filename: str | None = None) -> dict[str, Any]:
+        """Return available cores for a platform along with the active selection.
+
+        The available-cores list is platform-wide (system-level). The active
+        selection is read per-game when ``rom_filename`` is provided, so a
+        ``<altemulator>`` per-game override surfaces instead of the system
+        core; ``None`` reads the system-level active core.
+        """
         system = self._resolve_system(platform_slug)
         cores = self._core_info.get_available_cores(system)
-        active_so, active_label = self._core_info.get_active_core(system)
+        active_so, active_label = self._core_info.get_active_core(system, rom_filename=rom_filename)
         return {
             "cores": cores,
             "active_core": active_so,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -236,8 +236,9 @@ export const setGameCore = callable<
 >("set_game_core");
 // Dedicated core-info path (#923) — active core + available cores for a
 // platform, decoupled from the BIOS firmware status. The per-game detail page
-// and the per-system System page read core data from here.
-export const getPlatformCoreInfo = callable<[string], CoreInfo>("get_platform_core_info");
+// passes the ROM filename so a per-game <altemulator> override is read back as
+// the active core (#936); the per-system System page omits it (system-level).
+export const getPlatformCoreInfo = callable<[string, string?], CoreInfo>("get_platform_core_info");
 export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
 export const debugLog = callable<[string], void>("debug_log");
 const frontendLog = callable<[string, string], void>("frontend_log");

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -373,6 +373,22 @@ describe("RomMGameInfoPanel", () => {
       expect(backend.getRomMetadata).toHaveBeenCalledWith(99);
     });
 
+    it("forwards platform_slug + rom_file to the dedicated core-info path on mount (#936)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 99,
+        platform_slug: "snes",
+        rom_file: "mario.sfc",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      // The background core-info fetch reads the per-game override by passing the
+      // bare basename alongside the platform slug.
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes", "mario.sfc");
+    });
+
     it("skips metadata refresh when metadata exists AND not in stale_fields", async () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
@@ -959,14 +975,25 @@ describe("RomMGameInfoPanel", () => {
       // Mount without bios_status so the initial state.biosStatus is null
       // and the BIOS tab is NOT visible. Then dispatch core_changed with a
       // cache response that DOES carry bios_status — the handler's setState
-      // call is the only path that surfaces the BIOS tab.
-      const { container } = await mountWithRomId(60);
+      // call is the only path that surfaces the BIOS tab. Mount carries a
+      // rom_file so romFileRef is populated for the per-game read-back (#936).
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 60,
+        rom_file: "mario.sfc",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
       expect(container.textContent).not.toContain("BIOS");
       vi.mocked(cachedStore.invalidateCachedGameDetail).mockClear();
       vi.mocked(cachedStore.getCachedGameDetail).mockClear();
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 60,
+        rom_file: "mario.sfc",
         bios_status: {
           platform_slug: "snes",
           server_count: 1,
@@ -976,7 +1003,8 @@ describe("RomMGameInfoPanel", () => {
         metadata: makeMetadata(),
         stale_fields: [],
       });
-      // Core data comes from the dedicated path (#923), keyed on the event slug.
+      // Core data comes from the dedicated path (#923), keyed on the event slug
+      // AND the ROM filename from romFileRef (per-game override read-back, #936).
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "from_core_changed.so",
         active_core_label: "FROM_CORE_CHANGED",
@@ -993,7 +1021,8 @@ describe("RomMGameInfoPanel", () => {
       });
       expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(testAppId);
       expect(vi.mocked(cachedStore.getCachedGameDetail)).toHaveBeenCalled();
-      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes");
+      // The bare basename (from romFileRef, not the event) is forwarded.
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes", "mario.sfc");
       // biosStatus now non-null → BIOS tab visible. Removing the
       // handler's `setState((prev) => ({ ..., biosStatus }))` line
       // makes this assertion fail.

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -72,6 +72,9 @@ interface PanelState {
   romName: string;
   platformName: string;
   platformSlug: string;
+  // ROM filename (bare basename), threaded into the dedicated core-info path so
+  // a per-game <altemulator> override reads back as the active core (#936).
+  romFile: string;
   installed: boolean;
   installedRom: InstalledRom | null;
   metadata: RomMetadata | null;
@@ -228,20 +231,23 @@ function startBackgroundRefreshes(
 
   // Core info from its own path (#923), decoupled from BIOS status.
   if (cached.platform_slug) {
-    bgPromises.push(refreshCoreInfoInBackground(cached.platform_slug, cancelled, setter));
+    bgPromises.push(refreshCoreInfoInBackground(cached.platform_slug, cached.rom_file || "", cancelled, setter));
   }
 
   return Promise.all(bgPromises);
 }
 
 /** Fetch active-core + available-cores for a platform from the dedicated
- *  `get_platform_core_info` path (#923) and merge into panel state. */
+ *  `get_platform_core_info` path (#923) and merge into panel state. The ROM
+ *  filename reads a per-game `<altemulator>` override back as the active core
+ *  (#936). */
 function refreshCoreInfoInBackground(
   platformSlug: string,
+  romFile: string,
   cancelled: () => boolean,
   setter: React.Dispatch<React.SetStateAction<PanelState>>,
 ): Promise<void> {
-  return getPlatformCoreInfo(platformSlug)
+  return getPlatformCoreInfo(platformSlug, romFile)
     .then((coreInfo) => {
       if (!cancelled()) {
         setter((prev) => ({ ...prev, coreInfo }));
@@ -258,6 +264,7 @@ async function loadData(
   appId: number,
   cancelled: () => boolean,
   romIdRef: React.MutableRefObject<number | null>,
+  romFileRef: React.MutableRefObject<string>,
   setter: React.Dispatch<React.SetStateAction<PanelState>>,
 ): Promise<void> {
   try {
@@ -273,8 +280,10 @@ async function loadData(
     const romName = cached.rom_name || "";
     const platformName = cached.platform_name || "";
     const platformSlug = cached.platform_slug || "";
+    const romFile = cached.rom_file || "";
 
     romIdRef.current = romId;
+    romFileRef.current = romFile;
 
     const biosStatus = biosStatusFromCache(cached.bios_status);
     const saveStatus = saveStatusFromCache(romId, cached.save_status);
@@ -288,6 +297,7 @@ async function loadData(
       romName,
       platformName,
       platformSlug,
+      romFile,
       installed: cached.installed ?? false,
       installedRom: null, // Will be filled by background fetch if installed
       metadata: cached.metadata as RomMetadata | null,
@@ -334,6 +344,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     romName: "",
     platformName: "",
     platformSlug: "",
+    romFile: "",
     installed: false,
     installedRom: null,
     metadata: null,
@@ -355,6 +366,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     slotsLoading: false,
   });
   const romIdRef = useRef<number | null>(null);
+  // Mirror of the ROM filename, kept in a ref so the core_changed handler can
+  // read it without a stale `state` closure (it sources platform_slug from the
+  // event for the same reason). Drives the per-game core read-back (#936).
+  const romFileRef = useRef<string>("");
   const [migration, setMigration] = useState(getMigrationState());
   const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);
 
@@ -379,7 +394,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   useEffect(() => {
     let cancelled = false;
 
-    detach(loadData(appId, () => cancelled, romIdRef, setState));
+    detach(loadData(appId, () => cancelled, romIdRef, romFileRef, setState));
 
     // Listen for uninstall events to update state (uses ref to avoid stale closure)
     const onUninstall = (e: Event) => {
@@ -438,9 +453,12 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
       // Re-fetch cached game detail to pick up the new core-aware BIOS status.
       invalidateCachedGameDetail(appId);
       // Core info comes from its own path (#923), keyed on the event's
-      // platform_slug; BIOS status is re-read from the (now core-free) cache.
+      // platform_slug and the ROM filename from a ref — both avoid a stale
+      // `state` closure. Passing the filename reads the per-game <altemulator>
+      // override back as the active core (#936). BIOS status is re-read from the
+      // (now core-free) cache.
       const [coreInfo, cached] = await Promise.all([
-        getPlatformCoreInfo(detail.platform_slug).catch((): CoreInfo | null => null),
+        getPlatformCoreInfo(detail.platform_slug, romFileRef.current).catch((): CoreInfo | null => null),
         getCachedGameDetail(appId),
       ]);
       if (cancelled || !cached.found) return;

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -257,7 +257,7 @@ describe("RomMPlaySection", () => {
     // mock result into state so the core button / menu render as in production,
     // where the dedicated core-info path (#923) populates these fields. The
     // extractCoreInfo mock ignores its argument, so the dummy CoreInfo is fine.
-    vi.mocked(sectionRefresh.refreshCoreInfoInBackground).mockImplementation((_slug, cancelled, setter) => {
+    vi.mocked(sectionRefresh.refreshCoreInfoInBackground).mockImplementation((_slug, _romFile, cancelled, setter) => {
       if (cancelled()) return;
       const coreFields = playSectionUtils.extractCoreInfo({ cores: [], active_core: null, active_core_label: null });
       act(() => {
@@ -427,10 +427,12 @@ describe("RomMPlaySection", () => {
         expect.any(Function),
         expect.any(Function),
       );
-      // Core info is fetched from its own path (#923), keyed on the platform slug,
-      // independent of the BIOS refresh.
+      // Core info is fetched from its own path (#923), keyed on the platform slug
+      // AND the ROM filename (per-game override read-back, #936), independent of
+      // the BIOS refresh.
       expect(sectionRefresh.refreshCoreInfoInBackground).toHaveBeenCalledWith(
         "snes",
+        "test.sfc",
         expect.any(Function),
         expect.any(Function),
       );
@@ -1045,11 +1047,15 @@ describe("RomMPlaySection", () => {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
         rom_id: 60,
+        // The ROM filename is mirrored into romFileRef on load and forwarded to
+        // the per-game core read-back (#936).
+        rom_file: "mario.sfc",
       });
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
 
-      // Core data comes from the dedicated path (#923), keyed on the event slug.
+      // Core data comes from the dedicated path (#923), keyed on the event slug
+      // AND the ROM filename (per-game override read-back, #936).
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "blastem.so",
         active_core_label: "BlastEm",
@@ -1080,7 +1086,8 @@ describe("RomMPlaySection", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes");
+      // The bare basename (sourced from romFileRef, not the event) is forwarded.
+      expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes", "mario.sfc");
       expect(vi.mocked(backend.getBiosStatus)).toHaveBeenCalledWith(60);
     });
 
@@ -2060,7 +2067,8 @@ describe("RomMPlaySection", () => {
         });
         expect(vi.mocked(backend.setGameCore)).toHaveBeenCalledWith("snes", "./mario.sfc", "BlastEm");
         // Core display refreshed via the dedicated path, not the BIOS payload (#923).
-        expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes");
+        // The bare basename is forwarded so the per-game override reads back (#936).
+        expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith("snes", "mario.sfc");
         expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Core set to BlastEm" }));
         expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(testAppId);
         const ev = listener.mock.calls.map((c) => c[0] as CustomEvent).find((e) => e.detail.type === "core_changed");

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -110,6 +110,7 @@ async function loadCached(
   appId: number,
   cancelled: () => boolean,
   romIdRef: React.MutableRefObject<number | null>,
+  romFileRef: React.MutableRefObject<string>,
   setter: React.Dispatch<React.SetStateAction<InfoState>>,
 ) {
   try {
@@ -118,6 +119,7 @@ async function loadCached(
 
     const romId = cached.rom_id!;
     romIdRef.current = romId;
+    romFileRef.current = cached.rom_file || "";
 
     // Process save sync from backend-computed display fields
     let saveSyncStatus: "synced" | "conflict" | "none" | null = null;
@@ -186,7 +188,7 @@ async function loadCached(
     // Fetched non-blocking so the core button / badge can render once cores are
     // known, regardless of whether the platform needs BIOS.
     if (cached.platform_slug) {
-      refreshCoreInfoInBackground(cached.platform_slug, cancelled, setter);
+      refreshCoreInfoInBackground(cached.platform_slug, cached.rom_file || "", cancelled, setter);
     }
   } catch (e) {
     detach(debugLog(`RomMPlaySection: loadCached error: ${e}`));
@@ -231,12 +233,16 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
   const [connectionState, setConnectionState] = useState<ConnectionState>("checking");
   const [actionPending, setActionPending] = useState<string | null>(null);
   const romIdRef = useRef<number | null>(null);
+  // Mirror of the ROM filename, kept in a ref so the core_changed handler can
+  // read it without a stale `info` closure (it deliberately sources platform_slug
+  // from the event for the same reason). Drives the per-game core read-back (#936).
+  const romFileRef = useRef<string>("");
 
   // Cache-first load: render instantly from cached data, then check connection in background
   useEffect(() => {
     let cancelled = false;
 
-    detach(loadCached(appId, () => cancelled, romIdRef, setInfo));
+    detach(loadCached(appId, () => cancelled, romIdRef, romFileRef, setInfo));
 
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/romIdRef/setInfo closure.
@@ -262,11 +268,13 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       const rid = romIdRef.current;
       if (!rid) return;
       // Core data comes from the dedicated core-info path (#923), keyed on the
-      // event's platform_slug to avoid a stale-closure read of InfoState. BIOS
-      // level/label still come from the (now core-free) BIOS status — the active
-      // core just switched, so the BIOS requirements may have changed.
+      // event's platform_slug and the ROM filename from a ref — both avoid a
+      // stale-closure read of InfoState. Passing the filename reads the per-game
+      // <altemulator> override back as the active core (#936). BIOS level/label
+      // still come from the (now core-free) BIOS status — the active core just
+      // switched, so the BIOS requirements may have changed.
       const [coreInfo, biosResult] = await Promise.all([
-        getPlatformCoreInfo(detail.platform_slug),
+        getPlatformCoreInfo(detail.platform_slug, romFileRef.current),
         getBiosStatus(rid),
       ]);
       if (cancelled) return;
@@ -688,9 +696,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         toaster.toast({ title: "RomM Sync", body: `Core set to ${coreLabel}` });
         if (info.romId) {
           // Core data comes from the dedicated core-info path (#923), no longer
-          // from the BIOS payload. BIOS level/label still come from getBiosStatus.
+          // from the BIOS payload. The ROM filename reads the per-game
+          // <altemulator> override back as the active core (#936). BIOS
+          // level/label still come from getBiosStatus.
           const [coreInfo, refreshed] = await Promise.all([
-            getPlatformCoreInfo(platformSlug),
+            getPlatformCoreInfo(platformSlug, info.romFile),
             getBiosStatus(info.romId).catch(() => ({
               bios_status: null as BiosStatus | null,
               bios_level: null as "ok" | "partial" | "missing" | null,

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -225,7 +225,7 @@ describe("refreshBiosInBackground", () => {
 describe("refreshCoreInfoInBackground", () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it("merges the projected core fields from the dedicated path (#923) when not cancelled", async () => {
+  it("forwards the ROM filename and flows a non-default per-game core back (gold icon, #936)", async () => {
     vi.mocked(backend.getPlatformCoreInfo).mockResolvedValueOnce({
       active_core: "parallel_n64_libretro.so",
       active_core_label: "ParaLLEl N64",
@@ -236,10 +236,17 @@ describe("refreshCoreInfoInBackground", () => {
     });
 
     const setter = vi.fn<(updater: (prev: CoreState) => CoreState) => void>();
-    refreshCoreInfoInBackground("n64", () => false, setter as unknown as Dispatch<SetStateAction<CoreState>>);
+    refreshCoreInfoInBackground(
+      "n64",
+      "zelda.z64",
+      () => false,
+      setter as unknown as Dispatch<SetStateAction<CoreState>>,
+    );
     await flushMicrotasks();
 
-    expect(backend.getPlatformCoreInfo).toHaveBeenCalledWith("n64");
+    // The ROM filename is forwarded so a per-game <altemulator> override reads
+    // back as the active core (#936).
+    expect(backend.getPlatformCoreInfo).toHaveBeenCalledWith("n64", "zelda.z64");
     expect(setter).toHaveBeenCalledOnce();
     const next = setter.mock.calls[0]![0]({
       activeCoreLabel: null,
@@ -261,7 +268,7 @@ describe("refreshCoreInfoInBackground", () => {
       cores: [],
     });
     const setter = vi.fn();
-    refreshCoreInfoInBackground("n64", () => true, setter);
+    refreshCoreInfoInBackground("n64", "zelda.z64", () => true, setter);
     await flushMicrotasks();
     expect(setter).not.toHaveBeenCalled();
   });
@@ -274,7 +281,7 @@ describe("refreshCoreInfoInBackground", () => {
 
     let cancelled = false;
     const setter = vi.fn();
-    refreshCoreInfoInBackground("n64", () => cancelled, setter);
+    refreshCoreInfoInBackground("n64", "zelda.z64", () => cancelled, setter);
 
     cancelled = true;
     d.resolve({ active_core: null, active_core_label: null, cores: [] });
@@ -287,7 +294,7 @@ describe("refreshCoreInfoInBackground", () => {
     vi.mocked(backend.getPlatformCoreInfo).mockRejectedValueOnce(new Error("network"));
     vi.mocked(backend.debugLog).mockResolvedValue(undefined);
     const setter = vi.fn();
-    refreshCoreInfoInBackground("n64", () => false, setter);
+    refreshCoreInfoInBackground("n64", "zelda.z64", () => false, setter);
     await flushMicrotasks();
 
     expect(setter).not.toHaveBeenCalled();

--- a/src/utils/sectionRefresh.ts
+++ b/src/utils/sectionRefresh.ts
@@ -53,13 +53,16 @@ export function refreshBiosInBackground<S extends BiosInfoFields>(
 }
 
 /** Refresh core-selection state from the dedicated `get_platform_core_info`
- *  path (#923), fully decoupled from BIOS status. Keyed on the platform slug. */
+ *  path (#923), fully decoupled from BIOS status. Keyed on the platform slug
+ *  and the ROM filename so a per-game `<altemulator>` override reads back as
+ *  the active core (#936). */
 export function refreshCoreInfoInBackground<S extends CoreInfoFields>(
   platformSlug: string,
+  romFile: string,
   cancelled: () => boolean,
   setter: Dispatch<SetStateAction<S>>,
 ): void {
-  getPlatformCoreInfo(platformSlug)
+  getPlatformCoreInfo(platformSlug, romFile)
     .then((coreInfo) => {
       if (!cancelled()) {
         setter((prev) => ({

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -165,6 +165,38 @@ class TestGetAvailableCores:
         result = event_loop.run_until_complete(service.get_available_cores("snes"))
         assert result["cores"] == []
 
+    def test_system_level_read_passes_none_rom_filename(self, event_loop, service, core_info):
+        # No rom_filename → the active-core read is SYSTEM-LEVEL.
+        event_loop.run_until_complete(service.get_available_cores("snes"))
+        assert core_info.active_core_calls == [("snes", None)]
+
+    def test_per_game_read_forwards_rom_filename(self, event_loop, service, core_info):
+        # A rom_filename narrows the active-core read to the per-game
+        # <altemulator> override (#936). The available-cores list stays
+        # platform-wide (system-level), so it is read with the bare system only.
+        core_info.active_core = ("bsnes_libretro", "bsnes")
+        result = event_loop.run_until_complete(
+            service.get_available_cores("snes", rom_filename="mario.sfc"),
+        )
+        # Active read is per-game (filename forwarded to get_active_core).
+        assert core_info.active_core_calls == [("snes", "mario.sfc")]
+        # Available-cores enumeration never receives the filename — it is the
+        # platform-wide options list.
+        assert core_info.available_cores_calls == ["snes"]
+        assert result["active_core"] == "bsnes_libretro"
+        assert result["active_core_label"] == "bsnes"
+
+    def test_per_game_override_overrides_system_core(self, event_loop, service, core_info):
+        # The whole point of #936: with a filename, the per-game core surfaces
+        # instead of the system default. The fake returns whatever active_core
+        # is set; assert the filename reached the seam that resolves it.
+        core_info.active_core = ("parallel_n64_libretro", "ParaLLEl N64")
+        result = event_loop.run_until_complete(
+            service.get_available_cores("n64", rom_filename="zelda.z64"),
+        )
+        assert ("n64", "zelda.z64") in core_info.active_core_calls
+        assert result["active_core_label"] == "ParaLLEl N64"
+
 
 # ── get_platform_core_info (the dedicated core-info path, #923) ─────────
 

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -214,13 +214,25 @@ class TestCoreCallableDelegation:
     @pytest.mark.asyncio
     async def test_get_platform_core_info_delegates(self, plugin):
         # Core info is served via its OWN path (CoreService.get_available_cores),
-        # independent of the BIOS firmware status (#923).
+        # independent of the BIOS firmware status (#923). Without a rom_filename
+        # the active read is SYSTEM-LEVEL (rom_filename=None).
         plugin._core_service.get_available_cores = AsyncMock(
             return_value={"cores": [], "active_core": "snes9x_libretro", "active_core_label": "Snes9x"}
         )
         result = await plugin.get_platform_core_info("snes")
-        plugin._core_service.get_available_cores.assert_awaited_once_with("snes")
+        plugin._core_service.get_available_cores.assert_awaited_once_with("snes", rom_filename=None)
         assert result == {"cores": [], "active_core": "snes9x_libretro", "active_core_label": "Snes9x"}
+
+    @pytest.mark.asyncio
+    async def test_get_platform_core_info_forwards_rom_filename(self, plugin):
+        # The per-game detail page passes the ROM filename so a per-game
+        # <altemulator> override reads back as the active core (#936).
+        plugin._core_service.get_available_cores = AsyncMock(
+            return_value={"cores": [], "active_core": "bsnes_libretro", "active_core_label": "bsnes"}
+        )
+        result = await plugin.get_platform_core_info("snes", "mario.sfc")
+        plugin._core_service.get_available_cores.assert_awaited_once_with("snes", rom_filename="mario.sfc")
+        assert result == {"cores": [], "active_core": "bsnes_libretro", "active_core_label": "bsnes"}
 
 
 class TestFirmwareCallableDelegation:


### PR DESCRIPTION
Closes #936. Regression from #923.

## What

Selecting a per-game core on the game-detail page had no visual effect (icon never gold, dropdown always system default) — #923 routed the active-core read through the platform-level `get_platform_core_info`, which dropped `rom_filename`, so `get_active_core(system)` returned the system core, never the per-game `<altemulator>` override.

This threads `rom_filename` back through the game-detail path only:
- **Backend:** `get_platform_core_info(platform_slug, rom_filename=None)` → `CoreService.get_available_cores(platform_slug, rom_filename=None)` → `get_active_core(system, rom_filename=…)`. The available-cores options list stays system-level; no Protocol change. `firmware.py` is untouched.
- **Frontend:** `getPlatformCoreInfo` gains an optional rom-file arg, passed (bare basename) at all 5 call sites; `RomMGameInfoPanel`'s `PanelState` gains a `romFile`; the `core_changed` handlers read the filename from a `romFileRef` to avoid a stale-closure read.

## #923 decoupling preserved

`check_platform_bios` / `_cached` still return **zero** core fields, and the System-page per-system dropdown stays system-level (`get_firmware_status` overview, unchanged). The active-core resolution is only an input to BIOS filtering, never re-serialised onto the BIOS payload.

## Tests

`test_cores.py` (rom_filename forwarded per-game, system-level when None), callable-delegation + frontend call-arg assertions, and a case proving a non-default per-game core flows back → `activeCoreIsDefault === false` (gold icon).

docs: N/A — bug fix restoring previously-working per-game core selection; no new flow or architecture change.
