### PR TITLE
chore(legal): ship vdf LICENSE + provenance in _vendor, drop stale eslint ignore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,10 @@ basedpyright, and Sonar (analysis + coverage) so any future vendored package is 
 our code, we don't lint or coverage-track it, but we may patch it (e.g. fix self-imports broken by the move into
 `_vendor/`). Ruff's isort lists `_vendor` under `known-third-party` so the imports group alongside other third-party
 deps. `import-linter` enforces a `domain-stdlib-only` contract that forbids `domain` from importing `_vendor.*` (domain
-stays stdlib-only); no other layer forbids `_vendor`, since adapters legitimately import it.
+stays stdlib-only); no other layer forbids `_vendor`, since adapters legitimately import it. Every vendored package
+ships its upstream `LICENSE` (the release zip redistributes `_vendor/`, and MIT/BSD-style licenses require preserving
+the copyright notice on redistribution) and a provenance entry in `_vendor/README.md` — upstream URL, pinned
+version/commit, and the list of local patches — so updating a vendored dep is a deliberate diff, not "diff and pray".
 
 **Process boundaries — `main.py` vs `bootstrap.py`**: `[ours]` `main.py` owns the Decky lifecycle (`_main`, `_unload`)
 and the callable surface (one `async def` method per `@callable` exposed to the frontend). `bootstrap.py` owns adapter

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -155,7 +155,9 @@ py_modules/
   models/                            # Data shapes (TypedDicts/dataclasses) — independent of other layers
   lib/                               # Cross-cutting utilities (errors, list_result, iso_time, path_safety, late_binding, ...)
   _vendor/                           # Vendored third-party deps — not our code, only imported by adapters
+    README.md                        # Provenance per package: upstream URL, version/commit, local patches
     vdf/                             # Valve Data Format parser (Steam shortcuts.vdf)
+      LICENSE                        # Upstream MIT license — preserved on redistribution
 src/                                 # Frontend TypeScript
   index.tsx                          # Plugin entry, event listeners, QAM router
   components/                        # React components (QAM pages, game detail UI)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,6 @@ export default tseslint.config(
       ".worktrees",
       ".venv",
       "site",
-      "py_modules/vdf",
     ],
   },
   js.configs.recommended,

--- a/py_modules/_vendor/README.md
+++ b/py_modules/_vendor/README.md
@@ -1,0 +1,14 @@
+# Vendored third-party packages
+
+Decky Loader has no plugin-level package manager, so third-party runtime dependencies are vendored here and imported as
+`from _vendor import <package>`. Only adapters import from `_vendor.*`. The release zip redistributes this directory, so
+each package keeps its upstream `LICENSE`, and the provenance below makes updating a vendored dep a deliberate diff
+rather than "diff and pray". See the `_vendor/` rules in [`CLAUDE.md`](../../CLAUDE.md).
+
+## vdf
+
+- **Upstream:** <https://github.com/ValvePython/vdf>
+- **Version:** 3.4 — tag `v3.4`, commit `8104cb27c0b222bd802b69df58204ab389fc714c`
+- **License:** MIT — see [`vdf/LICENSE`](vdf/LICENSE)
+- **Local patches:** `vdf/__init__.py` — `from vdf.vdict import VDFDict` changed to `from .vdict import VDFDict`
+  (relative self-import so the package resolves under `_vendor.vdf`, not a top-level `vdf`).

--- a/py_modules/_vendor/vdf/LICENSE
+++ b/py_modules/_vendor/vdf/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Rossen Georgiev <rossen@rgp.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #988.

The vendored `vdf` package (MIT, ValvePython/vdf) shipped in the release zip without its LICENSE. MIT requires preserving the copyright notice on redistribution, so this needs fixing before any Decky Store submission.

## Changes

- **`_vendor/vdf/LICENSE`** — the upstream MIT license, byte-identical to ValvePython/vdf at tag `v3.4` (verified against the GitHub API).
- **`_vendor/README.md`** — provenance record: upstream URL, pinned version (3.4) + commit, license, and the one local patch (`from vdf.vdict import VDFDict` → `from .vdict import VDFDict`, the relative self-import fix from the move into `_vendor/`).
- **`eslint.config.js`** — dropped the `py_modules/vdf` ignore entry. eslint never lints `.py`, and the path moved to `_vendor/vdf` anyway — a purely decorative stale list entry.
- **`CLAUDE.md`** — folded "every vendored package ships its LICENSE + a provenance entry in `_vendor/README.md`" into the vendoring convention, so the next vendored dep starts with provenance.
- **`docs/contributing/development.md`** — file-structure tree now shows the new provenance files.

## Notes

The issue also mentions a stale `py_modules/vdf/` directory — it only ever held `__pycache__` (untracked/gitignored), so there is nothing tracked to delete and no diff for it.