### PR TITLE
chore(ci): deny adapters wholesale in import-linter + self-check the service-independence list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Check import boundaries
         run: PYTHONPATH=py_modules lint-imports
 
+      - name: Check service-independence contract is complete
+        run: python scripts/check_service_independence_contract.py
+
       - name: Check Cosmic Python call bans
         run: bash scripts/check_cosmic_call_bans.sh
 

--- a/.importlinter
+++ b/.importlinter
@@ -7,21 +7,20 @@ root_packages =
     models
 include_external_packages = True
 
-# Services must not import concrete adapters (protocols are OK).
+# Services must not import concrete adapters (Protocols are OK). Forbid the
+# ``adapters`` root package wholesale, not a hand-enumerated denylist: services
+# depend only on Protocols (defined in ``services/protocols/``), so they have
+# zero legitimate adapter imports. A denylist rots — the old 8-module list had
+# silently stopped covering ``adapters.repositories.*`` and ~15 other modules
+# (#985). The completeness of the sibling ``service-independence`` list is
+# guarded by ``scripts/check_service_independence_contract.py``.
 [importlinter:contract:no-adapter-impl-in-services]
 name = Services must not import concrete adapter implementations
 type = forbidden
 source_modules =
     services
 forbidden_modules =
-    adapters.romm.http
-    adapters.romm.romm_api
-    adapters.steam_config
-    adapters.steamgriddb
-    adapters.persistence
-    adapters.retrodeck_paths
-    adapters.retroarch_config
-    adapters.retroarch_core_info
+    adapters
 
 # Adapters must not import services
 [importlinter:contract:no-services-in-adapters]
@@ -116,6 +115,7 @@ name = Services must not import other services
 type = independence
 modules =
     services.achievements
+    services.active_core_resolver
     services.artwork
     services.connection
     services.cores

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,9 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Aggregate field-assignment ban**: `scripts/check_aggregate_field_assignment.py` — AST check that fails CI if
   `services/` assigns `aggregate.field = value` on a `@cosmic_aggregate` root (mutation must go through verb-named
   methods). Enforces the Aggregates `[CP]` rule.
+- **Service-independence contract self-check**: `scripts/check_service_independence_contract.py` — derives the expected
+  service list from `py_modules/services/` and fails CI if `.importlinter`'s `service-independence` contract omits a
+  service or carries a stale entry, keeping the hand-maintained `modules` list self-healing.
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
 ## Architecture — Cosmic Python rules

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -350,7 +350,7 @@ Four CI-gated layers keep the dependency direction and the call-site rules from 
 [importlinter:contract:no-adapter-impl-in-services]
 type = forbidden
 source_modules = services
-forbidden_modules = adapters.romm.http, adapters.romm.romm_api, adapters.steam_config, ...
+forbidden_modules = adapters
 
 # Adapters must not import services
 [importlinter:contract:no-services-in-adapters]
@@ -395,6 +395,10 @@ modules = services.library, services.saves, services.playtime, ...
 ```
 
 Run with `PYTHONPATH=py_modules lint-imports` (or `mise run lint`). CI gates on this.
+
+The `service-independence` `modules` list is hand-enumerated, so `scripts/check_service_independence_contract.py`
+(bundled into `mise run lint` and gated in CI) derives the expected services from `py_modules/services/` and fails if
+the contract omits a service or carries a stale entry — keeping the list self-healing rather than silently rotting.
 
 ### 2. Cosmic Python call bans
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -96,6 +96,10 @@ The `.importlinter` config enforces the layer boundary contracts:
 services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `time.monotonic()` / `uuid.uuid4()` /
 `random.*` directly — they inject the `Clock` / `Sleeper` / `UuidGen` Protocol instead.
 
+`mise run lint` (and CI) also runs `scripts/check_service_independence_contract.py`, which derives the expected service
+list from `py_modules/services/` and fails if `.importlinter`'s `service-independence` contract drifts — omitting a
+service or carrying a stale entry — keeping the hand-maintained `modules` list self-healing.
+
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,7 @@ description = "Check Cosmic Python architecture rules (layer imports + forbidden
 depends = ["lint:md"]
 run = [
     "PYTHONPATH=py_modules lint-imports",
+    "python scripts/check_service_independence_contract.py",
     "bash scripts/check_cosmic_call_bans.sh",
 ]
 

--- a/scripts/check_service_independence_contract.py
+++ b/scripts/check_service_independence_contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Service-independence contract completeness check.
+
+``.importlinter``'s ``service-independence`` contract is an ``independence``
+contract over a hand-enumerated ``modules`` list. Hand-maintained lists rot: a
+new service module is easy to add under ``py_modules/services/`` while forgetting
+to enrol it, and a renamed or removed service leaves a stale entry behind. Either
+way the flagship layer-boundary enforcement silently stops covering reality.
+
+This check derives the expected service set from the filesystem and fails when
+``.importlinter`` and the directory diverge — making the list self-healing.
+
+Derivation rule (a "service" = one independence entry):
+
+  * every ``py_modules/services/<name>.py`` except ``__init__.py`` -> ``services.<name>``
+  * every ``py_modules/services/<dir>/`` package (has ``__init__.py``) except
+    ``protocols/`` -> ``services.<dir>``
+
+A sub-package (e.g. ``services.saves``, ``services.library``) counts as ONE entry,
+not one-per-file: the sub-services inside a bounded context may import each other
+concretely (the documented carve-out in CLAUDE.md); independence is enforced
+between the top-level entries, so the contract lists the package, not its
+internals. ``services.protocols`` is not a service — it is the Protocol namespace
+services depend on — so it is excluded.
+
+``EXEMPT`` holds services deliberately kept out of the contract. It is empty
+today; an entry here is a conscious "this service is intentionally not subject to
+the independence contract" decision — the alternative the failure message offers
+to simply enrolling the service.
+
+Exit 0 when the contract matches the filesystem, 1 (one line per discrepancy)
+otherwise.
+"""
+
+from __future__ import annotations
+
+import configparser
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SERVICES_DIR = REPO_ROOT / "py_modules" / "services"
+IMPORTLINTER_PATH = REPO_ROOT / ".importlinter"
+
+CONTRACT_NAME = "service-independence"
+CONTRACT_SECTION = f"importlinter:contract:{CONTRACT_NAME}"
+CONTRACT_KEY = "modules"
+
+# Sub-directories under services/ that are NOT services in their own right.
+_NON_SERVICE_DIRS = {"protocols"}
+
+# Services deliberately excluded from the independence contract. Empty today;
+# add an entry only as a conscious decision (see the module docstring).
+EXEMPT: set[str] = set()
+
+
+def derive_services(services_dir: Path) -> set[str]:
+    """Return the service module names the independence contract should enumerate."""
+    services: set[str] = set()
+    if not services_dir.is_dir():
+        return services
+    for entry in sorted(services_dir.iterdir()):
+        if entry.is_file() and entry.suffix == ".py" and entry.stem != "__init__":
+            services.add(f"services.{entry.stem}")
+        elif entry.is_dir() and entry.name not in _NON_SERVICE_DIRS and (entry / "__init__.py").is_file():
+            services.add(f"services.{entry.name}")
+    return services
+
+
+def parse_contract_modules(importlinter_path: Path) -> set[str]:
+    """Read the ``modules`` list of the service-independence contract from ``.importlinter``."""
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(importlinter_path, encoding="utf-8")
+    raw = parser.get(CONTRACT_SECTION, CONTRACT_KEY, fallback="")
+    return {token.strip() for token in raw.split() if token.strip()}
+
+
+def find_discrepancies(on_disk: set[str], contract: set[str], exempt: set[str]) -> list[str]:
+    """Compare the derived service set against the contract. One message per discrepancy."""
+    expected = on_disk - exempt
+    findings: list[str] = [
+        f"{missing}: service module exists but is not enrolled in the [{CONTRACT_NAME}] "
+        f"contract — add it to .importlinter, or add it to EXEMPT in this script if it is "
+        f"intentionally outside the contract."
+        for missing in sorted(expected - contract)
+    ]
+    findings.extend(
+        f"{stale}: listed in the [{CONTRACT_NAME}] contract but no such service module exists "
+        f"under py_modules/services/ — remove the stale entry (or fix a rename)."
+        for stale in sorted(contract - on_disk)
+    )
+    findings.extend(
+        f"{contradiction}: marked EXEMPT in this script but also listed in the contract — remove it from one."
+        for contradiction in sorted(exempt & contract)
+    )
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+    on_disk = derive_services(SERVICES_DIR)
+    contract = parse_contract_modules(IMPORTLINTER_PATH)
+    findings = find_discrepancies(on_disk, contract, EXEMPT)
+    if findings:
+        for line in findings:
+            print(line)
+        print()
+        print(
+            f"ERROR: the [{CONTRACT_NAME}] contract in .importlinter has drifted from "
+            "py_modules/services/. Every service must be enrolled (or explicitly EXEMPT) so the "
+            "independence enforcement keeps covering reality."
+        )
+        return 1
+    print(f"OK: [{CONTRACT_NAME}] contract matches {SERVICES_DIR.relative_to(REPO_ROOT)} ({len(contract)} services).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/scripts/test_check_service_independence_contract.py
+++ b/tests/scripts/test_check_service_independence_contract.py
@@ -1,0 +1,196 @@
+"""Tests for ``scripts/check_service_independence_contract.py``.
+
+Loaded via ``importlib`` because ``scripts/`` is not on ``sys.path`` (and is
+excluded from ruff/basedpyright). Fixtures build a fake ``py_modules/services/``
+tree and a fake ``.importlinter`` under ``tmp_path`` and monkeypatch the script's
+module-level path constants.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_service_independence_contract.py"
+
+
+def _load_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_service_independence_contract", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_check_module()
+
+
+def _make_services_tree(tmp_path: Path, *, files: list[str], packages: list[str]) -> Path:
+    """Build a fake ``py_modules/services/`` tree: ``files`` -> ``<name>.py``, ``packages`` -> ``<dir>/__init__.py``."""
+    services_dir = tmp_path / "py_modules" / "services"
+    services_dir.mkdir(parents=True)
+    (services_dir / "__init__.py").write_text("", encoding="utf-8")
+    for name in files:
+        (services_dir / f"{name}.py").write_text("", encoding="utf-8")
+    for pkg in packages:
+        pkg_dir = services_dir / pkg
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
+    return services_dir
+
+
+def _write_importlinter(tmp_path: Path, modules: list[str]) -> Path:
+    """Write a minimal ``.importlinter`` carrying just the service-independence contract."""
+    listing = "\n".join(f"    {m}" for m in modules)
+    content = (
+        textwrap.dedent(
+            """\
+            [importlinter]
+            root_packages =
+                services
+
+            [importlinter:contract:service-independence]
+            name = Services must not import other services
+            type = independence
+            modules =
+            """
+        )
+        + listing
+        + "\n"
+    )
+    path = tmp_path / ".importlinter"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestDeriveServices:
+    def test_top_level_modules_and_packages(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, files=["connection", "settings"], packages=["saves", "library"])
+        assert check.derive_services(services_dir) == {
+            "services.connection",
+            "services.settings",
+            "services.saves",
+            "services.library",
+        }
+
+    def test_init_excluded(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, files=["connection"], packages=[])
+        assert "services.__init__" not in check.derive_services(services_dir)
+
+    def test_protocols_package_excluded(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, files=["connection"], packages=["protocols", "saves"])
+        result = check.derive_services(services_dir)
+        assert "services.protocols" not in result
+        assert result == {"services.connection", "services.saves"}
+
+    def test_subpackage_counts_as_one_entry(self, tmp_path: Path):
+        # Files INSIDE a sub-package must not become their own entries.
+        services_dir = _make_services_tree(tmp_path, files=[], packages=["saves"])
+        (services_dir / "saves" / "versions.py").write_text("", encoding="utf-8")
+        (services_dir / "saves" / "sync_engine").mkdir()
+        (services_dir / "saves" / "sync_engine" / "__init__.py").write_text("", encoding="utf-8")
+        assert check.derive_services(services_dir) == {"services.saves"}
+
+    def test_non_package_dir_ignored(self, tmp_path: Path):
+        # A directory without __init__.py (e.g. __pycache__) is not a service.
+        services_dir = _make_services_tree(tmp_path, files=["connection"], packages=[])
+        (services_dir / "__pycache__").mkdir()
+        assert check.derive_services(services_dir) == {"services.connection"}
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path):
+        assert check.derive_services(tmp_path / "does_not_exist") == set()
+
+
+class TestParseContractModules:
+    def test_reads_multiline_list(self, tmp_path: Path):
+        path = _write_importlinter(tmp_path, ["services.connection", "services.saves", "services.library"])
+        assert check.parse_contract_modules(path) == {
+            "services.connection",
+            "services.saves",
+            "services.library",
+        }
+
+    def test_missing_section_returns_empty(self, tmp_path: Path):
+        path = tmp_path / ".importlinter"
+        path.write_text("[importlinter]\nroot_packages =\n    services\n", encoding="utf-8")
+        assert check.parse_contract_modules(path) == set()
+
+
+class TestFindDiscrepancies:
+    def test_in_sync_no_findings(self):
+        on_disk = {"services.a", "services.b"}
+        assert check.find_discrepancies(on_disk, {"services.a", "services.b"}, set()) == []
+
+    def test_missing_from_contract_flagged(self):
+        findings = check.find_discrepancies({"services.a", "services.b"}, {"services.a"}, set())
+        assert len(findings) == 1
+        assert "services.b" in findings[0]
+        assert "not enrolled" in findings[0]
+
+    def test_stale_contract_entry_flagged(self):
+        findings = check.find_discrepancies({"services.a"}, {"services.a", "services.gone"}, set())
+        assert len(findings) == 1
+        assert "services.gone" in findings[0]
+        assert "no such service" in findings[0]
+
+    def test_exempt_service_not_flagged_as_missing(self):
+        # Service on disk, absent from contract, but EXEMPT -> not a discrepancy.
+        findings = check.find_discrepancies({"services.a", "services.b"}, {"services.a"}, {"services.b"})
+        assert findings == []
+
+    def test_exempt_and_listed_is_contradiction(self):
+        findings = check.find_discrepancies({"services.a"}, {"services.a"}, {"services.a"})
+        assert len(findings) == 1
+        assert "services.a" in findings[0]
+        assert "EXEMPT" in findings[0]
+
+
+class TestMainEntryPoint:
+    def test_help_flag_returns_zero(self, capsys: pytest.CaptureFixture[str]):
+        rc = check.main(["--help"])
+        assert rc == 0
+        assert "Service-independence contract" in capsys.readouterr().out
+
+    def test_short_help_flag_returns_zero(self):
+        assert check.main(["-h"]) == 0
+
+    def test_real_repo_run_is_clean(self, capsys: pytest.CaptureFixture[str]):
+        # Locks the actual .importlinter service-independence contract in sync with
+        # py_modules/services/. If this fails, a service was added/renamed without
+        # updating the contract (the whole point of the check).
+        rc = check.main([])
+        assert rc == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_drift_reports_and_returns_one(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        services_dir = _make_services_tree(tmp_path, files=["connection", "settings"], packages=["saves"])
+        importlinter_path = _write_importlinter(tmp_path, ["services.connection", "services.saves"])
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        monkeypatch.setattr(check, "IMPORTLINTER_PATH", importlinter_path)
+        monkeypatch.setattr(check, "EXEMPT", set())
+        rc = check.main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "services.settings" in out
+        assert "ERROR:" in out
+
+    def test_in_sync_fake_repo_returns_zero(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, files=["connection"], packages=["saves"])
+        importlinter_path = _write_importlinter(tmp_path, ["services.connection", "services.saves"])
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        monkeypatch.setattr(check, "IMPORTLINTER_PATH", importlinter_path)
+        monkeypatch.setattr(check, "EXEMPT", set())
+        assert check.main([]) == 0


### PR DESCRIPTION
Closes #985.

The flagship layer-boundary contracts had rotted exactly where they were hand-enumerated.

## Problem

- `no-adapter-impl-in-services` was a denylist of 8 adapter modules, but `py_modules/adapters/` holds ~25 — including the entire `adapters/repositories/` package (the most likely wrong import after the SQLite epic), `sqlite_migrations`, `sgdb_artwork_cache`, and more. A service could `from adapters.repositories.rom import SqliteRomRepository` and CI stayed green.
- `service-independence` enumerated 19 service modules; `services.active_core_resolver` existed and was missing from the list.

## Fix

- **Wholesale ban**: `forbidden_modules = adapters`. Services depend only on Protocols (in `services/protocols/`), so they have zero legitimate adapter imports — a denylist is the wrong shape. Verified no current service imports `adapters`, and that the wholesale form catches `adapters.repositories.*` (which the old list missed).
- **Add the missing service** to `service-independence`.
- **Self-healing list**: `scripts/check_service_independence_contract.py` derives the expected service list from `py_modules/services/` (top-level modules + sub-packages, one entry each; `protocols/` excluded) and fails if `.importlinter`'s contract omits a service or carries a stale entry. An `EXEMPT` set (empty today) is the explicit escape hatch. Wired into `mise run lint` and CI; covered by 18 tests.

docs: updated — `backend-architecture.md` (contract example + self-check paragraph), `development.md` (linting section), `CLAUDE.md` (Code Quality).