### PR TITLE
chore: add worktree:new mise task for fresh-worktree env setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,10 @@ _.python.venv = { path = ".venv", create = true }
 description = "Install JS and Python dependencies"
 run = ["pnpm install", "uv pip install -r requirements-dev.txt", "git config core.hooksPath .githooks"]
 
+[tasks."worktree:new"]
+description = "Create .worktrees/<type>/<slug>, trust its mise config, install deps so tooling/LSP work immediately (args: <type> <slug> [base=main])"
+run = "bash scripts/worktree-new.sh"
+
 [tasks.build]
 description = "Build frontend (dev: with source maps)"
 run = "pnpm build:dev"

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Create a .worktrees/<type>/<slug> worktree, trust its mise config, and install
+# its dependencies — so tests, ruff, basedpyright and the editor LSP work inside
+# the worktree immediately (a fresh worktree gets its own empty .venv otherwise).
+#
+# After this finishes, re-root the Claude session into the worktree with
+# EnterWorktree({ path: ".worktrees/<type>/<slug>" }) for clean diagnostics.
+#
+# Usage: mise run worktree:new <type> <slug> [base]   (base defaults to main)
+set -euo pipefail
+
+type="${1:?usage: mise run worktree:new <type> <slug> [base=main]}"
+slug="${2:?usage: mise run worktree:new <type> <slug> [base=main]}"
+base="${3:-main}"
+wt=".worktrees/${type}/${slug}"
+
+git worktree add "$wt" -b "${type}/${slug}" "$base"
+mise trust "$wt/mise.toml"
+mise -C "$wt" run setup
+
+echo
+echo "✓ worktree ready: $wt  (branch ${type}/${slug})"
+echo "  next: EnterWorktree({ path: \"$wt\" })  — re-roots the session for clean LSP/tooling"


### PR DESCRIPTION
Adds `mise run worktree:new <type> <slug> [base=main]` (impl: `scripts/worktree-new.sh`) — does `git worktree add` → `mise trust` → `mise run setup`, so a fresh worktree's tooling (tests, ruff, basedpyright, editor LSP) works immediately instead of hitting an empty per-worktree `.venv`.

docs: N/A — dev tooling only; no user-facing behavior or architecture change.