### PR TITLE
fix(ui): system page lists only currently-synced systems (#956)

### DIFF
--- a/docs/user-guide/bios-management.md
+++ b/docs/user-guide/bios-management.md
@@ -42,10 +42,12 @@ is highlighted in amber so you can spot at a glance which core's requirements th
 ## System Page
 
 The **System** page is the per-system emulator settings page: for each platform it shows the **active emulator core**
-first, then the BIOS files that core needs.
+first, then the BIOS files that core needs. It lists only your **currently-synced systems** — platforms with at least
+one synced game (whether synced by platform or by collection). Systems you have no synced games for don't appear, even
+if your RomM server has BIOS files for them.
 
 1. From the main QAM page, tap **System**
-2. Platforms with synced games that still need required BIOS files appear first, marked with "BIOS needed"
+2. Platforms with synced games that still need required BIOS files are marked with "BIOS needed"
 3. For platforms with more than one available core, an **Emulator Core** dropdown is shown at the top of the platform's
    section — this is the primary per-system control
 4. Below the core, each platform shows how many BIOS files are downloaded vs. available (e.g. "3 / 5 files")

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -370,12 +370,21 @@ class FirmwareService:
                 )
         return platforms_map
 
-    def _read_installed_slugs(self) -> set[str]:
-        """Return the set of platform slugs that have at least one synced ROM."""
-        with self._uow_factory() as uow:
-            return {rom.platform_slug for rom in uow.roms.iter_all() if rom.platform_slug}
+    def _read_synced_slugs(self) -> set[str]:
+        """Return platform slugs with at least one ROM bound to a Steam shortcut.
 
-    def _enrich_platform_map(self, platforms_map, installed_slugs):
+        A bound ROM (``shortcut_app_id`` set) is one that is currently in the
+        synced library, covering both platform- and collection-sync. Deselected
+        platforms get unbound on the next sync (ADR-0007) and drop out.
+        """
+        with self._uow_factory() as uow:
+            return {
+                rom.platform_slug
+                for rom in uow.roms.iter_all()
+                if rom.platform_slug and rom.shortcut_app_id is not None
+            }
+
+    def _enrich_platform_map(self, platforms_map, synced_slugs):
         """Add core info and game-installed flags to each platform entry.
 
         The core read seams key by the resolved RetroDECK ``system`` (ADR-0010
@@ -391,7 +400,7 @@ class FirmwareService:
             plat["active_core_label"] = core_label
             plat["available_cores"] = self._core_info.get_available_cores(system)
             plat["files"] = [self._enrich_firmware_file(f, core_so=core_so) for f in plat["files"]]
-            plat["has_games"] = slug in installed_slugs
+            plat["has_games"] = slug in synced_slugs
             plat["all_downloaded"] = all(f["downloaded"] for f in plat["files"])
 
     async def get_firmware_status(self):
@@ -409,8 +418,8 @@ class FirmwareService:
             server_offline = True
             platforms_map = self._group_registry_firmware()
 
-        installed_slugs = await self._loop.run_in_executor(None, self._read_installed_slugs)
-        self._enrich_platform_map(platforms_map, installed_slugs)
+        synced_slugs = await self._loop.run_in_executor(None, self._read_synced_slugs)
+        self._enrich_platform_map(platforms_map, synced_slugs)
         platforms = sorted(platforms_map.values(), key=lambda p: p["platform_slug"])
         return {"success": True, "server_offline": server_offline, "platforms": platforms}
 

--- a/src/components/SystemPage.test.tsx
+++ b/src/components/SystemPage.test.tsx
@@ -230,14 +230,45 @@ describe("SystemPage", () => {
       expect(container.textContent).toContain("Failed to fetch firmware status: Error: network");
     });
 
-    it("renders the no-firmware empty state when platforms list is empty", async () => {
+    it("renders the no-synced-systems empty state when platforms list is empty", async () => {
       vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
         success: true,
         platforms: [],
       });
       const { container } = render(<SystemPage onBack={vi.fn()} />);
       await flushAsync();
-      expect(container.textContent).toContain("No firmware files found");
+      expect(container.textContent).toContain("No synced systems");
+    });
+
+    it("renders only currently-synced systems (has_games), hiding unsynced ones", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [
+          makeBiosPlatform({ platform_slug: "snes", has_games: true }),
+          makeBiosPlatform({ platform_slug: "ps2", has_games: false }),
+        ],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      // The synced platform renders; the unsynced one is filtered out entirely.
+      expect(container.textContent).toContain("snes");
+      expect(container.textContent).not.toContain("ps2");
+    });
+
+    it("renders the no-synced-systems empty state when BIOS platforms exist but none are synced", async () => {
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [
+          makeBiosPlatform({ platform_slug: "snes", has_games: false }),
+          makeBiosPlatform({ platform_slug: "ps2", has_games: false }),
+        ],
+      });
+      const { container } = render(<SystemPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(container.textContent).toContain("No synced systems");
+      // Neither unsynced platform is rendered as a section.
+      expect(container.textContent).not.toContain("snes");
+      expect(container.textContent).not.toContain("ps2");
     });
   });
 

--- a/src/components/SystemPage.tsx
+++ b/src/components/SystemPage.tsx
@@ -214,8 +214,9 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
     }
   };
 
-  const withGames = biosPlatforms.filter((p) => p.has_games);
-  const withoutGames = biosPlatforms.filter((p) => !p.has_games);
+  // Only currently-synced systems are shown (#956): a platform counts as synced
+  // when it has at least one ROM bound to a Steam shortcut (has_games).
+  const syncedPlatforms = biosPlatforms.filter((p) => p.has_games);
 
   const renderBiosPlatform = (platform: FirmwarePlatformExt) => {
     const total = platform.files.length;
@@ -433,9 +434,9 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
           </PanelSectionRow>
         )}
 
-        {!biosLoading && !biosError && biosPlatforms.length === 0 && (
+        {!biosLoading && !biosError && syncedPlatforms.length === 0 && (
           <PanelSectionRow>
-            <Field label="No firmware files found" />
+            <Field label="No synced systems" description="Sync some games to manage their cores and BIOS files here." />
           </PanelSectionRow>
         )}
 
@@ -446,8 +447,7 @@ export const SystemPage: FC<SystemPageProps> = ({ onBack }) => {
         )}
       </PanelSection>
 
-      {withGames.map(renderBiosPlatform)}
-      {withoutGames.map(renderBiosPlatform)}
+      {syncedPlatforms.map(renderBiosPlatform)}
     </>
   );
 };

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -50,8 +50,12 @@ def _make_clock() -> FakeClock:
     return FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
 
 
-def _seed_rom(uow: FakeUnitOfWork, *, rom_id: int, platform_slug: str, app_id: int = 1) -> None:
-    """Seed one ``Rom`` so firmware's installed-platform read sees the platform."""
+def _seed_rom(uow: FakeUnitOfWork, *, rom_id: int, platform_slug: str, app_id: int | None = 1) -> None:
+    """Seed one ``Rom`` so firmware's synced-platform read sees the platform.
+
+    ``app_id=None`` seeds an *unbound* ROM (no Steam shortcut) — its platform
+    does not count as synced.
+    """
     uow.roms.save(
         Rom(
             rom_id=rom_id,
@@ -312,24 +316,33 @@ class TestGetFirmwareStatus:
         assert resolver.calls == [("dc", None)]
 
     @pytest.mark.asyncio
-    async def test_has_games_reflects_synced_roms(self, plugin, fw):
-        """``has_games`` is True only for platforms with a synced ROM in the registry."""
+    async def test_has_games_reflects_bound_roms(self, plugin, fw):
+        """``has_games`` is True only for platforms with a ROM bound to a shortcut.
+
+        - ``dc``: one bound ROM (``shortcut_app_id`` set) -> True.
+        - ``ps2``: only an *unbound* ROM (``shortcut_app_id is None``) -> False.
+        - ``gba``: no ROM rows at all -> False.
+        """
         firmware_list = [
             {"id": 1, "file_name": "bios_dc.bin", "file_path": "bios/dc/bios_dc.bin", "file_size_bytes": 100},
             {"id": 2, "file_name": "scph.bin", "file_path": "bios/ps2/scph.bin", "file_size_bytes": 200},
+            {"id": 3, "file_name": "gba_bios.bin", "file_path": "bios/gba/gba_bios.bin", "file_size_bytes": 300},
         ]
         # A real loop so the executor-run reads hit the shared fake UoW.
         fw._loop = asyncio.get_event_loop()
-        # Seed one ROM on "dc" only.
-        _seed_rom(plugin._uow, rom_id=42, platform_slug="dc")
+        # "dc": a bound ROM. "ps2": only an unbound ROM. "gba": no ROM rows.
+        _seed_rom(plugin._uow, rom_id=42, platform_slug="dc", app_id=1)
+        _seed_rom(plugin._uow, rom_id=43, platform_slug="ps2", app_id=None)
 
         with patch.object(plugin._romm_api, "list_firmware", return_value=firmware_list):
             result = await fw.get_firmware_status()
 
         dc_plat = next(p for p in result["platforms"] if p["platform_slug"] == "dc")
         ps2_plat = next(p for p in result["platforms"] if p["platform_slug"] == "ps2")
+        gba_plat = next(p for p in result["platforms"] if p["platform_slug"] == "gba")
         assert dc_plat["has_games"] is True
         assert ps2_plat["has_games"] is False
+        assert gba_plat["has_games"] is False
 
     @pytest.mark.asyncio
     async def test_detects_downloaded_files(self, fw, tmp_path):


### PR DESCRIPTION
**What** — The QAM System page now lists only **currently-synced systems** instead of every platform that has BIOS files on the RomM server / in the registry.

**Why** — The page grouped by every BIOS-bearing platform and used `has_games` only for ordering, so a platform with BIOS-on-server but no synced games still appeared.

**How** — "Currently synced" = a platform with at least one ROM **bound to a Steam shortcut** (`shortcut_app_id` set). Any synced ROM — whether from platform-sync or collection-sync — is bound and carries a `platform_slug`, and deselected platforms get unbound on the next sync (ADR-0007), so they drop out. DB-only and offline-safe — no live resolution of `enabled_platforms`/collections.

- Backend: `firmware.py` `_read_installed_slugs` → `_read_synced_slugs`, now counts only ROMs with `shortcut_app_id is not None`; the `has_games` payload field keeps its name and now matches its "synced ROM" docstring. The platform grouping source is unchanged (scope limited to filtering down).
- Frontend: `SystemPage.tsx` renders only synced platforms (dropped the non-synced bucket); the empty state now fires when BIOS platforms exist but none are synced ("No synced systems").

Docs: `docs/user-guide/bios-management.md` updated.

Part of epic #926. Closes #956.