### PR TITLE
feat(ui): per-game core menu — (system) marker + 'Use System Override' reset item

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -160,10 +160,15 @@ cores are available for the game's platform.
 
 1. Open a game's detail page
 2. Tap the **CPU button** (microchip icon)
-3. Pick a core from the menu — each entry can carry up to three markers (see below)
+3. Pick a core from the menu, or the **Use System Override** item at the top (see below)
 4. The BIOS status, core badge, and game info panel update immediately
 
-Each core in the menu can show up to three markers, one per role:
+At the top of the menu, above the core list, is a dedicated **Use System Override (X)** item. Selecting it **clears**
+the per-game core so the game follows whatever the system would pick — the per-platform core you set on the System page,
+or the platform's default core when no per-platform override is set. **X** is that fallback core's name, shown in
+parentheses so you know what the game will fall back to.
+
+Each core in the list below can show up to three markers, one per role:
 
 - **(default)** — the RetroDECK/es_systems default core for this platform.
 - **(system)** — the per-platform core you picked on the [System page](#per-platform-system-page) (stored in the
@@ -174,9 +179,15 @@ The three roles are independent, so a single core can carry more than one marker
 per-platform pick happens to equal the default, or "(system) ✓" when the per-platform core is also the one the game
 launches with.
 
-A per-game core takes priority over the platform default. Picking a non-default core from the list **pins** that core
-for the game. To drop the per-game core and follow the platform default again, pick the **default-marked core** (the
-entry labelled "(default)") — that clears the per-game override.
+A per-game core takes priority over the platform default. **Every core in the list pins** when you pick it — including
+the one marked **(default)**. Pinning the default-marked core fixes the game to that specific core even if you later
+change the per-platform override; it is no longer the way to "follow the system".
+
+To drop the per-game core and follow the platform/system core again, pick the **Use System Override** item at the top —
+that is the only thing that clears the per-game override. The **✓** can appear in two places at once: when the game is
+following the system (no per-game core), the **Use System Override** item carries the ✓ **and** so does the core that is
+actually in effect. When you pin a per-game core, only that pinned core carries the ✓ and the **Use System Override**
+item does not.
 
 When you set or reset a per-game core for an installed game, the plugin updates the game's Steam shortcut immediately
 and confirms the change landed before reporting success. If Steam can't accept the change in the current session, you'll

--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -160,8 +160,19 @@ cores are available for the game's platform.
 
 1. Open a game's detail page
 2. Tap the **CPU button** (microchip icon)
-3. Pick a core from the menu — the active core is marked with a checkmark
+3. Pick a core from the menu — each entry can carry up to three markers (see below)
 4. The BIOS status, core badge, and game info panel update immediately
+
+Each core in the menu can show up to three markers, one per role:
+
+- **(default)** — the RetroDECK/es_systems default core for this platform.
+- **(system)** — the per-platform core you picked on the [System page](#per-platform-system-page) (stored in the
+  plugin's settings). Absent when the platform has no per-platform override.
+- **✓** (checkmark) — the core this game actually launches with right now.
+
+The three roles are independent, so a single core can carry more than one marker: "(default) (system)" when your
+per-platform pick happens to equal the default, or "(system) ✓" when the per-platform core is also the one the game
+launches with.
 
 A per-game core takes priority over the platform default. Picking a non-default core from the list **pins** that core
 for the game. To drop the per-game core and follow the platform default again, pick the **default-marked core** (the

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -89,15 +89,23 @@ class CoreService:
         selection is the per-ROM resolution from :class:`ActiveCoreResolver`, so
         a pinned ``emulator_override`` (or per-platform core) surfaces over the
         system default and the menu can highlight the active core (or offer
-        Reset). When ``rom_id`` is unknown the cores list is empty and the active
-        core is ``(None, None)``.
+        Reset). ``platform_core_label`` carries the per-platform override label
+        (``settings.json`` ``platform_cores``) so the menu can mark the
+        system-level selection distinctly from the active core. When ``rom_id``
+        is unknown the cores list is empty and the active core is
+        ``(None, None)``.
         """
         return await self._loop.run_in_executor(None, self._available_cores_io, rom_id)
 
     def _available_cores_io(self, rom_id: int) -> dict[str, Any]:
         rom = self._read_rom(rom_id)
         if rom is None:
-            return {"cores": [], "active_core": None, "active_core_label": None}
+            return {
+                "cores": [],
+                "active_core": None,
+                "active_core_label": None,
+                "platform_core_label": None,
+            }
         system = self._resolve_system(rom.platform_slug)
         cores = self._core_info.get_available_cores(system)
         active_so, active_label = self._active_core.active_core_for_rom(rom_id)
@@ -105,6 +113,7 @@ class CoreService:
             "cores": cores,
             "active_core": active_so,
             "active_core_label": active_label,
+            "platform_core_label": self._settings.get("platform_cores", {}).get(rom.platform_slug),
         }
 
     def _set_system_core_io(self, platform_slug: str, core_label: str) -> list[dict[str, Any]]:

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -91,9 +91,12 @@ class CoreService:
         system default and the menu can highlight the active core (or offer
         Reset). ``platform_core_label`` carries the per-platform override label
         (``settings.json`` ``platform_cores``) so the menu can mark the
-        system-level selection distinctly from the active core. When ``rom_id``
-        is unknown the cores list is empty and the active core is
-        ``(None, None)``.
+        system-level selection distinctly from the active core.
+        ``has_game_override`` reports whether a per-game pin is set — the menu
+        can't infer this from the active core alone (pinning the same core as
+        the per-platform override is indistinguishable), so the flag drives the
+        "follow the system" reset item's checkmark. When ``rom_id`` is unknown
+        the cores list is empty and the active core is ``(None, None)``.
         """
         return await self._loop.run_in_executor(None, self._available_cores_io, rom_id)
 
@@ -105,6 +108,7 @@ class CoreService:
                 "active_core": None,
                 "active_core_label": None,
                 "platform_core_label": None,
+                "has_game_override": False,
             }
         system = self._resolve_system(rom.platform_slug)
         cores = self._core_info.get_available_cores(system)
@@ -114,6 +118,7 @@ class CoreService:
             "active_core": active_so,
             "active_core_label": active_label,
             "platform_core_label": self._settings.get("platform_cores", {}).get(rom.platform_slug),
+            "has_game_override": rom.emulator_override is not None,
         }
 
     def _set_system_core_io(self, platform_slug: str, core_label: str) -> list[dict[str, Any]]:

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -234,6 +234,7 @@ describe("RomMGameInfoPanel", () => {
       cores: [],
       active_core: null,
       active_core_label: null,
+      platform_core_label: null,
     });
     vi.mocked(backend.getSaveStatus).mockResolvedValue({
       rom_id: 0,
@@ -1006,6 +1007,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "from_core_changed.so",
         active_core_label: "FROM_CORE_CHANGED",
+        platform_core_label: null,
         cores: [{ core_so: "from_core_changed.so", label: "FROM_CORE_CHANGED", is_default: true }],
       });
       await act(async () => {
@@ -1056,6 +1058,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "initial_core.so",
         active_core_label: "INITIAL_CORE",
+        platform_core_label: null,
         cores: [{ core_so: "initial_core.so", label: "INITIAL_CORE", is_default: true }],
       });
       const view = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1797,6 +1800,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "snes9x_libretro",
         active_core_label: "Snes9x",
+        platform_core_label: null,
         cores: [{ core_so: "snes9x_libretro", label: "Snes9x", is_default: true }],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1952,6 +1956,7 @@ describe("RomMGameInfoPanel", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "mycore.so",
         active_core_label: "MyCore",
+        platform_core_label: null,
         cores: [{ core_so: "mycore.so", label: "MyCore", is_default: true }],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -235,6 +235,7 @@ describe("RomMGameInfoPanel", () => {
       active_core: null,
       active_core_label: null,
       platform_core_label: null,
+      has_game_override: false,
     });
     vi.mocked(backend.getSaveStatus).mockResolvedValue({
       rom_id: 0,
@@ -1008,6 +1009,7 @@ describe("RomMGameInfoPanel", () => {
         active_core: "from_core_changed.so",
         active_core_label: "FROM_CORE_CHANGED",
         platform_core_label: null,
+        has_game_override: false,
         cores: [{ core_so: "from_core_changed.so", label: "FROM_CORE_CHANGED", is_default: true }],
       });
       await act(async () => {
@@ -1059,6 +1061,7 @@ describe("RomMGameInfoPanel", () => {
         active_core: "initial_core.so",
         active_core_label: "INITIAL_CORE",
         platform_core_label: null,
+        has_game_override: false,
         cores: [{ core_so: "initial_core.so", label: "INITIAL_CORE", is_default: true }],
       });
       const view = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1801,6 +1804,7 @@ describe("RomMGameInfoPanel", () => {
         active_core: "snes9x_libretro",
         active_core_label: "Snes9x",
         platform_core_label: null,
+        has_game_override: false,
         cores: [{ core_so: "snes9x_libretro", label: "Snes9x", is_default: true }],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
@@ -1957,6 +1961,7 @@ describe("RomMGameInfoPanel", () => {
         active_core: "mycore.so",
         active_core_label: "MyCore",
         platform_core_label: null,
+        has_game_override: false,
         cores: [{ core_so: "mycore.so", label: "MyCore", is_default: true }],
       });
       const { container } = render(<RomMGameInfoPanel appId={testAppId} />);

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -77,11 +77,14 @@ vi.mock("../utils/playSection", () => ({
     biosStatus: "ok",
     biosLabel: "OK",
   })),
-  extractCoreInfo: vi.fn((c: { active_core_label?: string | null; cores?: unknown[] }) => ({
-    activeCoreLabel: c.active_core_label ?? null,
-    activeCoreIsDefault: true,
-    availableCores: c.cores ?? [],
-  })),
+  extractCoreInfo: vi.fn(
+    (c: { active_core_label?: string | null; platform_core_label?: string | null; cores?: unknown[] }) => ({
+      activeCoreLabel: c.active_core_label ?? null,
+      activeCoreIsDefault: true,
+      availableCores: c.cores ?? [],
+      platformCoreLabel: c.platform_core_label ?? null,
+    }),
+  ),
   resolveSaveSyncLabel: vi.fn(() => "synced label"),
   // timeoutMs returns a Promise that never resolves — Promise.race with
   // testConnection always wins. Tests can override per-case to drive the
@@ -261,6 +264,7 @@ describe("RomMPlaySection", () => {
       activeCoreLabel: null,
       activeCoreIsDefault: true,
       availableCores: [],
+      platformCoreLabel: null,
     });
     // refreshCoreInfoInBackground (mocked) merges the current extractCoreInfo
     // mock result into state so the core button / menu render as in production,
@@ -268,7 +272,12 @@ describe("RomMPlaySection", () => {
     // extractCoreInfo mock ignores its argument, so the dummy CoreInfo is fine.
     vi.mocked(sectionRefresh.refreshCoreInfoInBackground).mockImplementation((_romId, cancelled, setter) => {
       if (cancelled()) return;
-      const coreFields = playSectionUtils.extractCoreInfo({ cores: [], active_core: null, active_core_label: null });
+      const coreFields = playSectionUtils.extractCoreInfo({
+        cores: [],
+        active_core: null,
+        active_core_label: null,
+        platform_core_label: null,
+      });
       act(() => {
         setter((prev) => ({ ...prev, ...coreFields }));
       });
@@ -283,6 +292,7 @@ describe("RomMPlaySection", () => {
       cores: [],
       active_core: null,
       active_core_label: null,
+      platform_core_label: null,
     });
 
     // Steam globals — appStore for the synchronous overview read.
@@ -1067,6 +1077,7 @@ describe("RomMPlaySection", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "blastem.so",
         active_core_label: "BlastEm",
+        platform_core_label: null,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -1117,6 +1128,7 @@ describe("RomMPlaySection", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "blastem.so",
         active_core_label: "BlastEm",
+        platform_core_label: null,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -2025,6 +2037,7 @@ describe("RomMPlaySection", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "snes9x.so",
         active_core_label: "Snes9x",
+        platform_core_label: null,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -2037,6 +2050,7 @@ describe("RomMPlaySection", () => {
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
+        platformCoreLabel: null,
       });
     }
 
@@ -2252,6 +2266,7 @@ describe("RomMPlaySection", () => {
       vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
         active_core: "blastem.so",
         active_core_label: "BlastEm",
+        platform_core_label: null,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -2265,6 +2280,7 @@ describe("RomMPlaySection", () => {
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
+        platformCoreLabel: null,
       });
     }
 
@@ -2436,6 +2452,7 @@ describe("RomMPlaySection", () => {
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
+        platformCoreLabel: null,
       });
       // 1 disabled compat note + 2 core items (separator filtered out, no Reset).
       expect(items).toHaveLength(3);
@@ -2455,12 +2472,33 @@ describe("RomMPlaySection", () => {
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
+        platformCoreLabel: null,
       });
       expect(items).toHaveLength(3);
       // The default entry has no ✓ when an override is pinned …
       expect(items[1]!.props.children).toBe("Snes9x (default)");
       // … and the pinned core carries it instead.
       expect(items[2]!.props.children).toBe("BlastEm ✓");
+    });
+
+    it("showCoreMenu marks the per-platform override core with (system), and only that core (#954)", async () => {
+      // BlastEm is the per-platform override set on the System page; the active
+      // core is the default Snes9x. The (system) marker sits on BlastEm only —
+      // Snes9x carries (default) ✓ but NOT (system).
+      const items = await setupCoreMenuStructure({
+        activeCoreLabel: "Snes9x",
+        activeCoreIsDefault: true,
+        availableCores: [
+          { core_so: "snes9x.so", label: "Snes9x", is_default: true },
+          { core_so: "blastem.so", label: "BlastEm", is_default: false },
+        ],
+        platformCoreLabel: "BlastEm",
+      });
+      expect(items).toHaveLength(3);
+      // The per-platform override core carries (system); a different core does not.
+      expect(items[2]!.props.children).toBe("BlastEm (system)");
+      expect(items[1]!.props.children).toBe("Snes9x (default) ✓");
+      expect(items[1]!.props.children).not.toContain("(system)");
     });
 
     it("showSteamMenu Properties → SteamClient.Apps.OpenAppSettingsDialog(appId, 'general')", async () => {
@@ -2646,6 +2684,7 @@ describe("RomMPlaySection", () => {
         activeCoreLabel: "OnlyOne",
         activeCoreIsDefault: true,
         availableCores: [{ core_so: "x.so", label: "OnlyOne", is_default: true }],
+        platformCoreLabel: null,
       });
       const { queryByTitle } = render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -78,11 +78,17 @@ vi.mock("../utils/playSection", () => ({
     biosLabel: "OK",
   })),
   extractCoreInfo: vi.fn(
-    (c: { active_core_label?: string | null; platform_core_label?: string | null; cores?: unknown[] }) => ({
+    (c: {
+      active_core_label?: string | null;
+      platform_core_label?: string | null;
+      has_game_override?: boolean;
+      cores?: unknown[];
+    }) => ({
       activeCoreLabel: c.active_core_label ?? null,
       activeCoreIsDefault: true,
       availableCores: c.cores ?? [],
       platformCoreLabel: c.platform_core_label ?? null,
+      hasGameOverride: c.has_game_override ?? false,
     }),
   ),
   resolveSaveSyncLabel: vi.fn(() => "synced label"),
@@ -265,6 +271,7 @@ describe("RomMPlaySection", () => {
       activeCoreIsDefault: true,
       availableCores: [],
       platformCoreLabel: null,
+      hasGameOverride: false,
     });
     // refreshCoreInfoInBackground (mocked) merges the current extractCoreInfo
     // mock result into state so the core button / menu render as in production,
@@ -277,6 +284,7 @@ describe("RomMPlaySection", () => {
         active_core: null,
         active_core_label: null,
         platform_core_label: null,
+        has_game_override: false,
       });
       act(() => {
         setter((prev) => ({ ...prev, ...coreFields }));
@@ -293,6 +301,7 @@ describe("RomMPlaySection", () => {
       active_core: null,
       active_core_label: null,
       platform_core_label: null,
+      has_game_override: false,
     });
 
     // Steam globals — appStore for the synchronous overview read.
@@ -1078,6 +1087,7 @@ describe("RomMPlaySection", () => {
         active_core: "blastem.so",
         active_core_label: "BlastEm",
         platform_core_label: null,
+        has_game_override: false,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -1129,6 +1139,7 @@ describe("RomMPlaySection", () => {
         active_core: "blastem.so",
         active_core_label: "BlastEm",
         platform_core_label: null,
+        has_game_override: false,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -2038,6 +2049,7 @@ describe("RomMPlaySection", () => {
         active_core: "snes9x.so",
         active_core_label: "Snes9x",
         platform_core_label: null,
+        has_game_override: false,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
@@ -2051,13 +2063,15 @@ describe("RomMPlaySection", () => {
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
         platformCoreLabel: null,
+        hasGameOverride: false,
       });
     }
 
-    // Core menu (after the #945 reset-item removal): [compat(disabled), Snes9x
-    // (default), BlastEm] — the separator is filtered out by isMenuItem, and the
-    // explicit Reset item is gone (picking the default core clears the override).
-    const BLASTEM_IDX = 2;
+    // Core menu after the #211 reset-item re-introduction: [compat(disabled),
+    // Use System Override, Snes9x (default), BlastEm] — the two separators are
+    // filtered out by isMenuItem. Every core (including the default) now PINS;
+    // the dedicated "Use System Override" item at index 1 is the clear path.
+    const BLASTEM_IDX = 3;
 
     it("happy path: setGameCore(rom_id, label) → confirms re-baked launch_options, toasts, invalidates + dispatches core_changed", async () => {
       await setupCoreAction();
@@ -2238,11 +2252,12 @@ describe("RomMPlaySection", () => {
   });
 
   // ------------------------------------------------------------------
-  // M2. handleResetGameCore — triggered by picking the default-marked core
-  // (the explicit "Reset" item is gone; the default entry is the clear path)
+  // M2. handleResetGameCore — triggered by the dedicated "Use System Override"
+  // item. Picking a core (incl. the default) PINS it; the reset item is the
+  // only clear path (#211).
   // ------------------------------------------------------------------
 
-  describe("handleResetGameCore (picking the default-marked core)", () => {
+  describe("handleResetGameCore (Use System Override item)", () => {
     async function setupCoreAction() {
       vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
         found: true,
@@ -2267,12 +2282,14 @@ describe("RomMPlaySection", () => {
         active_core: "blastem.so",
         active_core_label: "BlastEm",
         platform_core_label: null,
+        has_game_override: true,
         cores: [
           { core_so: "snes9x.so", label: "Snes9x", is_default: true },
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
       });
-      // A non-default core is active, so picking the default-marked core clears it.
+      // A per-game core (BlastEm) is pinned (hasGameOverride=true), so the
+      // "Use System Override" item carries no ✓ but still clears the pin.
       vi.mocked(playSectionUtils.extractCoreInfo).mockReturnValue({
         activeCoreLabel: "BlastEm",
         activeCoreIsDefault: false,
@@ -2281,14 +2298,16 @@ describe("RomMPlaySection", () => {
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
         platformCoreLabel: null,
+        hasGameOverride: true,
       });
     }
 
-    // Picking the default-marked core (Snes9x) is the clear path. Menu after the
-    // #945 reset-item removal: [compat(disabled), Snes9x (default), BlastEm].
-    const DEFAULT_CORE_IDX = 1;
+    // Menu (#211): [compat(disabled), Use System Override, Snes9x (default),
+    // BlastEm] — separators filtered out by isMenuItem.
+    const FOLLOW_SYSTEM_IDX = 1;
+    const DEFAULT_CORE_IDX = 2;
 
-    it("picking the default-marked core calls clearGameCore(rom_id) + confirms the PLAIN launch_options + toasts 'Reverted to default'", async () => {
+    it("the Use System Override item calls clearGameCore(rom_id) + confirms the PLAIN launch_options + toasts 'Now following the system core'", async () => {
       await setupCoreAction();
       vi.mocked(backend.clearGameCore).mockResolvedValue({
         success: true,
@@ -2303,27 +2322,29 @@ describe("RomMPlaySection", () => {
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
       const coreItems = await openCoreMenuAndGetItems(testAppId);
-      // The default-marked core entry is the clear path (no separate Reset item).
-      // In this setup a non-default core (BlastEm) is active, so the ✓ sits on
-      // BlastEm — the default entry has no ✓ but still clears the override.
-      expect(coreItems[DEFAULT_CORE_IDX]!.props.children).toBe("Snes9x (default)");
+      // The reset item is the dedicated clear path. A per-game core is pinned
+      // (hasGameOverride=true), so the item carries NO ✓; the fallback label is
+      // the es_systems default (Snes9x) since no per-platform override is set.
+      expect(coreItems[FOLLOW_SYSTEM_IDX]!.props.children).toBe("Use System Override (Snes9x)");
       vi.mocked(toaster.toast).mockClear();
       vi.mocked(backend.getPlatformCoreInfo).mockClear();
       const listener = vi.fn();
       globalThis.addEventListener("romm_data_changed", listener);
       try {
         await act(async () => {
-          await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+          await coreItems[FOLLOW_SYSTEM_IDX]!.props.onClick?.();
         });
         expect(vi.mocked(backend.clearGameCore)).toHaveBeenCalledWith(42);
-        // Picking a core entry must NOT have been used to clear.
+        // The reset item must NOT pin a core.
         expect(vi.mocked(backend.setGameCore)).not.toHaveBeenCalled();
         // The PLAIN (no -e) launch_options is confirm-set on the bound shortcut.
         expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledWith(
           888,
           'flatpak run net.retrodeck.retrodeck "/roms/mario.sfc"',
         );
-        expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Reverted to default" }));
+        expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+          expect.objectContaining({ body: "Now following the system core" }),
+        );
         expect(vi.mocked(backend.getPlatformCoreInfo)).toHaveBeenCalledWith(42);
         expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(testAppId);
         const ev = listener.mock.calls.map((c) => c[0] as CustomEvent).find((e) => e.detail.type === "core_changed");
@@ -2333,7 +2354,34 @@ describe("RomMPlaySection", () => {
       }
     });
 
-    it("default-pick false-confirm → DISTINCT restart toast, NOT success", async () => {
+    it("picking the default-marked core PINS it via setGameCore (no longer clears) (#211)", async () => {
+      await setupCoreAction();
+      vi.mocked(backend.setGameCore).mockResolvedValue({
+        success: true,
+        launch_options: 'flatpak run net.retrodeck.retrodeck -e "...snes9x.so..." "/roms/mario.sfc"',
+        app_id: 777,
+      });
+      vi.mocked(backend.getBiosStatus).mockResolvedValue({
+        bios_status: null,
+        bios_level: null,
+        bios_label: null,
+      });
+      render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      const coreItems = await openCoreMenuAndGetItems(testAppId);
+      expect(coreItems[DEFAULT_CORE_IDX]!.props.children).toBe("Snes9x (default)");
+      vi.mocked(toaster.toast).mockClear();
+      await act(async () => {
+        await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+      });
+      // The default core now PINS via setGameCore — the clear path is the
+      // dedicated reset item only.
+      expect(vi.mocked(backend.setGameCore)).toHaveBeenCalledWith(42, "Snes9x");
+      expect(vi.mocked(backend.clearGameCore)).not.toHaveBeenCalled();
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Core set to Snes9x" }));
+    });
+
+    it("reset-item false-confirm → DISTINCT restart toast, NOT success", async () => {
       await setupCoreAction();
       vi.mocked(backend.clearGameCore).mockResolvedValue({
         success: true,
@@ -2346,17 +2394,17 @@ describe("RomMPlaySection", () => {
       const coreItems = await openCoreMenuAndGetItems(testAppId);
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
-        await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+        await coreItems[FOLLOW_SYSTEM_IDX]!.props.onClick?.();
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
         expect.objectContaining({ body: "Core saved — restart Steam to apply" }),
       );
       expect(vi.mocked(toaster.toast)).not.toHaveBeenCalledWith(
-        expect.objectContaining({ body: "Reverted to default" }),
+        expect.objectContaining({ body: "Now following the system core" }),
       );
     });
 
-    it("default-pick uninstalled/unbound: success without launch_options/app_id → success toast, no confirm-set", async () => {
+    it("reset-item uninstalled/unbound: success without launch_options/app_id → success toast, no confirm-set", async () => {
       await setupCoreAction();
       vi.mocked(backend.clearGameCore).mockResolvedValue({ success: true });
       render(<RomMPlaySection appId={testAppId} />);
@@ -2364,13 +2412,15 @@ describe("RomMPlaySection", () => {
       const coreItems = await openCoreMenuAndGetItems(testAppId);
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
-        await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+        await coreItems[FOLLOW_SYSTEM_IDX]!.props.onClick?.();
       });
       expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
-      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Reverted to default" }));
+      expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+        expect.objectContaining({ body: "Now following the system core" }),
+      );
     });
 
-    it("default-pick {success:false} → toasts result.message", async () => {
+    it("reset-item {success:false} → toasts result.message", async () => {
       await setupCoreAction();
       vi.mocked(backend.clearGameCore).mockResolvedValue({ success: false, message: "clear failed" });
       render(<RomMPlaySection appId={testAppId} />);
@@ -2378,12 +2428,12 @@ describe("RomMPlaySection", () => {
       const coreItems = await openCoreMenuAndGetItems(testAppId);
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
-        await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+        await coreItems[FOLLOW_SYSTEM_IDX]!.props.onClick?.();
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "clear failed" }));
     });
 
-    it("default-pick throw → 'Failed to reset core'", async () => {
+    it("reset-item throw → 'Failed to reset core'", async () => {
       await setupCoreAction();
       vi.mocked(backend.clearGameCore).mockRejectedValue(new Error("boom"));
       render(<RomMPlaySection appId={testAppId} />);
@@ -2391,7 +2441,7 @@ describe("RomMPlaySection", () => {
       const coreItems = await openCoreMenuAndGetItems(testAppId);
       vi.mocked(toaster.toast).mockClear();
       await act(async () => {
-        await coreItems[DEFAULT_CORE_IDX]!.props.onClick?.();
+        await coreItems[FOLLOW_SYSTEM_IDX]!.props.onClick?.();
       });
       expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Failed to reset core" }));
     });
@@ -2442,9 +2492,9 @@ describe("RomMPlaySection", () => {
       return openCoreMenuAndGetItems(testAppId);
     }
 
-    it("showCoreMenu yields the compat note + 1 MenuItem per core (no separate Reset item); ✓ on the default core when it is active (#945)", async () => {
-      // Default core active → the override is NOT pinned, so the ✓ sits on the
-      // default-marked core entry (which is also the clear path).
+    it("showCoreMenu yields compat note + Use System Override item + 1 MenuItem per core; ✓ on the active default core (#945/#211)", async () => {
+      // Default core active, no per-game override → following the system, so the
+      // ✓ sits on BOTH the reset item and the active default core (#211).
       const items = await setupCoreMenuStructure({
         activeCoreLabel: "Snes9x",
         activeCoreIsDefault: true,
@@ -2453,18 +2503,23 @@ describe("RomMPlaySection", () => {
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
         platformCoreLabel: null,
+        hasGameOverride: false,
       });
-      // 1 disabled compat note + 2 core items (separator filtered out, no Reset).
-      expect(items).toHaveLength(3);
+      // 1 disabled compat note + Use System Override + 2 core items (both
+      // separators filtered out by isMenuItem).
+      expect(items).toHaveLength(4);
       // The obsolete RetroDECK-bug warning MenuItem is gone — only ONE disabled item.
       expect(items.filter((i) => i.props.disabled === true)).toHaveLength(1);
       expect(items[0]!.props.disabled).toBe(true);
-      // The default-marked core carries the ✓ because it is active.
-      expect(items[1]!.props.children).toBe("Snes9x (default) ✓");
-      expect(items[2]!.props.children).toBe("BlastEm");
+      // The reset item carries the ✓ (no per-game override) and the fallback
+      // label is the es_systems default (no per-platform override set).
+      expect(items[1]!.props.children).toBe("Use System Override (Snes9x) ✓");
+      // The active default core ALSO carries the ✓ (in effect).
+      expect(items[2]!.props.children).toBe("Snes9x (default) ✓");
+      expect(items[3]!.props.children).toBe("BlastEm");
     });
 
-    it("showCoreMenu marks the pinned non-default core with ✓ (not the default entry) (#945)", async () => {
+    it("showCoreMenu marks the pinned non-default core with ✓ (not the default entry, not the reset item) (#945/#211)", async () => {
       const items = await setupCoreMenuStructure({
         activeCoreLabel: "BlastEm",
         activeCoreIsDefault: false,
@@ -2473,12 +2528,15 @@ describe("RomMPlaySection", () => {
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
         platformCoreLabel: null,
+        hasGameOverride: true,
       });
-      expect(items).toHaveLength(3);
-      // The default entry has no ✓ when an override is pinned …
-      expect(items[1]!.props.children).toBe("Snes9x (default)");
-      // … and the pinned core carries it instead.
-      expect(items[2]!.props.children).toBe("BlastEm ✓");
+      expect(items).toHaveLength(4);
+      // A per-game core is pinned → the reset item has NO ✓ …
+      expect(items[1]!.props.children).toBe("Use System Override (Snes9x)");
+      // … the default entry has no ✓ …
+      expect(items[2]!.props.children).toBe("Snes9x (default)");
+      // … and only the pinned core carries it.
+      expect(items[3]!.props.children).toBe("BlastEm ✓");
     });
 
     it("showCoreMenu marks the per-platform override core with (system), and only that core (#954)", async () => {
@@ -2493,12 +2551,70 @@ describe("RomMPlaySection", () => {
           { core_so: "blastem.so", label: "BlastEm", is_default: false },
         ],
         platformCoreLabel: "BlastEm",
+        hasGameOverride: false,
       });
-      expect(items).toHaveLength(3);
+      expect(items).toHaveLength(4);
       // The per-platform override core carries (system); a different core does not.
-      expect(items[2]!.props.children).toBe("BlastEm (system)");
-      expect(items[1]!.props.children).toBe("Snes9x (default) ✓");
-      expect(items[1]!.props.children).not.toContain("(system)");
+      expect(items[3]!.props.children).toBe("BlastEm (system)");
+      expect(items[2]!.props.children).toBe("Snes9x (default) ✓");
+      expect(items[2]!.props.children).not.toContain("(system)");
+    });
+
+    it("Use System Override fallback label is the per-platform override when one is set (#211)", async () => {
+      // A per-platform override (BlastEm) is set → the reset item's fallback
+      // label is the per-platform core, NOT the es_systems default. No per-game
+      // override → the reset item carries the ✓.
+      const items = await setupCoreMenuStructure({
+        activeCoreLabel: "BlastEm",
+        activeCoreIsDefault: false,
+        availableCores: [
+          { core_so: "snes9x.so", label: "Snes9x", is_default: true },
+          { core_so: "blastem.so", label: "BlastEm", is_default: false },
+        ],
+        platformCoreLabel: "BlastEm",
+        hasGameOverride: false,
+      });
+      expect(items[1]!.props.children).toBe("Use System Override (BlastEm) ✓");
+    });
+
+    it("following the system: BOTH the reset item AND the resolved active core carry ✓ (#211)", async () => {
+      // No per-game override, per-platform override (BlastEm) is the active core
+      // → the game follows the system, so the ✓ appears on the reset item and on
+      // the resolved active core (BlastEm), but NOT on the default Snes9x.
+      const items = await setupCoreMenuStructure({
+        activeCoreLabel: "BlastEm",
+        activeCoreIsDefault: false,
+        availableCores: [
+          { core_so: "snes9x.so", label: "Snes9x", is_default: true },
+          { core_so: "blastem.so", label: "BlastEm", is_default: false },
+        ],
+        platformCoreLabel: "BlastEm",
+        hasGameOverride: false,
+      });
+      expect(items[1]!.props.children).toContain("✓");
+      expect(items[1]!.props.children).toBe("Use System Override (BlastEm) ✓");
+      // The resolved active core carries (system) + ✓.
+      expect(items[3]!.props.children).toBe("BlastEm (system) ✓");
+      // The default (not active) carries neither.
+      expect(items[2]!.props.children).toBe("Snes9x (default)");
+    });
+
+    it("per-game core pinned: only the pinned core carries ✓, the reset item does not (#211)", async () => {
+      // A per-game override pins BlastEm (also the per-platform override). Only
+      // BlastEm carries the ✓; the reset item does NOT (hasGameOverride=true).
+      const items = await setupCoreMenuStructure({
+        activeCoreLabel: "BlastEm",
+        activeCoreIsDefault: false,
+        availableCores: [
+          { core_so: "snes9x.so", label: "Snes9x", is_default: true },
+          { core_so: "blastem.so", label: "BlastEm", is_default: false },
+        ],
+        platformCoreLabel: "BlastEm",
+        hasGameOverride: true,
+      });
+      expect(items[1]!.props.children).not.toContain("✓");
+      expect(items[1]!.props.children).toBe("Use System Override (BlastEm)");
+      expect(items[3]!.props.children).toBe("BlastEm (system) ✓");
     });
 
     it("showSteamMenu Properties → SteamClient.Apps.OpenAppSettingsDialog(appId, 'general')", async () => {
@@ -2685,6 +2801,7 @@ describe("RomMPlaySection", () => {
         activeCoreIsDefault: true,
         availableCores: [{ core_so: "x.so", label: "OnlyOne", is_default: true }],
         platformCoreLabel: null,
+        hasGameOverride: false,
       });
       const { queryByTitle } = render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();
@@ -2729,7 +2846,8 @@ async function openCoreMenuAndGetItems(_appId: number): Promise<MenuItemElement[
   const calls = vi.mocked(showContextMenu).mock.calls;
   const el = calls[calls.length - 1]?.[0] as ReactElement | undefined;
   if (!el) throw new Error("No context menu shown");
-  // Core menu has: 1 disabled compat note + separator + Reset MenuItem + N core
-  // MenuItems (the separator is dropped by isMenuItem). (#945)
+  // Core menu has: 1 disabled compat note + separator + Use System Override
+  // MenuItem + separator + N core MenuItems (separators dropped by isMenuItem).
+  // (#211)
   return getMenuItemsFromElement(el).filter(isMenuItem);
 }

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -92,6 +92,7 @@ interface InfoState {
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
   availableCores: Array<{ core_so: string; label: string; is_default: boolean }>;
+  platformCoreLabel: string | null;
   activeSlot: string | null;
   raId: number | null;
   achievementEarned: number;
@@ -223,6 +224,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     activeCoreLabel: null,
     activeCoreIsDefault: true,
     availableCores: [],
+    platformCoreLabel: null,
     activeSlot: "default",
     raId: null,
     achievementEarned: 0,
@@ -780,6 +782,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           // The active marker sits on the ACTIVE core: the default-marked entry
           // when no override is pinned, otherwise the pinned core (#945).
           const isActive = info.activeCoreIsDefault ? c.is_default : info.activeCoreLabel === c.label;
+          // The (system) marker sits on the per-platform override set on the
+          // System page (settings.json platform_cores). A core can carry both
+          // "(default) (system)" and "(system) ✓" — all three roles are
+          // independent (#954).
+          const isPlatformCore = info.platformCoreLabel !== null && c.label === info.platformCoreLabel;
           return createElement(
             MenuItem,
             {
@@ -791,7 +798,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
                 detach(c.is_default ? handleResetGameCore() : handleChangeGameCore(c.label));
               },
             },
-            `${c.label}${c.is_default ? " (default)" : ""}${isActive ? " \u2713" : ""}`,
+            `${c.label}${c.is_default ? " (default)" : ""}${isPlatformCore ? " (system)" : ""}${isActive ? " \u2713" : ""}`,
           );
         }),
       ),

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -93,6 +93,7 @@ interface InfoState {
   activeCoreIsDefault: boolean;
   availableCores: Array<{ core_so: string; label: string; is_default: boolean }>;
   platformCoreLabel: string | null;
+  hasGameOverride: boolean;
   activeSlot: string | null;
   raId: number | null;
   achievementEarned: number;
@@ -225,6 +226,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     activeCoreIsDefault: true,
     availableCores: [],
     platformCoreLabel: null,
+    hasGameOverride: false,
     activeSlot: "default",
     raId: null,
     achievementEarned: 0,
@@ -761,7 +763,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     try {
       const result = await clearGameCore(romId);
       detach(debugLog(`handleResetGameCore: result success=${result.success}`));
-      await applyCoreResult(result, romId, platformSlug, "Reverted to default");
+      await applyCoreResult(result, romId, platformSlug, "Now following the system core");
     } catch {
       toaster.toast({ title: "RomM Sync", body: "Failed to reset core" });
     }
@@ -778,6 +780,32 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           "Switching cores may affect save compatibility",
         ),
         createElement(MenuSeparator, { key: "core-sep" }),
+        // "Use System Override" is the dedicated reset item: selecting it CLEARS
+        // the per-game pin so the game follows the per-platform/system core. The
+        // fallback label (the core the game falls back to with no pin) is the
+        // per-platform override when set, else the es_systems default. The
+        // checkmark sits here when there is NO per-game override — i.e. the
+        // game already follows the system. "System Override" deliberately
+        // differs from the "(default)" core marker so the menu never shows two
+        // "defaults" (#211).
+        (() => {
+          const defaultLabel = info.availableCores.find((c) => c.is_default)?.label;
+          const fallbackLabel = info.platformCoreLabel ?? defaultLabel ?? null;
+          const fallbackSuffix = fallbackLabel ? ` (${fallbackLabel})` : "";
+          // ✓ when the game already follows the system (no per-game pin).
+          const followsSystemMark = info.hasGameOverride ? "" : " ✓";
+          return createElement(
+            MenuItem,
+            {
+              key: "core-follow-system",
+              onClick: () => {
+                detach(handleResetGameCore());
+              },
+            },
+            `Use System Override${fallbackSuffix}${followsSystemMark}`,
+          );
+        })(),
+        createElement(MenuSeparator, { key: "core-follow-sep" }),
         ...info.availableCores.map((c) => {
           // The active marker sits on the ACTIVE core: the default-marked entry
           // when no override is pinned, otherwise the pinned core (#945).
@@ -791,11 +819,11 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
             MenuItem,
             {
               key: `core-${c.core_so}`,
-              // Picking the default-marked core CLEARS the per-game override
-              // (follow default); any other core PINS it. The default entry is
-              // the reset path \u2014 there is no separate "Reset" item.
+              // Every core PINS the per-game override, including the
+              // default-marked one. The dedicated "Use System Override" item
+              // above is the only clear path (#211).
               onClick: () => {
-                detach(c.is_default ? handleResetGameCore() : handleChangeGameCore(c.label));
+                detach(handleChangeGameCore(c.label));
               },
             },
             `${c.label}${c.is_default ? " (default)" : ""}${isPlatformCore ? " (system)" : ""}${isActive ? " \u2713" : ""}`,

--- a/src/types/firmware.ts
+++ b/src/types/firmware.ts
@@ -39,6 +39,7 @@ export interface CoreInfo {
   active_core: string | null;
   active_core_label: string | null;
   platform_core_label: string | null;
+  has_game_override: boolean;
 }
 
 /**

--- a/src/types/firmware.ts
+++ b/src/types/firmware.ts
@@ -38,6 +38,7 @@ export interface CoreInfo {
   cores: AvailableCore[];
   active_core: string | null;
   active_core_label: string | null;
+  platform_core_label: string | null;
 }
 
 /**

--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -100,6 +100,7 @@ describe("extractCoreInfo", () => {
     active_core: "mupen64plus_next_libretro.so",
     active_core_label: "Mupen64Plus-Next",
     platform_core_label: null,
+    has_game_override: false,
     cores: [
       { core_so: "mupen64plus_next_libretro.so", label: "Mupen64Plus-Next", is_default: true },
       { core_so: "parallel_n64_libretro.so", label: "ParaLLEl N64", is_default: false },
@@ -112,6 +113,17 @@ describe("extractCoreInfo", () => {
     expect(result.activeCoreIsDefault).toBe(true);
     expect(result.availableCores).toHaveLength(2);
     expect(result.platformCoreLabel).toBeNull();
+    expect(result.hasGameOverride).toBe(false);
+  });
+
+  it("maps has_game_override=true through to hasGameOverride (#211)", () => {
+    const result = extractCoreInfo({ ...baseCoreInfo, has_game_override: true });
+    expect(result.hasGameOverride).toBe(true);
+  });
+
+  it("maps has_game_override=false through to hasGameOverride (#211)", () => {
+    const result = extractCoreInfo({ ...baseCoreInfo, has_game_override: false });
+    expect(result.hasGameOverride).toBe(false);
   });
 
   it("marks activeCoreIsDefault=false when active core differs from default", () => {
@@ -140,6 +152,7 @@ describe("extractCoreInfo", () => {
       active_core: null,
       active_core_label: null,
       platform_core_label: null,
+      has_game_override: false,
       cores: [],
     });
     expect(result.availableCores).toEqual([]);

--- a/src/utils/playSection.test.ts
+++ b/src/utils/playSection.test.ts
@@ -99,6 +99,7 @@ describe("extractCoreInfo", () => {
   const baseCoreInfo: CoreInfo = {
     active_core: "mupen64plus_next_libretro.so",
     active_core_label: "Mupen64Plus-Next",
+    platform_core_label: null,
     cores: [
       { core_so: "mupen64plus_next_libretro.so", label: "Mupen64Plus-Next", is_default: true },
       { core_so: "parallel_n64_libretro.so", label: "ParaLLEl N64", is_default: false },
@@ -110,6 +111,7 @@ describe("extractCoreInfo", () => {
     expect(result.activeCoreLabel).toBe("Mupen64Plus-Next");
     expect(result.activeCoreIsDefault).toBe(true);
     expect(result.availableCores).toHaveLength(2);
+    expect(result.platformCoreLabel).toBeNull();
   });
 
   it("marks activeCoreIsDefault=false when active core differs from default", () => {
@@ -123,8 +125,23 @@ describe("extractCoreInfo", () => {
     expect(result.activeCoreLabel).toBeNull();
   });
 
+  it("maps a non-null platform_core_label through to platformCoreLabel (#954)", () => {
+    const result = extractCoreInfo({ ...baseCoreInfo, platform_core_label: "ParaLLEl N64" });
+    expect(result.platformCoreLabel).toBe("ParaLLEl N64");
+  });
+
+  it("maps a null platform_core_label through to null platformCoreLabel (#954)", () => {
+    const result = extractCoreInfo({ ...baseCoreInfo, platform_core_label: null });
+    expect(result.platformCoreLabel).toBeNull();
+  });
+
   it("defaults availableCores to [] when cores missing", () => {
-    const result = extractCoreInfo({ active_core: null, active_core_label: null, cores: [] });
+    const result = extractCoreInfo({
+      active_core: null,
+      active_core_label: null,
+      platform_core_label: null,
+      cores: [],
+    });
     expect(result.availableCores).toEqual([]);
   });
 });

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -26,6 +26,7 @@ export interface CoreInfoFields {
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
   availableCores: AvailableCore[];
+  platformCoreLabel: string | null;
 }
 
 export interface SaveSyncResolution {
@@ -86,6 +87,7 @@ export function extractCoreInfo(coreInfo: CoreInfo): CoreInfoFields {
     activeCoreLabel,
     activeCoreIsDefault,
     availableCores,
+    platformCoreLabel: coreInfo.platform_core_label ?? null,
   };
 }
 

--- a/src/utils/playSection.ts
+++ b/src/utils/playSection.ts
@@ -27,6 +27,7 @@ export interface CoreInfoFields {
   activeCoreIsDefault: boolean;
   availableCores: AvailableCore[];
   platformCoreLabel: string | null;
+  hasGameOverride: boolean;
 }
 
 export interface SaveSyncResolution {
@@ -88,6 +89,7 @@ export function extractCoreInfo(coreInfo: CoreInfo): CoreInfoFields {
     activeCoreIsDefault,
     availableCores,
     platformCoreLabel: coreInfo.platform_core_label ?? null,
+    hasGameOverride: coreInfo.has_game_override,
   };
 }
 

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -25,6 +25,7 @@ interface CoreState {
   activeCoreIsDefault: boolean;
   availableCores: Array<{ core_so: string; label: string; is_default: boolean }>;
   platformCoreLabel: string | null;
+  hasGameOverride: boolean;
   unrelated: string;
 }
 
@@ -231,6 +232,7 @@ describe("refreshCoreInfoInBackground", () => {
       active_core: "parallel_n64_libretro.so",
       active_core_label: "ParaLLEl N64",
       platform_core_label: null,
+      has_game_override: false,
       cores: [
         { core_so: "mupen64plus_next_libretro.so", label: "Mupen64Plus-Next", is_default: true },
         { core_so: "parallel_n64_libretro.so", label: "ParaLLEl N64", is_default: false },
@@ -250,6 +252,7 @@ describe("refreshCoreInfoInBackground", () => {
       activeCoreIsDefault: true,
       availableCores: [],
       platformCoreLabel: null,
+      hasGameOverride: false,
       unrelated: "keep",
     });
     expect(next.activeCoreLabel).toBe("ParaLLEl N64");
@@ -264,6 +267,7 @@ describe("refreshCoreInfoInBackground", () => {
       active_core: null,
       active_core_label: null,
       platform_core_label: null,
+      has_game_override: false,
       cores: [],
     });
     const setter = vi.fn();
@@ -283,7 +287,13 @@ describe("refreshCoreInfoInBackground", () => {
     refreshCoreInfoInBackground(404, () => cancelled, setter);
 
     cancelled = true;
-    d.resolve({ active_core: null, active_core_label: null, platform_core_label: null, cores: [] });
+    d.resolve({
+      active_core: null,
+      active_core_label: null,
+      platform_core_label: null,
+      has_game_override: false,
+      cores: [],
+    });
     await flushMicrotasks();
 
     expect(setter).not.toHaveBeenCalled();

--- a/src/utils/sectionRefresh.test.ts
+++ b/src/utils/sectionRefresh.test.ts
@@ -24,6 +24,7 @@ interface CoreState {
   activeCoreLabel: string | null;
   activeCoreIsDefault: boolean;
   availableCores: Array<{ core_so: string; label: string; is_default: boolean }>;
+  platformCoreLabel: string | null;
   unrelated: string;
 }
 
@@ -229,6 +230,7 @@ describe("refreshCoreInfoInBackground", () => {
     vi.mocked(backend.getPlatformCoreInfo).mockResolvedValueOnce({
       active_core: "parallel_n64_libretro.so",
       active_core_label: "ParaLLEl N64",
+      platform_core_label: null,
       cores: [
         { core_so: "mupen64plus_next_libretro.so", label: "Mupen64Plus-Next", is_default: true },
         { core_so: "parallel_n64_libretro.so", label: "ParaLLEl N64", is_default: false },
@@ -247,6 +249,7 @@ describe("refreshCoreInfoInBackground", () => {
       activeCoreLabel: null,
       activeCoreIsDefault: true,
       availableCores: [],
+      platformCoreLabel: null,
       unrelated: "keep",
     });
     expect(next.activeCoreLabel).toBe("ParaLLEl N64");
@@ -260,6 +263,7 @@ describe("refreshCoreInfoInBackground", () => {
     vi.mocked(backend.getPlatformCoreInfo).mockResolvedValueOnce({
       active_core: null,
       active_core_label: null,
+      platform_core_label: null,
       cores: [],
     });
     const setter = vi.fn();
@@ -279,7 +283,7 @@ describe("refreshCoreInfoInBackground", () => {
     refreshCoreInfoInBackground(404, () => cancelled, setter);
 
     cancelled = true;
-    d.resolve({ active_core: null, active_core_label: null, cores: [] });
+    d.resolve({ active_core: null, active_core_label: null, platform_core_label: null, cores: [] });
     await flushMicrotasks();
 
     expect(setter).not.toHaveBeenCalled();

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -186,6 +186,7 @@ class TestGetAvailableCores:
             "active_core": "snes9x_libretro",
             "active_core_label": "Snes9x",
             "platform_core_label": None,
+            "has_game_override": False,
         }
 
     def test_unknown_rom_returns_empty(self, event_loop, service, core_info):
@@ -197,6 +198,7 @@ class TestGetAvailableCores:
             "active_core": None,
             "active_core_label": None,
             "platform_core_label": None,
+            "has_game_override": False,
         }
         assert core_info.available_cores_calls == []
 
@@ -226,6 +228,22 @@ class TestGetAvailableCores:
         assert result["active_core"] == "bsnes_libretro"
         assert result["active_core_label"] == "bsnes"
         assert active_core.calls == [42]
+
+    def test_has_game_override_true_when_rom_is_pinned(self, event_loop, service, uow):
+        # A ROM with a per-game emulator_override surfaces has_game_override=True
+        # so the menu's "Use System Override" reset item drops its ✓ (#211). The
+        # frontend can't infer this from the active core — pinning the same core
+        # as the per-platform override would be indistinguishable.
+        _seed_rom(uow, rom_id=42, platform_slug="snes", emulator_override="bsnes")
+        result = event_loop.run_until_complete(service.get_available_cores(42))
+        assert result["has_game_override"] is True
+
+    def test_has_game_override_false_when_rom_unpinned(self, event_loop, service, uow):
+        # An unpinned ROM (NULL override) follows the system → has_game_override
+        # is False so the reset item carries the ✓ (#211).
+        _seed_rom(uow, rom_id=42, platform_slug="snes")
+        result = event_loop.run_until_complete(service.get_available_cores(42))
+        assert result["has_game_override"] is False
 
     def test_active_marker_falls_back_to_system_default(self, event_loop, service, uow, active_core):
         # An unpinned ROM (NULL override) surfaces the system default via the

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -185,14 +185,37 @@ class TestGetAvailableCores:
             "cores": core_info.available_cores,
             "active_core": "snes9x_libretro",
             "active_core_label": "Snes9x",
+            "platform_core_label": None,
         }
 
     def test_unknown_rom_returns_empty(self, event_loop, service, core_info):
         # No ROM seeded for rom_id=7 → empty cores + no active core, and the
         # platform-wide core enumeration is never reached.
         result = event_loop.run_until_complete(service.get_available_cores(7))
-        assert result == {"cores": [], "active_core": None, "active_core_label": None}
+        assert result == {
+            "cores": [],
+            "active_core": None,
+            "active_core_label": None,
+            "platform_core_label": None,
+        }
         assert core_info.available_cores_calls == []
+
+    def test_platform_core_label_surfaces_per_platform_override(self, event_loop, service, uow, settings):
+        # A per-platform override set on the System page (settings.json
+        # platform_cores) surfaces as platform_core_label so the menu can mark
+        # the system-level selection distinctly from the active core (#954).
+        _seed_rom(uow, rom_id=42, platform_slug="snes")
+        settings["platform_cores"]["snes"] = "bsnes"
+        result = event_loop.run_until_complete(service.get_available_cores(42))
+        assert result["platform_core_label"] == "bsnes"
+
+    def test_platform_core_label_none_when_platform_absent(self, event_loop, service, uow, settings):
+        # A platform with no per-platform override → platform_core_label is None
+        # even when OTHER platforms carry one.
+        _seed_rom(uow, rom_id=42, platform_slug="snes")
+        settings["platform_cores"]["gba"] = "mGBA"
+        result = event_loop.run_until_complete(service.get_available_cores(42))
+        assert result["platform_core_label"] is None
 
     def test_active_marker_reflects_pin(self, event_loop, service, uow, active_core):
         # A pinned ROM surfaces the OVERRIDE core as active (via the resolver),


### PR DESCRIPTION
Two related changes to the per-game Emulator Core menu (`RomMPlaySection`), shipped together because they reshape the same surface and are best tested as a package.

## #954 — `(system)` marker
The menu marks the per-platform (system-level) override core with `(system)`, so the three core roles on each line are separable:

- `(default)` — es_systems / RetroDECK default
- `(system)` — the per-platform core set on the System page (`settings.json` `platform_cores`)
- `✓` — the core this game actually launches with

## #211 — "Use System Override" reset item
Decouples "follow the system" from picking a core, making the full hierarchy (per-game > per-platform > es_systems default > core_defaults) expressible at the per-game level:

- New **"Use System Override (X)"** item at the top clears the per-game override; X is the resolved fallback (the per-platform override if set, else the es_systems default).
- Every core — including the `(default)`-marked one — is now pinnable per-game. Previously picking the default cleared the override, so the es_systems default couldn't be pinned over a per-platform override.
- `✓` marks what's in effect: on the active core always, and on "Use System Override" when no per-game override is set. Following the system lights both; a per-game pin lights only the pinned core.

## Backend
`get_platform_core_info` gains two additive fields: `platform_core_label` (the per-platform override label) and `has_game_override` (whether a per-game pin exists — the menu can't infer it from the active core alone). Display/selection only — no precedence or launch-command change.

Docs: `docs/user-guide/bios-management.md` documents the markers and the reset item.

Part of epic #926. Closes #954. Closes #211.