### PR TITLE
feat(saves): detect & gate save sync when savefiles_in_content_dir is on (#239)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -288,10 +288,17 @@ The backend reads `retrodeck.json` → `paths.saves_path` as the source of truth
 (`py_modules/adapters/retrodeck_paths.py`). When that file is unreadable — e.g. a fresh install with no RetroDECK
 configured yet — it falls back to the hardcoded RetroDECK default `~/retrodeck/saves`.
 
-The plugin deliberately does **not** read `savefile_directory` from `retroarch.cfg`. RetroDECK re-derives
-`savefile_directory = saves_path` on every launch/reset/move (its `component_prepare.sh` rewrites the key, and the "move
-data" flow updates `retrodeck.json` and `retroarch.cfg` in lockstep), so `retrodeck.json` is the single source of truth
-and reading the cfg key would only track a value RetroDECK is about to overwrite.
+The plugin deliberately does **not** read `savefile_directory` from `retroarch.cfg`; it takes the saves root from
+`retrodeck.json` → `paths.saves_path`. RetroDECK re-pins `savefile_directory = saves_path` only at **first-run
+install**, **config reset** (explicit / factory / component update / multi-user switch), and **data-move** (`postmove`)
+— **not** on every game launch or routine boot. Between those events `retroarch.cfg` is user-owned and edits persist, so
+the plugin reads the live cfg for save **sorting** to stay correct. The one key it does not yet read —
+`savefiles_in_content_dir` — is therefore a **persistent** blind spot until the user toggles it back or a reset/install
+re-copies the default cfg ([#239](https://github.com/danielcopper/decky-romm-sync/issues/239)).
+
+_Verified against RetroDECK source on 2026-06-09: `RetroDECK/components` `retroarch/component_prepare.sh` sets the key
+only in its `reset` and `postmove` branches, and every `prepare_component` call in `RetroDECK/RetroDECK` uses action
+`reset` / `postmove` / `factory-reset` — none from a launch (`run_game`) path._
 
 ### RetroArch .srm pattern
 
@@ -334,26 +341,36 @@ as the ROM file** (e.g. `roms/gba/Game/Game.srm`) instead of the configured `sav
 `sort_savefiles_*` settings discussed above become irrelevant in that case because saves no longer live in the savefile
 directory at all.
 
-**The plugin does not handle this configuration.** `adapters/retroarch_config.py` reads only
-`sort_savefiles_by_content_enable` and `sort_savefiles_enable` — it does not read or react to
-`savefiles_in_content_dir`. If a user enables it, the plugin's save sync, conflict detection, and save-sort migration
-will silently miss every save because they only look inside `savefile_directory`.
+**The plugin detects this configuration and disables save sync for it — it does not silently miss saves
+([#239](https://github.com/danielcopper/decky-romm-sync/issues/239)).** `adapters/retroarch_config.py` reads all three
+layout keys and models them as a `SaveLayout` value object (`domain/save_layout.py`): `ContentDir` when
+`savefiles_in_content_dir=true`, otherwise `InSaveDir(sort_by_content, sort_by_core)`. When the layout is `ContentDir`,
+the four save-sync entry points (`pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`, `sync_all_saves`) return a
+benign skip (`{success: false, reason: "savefiles_in_content_dir", …}` — the game still launches, no error), and
+`get_save_status` carries an additive `savefiles_in_content_dir: true` flag so the game-detail play section shows a
+banner asking the user to turn the setting back off. Actually _syncing_ ROM-adjacent saves stays unsupported (the
+deferred multi-emulator work).
+
+This blind spot is **persistent**: RetroDECK only restores the `false` default on a full config reset or first-run
+install — never on a normal launch (verified 2026-06-09) — so the plugin reads the layout live on every sync rather than
+assume RetroDECK keeps it off.
 
 **Why this is easy to confuse**: the RetroArch UI labels are deliberately similar. "Write Saves to **Content
 Directory**" controls the **destination** (next to the ROM vs the saves directory), while "Sort Saves **Into Folders by
 Content Directory**" controls the **layout within** the saves directory. They sound nearly identical but mean very
 different things.
 
-| RetroArch UI label                           | cfg key                            | What it controls                                                                                           |
-| -------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Write Saves to Content Directory             | `savefiles_in_content_dir`         | **Destination** — next to ROM (true) vs `savefile_directory` (false). Plugin does **not** handle `true`.   |
-| Sort Saves Into Folders by Content Directory | `sort_savefiles_by_content_enable` | **Layout inside `savefile_directory`** — group by ROM parent folder name. Plugin handles both values.      |
-| Sort Saves Into Folders by Core Name         | `sort_savefiles_enable`            | **Layout inside `savefile_directory`** — further group by RetroArch core name. Plugin handles both values. |
+| RetroArch UI label                           | cfg key                            | What it controls                                                                                                           |
+| -------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Write Saves to Content Directory             | `savefiles_in_content_dir`         | **Destination** — next to ROM (true) vs `savefile_directory` (false). Plugin **detects `true`, warns, skips sync** (#239). |
+| Sort Saves Into Folders by Content Directory | `sort_savefiles_by_content_enable` | **Layout inside `savefile_directory`** — group by ROM parent folder name. Plugin handles both values.                      |
+| Sort Saves Into Folders by Core Name         | `sort_savefiles_enable`            | **Layout inside `savefile_directory`** — further group by RetroArch core name. Plugin handles both values.                 |
 
-**Status**: tracked as an enhancement in [#239](https://github.com/danielcopper/decky-romm-sync/issues/239). Minimum
-scope there is detect-and-warn (read the key, surface a banner explaining save sync is disabled, skip all save
-operations). Full support — resolving save paths relative to the ROM's actual on-disk location — is a larger refactor
-deferred to multi-emulator work.
+**Status**: detect-and-warn is **implemented** ([#239](https://github.com/danielcopper/decky-romm-sync/issues/239)) —
+the layout is read into `SaveLayout`, `ContentDir` hard-gates the four sync entry points, and the play-section banner
+surfaces it. Full support — resolving save paths relative to the ROM's actual on-disk location — remains deferred to the
+multi-emulator save work ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129) /
+[#255](https://github.com/danielcopper/decky-romm-sync/issues/255)).
 
 ## Save-Sort Migration: Automatic Detection and Conflict Resolution
 

--- a/py_modules/adapters/retroarch_config.py
+++ b/py_modules/adapters/retroarch_config.py
@@ -1,10 +1,11 @@
 """RetroArch config adapter — reads retroarch.cfg for runtime settings.
 
 Exposes only what the plugin currently needs from ``retroarch.cfg``:
-the save-sorting flags that drive per-content and per-core save
-directory layout. The adapter tries a small list of standard
-``retroarch.cfg`` paths (RetroDECK Flatpak, standalone RetroArch
-Flatpak, native install) and returns the first match.
+the save-file layout — whether saves go under the RetroDECK saves root
+(and with which subdir sorting) or next to the ROM in the content
+directory. The adapter tries a small list of standard ``retroarch.cfg``
+paths (RetroDECK Flatpak, standalone RetroArch Flatpak, native install)
+and returns the first match as a ``SaveLayout`` value object.
 
 No caching today — the cfg is read on each call. RetroDECK's default
 call frequency is low (bootstrap + migration detection), so a TTL cache
@@ -16,6 +17,8 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING
+
+from domain.save_layout import ContentDir, InSaveDir, SaveLayout
 
 if TYPE_CHECKING:
     import logging
@@ -35,30 +38,40 @@ class RetroArchConfigAdapter:
         self._user_home = user_home
         self._logger = logger
 
-    def get_retroarch_save_sorting(self) -> tuple[bool, bool]:
-        """Read save file sorting settings from retroarch.cfg.
+    def get_save_layout(self) -> SaveLayout:
+        """Read the RetroArch save-file layout from retroarch.cfg.
 
-        Returns (sort_by_content, sort_by_core) booleans.
-        Defaults to (True, False) matching RetroDECK defaults.
+        Returns ``ContentDir()`` when ``savefiles_in_content_dir=true`` —
+        saves are written next to the ROM and plugin save sync is
+        unsupported. Otherwise returns ``InSaveDir(sort_by_content,
+        sort_by_core)`` from the two ``sort_savefiles_*`` flags. Defaults
+        to ``InSaveDir(sort_by_content=True, sort_by_core=False)`` matching
+        RetroDECK defaults when no readable cfg is found.
         """
-        sort_by_content = True  # RetroDECK default
-        sort_by_core = False
         for suffix in self._RETROARCH_CFG_SUFFIXES:
             cfg_path = os.path.join(self._user_home, suffix)
             try:
+                in_content_dir = False
+                sort_by_content = True  # RetroDECK default
+                sort_by_core = False
                 with open(cfg_path) as f:
                     for line in f:
                         stripped = line.strip()
-                        if stripped.startswith("sort_savefiles_by_content_enable"):
+                        if stripped.startswith("savefiles_in_content_dir"):
+                            val = stripped.split("=", 1)[1].strip().strip('"').lower()
+                            in_content_dir = val == "true"
+                        elif stripped.startswith("sort_savefiles_by_content_enable"):
                             val = stripped.split("=", 1)[1].strip().strip('"').lower()
                             sort_by_content = val == "true"
                         elif stripped.startswith("sort_savefiles_enable"):
                             val = stripped.split("=", 1)[1].strip().strip('"').lower()
                             sort_by_core = val == "true"
-                return (sort_by_content, sort_by_core)
+                if in_content_dir:
+                    return ContentDir()
+                return InSaveDir(sort_by_content=sort_by_content, sort_by_core=sort_by_core)
             except FileNotFoundError:
                 continue
             except (OSError, UnicodeDecodeError) as exc:
                 self._logger.warning(f"Failed to read {cfg_path}: {exc}")
                 continue
-        return (sort_by_content, sort_by_core)
+        return InSaveDir(sort_by_content=True, sort_by_core=False)

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
         PathExistsReader,
         PlatformCoreReader,
         PluginMetadataReader,
-        RetroArchSaveSortingProvider,
+        RetroArchSaveLayoutProvider,
         RetroDeckPaths,
         RomFileStore,
         RommApi,
@@ -153,7 +153,7 @@ class CallbackBundle:
     """Provider callables and persister Protocols injected into services."""
 
     retrodeck_paths: RetroDeckPaths
-    get_retroarch_save_sorting: RetroArchSaveSortingProvider
+    get_save_layout: RetroArchSaveLayoutProvider
     get_core_name: CoreNameProviderFn
     platform_core_reader: PlatformCoreReader
     settings_persister: SettingsPersister
@@ -350,7 +350,7 @@ def bootstrap(
     )
     callbacks = CallbackBundle(
         retrodeck_paths=retrodeck_paths,
-        get_retroarch_save_sorting=retroarch_config.get_retroarch_save_sorting,
+        get_save_layout=retroarch_config.get_save_layout,
         get_core_name=retroarch_core_info.get_corename,
         platform_core_reader=platform_core_reader,
         settings_persister=settings_persister,
@@ -425,7 +425,7 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
             emit=cfg.runtime.emit,
             get_bios_files_index=bios_files_index_binding.get,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
-            get_retroarch_save_sorting=cfg.callbacks.get_retroarch_save_sorting,
+            get_save_layout=cfg.callbacks.get_save_layout,
             active_core=active_core_resolver,
             get_core_name=cfg.callbacks.get_core_name,
             uow_factory=cfg.callbacks.uow_factory,
@@ -450,6 +450,9 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
         plugin_metadata=cfg.callbacks.plugin_metadata,
         plugin_dir=cfg.runtime.plugin_dir,
         emit=cfg.runtime.emit,
+        # StatusService reports the live layout so the SAVES tab can warn when
+        # saves go to the content dir (#239).
+        get_save_layout=cfg.callbacks.get_save_layout,
         # SaveService must observe fresh sort state before computing saves_dir (#238).
         detect_sort_change=migration_service.detect_save_sort_change,
         is_retrodeck_migration_pending=migration_service.is_retrodeck_migration_pending,

--- a/py_modules/domain/save_layout.py
+++ b/py_modules/domain/save_layout.py
@@ -1,0 +1,41 @@
+"""RetroArch save-file layout value objects.
+
+The single source of truth for *where* RetroArch writes save files, as
+observed from ``retroarch.cfg``. The ``SaveLayout`` union models the two
+mutually-exclusive states the plugin must distinguish: saves under the
+RetroDECK saves root (``InSaveDir``, the supported case whose two flags
+pick the subdirectory layout) versus saves written next to the ROM
+(``ContentDir``, ``savefiles_in_content_dir=true`` — the case where
+plugin save sync is impossible because the files live outside the saves
+tree the plugin scans).
+
+Pure value objects only — no I/O, no parsing. The adapter that reads
+``retroarch.cfg`` produces these; services pattern-match on them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class InSaveDir:
+    """Saves live under the RetroDECK saves root; the two flags pick the subdir layout."""
+
+    sort_by_content: bool
+    sort_by_core: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ContentDir:
+    """RetroArch savefiles_in_content_dir=true: saves live next to the ROM — unsupported."""
+
+
+SaveLayout = InSaveDir | ContentDir
+
+# Canonical ``reason`` slug for the benign-skip outcome a ``ContentDir`` layout
+# produces. Lives here as the single source of truth so every service routes on
+# the SAME value without a service→service import: the saves sync-engine gate
+# stamps it on its skip result and the session-lifecycle post-exit branch reads
+# it to suppress the false-failure toast (#239).
+SAVE_SYNC_CONTENT_DIR_REASON = "savefiles_in_content_dir"

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from models.state import SaveSortSettings
 
     from domain.rom_install import RomInstall
-    from domain.save_layout import SaveLayout
+    from domain.save_layout import InSaveDir, SaveLayout
     from services.protocols import (
         ActiveCoreReader,
         CoreNameProviderFn,
@@ -690,19 +690,26 @@ class MigrationService:
                     "next to the ROM, so plugin save sync is unsupported and is disabled."
                 )
                 self._content_dir_warned = True
-            return layout
+        else:
+            self._detect_in_save_dir_change(layout)
+        return layout
 
-        sort_by_content = layout.sort_by_content
-        sort_by_core = layout.sort_by_core
-        current: SaveSortSettings = {"sort_by_content": sort_by_content, "sort_by_core": sort_by_core}
+    def _detect_in_save_dir_change(self, layout: InSaveDir) -> None:
+        """Run the cross-run save-sort change detection for a supported ``InSaveDir`` layout.
+
+        Records the current sort settings as the ``_KV_SAVE_SORT`` observation; when they
+        differ from the stored one, sets the ``_KV_SAVE_SORT_PREVIOUS`` pending-migration
+        marker and emits ``save_sort_changed`` so the frontend can offer the migration (#238).
+        """
+        current: SaveSortSettings = {"sort_by_content": layout.sort_by_content, "sort_by_core": layout.sort_by_core}
         with self._uow_factory() as uow:
             stored = self._read_save_sort_settings(uow)
         if stored is None:
             with self._uow_factory() as uow:
                 uow.kv_config.set(_KV_SAVE_SORT, json.dumps(current))
-            return layout
+            return
         if stored == current:
-            return layout
+            return
         with self._uow_factory() as uow:
             uow.kv_config.set(_KV_SAVE_SORT_PREVIOUS, json.dumps(stored))
             uow.kv_config.set(_KV_SAVE_SORT, json.dumps(current))
@@ -717,7 +724,6 @@ class MigrationService:
             ),
             self._loop,
         )
-        return layout
 
     def _resolve_retroarch_corename(self, rom_id: int) -> tuple[str | None, str | None]:
         """Resolve the RetroArch save subdirectory name for a ROM by ``rom_id``.

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.save_extensions import get_save_extensions
+from domain.save_layout import ContentDir
 from domain.save_path import resolve_save_dir
 from domain.shortcut_data import build_launch_options, resolve_emulator_invocation
 
@@ -26,12 +27,13 @@ if TYPE_CHECKING:
     from models.state import SaveSortSettings
 
     from domain.rom_install import RomInstall
+    from domain.save_layout import SaveLayout
     from services.protocols import (
         ActiveCoreReader,
         CoreNameProviderFn,
         EventEmitter,
         MigrationFileStore,
-        RetroArchSaveSortingProvider,
+        RetroArchSaveLayoutProvider,
         RetroDeckPaths,
         SettingsPersister,
         UnitOfWorkFactory,
@@ -68,7 +70,7 @@ class MigrationServiceConfig:
     emit: EventEmitter
     get_bios_files_index: Callable[[], dict[str, dict[str, Any]]]
     retrodeck_paths: RetroDeckPaths
-    get_retroarch_save_sorting: RetroArchSaveSortingProvider
+    get_save_layout: RetroArchSaveLayoutProvider
     active_core: ActiveCoreReader
     get_core_name: CoreNameProviderFn
     uow_factory: UnitOfWorkFactory
@@ -86,10 +88,14 @@ class MigrationService:
         self._emit = config.emit
         self._get_bios_files_index = config.get_bios_files_index
         self._retrodeck_paths = config.retrodeck_paths
-        self._get_retroarch_save_sorting = config.get_retroarch_save_sorting
+        self._get_save_layout = config.get_save_layout
         self._active_core = config.active_core
         self._get_core_name = config.get_core_name
         self._uow_factory = config.uow_factory
+        # One-shot guard so the ContentDir "save sync unsupported" warning is
+        # logged at most once per process rather than on every save-sort detect
+        # pass (which runs at the entry of every sync flow).
+        self._content_dir_warned = False
         # Strong refs to in-flight background tasks. ``loop.create_task``
         # alone is not enough — without a strong ref, the loop is free to
         # garbage-collect the task before it completes. ``add_done_callback``
@@ -652,27 +658,51 @@ class MigrationService:
         raw = uow.kv_config.get(_KV_SAVE_SORT_PREVIOUS)
         return json.loads(raw) if raw is not None else None
 
-    def detect_save_sort_change(self) -> None:
-        """Check if RetroArch save sorting settings changed since last run.
+    def detect_save_sort_change(self) -> SaveLayout:
+        """Refresh save-sort state from the live RetroArch config; return the layout.
+
+        Reads the live ``SaveLayout`` and returns it so the SyncEngine can
+        hard-gate save sync when it is ``ContentDir`` (#239). When the
+        layout is ``ContentDir`` the kv_config save-sort change-detection
+        markers are never touched — content-dir saves live next to the ROM,
+        outside the saves tree the plugin syncs, so there is no sort layout
+        to migrate. A single per-process warning is logged so the unsupported
+        state is visible without spamming every sync.
+
+        For the supported ``InSaveDir`` case, runs the cross-run change
+        detection against the stored observation, writing the
+        ``_KV_SAVE_SORT`` / ``_KV_SAVE_SORT_PREVIOUS`` markers and emitting
+        ``save_sort_changed`` when the layout flips (#238).
 
         May be called from a worker thread (via
-        ``SaveService._refresh_save_sort_state`` → ``run_in_executor``) or
+        ``SyncEngine._refresh_save_sort_state`` → ``run_in_executor``) or
         from the loop thread. Use ``asyncio.run_coroutine_threadsafe`` to
         schedule the emit coroutine: it is explicitly thread-safe and
         also works correctly when invoked from the loop thread itself.
         ``loop.create_task`` is NOT thread-safe and races with loop
         internals on CPython (#238 review).
         """
-        sort_by_content, sort_by_core = self._get_retroarch_save_sorting()
+        layout = self._get_save_layout()
+        if isinstance(layout, ContentDir):
+            if not self._content_dir_warned:
+                self._logger.warning(
+                    "RetroArch savefiles_in_content_dir is enabled — saves are written "
+                    "next to the ROM, so plugin save sync is unsupported and is disabled."
+                )
+                self._content_dir_warned = True
+            return layout
+
+        sort_by_content = layout.sort_by_content
+        sort_by_core = layout.sort_by_core
         current: SaveSortSettings = {"sort_by_content": sort_by_content, "sort_by_core": sort_by_core}
         with self._uow_factory() as uow:
             stored = self._read_save_sort_settings(uow)
         if stored is None:
             with self._uow_factory() as uow:
                 uow.kv_config.set(_KV_SAVE_SORT, json.dumps(current))
-            return
+            return layout
         if stored == current:
-            return
+            return layout
         with self._uow_factory() as uow:
             uow.kv_config.set(_KV_SAVE_SORT_PREVIOUS, json.dumps(stored))
             uow.kv_config.set(_KV_SAVE_SORT, json.dumps(current))
@@ -687,6 +717,7 @@ class MigrationService:
             ),
             self._loop,
         )
+        return layout
 
     def _resolve_retroarch_corename(self, rom_id: int) -> tuple[str | None, str | None]:
         """Resolve the RetroArch save subdirectory name for a ROM by ``rom_id``.

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -65,7 +65,7 @@ from services.protocols.paths import (
     PlatformCoreReader,
     RetroArchConfigReader,
     RetroArchCoreInfoReader,
-    RetroArchSaveSortingProvider,
+    RetroArchSaveLayoutProvider,
     RetroDeckPaths,
     SystemResolver,
 )
@@ -136,7 +136,7 @@ __all__ = [
     "PluginMetadataReader",
     "RetroArchConfigReader",
     "RetroArchCoreInfoReader",
-    "RetroArchSaveSortingProvider",
+    "RetroArchSaveLayoutProvider",
     "RetroDeckPaths",
     "RetryStrategy",
     "RomFileStore",

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 if TYPE_CHECKING:
     from models.state import InstalledRomEntry, ShortcutRegistryEntry
 
+    from domain.save_layout import SaveLayout
+
 
 class RetryStrategy(Protocol):
     """HTTP retry wrapper pair consumed by SaveService and PlaytimeService."""
@@ -198,10 +200,12 @@ class SaveSortChangeFn(Protocol):
     ``MigrationService.detect_save_sort_change``. SaveService invokes
     this at the entry point of ``pre_launch_sync`` and
     ``post_exit_sync`` to refresh save-sort state from the live
-    RetroArch config before computing ``saves_dir`` (#238).
+    RetroArch config before computing ``saves_dir`` (#238). It returns
+    the live ``SaveLayout`` it just observed: the SyncEngine reads this
+    to hard-gate save sync when the layout is ``ContentDir`` (#239).
     """
 
-    def __call__(self) -> None: ...
+    def __call__(self) -> SaveLayout: ...
 
 
 class MigrationPendingFn(Protocol):

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -2,8 +2,8 @@
 
 Services query the host RetroDECK/RetroArch/ES-DE environment through
 these Protocols: filesystem path getters (saves, roms, BIOS,
-RetroDECK home), platform-to-system resolution, RetroArch save sorting
-toggles, and RetroArch core lookups for ES-DE configured systems.
+RetroDECK home), platform-to-system resolution, the RetroArch save-file
+layout, and RetroArch core lookups for ES-DE configured systems.
 ``PlatformCoreReader`` exposes the plugin-owned per-platform core
 selection (stored in ``settings.json``, not the ES-DE gamelist) that the
 resolver layers over the es_systems default.
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from domain.save_layout import SaveLayout
     from lib.retrodeck_health import RetroDeckConfigHealth
 
 
@@ -50,10 +51,10 @@ class RetroDeckPaths(Protocol):
     def config_health(self) -> RetroDeckConfigHealth: ...
 
 
-class RetroArchSaveSortingProvider(Protocol):
-    """Return RetroArch save sorting settings as (sort_by_content, sort_by_core)."""
+class RetroArchSaveLayoutProvider(Protocol):
+    """Return the live RetroArch save-file layout as a ``SaveLayout`` value object."""
 
-    def __call__(self) -> tuple[bool, bool]: ...
+    def __call__(self) -> SaveLayout: ...
 
 
 class CoreResolverFn(Protocol):
@@ -111,14 +112,14 @@ class CoreNameProviderFn(Protocol):
 class RetroArchConfigReader(Protocol):
     """Object seam for ``retroarch.cfg`` reads.
 
-    Held by ``main.py`` to bind ``get_retroarch_save_sorting`` as a
-    callable forwarded into service wiring. Distinct from
-    :class:`RetroArchSaveSortingProvider` (the call-shaped Protocol for
+    Held by ``main.py`` to bind ``get_save_layout`` as a callable
+    forwarded into service wiring. Distinct from
+    :class:`RetroArchSaveLayoutProvider` (the call-shaped Protocol for
     the bound method itself) — that one is what services receive; this
     one is what ``main.py`` holds.
     """
 
-    def get_retroarch_save_sorting(self) -> tuple[bool, bool]: ...
+    def get_save_layout(self) -> SaveLayout: ...
 
 
 class RetroArchCoreInfoReader(Protocol):

--- a/py_modules/services/saves/_config.py
+++ b/py_modules/services/saves/_config.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
         MachineIdReader,
         MigrationPendingFn,
         PluginMetadataReader,
+        RetroArchSaveLayoutProvider,
         RetroDeckPaths,
         RetryStrategy,
         RommSyncApi,
@@ -103,6 +104,12 @@ class SaveServiceConfig:
         :meth:`PluginMetadataReader.read_version`.
     emit:
         Event emitter for pushing save-sync progress to the frontend.
+    get_save_layout:
+        ``RetroArchSaveLayoutProvider`` seam returning the live
+        ``SaveLayout`` from ``retroarch.cfg``. StatusService reads it so
+        the SAVES tab can surface the ``savefiles_in_content_dir`` warning
+        when RetroArch is set to write saves next to the ROM — the
+        unsupported case where plugin save sync is hard-gated off (#239).
     detect_sort_change:
         Synchronous callback that refreshes save-sort state from the
         live RetroArch config (wired to
@@ -147,6 +154,7 @@ class SaveServiceConfig:
     plugin_dir: str
     get_core_name: CoreNameProviderFn
     emit: EventEmitter
+    get_save_layout: RetroArchSaveLayoutProvider
     detect_sort_change: SaveSortChangeFn
     is_retrodeck_migration_pending: MigrationPendingFn
     uow_factory: UnitOfWorkFactory

--- a/py_modules/services/saves/_messages.py
+++ b/py_modules/services/saves/_messages.py
@@ -6,5 +6,16 @@ consistent across modules. Add to this file rather than inlining new
 literals in service code.
 """
 
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+
 SAVE_SYNC_DISABLED = "Save sync is disabled"
 DEVICE_NOT_REGISTERED = "Device not registered"
+# RetroArch ``savefiles_in_content_dir=true``: saves are written next to the
+# ROM, outside the saves tree the plugin syncs, so save sync is unavailable.
+# Neutral phrasing — the frontend treats this as a benign skip, not an error.
+SAVE_SYNC_IN_CONTENT_DIR = "Save sync is unavailable: RetroArch is set to write saves to the content directory."
+# ``reason`` slug on the sync-gate failure shape; the frontend routes on this to
+# treat the result as a skip (no error, launch proceeds), not a failure. Single
+# source of truth is ``domain.save_layout`` — re-exported here so the saves
+# service code keeps importing it from its own message module.
+SAVE_SYNC_IN_CONTENT_DIR_REASON = SAVE_SYNC_CONTENT_DIR_REASON

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -108,6 +108,7 @@ class SaveService:
                 log_debug=config.log_debug,
                 active_core=config.active_core,
                 emit=config.emit,
+                get_save_layout=config.get_save_layout,
             ),
         )
 

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -109,6 +109,7 @@ class SlotsService:
             logger=config.logger,
             save_file_store=config.save_file_store,
             log_debug=config.log_debug,
+            sync_engine=config.sync_engine,
         )
         self._deleter = SlotDeleter(
             settings=config.settings,

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
 from domain.rom_save_state import RomSaveState
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
 from services.saves._settings import resolve_default_slot
 
 if TYPE_CHECKING:
@@ -29,6 +31,7 @@ if TYPE_CHECKING:
         UnitOfWorkFactory,
     )
     from services.saves.rom_info import RomInfoService
+    from services.saves.sync_engine import SyncEngine
 
 
 NO_MIGRATION = object()  # sentinel: no slot migration requested
@@ -50,6 +53,7 @@ class SetupWizard:
         logger: logging.Logger,
         save_file_store: SaveFileStore,
         log_debug: DebugLogger,
+        sync_engine: SyncEngine,
     ) -> None:
         self._settings = settings
         self._uow_factory = uow_factory
@@ -61,6 +65,7 @@ class SetupWizard:
         self._logger = logger
         self._save_file_store = save_file_store
         self._log_debug = log_debug
+        self._sync_engine = sync_engine
 
     def _read_save_state(self, rom_id: int) -> RomSaveState | None:
         with self._uow_factory() as uow:
@@ -203,6 +208,13 @@ class SetupWizard:
         If migrate_from_slot is provided (can be None for legacy no-slot saves),
         migrates saves: upload local files to chosen_slot, then delete old server saves.
         Pass NO_MIGRATION sentinel (the default) to skip migration.
+
+        When a migration is requested but RetroArch writes saves to the content
+        dir (#239), the migration is refused before any upload/delete (the local
+        files it would carry are not under ``saves_dir``); the response carries
+        ``success=False`` with ``reason="savefiles_in_content_dir"``. The slot
+        confirmation itself — a non-destructive metadata flip — is still
+        persisted. The non-migration path is never gated (no file write).
         """
         rom_id = int(rom_id)
         chosen_slot = str(chosen_slot).strip()
@@ -215,6 +227,20 @@ class SetupWizard:
 
         # Migration: re-upload local files to new slot, delete old server saves
         if migrate_from_slot is not NO_MIGRATION:
+            # #239: RetroArch writes saves to the content dir — the migration
+            # uploads local files read from ``saves_dir``, which holds nothing
+            # in content-dir mode, so the migration could not carry real saves.
+            # Refuse the migration before any upload/delete; the slot itself is
+            # still confirmed in state (a non-destructive metadata flip).
+            if await self._sync_engine.content_dir_blocked("confirm_slot_choice"):
+                self._log_debug(f"confirm_slot_choice: content-dir layout for rom {rom_id}; skipping migration")
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+                return {
+                    "success": False,
+                    "reason": SAVE_SYNC_CONTENT_DIR_REASON,
+                    "needs_conflict_resolution": False,
+                    "message": SAVE_SYNC_IN_CONTENT_DIR,
+                }
             # migrate_from_slot can be None (legacy no-slot) or a string slot name
             from_slot: str | None = migrate_from_slot if isinstance(migrate_from_slot, str) else None
             try:

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from lib.list_result import ErrorCode
 from services.saves._helpers import local_save_target
+from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
 from services.saves._settings import resolve_default_slot, save_sync_enabled
 
 if TYPE_CHECKING:
@@ -133,8 +135,11 @@ class SlotSwitcher:
         Pre-checks (all must pass):
         1. Save sync must be enabled.
         2. ROM must be installed.
-        3. No local files with pending changes (changed since last sync to current slot).
-        4. Server must be reachable.
+        3. RetroArch must not write saves to the content dir — otherwise the
+           switch's ``saves_dir`` writes are ignored by RetroArch (#239). The
+           refusal carries ``reason="savefiles_in_content_dir"``.
+        4. No local files with pending changes (changed since last sync to current slot).
+        5. Server must be reachable.
 
         On success:
         - If the new slot has server saves: downloads them, replacing local files.
@@ -155,6 +160,18 @@ class SlotSwitcher:
         info = self._rom_info.get_rom_save_info(rom_id)
         if not info:
             return {"success": False, "reason": "not_installed"}
+
+        # #239: RetroArch writes saves to the content dir — switching slots
+        # would download/delete files under ``saves_dir``, which RetroArch
+        # ignores, so the switch could not take effect. Refuse before any
+        # file write or server fetch.
+        if await self._sync_engine.content_dir_blocked("switch_slot"):
+            self._log_debug(f"switch_slot: content-dir layout for rom {rom_id}; refusing")
+            return {
+                "success": False,
+                "reason": SAVE_SYNC_CONTENT_DIR_REASON,
+                "message": SAVE_SYNC_IN_CONTENT_DIR,
+            }
 
         saves_dir = info["saves_dir"]
         system = info["system"]

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -7,6 +7,7 @@ from domain.emulator_tag import detect_core_change
 from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_attribution import compute_uploaded_by_us
+from domain.save_layout import ContentDir
 from domain.save_status import compute_multi_file_slot, compute_save_sync_display
 from domain.save_status_builders import (
     build_file_status,
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
         ActiveCoreReader,
         DebugLogger,
         EventEmitter,
+        RetroArchSaveLayoutProvider,
         RetryStrategy,
         RommSaveApi,
         UnitOfWorkFactory,
@@ -41,8 +43,10 @@ class StatusServiceConfig:
     repositories), the peer save sub-services (sync_engine, rom_info),
     the Protocol-typed RomM adapter and retry strategy, the plugin event
     loop, the standard-library logger, the ``DebugLogger`` seam, the
-    per-ROM active-core resolver, and the event emitter used to push background
-    status updates to the frontend.
+    per-ROM active-core resolver, the event emitter used to push background
+    status updates to the frontend, and the ``RetroArchSaveLayoutProvider``
+    seam that reports whether RetroArch writes saves to the content dir
+    (the unsupported case surfaced as ``savefiles_in_content_dir`` — #239).
     """
 
     settings: dict[str, Any]
@@ -56,6 +60,7 @@ class StatusServiceConfig:
     log_debug: DebugLogger
     active_core: ActiveCoreReader
     emit: EventEmitter
+    get_save_layout: RetroArchSaveLayoutProvider
 
 
 class StatusService:
@@ -74,6 +79,7 @@ class StatusService:
         self._log_debug = config.log_debug
         self._active_core = config.active_core
         self._emit = config.emit
+        self._get_save_layout = config.get_save_layout
 
     def _status_entry_from_outcome(
         self,
@@ -191,7 +197,13 @@ class StatusService:
         misleading "ready to upload" indicator on what is in fact a
         connectivity blip.
         """
-        info = self._rom_info.get_rom_save_info(rom_id)
+        # RetroArch ``savefiles_in_content_dir=true``: saves live next to the
+        # ROM, outside the saves tree we scan, so save sync is unsupported.
+        # Skip all local save-file probing (the files are not where we look)
+        # but keep playtime / device_id / last_sync_check_at intact (#239).
+        savefiles_in_content_dir = isinstance(self._get_save_layout(), ContentDir)
+
+        info = None if savefiles_in_content_dir else self._rom_info.get_rom_save_info(rom_id)
 
         with self._uow_factory() as uow:
             save_state = uow.rom_save_states.get(rom_id)
@@ -242,6 +254,24 @@ class StatusService:
         playtime_dict = _playtime_to_dict(playtime)
         last_sync_check_at = save_state.last_sync_check_at if save_state else None
 
+        # When saves go to the content dir, override the display with a clear
+        # "not supported" status — no local files were probed, so the normal
+        # computation would report a misleading "No saves" (#239).
+        if savefiles_in_content_dir:
+            save_sync_display = {
+                "status": "none",
+                "label": "Save sync off — saves in content dir",
+                "last_sync_check_at": None,
+            }
+        else:
+            save_sync_display = asdict(
+                compute_save_sync_display(
+                    file_statuses,
+                    last_sync_check_at,
+                    server_query_failed=server_query_failed,
+                )
+            )
+
         return {
             "rom_id": rom_id,
             "files": file_statuses,
@@ -250,13 +280,8 @@ class StatusService:
             "last_sync_check_at": last_sync_check_at,
             "conflicts": conflicts,
             "save_sort_changed": self._rom_info.is_save_sort_changed(),
-            "save_sync_display": asdict(
-                compute_save_sync_display(
-                    file_statuses,
-                    last_sync_check_at,
-                    server_query_failed=server_query_failed,
-                )
-            ),
+            "savefiles_in_content_dir": savefiles_in_content_dir,
+            "save_sync_display": save_sync_display,
             "server_query_failed": server_query_failed,
             # Interim #908 guard: a slot whose current save spans >1 distinct
             # file (e.g. Saturn .bkr/.bcr/.smpc) is an N-file *set*, not a
@@ -266,7 +291,11 @@ class StatusService:
             # until grouped save-states land (#908).
             "multi_file": multi_file.is_multi_file,
             "component_files": multi_file.component_files,
-            "rollback_supported": not multi_file.is_multi_file,
+            # Rollback writes to ``saves_dir``, which RetroArch ignores in
+            # content-dir mode — so rollback is unsupported there regardless of
+            # the (empty) file list. Make it explicit rather than relying on
+            # ``files == []`` to suppress the rollback UI (#239).
+            "rollback_supported": not multi_file.is_multi_file and not savefiles_in_content_dir,
         }
 
     # ------------------------------------------------------------------
@@ -281,6 +310,11 @@ class StatusService:
         and each surfaced file is marked ``status="unknown"`` instead of
         the matrix-derived "ready to upload" label that an empty server
         list would otherwise produce — see ``_get_save_status_io``.
+
+        The additive ``savefiles_in_content_dir: bool`` flag is ``True``
+        when RetroArch writes saves next to the ROM (the unsupported case):
+        local probing is skipped and the display reads "Save sync off",
+        while playtime / device_id stay intact (#239).
 
         The ``rom_save_states`` read-modify-write (the baseline-adopt
         write in ``_get_save_status_io``) runs under the per-ROM sync lock

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -23,7 +23,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
-from services.saves._messages import DEVICE_NOT_REGISTERED, SAVE_SYNC_DISABLED
+from domain.save_layout import ContentDir
+from services.saves._messages import (
+    DEVICE_NOT_REGISTERED,
+    SAVE_SYNC_DISABLED,
+    SAVE_SYNC_IN_CONTENT_DIR,
+    SAVE_SYNC_IN_CONTENT_DIR_REASON,
+)
 from services.saves._settings import resolve_default_slot, save_sync_enabled, sync_after_exit, sync_before_launch
 from services.saves.sync_engine.devices import DeviceRegistry
 from services.saves.sync_engine.matrix import MatrixExecutor, MatrixOutcome
@@ -33,6 +39,7 @@ if TYPE_CHECKING:
     import logging
     from collections.abc import Iterator
 
+    from domain.save_layout import SaveLayout
     from services.protocols import (
         ActiveCoreReader,
         Clock,
@@ -111,6 +118,11 @@ class SyncEngine:
         self._plugin_version = config.plugin_version
         self._detect_sort_change = config.detect_sort_change
         self._is_retrodeck_migration_pending = config.is_retrodeck_migration_pending
+        # Last observed RetroArch save-file layout, refreshed by
+        # ``_refresh_save_sort_state`` at the entry of every public sync flow.
+        # ``None`` until the first refresh — treated as "not blocked" so a
+        # transient cfg read error fails OPEN (never blocks sync on a blip).
+        self._current_layout: SaveLayout | None = None
         # Per-rom lock dict — serializes concurrent sync operations on the
         # same rom_id (pre_launch_sync, post_exit_sync, manual sync, resolve).
         self._rom_sync_locks: dict[int, asyncio.Lock] = {}
@@ -326,16 +338,74 @@ class SyncEngine:
         Graceful degradation: if detect fails (e.g. retroarch.cfg is
         temporarily unreadable) we log and continue with the
         previously-known state — save-sync must not abort because of a
-        config read error.
+        config read error. The returned ``SaveLayout`` is stashed on
+        ``_current_layout`` so :meth:`_save_sync_blocked` can hard-gate
+        sync when RetroArch writes saves to the content dir (#239); on
+        failure ``_current_layout`` is left as-is (fail-OPEN).
         """
         try:
-            await self._loop.run_in_executor(None, self._detect_sort_change)
+            self._current_layout = await self._loop.run_in_executor(None, self._detect_sort_change)
         except Exception as e:
             self._logger.warning(
                 "%s: detect_sort_change failed (%s) — proceeding with stale state",
                 where,
                 e,
             )
+
+    def _save_sync_blocked(self) -> bool:
+        """Whether save sync must be hard-gated off for the live save-file layout.
+
+        ``True`` only when the last observed layout is ``ContentDir``
+        (RetroArch ``savefiles_in_content_dir=true``) — saves live next to
+        the ROM, outside the saves tree the plugin syncs, so every sync
+        flow short-circuits with the benign-skip shape (#239). ``None``
+        (no layout observed yet, or a refresh that failed) is not blocked:
+        a transient cfg read error must never disable sync.
+        """
+        return isinstance(self._current_layout, ContentDir)
+
+    async def content_dir_blocked(self, where: str) -> bool:
+        """Refresh the live layout and report whether ContentDir gates save writes.
+
+        The shared gate every save-WRITE callable consults at its entry —
+        the four sync entry points (``pre_launch_sync`` / ``post_exit_sync``
+        / ``sync_rom_saves`` / ``sync_all_saves``) inline the refresh + check
+        themselves; the secondary write callables (rollback, slot switch,
+        conflict resolve, slot-choice migration) call this so the
+        ``saves_dir`` write is never attempted in content-dir mode (#239).
+
+        Public (peer-called, no leading underscore): the slots / versions /
+        rollback sub-services invoke it across the saves bounded context.
+        Refreshes ``_current_layout`` from the live RetroArch config (fail
+        OPEN on a transient read error) before reporting the verdict.
+        """
+        await self._refresh_save_sort_state(where)
+        return self._save_sync_blocked()
+
+    @staticmethod
+    def _content_dir_skip(*, all_saves: bool = False) -> dict[str, Any]:
+        """Build the benign-skip result returned when saves go to the content dir.
+
+        Carries ``success: False`` + the ``savefiles_in_content_dir`` reason
+        slug the frontend routes on (treat as skip, no error, launch
+        proceeds) alongside zero/empty counts. *all_saves* selects the
+        ``sync_all_saves`` return shape (``conflicts`` int + ``conflicts_list``
+        / ``roms_checked``) over the single-ROM shape (``conflicts`` list).
+        """
+        base: dict[str, Any] = {
+            "success": False,
+            "reason": SAVE_SYNC_IN_CONTENT_DIR_REASON,
+            "message": SAVE_SYNC_IN_CONTENT_DIR,
+            "synced": 0,
+            "errors": [],
+        }
+        if all_saves:
+            base["conflicts"] = 0
+            base["conflicts_list"] = []
+            base["roms_checked"] = 0
+        else:
+            base["conflicts"] = []
+        return base
 
     async def _run_rom_sync(self, rom_id: int) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Read inputs → sync in executor → persist, for one ROM under its lock.
@@ -384,6 +454,10 @@ class SyncEngine:
 
             # Refresh save-sort state before the migration gate — see #238.
             await self._refresh_save_sort_state("pre_launch_sync")
+
+            # Hard-gate: saves go to the content dir — sync is impossible (#239).
+            if self._save_sync_blocked():
+                return self._content_dir_skip()
 
             if self._rom_info.is_save_sort_changed():
                 return {
@@ -443,6 +517,11 @@ class SyncEngine:
             # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
             await self._refresh_save_sort_state("post_exit_sync")
 
+            # Hard-gate: saves go to the content dir — sync is impossible (#239).
+            if self._save_sync_blocked():
+                self._logger.info("post_exit_sync skipped: savefiles_in_content_dir")
+                return self._content_dir_skip()
+
             try:
                 await self._loop.run_in_executor(None, self._romm_api.heartbeat)
             except Exception:
@@ -490,6 +569,10 @@ class SyncEngine:
             # sync before any detect has fired.
             await self._refresh_save_sort_state("sync_rom_saves")
 
+            # Hard-gate: saves go to the content dir — sync is impossible (#239).
+            if self._save_sync_blocked():
+                return self._content_dir_skip()
+
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
@@ -525,6 +608,10 @@ class SyncEngine:
         # edit retroarch.cfg outside of a session and then trigger a manual
         # sync before any detect has fired.
         await self._refresh_save_sort_state("sync_all_saves")
+
+        # Hard-gate: saves go to the content dir — sync is impossible (#239).
+        if self._save_sync_blocked():
+            return self._content_dir_skip(all_saves=True)
 
         if not self.get_device_id():
             reg = await self.ensure_device_registered()
@@ -593,6 +680,17 @@ class SyncEngine:
         """
         rom_id_int = int(rom_id)
         async with self.rom_lock(rom_id_int):
+            # #239: RetroArch writes saves to the content dir — both keep_local
+            # (PUT after reading the local file under saves_dir) and use_server
+            # (download into saves_dir) write to a directory RetroArch ignores,
+            # so the resolution could not take effect. Refuse before the
+            # orchestrator does any server fetch or file write.
+            if await self.content_dir_blocked("resolve_sync_conflict"):
+                return {
+                    "success": False,
+                    "reason": SAVE_SYNC_IN_CONTENT_DIR_REASON,
+                    "message": SAVE_SYNC_IN_CONTENT_DIR,
+                }
             return await self._rollback.resolve(
                 rom_id_int,
                 filename,

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_status import compute_multi_file_slot
 from services.saves._helpers import local_save_target
 from services.saves._settings import resolve_default_slot
@@ -296,6 +297,13 @@ class VersionsService:
           ``.smpc``). Per-version rollback would revert one component and
           leave the others — an incoherent save — so it is refused.
           Interim #908 guard; grouped atomic-set rollback is tracked there.
+          The same status carries an additive
+          ``"reason": "savefiles_in_content_dir"`` field when the refusal is
+          instead because RetroArch writes saves to the content dir (#239):
+          the rollback's ``saves_dir`` target is ignored by RetroArch, so the
+          switch could never take effect. The frontend already hides the panel
+          via ``get_save_status``'s ``rollback_supported=False``; the
+          additive reason lets a direct caller distinguish the two causes.
         - ``{"status": "version_deleted"}`` if the chosen save id is no
           longer on the server (genuinely deleted — the ``list_saves``
           call succeeded and the id was absent).
@@ -334,6 +342,16 @@ class VersionsService:
             if compute_multi_file_slot(component_files).is_multi_file:
                 self._log_debug(f"rollback_to_version: multi-file slot for rom {rom_id} ({component_files}); refusing")
                 return {"status": "unsupported"}
+
+            # #239: RetroArch writes saves to the content dir — the rollback's
+            # download/PUT target is ``saves_dir``, which RetroArch ignores, so
+            # the switch could not take effect. Refuse before any preflight or
+            # destructive I/O. Reuse the existing ``unsupported`` status (the
+            # frontend already routes it to a benign refusal toast) and add the
+            # ``reason`` slug so a direct caller can distinguish the cause.
+            if await self._sync_engine.content_dir_blocked("rollback_to_version"):
+                self._log_debug(f"rollback_to_version: content-dir layout for rom {rom_id}; refusing")
+                return {"status": "unsupported", "reason": SAVE_SYNC_CONTENT_DIR_REASON}
 
             save_state, device_id = await self._loop.run_in_executor(None, self._read_inputs, rom_id)
             core_so = await self._loop.run_in_executor(None, self._resolve_core, rom_id)

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -17,6 +17,8 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
+
 if TYPE_CHECKING:
     import logging
 
@@ -265,6 +267,20 @@ class SessionLifecycleService:
                 conflicts=[],
                 toast_title=_TOAST_TITLE,
                 toast_body=_TOAST_BODY_FAILED,
+                conflicts_toast=None,
+            )
+
+        if result.get("reason") == SAVE_SYNC_CONTENT_DIR_REASON:
+            # #239 benign skip: RetroArch writes saves to the content dir, so post-exit
+            # sync correctly did nothing. Suppress the failure toast — the game-detail
+            # play section already shows the persistent banner.
+            return SessionFinalizeSyncResult(
+                offline=False,
+                success=False,
+                synced=0,
+                conflicts=[],
+                toast_title=None,
+                toast_body=None,
                 conflicts_toast=None,
             )
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -302,15 +302,16 @@ export const listDevices = callable<[], ListDevicesResponse>("list_devices");
 export const getSaveStatus = callable<[number], SaveStatus>("get_save_status");
 export const preLaunchSync = callable<
   [number],
-  { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[] }
+  { success: boolean; message: string; synced?: number; errors?: string[]; conflicts?: SyncConflict[]; reason?: string }
 >("pre_launch_sync");
 export const syncRomSaves = callable<
   [number],
-  { success: boolean; message: string; synced: number; errors?: string[]; conflicts?: SyncConflict[] }
+  { success: boolean; message: string; synced: number; errors?: string[]; conflicts?: SyncConflict[]; reason?: string }
 >("sync_rom_saves");
-export const syncAllSaves = callable<[], { success: boolean; message: string; synced: number; conflicts: number }>(
-  "sync_all_saves",
-);
+export const syncAllSaves = callable<
+  [],
+  { success: boolean; message: string; synced: number; conflicts: number; reason?: string }
+>("sync_all_saves");
 export const resolveSyncConflict = callable<
   [number, string, number, "keep_local" | "use_server"],
   { success: boolean; message?: string; error_code?: "stale_conflict"; action?: "keep_local" | "use_server" }

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -16,8 +16,10 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, waitFor, act } from "@testing-library/react";
+import { toaster } from "@decky/api";
 import { CustomPlayButton } from "./CustomPlayButton";
 import { emitDeckyEvent, deckyEventListenerCount } from "../test-utils/decky-api-mock";
+import * as backend from "../api/backend";
 import type { CachedGameDetail } from "../api/backend";
 import type { DownloadFailedEvent } from "../types";
 
@@ -117,5 +119,62 @@ describe("CustomPlayButton — download_failed listener", () => {
 
     unmount();
     expect(deckyEventListenerCount("download_failed")).toBe(0);
+  });
+});
+
+describe("CustomPlayButton — pre-launch savefiles_in_content_dir benign skip (#239)", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(toaster.toast).mockReset();
+    // Gate predecessors of runPreLaunchSync: tracking configured + no core change
+    // so handlePlay reaches preLaunchSync and then the launch dispatch.
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
+    vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
+    // RunGame is the launch sink — assert it fires on the benign-skip path.
+    vi.stubGlobal("SteamClient", {
+      Apps: { RunGame: vi.fn() },
+    });
+    vi.stubGlobal("appStore", {
+      GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
+      allApps: [],
+    });
+  });
+
+  it("treats the benign skip as a no-op: no error toast AND the game still launches", async () => {
+    vi.mocked(getCachedGameDetail).mockResolvedValue({
+      found: true,
+      rom_id: 42,
+      rom_name: "Test ROM",
+      installed: true,
+    });
+    // Backend benign-skip blocked shape: success:false but reason is the
+    // content-dir slug, synced 0, no errors, no conflicts.
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: false,
+      reason: "savefiles_in_content_dir",
+      message: "Save sync is unavailable: RetroArch is set to write saves to the content directory.",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+
+    await act(async () => {
+      playBtn.click();
+      // Drain the handlePlay gate chain (tracking → core → preLaunchSync → launch).
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Launch proceeded — RunGame fired with the resolved gameId.
+    expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
+    // No error / fallback toast surfaced for the benign skip.
+    expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
+    // No fallback-launch confirm modal was opened (would mean we treated it as failure).
+    expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42);
   });
 });

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -35,6 +35,7 @@ import { handleButtonDownloadFailure } from "../utils/downloadFailure";
 import { showCoreChangeModal } from "./CoreChangeModal";
 import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SyncConflict } from "../types";
+import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
 import { detach } from "../utils/detach";
 
 type PlayButtonState =
@@ -364,6 +365,16 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           `CustomPlayButton: preLaunchSync result: synced=${result.synced} conflicts=${result.conflicts?.length ?? 0} success=${result.success}`,
         ),
       );
+
+      // Benign skip (#239): RetroArch writes saves to the content dir, so sync
+      // is unsupported. NOT a failure — proceed to launch silently (no toast,
+      // no fallback-launch confirm). The "Save sync off" banner in
+      // RomMPlaySection already informs the user; nagging on every launch would
+      // be noise.
+      if (result.reason === SAVEFILES_IN_CONTENT_DIR_REASON) {
+        detach(debugLog("CustomPlayButton: pre-launch sync skipped (savefiles_in_content_dir) — launching"));
+        return "proceed";
+      }
 
       if (result.conflicts && result.conflicts.length > 0) {
         const conflictResult = await handleConflicts(result.conflicts);

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -2808,6 +2808,105 @@ describe("RomMPlaySection", () => {
       expect(queryByTitle("Emulator Core")).toBeNull();
     });
   });
+
+  // ------------------------------------------------------------------
+  // G. savefiles_in_content_dir warning banner (#239)
+  // ------------------------------------------------------------------
+
+  describe("savefiles_in_content_dir warning banner (#239)", () => {
+    // The content-dir probe reads getSaveStatus live (NOT getCachedGameDetail),
+    // gated only on romId + saveSyncEnabled — intentionally NOT on connectivity,
+    // so the banner surfaces offline. These tests force the connection check
+    // offline to prove the banner does not depend on a connected server.
+    function stubSaveStatus(romId: number, savefilesInContentDir: boolean) {
+      vi.mocked(backend.getSaveStatus).mockResolvedValue({
+        rom_id: romId,
+        files: [],
+        playtime: { total_seconds: 0, session_count: 0, last_session_start: null, last_session_duration_sec: null },
+        device_id: "d",
+        last_sync_check_at: null,
+        savefiles_in_content_dir: savefilesInContentDir,
+        save_sync_display: { status: "none", label: "Save sync off — saves in content dir", last_sync_check_at: null },
+      });
+    }
+
+    it("renders the WarningCard with the explanatory message when the flag is true", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: true,
+      });
+      stubSaveStatus(42, true);
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      // Non-vacuous: assert the visible banner copy, not just a flag.
+      expect(container.textContent).toContain("Save sync off");
+      expect(container.textContent).toContain(
+        "RetroArch's 'Write Saves to Content Directory' is enabled, so saves go next to the ROM and can't be synced.",
+      );
+      expect(container.textContent).toContain("RetroArch → Settings → Saving");
+    });
+
+    it("surfaces the banner even when the RomM server is OFFLINE (flag is local)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 7,
+        save_sync_enabled: true,
+      });
+      // Server unreachable — the connection effect goes offline, but the
+      // local-derived content-dir flag must still populate the banner.
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: false, message: "" });
+      stubSaveStatus(7, true);
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      // Offline indicator AND the banner are both present.
+      expect(container.textContent).toContain("RomM offline");
+      expect(container.textContent).toContain("Save sync off");
+      expect(container.textContent).toContain("can't be synced");
+    });
+
+    it("does NOT render the banner when the flag is false", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: true,
+      });
+      stubSaveStatus(42, false);
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
+      // The play row still renders (game remains playable).
+      expect(container.querySelector('[data-testid="play-button"]')).not.toBeNull();
+    });
+
+    it("does NOT probe getSaveStatus for the flag when save sync is disabled", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: false,
+      });
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: false, message: "" });
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(vi.mocked(backend.getSaveStatus)).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
+    });
+
+    it("logs via debugLog when the content-dir probe rejects (non-vacuous catch)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 42,
+        save_sync_enabled: true,
+      });
+      // Reject from getSaveStatus — the probe's catch must log, and the banner
+      // must stay hidden (flag defaults to false).
+      vi.mocked(backend.getSaveStatus).mockRejectedValue(new Error("cfgfail"));
+      const { container } = render(<RomMPlaySection appId={testAppId} />);
+      await flushAsync();
+      expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("content-dir probe error"));
+      expect(container.textContent).not.toContain("Write Saves to Content Directory");
+    });
+  });
 });
 
 // ----- Shared helpers — placed at the bottom of the file so they read like

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -25,6 +25,7 @@ import {
 import { basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { FaGamepad, FaCog, FaMicrochip, FaExclamationTriangle } from "react-icons/fa";
 import { CustomPlayButton } from "./CustomPlayButton";
+import { WarningCard } from "./WarningCard";
 import { SgdbGamePickerModalContent } from "./SgdbGamePickerModal";
 import { applyArtwork } from "../utils/artwork";
 import { hasAnySaveConflict } from "../utils/saveStatus";
@@ -86,6 +87,11 @@ interface InfoState {
   saveSyncEnabled: boolean;
   saveSyncStatus: "synced" | "conflict" | "none" | null;
   saveSyncLabel: string;
+  /** RetroArch `savefiles_in_content_dir=true` — saves go next to the ROM and
+   *  can't be synced (#239). Derived from a LOCAL retroarch.cfg read, so it is
+   *  populated even offline (independent of connectivity). Drives the prominent
+   *  "Save sync off" WarningCard. */
+  savefilesInContentDir: boolean;
   biosNeeded: boolean;
   biosStatus: "ok" | "partial" | "missing" | null; // NOSONAR(typescript:S4323) — inline union inside InfoState; extracting an alias adds indirection for no reuse benefit.
   biosLabel: string;
@@ -112,7 +118,7 @@ import { detach } from "../utils/detach";
 async function loadCached(
   appId: number,
   cancelled: () => boolean,
-  romIdRef: React.MutableRefObject<number | null>,
+  romIdRef: React.RefObject<number | null>,
   setter: React.Dispatch<React.SetStateAction<InfoState>>,
 ) {
   try {
@@ -219,6 +225,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     saveSyncEnabled: false,
     saveSyncStatus: null,
     saveSyncLabel: "",
+    savefilesInContentDir: false,
     biosNeeded: false,
     biosStatus: null,
     biosLabel: "",
@@ -253,12 +260,25 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         if (rid) {
           const saveStatus = await getSaveStatus(rid).catch((): SaveStatus | null => null);
           const { status: ss, label: sl } = applySaveSyncDisplay(saveStatus?.save_sync_display, saveStatus);
-          setInfo((prev) => ({ ...prev, saveSyncEnabled: true, saveSyncStatus: ss, saveSyncLabel: sl }));
+          setInfo((prev) => ({
+            ...prev,
+            saveSyncEnabled: true,
+            saveSyncStatus: ss,
+            saveSyncLabel: sl,
+            savefilesInContentDir: !!saveStatus?.savefiles_in_content_dir,
+          }));
         } else {
           setInfo((prev) => ({ ...prev, saveSyncEnabled: true }));
         }
       } else {
-        setInfo((prev) => ({ ...prev, saveSyncEnabled: false, saveSyncStatus: null, saveSyncLabel: "" }));
+        // Save sync turned off entirely — the content-dir banner is meaningless.
+        setInfo((prev) => ({
+          ...prev,
+          saveSyncEnabled: false,
+          saveSyncStatus: null,
+          saveSyncLabel: "",
+          savefilesInContentDir: false,
+        }));
       }
     };
 
@@ -376,6 +396,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
           ...prev,
           saveSyncStatus: ss,
           saveSyncLabel: sl,
+          savefilesInContentDir: !!saveStatus.savefiles_in_content_dir,
           activeSlot: "active_slot" in saveStatus ? (saveStatus.active_slot ?? null) : prev.activeSlot,
         }));
       } catch (e) {
@@ -425,6 +446,37 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       cancelled = true;
     };
   }, [info.saveSyncEnabled, appId]);
+
+  // Content-dir warning probe (#239) — populates `savefilesInContentDir` from a
+  // dedicated getSaveStatus call that is INTENTIONALLY NOT gated on connectivity.
+  // The backend derives `savefiles_in_content_dir` from a LOCAL retroarch.cfg
+  // read (independent of `server_query_failed`), so the banner must surface even
+  // when RomM is offline. The connected-only `doSaveCheck` above can't be relied
+  // on for this. We read getSaveStatus live (not getCachedGameDetail, which does
+  // not carry the flag and may be stale) and consume ONLY the content-dir flag —
+  // the server-dependent save-sync display is owned by doSaveCheck / the event
+  // handlers. Runs once romId + saveSyncEnabled are known.
+  useEffect(() => {
+    let cancelled = false;
+    const romId = info.romId;
+    if (!romId || !info.saveSyncEnabled) return;
+
+    async function probeContentDir(rid: number, isCancelled: () => boolean) {
+      try {
+        const saveStatus = await getSaveStatus(rid);
+        if (isCancelled()) return;
+        const inContentDir = saveStatus.savefiles_in_content_dir === true;
+        setInfo((prev) => ({ ...prev, savefilesInContentDir: inContentDir }));
+      } catch (e) {
+        detach(debugLog(`RomMPlaySection: content-dir probe error: ${e}`));
+      }
+    }
+
+    detach(probeContentDir(romId, () => cancelled));
+    return () => {
+      cancelled = true;
+    };
+  }, [info.romId, info.saveSyncEnabled]);
 
   // Reactive PLAYTIME display (#869) — re-read Steam's overview whenever the
   // playtime write-chokepoint (updatePlaytimeDisplay) fires romm_playtime_changed
@@ -1089,7 +1141,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     );
   }
 
-  return createElement(
+  const playSectionRow = createElement(
     Focusable,
     {
       "data-romm": "true",
@@ -1173,4 +1225,23 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       ),
     ),
   );
+
+  // Content-dir warning (#239) — prominent banner above the play row when
+  // RetroArch writes saves to the content directory. The play row still renders
+  // below it: the game remains fully playable, only save sync is unavailable.
+  if (info.savefilesInContentDir) {
+    return createElement(
+      "div",
+      { style: { display: "flex", flexDirection: "column" } },
+      createElement(WarningCard, {
+        key: "savefiles-content-dir-warning",
+        title: "Save sync off",
+        message:
+          "RetroArch's 'Write Saves to Content Directory' is enabled, so saves go next to the ROM and can't be synced. Turn it off in RetroArch → Settings → Saving to re-enable save sync.",
+      }),
+      playSectionRow,
+    );
+  }
+
+  return playSectionRow;
 };

--- a/src/types/saves.ts
+++ b/src/types/saves.ts
@@ -12,6 +12,12 @@ export interface SaveSyncSettings {
   autocleanup_limit: number;
 }
 
+/** The `reason` slug the sync callables return when save sync is blocked because
+ *  RetroArch writes saves to the content directory (#239). A BENIGN SKIP — the
+ *  game still launches and no error is surfaced. Mirrors the backend
+ *  `SAVE_SYNC_IN_CONTENT_DIR_REASON`. */
+export const SAVEFILES_IN_CONTENT_DIR_REASON = "savefiles_in_content_dir";
+
 export interface SyncConflict {
   type: "sync_conflict";
   rom_id: number;
@@ -96,6 +102,13 @@ export interface SaveStatus {
   /** False when per-version rollback is unavailable for the slot — currently
    *  only for multi-file saves (mirrors `!multi_file`). */
   rollback_supported?: boolean;
+  /** True when RetroArch's `savefiles_in_content_dir=true` — saves are written
+   *  next to the ROM, outside the saves tree the plugin syncs, so save sync is
+   *  unsupported. Derived from a LOCAL retroarch.cfg read, so it is correct even
+   *  when the server is unreachable (independent of `server_query_failed`). In
+   *  this case `files` is `[]` and `save_sync_display` reports the "off" state
+   *  (#239). */
+  savefiles_in_content_dir?: boolean;
 }
 
 export interface SaveSlotSummary {

--- a/tests/adapters/test_retroarch_config.py
+++ b/tests/adapters/test_retroarch_config.py
@@ -6,52 +6,39 @@ import logging
 from unittest.mock import patch
 
 from adapters.retroarch_config import RetroArchConfigAdapter
+from domain.save_layout import ContentDir, InSaveDir
 
 
 def _make_adapter(tmp_path) -> RetroArchConfigAdapter:
     return RetroArchConfigAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
 
 
-class TestRetroArchSaveSorting:
+def _write_cfg(tmp_path, text: str) -> None:
+    cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "retroarch.cfg").write_text(text)
+
+
+class TestSaveLayoutInSaveDir:
     def test_defaults_when_no_cfg(self, tmp_path):
-        """No cfg file found — returns RetroDECK defaults (True, False)."""
+        """No cfg file found — returns the RetroDECK-default InSaveDir(True, False)."""
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is True
-        assert sort_by_core is False
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=True, sort_by_core=False)
 
     def test_reads_sort_by_content_false(self, tmp_path):
-        cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
-        cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "retroarch.cfg").write_text(
-            'sort_savefiles_by_content_enable = "false"\nsort_savefiles_enable = "false"\n'
-        )
+        _write_cfg(tmp_path, 'sort_savefiles_by_content_enable = "false"\nsort_savefiles_enable = "false"\n')
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is False
-        assert sort_by_core is False
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=False, sort_by_core=False)
 
     def test_reads_sort_by_core_true(self, tmp_path):
-        cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
-        cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "retroarch.cfg").write_text(
-            'sort_savefiles_by_content_enable = "true"\nsort_savefiles_enable = "true"\n'
-        )
+        _write_cfg(tmp_path, 'sort_savefiles_by_content_enable = "true"\nsort_savefiles_enable = "true"\n')
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is True
-        assert sort_by_core is True
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=True, sort_by_core=True)
 
     def test_mixed_settings(self, tmp_path):
-        cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
-        cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "retroarch.cfg").write_text(
-            'sort_savefiles_by_content_enable = "false"\nsort_savefiles_enable = "true"\n'
-        )
+        _write_cfg(tmp_path, 'sort_savefiles_by_content_enable = "false"\nsort_savefiles_enable = "true"\n')
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is False
-        assert sort_by_core is True
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=False, sort_by_core=True)
 
     def test_standalone_retroarch_flatpak_path(self, tmp_path):
         """Falls back to the standalone RetroArch Flatpak path if RetroDECK's is missing."""
@@ -59,8 +46,9 @@ class TestRetroArchSaveSorting:
         cfg_dir.mkdir(parents=True, exist_ok=True)
         (cfg_dir / "retroarch.cfg").write_text('sort_savefiles_enable = "true"\n')
         adapter = _make_adapter(tmp_path)
-        _, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_core is True
+        layout = adapter.get_save_layout()
+        assert isinstance(layout, InSaveDir)
+        assert layout.sort_by_core is True
 
     def test_native_retroarch_path(self, tmp_path):
         """Falls back to ~/.config/retroarch/retroarch.cfg as last resort."""
@@ -68,43 +56,73 @@ class TestRetroArchSaveSorting:
         cfg_dir.mkdir(parents=True, exist_ok=True)
         (cfg_dir / "retroarch.cfg").write_text('sort_savefiles_by_content_enable = "false"\n')
         adapter = _make_adapter(tmp_path)
-        sort_by_content, _ = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is False
+        layout = adapter.get_save_layout()
+        assert isinstance(layout, InSaveDir)
+        assert layout.sort_by_content is False
 
     def test_ignores_unrelated_cfg_lines(self, tmp_path):
         """Cfg lines that don't match either sort key are skipped cleanly."""
-        cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
-        cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "retroarch.cfg").write_text(
+        _write_cfg(
+            tmp_path,
             "# RetroArch configuration\n"
             'video_driver = "glcore"\n'
             'audio_driver = "alsa"\n'
             'sort_savefiles_enable = "true"\n'
-            'some_other_option = "false"\n'
+            'some_other_option = "false"\n',
         )
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is True  # default
-        assert sort_by_core is True
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=True, sort_by_core=True)
 
     def test_cfg_line_order_does_not_matter(self, tmp_path):
         """``sort_savefiles_enable`` appears before ``sort_savefiles_by_content_enable``
         — parsing order does not change the result."""
-        cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
-        cfg_dir.mkdir(parents=True, exist_ok=True)
-        (cfg_dir / "retroarch.cfg").write_text(
-            'sort_savefiles_enable = "true"\nsort_savefiles_by_content_enable = "false"\n'
+        _write_cfg(tmp_path, 'sort_savefiles_enable = "true"\nsort_savefiles_by_content_enable = "false"\n')
+        adapter = _make_adapter(tmp_path)
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=False, sort_by_core=True)
+
+
+class TestSaveLayoutContentDir:
+    """``savefiles_in_content_dir=true`` wins over any sort flags — saves are
+    written next to the ROM, so plugin save sync is unsupported (#239)."""
+
+    def test_content_dir_true_returns_content_dir(self, tmp_path):
+        _write_cfg(tmp_path, 'savefiles_in_content_dir = "true"\n')
+        adapter = _make_adapter(tmp_path)
+        assert adapter.get_save_layout() == ContentDir()
+
+    def test_content_dir_true_overrides_sort_flags(self, tmp_path):
+        """When in-content-dir is on, the sort flags are irrelevant — ContentDir wins."""
+        _write_cfg(
+            tmp_path,
+            'savefiles_in_content_dir = "true"\n'
+            'sort_savefiles_by_content_enable = "true"\n'
+            'sort_savefiles_enable = "true"\n',
         )
         adapter = _make_adapter(tmp_path)
-        sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
-        assert sort_by_content is False
-        assert sort_by_core is True
+        assert adapter.get_save_layout() == ContentDir()
+
+    def test_content_dir_false_falls_through_to_in_save_dir(self, tmp_path):
+        """Explicit ``savefiles_in_content_dir = "false"`` reads the sort flags."""
+        _write_cfg(
+            tmp_path,
+            'savefiles_in_content_dir = "false"\n'
+            'sort_savefiles_by_content_enable = "false"\n'
+            'sort_savefiles_enable = "true"\n',
+        )
+        adapter = _make_adapter(tmp_path)
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=False, sort_by_core=True)
+
+    def test_content_dir_missing_defaults_to_in_save_dir(self, tmp_path):
+        """No ``savefiles_in_content_dir`` line — defaults to the InSaveDir branch."""
+        _write_cfg(tmp_path, 'sort_savefiles_enable = "true"\n')
+        adapter = _make_adapter(tmp_path)
+        assert adapter.get_save_layout() == InSaveDir(sort_by_content=True, sort_by_core=True)
 
 
 class TestOsErrorHandling:
     def test_permission_error_logs_and_returns_defaults(self, tmp_path, caplog):
         """The only candidate file raises PermissionError — adapter logs a
-        warning and returns RetroDECK defaults instead of crashing."""
+        warning and returns the RetroDECK-default InSaveDir instead of crashing."""
         cfg_dir = tmp_path / ".var" / "app" / "net.retrodeck.retrodeck" / "config" / "retroarch"
         cfg_dir.mkdir(parents=True, exist_ok=True)
         cfg_file = cfg_dir / "retroarch.cfg"
@@ -119,10 +137,9 @@ class TestOsErrorHandling:
 
         with patch("builtins.open", side_effect=fake_open), caplog.at_level(logging.WARNING):
             adapter = _make_adapter(tmp_path)
-            sort_by_content, sort_by_core = adapter.get_retroarch_save_sorting()
+            layout = adapter.get_save_layout()
 
-        assert sort_by_content is True  # RetroDECK default
-        assert sort_by_core is False
+        assert layout == InSaveDir(sort_by_content=True, sort_by_core=False)
         assert any("Failed to read" in rec.message for rec in caplog.records)
 
     def test_permission_error_on_first_candidate_tries_second(self, tmp_path, caplog):
@@ -148,7 +165,8 @@ class TestOsErrorHandling:
 
         with patch("builtins.open", side_effect=fake_open), caplog.at_level(logging.WARNING):
             adapter = _make_adapter(tmp_path)
-            _, sort_by_core = adapter.get_retroarch_save_sorting()
+            layout = adapter.get_save_layout()
 
-        assert sort_by_core is True
+        assert isinstance(layout, InSaveDir)
+        assert layout.sort_by_core is True
         assert any("Failed to read" in rec.message for rec in caplog.records)

--- a/tests/domain/test_save_layout.py
+++ b/tests/domain/test_save_layout.py
@@ -1,0 +1,51 @@
+"""Tests for domain.save_layout value objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.save_layout import ContentDir, InSaveDir, SaveLayout
+
+
+class TestInSaveDir:
+    def test_construction_exposes_flags(self):
+        layout = InSaveDir(sort_by_content=True, sort_by_core=False)
+        assert layout.sort_by_content is True
+        assert layout.sort_by_core is False
+
+    def test_equality_by_flags(self):
+        assert InSaveDir(sort_by_content=True, sort_by_core=True) == InSaveDir(sort_by_content=True, sort_by_core=True)
+
+    def test_inequality_on_differing_flags(self):
+        assert InSaveDir(sort_by_content=True, sort_by_core=False) != InSaveDir(
+            sort_by_content=False, sort_by_core=False
+        )
+
+    def test_frozen_rejects_mutation(self):
+        layout = InSaveDir(sort_by_content=True, sort_by_core=False)
+        with pytest.raises((AttributeError, TypeError)):
+            layout.sort_by_content = False  # type: ignore[misc]
+
+
+class TestContentDir:
+    def test_construction(self):
+        # No fields — purely a tag in the union.
+        assert ContentDir() == ContentDir()
+
+    def test_not_equal_to_in_save_dir(self):
+        assert ContentDir() != InSaveDir(sort_by_content=True, sort_by_core=False)
+
+    def test_frozen_rejects_attribute_set(self):
+        layout = ContentDir()
+        with pytest.raises((AttributeError, TypeError)):
+            layout.foo = 1  # type: ignore[attr-defined]
+
+
+class TestSaveLayoutUnion:
+    def test_isinstance_discriminates_the_union(self):
+        in_dir: SaveLayout = InSaveDir(sort_by_content=True, sort_by_core=False)
+        content: SaveLayout = ContentDir()
+        assert isinstance(in_dir, InSaveDir)
+        assert not isinstance(in_dir, ContentDir)
+        assert isinstance(content, ContentDir)
+        assert not isinstance(content, InSaveDir)

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -21,6 +21,7 @@ from adapters.save_file import SaveFileAdapter
 from domain.rom import Rom
 from domain.rom_install import RomInstall
 from domain.rom_save_state import FileSyncState, RomSaveState
+from domain.save_layout import InSaveDir
 from services.saves import SaveService, SaveServiceConfig
 
 
@@ -58,7 +59,10 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         "plugin_dir": str(tmp_path / "plugin"),
         "emit": emit if emit is not None else _noop_emit,
         "get_core_name": lambda core_so: None,
-        "detect_sort_change": lambda: None,
+        # Supported layout by default; tests that exercise the content-dir
+        # gate override both seams with a ``ContentDir``-returning callable.
+        "get_save_layout": lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
+        "detect_sort_change": lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
         "is_retrodeck_migration_pending": lambda: False,
         "uow_factory": FakeUnitOfWorkFactory(),
     }

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -10,6 +10,7 @@ import logging
 
 import pytest
 
+from domain.save_layout import ContentDir, InSaveDir
 from lib.errors import RommApiError
 from tests.services.saves._helpers import (
     _create_save,
@@ -705,6 +706,122 @@ class TestSyncEngineDelegates:
         assert result["success"] is True
         assert len(result["devices"]) == 1
         assert result["devices"][0]["is_current_device"] is True
+
+
+class TestSaveSyncContentDirGate:
+    """All four public sync entry points hard-gate save sync when RetroArch
+    writes saves to the content dir (savefiles_in_content_dir=true). The gate
+    reads ``_current_layout``, populated from ``detect_sort_change``'s return at
+    the top of each flow. The result is the benign-skip shape the frontend
+    treats as "skip, no error, launch proceeds" (#239)."""
+
+    _CONTENT_DIR_SKIP_MESSAGE_FRAGMENT = "content directory"
+
+    def _assert_benign_skip(self, result, *, all_saves=False):
+        assert result["success"] is False
+        assert result["reason"] == "savefiles_in_content_dir"
+        assert self._CONTENT_DIR_SKIP_MESSAGE_FRAGMENT in result["message"]
+        assert result["synced"] == 0
+        assert result["errors"] == []
+        if all_saves:
+            assert result["conflicts"] == 0
+            assert result["conflicts_list"] == []
+            assert result["roms_checked"] == 0
+        else:
+            assert result["conflicts"] == []
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_skips_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        ss = _server_save()
+        fake.saves[100] = ss
+
+        result = await svc.pre_launch_sync(42)
+
+        self._assert_benign_skip(result)
+        # No sync ran — the gate fired before any transfer.
+        assert not any(c[0] in ("upload_save", "download_save_content") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_skips_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"unsyncable")
+
+        result = await svc.post_exit_sync(42)
+
+        self._assert_benign_skip(result)
+        # The gate fires before the heartbeat probe and before any upload.
+        assert not any(c[0] in ("upload_save", "heartbeat") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_skips_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"unsyncable")
+
+        result = await svc.sync_rom_saves(42)
+
+        self._assert_benign_skip(result)
+        assert not any(c[0] in ("upload_save", "download_save_content") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_skips_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        result = await svc.sync_all_saves()
+
+        self._assert_benign_skip(result, all_saves=True)
+        assert not any(c[0] in ("upload_save", "download_save_content") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_in_save_dir_layout_does_not_block(self, tmp_path):
+        """Control: a supported InSaveDir layout syncs normally — no gate."""
+        svc, _ = make_service(
+            tmp_path,
+            detect_sort_change=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
+        )
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        result = await svc.sync_rom_saves(42)
+
+        assert result["success"] is True
+        assert "reason" not in result
+        assert result["synced"] == 1
+
+    @pytest.mark.asyncio
+    async def test_detect_failure_fails_open_does_not_block(self, tmp_path):
+        """A detect that raises leaves ``_current_layout`` unset — sync proceeds."""
+
+        def boom():
+            raise RuntimeError("cfg unreadable")
+
+        svc, _ = make_service(tmp_path, detect_sort_change=boom)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"progress")
+
+        result = await svc.sync_rom_saves(42)
+
+        # Fail-open: no benign-skip reason, sync ran.
+        assert "reason" not in result
+        assert result["success"] is True
+        assert result["synced"] == 1
 
 
 class TestPreLaunchSaveSortGate:

--- a/tests/services/saves/sync_engine/test_rollback.py
+++ b/tests/services/saves/sync_engine/test_rollback.py
@@ -11,6 +11,7 @@ import os
 import pytest
 
 from domain.rom_save_state import FileSyncState, RomSaveState
+from domain.save_layout import ContentDir
 from lib.errors import RommApiError
 from tests.services.saves._helpers import (
     _create_save,
@@ -509,3 +510,78 @@ class TestResolveSyncConflictStaleConflict:
         assert upload_calls[0][2]["save_id"] == 100
         file_state = _require_save_state(svc, 42).files["pokemon.srm"]
         assert file_state.last_sync_hash == local_hash
+
+
+class TestResolveSyncConflictContentDirGate:
+    """#239: both keep_local (PUT after reading the local file under saves_dir)
+    and use_server (download into saves_dir) write to a directory RetroArch
+    ignores in content-dir mode — so conflict resolution is refused before any
+    server fetch or file write."""
+
+    def _seed_conflict(self, svc, tmp_path):
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path, content=b"local content")
+        _seed_save_state(
+            svc,
+            42,
+            RomSaveState(
+                active_slot="default",
+                files={
+                    "pokemon.srm": FileSyncState(
+                        last_sync_hash=_file_md5(str(save_path)),
+                        tracked_save_id=100,
+                    ),
+                },
+            ),
+        )
+        return save_path
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("action", ["keep_local", "use_server"])
+    async def test_refuses_and_writes_nothing_on_content_dir(self, tmp_path, action):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        save_path = self._seed_conflict(svc, tmp_path)
+        original = save_path.read_bytes()
+        fake.saves[100] = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action=action,
+        )
+
+        assert result["success"] is False
+        assert result["reason"] == "savefiles_in_content_dir"
+        assert "content directory" in result["message"]
+        # No server fetch, no download, no upload — gate fired before the orchestrator.
+        assert not any(c[0] in ("list_saves", "download_save_content", "upload_save") for c in fake.call_log), (
+            fake.call_log
+        )
+        # Local file untouched.
+        assert save_path.read_bytes() == original
+
+    @pytest.mark.asyncio
+    async def test_in_save_dir_layout_still_resolves(self, tmp_path):
+        """Control: a supported layout resolves the conflict normally (no gate)."""
+        svc, fake = make_service(tmp_path)  # default layout is InSaveDir
+        save_path = self._seed_conflict(svc, tmp_path)
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        fake.saves[100] = ss
+        # Identical content so keep_local short-circuits to adopt-without-upload.
+        fake.uploaded_files[100] = str(save_path)
+
+        result = await svc.resolve_sync_conflict(
+            rom_id=42,
+            filename="pokemon.srm",
+            server_save_id=100,
+            action="keep_local",
+        )
+
+        assert result["success"] is True
+        assert "reason" not in result

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -6,6 +6,7 @@ import hashlib
 import pytest
 
 from domain.rom_save_state import FileSyncState, RomSaveState
+from domain.save_layout import ContentDir
 from lib.errors import RommApiError
 from tests.services.saves._helpers import (
     _create_save,
@@ -1068,6 +1069,115 @@ class TestSwitchSlot:
         # Must be "" (legacy key), NOT "default"
         assert "" in slot_names
         assert "default" not in slot_names
+
+
+class TestSlotsContentDirGate:
+    """#239: slot-switch and slot-choice migration write to ``saves_dir``,
+    which RetroArch ignores in content-dir mode — so they are refused before
+    any download / upload / delete I/O."""
+
+    @pytest.mark.asyncio
+    async def test_switch_slot_refuses_and_writes_nothing_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+        local_hash = _file_md5(str(save_path))
+        _seed_save_state(
+            svc,
+            42,
+            RomSaveState(
+                active_slot="default",
+                slot_confirmed=True,
+                files={
+                    "pokemon.srm": FileSyncState(
+                        last_sync_hash=local_hash,
+                        last_sync_at="2026-01-01T00:00:00Z",
+                        tracked_save_id=100,
+                    ),
+                },
+            ),
+        )
+        # Server has a save in the target slot — must not be downloaded.
+        fake.saves[200] = _server_save(save_id=200, slot="desktop")
+
+        result = await svc.switch_slot(42, "desktop")
+
+        assert result["success"] is False
+        assert result["reason"] == "savefiles_in_content_dir"
+        assert "content directory" in result["message"]
+        # Active slot unchanged, no download, no list_saves, local file untouched.
+        assert _require_save_state(svc, 42).active_slot == "default"
+        assert not any(c[0] in ("download_save_content", "list_saves") for c in fake.call_log), fake.call_log
+        assert save_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_switch_slot_in_save_dir_still_switches(self, tmp_path):
+        """Control: a supported layout switches normally (no gate)."""
+        svc, fake = make_service(tmp_path)  # default layout is InSaveDir
+        svc._config.settings["save_sync_enabled"] = True
+        _install_rom(svc, tmp_path)
+        save_path = _create_save(tmp_path)
+        local_hash = _file_md5(str(save_path))
+        _seed_save_state(
+            svc,
+            42,
+            RomSaveState(
+                active_slot="default",
+                slot_confirmed=True,
+                files={
+                    "pokemon.srm": FileSyncState(
+                        last_sync_hash=local_hash,
+                        last_sync_at="2026-01-01T00:00:00Z",
+                        tracked_save_id=100,
+                    ),
+                },
+            ),
+        )
+        fake.saves[200] = _server_save(save_id=200, slot="desktop")
+
+        result = await svc.switch_slot(42, "desktop")
+
+        assert result["success"] is True
+        assert "reason" not in result
+        assert _require_save_state(svc, 42).active_slot == "desktop"
+
+    @pytest.mark.asyncio
+    async def test_confirm_slot_choice_migration_refused_on_content_dir(self, tmp_path):
+        """Migration path is refused (no upload/delete) but the slot still confirms."""
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[1] = _server_save(save_id=1, slot="desktop")
+
+        result = await svc.confirm_slot_choice(42, "default", migrate_from_slot="desktop")
+
+        assert result["success"] is False
+        assert result["reason"] == "savefiles_in_content_dir"
+        assert "content directory" in result["message"]
+        # No migration I/O — gate fired before the upload/delete/list path.
+        assert not any(c[0] in ("upload_save", "delete_server_saves", "list_saves") for c in fake.call_log), (
+            fake.call_log
+        )
+        # The slot confirmation itself (a metadata flip, no file write) still persisted.
+        assert _require_save_state(svc, 42).slot_confirmed is True
+
+    @pytest.mark.asyncio
+    async def test_confirm_slot_choice_no_migration_not_gated_on_content_dir(self, tmp_path):
+        """The non-migration path writes no files, so it is never gated."""
+        svc, _ = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+
+        result = await svc.confirm_slot_choice(42, "default")
+
+        # No migration requested → no gate, slot confirmed normally.
+        assert result["success"] is True
+        assert "reason" not in result
+        assert _require_save_state(svc, 42).slot_confirmed is True
 
 
 class TestDeleteSlot:

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -6,6 +6,7 @@ import threading
 import pytest
 
 from domain.rom_save_state import RomSaveState
+from domain.save_layout import ContentDir, InSaveDir
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
@@ -103,6 +104,72 @@ class TestSaveStatus:
         assert len(result["files"]) == 1
         assert result["files"][0]["status"] == "upload"
         assert result["files"][0]["server_save_id"] is None
+
+
+class TestSaveStatusContentDir:
+    """get_save_status surfaces the additive ``savefiles_in_content_dir`` flag
+    and a "not supported" display when RetroArch writes saves next to the ROM,
+    while keeping playtime / device_id intact (#239)."""
+
+    @pytest.mark.asyncio
+    async def test_content_dir_sets_flag_and_skips_local_probing(self, tmp_path):
+        svc, _ = make_service(tmp_path, get_save_layout=lambda: ContentDir())
+        _install_rom(svc, tmp_path)
+        # A local save file exists, but content-dir mode must NOT probe for it.
+        _create_save(tmp_path)
+
+        result = await svc.get_save_status(42)
+
+        assert result["savefiles_in_content_dir"] is True
+        # Local probing skipped → no files surfaced even though one exists on disk.
+        assert result["files"] == []
+        # Display reads "not supported", not a misleading "No saves".
+        assert result["save_sync_display"]["status"] == "none"
+        assert "content dir" in result["save_sync_display"]["label"].lower()
+        # Rollback is explicitly unsupported in content-dir mode (#239) — not
+        # left to ``files == []`` to suppress the UI.
+        assert result["rollback_supported"] is False
+
+    @pytest.mark.asyncio
+    async def test_in_save_dir_rollback_supported_true(self, tmp_path):
+        """Control: a supported single-file layout keeps ``rollback_supported`` True."""
+        svc, _ = make_service(tmp_path, get_save_layout=lambda: InSaveDir(sort_by_content=True, sort_by_core=False))
+        _install_rom(svc, tmp_path)
+
+        result = await svc.get_save_status(42)
+
+        assert result["savefiles_in_content_dir"] is False
+        assert result["rollback_supported"] is True
+
+    @pytest.mark.asyncio
+    async def test_content_dir_keeps_playtime_and_device_id(self, tmp_path):
+        svc, _ = make_service(tmp_path, get_save_layout=lambda: ContentDir())
+        _install_rom(svc, tmp_path)
+        _set_device_id(svc, "server-dev-1")
+
+        result = await svc.get_save_status(42)
+
+        assert result["savefiles_in_content_dir"] is True
+        # Non-destructive: identity fields are still present.
+        assert result["device_id"] == "server-dev-1"
+        assert result["rom_id"] == 42
+        assert "playtime" in result
+
+    @pytest.mark.asyncio
+    async def test_in_save_dir_sets_flag_false_and_behaves_normally(self, tmp_path):
+        svc, fake = make_service(
+            tmp_path,
+            get_save_layout=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
+        )
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)
+        fake.saves[100] = _server_save()
+
+        result = await svc.get_save_status(42)
+
+        assert result["savefiles_in_content_dir"] is False
+        # Normal behaviour: the local file is probed and surfaced.
+        assert len(result["files"]) >= 1
 
 
 class TestGetSaveStatusComputeAction:

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from domain.save_layout import ContentDir
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
@@ -800,3 +801,59 @@ class TestRollbackToVersion:
         # tracked_save_id still 50
         file_state = _require_save_state(svc, 42).files["pokemon.srm"]
         assert file_state.tracked_save_id == 50
+
+
+class TestRollbackToVersionContentDirGate:
+    """#239: rollback writes to ``saves_dir``, which RetroArch ignores in
+    content-dir mode — so it is refused before any preflight or destructive I/O."""
+
+    @pytest.mark.asyncio
+    async def test_refuses_and_writes_nothing_on_content_dir(self, tmp_path):
+        svc, fake = make_service(tmp_path, detect_sort_change=lambda: ContentDir())
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": local_hash}},
+            },
+        )
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.rollback_to_version(42, "default", 50)
+
+        # Reuses the existing ``unsupported`` status + additive reason slug.
+        assert result == {"status": "unsupported", "reason": "savefiles_in_content_dir"}
+        # No preflight sync, no download, no PUT — gate fired before any I/O.
+        assert not any(c[0] in ("upload_save", "download_save_content", "list_saves") for c in fake.call_log), (
+            fake.call_log
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_save_dir_layout_still_rolls_back(self, tmp_path):
+        """Control: a supported layout rolls back normally (no gate)."""
+        svc, fake = make_service(tmp_path)  # default layout is InSaveDir
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        _install_rom(svc, tmp_path)
+        _enable_sync_with_device(svc)
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "files": {"pokemon.srm": {"tracked_save_id": 50, "last_sync_hash": local_hash}},
+            },
+        )
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-02-01T10:00:00Z")
+
+        result = await svc.rollback_to_version(42, "default", 50)
+
+        assert result["status"] == "ok"
+        assert "reason" not in result

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -22,6 +22,7 @@ from adapters.firmware_file import FirmwareFileAdapter
 from adapters.save_file import SaveFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.rom_save_state import FileSyncState
+from domain.save_layout import InSaveDir
 from services.achievements import AchievementsService, AchievementsServiceConfig
 from services.firmware import FirmwareService, FirmwareServiceConfig
 from services.game_detail import GameDetailService, GameDetailServiceConfig
@@ -99,7 +100,8 @@ def plugin(tmp_path):
             plugin_dir=str(tmp_path / "plugin"),
             emit=AsyncMock(),
             get_core_name=lambda core_so: None,
-            detect_sort_change=lambda: None,
+            get_save_layout=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
+            detect_sort_change=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
             is_retrodeck_migration_pending=lambda: False,
             uow_factory=FakeUnitOfWorkFactory(),
         ),

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -22,6 +22,7 @@ from adapters.firmware_file import FirmwareFileAdapter
 from adapters.migration_file import MigrationFileAdapter
 from adapters.persistence import PersistenceAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_layout import InSaveDir, SaveLayout
 from services.active_core_resolver import ActiveCoreResolver, ActiveCoreResolverConfig
 from services.firmware import FirmwareService, FirmwareServiceConfig
 from services.library import LibraryService, LibraryServiceConfig
@@ -117,8 +118,8 @@ def plugin(tmp_path, fake_romm_api):
     def _no_core_name(core_so: str) -> str | None:
         return None
 
-    def _default_save_sorting() -> tuple[bool, bool]:
-        return (True, False)
+    def _default_save_layout() -> SaveLayout:
+        return InSaveDir(sort_by_content=True, sort_by_core=False)
 
     p._migration_service = MigrationService(
         config=MigrationServiceConfig(
@@ -130,7 +131,7 @@ def plugin(tmp_path, fake_romm_api):
             emit=RecordingEmitter(),
             get_bios_files_index=lambda: p._firmware_service.bios_files_index,
             retrodeck_paths=FakeRetroDeckPaths(),
-            get_retroarch_save_sorting=_default_save_sorting,
+            get_save_layout=_default_save_layout,
             active_core=p._active_core,
             get_core_name=_no_core_name,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -1418,7 +1419,7 @@ class TestDetectSaveSortChangeThreadSafety:
 
         with plugin._uow as uow:
             uow.kv_config.set("save_sort_settings", json.dumps({"sort_by_content": True, "sort_by_core": False}))
-        plugin._migration_service._get_retroarch_save_sorting = lambda: (True, True)
+        plugin._migration_service._get_save_layout = lambda: InSaveDir(sort_by_content=True, sort_by_core=True)
 
         # Use an ``asyncio.Queue``-backed emitter so the test can await the
         # emission from the loop thread regardless of which thread scheduled
@@ -1475,7 +1476,7 @@ class TestMigrationFailureInjection:
             "emit": RecordingEmitter(),
             "get_bios_files_index": dict,
             "retrodeck_paths": FakeRetroDeckPaths(),
-            "get_retroarch_save_sorting": lambda: (False, False),
+            "get_save_layout": lambda: InSaveDir(sort_by_content=False, sort_by_core=False),
             "active_core": FakeActiveCoreResolver(default=(None, None)),
             "get_core_name": lambda core_so: None,
             "uow_factory": FakeUnitOfWorkFactory(uow=uow),

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -18,6 +18,7 @@ from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from adapters.migration_file import MigrationFileAdapter
 from domain.rom import Rom
 from domain.rom_install import RomInstall
+from domain.save_layout import ContentDir, InSaveDir, SaveLayout
 from services.migration import MigrationService, MigrationServiceConfig
 
 if TYPE_CHECKING:
@@ -76,6 +77,7 @@ def _make_service(
     tmp_path,
     *,
     sort_settings=(True, False),
+    save_layout=None,
     installed_roms=None,
     state_overrides=None,
     active_core=None,
@@ -87,6 +89,10 @@ def _make_service(
     Returns (service, uow) so callers can seed installs/markers and assert on the
     commit flag and the kv_config values. Pass ``migration_file_store`` to swap
     the real ``MigrationFileAdapter`` for a fake when a test needs failure injection.
+
+    ``sort_settings`` is the ``(sort_by_content, sort_by_core)`` tuple the
+    ``InSaveDir`` layout is built from. Pass an explicit ``save_layout``
+    (e.g. ``ContentDir()``) to override the supported-layout default.
     """
     uow = FakeUnitOfWork()
     if installed_roms:
@@ -96,6 +102,12 @@ def _make_service(
 
     saves_path = str(tmp_path / "saves")
     roms_path = str(tmp_path / "roms")
+
+    layout: SaveLayout = (
+        save_layout
+        if save_layout is not None
+        else InSaveDir(sort_by_content=sort_settings[0], sort_by_core=sort_settings[1])
+    )
 
     svc = MigrationService(
         config=MigrationServiceConfig(
@@ -112,7 +124,7 @@ def _make_service(
                 bios=str(tmp_path / "bios"),
                 home=str(tmp_path),
             ),
-            get_retroarch_save_sorting=lambda: sort_settings,
+            get_save_layout=lambda: layout,
             active_core=active_core if active_core is not None else FakeActiveCoreResolver(default=(None, None)),
             get_core_name=get_core_name,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -128,8 +140,10 @@ class TestDetectSaveSortChange:
         mock_loop = MagicMock()
         svc._loop = mock_loop
 
-        svc.detect_save_sort_change()
+        layout = svc.detect_save_sort_change()
 
+        # Returns the live InSaveDir layout it observed.
+        assert layout == InSaveDir(sort_by_content=True, sort_by_core=False)
         with uow:
             assert _read_marker(uow, "save_sort_settings") == {
                 "sort_by_content": True,
@@ -150,13 +164,65 @@ class TestDetectSaveSortChange:
         svc._loop = mock_loop
         set_count_before = uow.kv_config.set_count
 
-        svc.detect_save_sort_change()
+        layout = svc.detect_save_sort_change()
 
+        assert layout == InSaveDir(sort_by_content=True, sort_by_core=False)
         mock_loop.create_task.assert_not_called()
         # No marker write occurred (no new kv_config.set beyond the seed).
         assert uow.kv_config.set_count == set_count_before
         with uow:
             assert uow.kv_config.get("save_sort_settings_previous") is None
+
+
+class TestDetectSaveSortChangeContentDir:
+    """ContentDir layout (savefiles_in_content_dir=true) is unsupported — the
+    detect pass must never touch the kv_config sort markers, must return the
+    ContentDir layout for the SyncEngine gate, and must warn only once."""
+
+    def test_content_dir_returns_layout_and_writes_no_markers(self, tmp_path):
+        """ContentDir → no kv_config write at all, returns ContentDir()."""
+        svc, uow = _make_service(tmp_path, save_layout=ContentDir())
+        mock_loop = MagicMock()
+        svc._loop = mock_loop
+        set_count_before = uow.kv_config.set_count
+
+        layout = svc.detect_save_sort_change()
+
+        assert isinstance(layout, ContentDir)
+        # No sort markers written — content-dir saves are outside the saves tree.
+        assert uow.kv_config.set_count == set_count_before
+        with uow:
+            assert uow.kv_config.get("save_sort_settings") is None
+            assert uow.kv_config.get("save_sort_settings_previous") is None
+        mock_loop.create_task.assert_not_called()
+
+    def test_content_dir_does_not_overwrite_existing_sort_markers(self, tmp_path):
+        """A pre-existing InSaveDir observation survives a ContentDir detect."""
+        svc, uow = _make_service(
+            tmp_path,
+            save_layout=ContentDir(),
+            state_overrides={"save_sort_settings": {"sort_by_content": True, "sort_by_core": False}},
+        )
+        set_count_before = uow.kv_config.set_count
+
+        layout = svc.detect_save_sort_change()
+
+        assert isinstance(layout, ContentDir)
+        assert uow.kv_config.set_count == set_count_before
+        with uow:
+            assert _read_marker(uow, "save_sort_settings") == {"sort_by_content": True, "sort_by_core": False}
+
+    def test_content_dir_warns_once_per_process(self, tmp_path, caplog):
+        """The unsupported-state warning fires once, not on every detect pass."""
+        svc, _ = _make_service(tmp_path, save_layout=ContentDir())
+
+        with caplog.at_level(logging.WARNING):
+            svc.detect_save_sort_change()
+            svc.detect_save_sort_change()
+            svc.detect_save_sort_change()
+
+        content_dir_warnings = [r for r in caplog.records if "savefiles_in_content_dir" in r.getMessage()]
+        assert len(content_dir_warnings) == 1
 
     def test_change_emits_event(self, tmp_path):
         """Settings changed — emits event, stores old + new."""
@@ -187,10 +253,11 @@ class TestDetectSaveSortChange:
         original = migration_module.asyncio.run_coroutine_threadsafe
         migration_module.asyncio.run_coroutine_threadsafe = fake_schedule  # type: ignore[assignment]
         try:
-            svc.detect_save_sort_change()
+            layout = svc.detect_save_sort_change()
         finally:
             migration_module.asyncio.run_coroutine_threadsafe = original  # type: ignore[assignment]
 
+        assert layout == InSaveDir(sort_by_content=False, sort_by_core=True)
         with uow:
             assert _read_marker(uow, "save_sort_settings") == {
                 "sort_by_content": False,

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -362,6 +362,63 @@ class TestFinalizeSyncToasts:
         assert result.sync.toast_body is None
 
 
+class TestFinalizeContentDirBenignSkip:
+    """#239: when post-exit sync returns the ``savefiles_in_content_dir`` reason,
+    the sync correctly did nothing — suppress the false-failure toast."""
+
+    def test_content_dir_reason_suppresses_failure_toast(self, event_loop, logger):
+        """benign-skip dict → no toast (title/body None), conflicts empty, no false failure."""
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "reason": "savefiles_in_content_dir",
+                "message": "Save sync is unavailable: RetroArch is set to write saves to the content directory.",
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        # The post-exit sync ran (benign skip is the sync's own verdict)...
+        assert post.calls == [99]
+        # ...but NO toast fires — neither the failure toast nor any other.
+        assert result.sync.toast_title is None
+        assert result.sync.toast_body is None
+        assert result.sync.conflicts_toast is None
+        # Verdict flags reflect a non-error skip.
+        assert result.sync.offline is False
+        assert result.sync.success is False
+        assert result.sync.synced == 0
+        assert result.sync.conflicts == []
+
+    def test_failure_without_content_dir_reason_still_renders_failure_toast(self, event_loop, logger):
+        """Control: a plain ``success=False`` (no content-dir reason) keeps the failure toast."""
+        post = FakePostExitSync(payload={"success": False, "synced": 0, "conflicts": []})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+
+
 class TestFinalizeConflicts:
     def test_single_conflict_renders_singular_string(self, event_loop, logger):
         """One conflict → "1 save conflict need resolution" (singular form)."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -36,6 +36,7 @@ from adapters.retrodeck_paths import RetroDeckPathsAdapter
 from adapters.romm.http import RommHttpAdapter
 from adapters.romm.romm_api import RommApiAdapter
 from adapters.steam_config import SteamConfigAdapter
+from domain.save_layout import InSaveDir
 from services.achievements import AchievementsService
 from services.cores import CoreService
 from services.downloads import DownloadService
@@ -224,7 +225,7 @@ class TestWireServices:
                 bios=str(tmp_path / "retrodeck" / "bios"),
                 home=str(tmp_path / "retrodeck"),
             ),
-            "get_retroarch_save_sorting": MagicMock(return_value=(True, False)),
+            "get_save_layout": MagicMock(return_value=InSaveDir(sort_by_content=True, sort_by_core=False)),
             "get_core_name": MagicMock(return_value="Snes9x"),
             "platform_core_reader": FakePlatformCoreReader(),
             "settings_persister": MagicMock(),
@@ -270,7 +271,7 @@ class TestWireServices:
             ),
             callbacks=CallbackBundle(
                 retrodeck_paths=deps["retrodeck_paths"],
-                get_retroarch_save_sorting=deps["get_retroarch_save_sorting"],
+                get_save_layout=deps["get_save_layout"],
                 get_core_name=deps["get_core_name"],
                 platform_core_reader=deps["platform_core_reader"],
                 settings_persister=deps["settings_persister"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -886,7 +886,7 @@ class TestMainStartupOrdering:
             ),
             callbacks=CallbackBundle(
                 retrodeck_paths=MagicMock(),
-                get_retroarch_save_sorting=MagicMock(),
+                get_save_layout=MagicMock(),
                 get_core_name=MagicMock(),
                 platform_core_reader=MagicMock(),
                 settings_persister=MagicMock(),

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -25,6 +25,7 @@ from domain.playtime import Playtime
 from domain.rom import Rom
 from domain.rom_install import RomInstall
 from domain.rom_save_state import FileSyncState, RomSaveState
+from domain.save_layout import InSaveDir
 from services.library import LibraryService, LibraryServiceConfig
 from services.migration import MigrationService, MigrationServiceConfig
 from services.playtime import PlaytimeService, PlaytimeServiceConfig
@@ -105,7 +106,8 @@ def plugin(tmp_path):
             plugin_dir=str(tmp_path / "plugin"),
             emit=AsyncMock(),
             get_core_name=lambda core_so: None,
-            detect_sort_change=lambda: None,
+            get_save_layout=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
+            detect_sort_change=lambda: InSaveDir(sort_by_content=True, sort_by_core=False),
             is_retrodeck_migration_pending=lambda: False,
             uow_factory=p._uow_factory,
         ),
@@ -509,9 +511,9 @@ class TestPostExitSync:
 
         # Wire a REAL MigrationService on the SAME UoW as the plugin's
         # SaveService, then point SaveService's ``detect_sort_change`` at the
-        # real bound method. ``get_retroarch_save_sorting`` reports the CURRENT
-        # on-disk cfg (NEW: sort_by_content=False, sort_by_core=False) — the
-        # mismatch with the stored marker is what detect will discover.
+        # real bound method. ``get_save_layout`` reports the CURRENT on-disk
+        # cfg (NEW: sort_by_content=False, sort_by_core=False) — the mismatch
+        # with the stored marker is what detect will discover.
         real_migration = MigrationService(
             config=MigrationServiceConfig(
                 migration_file_store=MigrationFileAdapter(),
@@ -522,7 +524,7 @@ class TestPostExitSync:
                 emit=MagicMock(),
                 get_bios_files_index=dict,
                 retrodeck_paths=FakeRetroDeckPaths(),
-                get_retroarch_save_sorting=lambda: (False, False),
+                get_save_layout=lambda: InSaveDir(sort_by_content=False, sort_by_core=False),
                 active_core=FakeActiveCoreResolver(default=(None, None)),
                 get_core_name=lambda core_so: None,
                 uow_factory=plugin._uow_factory,


### PR DESCRIPTION
Closes #239.

## What

RetroArch's `savefiles_in_content_dir` setting makes RetroArch write saves next to the ROM instead of the configured saves directory — where the plugin's per-game save sync can't see or reach them. The plugin previously ignored the setting and would silently sync nothing.

This change detects it and surfaces it instead of failing silently:

- Reads RetroArch's three save-location keys into a `SaveLayout` value type — `InSaveDir(sort_by_content, sort_by_core)` (the supported layouts) or `ContentDir` (unsupported). The sum type makes the contradictory `content_dir + sort` state unrepresentable.
- When `ContentDir`, **hard-gates every save-write path** — the four sync entry points (pre-launch, post-exit, per-ROM, all) plus rollback, slot switch, conflict resolution, and slot migration. The gate is a benign skip: nothing is written, no error toast fires, and the game still launches.
- Surfaces a banner in the game-detail play section explaining how to turn the setting back off. It shows even offline (the check is a local config read).

Actually syncing ROM-adjacent saves remains out of scope — deferred to the multi-emulator save work (#129 / #255).

## Docs

Corrects a factual error in `docs/architecture/save-file-sync-architecture.md`: RetroDECK does **not** re-pin `savefile_directory` "on every launch" — verified against RetroDECK source, it only happens on config reset / data-move / first-run install. So `savefiles_in_content_dir` is a *persistent* blind spot, which is why the plugin reads the layout live on every sync. The section now documents the detect/gate/warn behavior.

## Tests

Unit coverage for the new domain type, the adapter's three-key parse, the migration branch (ContentDir writes no save-sort migration markers), the gate on every save-write path (asserting no upload/download/file-write occurs), the `get_save_status` flag, the post-exit toast suppression (gated on the reason, not on `success`), and the frontend banner (online + offline) + benign-skip launch path.