### PR TITLE
feat(ui): highlight the active core in the game-page BIOS list (#955)

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -31,7 +31,9 @@ The "BIOS missing" indicator is computed against the **active core** for that ga
 no BIOS (or that treats a file as optional) clears the warning, while switching to a core that requires a missing file
 surfaces it.
 
-Tap the BIOS status indicator to see a detailed list of individual files and which ones are present or missing.
+Tap the BIOS status indicator to see a detailed list of individual files and which ones are present or missing. Each
+file lists the cores that use it (e.g. _Beetle PSX HW (required)_, _SwanStation (optional)_); the **active core**'s line
+is highlighted in amber so you can spot at a glance which core's requirements the file applies to.
 
 <!-- Screenshot: Game detail page showing orange BIOS status with "3/5 downloaded" -->
 

--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -1819,6 +1819,169 @@ describe("RomMGameInfoPanel", () => {
       // note appears instead.
       expect(container.textContent).toContain("other file");
     });
+
+    it("highlights the active core's per-BIOS line and leaves non-active cores grey (#955)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 56,
+        platform_slug: "psx",
+        bios_status: {
+          needs_bios: true,
+          platform_slug: "psx",
+          server_count: 1,
+          local_count: 0,
+          all_downloaded: false,
+          required_count: 1,
+          required_downloaded: 0,
+          files: [
+            {
+              file_name: "scph5501.bin",
+              description: "PSX BIOS",
+              downloaded: false,
+              classification: "required",
+              cores: {
+                beetle_psx_hw_libretro: { required: true },
+                swanstation_libretro: { required: false },
+              },
+              used_by_active: true,
+            },
+          ],
+        } as never,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      // Active core is Beetle PSX HW; SwanStation is an alternative core.
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
+        active_core: "beetle_psx_hw_libretro",
+        active_core_label: "Beetle PSX HW",
+        platform_core_label: null,
+        has_game_override: false,
+        cores: [
+          { core_so: "beetle_psx_hw_libretro", label: "Beetle PSX HW", is_default: true },
+          { core_so: "swanstation_libretro", label: "SwanStation", is_default: false },
+        ],
+      });
+      const { getByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        await Promise.resolve();
+      });
+      // Active core line: amber + bold.
+      const activeLine = getByText("Beetle PSX HW (required)");
+      expect(activeLine.style.color).toBe("#d4a72c");
+      expect(activeLine.style.fontWeight).toBe("bold");
+      // Non-active core line: grey + normal weight.
+      const inactiveLine = getByText("SwanStation (optional)");
+      expect(inactiveLine.style.color).toBe("rgba(255, 255, 255, 0.5)");
+      expect(inactiveLine.style.fontWeight).toBe("normal");
+    });
+
+    it("highlights no core line when active_core is null (#955)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 57,
+        platform_slug: "psx",
+        bios_status: {
+          needs_bios: true,
+          platform_slug: "psx",
+          server_count: 1,
+          local_count: 0,
+          all_downloaded: false,
+          required_count: 1,
+          required_downloaded: 0,
+          files: [
+            {
+              file_name: "scph5501.bin",
+              description: "PSX BIOS",
+              downloaded: false,
+              classification: "required",
+              cores: {
+                beetle_psx_hw_libretro: { required: true },
+                swanstation_libretro: { required: false },
+              },
+              used_by_active: false,
+            },
+          ],
+        } as never,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      // No active core resolved → no line is highlighted.
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
+        active_core: null,
+        active_core_label: null,
+        platform_core_label: null,
+        has_game_override: false,
+        cores: [
+          { core_so: "beetle_psx_hw_libretro", label: "Beetle PSX HW", is_default: false },
+          { core_so: "swanstation_libretro", label: "SwanStation", is_default: false },
+        ],
+      });
+      const { getByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        await Promise.resolve();
+      });
+      const beetleLine = getByText("Beetle PSX HW (required)");
+      expect(beetleLine.style.color).toBe("rgba(255, 255, 255, 0.5)");
+      expect(beetleLine.style.fontWeight).toBe("normal");
+      const swanLine = getByText("SwanStation (optional)");
+      expect(swanLine.style.color).toBe("rgba(255, 255, 255, 0.5)");
+      expect(swanLine.style.fontWeight).toBe("normal");
+    });
+
+    it("falls back to the de-suffixed .so when a core is absent from coreInfo (#955)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 58,
+        platform_slug: "psx",
+        bios_status: {
+          needs_bios: true,
+          platform_slug: "psx",
+          server_count: 1,
+          local_count: 0,
+          all_downloaded: false,
+          required_count: 1,
+          required_downloaded: 0,
+          files: [
+            {
+              file_name: "scph5501.bin",
+              description: "PSX BIOS",
+              downloaded: false,
+              classification: "required",
+              cores: {
+                some_obscure_libretro: { required: true },
+              },
+              used_by_active: true,
+            },
+          ],
+        } as never,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      // coreInfo does NOT enumerate `some_obscure_libretro`, so coreLabelMap[coreSo]
+      // is undefined and the `.replace(/_libretro$/, "")` fallback renders the label.
+      vi.mocked(backend.getPlatformCoreInfo).mockResolvedValue({
+        active_core: "beetle_psx_hw_libretro",
+        active_core_label: "Beetle PSX HW",
+        platform_core_label: null,
+        has_game_override: false,
+        cores: [{ core_so: "beetle_psx_hw_libretro", label: "Beetle PSX HW", is_default: true }],
+      });
+      const { getByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      await act(async () => {
+        globalThis.dispatchEvent(new CustomEvent("romm_tab_switch", { detail: { tab: "bios" } }));
+        await Promise.resolve();
+      });
+      // Fallback label = `.so` key with `_libretro` stripped; not the active core,
+      // so it stays grey + normal weight.
+      const fallbackLine = getByText("some_obscure (required)");
+      expect(fallbackLine.style.color).toBe("rgba(255, 255, 255, 0.5)");
+      expect(fallbackLine.style.fontWeight).toBe("normal");
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -177,6 +177,34 @@ function biosStatusFromCache(cachedBios: Record<string, unknown> | null | undefi
   };
 }
 
+/** Render the per-core lines under a BIOS file — one row per core that uses it. */
+function buildBiosCoreLines(
+  cores: Record<string, { required: boolean }>,
+  coreLabelMap: Record<string, string>,
+  activeCore: string | null | undefined,
+): ReturnType<typeof createElement>[] {
+  return Object.entries(cores).map(([coreSo, coreData]) => {
+    const label = coreLabelMap[coreSo] || coreSo.replace(/_libretro$/, "");
+    const suffix = coreData.required ? " (required)" : " (optional)";
+    // Highlight the resolved active core's line (#955). active_core is the
+    // core's `.so`, same identifier space as the cores keys; a null/undefined
+    // active core matches nothing.
+    const isActiveCore = coreSo === activeCore;
+    return createElement(
+      "div",
+      {
+        key: `core-${coreSo}`,
+        style: {
+          color: isActiveCore ? "#d4a72c" : "rgba(255, 255, 255, 0.5)",
+          fontSize: "12px",
+          fontWeight: isActiveCore ? "bold" : "normal",
+        },
+      },
+      `${label}${suffix}`,
+    );
+  });
+}
+
 /** Build a `SaveStatus` from a cached game detail's `save_status` field. */
 function saveStatusFromCache(
   romId: number,
@@ -837,23 +865,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
         }
 
         // Build per-core lines
-        const coreLines: ReturnType<typeof createElement>[] = [];
-        if (f.cores) {
-          for (const [coreSo, coreData] of Object.entries(f.cores)) {
-            const label = coreLabelMap[coreSo] || coreSo.replace(/_libretro$/, "");
-            const suffix = coreData.required ? " (required)" : " (optional)";
-            coreLines.push(
-              createElement(
-                "div",
-                {
-                  key: `core-${coreSo}`,
-                  style: { color: "rgba(255, 255, 255, 0.5)", fontSize: "12px" },
-                },
-                `${label}${suffix}`,
-              ),
-            );
-          }
-        }
+        const coreLines = f.cores ? buildBiosCoreLines(f.cores, coreLabelMap, state.coreInfo?.active_core) : [];
 
         return createElement(
           "div",


### PR DESCRIPTION
**What** — On the game-detail BIOS tab (`RomMGameInfoPanel`), each BIOS file lists the cores that use it (e.g. _Beetle PSX HW (required)_, _SwanStation (optional)_). The line of the **active core** is now highlighted in amber + bold so it's easy to spot which core's requirements a file applies to.

**Why** — Every core's line rendered in the same grey, so there was no cue for the core the game actually launches with.

**How** — Frontend-only. In the per-core line loop, `isActiveCore = coreSo === state.coreInfo?.active_core` (the resolved active core's `.so`, same identifier space as the `cores` keys); the active line gets `color: #d4a72c` + `fontWeight: bold`, others keep grey/normal. When no active core resolves (`active_core` null), nothing highlights. No backend change.

Docs: `docs/user-guide/bios-management.md` notes the highlight.

Part of epic #926. Closes #955.