### PR TITLE
fix(ui): single save-compatibility banner + emit bios event on BIOS delete

### DIFF
--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -566,6 +566,60 @@ describe("DangerZone", () => {
       expect(container.textContent).toContain("Deleted 2 BIOS files");
     });
 
+    it("dispatches a romm_data_changed {type:'bios', platform_slug} event on success", async () => {
+      setupOnePlatform();
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: true,
+        deleted_count: 2,
+        message: "Deleted 2 BIOS files",
+      });
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (1)"));
+      const platformModal = lastShownModalProps<{ onDeleteBios?: () => void }>();
+      const listener = vi.fn();
+      globalThis.addEventListener("romm_data_changed", listener);
+      try {
+        await act(async () => {
+          platformModal?.onDeleteBios?.();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(listener).toHaveBeenCalledTimes(1);
+        const ev = listener.mock.calls[0]?.[0] as CustomEvent;
+        expect(ev.detail).toEqual({ type: "bios", platform_slug: "snes" });
+      } finally {
+        globalThis.removeEventListener("romm_data_changed", listener);
+      }
+    });
+
+    it("does NOT dispatch romm_data_changed when deletePlatformBios reports success=false", async () => {
+      setupOnePlatform();
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: false,
+        deleted_count: 0,
+        message: "Nothing to delete",
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (1)"));
+      const platformModal = lastShownModalProps<{ onDeleteBios?: () => void }>();
+      const listener = vi.fn();
+      globalThis.addEventListener("romm_data_changed", listener);
+      try {
+        await act(async () => {
+          platformModal?.onDeleteBios?.();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        // Failure branch surfaces the message but emits no refresh event.
+        expect(container.textContent).toContain("Nothing to delete");
+        expect(listener).not.toHaveBeenCalled();
+      } finally {
+        globalThis.removeEventListener("romm_data_changed", listener);
+      }
+    });
+
     it("surfaces 'Failed to delete BIOS files' on rejection", async () => {
       setupOnePlatform();
       vi.mocked(backend.deletePlatformBios).mockRejectedValue(new Error("io"));

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -192,6 +192,12 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     try {
       const result = await deletePlatformBios(p.slug);
       setActionStatus(result.message);
+      if (result.success) {
+        // Notify an open game-detail page so it re-checks BIOS status (#939).
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: p.slug } }),
+        );
+      }
     } catch {
       setActionStatus("Failed to delete BIOS files");
     }

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -1167,6 +1167,116 @@ describe("SystemPage", () => {
       // CATCH-REJECTION assert: status string rendered.
       expect(container.textContent).toContain("Failed to delete BIOS files: Error: io");
     });
+
+    it("dispatches a romm_data_changed {type:'bios', platform_slug} event on confirm + success", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: true,
+        deleted_count: 1,
+        message: "Deleted 1 BIOS file",
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      await act(async () => {
+        lastConfirmModalProps()?.onOK?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const biosEvents = dispatchSpy.mock.calls
+        .map((c) => c[0])
+        .filter((e): e is CustomEvent => e instanceof CustomEvent && e.type === "romm_data_changed");
+      expect(biosEvents).toHaveLength(1);
+      expect(biosEvents[0]!.detail).toEqual({ type: "bios", platform_slug: "ps1" });
+      dispatchSpy.mockRestore();
+    });
+
+    it("does NOT dispatch romm_data_changed when deletePlatformBios reports success=false", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [biosPlatformWithDownloaded()],
+      });
+      vi.mocked(backend.deletePlatformBios).mockResolvedValue({
+        success: false,
+        deleted_count: 0,
+        message: "Nothing to delete",
+      });
+      const dispatchSpy = vi.spyOn(globalThis, "dispatchEvent");
+      const { getByText } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Delete BIOS (1)"));
+      await act(async () => {
+        lastConfirmModalProps()?.onOK?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const biosEvents = dispatchSpy.mock.calls
+        .map((c) => c[0])
+        .filter((e): e is CustomEvent => e instanceof CustomEvent && e.type === "romm_data_changed");
+      expect(biosEvents).toHaveLength(0);
+      dispatchSpy.mockRestore();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // N3. Save-compatibility banner (#938) — shown once at the top, not per core
+  // ------------------------------------------------------------------
+  describe("save-compatibility banner", () => {
+    function platformWithMultipleCores(slug: string): FirmwarePlatformExt {
+      return makeBiosPlatform({
+        platform_slug: slug,
+        files: [],
+        available_cores: [
+          { core_so: "a.so", label: "core-a", is_default: true },
+          { core_so: "b.so", label: "core-b", is_default: false },
+        ],
+        active_core_label: "core-a",
+      });
+    }
+
+    const BANNER = "Switching cores may affect save compatibility";
+
+    function countOccurrences(haystack: string, needle: string): number {
+      let count = 0;
+      let idx = haystack.indexOf(needle);
+      while (idx !== -1) {
+        count++;
+        idx = haystack.indexOf(needle, idx + needle.length);
+      }
+      return count;
+    }
+
+    it("renders the banner exactly once even with multiple multi-core platforms", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [
+          platformWithMultipleCores("snes"),
+          platformWithMultipleCores("ps1"),
+          platformWithMultipleCores("n64"),
+        ],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      // Three multi-core dropdowns render, but the banner is page-level (#938).
+      expect(capturedDropdowns.length).toBe(3);
+      expect(countOccurrences(container.textContent, BANNER)).toBe(1);
+    });
+
+    it("renders the banner once even when there are no platforms at all", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(countOccurrences(container.textContent, BANNER)).toBe(1);
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -143,6 +143,11 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
       setBiosStatus(result.message);
       if (result.success) {
         await refreshSystem();
+        // Notify an open game-detail page so it re-checks BIOS status (#939).
+        // Mirrors the download-path emit in RomMPlaySection.
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", { detail: { type: "bios", platform_slug: platformSlug } }),
+        );
       }
     } catch (e) {
       setBiosStatus(`Failed to delete BIOS files: ${e}`);
@@ -224,28 +229,21 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
         {/* Emulator core selection is the primary per-system concern (#923),
             shown above the BIOS file management. */}
         {hasMultipleCores && (
-          <>
-            <PanelSectionRow>
-              <DropdownItem
-                label="Emulator Core"
-                rgOptions={[
-                  ...platform.available_cores!.map((c) => ({
-                    data: c.label,
-                    label: c.is_default ? `${c.label} (default)` : c.label,
-                  })),
-                ]}
-                selectedOption={
-                  platform.active_core_label || platform.available_cores!.find((c) => c.is_default)?.label || ""
-                }
-                onChange={(option: { data: string }) => detach(handleSystemCoreChange(platform, option.data))}
-              />
-            </PanelSectionRow>
-            <PanelSectionRow>
-              <div style={{ fontSize: "11px", color: "#ffb74d", padding: "0 16px 4px" }}>
-                Switching cores may affect save compatibility
-              </div>
-            </PanelSectionRow>
-          </>
+          <PanelSectionRow>
+            <DropdownItem
+              label="Emulator Core"
+              rgOptions={[
+                ...platform.available_cores!.map((c) => ({
+                  data: c.label,
+                  label: c.is_default ? `${c.label} (default)` : c.label,
+                })),
+              ]}
+              selectedOption={
+                platform.active_core_label || platform.available_cores!.find((c) => c.is_default)?.label || ""
+              }
+              onChange={(option: { data: string }) => detach(handleSystemCoreChange(platform, option.data))}
+            />
+          </PanelSectionRow>
         )}
         {platform.active_core_label && !hasMultipleCores && (
           <PanelSectionRow>
@@ -380,6 +378,13 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
         <PanelSectionRow>
           <div style={{ fontSize: "11px", color: "#8f98a0", padding: "0 16px 4px" }}>
             Per-system emulator core and BIOS files. The active core determines which BIOS files a system needs.
+          </div>
+        </PanelSectionRow>
+        {/* General note about core switching — shown once at the top, not per
+            platform, since the caveat is the same for every system (#938). */}
+        <PanelSectionRow>
+          <div style={{ fontSize: "11px", color: "#ffb74d", padding: "0 16px 4px" }}>
+            Switching cores may affect save compatibility
           </div>
         </PanelSectionRow>
         {biosLoading && (


### PR DESCRIPTION
Closes #938, #939.

## #938 — save-compatibility warning once at the top
The System page repeated **"Switching cores may affect save compatibility"** under every platform's core dropdown. Moved it to a single banner at the top of the page (inside the System section, above the platform cards); removed the per-platform copy.

## #939 — game-detail BIOS status stale after delete
Deleting a platform's BIOS (System page or Data Management) didn't notify an open game-detail page, so its BIOS section stayed stale (still "downloaded"). `handleDeleteBios` in **both** `SystemPage` and `DangerZone` now dispatch `romm_data_changed { type: "bios", platform_slug }` on success — triggering the existing game-detail `handleBiosChange` listener to re-check. (The DangerZone BIOS-delete path had the same missing-emit gap; fixed too.)

## Tests
SystemPage: the banner renders **exactly once** regardless of platform count; a successful delete dispatches the `bios` event (mutation-verified). DangerZone: BIOS delete dispatches the event.

docs: N/A — UI polish + a refresh-event bug fix on an already-documented surface; no new flow or architecture change.
