### PR TITLE
fix(auth): drop empty Bearer header that deadlocks fresh setup

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -11,14 +11,15 @@ The Connection Settings page manages your RomM server connection.
 
 - **RomM URL** — the full URL of your RomM server, including port if needed (e.g. `http://192.168.1.100:8080`). Tap
   **Edit** to change it; the URL saves automatically.
-- **RomM Account** — shows **Connected** once a token is stored, or **Not connected** otherwise. Tap **Connect** to open
+- **RomM Account** — shows **Signed in** once a token is stored, or **Not signed in** otherwise. Tap **Sign in** to open
   a one-time prompt for your RomM username and password. The plugin exchanges them for a RomM Client API Token and
   stores only the token; your password is discarded after the token is minted and never saved. The username and password
   are write-only — they are never pre-filled or shown back to you. If your account cannot create API tokens, the status
   reports that.
 - **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
   only).
-- **Test Connection** — verifies the plugin can reach and authenticate with your RomM server using the stored token.
+- **Test Connection** — available once you are signed in; verifies the plugin can reach and authenticate with your RomM
+  server using the stored token.
 
 ## SteamGridDB API Key
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -69,15 +69,16 @@ After installation, you need to connect the plugin to your RomM server:
 1. Open the QAM and find **decky-romm-sync**
 2. Tap **Connection Settings**
 3. Enter your RomM server URL (e.g. `http://192.168.1.100:8080`) — this saves automatically
-4. Tap **Connect**, enter your RomM username and password once, and confirm
-5. The **RomM Account** row shows **Connected** on success. Tap **Test Connection** to re-verify at any time
+4. Tap **Sign in**, enter your RomM username and password once, and confirm
+5. The **RomM Account** row shows **Signed in** on success. Once signed in, tap **Test Connection** to re-verify at any
+   time
 
 The plugin mints a RomM Client API Token from the credentials you enter and discards the password — it is never stored.
 The same applies if the plugin auto-migrates an older install that still had a saved password: the password is discarded
-as soon as a token is minted. If your RomM account is not allowed to create API tokens, the Connect step reports that
+as soon as a token is minted. If your RomM account is not allowed to create API tokens, the sign-in step reports that
 and you'll need an account with token permissions.
 
-<!-- Screenshot: Connection Settings page with URL field, Connect button, and token status -->
+<!-- Screenshot: Connection Settings page with URL field, Sign in button, and token status -->
 
 Once connected, you're ready to sync your library. See [Configuration](configuration.md) for additional settings, or
 jump straight to [Syncing Your Library](syncing-your-library.md).

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -114,10 +114,24 @@ class RommHttpAdapter:
             ctx.verify_mode = ssl.CERT_NONE
         return ctx
 
-    def auth_header(self) -> str:
-        """Bearer auth header value built from the stored Client API Token."""
+    def auth_header(self) -> str | None:
+        """Bearer auth header value, or ``None`` when no Client API Token is stored.
+
+        Returning ``None`` lets callers omit the ``Authorization`` header on
+        unauthenticated probes (fresh setup, before a token is minted). An empty
+        ``Bearer `` value is malformed and some RomM versions 500 on it, which
+        would deadlock first-time connection setup.
+        """
         token = self._settings.get("romm_api_token") or ""
-        return f"Bearer {token}"
+        return f"Bearer {token}" if token else None
+
+    def _apply_default_headers(self, req: urllib.request.Request) -> None:
+        """Attach the standard outgoing headers: ``User-Agent`` always, and
+        ``Authorization`` only when a Client API Token is stored."""
+        header = self.auth_header()
+        if header is not None:
+            req.add_header("Authorization", header)
+        req.add_header("User-Agent", self._user_agent)
 
     @staticmethod
     def _basic_auth_header(username: str, password: str) -> str:
@@ -218,8 +232,7 @@ class RommHttpAdapter:
 
         def _do_request():
             req = urllib.request.Request(url, method="GET")
-            req.add_header("Authorization", self.auth_header())
-            req.add_header("User-Agent", self._user_agent)
+            self._apply_default_headers(req)
             try:
                 with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
                     return json.loads(resp.read().decode())
@@ -273,8 +286,7 @@ class RommHttpAdapter:
 
         def _do_download():
             req = urllib.request.Request(url, method="GET")
-            req.add_header("Authorization", self.auth_header())
-            req.add_header("User-Agent", self._user_agent)
+            self._apply_default_headers(req)
             ctx = self.ssl_context()
             try:
                 with urllib.request.urlopen(req, context=ctx, timeout=self._CONNECT_TIMEOUT) as resp:
@@ -300,8 +312,7 @@ class RommHttpAdapter:
             body = json.dumps(data).encode("utf-8")
             req = urllib.request.Request(url, data=body, method=method)
             req.add_header("Content-Type", "application/json")
-            req.add_header("Authorization", self.auth_header())
-            req.add_header("User-Agent", self._user_agent)
+            self._apply_default_headers(req)
             try:
                 with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
                     return json.loads(resp.read().decode())
@@ -341,8 +352,7 @@ class RommHttpAdapter:
         url = self._settings["romm_url"].rstrip("/") + path
         req = urllib.request.Request(url, data=body, method=method)
         req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
-        req.add_header("Authorization", self.auth_header())
-        req.add_header("User-Agent", self._user_agent)
+        self._apply_default_headers(req)
         try:
             with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
                 return json.loads(resp.read().decode())

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -68,13 +68,21 @@ class ConnectionService:
         """Probe the configured server and return a frontend-shaped result dict.
 
         The result dict always carries ``success`` and ``message``. On
-        failure, ``error_code`` classifies the cause (``config_error``,
+        failure, ``error_code`` classifies the cause (``config_error`` when
+        the server URL is unset or no token has been minted yet,
         ``version_error``, or an :func:`lib.errors.error_response` code).
         On success or version failure, ``romm_version`` carries the
         detected server version when the heartbeat exposed one.
         """
         if not self._settings.get("romm_url"):
             return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+
+        if not self._settings.get("romm_api_token"):
+            return {
+                "success": False,
+                "message": "Not signed in — sign in to RomM first",
+                "error_code": "config_error",
+            }
 
         try:
             version = await self._loop.run_in_executor(None, self._probe_version)

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -596,7 +596,7 @@ describe("SettingsPage", () => {
       expect(conn?.hasToken).toBe(false);
     });
 
-    it("sets status='Connection failed' when connectWithCredentials throws", async () => {
+    it("sets status='Sign-in failed' when connectWithCredentials throws", async () => {
       vi.mocked(backend.connectWithCredentials).mockRejectedValue(new Error("net"));
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
@@ -606,7 +606,7 @@ describe("SettingsPage", () => {
         await Promise.resolve();
       });
 
-      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Connection failed");
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
     });
   });
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -291,7 +291,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setHasToken(true);
       }
     } catch {
-      setStatus("Connection failed");
+      setStatus("Sign-in failed");
     }
   };
 

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -54,7 +54,7 @@ describe("ConnectModal", () => {
     expect(pass.getAttribute("data-is-password")).toBe("true");
   });
 
-  it("calls onConnect with the entered username + password on Connect", () => {
+  it("calls onConnect with the entered username + password on Sign in", () => {
     const onConnect = vi.fn();
     const { getByTestId } = render(<ConnectModal onConnect={onConnect} />);
 
@@ -73,8 +73,8 @@ describe("ConnectModal", () => {
     expect(onConnect).toHaveBeenCalledWith("", "");
   });
 
-  it("uses 'Connect' as the OK button label", () => {
+  it("uses 'Sign in' as the OK button label", () => {
     const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} />);
-    expect(getByTestId("ok-button").textContent).toBe("Connect");
+    expect(getByTestId("ok-button").textContent).toBe("Sign in");
   });
 });

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -27,8 +27,8 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect }) =
       onOK={() => {
         onConnect(username, password);
       }}
-      strTitle="Connect to RomM"
-      strOKButtonText="Connect"
+      strTitle="Sign in to RomM"
+      strOKButtonText="Sign in"
       bDisableBackgroundDismiss={true}
     >
       <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -7,10 +7,10 @@ import { showModal } from "@decky/ui";
 // Local re-mock: the URL + RomM Account rows are Field + DialogButton again,
 // so Field renders its `label` + `description` (those copy strings stay
 // queryable via field-label/field-desc) and DialogButton renders its
-// `children` ("Edit"/"Connect") forwarding `onClick`; ButtonItem stays for the
-// layout="below" Test Connection row, forwarding `disabled` + `children`;
-// ToggleField forwards `checked` + a usable onChange that mirrors the global
-// stub's (boolean) signature.
+// `children` ("Edit"/"Sign in") forwarding `onClick`; ButtonItem stays for the
+// layout="below" Test Connection row, forwarding `disabled` + `description` +
+// `children`; ToggleField forwards `checked` + a usable onChange that mirrors
+// the global stub's (boolean) signature.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 interface ToggleFieldProps {
   label?: unknown;
@@ -37,10 +37,12 @@ vi.mock("@decky/ui", () => ({
     children,
     onClick,
     disabled,
+    description,
   }: AnyProps & {
     onClick?: () => void;
     disabled?: boolean;
-  }) => createElement("button", { onClick, disabled }, children as never),
+    description?: unknown;
+  }) => createElement("button", { onClick, disabled, "data-description": description as never }, children as never),
   ToggleField: (p: ToggleFieldProps) => {
     toggleCaptured.items.push(p);
     return createElement("input", {
@@ -54,7 +56,7 @@ vi.mock("@decky/ui", () => ({
 }));
 
 // Captured props off the modals opened via showModal. The URL Edit opens a
-// TextInputModal (field='url'); the Connect button opens a ConnectModal
+// TextInputModal (field='url'); the Sign in button opens a ConnectModal
 // (onConnect callback).
 interface UrlModalProps {
   label?: string;
@@ -128,16 +130,16 @@ describe("ConnectionSection", () => {
       expect(labels).toContain("RomM Account");
     });
 
-    it("shows 'Connected' description when hasToken is true", () => {
+    it("shows 'Signed in' description when hasToken is true", () => {
       const { getAllByTestId } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
       const descs = getAllByTestId("field-desc").map((el) => el.textContent);
-      expect(descs).toContain("Connected");
+      expect(descs).toContain("Signed in");
     });
 
-    it("shows 'Not connected' description when hasToken is false", () => {
+    it("shows 'Not signed in' description when hasToken is false", () => {
       const { getAllByTestId } = render(<ConnectionSection {...defaultProps({ hasToken: false })} />);
       const descs = getAllByTestId("field-desc").map((el) => el.textContent);
-      expect(descs).toContain("Not connected");
+      expect(descs).toContain("Not signed in");
     });
 
     it("never renders the removed Username/Password fields", () => {
@@ -147,16 +149,16 @@ describe("ConnectionSection", () => {
     });
   });
 
-  describe("Connect button", () => {
-    it("renders a Connect button", () => {
+  describe("Sign in button", () => {
+    it("renders a Sign in button", () => {
       const { getByText } = render(<ConnectionSection {...defaultProps()} />);
-      expect(getByText("Connect")).toBeTruthy();
+      expect(getByText("Sign in")).toBeTruthy();
     });
 
     it("opens a ConnectModal wired to onConnect when clicked", () => {
       const onConnect = vi.fn();
       const { getByText } = render(<ConnectionSection {...defaultProps({ onConnect })} />);
-      fireEvent.click(getByText("Connect"));
+      fireEvent.click(getByText("Sign in"));
       const props = lastShownModalProps<ConnectModalProps>();
       expect(props?.onConnect).toBe(onConnect);
     });
@@ -200,14 +202,29 @@ describe("ConnectionSection", () => {
   describe("Test Connection button", () => {
     it("fires onTestConnection when clicked", () => {
       const onTestConnection = vi.fn();
-      const { getByText } = render(<ConnectionSection {...defaultProps({ onTestConnection })} />);
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true, onTestConnection })} />);
       fireEvent.click(getByText("Test Connection"));
       expect(onTestConnection).toHaveBeenCalledTimes(1);
     });
 
     it("is disabled while loading", () => {
-      const { getByText } = render(<ConnectionSection {...defaultProps({ loading: true })} />);
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true, loading: true })} />);
       expect(getByText("Test Connection")).toBeDisabled();
+    });
+
+    it("is disabled and shows the sign-in hint when not signed in", () => {
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: false })} />);
+      const button = getByText("Test Connection");
+      expect(button).toBeDisabled();
+      expect(button.getAttribute("data-description")).toBe("Sign in to RomM first to test the connection.");
+    });
+
+    it("is enabled with no hint once signed in", () => {
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
+      const button = getByText("Test Connection");
+      expect(button).not.toBeDisabled();
+      // `description={undefined}` renders no data-description attribute.
+      expect(button.getAttribute("data-description")).toBeNull();
     });
   });
 

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -1,8 +1,8 @@
 /**
- * RomM server connection settings — URL, account/token connection, SSL
- * toggle, and the "Test Connection" affordance. Pure renderer: the parent
- * owns the field values, the has-token flag, the status string, and the
- * save/connect/test logic.
+ * RomM server connection settings — URL, account sign-in/token, SSL toggle,
+ * and the "Test Connection" affordance. Pure renderer: the parent owns the
+ * field values, the has-token flag, the status string, and the
+ * save/sign-in/test logic.
  */
 
 import { FC } from "react";
@@ -48,12 +48,12 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
         </Field>
       </PanelSectionRow>
       <PanelSectionRow>
-        <Field label="RomM Account" description={hasToken ? "Connected" : "Not connected"}>
+        <Field label="RomM Account" description={hasToken ? "Signed in" : "Not signed in"}>
           <DialogButton
             style={{ minWidth: "auto", width: "auto" }}
             onClick={() => showModal(<ConnectModal onConnect={onConnect} />)}
           >
-            Connect
+            Sign in
           </DialogButton>
         </Field>
       </PanelSectionRow>
@@ -68,7 +68,12 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
         </PanelSectionRow>
       )}
       <PanelSectionRow>
-        <ButtonItem layout="below" onClick={onTestConnection} disabled={loading}>
+        <ButtonItem
+          layout="below"
+          onClick={onTestConnection}
+          disabled={loading || !hasToken}
+          description={hasToken ? undefined : "Sign in to RomM first to test the connection."}
+        >
           Test Connection
         </ButtonItem>
       </PanelSectionRow>

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -152,15 +152,15 @@ class TestRommAuthHeader:
         header = plugin._http_adapter.auth_header()
         assert header == "Bearer rmm_abc123"
 
-    def test_bearer_empty_when_no_token(self, plugin):
+    def test_returns_none_when_no_token(self, plugin):
         plugin.settings.pop("romm_api_token", None)
         header = plugin._http_adapter.auth_header()
-        assert header == "Bearer "
+        assert header is None
 
-    def test_bearer_empty_when_token_none(self, plugin):
+    def test_returns_none_when_token_none(self, plugin):
         plugin.settings["romm_api_token"] = None
         header = plugin._http_adapter.auth_header()
-        assert header == "Bearer "
+        assert header is None
 
 
 class TestRommBasicAuthRequest:
@@ -326,6 +326,49 @@ class TestRommRequest:
         req = mock_open.call_args[0][0]
         assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
 
+    def test_omits_authorization_when_no_token(self, plugin):
+        """A pre-mint probe (no stored token) must not send an empty ``Bearer ``
+        header — some RomM versions 500 on it. The User-Agent is still sent."""
+        import json as _json
+        from unittest.mock import MagicMock, patch
+
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings.pop("romm_api_token", None)
+        plugin.settings["romm_allow_insecure_ssl"] = False
+
+        fake_resp = MagicMock()
+        fake_resp.read.return_value = _json.dumps({"ok": True}).encode()
+        fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=fake_resp) as mock_open:
+            plugin._http_adapter.request("/api/test")
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
+
+    def test_sends_authorization_when_token_present(self, plugin):
+        """With a stored token, the Bearer header is sent alongside the UA."""
+        import json as _json
+        from unittest.mock import MagicMock, patch
+
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_runtime"
+        plugin.settings["romm_allow_insecure_ssl"] = False
+
+        fake_resp = MagicMock()
+        fake_resp.read.return_value = _json.dumps({"ok": True}).encode()
+        fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=fake_resp) as mock_open:
+            plugin._http_adapter.request("/api/test")
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer rmm_runtime"
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
+
 
 class TestRommJsonRequest:
     def test_post_json(self, plugin):
@@ -369,6 +412,27 @@ class TestRommJsonRequest:
 
         req = mock_open.call_args[0][0]
         assert req.get_method() == "PUT"
+
+    def test_omits_authorization_when_no_token(self, plugin):
+        """A token-less JSON request omits the Authorization header (no empty Bearer)."""
+        import json as _json
+        from unittest.mock import MagicMock, patch
+
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings.pop("romm_api_token", None)
+        plugin.settings["romm_allow_insecure_ssl"] = False
+
+        fake_resp = MagicMock()
+        fake_resp.read.return_value = _json.dumps({"id": 1}).encode()
+        fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+        fake_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=fake_resp) as mock_open:
+            plugin._http_adapter.post_json("/api/saves", {"filename": "test.srm"})
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
 
 
 class TestRommUploadMultipart:
@@ -486,6 +550,7 @@ def _setup_plugin(plugin):
     plugin.settings["romm_url"] = "http://romm.local"
     plugin.settings["romm_user"] = "user"
     plugin.settings["romm_pass"] = "pass"
+    plugin.settings["romm_api_token"] = "rmm_token"
     plugin.settings["romm_allow_insecure_ssl"] = False
     plugin.loop = asyncio.get_event_loop()
     plugin._connection_service = ConnectionService(
@@ -1360,6 +1425,29 @@ class TestDownloadTimeout:
             adapter.download("/roms/game.zip", dest)
 
         req = mock_open.call_args[0][0]
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
+
+    def test_download_omits_authorization_when_no_token(self, tmp_path):
+        """A token-less download omits the Authorization header (no empty Bearer)."""
+        from io import BytesIO
+
+        adapter = self._make_adapter()
+        adapter._settings.pop("romm_api_token", None)
+        dest = str(tmp_path / "rom.zip")
+        data = b"hello"
+
+        mock_resp = MagicMock()
+        mock_resp.headers = {"Content-Length": str(len(data))}
+        stream = BytesIO(data)
+        mock_resp.read = stream.read
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            adapter.download("/roms/game.zip", dest)
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
         assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
 
     def test_connection_timeout_still_works(self, tmp_path):

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -64,7 +64,7 @@ def _make_service(
 
 class TestTestConnectionHappyPath:
     def test_returns_success_with_version(self, event_loop, romm_api, logger):
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is True
@@ -74,7 +74,7 @@ class TestTestConnectionHappyPath:
 
     def test_version_exact_minimum_succeeds(self, event_loop, romm_api, logger):
         """Version equal to minimum tuple is accepted (>= comparison)."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -101,8 +101,22 @@ class TestTestConnectionBadPath:
         result = event_loop.run_until_complete(service.test_connection())
         assert result["error_code"] == "config_error"
 
-    def test_heartbeat_connection_error_clears_version(self, event_loop, romm_api, logger):
+    def test_no_token_returns_config_error_without_probing(self, event_loop, romm_api, logger):
+        """A configured URL but no minted token short-circuits before any network
+        call — an unauthenticated scoped probe is never fired (#928)."""
         settings = {"romm_url": "http://romm.local"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result == {
+            "success": False,
+            "message": "Not signed in — sign in to RomM first",
+            "error_code": "config_error",
+        }
+        romm_api.heartbeat.assert_not_called()
+        romm_api.list_platforms.assert_not_called()
+
+    def test_heartbeat_connection_error_clears_version(self, event_loop, romm_api, logger):
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.side_effect = RommConnectionError("connection refused")
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -113,7 +127,7 @@ class TestTestConnectionBadPath:
 
     def test_list_platforms_server_error_prefixed(self, event_loop, romm_api, logger):
         """Non-auth/forbidden errors from list_platforms get prefixed."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.list_platforms.side_effect = RommServerError("boom", status_code=503)
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -123,7 +137,7 @@ class TestTestConnectionBadPath:
 
     def test_list_platforms_auth_error_not_prefixed(self, event_loop, romm_api, logger):
         """auth_error / forbidden_error keep their original message — no prefix."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.list_platforms.side_effect = RommAuthError("bad credentials")
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -134,7 +148,7 @@ class TestTestConnectionBadPath:
 
 class TestTestConnectionVersionGate:
     def test_version_below_minimum_rejected(self, event_loop, romm_api, logger):
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -146,7 +160,7 @@ class TestTestConnectionVersionGate:
 
     def test_version_one_patch_below_minimum_rejected(self, event_loop, romm_api, logger):
         """4.8.0 is below 4.8.1 — must be rejected."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.0"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -154,7 +168,7 @@ class TestTestConnectionVersionGate:
 
     def test_development_version_bypasses_gate(self, event_loop, romm_api, logger):
         """``development`` version string skips the minimum-version check."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "development"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -166,7 +180,7 @@ class TestTestConnectionVersionGate:
 class TestTestConnectionEdgeCases:
     def test_heartbeat_without_system_field(self, event_loop, romm_api, logger):
         """Heartbeat dict without SYSTEM.VERSION → list_platforms still probed, success without romm_version."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -177,7 +191,7 @@ class TestTestConnectionEdgeCases:
 
     def test_heartbeat_returns_none_safely_handled(self, event_loop, romm_api, logger):
         """A ``None`` heartbeat payload is tolerated via ``contextlib.suppress``."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = None
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -187,7 +201,7 @@ class TestTestConnectionEdgeCases:
 
     def test_heartbeat_with_malformed_system_field(self, event_loop, romm_api, logger):
         """SYSTEM field that is not a dict raises AttributeError, suppressed → version=None."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": "not-a-dict"}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
@@ -196,7 +210,7 @@ class TestTestConnectionEdgeCases:
 
     def test_min_required_version_injected(self, event_loop, romm_api, logger):
         """Service uses the injected minimum, not a hard-coded tuple."""
-        settings = {"romm_url": "http://romm.local"}
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "5.0.0"}}
         # Inject a higher minimum so 5.0.0 is rejected.
         service = _make_service(
@@ -228,6 +242,18 @@ class TestEstablishTokenHappyPath:
         assert settings["romm_api_token_id"] == 42
         # URL persisted + token persisted → at least two saves.
         assert settings_persister.save_settings.call_count >= 2
+
+    def test_mints_with_no_preexisting_token(self, event_loop, romm_api, logger):
+        """``establish_token`` is the path that mints the first token — it must
+        proceed even though no token is stored yet (#928 guard applies only to
+        ``test_connection``, never here)."""
+        settings: dict[str, Any] = {}
+        assert "romm_api_token" not in settings
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_token("http://romm.local", "alice", "secret"))
+        assert result["success"] is True
+        romm_api.mint_client_token.assert_called_once()
+        assert settings["romm_api_token"] == "rmm_minted"
 
     def test_does_not_persist_credentials(self, event_loop, romm_api, logger):
         settings: dict[str, Any] = {}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -187,6 +187,7 @@ class TestConnection:
 
         plugin.loop = asyncio.get_event_loop()
         plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_token"
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         plugin._romm_api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
         # Rebuild connection service with the live event loop so executor


### PR DESCRIPTION
## Problem

On a **fresh** setup with no stored Client API Token, the plugin sent `Authorization: Bearer ` (empty token) on its pre-mint probes. RomM 4.8.x returns **HTTP 500** on that malformed header (unguarded `.split()` in its auth middleware), so the heartbeat probe in `establish_token()` failed *before* the token was ever minted — a hard connection-setup deadlock. Reported in #928 with a precise repro.

Upgraders never hit it: legacy credential migration mints from stored credentials with no pre-flight probe.

## Fix

- `auth_header()` returns `None` when no token is stored; a single `_apply_default_headers()` helper attaches `User-Agent` always and `Authorization` only when present, applied to `request`/`download`/`json_request`/`upload_multipart`. `basic_auth_request` keeps its own Basic header. Unauthenticated probes now go out clean (heartbeat is public → 200), and the mint proceeds.
- `test_connection()` short-circuits with a clear "not signed in" result when no token exists, so its probe never fires an unauthenticated **scoped** request (`/api/platforms` requires `PLATFORMS_READ`, which would 403 on a fresh setup once the empty-Bearer crash is gone). The **Test Connection** button is disabled until signed in.

## UI

The account action is renamed **Connect → Sign in** ("Signed in" / "Not signed in"): it mints and stores a token, not a persistent connection. The modal title/button and the failure status follow the same vocabulary. "Test Connection" keeps its name.

## Testing

- **Hardware-verified**: a fresh (no-token) sign-in against RomM 4.8.1 behind a header-forwarding proxy now connects cleanly — heartbeat 200 (no `Authorization` header) instead of 500, followed by the token mint.
- Unit tests: header omitted/present per token state (non-vacuous `req.get_header` assertions), `test_connection` no-token short-circuit makes **no** network call, `establish_token` still mints with no pre-existing token. Frontend tests cover the disabled Test Connection state and the relabels.

## Docs

`getting-started.md` and `configuration.md` updated to the Sign in vocabulary and that Test Connection is available once signed in.

## Upstream

RomM's 500-on-malformed-header is the server-side root; fixed upstream in rommapp/romm#3489 (merged to `master`, not yet released). This client fix stands on its own — we support RomM ≥ 4.8.1 and shouldn't send an empty `Bearer ` regardless.

Closes #928
