### PR TITLE
test(saves): property-based spec for the save-sync decision kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
+.hypothesis/
 
 # Logs
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,24 @@ Every backend feature or callable where testing makes sense MUST have unit tests
 Tests mirror the source structure: `tests/services/`, `tests/adapters/`, `tests/domain/`, `tests/models/`, `tests/lib/`.
 Each test file maps 1:1 to a source module. Shared mocks live in `tests/conftest.py`.
 
+### Property-based tests — pure decision kernels (hypothesis)
+
+The pure save-sync decision kernels (`domain/sync_action.py`, `domain/save_path.py`, `domain/iso_time.py`) carry a
+property-test tier on top of the hand-enumerated cases, in `tests/domain/test_*_property.py`. Properties state the
+safety invariant directly (no destructive action without a recovery source; decisions stable under timestamp-format
+variation; canonical-target grouping never mixes targets; replay determinism) and Hypothesis searches a generated input
+space for a counterexample. `hypothesis` is a **dev-only** dependency (`requirements-dev.txt` → `requirements-dev.lock`
+via `mise run lock-update`); it never ships in the plugin. A CI-safe profile in `tests/conftest.py` sets `deadline=None`
+and a fixed `max_examples`; the example DB writes to gitignored `.hypothesis/`.
+
+**Convention — pinning a property that encodes an open bug:** a property states the TRUE invariant, never a watered-down
+one. If the invariant's fix is still open, the property FAILS today — pin it
+`@pytest.mark.xfail(strict=True,
+reason="#<issue>: <one-line>")`. `strict=True` means that the day the fix lands the
+property passes → the run reports XPASS → CI fails → the marker must be removed, and the property then guards against
+regression. So a property never gets weakened to go green: it either passes live (a regression guard) or is
+`xfail`-pinned to its open bug.
+
 ### Frontend component tests — `@decky/api` event harness
 
 `src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -52,6 +52,22 @@ with each test file mapping 1:1 to a source module. Shared mocks live in `tests/
 Frontend component tests run with `mise run test:frontend` (`pnpm test`); see the CLAUDE.md "Frontend component tests"
 section for the `@decky/api` event harness.
 
+### Property-based tests
+
+The pure save-sync decision kernels (`domain/sync_action.py`, `domain/save_path.py`, `domain/iso_time.py`) carry an
+extra tier of [Hypothesis](https://hypothesis.readthedocs.io/) property tests (`tests/domain/test_*_property.py`)
+alongside the hand-enumerated cases. They state the safety invariants directly and exercise them across a generated
+input space. Run them like any other test:
+
+```bash
+python -m pytest tests/domain/test_sync_action_property.py tests/domain/test_save_path_property.py -q
+```
+
+Hypothesis is a dev-only dependency (pinned in `requirements-dev.txt`, compiled into `requirements-dev.lock` via
+`mise run lock-update` — it never ships in the plugin). A CI-safe profile in `tests/conftest.py` sets `deadline=None`
+(no timing flakes on shared runners) and a fixed example count. The example database is written to `.hypothesis/`, which
+is gitignored. See the CLAUDE.md "Testing" section for the convention on pinning a property that encodes an open bug.
+
 Every backend feature or callable where testing makes sense should have unit tests covering:
 
 - **Happy path** — normal successful operation

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -8,6 +8,8 @@ coverage==7.14.1
     # via pytest-cov
 grimp==3.14
     # via import-linter
+hypothesis==6.155.2
+    # via -r requirements-dev.txt
 import-linter==2.11
     # via -r requirements-dev.txt
 iniconfig==2.3.0
@@ -41,6 +43,8 @@ rich==15.0.0
     # via import-linter
 ruff==0.15.16
     # via -r requirements-dev.txt
+sortedcontainers==2.4.0
+    # via hypothesis
 typing-extensions==4.15.0
     # via
     #   grimp

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 pytest>=9.0.3,<10.0
 pytest-asyncio>=1.3.0,<1.4  # 1.4.0 changed event-loop semantics; tracked in #806
 pytest-cov>=7.1.0,<8.0
+hypothesis>=6.155,<7.0  # property-based tests for the save-sync decision kernels (#1028)
 ruff>=0.15.16,<0.16
 basedpyright>=1.39.7,<2.0
 import-linter>=2.11,<3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,18 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from hypothesis import HealthCheck, settings
+
+# CI-safe hypothesis profile: deadline=None avoids timing flakes on shared CI
+# runners; 200 examples balances coverage against suite runtime. Loaded by
+# default for every property test (#1028).
+settings.register_profile(
+    "ci",
+    deadline=None,
+    max_examples=200,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile("ci")
 
 # Mirror Decky's sys.path setup: add py_modules/ so `from lib.xxx import` works
 _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/domain/test_iso_time_property.py
+++ b/tests/domain/test_iso_time_property.py
@@ -1,0 +1,82 @@
+"""Property-based tests for ISO-8601 epoch parsing (#1028).
+
+Invariant 3 sharpener (#1014 — lexicographic timestamp ordering): the
+save-sync kernels order server saves by ``parse_iso_to_epoch`` rather than by
+raw string comparison. This module pins the underlying parse: two ISO forms
+that denote the *same instant* — ``…Z`` vs ``…+00:00`` vs
+``….000000+00:00`` — must parse to the same epoch, so any ``max``/sort keyed
+on the epoch is stable under format variation. The #1014 bug is the opposite:
+sites that compared the raw strings mis-ordered mixed-shape timestamps.
+
+See ``tests.domain.test_sync_action_property`` for the convention note on the
+``xfail(strict=True)`` pinning of properties that encode an open bug.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.iso_time import parse_iso_to_epoch
+
+# Aware UTC datetimes across a wide range; whole-second and microsecond
+# resolution both exercised by the formatting helper below.
+_utc_datetimes = st.datetimes(
+    min_value=datetime(2000, 1, 1),
+    max_value=datetime(2099, 12, 31, 23, 59, 59),
+    timezones=st.just(UTC),
+)
+
+
+def _iso_forms(dt: datetime) -> list[str]:
+    """All semantically-equal ISO renderings of a UTC instant the kernels see.
+
+    RomM has emitted ``updated_at`` with a trailing ``Z``, with an explicit
+    ``+00:00`` offset, and with/without microseconds across versions. These
+    must all parse to one epoch.
+    """
+    whole = dt.replace(microsecond=0)
+    base = whole.strftime("%Y-%m-%dT%H:%M:%S")
+    micros = f"{base}.000000"
+    return [
+        f"{base}+00:00",
+        f"{base}Z",
+        f"{micros}+00:00",
+        f"{micros}Z",
+    ]
+
+
+@given(dt=_utc_datetimes)
+def test_equivalent_iso_forms_parse_to_same_epoch(dt: datetime) -> None:
+    """Every semantically-equal ISO rendering of an instant parses to the same
+    epoch. A ``max``/sort keyed on the epoch is therefore order-stable under
+    format variation — the property the #1014 sites violated by comparing raw
+    strings.
+    """
+    epochs = {parse_iso_to_epoch(form) for form in _iso_forms(dt)}
+    assert len(epochs) == 1
+    (only,) = epochs
+    assert only is not None
+
+
+@given(earlier=_utc_datetimes, later=_utc_datetimes)
+def test_epoch_ordering_independent_of_format(earlier: datetime, later: datetime) -> None:
+    """Ordering by parsed epoch reflects true chronology regardless of the ISO
+    *shape* each side is rendered in. Picks the ``Z`` form for the earlier and
+    the ``+00:00`` form for the later instant — the exact mixed-shape pairing
+    a lexicographic string compare can invert.
+    """
+    e0 = earlier.replace(microsecond=0)
+    l0 = later.replace(microsecond=0)
+    earlier_str = e0.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+    later_str = l0.strftime("%Y-%m-%dT%H:%M:%S") + "+00:00"
+
+    epoch_earlier = parse_iso_to_epoch(earlier_str)
+    epoch_later = parse_iso_to_epoch(later_str)
+    assert epoch_earlier is not None
+    assert epoch_later is not None
+
+    # Epoch ordering must match true instant ordering.
+    assert (epoch_earlier <= epoch_later) == (e0 <= l0)

--- a/tests/domain/test_save_path_property.py
+++ b/tests/domain/test_save_path_property.py
@@ -1,0 +1,113 @@
+"""Property-based tests for the canonical-target grouping key (#1028).
+
+Invariant 1 (#1006 — cross-extension save corruption): a local file's sync
+action must only ever be computed against server saves in its *own* canonical
+target group. The grouping key is the pure
+``compute_local_save_target(server_save, rom_name).filename`` — the same key
+``services.saves._helpers.local_save_target`` wraps and the matrix groups by.
+
+This property pins the *key*: grouping a generated server-save list by that
+key never mixes two distinct canonical targets, and saves that differ only in
+``file_extension`` for the same ``rom_name`` land in distinct groups. The
+#1006 fix makes the matrix's local-file loop filter to this same group; the
+key itself is already correct, so this is a live regression guard.
+
+See ``tests.domain.test_sync_action_property`` for the convention note on the
+``xfail(strict=True)`` pinning of properties that encode an open bug.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.save_extensions import get_save_extensions
+from domain.save_path import compute_local_save_target
+
+# Every extension the generators draw from — the union across all systems in
+# domain.save_extensions, leading dot stripped to match the file_extension shape.
+_SYSTEMS: tuple[str | None, ...] = (
+    None,
+    "nds",
+    "segacd",
+    "saturn",
+    "ngp",
+    "ngpc",
+    "pokemini",
+    "amiga",
+    "amigacd32",
+)
+_ALL_EXTENSIONS: tuple[str, ...] = tuple(
+    sorted({ext.lstrip(".") for system in _SYSTEMS for ext in get_save_extensions(system)})
+)
+
+# A safe rom_name space: plain identifiers plus a couple of realistic names
+# with spaces/parentheses. Excludes path-separator / traversal inputs (those
+# are covered by the hand-enumerated sanitization tests) so the grouping key
+# stays the clean <rom_name>.<ext> form this invariant is about.
+_rom_names = st.sampled_from(
+    [
+        "Game",
+        "Pokemon Emerald",
+        "Sonic (USA)",
+        "Final-Fantasy_VI",
+        "Game.2",
+    ]
+)
+
+_extensions = st.sampled_from(_ALL_EXTENSIONS)
+
+
+def _server_save(save_id: int, file_extension: str) -> dict[str, Any]:
+    """Minimal server-save dict carrying only what the grouping key reads."""
+    return {
+        "id": save_id,
+        "slot": 0,
+        "updated_at": "2024-01-01T00:00:00+00:00",
+        "file_extension": file_extension,
+        "device_syncs": [],
+    }
+
+
+@st.composite
+def _server_save_list(draw: st.DrawFn) -> list[dict[str, Any]]:
+    exts = draw(st.lists(_extensions, min_size=0, max_size=8))
+    return [_server_save(i, ext) for i, ext in enumerate(exts)]
+
+
+@given(saves=_server_save_list(), rom_name=_rom_names)
+def test_grouping_never_mixes_canonical_targets(saves: list[dict[str, Any]], rom_name: str) -> None:
+    """Grouping by the canonical-target key never places two saves with
+    different canonical targets in the same group, and every member of a group
+    resolves back to that group's key. This is the structural guarantee the
+    #1006 fix relies on when it filters the local-file loop to a file's own
+    group.
+    """
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ss in saves:
+        key = compute_local_save_target(ss, rom_name).filename
+        groups[key].append(ss)
+
+    for key, members in groups.items():
+        # Every member of a group resolves to exactly that group's key — no
+        # member can belong to a different canonical target.
+        assert all(compute_local_save_target(m, rom_name).filename == key for m in members)
+
+
+@given(rom_name=_rom_names, ext_a=_extensions, ext_b=_extensions)
+def test_different_extension_same_rom_distinct_targets(rom_name: str, ext_a: str, ext_b: str) -> None:
+    """Two server saves that differ only in ``file_extension`` for the same
+    ``rom_name`` land in *distinct* canonical-target groups whenever the
+    extensions differ. This is the exact #1006 condition: a multi-file save
+    set (e.g. GBA ``.srm`` + ``.rtc``) must never collapse into one group, or
+    one file's bytes can be PUT over the other's server record.
+    """
+    target_a = compute_local_save_target(_server_save(1, ext_a), rom_name).filename
+    target_b = compute_local_save_target(_server_save(2, ext_b), rom_name).filename
+    if ext_a != ext_b:
+        assert target_a != target_b
+    else:
+        assert target_a == target_b

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -1,0 +1,337 @@
+"""Property-based tests for ``domain.sync_action.compute_sync_action`` (#1028).
+
+The save-sync decision kernel is pure and safety-critical: a wrong action can
+overwrite or lose a player's save. Hand-enumerated cases
+(``test_sync_action.py``) pin specific input shapes; these properties state the
+*invariants* the kernel must hold across the whole input space the generators
+sample.
+
+Property-test convention — pinning open bugs
+---------------------------------------------
+A property states the TRUE invariant. If it FAILS today, the invariant's bug
+is still open, so the property is pinned ``@pytest.mark.xfail(strict=True,
+reason="#<issue>: …")``. ``strict=True`` means the day the fix lands the
+property passes → the run reports XPASS → CI fails → the marker must be
+removed, and the property then guards against regression. Never weaken a
+property to make it pass.
+
+Invariants encoded here:
+- Inv2 (#965): no kernel output destroys a present local file without the
+  carried ``server_save`` being the recovery source.
+- Inv3 (#1014): the action is identical under semantically-equal
+  ``updated_at`` / ``mtime`` ISO renderings.
+- Inv4 (#1013): same inputs replayed → same action (pure determinism), and
+  after a first-sync ``Upload(None)`` baseline is adopted the next run is
+  ``Skip("synced")`` — never another POST.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from domain.sync_action import (
+    Conflict,
+    Download,
+    Skip,
+    SyncAction,
+    Upload,
+    compute_sync_action,
+)
+
+DEVICE_ID = "device-abc"
+OTHER_DEVICE_ID = "device-xyz"
+
+# A bounded epoch window (year 2000-2099) so both local mtimes and server
+# updated_at instants are realistic and comparable.
+_MIN_EPOCH = datetime(2000, 1, 1, tzinfo=UTC).timestamp()
+_MAX_EPOCH = datetime(2099, 12, 31, tzinfo=UTC).timestamp()
+
+_epochs = st.floats(min_value=_MIN_EPOCH, max_value=_MAX_EPOCH, allow_nan=False, allow_infinity=False)
+
+# Hashes are opaque MD5-shaped tokens; the kernel only compares them for
+# equality, so a small alphabet keeps generation cheap while still exercising
+# both the equal and diverged branches.
+_hashes = st.sampled_from(["hash-a", "hash-b", "hash-c"])
+_opt_hashes = st.none() | _hashes
+
+
+def _epoch_to_iso(epoch: float, *, zulu: bool, micros: bool) -> str:
+    """Render an epoch as one of the ISO shapes RomM has emitted."""
+    dt = datetime.fromtimestamp(epoch, tz=UTC).replace(microsecond=0)
+    base = dt.strftime("%Y-%m-%dT%H:%M:%S")
+    if micros:
+        base = f"{base}.000000"
+    return f"{base}Z" if zulu else f"{base}+00:00"
+
+
+@st.composite
+def _local_files(draw: st.DrawFn) -> dict[str, Any]:
+    mtime = draw(_epochs)
+    return {
+        "filename": "Game.srm",
+        "path": "/tmp/Game.srm",
+        "size": draw(st.integers(min_value=0, max_value=1_048_576)),
+        "mtime": mtime,
+    }
+
+
+_opt_local_files = st.none() | _local_files()
+
+
+@st.composite
+def _device_syncs(draw: st.DrawFn) -> list[dict[str, Any]]:
+    """A device_syncs list that may include our device, another device, both,
+    or neither — exercising all three branches (is_current, not-current,
+    no-entry)."""
+    entries: list[dict[str, Any]] = []
+    if draw(st.booleans()):
+        entries.append({"device_id": DEVICE_ID, "is_current": draw(st.booleans())})
+    if draw(st.booleans()):
+        entries.append({"device_id": OTHER_DEVICE_ID, "is_current": draw(st.booleans())})
+    return entries
+
+
+@st.composite
+def _server_saves(draw: st.DrawFn) -> dict[str, Any]:
+    epoch = draw(_epochs)
+    return {
+        "id": draw(st.integers(min_value=1, max_value=9999)),
+        "slot": 0,
+        "updated_at": _epoch_to_iso(epoch, zulu=draw(st.booleans()), micros=draw(st.booleans())),
+        "file_extension": "srm",
+        "device_syncs": draw(_device_syncs()),
+    }
+
+
+_server_lists = st.lists(_server_saves(), min_size=0, max_size=5)
+_files_states = st.fixed_dictionaries({}, optional={"last_sync_hash": _hashes})
+
+
+def _action(
+    local_file: dict[str, Any] | None,
+    server_saves: list[dict[str, Any]],
+    files_state: dict[str, Any],
+    local_hash: str | None,
+) -> SyncAction:
+    return compute_sync_action(
+        local_file=local_file,
+        server_saves_in_slot=server_saves,
+        files_state=files_state,
+        device_id=DEVICE_ID,
+        local_hash=local_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 (#965): no destructive action without a recovery source.
+# ---------------------------------------------------------------------------
+
+
+@given(
+    local_file=_opt_local_files,
+    server_saves=_server_lists,
+    files_state=_files_states,
+    local_hash=_opt_hashes,
+)
+def test_no_destructive_action_without_recovery(
+    local_file: dict[str, Any] | None,
+    server_saves: list[dict[str, Any]],
+    files_state: dict[str, Any],
+    local_hash: str | None,
+) -> None:
+    """The kernel never emits an action that loses local data without a
+    recovery source.
+
+    Concretely, for any inputs:
+    - ``Skip("nothing_to_sync")`` only when there is no local file (nothing was
+      lost — there was nothing to protect).
+    - ``Download`` / ``Conflict`` always carry a ``server_save`` drawn from the
+      input slot — so when they overwrite a present local file, the bytes that
+      replace it are a real server record (the recovery source), never a
+      fabricated or empty one.
+    - ``Upload`` never targets a save id absent from the slot.
+
+    This is the kernel-output half of the #965 class (never delete local data
+    that has neither a server copy nor a backup). The destructive *deletion*
+    path #965 reports lives in the slot-switch service, not in this pure
+    kernel; here we pin that the kernel itself never originates such an action.
+    """
+    result = _action(local_file, server_saves, files_state, local_hash)
+    slot_ids = {ss.get("id") for ss in server_saves}
+    slot_identities = {id(ss) for ss in server_saves}
+
+    if isinstance(result, Skip) and result.reason == "nothing_to_sync":
+        assert local_file is None
+    elif isinstance(result, (Download, Conflict)):
+        # The carried save must be one of the actual server records in the
+        # slot — the recovery source, not a fabricated dict.
+        assert id(result.server_save) in slot_identities
+    elif isinstance(result, Upload) and result.target_save_id is not None:
+        # POST (None) is always allowed; a PUT must target a real slot save.
+        assert result.target_save_id in slot_ids
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 (#1014): decisions stable under timestamp-format variation.
+# ---------------------------------------------------------------------------
+
+
+def _reformat_server(ss: dict[str, Any], *, zulu: bool, micros: bool) -> dict[str, Any]:
+    """Return a copy of *ss* with ``updated_at`` re-rendered in another
+    semantically-equal ISO shape."""
+    epoch = datetime.fromisoformat(ss["updated_at"].replace("Z", "+00:00")).timestamp()
+    return {**ss, "updated_at": _epoch_to_iso(epoch, zulu=zulu, micros=micros)}
+
+
+@given(
+    local_file=_opt_local_files,
+    server_saves=_server_lists,
+    files_state=_files_states,
+    local_hash=_opt_hashes,
+    zulu=st.booleans(),
+    micros=st.booleans(),
+)
+def test_action_stable_under_timestamp_format(
+    local_file: dict[str, Any] | None,
+    server_saves: list[dict[str, Any]],
+    files_state: dict[str, Any],
+    local_hash: str | None,
+    zulu: bool,
+    micros: bool,
+) -> None:
+    """Re-rendering every ``updated_at`` in a different but semantically-equal
+    ISO shape (``Z`` ⇄ ``+00:00``, with/without microseconds) yields an
+    IDENTICAL ``SyncAction``. The kernel orders by ``parse_iso_to_epoch``, so
+    format must not influence the decision — the #1014 class (lexicographic
+    ordering) at the kernel surface.
+    """
+    base = _action(local_file, server_saves, files_state, local_hash)
+    reformatted = [_reformat_server(ss, zulu=zulu, micros=micros) for ss in server_saves]
+    other = _action(local_file, reformatted, files_state, local_hash)
+
+    # Compare by value. Download/Conflict carry the server dict, which differs
+    # only in updated_at formatting between the two runs; compare structurally
+    # on everything except that one field. Skip/Upload carry no timestamp, so
+    # they must be value-equal outright.
+    assert type(base) is type(other)
+    if isinstance(base, (Download, Conflict)):
+        other_save = other.server_save  # type: ignore[union-attr]
+        picked = base.server_save
+        assert picked["id"] == other_save["id"]
+        epoch_picked = datetime.fromisoformat(picked["updated_at"].replace("Z", "+00:00")).timestamp()
+        epoch_other = datetime.fromisoformat(other_save["updated_at"].replace("Z", "+00:00")).timestamp()
+        assert epoch_picked == epoch_other
+    else:
+        assert base == other
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 (#1013): replay determinism + idempotence after baseline adoption.
+# ---------------------------------------------------------------------------
+
+
+@given(
+    local_file=_opt_local_files,
+    server_saves=_server_lists,
+    files_state=_files_states,
+    local_hash=_opt_hashes,
+)
+def test_replay_determinism(
+    local_file: dict[str, Any] | None,
+    server_saves: list[dict[str, Any]],
+    files_state: dict[str, Any],
+    local_hash: str | None,
+) -> None:
+    """The kernel is a pure function: identical inputs replayed yield an
+    identical action. The foundation of the no-loop guarantee."""
+    first = _action(local_file, server_saves, files_state, local_hash)
+    second = _action(local_file, server_saves, files_state, local_hash)
+    assert first == second
+
+
+@given(local_file=_local_files(), server_epoch=_epochs, local_hash=_hashes)
+def test_idempotent_after_branch6_upload_and_baseline_adoption(
+    local_file: dict[str, Any],
+    server_epoch: float,
+    local_hash: str,
+) -> None:
+    """Branch-6 → adopt → Skip replay invariance (the #1013 no-loop property).
+
+    Step 1: a save with no ``device_syncs`` entry for our device and a local
+    mtime at-or-after the server's ``updated_at`` dispatches ``Upload(None)``
+    (POST a new save).
+
+    Step 2: the service adopts the baseline — the server save now carries our
+    ``device_syncs`` entry with ``is_current=True`` and
+    ``files_state["last_sync_hash"]`` equals the local hash. Re-running the
+    kernel on those updated inputs MUST return ``Skip("synced")``, never
+    another ``Upload`` — otherwise sync churns out duplicate server saves on
+    every pass.
+    """
+    # Local mtime at-or-after server updated_at so step 1 is the POST branch.
+    local_file = {**local_file, "mtime": server_epoch + 3600}
+    server = {
+        "id": 7,
+        "slot": 0,
+        "updated_at": _epoch_to_iso(server_epoch, zulu=False, micros=False),
+        "file_extension": "srm",
+        "device_syncs": [{"device_id": OTHER_DEVICE_ID, "is_current": True}],
+    }
+
+    step1 = _action(local_file, [server], {}, local_hash)
+    assume(isinstance(step1, Upload) and step1.target_save_id is None)
+
+    # Service adopts baseline: our device entry is now current, and the
+    # recorded baseline hash matches the local content.
+    adopted_server = {
+        **server,
+        "device_syncs": [{"device_id": DEVICE_ID, "is_current": True}],
+    }
+    step2 = _action(local_file, [adopted_server], {"last_sync_hash": local_hash}, local_hash)
+    assert step2 == Skip(reason="synced")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#1013: branch 6 ignores content hashes — byte-identical content with no device entry POSTs a duplicate",
+)
+@given(local_file=_local_files(), server_epoch=_epochs, local_hash=_hashes)
+def test_no_entry_identical_content_does_not_duplicate(
+    local_file: dict[str, Any],
+    server_epoch: float,
+    local_hash: str,
+) -> None:
+    """No device entry + content byte-identical to the slot's server save must
+    NOT POST a duplicate (the #1013 invariant).
+
+    The slot already holds a server save whose content hash equals the local
+    content (``content_hash == local_hash`` — a copied SD card, a restored
+    backup, a fresh reinstall). Our device has no ``device_syncs`` entry, and
+    the local mtime is at-or-after the server's ``updated_at``. The correct
+    action adopts the existing server save as the baseline
+    (``Skip(adopt_baseline=True)``); POSTing a second copy of identical bytes
+    creates a duplicate server save and churns autocleanup.
+
+    Today branch 6 (`_decide_when_no_entry`) compares only mtime and returns
+    ``Upload(target_save_id=None)`` — this property fails until #1013 threads
+    the server content hash into the decision. When the fix lands the property
+    XPASSes, ``strict=True`` flips the run red, the marker is removed, and the
+    property guards against the duplicate-POST regression thereafter.
+    """
+    local_file = {**local_file, "mtime": server_epoch + 3600}
+    server = {
+        "id": 7,
+        "slot": 0,
+        "updated_at": _epoch_to_iso(server_epoch, zulu=False, micros=False),
+        "file_extension": "srm",
+        "content_hash": local_hash,
+        "device_syncs": [{"device_id": OTHER_DEVICE_ID, "is_current": True}],
+    }
+    result = _action(local_file, [server], {}, local_hash)
+    # Identical content already on the server → adopt it, never POST a duplicate.
+    assert result == Skip(reason="synced", adopt_baseline=True)


### PR DESCRIPTION
Closes #1028.

`compute_sync_action` (`domain/sync_action.py`) and the canonical-target grouping key (`domain/save_path.py`) are pure, safety-critical functions previously covered only by hand-enumerated cases — which missed the cross-extension (#1006) and duplicate-POST (#1013) classes. This adds [hypothesis](https://hypothesis.readthedocs.io) property tests encoding the four save-sync invariants on the pure kernels, as the executable spec the #794/#793 fix must satisfy.

## Discipline

Each property states the **true** invariant. A property whose bug is still open is pinned `@pytest.mark.xfail(strict=True, reason="#<bug>")` — never weakened. `strict=True` means the day the fix lands the property passes → XPASS → CI red → the marker must be removed, and the property then guards against regression.

## What running the spec revealed

Of the four invariants, only **#1013 originates in the pure kernel** — the others live in impure orchestration code, where the kernel surfaces themselves are already correct:

| Invariant | Bug | Where it actually lives | In this PR |
|---|---|---|---|
| Idempotence / no duplicate POST | #1013 | `sync_action.py` branch 6 (`_decide_when_no_entry`) ignores the content hash | **`xfail(strict, "#1013")`** — flips to XPASS on fix |
| Group isolation | #1006 | `matrix.py` local-file loop passes the whole slot unfiltered (impure) | live guard on the grouping key `compute_local_save_target` |
| No destructive delete | #965 | `switching.py` deletes without backup; the kernel has no delete action | live guard on kernel output |
| Timestamp-format stability | #1014 | lexicographic `updated_at` sort in `versions.py` / `setup.py`; the kernel already orders by epoch | live guard on kernel + `parse_iso_to_epoch` |

So this PR is the faithful **pure-kernel** spec: it catches and guards #1013, and pins the correct kernel behaviour for the other three classes. Catching #1006/#965/#1014 at their **real sites** (the impure matrix/switch/versions paths) belongs to the fix PRs (#794/#793) — same xfail-then-fix discipline applied there.

## Mechanics

- `hypothesis` added as a dev-only dependency, compiled into `requirements-dev.lock` via `mise run lock-update` (not in the docs lock).
- CI-safe hypothesis profile in `tests/conftest.py` (`deadline=None`, `max_examples=200`); `.hypothesis/` gitignored.
- 8 live properties pass, 1 xfailed; deterministic across repeated runs.

docs: updated — `CLAUDE.md` (Testing: property tier + the `xfail(strict)` open-bug-pinning convention) and `docs/contributing/development.md` (running property tests + hypothesis).