### PR TITLE
test(contract): callable contract-test harness + read-surface coverage (#1027 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,36 @@ property passes → the run reports XPASS → CI fails → the marker must be re
 regression. So a property never gets weakened to go green: it either passes live (a regression guard) or is
 `xfail`-pinned to its open bug.
 
+### Contract tests — real `Plugin` over real `bootstrap`, callables driven frontend-shaped
+
+`tests/contract/` is a tier that crosses the frontend↔backend wire. The unit tests exercise each side against its own
+mocked idea of the other; the contract tier builds the **real** `Plugin` through the **real** `bootstrap()` +
+`wire_services()` (real settings dict, real SQLite + migrations, real file-store adapters, all rooted under `tmp_path`)
+and drives the actual `main.py` callable methods. Only the outermost edges are faked: `romm_api` → `FakeRommApi`,
+`sgdb_adapter` → `FakeSteamGridDbApi`, the Clock/UuidGen/Sleeper seams → the deterministic fakes, `emit` → an
+`AsyncMock`, and `http_adapter.with_retry` → a single-attempt pass-through (so a failure-injection test pays no backoff
+sleep). The harness + its `harness` fixture live in `tests/contract/_harness.py` / `conftest.py`; shared
+relational/server seeding helpers live in `tests/contract/_seed.py`.
+
+Rules for this tier:
+
+- **Call callables exactly as the frontend does** — positional, JSON-shaped arguments with the arg TYPES declared in
+  `src/api/backend.ts` (literal `None` where the TS type says `null`, e.g. `get_installed_rom` returning `None`).
+- **Assert the response SHAPE + behavior (the contract), not delegation.** Pin the literal dict keys, the canonical
+  failure shape (`{success: False, reason, message}`), the discriminated-status union (`status: "ok" | ...`), and the
+  partial-success carve-outs (`server_query_failed: bool`, `recommended_action`). Where a callable has a
+  server-reachable failure mode, exercise BOTH the happy path AND the failure path — the failure-shape assertions are
+  what guard the #1009/#1004-class bugs.
+- The `harness` fixture is **async** so it binds the test's running event loop (the callables `await` on it; a
+  mismatched loop raises "got Future attached to a different loop"). Each test gets a fresh `tmp_path`, so
+  real-bootstrap state never leaks between tests.
+- A wiring drift (a renamed/added service) fails the fixture loudly via the bound-attribute assert, not as a confusing
+  mid-test `AttributeError`.
+
+Phase 2 — a `backend.ts` manifest gate that parses the `callable<[Args], Return>("name")` declarations into an artifact
+the pytest side consumes (so a renamed callable or changed default breaks CI) — is a forthcoming separate PR; it is not
+built yet.
+
 ### Frontend component tests — `@decky/api` event harness
 
 `src/test-utils/decky-api-mock.ts` exposes an in-memory event bus that `addEventListener` / `removeEventListener` route

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -68,6 +68,24 @@ Hypothesis is a dev-only dependency (pinned in `requirements-dev.txt`, compiled 
 (no timing flakes on shared runners) and a fixed example count. The example database is written to `.hypothesis/`, which
 is gitignored. See the CLAUDE.md "Testing" section for the convention on pinning a property that encodes an open bug.
 
+### Contract tests
+
+`tests/contract/` is a tier that crosses the frontend↔backend wire. Where the unit tests check each side against its own
+mocked idea of the other, the contract tier builds the **real** `Plugin` through the **real** `bootstrap()` +
+`wire_services()` (real settings dict, real SQLite + migrations, real file-store adapters, all under `tmp_path`) and
+drives the actual `main.py` callables **exactly as the frontend does** — positional, JSON-shaped arguments with the arg
+types declared in `src/api/backend.ts` (literal `None` where the TS type says `null`). The assertions pin the response
+_shape_ (canonical failure shape, discriminated-status unions, partial-success flags), not delegation. Only the
+outermost edges are faked: the RomM + SteamGridDB network transports, the Clock/UuidGen/Sleeper seams, `emit`, and the
+retry backoff. Run them like any other test:
+
+```bash
+python -m pytest tests/contract/ -q
+```
+
+A `backend.ts` manifest gate (Phase 2) that pins the frontend and backend to one parsed artifact is a forthcoming
+separate change. See the CLAUDE.md "Testing" section for the full contract-tier rules.
+
 Every backend feature or callable where testing makes sense should have unit tests covering:
 
 - **Happy path** — normal successful operation

--- a/tests/contract/_harness.py
+++ b/tests/contract/_harness.py
@@ -1,0 +1,213 @@
+"""Contract-test harness — the real ``Plugin`` over the real ``bootstrap()``.
+
+This tier drives the actual ``main.py`` callable surface the way the
+frontend does. Anything that builds, wires, or seeds the real plugin for
+a contract test belongs here; the per-callable contract assertions live
+in the sibling ``test_*.py`` modules.
+
+What stays real vs. what is faked
+=================================
+
+The harness calls the **real** :func:`bootstrap` (real settings dict,
+real SQLite database + migrations, real file-store adapters) rooted under
+a pytest ``tmp_path`` and wires the **real** services via the real
+:func:`wire_services`. Only the outermost edges are swapped:
+
+* ``romm_api`` → :class:`FakeRommApi` (the network transport — so tests
+  seed library/saves/server state and inject failures without HTTP).
+* ``sgdb_adapter`` → :class:`FakeSteamGridDbApi` (the SteamGridDB
+  network transport).
+* ``clock`` / ``uuid_gen`` / ``sleeper`` → the deterministic fakes from
+  ``tests.fakes.system_time`` so timestamped responses are assertable.
+* ``http_adapter.with_retry`` → a single-attempt pass-through so a
+  failure-injection test does not pay the real exponential backoff
+  ``time.sleep`` (1s, 3s …). Everything else on the real
+  ``RommHttpAdapter`` (``resolve_system``, settings binding) stays real —
+  it is a pure settings/file read with no network on the read paths.
+* ``emit`` → an ``AsyncMock`` so tests assert emissions.
+
+The SQLite database, the file stores, and the settings file all write
+into ``tmp_path``; that is intended and isolated per test (pytest hands
+each test a fresh ``tmp_path``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+from bootstrap import (
+    RuntimeBundle,
+    WiringConfig,
+    bootstrap,
+    wire_services,
+)
+from fakes.fake_romm_api import FakeRommApi
+from fakes.fake_steamgrid_db_api import FakeSteamGridDbApi
+from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Imported lazily inside the builder so ``conftest`` import order (which sets
+# up ``sys.path`` and the mock ``decky`` module) is respected before ``main``
+# is touched.
+
+# The service attributes ``main.py:_main`` binds onto ``Plugin``. The harness
+# binds the same set; the loud-failure assert below checks every one is present
+# so a wiring drift (a renamed/added service key) fails the fixture instead of
+# surfacing as a confusing ``AttributeError`` mid-test.
+_BOUND_SERVICE_ATTRS = {
+    "_save_sync_service": "save_sync_service",
+    "_playtime_service": "playtime_service",
+    "_sync_service": "sync_service",
+    "_download_service": "download_service",
+    "_rom_removal_service": "rom_removal_service",
+    "_firmware_service": "firmware_service",
+    "_sgdb_service": "sgdb_service",
+    "_metadata_service": "metadata_service",
+    "_achievements_service": "achievements_service",
+    "_migration_service": "migration_service",
+    "_game_detail_service": "game_detail_service",
+    "_artwork_service": "artwork_service",
+    "_shortcut_removal_service": "shortcut_removal_service",
+    "_settings_service": "settings_service",
+    "_core_service": "core_service",
+    "_connection_service": "connection_service",
+    "_startup_healing_service": "startup_healing_service",
+    "_launch_gate_service": "launch_gate_service",
+    "_session_lifecycle_service": "session_lifecycle_service",
+}
+
+
+@dataclass
+class ContractHarness:
+    """What a contract test reaches for: the wired plugin + the fake edges.
+
+    ``plugin`` is the real :class:`main.Plugin` with every service wired.
+    ``romm`` is the :class:`FakeRommApi` the plugin's services talk to —
+    tests seed library/saves/server state on it and arm its failure seams.
+    ``sgdb`` is the :class:`FakeSteamGridDbApi`. ``emit`` is the
+    ``AsyncMock`` the runtime emits through. ``clock`` is the deterministic
+    :class:`FakeClock`. ``tmp_path`` is the per-test root every real adapter
+    writes under.
+    """
+
+    plugin: Any
+    romm: FakeRommApi
+    sgdb: FakeSteamGridDbApi
+    emit: AsyncMock
+    clock: FakeClock
+    tmp_path: Any
+    # The real SQLite Unit-of-Work factory the wired services use. Tests open it
+    # to seed relational state (roms / rom_installs / rom_save_states / kv_config)
+    # exactly as the services read it — same database, same connection contract.
+    uow_factory: Any
+
+
+def _single_attempt_pass_through(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run ``fn`` exactly once, no retry/backoff — replaces ``http_adapter.with_retry``.
+
+    The real ``with_retry`` sleeps with exponential backoff on retryable
+    transport errors; a failure-injection contract test would otherwise pay
+    real wall-clock seconds. The single-attempt pass-through preserves the
+    contract (the wrapped call's value or exception propagates verbatim).
+    """
+    return fn(*args, **kwargs)
+
+
+def build_contract_harness(tmp_path: Any) -> ContractHarness:
+    """Build the real ``Plugin`` over the real ``bootstrap()``, faking only the edges.
+
+    Mirrors ``main.py:_main`` bindings exactly (see ``_BOUND_SERVICE_ATTRS``)
+    so the wired plugin behaves as it does in production, then asserts every
+    expected service attribute is bound — a wiring drift fails loudly here.
+    """
+    from main import Plugin
+
+    logger = logging.getLogger("contract")
+
+    # 1. Real bootstrap — real settings dict, real SQLite + migrations, real
+    #    file-store adapters, all rooted under tmp_path.
+    result = bootstrap(
+        settings_dir=str(tmp_path / "settings"),
+        runtime_dir=str(tmp_path / "runtime"),
+        plugin_dir=str(tmp_path / "plugin"),
+        user_home=str(tmp_path / "home"),
+        logger=logger,
+    )
+
+    # 2. Swap only the network edges in the returned AdapterBundle. The bundle
+    #    is frozen, so rebuild it with dataclasses.replace. The real
+    #    http_adapter is kept (resolve_system is a pure read) but its with_retry
+    #    is neutralised so failure-injection tests don't sleep.
+    fake_romm = FakeRommApi()
+    fake_sgdb = FakeSteamGridDbApi()
+    real_http = result.adapters.http_adapter
+    real_http.with_retry = _single_attempt_pass_through  # type: ignore[method-assign]
+    patched_adapters = dataclasses.replace(
+        result.adapters,
+        romm_api=fake_romm,
+        sgdb_adapter=fake_sgdb,
+    )
+
+    # Deterministic time/uuid/sleep seams so timestamped responses assert cleanly.
+    fake_clock = FakeClock()
+    fake_uuid = FakeUuidGen()
+    fake_sleeper = FakeSleeper()
+
+    emit = AsyncMock()
+    # The running loop the test executes in. The harness is built from inside an
+    # async fixture so this is the *same* loop the callables will await on —
+    # binding the loop captured at module import (a different loop) would make
+    # ``run_in_executor`` raise "got Future attached to a different loop".
+    loop = asyncio.get_event_loop()
+
+    # 3. Wire the real services with the patched bundle.
+    cfg = WiringConfig(
+        adapters=patched_adapters,
+        stores=result.stores,
+        runtime=RuntimeBundle(
+            loop=loop,
+            logger=logger,
+            plugin_dir=str(tmp_path / "plugin"),
+            runtime_dir=str(tmp_path / "runtime"),
+            emit=emit,
+            clock=fake_clock,
+            uuid_gen=fake_uuid,
+            sleeper=fake_sleeper,
+            hostname_provider=result.runtime_adapters.hostname_provider,
+            machine_id_provider=result.runtime_adapters.machine_id_provider,
+        ),
+        callbacks=result.callbacks,
+        min_required_version=Plugin._MIN_REQUIRED_VERSION,
+    )
+    services = wire_services(cfg)
+
+    # 4. Construct the real Plugin and bind exactly as main.py:_main does.
+    plugin = Plugin()
+    plugin.loop = loop
+    plugin.settings = result.stores.settings
+    plugin._debug_logger = result.handles.debug_logger
+    plugin._retrodeck_paths = result.callbacks.retrodeck_paths
+    for attr, key in _BOUND_SERVICE_ATTRS.items():
+        setattr(plugin, attr, services[key])
+
+    # Loud-failure guard: a wiring drift (renamed/added service) must fail the
+    # fixture here, not as a confusing AttributeError deep in a contract test.
+    missing = [attr for attr in _BOUND_SERVICE_ATTRS if getattr(plugin, attr, None) is None]
+    assert not missing, f"contract harness wiring drift — unbound service attrs: {missing}"
+
+    return ContractHarness(
+        plugin=plugin,
+        romm=fake_romm,
+        sgdb=fake_sgdb,
+        emit=emit,
+        clock=fake_clock,
+        tmp_path=tmp_path,
+        uow_factory=result.callbacks.uow_factory,
+    )

--- a/tests/contract/_seed.py
+++ b/tests/contract/_seed.py
@@ -1,0 +1,145 @@
+"""Seeding helpers for contract tests — write real relational + server state.
+
+These helpers write through the harness's *real* SQLite Unit of Work (the
+same one the wired services read) and onto the *real* settings dict, so a
+contract test seeds state the way production accumulates it. The server
+side is seeded directly on the :class:`FakeRommApi` public attributes.
+
+The real ``rom_save_states`` / ``rom_installs`` tables carry a ``rom_id``
+foreign key to ``roms`` (``PRAGMA foreign_keys=ON``), so any per-ROM child
+seed must seed the parent ``Rom`` row first — :func:`seed_rom` does that and
+is called by the child seeders.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from domain.rom import Rom
+from domain.rom_install import RomInstall
+from domain.rom_save_state import RomSaveState
+
+if TYPE_CHECKING:
+    from tests.contract._harness import ContractHarness
+
+
+def enable_save_sync(harness: ContractHarness, *, device_id: str = "device-1") -> None:
+    """Flip on save sync and bind a server device id (matches FakeRommApi seeds)."""
+    harness.plugin.settings["save_sync_enabled"] = True
+    with harness.uow_factory() as uow:
+        uow.kv_config.set("device_id", device_id)
+
+
+def seed_rom(
+    harness: ContractHarness,
+    rom_id: int,
+    *,
+    platform_slug: str = "gba",
+    shortcut_app_id: int = 0,
+) -> None:
+    """Seed a ``Rom`` registry row (the FK anchor for per-ROM child writes).
+
+    ``shortcut_app_id`` defaults to ``rom_id`` so the row counts as a bound
+    shortcut in registry/stat reads; pass ``0`` to seed a ROM with no Steam
+    shortcut bound (it then does not count toward bound-shortcut reads).
+    """
+    with harness.uow_factory() as uow:
+        uow.roms.save(
+            Rom.synced(
+                rom_id=rom_id,
+                platform_slug=platform_slug,
+                name=f"rom-{rom_id}",
+                fs_name=f"rom-{rom_id}",
+                shortcut_app_id=shortcut_app_id or rom_id,
+                synced_at="2026-01-01T00:00:00",
+            )
+        )
+
+
+def seed_install(
+    harness: ContractHarness,
+    rom_id: int,
+    *,
+    system: str = "gba",
+    platform_slug: str = "gba",
+    file_name: str = "game.gba",
+) -> str:
+    """Seed a ``RomInstall`` (seeds the ``Rom`` FK first). Returns the file path."""
+    seed_rom(harness, rom_id, platform_slug=platform_slug)
+    file_path = str(harness.tmp_path / "retrodeck" / "roms" / system / file_name)
+    with harness.uow_factory() as uow:
+        uow.rom_installs.save(
+            RomInstall.mark_installed(
+                rom_id=rom_id,
+                file_path=file_path,
+                rom_dir=None,
+                platform_slug=platform_slug,
+                system=system,
+                installed_at="2026-01-01T00:00:00",
+            )
+        )
+    return file_path
+
+
+def seed_save_state(
+    harness: ContractHarness,
+    rom_id: int,
+    state: RomSaveState,
+    *,
+    platform_slug: str = "gba",
+) -> None:
+    """Seed a ``RomSaveState`` aggregate (seeds the ``Rom`` FK first)."""
+    seed_rom(harness, rom_id, platform_slug=platform_slug)
+    with harness.uow_factory() as uow:
+        uow.rom_save_states.save(rom_id, state)
+
+
+def seed_confirmed_slot(
+    harness: ContractHarness,
+    rom_id: int,
+    *,
+    slot: str = "main",
+    source: str = "server",
+    platform_slug: str = "gba",
+) -> None:
+    """Seed a tracked + confirmed save slot for ``rom_id``.
+
+    Produces ``slot_confirmed=True`` and an ``active_slot``, with the slot
+    present in the persisted slots map (the shape ``get_slot_delete_info``
+    and ``is_save_tracking_configured`` read).
+    """
+    state = RomSaveState()
+    state.confirm_slot(slot)
+    state.refresh_slot_listing({slot: {"source": source, "count": 1, "latest_updated_at": "2026-01-01T00:00:00Z"}})
+    seed_save_state(harness, rom_id, state, platform_slug=platform_slug)
+
+
+def server_save(
+    *,
+    save_id: int,
+    rom_id: int,
+    file_name: str = "game.srm",
+    slot: str | None = "main",
+    updated_at: str = "2026-02-01T00:00:00Z",
+    emulator: str = "retroarch",
+    file_size_bytes: int = 1024,
+) -> dict[str, Any]:
+    """Build a server-save dict shaped like RomM's save payload."""
+    entry: dict[str, Any] = {
+        "id": save_id,
+        "rom_id": rom_id,
+        "file_name": file_name,
+        "updated_at": updated_at,
+        "emulator": emulator,
+        "file_size_bytes": file_size_bytes,
+    }
+    if slot is not None:
+        entry["slot"] = slot
+    return entry
+
+
+def seed_server_save(harness: ContractHarness, **kwargs: Any) -> dict[str, Any]:
+    """Seed one server save on the FakeRommApi and return the stored dict."""
+    entry = server_save(**kwargs)
+    harness.romm.saves[entry["id"]] = entry
+    return entry

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,28 @@
+"""Fixtures for the callable contract-test tier.
+
+Exposes the ``harness`` fixture: a real :class:`main.Plugin` wired through
+the real :func:`bootstrap` with only the network edges faked. See
+:mod:`tests.contract._harness` for the build recipe and the real-vs-faked
+boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.contract._harness import ContractHarness, build_contract_harness
+
+
+@pytest.fixture
+async def harness(tmp_path) -> ContractHarness:
+    """A wired real ``Plugin`` plus the fake edges a contract test drives.
+
+    Async so the harness binds the test's *running* event loop into the
+    services' ``RuntimeBundle.loop`` — the callables ``await`` on that loop,
+    and a mismatched loop would raise "got Future attached to a different
+    loop" on the first ``run_in_executor``.
+
+    Each test gets a fresh ``tmp_path`` (own SQLite db, settings file, file
+    stores), so state never leaks between contract tests.
+    """
+    return build_contract_harness(tmp_path)

--- a/tests/contract/test_download_read.py
+++ b/tests/contract/test_download_read.py
@@ -1,0 +1,59 @@
+"""Contract tests for the download read-surface callables.
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``getDownloadQueue = callable<[], {downloads: DownloadItem[]}>`` and
+``getInstalledRom = callable<[number], InstalledRom | null>``.
+
+The ``get_installed_rom`` ``null`` case is the #1004-class shape risk: the
+backend must return Python ``None`` (which marshals to JS ``null``), not a
+sentinel dict. The test asserts the literal ``None``.
+
+Out of Phase 1 (not tested here): ``start_download`` / ``cancel_download``
+mutation + event flows — their event contract is owned by #1017 and lands
+with that fix.
+"""
+
+from __future__ import annotations
+
+from ._seed import seed_install
+
+# ── get_download_queue ───────────────────────────────────────────────────
+
+
+async def test_get_download_queue_empty_shape(harness):
+    """Empty queue: downloads key present and an empty list."""
+    result = await harness.plugin.get_download_queue()
+    assert result == {"downloads": []}
+    assert isinstance(result["downloads"], list)
+
+
+# ── get_installed_rom ────────────────────────────────────────────────────
+
+
+async def test_get_installed_rom_not_installed_is_literal_none(harness):
+    """Not installed → literal Python None (→ JS null), NOT a sentinel dict.
+
+    #1004-class guard: the frontend's ``InstalledRom | null`` contract relies
+    on the backend returning ``None`` here.
+    """
+    result = await harness.plugin.get_installed_rom(999)
+    assert result is None
+
+
+async def test_get_installed_rom_installed_shape(harness):
+    """Installed → InstalledRom dict with the documented keys."""
+    seed_install(harness, 42, system="gba", platform_slug="gba", file_name="pokemon.gba")
+    result = await harness.plugin.get_installed_rom(42)
+    assert result is not None
+    assert set(result.keys()) == {
+        "rom_id",
+        "file_name",
+        "file_path",
+        "system",
+        "platform_slug",
+        "installed_at",
+    }
+    assert result["rom_id"] == 42
+    assert result["file_name"] == "pokemon.gba"
+    assert result["platform_slug"] == "gba"
+    assert isinstance(result["file_path"], str)

--- a/tests/contract/test_saves_read.py
+++ b/tests/contract/test_saves_read.py
@@ -1,0 +1,292 @@
+"""Contract tests for the save-sync read-surface callables.
+
+Driven frontend-shaped per ``src/api/backend.ts`` (positional args, the TS
+arg types). The failure-shape assertions are the ones that guard the
+#1009-class bug (frontend ignoring ``success: false``) and the #1004-class
+partial-success carve-outs: proving the backend returns the canonical /
+discriminated / additive-flag shapes makes the contract explicit.
+
+Failure injection note: the save read paths run their RomM calls through
+``http_adapter.with_retry``, which the harness neutralises to a single
+attempt (no backoff sleep). A ``RommConnectionError`` (a real
+server-unreachable transport error) is therefore fast to inject.
+
+Explicitly OUT of Phase 1 (NOT tested here, named as deferred):
+
+- ``confirm_slot_choice`` and ``switch_slot`` — their fixed contract is not
+  decided until #1004 / #1005; the contract tests land with that fix.
+- ``delete_slot`` / ``resolve_sync_conflict`` / ``sync_rom_saves`` and the
+  other mutation flows — mutation + event contracts (#1017) land with their
+  own fixes; this tier covers the read surface only.
+"""
+
+from __future__ import annotations
+
+from lib.errors import RommConnectionError
+from lib.list_result import ErrorCode
+
+from ._seed import enable_save_sync, seed_confirmed_slot, seed_install, seed_rom, seed_server_save
+
+# ── get_save_status ──────────────────────────────────────────────────────
+
+
+async def test_get_save_status_full_shape_and_partial_flag(harness):
+    """Happy path: full payload, with the additive server_query_failed flag present and a bool."""
+    enable_save_sync(harness)
+    result = await harness.plugin.get_save_status(42)
+    expected_keys = {
+        "rom_id",
+        "files",
+        "playtime",
+        "device_id",
+        "last_sync_check_at",
+        "conflicts",
+        "save_sort_changed",
+        "savefiles_in_content_dir",
+        "save_sync_display",
+        "server_query_failed",
+        "multi_file",
+        "component_files",
+        "rollback_supported",
+    }
+    assert set(result.keys()) == expected_keys
+    assert result["rom_id"] == 42
+    assert isinstance(result["files"], list)
+    assert isinstance(result["conflicts"], list)
+    # Partial-success carve-out: the additive flag is present and a bool.
+    assert isinstance(result["server_query_failed"], bool)
+    assert result["server_query_failed"] is False
+
+
+async def test_get_save_status_server_failure_keeps_full_payload(harness):
+    """Server unreachable: server_query_failed True, full payload still returned (partial-success)."""
+    enable_save_sync(harness)
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_save_status(42)
+    # The carve-out: a failure flag rides alongside the full payload, not a
+    # bare {success: False}. The frontend still renders local state.
+    assert result["server_query_failed"] is True
+    assert result["rom_id"] == 42
+    assert "files" in result
+    assert "save_sync_display" in result
+
+
+# ── get_save_slots ───────────────────────────────────────────────────────
+
+
+async def test_get_save_slots_happy_shape(harness):
+    enable_save_sync(harness)
+    # get_save_slots persists the merged slot listing → its rom_save_states write
+    # needs the roms FK parent (a synced ROM always has one in production).
+    seed_rom(harness, 42)
+    seed_server_save(harness, save_id=500, rom_id=42, slot="main")
+    result = await harness.plugin.get_save_slots(42)
+    assert result["success"] is True
+    assert isinstance(result["slots"], list)
+    assert isinstance(result["active_slot"], str)
+    if result["slots"]:
+        slot = result["slots"][0]
+        assert set(slot.keys()) == {"slot", "source", "count", "latest_updated_at"}
+
+
+async def test_get_save_slots_sync_disabled_failure_shape(harness):
+    """Sync disabled → failure shape WITH fallback fields the frontend renders."""
+    # save_sync_enabled defaults to False — do not enable it.
+    result = await harness.plugin.get_save_slots(42)
+    assert result["success"] is False
+    assert result["reason"] == "sync_disabled"
+    assert isinstance(result["message"], str)
+    assert result["message"]
+    assert result["slots"] == []
+    assert result["active_slot"] == "default"
+
+
+async def test_get_save_slots_server_failure_shape(harness):
+    """Server unreachable → canonical SERVER_UNREACHABLE failure with fallbacks."""
+    enable_save_sync(harness)
+    harness.romm.get_save_summary_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_save_slots(42)
+    assert result["success"] is False
+    assert result["reason"] == ErrorCode.SERVER_UNREACHABLE
+    assert isinstance(result["message"], str)
+    assert result["message"]
+    assert result["slots"] == []
+    assert "active_slot" in result
+
+
+# ── get_slot_saves ───────────────────────────────────────────────────────
+
+
+async def test_get_slot_saves_happy_shape(harness):
+    enable_save_sync(harness)
+    seed_server_save(harness, save_id=600, rom_id=42, slot="main", file_name="game.srm")
+    result = await harness.plugin.get_slot_saves(42, "main")
+    assert result["success"] is True
+    assert result["slot"] == "main"
+    assert isinstance(result["saves"], list)
+    assert len(result["saves"]) == 1
+    save = result["saves"][0]
+    assert set(save.keys()) == {"filename", "id", "size", "updated_at", "emulator"}
+    assert save["filename"] == "game.srm"
+    assert save["id"] == 600
+
+
+async def test_get_slot_saves_server_failure_shape(harness):
+    enable_save_sync(harness)
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_slot_saves(42, "main")
+    assert result["success"] is False
+    assert result["reason"] == ErrorCode.SERVER_UNREACHABLE
+    assert isinstance(result["message"], str)
+    assert result["slot"] == "main"
+    assert result["saves"] == []
+
+
+# ── get_slot_delete_info ─────────────────────────────────────────────────
+
+
+async def test_get_slot_delete_info_happy_shape(harness):
+    """Installed + tracked slot → full delete-info shape."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", platform_slug="gba")
+    seed_confirmed_slot(harness, 42, slot="main", source="server")
+    seed_server_save(harness, save_id=700, rom_id=42, slot="main")
+    result = await harness.plugin.get_slot_delete_info(42, "main")
+    assert result["success"] is True
+    assert set(result.keys()) == {
+        "success",
+        "slot",
+        "source",
+        "server_save_count",
+        "server_save_ids",
+        "local_file_count",
+        "local_filenames",
+        "is_active",
+    }
+    assert result["slot"] == "main"
+    assert result["is_active"] is True
+    assert isinstance(result["server_save_ids"], list)
+
+
+async def test_get_slot_delete_info_not_installed_failure_shape(harness):
+    """Documented guard: sync on but not installed → {success: False, reason: not_installed}."""
+    enable_save_sync(harness)
+    result = await harness.plugin.get_slot_delete_info(42, "main")
+    assert result == {"success": False, "reason": "not_installed"}
+
+
+async def test_get_slot_delete_info_server_failure_shape(harness):
+    """Server unreachable while inspecting a server slot → SERVER_UNREACHABLE."""
+    enable_save_sync(harness)
+    seed_install(harness, 42, system="gba", platform_slug="gba")
+    seed_confirmed_slot(harness, 42, slot="main", source="server")
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_slot_delete_info(42, "main")
+    assert result["success"] is False
+    assert result["reason"] == ErrorCode.SERVER_UNREACHABLE
+    assert isinstance(result["message"], str)
+    assert result["message"]
+
+
+# ── is_save_tracking_configured ──────────────────────────────────────────
+
+
+async def test_is_save_tracking_configured_unconfigured_shape(harness):
+    result = await harness.plugin.is_save_tracking_configured(42)
+    assert result == {"configured": False, "active_slot": None}
+
+
+async def test_is_save_tracking_configured_configured_shape(harness):
+    seed_confirmed_slot(harness, 42, slot="main")
+    result = await harness.plugin.is_save_tracking_configured(42)
+    assert result["configured"] is True
+    assert result["active_slot"] == "main"
+
+
+# ── get_save_setup_info ──────────────────────────────────────────────────
+
+
+async def test_get_save_setup_info_happy_shape(harness):
+    enable_save_sync(harness)
+    seed_server_save(harness, save_id=800, rom_id=42, slot="main")
+    result = await harness.plugin.get_save_setup_info(42)
+    expected_keys = {
+        "has_local_saves",
+        "local_files",
+        "server_slots",
+        "default_slot",
+        "slot_confirmed",
+        "active_slot",
+        "recommended_action",
+        "server_query_failed",
+    }
+    assert set(result.keys()) == expected_keys
+    assert result["server_query_failed"] is False
+    # Server answered → recommendation is authoritative, never the unreachable slug.
+    assert result["recommended_action"] in {"auto_confirm_default", "show_wizard"}
+    assert isinstance(result["server_slots"], list)
+
+
+async def test_get_save_setup_info_server_failure_carve_out(harness):
+    """Server unreachable → recommended_action carve-out + additive failure flag."""
+    enable_save_sync(harness)
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_save_setup_info(42)
+    # Partial-success carve-out: surface a distinct recommendation instead of
+    # auto-confirming a default that could clobber real server saves.
+    assert result["recommended_action"] == "server_unreachable"
+    assert result["server_query_failed"] is True
+    assert result["server_slots"] == []
+
+
+# ── get_save_sync_settings ───────────────────────────────────────────────
+
+
+async def test_get_save_sync_settings_shape(harness):
+    result = await harness.plugin.get_save_sync_settings()
+    assert set(result.keys()) == {
+        "save_sync_enabled",
+        "sync_before_launch",
+        "sync_after_exit",
+        "default_slot",
+        "autocleanup_limit",
+    }
+    assert isinstance(result["save_sync_enabled"], bool)
+    assert isinstance(result["sync_before_launch"], bool)
+    assert isinstance(result["sync_after_exit"], bool)
+    assert isinstance(result["autocleanup_limit"], int)
+
+
+# ── saves_list_file_versions (discriminated-status union) ─────────────────
+
+
+async def test_saves_list_file_versions_ok_shape(harness):
+    """status == 'ok' discriminant + versions list."""
+    enable_save_sync(harness)
+    seed_server_save(harness, save_id=900, rom_id=42, slot="main", file_name="game.srm")
+    result = await harness.plugin.saves_list_file_versions(42, "main", "game.srm")
+    assert result["status"] == "ok"
+    assert isinstance(result["versions"], list)
+    if result["versions"]:
+        v = result["versions"][0]
+        assert set(v.keys()) == {
+            "id",
+            "file_name",
+            "emulator",
+            "updated_at",
+            "file_size_bytes",
+            "device_syncs",
+            "uploaded_by_us",
+        }
+
+
+async def test_saves_list_file_versions_server_unreachable_shape(harness):
+    """status == 'server_unreachable' carries message: str (NOT error)."""
+    enable_save_sync(harness)
+    harness.romm.list_saves_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.saves_list_file_versions(42, "main", "game.srm")
+    assert result["status"] == "server_unreachable"
+    assert isinstance(result["message"], str)
+    assert result["message"]
+    # The discriminated-status union uses `message`, never the legacy `error`.
+    assert "error" not in result

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -1,0 +1,159 @@
+"""Contract tests for the library / sync read-surface callables.
+
+Each callable is driven exactly as the frontend declares it in
+``src/api/backend.ts`` — positional, JSON-shaped arguments with the TS arg
+types — and the assertions pin the *response shape* (the contract), not the
+delegation. Covered here:
+
+- ``get_sync_status`` / ``sync_heartbeat`` / ``get_sync_stats``
+- ``get_platforms`` (happy + server-failure)
+- ``get_collections`` (happy + server-failure)
+- ``get_registry_platforms``
+
+Note on the failure shape: ``get_platforms`` / ``get_collections`` return
+``{success: False, message, error_code}`` — the *legacy* failure shape that
+predates the canonical ``{success, reason, message}`` used by the save
+callables. These contract tests assert the shape the backend *actually*
+returns (``error_code``, not ``reason``); pinning the real divergence is the
+point of this tier. ``error_code`` is the ``classify_error`` slug
+(``"connection_error"`` for a ``RommConnectionError``). When #972 (collapse
+the failure-shape dialects onto the canonical shape) lands, these assertions
+will break — that is the intended coupling; update them to the unified shape
+as part of that fix.
+"""
+
+from __future__ import annotations
+
+from lib.errors import RommConnectionError
+
+from ._seed import seed_rom
+
+# ── get_sync_status ──────────────────────────────────────────────────────
+
+
+async def test_get_sync_status_idle_shape(harness):
+    """Idle: every progress field present; running is False."""
+    result = await harness.plugin.get_sync_status()
+    assert result == {
+        "running": False,
+        "stage": "",
+        "current": 0,
+        "total": 0,
+        "message": "",
+        "step": 0,
+        "totalSteps": 0,
+    }
+    assert result["running"] is False
+    for key in ("current", "total", "step", "totalSteps"):
+        assert isinstance(result[key], int)
+
+
+# ── sync_heartbeat ───────────────────────────────────────────────────────
+
+
+async def test_sync_heartbeat_shape(harness):
+    result = await harness.plugin.sync_heartbeat()
+    assert result == {"success": True}
+
+
+# ── get_sync_stats ───────────────────────────────────────────────────────
+
+
+async def test_get_sync_stats_shape(harness):
+    """Stats dict: every count key present and an int; last_sync None when never synced."""
+    result = await harness.plugin.get_sync_stats()
+    assert set(result.keys()) == {"last_sync", "platforms", "collections", "roms", "total_shortcuts"}
+    assert result["last_sync"] is None
+    for key in ("platforms", "collections", "roms", "total_shortcuts"):
+        assert isinstance(result[key], int)
+
+
+async def test_get_sync_stats_counts_bound_roms(harness):
+    """A bound ROM row lifts the roms / total_shortcuts counts."""
+    seed_rom(harness, 11, platform_slug="snes")
+    result = await harness.plugin.get_sync_stats()
+    assert result["roms"] == 1
+    assert result["total_shortcuts"] == 1
+
+
+# ── get_platforms ────────────────────────────────────────────────────────
+
+
+async def test_get_platforms_happy_shape(harness):
+    harness.romm.platforms = [
+        {"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3},
+        {"id": 2, "name": "Empty", "slug": "empty", "rom_count": 0},  # filtered out
+    ]
+    result = await harness.plugin.get_platforms()
+    assert result["success"] is True
+    assert isinstance(result["platforms"], list)
+    # rom_count==0 platform is filtered out
+    assert [p["slug"] for p in result["platforms"]] == ["snes"]
+    p = result["platforms"][0]
+    assert set(p.keys()) == {"id", "name", "slug", "rom_count", "sync_enabled"}
+    assert p["id"] == 1
+    assert isinstance(p["sync_enabled"], bool)
+
+
+async def test_get_platforms_server_failure_shape(harness):
+    """Server unreachable → legacy failure shape: success False + message + error_code."""
+    harness.romm.list_platforms_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_platforms()
+    assert result["success"] is False
+    assert "platforms" not in result
+    assert isinstance(result["message"], str)
+    assert result["message"]  # non-empty
+    # error_code is classify_error's slug (NOT a `reason` field) — the legacy shape.
+    assert result["error_code"] == "connection_error"
+    assert "reason" not in result
+
+
+# ── get_collections ──────────────────────────────────────────────────────
+
+
+async def test_get_collections_happy_shape(harness):
+    harness.romm.collections = [
+        {"id": 7, "name": "Favorites", "rom_count": 2, "is_favorite": True},
+    ]
+    result = await harness.plugin.get_collections()
+    assert result["success"] is True
+    assert isinstance(result["collections"], list)
+    assert len(result["collections"]) == 1
+    c = result["collections"][0]
+    assert c["id"] == "7"  # stringified
+    assert c["name"] == "Favorites"
+    assert c["kind"] == "user"
+    assert isinstance(c["sync_enabled"], bool)
+
+
+async def test_get_collections_server_failure_shape(harness):
+    """User-collection fetch failure → legacy failure shape."""
+    harness.romm.list_collections_side_effect = RommConnectionError("offline")
+    result = await harness.plugin.get_collections()
+    assert result["success"] is False
+    assert "collections" not in result
+    assert isinstance(result["message"], str)
+    assert result["message"]
+    assert result["error_code"] == "connection_error"
+    assert "reason" not in result
+
+
+# ── get_registry_platforms ───────────────────────────────────────────────
+
+
+async def test_get_registry_platforms_empty_shape(harness):
+    result = await harness.plugin.get_registry_platforms()
+    assert result == {"platforms": []}
+
+
+async def test_get_registry_platforms_counts_bound_roms(harness):
+    """Registry read is offline (no RomM call) and counts bound ROMs per slug."""
+    seed_rom(harness, 21, platform_slug="snes")
+    seed_rom(harness, 22, platform_slug="snes")
+    result = await harness.plugin.get_registry_platforms()
+    assert "platforms" in result
+    assert len(result["platforms"]) == 1
+    entry = result["platforms"][0]
+    assert set(entry.keys()) == {"name", "slug", "count"}
+    assert entry["slug"] == "snes"
+    assert entry["count"] == 2


### PR DESCRIPTION
Part of #1027 (Phase 1 of 2 — does **not** close the issue; the `backend.ts` manifest gate is Phase 2).

No backend test crossed the wire: every callable was tested either from the backend (service-shaped inputs) or from the frontend (against a mock), and the June audit's worst bugs (#1004, #1008, #1009, #1017) live in exactly that gap. This adds a contract-test tier.

## Harness (`tests/contract/`)

Builds the **real** `Plugin` through the real `bootstrap()` + `wire_services()`, faking only the outermost edges:
- HTTP transport → `FakeRommApi` / `FakeSteamGridDbApi` (the only network edges; **verified hermetic** — with `urlopen` + `socket.connect` globally poisoned, all 30 tests still pass)
- paths → `tmp_path` (real SQLite + migrations + file stores, rooted in tmp, fresh per test)
- deterministic `Clock`/`UuidGen`/`Sleeper`; `emit` is an `AsyncMock`

Callables are driven **exactly as `src/api/backend.ts` declares them** (positional, JSON-shaped args, literal `None` where the TS type says `null`), asserting the **response shape + behavior**, not delegation. A loud-failure guard fails the fixture if service wiring drifts.

## Coverage (30 tests)

Sync / download / saves read surface — `get_sync_status`, `sync_heartbeat`, `get_sync_stats`, `get_platforms`, `get_collections`, `get_registry_platforms`, `get_download_queue`, `get_installed_rom`, `get_save_status`, `get_save_slots`, `get_slot_saves`, `get_slot_delete_info`, `is_save_tracking_configured`, `get_save_setup_info`, `get_save_sync_settings`, `saves_list_file_versions` — happy **and** server-failure paths, including the canonical failure shape, the `server_query_failed`/`recommended_action` partial-success carve-outs, the discriminated-status union, and `get_installed_rom` returning literal `None` (the JS `null` contract). Non-vacuity verified: breaking a real service's shape fails the matching test.

## Finding pinned for #972

`get_platforms` / `get_collections` return the **legacy** `{success, message, error_code}` shape, not the canonical `{success, reason, message}`. The tests assert the actual shape and document it — when #972 (failure-shape unification) lands, these tests break and force an update. That is the intended coupling.

## Deferred (named, not silently skipped)

`confirm_slot_choice` / `switch_slot` → land with #1004/#1005 (their contract isn't decided until the fix); `start_download` / `cancel_download` event flow → #1017.

Test-only — no `py_modules/` or `main.py` changes.

docs: updated — `CLAUDE.md` (Testing: contract tier) + `docs/contributing/development.md` (running it).