### PR TITLE
chore(ci): anchor ruff scripts exclude so tests/scripts gets linted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ reportPrivateUsage = "none"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
-extend-exclude = ["py_modules/_vendor", "scripts"]
+extend-exclude = ["py_modules/_vendor", "./scripts"]
 
 [tool.ruff.lint]
 select = [

--- a/tests/scripts/test_check_aggregate_field_assignment.py
+++ b/tests/scripts/test_check_aggregate_field_assignment.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_aggregate_field_assignment.py"
 


### PR DESCRIPTION
Closes #1076.

Surfaced in #985: `ruff check .` (the CI invocation) was silently skipping the check-script tests under `tests/scripts/`.

## Cause

`[tool.ruff] extend-exclude` carried a bare `"scripts"` entry to exclude the top-level `scripts/` dir (custom CI check scripts, intentionally unlinted until #997). ruff matches these gitignore-style, so a bare `scripts` matches **any** path segment named `scripts` — it also excluded `tests/scripts/`. Those test files were therefore only linted by the pre-commit hook (explicit paths), never by `ruff check .`.

## Fix

- `pyproject.toml`: `"scripts"` → `"./scripts"` — anchors the exclude to the top-level dir only, so `tests/scripts/` is linted again while top-level `scripts/` stays excluded.
  - The ticket suggested `"/scripts"`, but that is wrong for ruff: a leading `/` does **not** anchor to the project root — it leaks the top-level scripts back into linting (10 findings surface). `"./scripts"` is the project-relative form that matches only the root dir. Verified empirically against both directions.
- `tests/scripts/test_check_aggregate_field_assignment.py`: fix the `TC003` this surfaced — move the annotation-only `ModuleType` import into a `TYPE_CHECKING` block (`pytest` stays top-level; runtime use via `@pytest.fixture`).
- basedpyright needs no change: it root-anchors its `exclude`, so `tests/scripts/` was already type-checked (verified by probe).

docs: N/A — CI-config/tooling fix; no user-visible or architecture change, and no doc references the exclude list.