### PR TITLE
fix(paths): surface RetroDECK config health instead of silent stale-root fallback

### DIFF
--- a/docs/architecture/config-source-parsers.md
+++ b/docs/architecture/config-source-parsers.md
@@ -249,6 +249,39 @@ The ES-DE `es_systems.xml` parser (`CoreResolver`) keeps its XML parsing inline 
 module; that is acceptable because the adapter owns its I/O. New `.info`-style sources that warrant a pure-parse split
 should follow the [parser layout template](#parser-layout-template) above (pure parse in `domain/`, I/O in `adapters/`).
 
+### Best-effort fallback and config health (`retrodeck.json`)
+
+`RetroDeckPathsAdapter` resolves all RetroDECK roots (ROMs, saves, BIOS, home) from the `paths` block of
+`retrodeck.json`. The path getters (`roms_path`, `saves_path`, `bios_path`, `retrodeck_home`) are **best-effort and
+never raise**: when the file is missing, unreadable, or malformed, each getter falls back to
+`<user_home>/retrodeck/<subdir>`. That fallback is RetroDECK's own default root, so it is correct for a default install
+but **wrong** for an SD-card install where the user pointed RetroDECK at external storage.
+
+Silently operating on the wrong root is the failure mode
+[#948](https://github.com/danielcopper/decky-romm-sync/issues/948) addresses. The fix keeps the getters
+silent-and-best-effort but pairs them with a loud health signal that the frontend surfaces as a QAM banner.
+`RetroDeckPathsAdapter.config_health()` returns a `RetroDeckConfigHealth` enum (`py_modules/lib/retrodeck_health.py` —
+placed in `lib/` because the adapter, the `RetroDeckPaths` Protocol, and `main.py` all import it, and import-linter
+forbids the adapter↔service directions). The four states:
+
+| State          | When                                                                                         | Loud? | Rationale                                                                                                                                                                     |
+| -------------- | -------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ok`           | `retrodeck.json` read successfully **and** the resolved home exists on disk                  | no    | Healthy — roots are trustworthy.                                                                                                                                              |
+| `absent`       | `retrodeck.json` not found (`FileNotFoundError`)                                             | no    | The legitimate fresh-install case — `~/retrodeck` is RetroDECK's own default root. `absent` wins over `root_missing` even when the `~/retrodeck` fallback does not exist yet. |
+| `unreadable`   | file exists but cannot be read or parsed (`OSError` / `PermissionError` / `JSONDecodeError`) | yes   | We know RetroDECK is configured but cannot read where its roots point — derived paths are likely wrong.                                                                       |
+| `root_missing` | `retrodeck.json` read OK, but the resolved home directory does not exist on disk             | yes   | The library volume is gone (e.g. SD card ejected) — syncs and downloads would target a missing/wrong location.                                                                |
+
+`config_health()` reuses the same 30-second TTL cache as the path getters (`_load_config()`) — no second independent
+file read — and tracks the last load outcome so it can distinguish `absent` from `unreadable` (a bare `None` would
+conflate them). The `root_missing` disk probe (`os.path.isdir`) only runs when the config read OK; it never runs for
+`absent`, so a fresh install stays quiet.
+
+`main.py` exposes this via the `get_retrodeck_status()` callable, a discriminated-status union
+(`{status, config_path, resolved_home}`) — the [Callable response shapes](backend-architecture.md) carve-out for >2
+outcomes. The backend returns only the discriminant plus the probed paths; the frontend owns the human-readable copy
+(`src/utils/retrodeckHealth.ts`) and renders the shared `WarningCard` in the QAM Status panel for the two loud states.
+`ok` and `absent` render no banner.
+
 ## Known consumer gaps
 
 One-parser-per-source compliance has two sides, and this page historically only covered one of them:

--- a/main.py
+++ b/main.py
@@ -75,6 +75,10 @@ class Plugin:
         )
         self.settings = result.stores.settings
         self._debug_logger = result.handles.debug_logger
+        # RetroDECK path resolver — held directly so the get_retrodeck_status
+        # callable can read the resolution health without routing through a
+        # service (it's a pure adapter read, no orchestration).
+        self._retrodeck_paths = result.callbacks.retrodeck_paths
 
         # ── 4. Wire services ────────────────────────────────────────────────
         services = wire_services(
@@ -180,6 +184,20 @@ class Plugin:
 
     async def get_settings(self):
         return self._settings_service.get_settings()
+
+    async def get_retrodeck_status(self):
+        """Report RetroDECK path-resolution health for the frontend banner.
+
+        Discriminated-status union (Callable response shapes carve-out):
+        ``status`` carries one of ``ok`` / ``absent`` / ``unreadable`` /
+        ``root_missing``. The frontend owns the human-readable copy; the
+        backend returns the discriminant plus the probed paths.
+        """
+        return {
+            "status": self._retrodeck_paths.config_health().value,
+            "config_path": self._retrodeck_paths.config_path(),
+            "resolved_home": self._retrodeck_paths.retrodeck_home(),
+        }
 
     async def get_whitelist_settings(self):
         return self._settings_service.get_whitelist_settings()

--- a/py_modules/adapters/retrodeck_paths.py
+++ b/py_modules/adapters/retrodeck_paths.py
@@ -6,6 +6,12 @@ configurator output) once and caches the result for 30 seconds — long
 enough to amortize repeated reads during a sync run, short enough to
 pick up edits made via the RetroDECK configurator within a single
 plugin session.
+
+Path getters are best-effort and never raise: a missing, unreadable, or
+malformed ``retrodeck.json`` falls back to ``<user_home>/retrodeck/*``.
+On an SD-card install that fallback root is wrong, so the silent
+fallback is paired with :meth:`RetroDeckPathsAdapter.config_health`,
+the loud signal ``main.py`` surfaces to the frontend banner.
 """
 
 from __future__ import annotations
@@ -14,6 +20,8 @@ import json
 import os
 import time
 from typing import TYPE_CHECKING, Any
+
+from lib.retrodeck_health import RetroDeckConfigHealth
 
 if TYPE_CHECKING:
     import logging
@@ -29,8 +37,13 @@ class RetroDeckPathsAdapter:
         self._logger = logger
         self._cached_config: dict[str, Any] | None = None
         self._cache_time = 0.0
+        # Load outcome that distinguishes "no file" (ABSENT, quiet) from
+        # "file present but unreadable" (UNREADABLE, loud). The getters
+        # only need the dict-or-None; ``config_health`` needs the reason.
+        self._last_load_health: RetroDeckConfigHealth = RetroDeckConfigHealth.ABSENT
 
-    def _config_path(self) -> str:
+    def config_path(self) -> str:
+        """Absolute path to ``retrodeck.json`` that this adapter probes."""
         return os.path.join(
             self._user_home,
             ".var",
@@ -45,22 +58,27 @@ class RetroDeckPathsAdapter:
         now = time.monotonic()
         if self._cached_config is not None and (now - self._cache_time) < self._CACHE_TTL:
             return self._cached_config
-        config_path = self._config_path()
+        config_path = self.config_path()
         try:
             with open(config_path) as f:
                 config = json.load(f)
             self._cached_config = config
             self._cache_time = now
+            self._last_load_health = RetroDeckConfigHealth.OK
             return config
         except FileNotFoundError:
             # Missing file is the expected fallback path (fresh install,
-            # no RetroDECK yet) — don't spam the log on every read.
+            # no RetroDECK yet) — don't spam the log on every read, and
+            # don't cache the time so the next read picks up a created
+            # file immediately.
             self._cached_config = None
+            self._last_load_health = RetroDeckConfigHealth.ABSENT
             return None
         except (OSError, json.JSONDecodeError) as exc:
             self._logger.warning(f"Failed to load RetroDECK config at {config_path}: {exc}")
             self._cached_config = None
             self._cache_time = now
+            self._last_load_health = RetroDeckConfigHealth.UNREADABLE
             return None
 
     def _get_path(self, key: str, fallback_subdir: str) -> str:
@@ -82,3 +100,31 @@ class RetroDeckPathsAdapter:
 
     def retrodeck_home(self) -> str:
         return self._get_path("rd_home_path", "")
+
+    def config_health(self) -> RetroDeckConfigHealth:
+        """Classify how trustworthy the resolved RetroDECK roots are.
+
+        Reuses the 30-second TTL cache via :meth:`_load_config` — no
+        second independent file read within the TTL. Four outcomes:
+
+        - ``ABSENT``: ``retrodeck.json`` not found — the legitimate
+          fresh-install case. Wins over ``ROOT_MISSING`` even when the
+          ``~/retrodeck`` fallback does not exist on disk, so it stays
+          quiet.
+        - ``UNREADABLE``: the file exists but could not be read/parsed.
+        - ``ROOT_MISSING``: the file read OK but the resolved RetroDECK
+          home directory does not exist on disk (e.g. SD card ejected).
+        - ``OK``: read OK and the resolved home exists.
+        """
+        self._load_config()
+        # ABSENT wins over the disk probe: ``~/retrodeck`` not existing on
+        # a fresh install is expected, not a failure.
+        if self._last_load_health in (
+            RetroDeckConfigHealth.ABSENT,
+            RetroDeckConfigHealth.UNREADABLE,
+        ):
+            return self._last_load_health
+        # Config read OK — probe the resolved home directory on disk.
+        if not os.path.isdir(self.retrodeck_home()):
+            return RetroDeckConfigHealth.ROOT_MISSING
+        return RetroDeckConfigHealth.OK

--- a/py_modules/lib/retrodeck_health.py
+++ b/py_modules/lib/retrodeck_health.py
@@ -1,0 +1,35 @@
+"""Health classification for RetroDECK path resolution from ``retrodeck.json``.
+
+Cross-cutting enum shared by the adapter that reads ``retrodeck.json``
+(``adapters/retrodeck_paths.py``), the Protocol services depend on
+(``services/protocols/paths.py``), and the ``main.py`` callable that
+surfaces the state to the frontend banner. It lives in ``lib/`` because
+all three layers must import it and ``import-linter`` forbids the
+adapter→service and service→adapter directions; ``lib/`` is the only
+namespace importable from every layer.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RetroDeckConfigHealth(StrEnum):
+    """How trustworthy the resolved RetroDECK roots are right now.
+
+    The path getters are always best-effort and never raise; this enum
+    is the loud signal that lets the frontend warn the user when the
+    resolved roots are likely wrong.
+    """
+
+    OK = "ok"
+    """``retrodeck.json`` read successfully AND the resolved RetroDECK home exists on disk."""
+
+    ABSENT = "absent"
+    """``retrodeck.json`` not found — the legitimate fresh-install fallback to ``~/retrodeck``. Stays quiet."""
+
+    UNREADABLE = "unreadable"
+    """``retrodeck.json`` exists but cannot be read or parsed — we know RetroDECK is configured but not where. Loud."""
+
+    ROOT_MISSING = "root_missing"
+    """``retrodeck.json`` read OK, but the resolved home is missing on disk (e.g. SD card ejected). Loud."""

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -11,7 +11,10 @@ resolver layers over the es_systems default.
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from lib.retrodeck_health import RetroDeckConfigHealth
 
 
 class SystemResolver(Protocol):
@@ -21,12 +24,17 @@ class SystemResolver(Protocol):
 
 
 class RetroDeckPaths(Protocol):
-    """Bundled accessor for the four RetroDECK runtime directory paths.
+    """Bundled accessor for the RetroDECK runtime directory paths plus a
+    health signal for how trustworthy those paths are.
 
     Distinct method names per path are deliberate: a single
     ``def __call__(self) -> str`` shape would make a saves-for-bios
     mix-up silently type-check at the call site. Separate names give
-    the type checker enough information to flag it.
+    the type checker enough information to flag it. The path getters are
+    best-effort and never raise; ``config_health`` is the loud signal
+    ``main.py`` surfaces to the frontend when the resolved roots are
+    likely wrong (``retrodeck.json`` unreadable, or its resolved home
+    missing on disk).
     """
 
     def saves_path(self) -> str: ...
@@ -36,6 +44,10 @@ class RetroDeckPaths(Protocol):
     def bios_path(self) -> str: ...
 
     def retrodeck_home(self) -> str: ...
+
+    def config_path(self) -> str: ...
+
+    def config_health(self) -> RetroDeckConfigHealth: ...
 
 
 class RetroArchSaveSortingProvider(Protocol):

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -34,6 +34,7 @@ import type {
   DeleteSlotResult,
   MigrationStatus,
   MigrationResult,
+  RetroDeckStatus,
   SaveSortMigrationStatus,
   RollbackStatus,
   ListFileVersionsResult,
@@ -354,6 +355,11 @@ export const reconcilePlaytime = callable<
   [number],
   { total_seconds: number; session_count: number; server_query_failed: boolean }
 >("reconcile_playtime");
+
+// RetroDECK path-resolution health for the QAM banner — discriminated status
+// ("ok" | "absent" | "unreadable" | "root_missing") plus the probed paths. The
+// frontend owns the human-readable copy; the backend returns the discriminant.
+export const getRetroDeckStatus = callable<[], RetroDeckStatus>("get_retrodeck_status");
 
 // RetroDECK path migration
 export const getMigrationStatus = callable<[], MigrationStatus>("get_migration_status");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -341,6 +341,11 @@ describe("MainPage", () => {
       total: 0,
       message: "",
     });
+    vi.mocked(backend.getRetroDeckStatus).mockResolvedValue({
+      status: "ok",
+      config_path: "/cfg/retrodeck.json",
+      resolved_home: "/home/deck/retrodeck",
+    });
     vi.mocked(backend.cancelSync).mockResolvedValue({
       success: true,
       message: "Cancelled",
@@ -1827,6 +1832,74 @@ describe("MainPage", () => {
       // Re-query — the toggle is re-rendered.
       const updated = container.querySelector('[data-testid="toggle-input"]') as HTMLInputElement | null;
       expect(updated!.checked).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // P. RetroDECK config-health banner
+  // ===========================================================================
+  describe("RetroDECK config-health banner", () => {
+    it("shows the unreadable banner when status is 'unreadable'", async () => {
+      vi.mocked(backend.getRetroDeckStatus).mockResolvedValue({
+        status: "unreadable",
+        config_path: "/cfg/retrodeck.json",
+        resolved_home: "/home/deck/retrodeck",
+      });
+      const { findByText } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(await findByText("RetroDECK configuration unreadable")).toBeInTheDocument();
+      expect(await findByText(/syncs and downloads may target the wrong location/)).toBeInTheDocument();
+      // Probed config path is surfaced.
+      expect(await findByText(/\/cfg\/retrodeck\.json/)).toBeInTheDocument();
+    });
+
+    it("shows the root-missing banner when status is 'root_missing'", async () => {
+      vi.mocked(backend.getRetroDeckStatus).mockResolvedValue({
+        status: "root_missing",
+        config_path: "/cfg/retrodeck.json",
+        resolved_home: "/run/media/sdcard/retrodeck",
+      });
+      const { findByText } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(await findByText("RetroDECK library not found")).toBeInTheDocument();
+      expect(await findByText(/make sure the card is inserted/)).toBeInTheDocument();
+      // Resolved home is surfaced.
+      expect(await findByText(/\/run\/media\/sdcard\/retrodeck/)).toBeInTheDocument();
+    });
+
+    it("renders no banner when status is 'ok'", async () => {
+      vi.mocked(backend.getRetroDeckStatus).mockResolvedValue({
+        status: "ok",
+        config_path: "/cfg/retrodeck.json",
+        resolved_home: "/home/deck/retrodeck",
+      });
+      const { queryByText } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(queryByText("RetroDECK configuration unreadable")).toBeNull();
+      expect(queryByText("RetroDECK library not found")).toBeNull();
+    });
+
+    it("renders no banner when status is 'absent' (fresh-install case)", async () => {
+      vi.mocked(backend.getRetroDeckStatus).mockResolvedValue({
+        status: "absent",
+        config_path: "/cfg/retrodeck.json",
+        resolved_home: "/home/deck/retrodeck",
+      });
+      const { queryByText } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(queryByText("RetroDECK configuration unreadable")).toBeNull();
+      expect(queryByText("RetroDECK library not found")).toBeNull();
+    });
+
+    it("leaves the banner cleared when getRetroDeckStatus rejects", async () => {
+      vi.mocked(backend.getRetroDeckStatus).mockRejectedValue(new Error("boom"));
+      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+      const { queryByText } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // No banner, and the rejection is logged (non-vacuous .catch assertion).
+      expect(queryByText("RetroDECK configuration unreadable")).toBeNull();
+      expect(queryByText("RetroDECK library not found")).toBeNull();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to query RetroDECK status"));
     });
   });
 });

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -26,6 +26,7 @@ import {
   clearSyncCache,
   refreshMigrationState,
   getSyncStatus,
+  getRetroDeckStatus,
   logError,
 } from "../api/backend";
 import { formatBytes } from "../utils/formatters";
@@ -40,7 +41,9 @@ import {
 } from "../utils/saveSortMigrationStore";
 import { requestSyncCancel } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
+import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
+import { WarningCard } from "./WarningCard";
 import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import type {
   SyncProgress,
@@ -177,6 +180,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [skipPreview, setSkipPreview] = useState(false);
   const [loading, setLoading] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<{ warning: boolean; current?: string } | null>(null);
+  const [retrodeckBanner, setRetrodeckBanner] = useState<RetroDeckBanner | null>(null);
   const [migration, setMigration] = useState<MigrationStatus>(getMigrationState());
   const [saveSortMigration, setSaveSortMigration] = useState(getSaveSortMigrationState());
   const [downloads, setDownloads] = useState<DownloadItem[]>([]);
@@ -212,6 +216,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         }
       })
       .catch((e) => logError(`Failed to load settings: ${e}`));
+
+    // RetroDECK path-resolution health — warn the user when the resolved roots
+    // are likely wrong (retrodeck.json unreadable, or its home missing on
+    // disk). "ok"/"absent" stay quiet (banner cleared to null).
+    getRetroDeckStatus()
+      .then((s) => setRetrodeckBanner(retroDeckBanner(s.status, s)))
+      .catch((e) => logError(`Failed to query RetroDECK status: ${e}`));
 
     // Backend is authoritative for in-flight sync state. Seed the module
     // store from get_sync_status() so a QAM close/reopen recovers the live
@@ -544,6 +555,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   return (
     <>
       <PanelSection title="Status">
+        {retrodeckBanner && (
+          <PanelSectionRow>
+            <WarningCard title={retrodeckBanner.title} message={retrodeckBanner.message} compact />
+          </PanelSectionRow>
+        )}
         <PanelSectionRow>
           <Field label="Connection">
             <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,3 +14,4 @@ export * from "./saves";
 export * from "./achievements";
 export * from "./migration";
 export * from "./devices";
+export * from "./retrodeck";

--- a/src/types/retrodeck.ts
+++ b/src/types/retrodeck.ts
@@ -1,0 +1,21 @@
+/**
+ * RetroDECK path-resolution health surfaced to the QAM banner. The backend
+ * resolves all RetroDECK roots (roms / saves / bios / home) from
+ * `retrodeck.json`; when that read is untrustworthy the path getters fall back
+ * silently, so this discriminated status lets the frontend warn the user that
+ * syncs and downloads may target the wrong location. Anything describing how
+ * trustworthy the resolved RetroDECK roots are lives here.
+ */
+
+/** How trustworthy the resolved RetroDECK roots are. Mirrors the backend
+ *  `RetroDeckConfigHealth` StrEnum (`py_modules/lib/retrodeck_health.py`). */
+export type RetroDeckHealth = "ok" | "absent" | "unreadable" | "root_missing";
+
+/** Discriminated-status response from `get_retrodeck_status`. `config_path` is
+ *  the probed `retrodeck.json`; `resolved_home` is the best-effort RetroDECK
+ *  home the path getters resolved to (the fallback when the read failed). */
+export interface RetroDeckStatus {
+  status: RetroDeckHealth;
+  config_path: string;
+  resolved_home: string;
+}

--- a/src/utils/retrodeckHealth.test.ts
+++ b/src/utils/retrodeckHealth.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { retroDeckBanner } from "./retrodeckHealth";
+
+const PATHS = { config_path: "/cfg/retrodeck.json", resolved_home: "/sd/retrodeck" };
+
+describe("retroDeckBanner", () => {
+  it("returns null for 'ok' (healthy — stays quiet)", () => {
+    expect(retroDeckBanner("ok", PATHS)).toBeNull();
+  });
+
+  it("returns null for 'absent' (fresh-install fallback — stays quiet)", () => {
+    expect(retroDeckBanner("absent", PATHS)).toBeNull();
+  });
+
+  it("returns the unreadable banner with the probed config path", () => {
+    const banner = retroDeckBanner("unreadable", PATHS);
+    expect(banner).not.toBeNull();
+    expect(banner!.title).toBe("RetroDECK configuration unreadable");
+    expect(banner!.message).toContain("syncs and downloads may target the wrong location");
+    expect(banner!.message).toContain("/cfg/retrodeck.json");
+  });
+
+  it("returns the root-missing banner with the resolved home path", () => {
+    const banner = retroDeckBanner("root_missing", PATHS);
+    expect(banner).not.toBeNull();
+    expect(banner!.title).toBe("RetroDECK library not found");
+    expect(banner!.message).toContain("make sure the card is inserted");
+    expect(banner!.message).toContain("/sd/retrodeck");
+  });
+});

--- a/src/utils/retrodeckHealth.ts
+++ b/src/utils/retrodeckHealth.ts
@@ -1,0 +1,48 @@
+/**
+ * User-facing copy and the loud/quiet decision for the RetroDECK
+ * path-resolution health banner. The backend's `get_retrodeck_status`
+ * returns only the discriminant plus paths; the human-readable banner copy
+ * lives here so the component stays presentation-only. Anything that maps a
+ * `RetroDeckHealth` status to banner text belongs in this module.
+ */
+
+import type { RetroDeckHealth } from "../types";
+
+/** Title + body for a loud RetroDECK health banner. */
+export interface RetroDeckBanner {
+  title: string;
+  message: string;
+}
+
+/**
+ * Map a RetroDECK health status to banner copy, or `null` when nothing should
+ * be shown. `ok` and `absent` stay quiet: `ok` is healthy, and `absent` is the
+ * legitimate fresh-install case (RetroDECK's own `~/retrodeck` default). Only
+ * `unreadable` and `root_missing` are loud — both mean the resolved roots are
+ * likely wrong, so syncs and downloads may target the wrong location.
+ */
+export function retroDeckBanner(
+  status: RetroDeckHealth,
+  paths: { config_path: string; resolved_home: string },
+): RetroDeckBanner | null {
+  switch (status) {
+    case "unreadable":
+      return {
+        title: "RetroDECK configuration unreadable",
+        message:
+          "Couldn't read RetroDECK's configuration — syncs and downloads may target the wrong location. " +
+          "Check that RetroDECK is installed correctly. " +
+          `Looked at: ${paths.config_path}`,
+      };
+    case "root_missing":
+      return {
+        title: "RetroDECK library not found",
+        message:
+          "RetroDECK's library folder doesn't exist on disk — if it's on an SD card, make sure the card is inserted. " +
+          `Expected at: ${paths.resolved_home}`,
+      };
+    default:
+      // "ok" and "absent" stay quiet.
+      return null;
+  }
+}

--- a/tests/adapters/test_retrodeck_paths.py
+++ b/tests/adapters/test_retrodeck_paths.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import patch
 
 from adapters.retrodeck_paths import RetroDeckPathsAdapter
+from lib.retrodeck_health import RetroDeckConfigHealth
 
 
 def _make_adapter(tmp_path, config: dict[str, Any] | None = None) -> RetroDeckPathsAdapter:
@@ -158,3 +159,103 @@ class TestLoadConfigLogging:
 
         assert result == os.path.join(str(tmp_path), "retrodeck", "bios")
         assert not any("Failed to load RetroDECK config" in rec.message for rec in caplog.records)
+
+
+class TestConfigPath:
+    def test_config_path_points_at_retrodeck_json(self, tmp_path):
+        adapter = _make_adapter(tmp_path)
+        assert adapter.config_path() == os.path.join(
+            str(tmp_path),
+            ".var",
+            "app",
+            "net.retrodeck.retrodeck",
+            "config",
+            "retrodeck",
+            "retrodeck.json",
+        )
+
+
+class TestConfigHealth:
+    def test_ok_when_config_present_and_home_exists(self, tmp_path):
+        """OK: ``retrodeck.json`` read AND the resolved home exists on disk."""
+        home = tmp_path / "rd-home"
+        home.mkdir()
+        adapter = _make_adapter(tmp_path, {"paths": {"rd_home_path": str(home)}})
+        assert adapter.config_health() is RetroDeckConfigHealth.OK
+
+    def test_absent_when_no_config_file(self, tmp_path):
+        """ABSENT: no ``retrodeck.json`` — the legitimate fresh-install case."""
+        adapter = _make_adapter(tmp_path)  # no config file
+        assert adapter.config_health() is RetroDeckConfigHealth.ABSENT
+
+    def test_absent_does_not_log(self, tmp_path, caplog):
+        """ABSENT stays quiet — no WARNING for the expected fresh-install path."""
+        adapter = _make_adapter(tmp_path)
+        with caplog.at_level(logging.WARNING):
+            assert adapter.config_health() is RetroDeckConfigHealth.ABSENT
+        assert not any("Failed to load RetroDECK config" in rec.message for rec in caplog.records)
+
+    def test_unreadable_on_malformed_json(self, tmp_path):
+        """UNREADABLE: the file exists but is not valid JSON."""
+        config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "retrodeck.json").write_text("not valid json")
+        adapter = RetroDeckPathsAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        assert adapter.config_health() is RetroDeckConfigHealth.UNREADABLE
+
+    def test_unreadable_on_permission_error(self, tmp_path):
+        """UNREADABLE: the file exists but cannot be opened."""
+        config_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retrodeck"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_file = config_dir / "retrodeck.json"
+        config_file.write_text(json.dumps({"paths": {"rd_home_path": "/whatever"}}))
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path) == str(config_file):
+                raise PermissionError(f"denied: {path}")
+            return real_open(path, *args, **kwargs)
+
+        adapter = RetroDeckPathsAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
+        with patch("builtins.open", side_effect=fake_open):
+            assert adapter.config_health() is RetroDeckConfigHealth.UNREADABLE
+
+    def test_root_missing_when_resolved_home_absent(self, tmp_path):
+        """ROOT_MISSING: config read OK but the resolved home is not on disk."""
+        missing_home = tmp_path / "ejected-sd-card" / "retrodeck"
+        adapter = _make_adapter(tmp_path, {"paths": {"rd_home_path": str(missing_home)}})
+        assert adapter.config_health() is RetroDeckConfigHealth.ROOT_MISSING
+
+    def test_absent_wins_over_root_missing(self, tmp_path):
+        """ABSENT must win even though the ``~/retrodeck`` fallback is absent.
+
+        With no ``retrodeck.json``, ``retrodeck_home()`` falls back to
+        ``<user_home>/retrodeck`` — which does not exist in this tmp dir.
+        The disk probe must NOT run for ABSENT, so the result stays
+        ABSENT (quiet) rather than ROOT_MISSING (loud).
+        """
+        adapter = _make_adapter(tmp_path)  # no config file
+        # Sanity: the fallback home does not exist on disk.
+        assert not os.path.isdir(adapter.retrodeck_home())
+        assert adapter.config_health() is RetroDeckConfigHealth.ABSENT
+
+    def test_health_reuses_ttl_cache_no_second_read(self, tmp_path):
+        """Within the TTL, ``config_health`` must not trigger a second file read."""
+        home = tmp_path / "rd-home"
+        home.mkdir()
+        adapter = _make_adapter(tmp_path, {"paths": {"rd_home_path": str(home)}})
+        # Prime the cache with one read.
+        assert adapter.config_health() is RetroDeckConfigHealth.OK
+
+        real_open = open
+        opened: list[str] = []
+
+        def tracking_open(path, *args, **kwargs):
+            opened.append(str(path))
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=tracking_open):
+            assert adapter.config_health() is RetroDeckConfigHealth.OK
+
+        assert opened == [], "config_health re-read retrodeck.json within the TTL"

--- a/tests/fakes/fake_retrodeck_paths.py
+++ b/tests/fakes/fake_retrodeck_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from lib.retrodeck_health import RetroDeckConfigHealth
+
 
 class FakeRetroDeckPaths:
     """In-memory ``RetroDeckPaths`` for tests.
@@ -19,11 +21,15 @@ class FakeRetroDeckPaths:
         roms: str = "",
         bios: str = "",
         home: str = "",
+        config_path: str = "/fake/retrodeck.json",
+        health: RetroDeckConfigHealth = RetroDeckConfigHealth.OK,
     ) -> None:
         self.saves = saves
         self.roms = roms
         self.bios = bios
         self.home = home
+        self.config = config_path
+        self.health = health
 
     def saves_path(self) -> str:
         return self.saves
@@ -36,3 +42,9 @@ class FakeRetroDeckPaths:
 
     def retrodeck_home(self) -> str:
         return self.home
+
+    def config_path(self) -> str:
+        return self.config
+
+    def config_health(self) -> RetroDeckConfigHealth:
+        return self.health

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,6 +16,7 @@ from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.persistence import PersistenceAdapter, SettingsPersisterAdapter
 from adapters.steam_config import SteamConfigAdapter
+from lib.retrodeck_health import RetroDeckConfigHealth
 
 # conftest.py patches decky before this import
 from main import Plugin
@@ -642,6 +643,8 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_whitelist_settings",
     "update_whitelist_settings",
     "save_collection_platform_groups",
+    # Read-only RetroDECK path-resolution health probe (for the frontend banner).
+    "get_retrodeck_status",
     # Cancel operations — must remain callable mid-operation when migration
     # marker fires so the user can stop in-flight work.
     "cancel_sync",
@@ -940,3 +943,43 @@ class TestCancelCallablesNotBlockedByMigration:
         result = await plugin.cancel_download(42)
         assert result.get("blocked_by_migration") is not True
         plugin._download_service.cancel_download.assert_called_once_with(42)
+
+
+class TestRetroDeckStatus:
+    @pytest.mark.asyncio
+    async def test_ok_status_carries_paths(self, plugin):
+        plugin._retrodeck_paths = FakeRetroDeckPaths(
+            home="/retrodeck",
+            config_path="/cfg/retrodeck.json",
+            health=RetroDeckConfigHealth.OK,
+        )
+        result = await plugin.get_retrodeck_status()
+        assert result == {
+            "status": "ok",
+            "config_path": "/cfg/retrodeck.json",
+            "resolved_home": "/retrodeck",
+        }
+
+    @pytest.mark.asyncio
+    async def test_status_is_plain_string_not_enum(self, plugin):
+        """The discriminant must serialize as a plain str for the WebSocket bridge."""
+        plugin._retrodeck_paths = FakeRetroDeckPaths(health=RetroDeckConfigHealth.UNREADABLE)
+        result = await plugin.get_retrodeck_status()
+        assert result["status"] == "unreadable"
+        assert type(result["status"]) is str
+
+    @pytest.mark.asyncio
+    async def test_root_missing_status(self, plugin):
+        plugin._retrodeck_paths = FakeRetroDeckPaths(
+            home="/missing",
+            health=RetroDeckConfigHealth.ROOT_MISSING,
+        )
+        result = await plugin.get_retrodeck_status()
+        assert result["status"] == "root_missing"
+        assert result["resolved_home"] == "/missing"
+
+    @pytest.mark.asyncio
+    async def test_absent_status(self, plugin):
+        plugin._retrodeck_paths = FakeRetroDeckPaths(health=RetroDeckConfigHealth.ABSENT)
+        result = await plugin.get_retrodeck_status()
+        assert result["status"] == "absent"


### PR DESCRIPTION
## Problem

RetroDECK roots (roms/saves/bios/home) resolve from `retrodeck.json`. When that file is missing, unreadable, or malformed, every path getter silently falls back to `<user_home>/retrodeck/*`. On an SD-card install that internal root is wrong, so all derived paths quietly point at the wrong place with no signal to the user. Surfaced during #945 (investigation finding #6) — not currently firing, but a latent silent-failure.

## Fix

Keep the getters best-effort (never raise) and pair them with a loud health signal:

- `RetroDeckConfigHealth` enum (`lib/`) — `ok` / `absent` / `unreadable` / `root_missing`. In `lib/` so the adapter, the `RetroDeckPaths` Protocol, and `main.py` can all import it without crossing import-linter boundaries.
- `RetroDeckPathsAdapter.config_health()` reuses the 30s TTL cache, distinguishes "no file" (fresh install — stays quiet, `~/retrodeck` is RetroDECK's own default) from "file present but unparseable" (loud), and probes the resolved home on disk to catch an ejected SD card (`root_missing`, loud). `absent` wins over the disk probe, so a fresh install never warns.
- `get_retrodeck_status()` callable returns the discriminant plus the probed `config_path` / `resolved_home` (discriminated-status union — the >2-outcome carve-out). The frontend owns the banner copy.
- `MainPage` queries on mount and renders a `WarningCard` in the Status panel for the two loud states only.

The path getters keep their previous best-effort behaviour unchanged — this only adds the signal on top.

## Tests

- **Adapter**: all four states (`unreadable` via both malformed JSON and permission error), the load-bearing edge that `absent` does not yield `root_missing` even when the fallback dir is missing, and the TTL-cache-no-second-read path — all against real `tmp_path` files.
- **Callable**: exact response shape, `.value` string serialization, all four statuses.
- **Frontend**: real `MainPage` render — banner visible for the two loud states (asserts rendered title/message/path), absent for `ok`/`absent`, plus a non-vacuous `.catch` assertion.

## Docs

`docs/architecture/config-source-parsers.md` — new "Best-effort fallback and config health" section (four states + rationale).

Closes #948.
