### PR TITLE
refactor(errors): collapse the three failure-shape dialects onto the canonical shape + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Check aggregate field-assignment ban
         run: python scripts/check_aggregate_field_assignment.py
 
+      - name: Check failure-shape dialect gate
+        run: python scripts/check_failure_shape.py --check
+
       - name: Check no bare ignores
         run: bash scripts/check_no_bare_ignores.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,10 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Service-independence contract self-check**: `scripts/check_service_independence_contract.py` — derives the expected
   service list from `py_modules/services/` and fails CI if `.importlinter`'s `service-independence` contract omits a
   service or carries a stale entry, keeping the hand-maintained `modules` list self-healing.
+- **Failure-shape dialect gate**: `scripts/check_failure_shape.py --check` — AST check that fails CI if any
+  `success: False` return in `services/` is missing the canonical `reason` + `message` keys or carries the forbidden
+  `error` / `error_code` key. The two documented carve-outs (discriminated-status unions, partial-success payloads) are
+  pattern-exempt. Enforces the "Callable response shapes" convention below.
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
 ## Architecture — Cosmic Python rules
@@ -249,15 +253,25 @@ the current state, not a settled ideal. Unification (converge `do_` onto `_io`) 
 ## Callable response shapes — canonical failure shape
 
 Decky callables that return a plain `dict` and can fail use the canonical failure shape
-`{success: False, reason: ErrorCode | str, message: str}`. Reuse `lib.list_result.ErrorCode` for server-reachability
-failures (`ErrorCode.SERVER_UNREACHABLE`). Never duplicate `reason` into a second `error` field; never replace `message`
-with `error`. `[ours]`
+`{success: False, reason: ErrorCode | str, message: str}`. Both `reason` and `message` are **required**. Reuse
+`lib.list_result.ErrorCode` (the Lean enum: `SERVER_UNREACHABLE`, `AUTH_FAILED`, `NOT_FOUND`, `UNSUPPORTED`, `UNKNOWN`,
+plus the frontend-routed `VERSION_ERROR` / `STALE_CONFLICT` / `STALE_PREVIEW`) for the coarse categories; bespoke
+non-server-reachability guards (`config_error`, `sync_disabled`, `not_installed`, `active_slot`, …) stay plain-string
+`reason` values — the `ErrorCode | str` union allows it. Transport failures collapse onto `SERVER_UNREACHABLE`; 401 and
+403 collapse onto `AUTH_FAILED` (same slug, but the `message` stays distinct so a Cloudflare bot-fight 403 reads
+differently from wrong credentials). The legacy `error_code` key and a second `error` key are **forbidden** — never
+duplicate `reason` into `error`, never replace `message` with `error`. `[ours]`
 
-Two carve-outs:
+`scripts/check_failure_shape.py --check` enforces this in CI (`mise run lint` + the CI gate step): every
+`success: False` return in `services/` must carry `reason` + `message` and must not carry `error` / `error_code`. In
+this repo, conventions with a mechanical check stay true; conventions in prose drift.
+
+Two carve-outs (also pattern-exempt in the gate):
 
 - **Discriminated-status unions** (the `status: "ok" | "server_unreachable" | "version_deleted" | …` shape used by the
-  saves version-history callables) keep the `status` discriminant — they carry more than two outcomes, so a binary
-  `success` boolean would erase the routing slug. Failure branches still carry `message: str`, not `error: str`.
+  saves version-history callables) keep the `status` discriminant — a dict with `status` and no `success`. They carry
+  more than two outcomes, so a binary `success` boolean would erase the routing slug. Failure branches still carry
+  `message: str`, not `error: str`.
 - **Partial-success responses** that return a full payload alongside a failure flag (e.g. `get_save_status`'s additive
   `server_query_failed: bool`, `get_save_setup_info`'s `recommended_action: "server_unreachable" | ...`) keep the
   additive flag. The call has half-broken half-working semantics that the binary boolean would erase.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -414,7 +414,18 @@ collects the class names decorated with `@cosmic_aggregate` in `domain/` (curren
 `services/` for `<aggregate>.<field> = ...` assignments and fails CI on any it finds. The escape hatch is a trailing
 `# pragma: no aggregate-check` on the offending line. Full detail in [Database Design](database-design.md).
 
-### 4. Enforced: underscore prefix
+### 4. Failure-shape dialect gate
+
+`scripts/check_failure_shape.py --check` (also bundled into `mise run lint`) is a small custom AST linter that enforces
+the **canonical failure shape** for dict-returning callables — every `success: False` return in `services/` must carry
+both `reason` and `message` and must not carry the legacy `error_code` key or a second `error` key. It collapses the
+three dialects that previously coexisted (`error_code`, `error`, and slug-less ad-hoc dicts) onto one vocabulary. The
+two documented carve-outs (discriminated-status unions — a `status` key with no `success`; and partial-success payloads
+carrying an additive `server_query_failed` / `recommended_action` flag) are pattern-exempt. Run without `--check` for
+the report-mode inventory grouped by classification. The routing slugs come from `lib.list_result.ErrorCode` (the Lean
+enum) plus bespoke plain-string reasons for non-server-reachability guards.
+
+### 5. Enforced: underscore prefix
 
 All internal methods use a `_` prefix; public callables (exposed to the frontend via `callable()`) have none. `main.py`
 callable methods delegate directly to the corresponding service method. Even synchronous callable bodies are `async def`

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -11,7 +11,7 @@ more). Standalone emulator saves (PCSX2, DuckStation, Dolphin, PPSSPP, melonDS, 
 
 ## RomM Save API
 
-Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `error_code: "version_error"`.
+Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `reason: "version_error"`.
 
 | Endpoint                                                 | Method | Notes                                                                                                                                                                                                                              |
 | -------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -570,7 +570,7 @@ The façade delegates to `SyncEngine.resolve_sync_conflict`, whose rollback sub-
 2. Fetches a fresh server-saves list and re-picks the newest in the active slot.
 3. **Round-trips `server_save_id`**: the caller passes the id the user was shown in the modal. If the freshly-picked
    head's id doesn't match, a third device has uploaded a newer save into the slot between the modal opening and the
-   click. The backend returns `{success: False, error_code: "stale_conflict", message: ...}` instead of dispatching —
+   click. The backend returns `{success: False, reason: "stale_conflict", message: ...}` instead of dispatching —
    silently PUTting local content over the third device's work would be a write-loss. The frontend surfaces an error and
    the user cancels + retries; the next sync re-evaluates the matrix with the fresh head.
 4. Dispatches:

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -138,6 +138,11 @@ services may not call `datetime.now()` / `asyncio.sleep()` / `time.time()` / `ti
 list from `py_modules/services/` and fails if `.importlinter`'s `service-independence` contract drifts — omitting a
 service or carrying a stale entry — keeping the hand-maintained `modules` list self-healing.
 
+`mise run lint` (and CI) also runs `scripts/check_failure_shape.py --check`, which fails if any `success: False` return
+in `services/` is missing the canonical `reason` + `message` keys or carries the forbidden `error` / `error_code` key —
+collapsing the failure-shape dialects onto one vocabulary (the two documented carve-outs are pattern-exempt). Run it
+without `--check` for a report-mode inventory.
+
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,7 @@ run = [
     "PYTHONPATH=py_modules lint-imports",
     "python scripts/check_service_independence_contract.py",
     "bash scripts/check_cosmic_call_bans.sh",
+    "python scripts/check_failure_shape.py --check",
 ]
 
 [tasks.deploy]

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -1,5 +1,7 @@
 """RomM API error types for structured error handling."""
 
+from lib.list_result import ErrorCode
+
 
 class SgdbApiError(Exception):
     """Raised by SteamGridDb adapter for non-2xx HTTP responses.
@@ -90,30 +92,55 @@ class RommUnsupportedError(RommApiError):
 
 
 def classify_error(exc):
-    """Return (error_code, user_friendly_message) for an exception."""
+    """Return ``(reason, user_friendly_message)`` for an exception.
+
+    ``reason`` is a canonical :class:`lib.list_result.ErrorCode` slug
+    (returned as its string value). Several exception types fold onto one
+    slug \u2014 connection/timeout/SSL/5xx/generic-API all map to
+    ``server_unreachable``; 401 and 403 both map to ``auth_failed`` \u2014 but
+    each branch keeps a distinct human ``message``. In particular the 403
+    branch stays distinguishable from the 401 branch: a Cloudflare
+    bot-fight 403 at the tunnel edge is not a wrong-credentials failure, so
+    the two share the ``auth_failed`` slug but explain different remedies.
+    """
     if isinstance(exc, RommAuthError):
-        return "auth_error", "Authentication failed \u2014 check your username and password"
+        return ErrorCode.AUTH_FAILED.value, "Authentication failed \u2014 check your username and password"
     if isinstance(exc, RommForbiddenError):
-        return "forbidden_error", "Access denied \u2014 your account lacks permissions for this action"
+        return ErrorCode.AUTH_FAILED.value, "Access denied \u2014 your account lacks permissions for this action"
     if isinstance(exc, RommSSLError):
-        return "ssl_error", "SSL certificate error \u2014 enable 'Allow Insecure SSL' in settings for self-signed certs"
+        return (
+            ErrorCode.SERVER_UNREACHABLE.value,
+            "SSL certificate error \u2014 enable 'Allow Insecure SSL' in settings for self-signed certs",
+        )
     if isinstance(exc, RommTimeoutError):
-        return "timeout_error", "Request timed out \u2014 server may be overloaded or network is slow"
+        return (
+            ErrorCode.SERVER_UNREACHABLE.value,
+            "Request timed out \u2014 server may be overloaded or network is slow",
+        )
     if isinstance(exc, RommConnectionError):
-        return "connection_error", "Server unreachable \u2014 check your URL and ensure RomM is running"
+        return (
+            ErrorCode.SERVER_UNREACHABLE.value,
+            "Server unreachable \u2014 check your URL and ensure RomM is running",
+        )
     if isinstance(exc, RommServerError):
         code = exc.status_code or 500
-        return "server_error", f"Server error ({code}) \u2014 check your RomM server logs"
+        return ErrorCode.SERVER_UNREACHABLE.value, f"Server error ({code}) \u2014 check your RomM server logs"
     if isinstance(exc, RommNotFoundError):
-        return "not_found_error", "Resource not found on server"
+        return ErrorCode.NOT_FOUND.value, "Resource not found on server"
     if isinstance(exc, RommUnsupportedError):
-        return "unsupported_error", f"This feature requires RomM {exc.min_version} or newer"
+        return ErrorCode.UNSUPPORTED.value, f"This feature requires RomM {exc.min_version} or newer"
     if isinstance(exc, RommApiError):
-        return "api_error", str(exc)
-    return "unknown_error", str(exc)
+        return ErrorCode.SERVER_UNREACHABLE.value, str(exc)
+    return ErrorCode.UNKNOWN.value, str(exc)
 
 
 def error_response(exc, fallback_message=None):
-    """Build a standard {success, message, error_code} dict from an exception."""
-    code, msg = classify_error(exc)
-    return {"success": False, "message": fallback_message or msg, "error_code": code}
+    """Build a canonical ``{success, reason, message}`` dict from an exception.
+
+    ``reason`` is the :func:`classify_error` slug; ``message`` is the
+    human-readable detail (overridable via *fallback_message*). The legacy
+    ``error_code`` key is gone \u2014 this is the single failure shape the
+    frontend reads (``scripts/check_failure_shape.py`` enforces it).
+    """
+    reason, msg = classify_error(exc)
+    return {"success": False, "reason": reason, "message": fallback_message or msg}

--- a/py_modules/lib/list_result.py
+++ b/py_modules/lib/list_result.py
@@ -26,8 +26,8 @@ Canonical failure response shape for dict-returning callables
 =============================================================
 
 For Decky callables that return a plain ``dict`` (rather than the typed
-:data:`ListResult` union above) and that can fail because the RomM server
-is unreachable, the canonical failure shape is::
+:data:`ListResult` union above) and that can fail, the canonical failure
+shape is::
 
     {"success": False, "reason": ErrorCode | str, "message": str, **extras}
 
@@ -35,22 +35,35 @@ Three required fields:
 
 * ``success: False`` — binary success discriminant.
 * ``reason`` — coarse routing slug. For server-reachability failures use
-  :data:`ErrorCode.SERVER_UNREACHABLE`; for static guards (sync_disabled,
-  not_installed, not_found, active_slot, …) a plain string literal is fine.
-  Never duplicate ``reason`` into a second ``error`` field.
+  :data:`ErrorCode.SERVER_UNREACHABLE`; the rest of the small Lean enum
+  (auth/not-found/unsupported/unknown plus the frontend-routed
+  ``version_error`` / ``stale_conflict`` / ``stale_preview``) covers the
+  categories a consumer branches on. For bespoke static guards
+  (``sync_disabled``, ``not_installed``, ``active_slot``,
+  ``config_error``, ``blocked_by_migration``, …) a plain string literal is
+  fine — the ``ErrorCode | str`` union allows it.
 * ``message: str`` — human-readable detail for logs and UI. Carries the
-  exception text on transport-layer failures.
+  exception text on transport-layer failures. Two transport failures may
+  share one ``reason`` slug but carry distinct messages (e.g. a 403
+  Cloudflare bot-fight block vs. wrong credentials both map to
+  ``AUTH_FAILED`` but explain different remedies).
+
+The legacy ``error_code`` key and a second ``error`` key are **forbidden**.
+``scripts/check_failure_shape.py --check`` enforces this: every
+``success: False`` return in ``py_modules/services/`` must carry ``reason``
+and ``message`` and must not carry ``error`` or ``error_code``.
 
 Optional payload-shape extras (``slot``, ``saves``, ``active_slot``, …) may
 appear alongside on a per-callable basis when the frontend needs to render
 fallback UI on failure.
 
-Two carve-outs:
+Two carve-outs (also recognised by the gate):
 
 * **Discriminated-status unions** (e.g. ``versions.rollback_to_version``,
   ``versions.list_file_versions``) keep the ``status: "ok" | "..."``
-  discriminant; the ``server_unreachable`` branch still carries
-  ``message: str`` instead of the legacy ``error: str``.
+  discriminant — a dict with a ``status`` key and no ``success`` key; the
+  ``server_unreachable`` branch still carries ``message: str`` instead of
+  the legacy ``error: str``.
 * **Partial-success responses** that return a full data payload alongside
   a failure flag (e.g. ``status.get_save_status``'s
   ``server_query_failed: bool``, ``setup.get_save_setup_info``'s
@@ -69,17 +82,32 @@ T = TypeVar("T")
 
 
 class ErrorCode(StrEnum):
-    """Coarse failure categories for list-returning calls.
+    """Coarse failure categories for the canonical ``reason`` slug.
 
-    Kept deliberately small — consumers route on these codes (retry vs.
-    surface auth prompt vs. show "unknown error"), so each addition is a
-    new branch downstream. Free-form detail goes in
-    :attr:`FailedListResult.error_message`, not here.
+    Kept deliberately small (Lean) — consumers route on these codes (retry
+    vs. surface auth prompt vs. show "unknown error"), so each addition is a
+    new branch downstream. Free-form detail goes in the failure dict's
+    ``message`` (or :attr:`FailedListResult.error_message`), not here.
+    Bespoke non-server-reachability failures stay plain-string ``reason``
+    values (``config_error``, ``sync_disabled``, ``not_installed``,
+    ``active_slot``, …) — the ``reason: ErrorCode | str`` union allows it.
+
+    The transport categories collapse several exception types onto one slug:
+    ``SERVER_UNREACHABLE`` folds connection/timeout/SSL/5xx/generic-API
+    failures; ``AUTH_FAILED`` folds 401 and 403 (same slug, distinct
+    ``message`` so a Cloudflare bot-fight 403 stays distinguishable from
+    wrong credentials). ``VERSION_ERROR`` / ``STALE_CONFLICT`` /
+    ``STALE_PREVIEW`` stay distinct because the frontend routes on them.
     """
 
     SERVER_UNREACHABLE = "server_unreachable"
     AUTH_FAILED = "auth_failed"
+    NOT_FOUND = "not_found"
+    UNSUPPORTED = "unsupported"
     UNKNOWN = "unknown"
+    VERSION_ERROR = "version_error"
+    STALE_CONFLICT = "stale_conflict"
+    STALE_PREVIEW = "stale_preview"
 
 
 @dataclass(frozen=True)

--- a/py_modules/services/achievements.py
+++ b/py_modules/services/achievements.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.achievements import extract_achievements_from_rom, extract_game_progress
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -158,7 +159,13 @@ class AchievementsService:
                     "total": len(stale["achievements"]),
                     "stale": True,
                 }
-            return {"success": False, "achievements": [], "total": 0, "message": str(e)}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": str(e),
+                "achievements": [],
+                "total": 0,
+            }
 
     def _progress_data_response(self, progress_data):
         """Build a success response from progress_data, excluding cached_at."""
@@ -175,7 +182,13 @@ class AchievementsService:
 
         ra_username = self.get_ra_username() or await self._fetch_ra_username()
         if not ra_username:
-            return {"success": False, "message": "No RA username configured in RomM", "earned": 0, "total": 0}
+            return {
+                "success": False,
+                "reason": "no_ra_username",
+                "message": "No RA username configured in RomM",
+                "earned": 0,
+                "total": 0,
+            }
 
         cached_progress = self.get_progress_cache_entry(rom_id_str)
         if cached_progress:
@@ -206,7 +219,14 @@ class AchievementsService:
             stale_progress = self._achievements_cache.get(rom_id_str, {}).get("user_progress")
             if stale_progress:
                 return {**self._progress_data_response(stale_progress), "stale": True}
-            return {"success": False, "earned": 0, "total": 0, "earned_achievements": [], "message": str(e)}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": str(e),
+                "earned": 0,
+                "total": 0,
+                "earned_achievements": [],
+            }
 
     async def sync_achievements_after_session(self, rom_id):
         """Post-session: force-refresh achievement progress from RomM.

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from domain.version import meets_min_version
 from lib.errors import RommForbiddenError, error_response
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -68,20 +69,21 @@ class ConnectionService:
         """Probe the configured server and return a frontend-shaped result dict.
 
         The result dict always carries ``success`` and ``message``. On
-        failure, ``error_code`` classifies the cause (``config_error`` when
+        failure, ``reason`` classifies the cause (``config_error`` when
         the server URL is unset or no token has been minted yet,
-        ``version_error``, or an :func:`lib.errors.error_response` code).
-        On success or version failure, ``romm_version`` carries the
-        detected server version when the heartbeat exposed one.
+        :data:`ErrorCode.VERSION_ERROR`, or an
+        :func:`lib.errors.error_response` slug). On success or version
+        failure, ``romm_version`` carries the detected server version when
+        the heartbeat exposed one.
         """
         if not self._settings.get("romm_url"):
-            return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+            return {"success": False, "reason": "config_error", "message": "No server URL configured"}
 
         if not self._settings.get("romm_api_token"):
             return {
                 "success": False,
+                "reason": "config_error",
                 "message": "Not signed in — sign in to RomM first",
-                "error_code": "config_error",
             }
 
         try:
@@ -94,7 +96,7 @@ class ConnectionService:
             await self._loop.run_in_executor(None, self._romm_api.list_platforms)
         except Exception as e:
             resp = error_response(e)
-            if resp["error_code"] not in ("auth_error", "forbidden_error"):
+            if resp["reason"] != ErrorCode.AUTH_FAILED.value:
                 resp["message"] = f"Server reachable but API request failed: {resp['message']}"
             return resp
 
@@ -118,11 +120,11 @@ class ConnectionService:
         device previously minted, mints a fresh scoped token, and
         persists ``romm_api_token`` / ``romm_api_token_id``. The
         username/password are never persisted. Returns the same
-        ``success`` / ``message`` / ``error_code`` shape as
+        ``success`` / ``reason`` / ``message`` shape as
         :meth:`test_connection`.
         """
         if not romm_url:
-            return {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+            return {"success": False, "reason": "config_error", "message": "No server URL configured"}
 
         self._settings["romm_url"] = romm_url
         if allow_insecure_ssl is not None:
@@ -147,7 +149,10 @@ class ConnectionService:
         try:
             minted = await self._loop.run_in_executor(None, self._mint, username, password)
         except RommForbiddenError:
-            return {"success": False, "message": _FORBIDDEN_TOKEN_MESSAGE, "error_code": "forbidden_error"}
+            # 403 on token mint: same AUTH_FAILED slug as a 401, but a distinct
+            # message — the account lacks token-creation permission (or a
+            # Cloudflare bot-fight 403 at the edge), not wrong credentials.
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _FORBIDDEN_TOKEN_MESSAGE}
         except Exception as e:
             return error_response(e)
 
@@ -156,8 +161,8 @@ class ConnectionService:
         if not raw_token or token_id is None:
             return {
                 "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
                 "message": "RomM did not return a usable token",
-                "error_code": "api_error",
             }
 
         try:
@@ -233,7 +238,7 @@ class ConnectionService:
         return version
 
     def _version_gate_error(self, version: str | None) -> dict[str, Any] | None:
-        """Return a ``version_error`` dict when *version* is below the minimum.
+        """Return a :data:`ErrorCode.VERSION_ERROR` dict when *version* is below the minimum.
 
         ``development`` builds and an absent version bypass the gate.
         """
@@ -241,12 +246,12 @@ class ConnectionService:
             min_str = ".".join(str(v) for v in self._min_required_version)
             return {
                 "success": False,
+                "reason": ErrorCode.VERSION_ERROR.value,
                 "message": (
                     f"This plugin requires RomM {min_str} or newer. "
                     f"Your server is running {version}. "
                     "Please update your RomM server to continue using this plugin."
                 ),
-                "error_code": "version_error",
                 "romm_version": version,
             }
         return None

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -26,6 +26,7 @@ from domain.shortcut_data import (
     label_to_core_so,
     resolve_emulator_invocation,
 )
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -188,7 +189,7 @@ class CoreService:
             return {"success": True, "bios_status": bios, "rebake_items": rebake_items}
         except Exception as e:
             self._logger.error(f"Failed to set system core: {e}")
-            return {"success": False, "message": str(e)}
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": str(e)}
 
     async def set_game_core(self, rom_id: int, label: str) -> dict[str, Any]:
         """Pin the per-game emulator/core override for ``rom_id`` to *label*.

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -25,6 +25,7 @@ from domain.rom_files import (
 from domain.rom_install import RomInstall
 from domain.shortcut_data import build_launch_options, resolve_emulator_invocation
 from lib.errors import error_response
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import logging
@@ -168,7 +169,7 @@ class DownloadService:
     async def start_download(self, rom_id):
         rom_id = int(rom_id)
         if rom_id in self._download_in_progress:
-            return {"success": False, "message": "Already downloading"}
+            return {"success": False, "reason": "already_downloading", "message": "Already downloading"}
 
         self._download_in_progress.add(rom_id)
         try:
@@ -204,7 +205,11 @@ class DownloadService:
             self._download_in_progress.discard(rom_id)
             free_mb = free_space // (1024 * 1024)
             need_mb = required // (1024 * 1024)
-            return {"success": False, "message": f"Not enough disk space ({free_mb}MB free, need {need_mb}MB)"}
+            return {
+                "success": False,
+                "reason": "insufficient_space",
+                "message": f"Not enough disk space ({free_mb}MB free, need {need_mb}MB)",
+            }
 
         target_path = os.path.join(roms_dir, file_name)
 
@@ -216,7 +221,7 @@ class DownloadService:
         except Exception as e:
             self._download_in_progress.discard(rom_id)
             self._logger.error(f"Failed to start download task for ROM {rom_id}: {e}")
-            return {"success": False, "message": "Failed to start download"}
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": "Failed to start download"}
 
         self._download_queue[rom_id] = {
             "rom_id": rom_id,
@@ -565,7 +570,7 @@ class DownloadService:
         rom_id = int(rom_id)
         task = self._download_tasks.get(rom_id)
         if not task:
-            return {"success": False, "message": "No active download for this ROM"}
+            return {"success": False, "reason": "no_active_download", "message": "No active download for this ROM"}
         task.cancel()
         return {"success": True, "message": "Download cancelled"}
 

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -21,6 +21,7 @@ from domain.bios import collect_firmware_status, compute_bios_level, format_bios
 from domain.bios_file import BiosFile
 from domain.firmware_cache import FirmwareCacheEntry
 from lib.errors import error_response
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -763,6 +764,7 @@ class FirmwareService:
         if errors:
             return {
                 "success": False,
+                "reason": ErrorCode.UNKNOWN.value,
                 "deleted_count": deleted,
                 "message": f"Deleted {deleted} file(s), {len(errors)} error(s)",
             }

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from domain.sync_state import SyncState
 from domain.work_unit import CollectionKind, WorkUnit
 from lib.errors import classify_error
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import logging
@@ -110,12 +111,16 @@ class LibraryFetcher:
             platforms: object = await self._loop.run_in_executor(None, self._romm_api.list_platforms)
         except Exception as e:
             self._logger.error(f"Failed to fetch platforms: {e}")
-            _code, _msg = classify_error(e)
-            return {"success": False, "message": _msg, "error_code": _code}
+            _reason, _msg = classify_error(e)
+            return {"success": False, "reason": _reason, "message": _msg}
 
         if not isinstance(platforms, list):
             self._logger.error(f"Unexpected platforms response type: {type(platforms).__name__}")
-            return {"success": False, "message": "Invalid server response", "error_code": "api_error"}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Invalid server response",
+            }
 
         enabled = self._settings.get("enabled_platforms", {})
         result = []
@@ -147,8 +152,8 @@ class LibraryFetcher:
             platforms = await self._loop.run_in_executor(None, self._romm_api.list_platforms)
         except Exception as e:
             self._logger.error(f"Failed to fetch platforms: {e}")
-            _code, _msg = classify_error(e)
-            return {"success": False, "message": _msg, "error_code": _code}
+            _reason, _msg = classify_error(e)
+            return {"success": False, "reason": _reason, "message": _msg}
 
         ep = {}
         for p in platforms:
@@ -164,8 +169,8 @@ class LibraryFetcher:
             user_collections = await self._loop.run_in_executor(None, self._romm_api.list_collections)
         except Exception as e:
             self._logger.error(f"Failed to fetch collections: {e}")
-            _code, _msg = classify_error(e)
-            return {"success": False, "message": _msg, "error_code": _code}
+            _reason, _msg = classify_error(e)
+            return {"success": False, "reason": _reason, "message": _msg}
         try:
             smart_collections = await self._loop.run_in_executor(None, self._romm_api.list_smart_collections)
         except Exception as e:
@@ -257,8 +262,8 @@ class LibraryFetcher:
             user_collections = await self._loop.run_in_executor(None, self._romm_api.list_collections)
         except Exception as e:
             self._logger.error(f"Failed to fetch collections: {e}")
-            _code, _msg = classify_error(e)
-            return {"success": False, "message": _msg, "error_code": _code}
+            _reason, _msg = classify_error(e)
+            return {"success": False, "reason": _reason, "message": _msg}
         for c in user_collections:
             if scope == "my" and bool(c.get("is_favorite", False)):
                 continue
@@ -276,8 +281,8 @@ class LibraryFetcher:
         except Exception as e:
             if scope == "smart":
                 self._logger.error(f"Failed to fetch smart collections: {e}")
-                _code, _msg = classify_error(e)
-                return {"success": False, "message": _msg, "error_code": _code}
+                _reason, _msg = classify_error(e)
+                return {"success": False, "reason": _reason, "message": _msg}
             self._logger.warning(f"Failed to fetch smart collections, continuing without them: {e}")
             return None
         for c in smart_collections:
@@ -297,8 +302,8 @@ class LibraryFetcher:
         except Exception as e:
             if scope == "franchise":
                 self._logger.error(f"Failed to fetch franchise collections: {e}")
-                _code, _msg = classify_error(e)
-                return {"success": False, "message": _msg, "error_code": _code}
+                _reason, _msg = classify_error(e)
+                return {"success": False, "reason": _reason, "message": _msg}
             self._logger.warning(f"Failed to fetch franchise collections, continuing without them: {e}")
             return None
         for c in franchise_collections:

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -32,6 +32,7 @@ from domain.sync_run import SyncRun
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
 from lib.errors import classify_error
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import logging
@@ -128,7 +129,7 @@ class SyncOrchestrator:
     def start_sync(self):
         box = self._sync_state
         if box.sync_state != SyncState.IDLE:
-            return {"success": False, "message": "Sync already in progress"}
+            return {"success": False, "reason": "sync_in_progress", "message": "Sync already in progress"}
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
@@ -166,7 +167,7 @@ class SyncOrchestrator:
         """
         box = self._sync_state
         if box.sync_state != SyncState.IDLE:
-            return {"success": False, "message": "Sync already in progress"}
+            return {"success": False, "reason": "sync_in_progress", "message": "Sync already in progress"}
         box.sync_state = SyncState.RUNNING
         box.current_sync_id = self._uuid_gen.uuid4()
         box.sync_last_heartbeat = self._clock.monotonic()
@@ -249,9 +250,9 @@ class SyncOrchestrator:
 
             self._logger.error(f"Sync preview failed: {e}\n{traceback.format_exc()}")
             box.pending_delta = None
-            _code, _msg = classify_error(e)
+            _reason, _msg = classify_error(e)
             await self.emit_progress(SyncStage.ERROR, message=_msg, running=False)
-            return {"success": False, "message": _msg, "error_code": _code}
+            return {"success": False, "reason": _reason, "message": _msg}
         finally:
             box.sync_state = SyncState.IDLE
 
@@ -285,14 +286,18 @@ class SyncOrchestrator:
     async def sync_apply_delta(self, preview_id):
         box = self._sync_state
         if not box.pending_delta or box.pending_delta.preview_id != preview_id:
-            return {"success": False, "message": "Preview expired, please re-sync", "error_code": "stale_preview"}
+            return {
+                "success": False,
+                "reason": ErrorCode.STALE_PREVIEW.value,
+                "message": "Preview expired, please re-sync",
+            }
         age = self._clock.time() - box.pending_delta.created_at
         if age > _PREVIEW_MAX_AGE_SECONDS:
             box.pending_delta = None
             return {
                 "success": False,
+                "reason": ErrorCode.STALE_PREVIEW.value,
                 "message": "Preview is older than 30 minutes, please re-run sync",
-                "error_code": "stale_preview",
             }
         box.pending_delta = None
         box.sync_state = SyncState.RUNNING

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -493,6 +493,7 @@ class MigrationService:
         if conflict_strategy is None and conflicts:
             return {
                 "success": False,
+                "reason": "needs_confirmation",
                 "needs_confirmation": True,
                 "conflict_count": len(conflicts),
                 "conflicts": conflicts,
@@ -597,7 +598,7 @@ class MigrationService:
             new_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
 
         if not old_home or not new_home or old_home == new_home:
-            return {"success": False, "message": "No path migration needed"}
+            return {"success": False, "reason": "no_migration_needed", "message": "No path migration needed"}
 
         result = await self._loop.run_in_executor(
             None, self._migrate_retrodeck_files_io, old_home, new_home, conflict_strategy
@@ -956,5 +957,5 @@ class MigrationService:
             old = self._read_save_sort_settings_previous(uow)
             new = self._read_save_sort_settings(uow)
         if not old or not new or old == new:
-            return {"success": False, "message": "No save sorting migration needed"}
+            return {"success": False, "reason": "no_migration_needed", "message": "No save sorting migration needed"}
         return await self._loop.run_in_executor(None, self._migrate_save_sort_files_io, old, new, conflict_strategy)

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.playtime import Playtime, parse_playtime_note_content
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -201,7 +202,7 @@ class PlaytimeService:
                 uow.playtime.save(rid, pt)
         except sqlite3.IntegrityError as e:
             self._log_debug(f"Failed to record session start for rom {rid}: {e}")
-            return {"success": False, "message": "Unknown ROM"}
+            return {"success": False, "reason": "unknown_rom", "message": "Unknown ROM"}
         return {"success": True}
 
     async def record_session_end(self, rom_id: int) -> dict[str, Any]:
@@ -227,18 +228,22 @@ class PlaytimeService:
             with self._uow_factory() as uow:
                 entry = uow.playtime.get(rom_id)
                 if entry is None or not entry.last_session_start:
-                    return {"success": False, "message": "No active session"}
+                    return {"success": False, "reason": "no_active_session", "message": "No active session"}
                 try:
                     entry.record_session(self._clock.now().isoformat())
                 except ValueError:
-                    return {"success": False, "message": "Failed to calculate session duration"}
+                    return {
+                        "success": False,
+                        "reason": ErrorCode.UNKNOWN.value,
+                        "message": "Failed to calculate session duration",
+                    }
                 uow.playtime.save(rom_id, entry)
                 duration = entry.last_session_duration_sec or 0
                 total_seconds = entry.total_seconds
                 session_count = entry.session_count
         except sqlite3.IntegrityError as e:
             self._log_debug(f"Failed to record session end for rom {rom_id}: {e}")
-            return {"success": False, "message": "Unknown ROM"}
+            return {"success": False, "reason": "unknown_rom", "message": "Unknown ROM"}
 
         # Best-effort sync playtime to RomM server notes (outside the UoW).
         with contextlib.suppress(Exception):

--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from lib.list_result import ErrorCode
 from lib.path_safety import is_safe_rom_path
 
 if TYPE_CHECKING:
@@ -104,13 +105,13 @@ class RomRemovalService:
         with self._uow_factory() as uow:
             install = uow.rom_installs.get(rom_id_int)
         if install is None:
-            return {"success": False, "message": "ROM not installed"}
+            return {"success": False, "reason": "not_installed", "message": "ROM not installed"}
 
         try:
             await self._loop.run_in_executor(None, self._remove_rom_io, rom_id_int, install)
         except Exception as e:
             self._logger.error(f"Failed to delete ROM files: {e}")
-            return {"success": False, "message": "Failed to delete ROM files"}
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": "Failed to delete ROM files"}
 
         if self._download_queue_cleanup is not None:
             self._download_queue_cleanup.evict(rom_id_int)

--- a/py_modules/services/saves/_messages.py
+++ b/py_modules/services/saves/_messages.py
@@ -10,6 +10,11 @@ from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 
 SAVE_SYNC_DISABLED = "Save sync is disabled"
 DEVICE_NOT_REGISTERED = "Device not registered"
+# Bespoke ``reason`` slugs for the canonical failure shape on the save-sync
+# guard returns. Plain strings (not :class:`ErrorCode`) — these are
+# domain-specific skip/guard categories, not server-reachability failures.
+SAVE_SYNC_DISABLED_REASON = "sync_disabled"
+DEVICE_NOT_REGISTERED_REASON = "device_not_registered"
 # RetroArch ``savefiles_in_content_dir=true``: saves are written next to the
 # ROM, outside the saves tree the plugin syncs, so save sync is unavailable.
 # Neutral phrasing — the frontend treats this as a benign skip, not an error.

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
+from lib.list_result import ErrorCode
 from services.saves._config import SaveServiceConfig
 from services.saves._settings import (
     ALLOWED_SETTINGS_KEYS,
@@ -366,6 +367,7 @@ class SaveService:
         if errors:
             return {
                 "success": False,
+                "reason": ErrorCode.UNKNOWN.value,
                 "deleted_count": deleted,
                 "message": f"Deleted {deleted} file(s), {len(errors)} error(s)",
             }
@@ -390,6 +392,7 @@ class SaveService:
         if total_errors:
             return {
                 "success": False,
+                "reason": ErrorCode.UNKNOWN.value,
                 "deleted_count": total_deleted,
                 "message": (f"Deleted {total_deleted} file(s) from {rom_count} ROM(s), {len(total_errors)} error(s)"),
             }

--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -75,15 +75,15 @@ class SlotDeleter:
         mutate it must persist via :meth:`_write_save_state`.
         """
         if not save_sync_enabled(self._settings):
-            return {"success": False, "reason": "disabled"}
+            return {"success": False, "reason": "disabled", "message": "Save sync is disabled"}
         if not self._rom_info.get_rom_save_info(rom_id):
-            return {"success": False, "reason": "not_installed"}
+            return {"success": False, "reason": "not_installed", "message": "ROM is not installed"}
         save_state = self._read_save_state(rom_id)
         if save_state is None:
-            return {"success": False, "reason": "not_found"}
+            return {"success": False, "reason": "not_found", "message": "No save state found"}
         slots_dict: dict[str, dict[str, Any]] = save_state.slots
         if slot not in slots_dict:
-            return {"success": False, "reason": "not_found"}
+            return {"success": False, "reason": "not_found", "message": "Slot not found"}
         return save_state, slots_dict
 
     async def get_slot_delete_info(self, rom_id: int, slot: str) -> dict[str, Any]:
@@ -123,7 +123,7 @@ class SlotDeleter:
                 )
                 return {
                     "success": False,
-                    "reason": ErrorCode.SERVER_UNREACHABLE,
+                    "reason": ErrorCode.SERVER_UNREACHABLE.value,
                     "message": "Cannot inspect slot — server unreachable",
                 }
 
@@ -170,7 +170,7 @@ class SlotDeleter:
             self._logger.warning(f"delete_slot: server delete failed for slot '{slot}': {e}")
             return {
                 "success": False,
-                "reason": "server_error",
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
                 "message": f"Failed to delete server saves: {e}",
             }
 

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -219,7 +219,12 @@ class SetupWizard:
         rom_id = int(rom_id)
         chosen_slot = str(chosen_slot).strip()
         if not chosen_slot:
-            return {"success": False, "needs_conflict_resolution": False, "message": "Slot name cannot be empty"}
+            return {
+                "success": False,
+                "reason": "invalid_slot_name",
+                "needs_conflict_resolution": False,
+                "message": "Slot name cannot be empty",
+            }
 
         # Load → confirm in memory; migration I/O runs outside the txn.
         save_state = await self._loop.run_in_executor(None, self._read_save_state, rom_id) or RomSaveState()

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -150,7 +150,7 @@ class SlotSwitcher:
 
         # 1. Save sync must be enabled
         if not save_sync_enabled(self._settings):
-            return {"success": False, "reason": "sync_disabled"}
+            return {"success": False, "reason": "sync_disabled", "message": "Save sync is disabled"}
 
         # 2. Slot normalisation (empty → None for legacy mode)
         slot_str = str(new_slot).strip() if new_slot else ""
@@ -159,7 +159,7 @@ class SlotSwitcher:
         # 3. ROM must be installed
         info = self._rom_info.get_rom_save_info(rom_id)
         if not info:
-            return {"success": False, "reason": "not_installed"}
+            return {"success": False, "reason": "not_installed", "message": "ROM is not installed"}
 
         # #239: RetroArch writes saves to the content dir — switching slots
         # would download/delete files under ``saves_dir``, which RetroArch
@@ -189,6 +189,7 @@ class SlotSwitcher:
             return {
                 "success": False,
                 "reason": readiness.get("reason", "pending_uploads"),
+                "message": "Pending local changes — upload or discard first",
                 "files": readiness.get("files", []),
             }
 
@@ -203,7 +204,7 @@ class SlotSwitcher:
         except Exception as e:
             return {
                 "success": False,
-                "reason": ErrorCode.SERVER_UNREACHABLE,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
                 "message": str(e),
             }
 

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -16,7 +16,14 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING, Any
 
+from lib.list_result import ErrorCode
 from services.saves._settings import save_sync_enabled
+
+# Both device callables short-circuit with the identical failure shape when
+# save sync is disabled — kept as one constant so the two branches never drift
+# into a per-call mini-dialect.
+_SYNC_DISABLED_REASON = "sync_disabled"
+_SYNC_DISABLED_MESSAGE = "Save sync is disabled"
 
 if TYPE_CHECKING:
     import asyncio
@@ -103,7 +110,14 @@ class DeviceRegistry:
         (``None``) the call degrades to no-fingerprint registration.
         """
         if not save_sync_enabled(self._settings):
-            return {"success": False, "device_id": "", "device_name": "", "disabled": True}
+            return {
+                "success": False,
+                "reason": _SYNC_DISABLED_REASON,
+                "message": _SYNC_DISABLED_MESSAGE,
+                "device_id": "",
+                "device_name": "",
+                "disabled": True,
+            }
 
         # Probe the RomM version when it has not been observed yet. Device
         # registration is the entrypoint reached from background launchers
@@ -166,12 +180,24 @@ class DeviceRegistry:
         except Exception as e:
             self._logger.warning(f"Server device registration failed: {e}")
 
-        return {"success": False, "device_id": "", "device_name": "", "error": "registration_failed"}
+        return {
+            "success": False,
+            "reason": ErrorCode.SERVER_UNREACHABLE.value,
+            "message": "Could not register device",
+            "device_id": "",
+            "device_name": "",
+        }
 
     async def list_devices(self, *, loop: asyncio.AbstractEventLoop) -> dict[str, Any]:
         """List all devices registered with the RomM server for this user."""
         if not save_sync_enabled(self._settings):
-            return {"success": False, "devices": [], "disabled": True}
+            return {
+                "success": False,
+                "reason": _SYNC_DISABLED_REASON,
+                "message": _SYNC_DISABLED_MESSAGE,
+                "devices": [],
+                "disabled": True,
+            }
         try:
             own_id = await loop.run_in_executor(None, self._get_device_id)
             devices = await loop.run_in_executor(
@@ -185,4 +211,9 @@ class DeviceRegistry:
             return {"success": True, "devices": enriched}
         except Exception as e:
             self._log_debug(f"list_devices failed: {e}")
-            return {"success": False, "devices": [], "error": "list_failed"}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Could not load devices",
+                "devices": [],
+            }

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -24,9 +24,12 @@ from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import ContentDir
+from lib.list_result import ErrorCode
 from services.saves._messages import (
     DEVICE_NOT_REGISTERED,
+    DEVICE_NOT_REGISTERED_REASON,
     SAVE_SYNC_DISABLED,
+    SAVE_SYNC_DISABLED_REASON,
     SAVE_SYNC_IN_CONTENT_DIR,
     SAVE_SYNC_IN_CONTENT_DIR_REASON,
 )
@@ -447,6 +450,7 @@ class SyncEngine:
             if self._is_retrodeck_migration_pending():
                 return {
                     "success": False,
+                    "reason": "blocked_by_migration",
                     "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
                     "synced": 0,
                     "blocked_by_migration": True,
@@ -462,6 +466,7 @@ class SyncEngine:
             if self._rom_info.is_save_sort_changed():
                 return {
                     "success": False,
+                    "reason": "save_sort_changed",
                     "message": "RetroArch save sorting changed — migrate saves in Settings first",
                     "synced": 0,
                     "save_sort_changed": True,
@@ -473,7 +478,7 @@ class SyncEngine:
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
-                    return {"success": False, "message": DEVICE_NOT_REGISTERED}
+                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
 
             synced, errors, conflicts = await self._run_rom_sync(rom_id)
 
@@ -505,6 +510,7 @@ class SyncEngine:
                 self._logger.info("post_exit_sync skipped: retrodeck migration pending")
                 return {
                     "success": False,
+                    "reason": "blocked_by_migration",
                     "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
                     "synced": 0,
                     "blocked_by_migration": True,
@@ -526,12 +532,18 @@ class SyncEngine:
                 await self._loop.run_in_executor(None, self._romm_api.heartbeat)
             except Exception:
                 self._logger.info("post_exit_sync skipped: server offline")
-                return {"success": False, "message": "Server offline", "synced": 0, "offline": True}
+                return {
+                    "success": False,
+                    "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                    "message": "Server offline",
+                    "synced": 0,
+                    "offline": True,
+                }
 
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
-                    return {"success": False, "message": DEVICE_NOT_REGISTERED}
+                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
 
             synced, errors, conflicts = await self._run_rom_sync(rom_id)
 
@@ -561,7 +573,12 @@ class SyncEngine:
         rom_id = int(rom_id)
         async with self.rom_lock(rom_id):
             if not self.is_save_sync_enabled():
-                return {"success": False, "message": SAVE_SYNC_DISABLED, "synced": 0}
+                return {
+                    "success": False,
+                    "reason": SAVE_SYNC_DISABLED_REASON,
+                    "message": SAVE_SYNC_DISABLED,
+                    "synced": 0,
+                }
 
             # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
             # Manual sync paths must observe fresh sort state too: a user could
@@ -576,7 +593,7 @@ class SyncEngine:
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()
                 if not reg.get("success"):
-                    return {"success": False, "message": DEVICE_NOT_REGISTERED}
+                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
 
             synced, errors, conflicts = await self._run_rom_sync(rom_id)
 
@@ -601,7 +618,13 @@ class SyncEngine:
     async def sync_all_saves(self) -> dict[str, Any]:
         """Manual full sync of all ROMs with shortcuts (both directions)."""
         if not self.is_save_sync_enabled():
-            return {"success": False, "message": SAVE_SYNC_DISABLED, "synced": 0, "conflicts": 0}
+            return {
+                "success": False,
+                "reason": SAVE_SYNC_DISABLED_REASON,
+                "message": SAVE_SYNC_DISABLED,
+                "synced": 0,
+                "conflicts": 0,
+            }
 
         # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
         # Manual sync paths must observe fresh sort state too: a user could
@@ -616,7 +639,7 @@ class SyncEngine:
         if not self.get_device_id():
             reg = await self.ensure_device_registered()
             if not reg.get("success"):
-                return {"success": False, "message": DEVICE_NOT_REGISTERED}
+                return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
 
         total_synced = 0
         total_errors: list[str] = []
@@ -668,7 +691,7 @@ class SyncEngine:
         the user in the conflict modal. The backend round-trips it: if a
         third device has uploaded a newer save into the slot since the modal
         opened, the picked server head won't match and we return
-        ``error_code="stale_conflict"`` instead of silently overwriting the
+        ``reason="stale_conflict"`` instead of silently overwriting the
         third device's work.
 
         ``action`` is one of:

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -25,6 +25,7 @@ from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_path import sanitize_save_filename
 from lib.errors import classify_error
+from lib.list_result import ErrorCode
 from services.saves._helpers import local_save_target
 
 if TYPE_CHECKING:
@@ -113,7 +114,7 @@ class RollbackOrchestrator:
         rom_id = int(rom_id)
 
         if action not in ("keep_local", "use_server"):
-            return {"success": False, "message": f"Invalid action: {action}"}
+            return {"success": False, "reason": "invalid_action", "message": f"Invalid action: {action}"}
 
         validation_error = self._validate_filename(rom_id, action, filename)
         if validation_error:
@@ -121,7 +122,7 @@ class RollbackOrchestrator:
 
         info = self._rom_info.get_rom_save_info(rom_id)
         if not info:
-            return {"success": False, "message": "ROM not installed"}
+            return {"success": False, "reason": "not_installed", "message": "ROM not installed"}
         system = info["system"]
         saves_dir = info["saves_dir"]
 
@@ -136,12 +137,16 @@ class RollbackOrchestrator:
             )
         except Exception as e:
             _code, _msg = classify_error(e)
-            return {"success": False, "message": f"Failed to fetch saves: {_msg}"}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": f"Failed to fetch saves: {_msg}",
+            }
 
         active_slot = save_state.active_slot
         server_in_slot = self._matrix.filter_server_saves_to_slot(server_saves, active_slot)
         if not server_in_slot:
-            return {"success": False, "message": "No server save in active slot"}
+            return {"success": False, "reason": "no_server_save", "message": "No server save in active slot"}
         server = max(server_in_slot, key=lambda s: parse_iso_to_epoch(s.get("updated_at")) or 0.0)
 
         actual_server_id = server.get("id")
@@ -155,7 +160,7 @@ class RollbackOrchestrator:
             )
             return {
                 "success": False,
-                "error_code": "stale_conflict",
+                "reason": ErrorCode.STALE_CONFLICT.value,
                 "message": "Server save changed since conflict was shown; please retry sync.",
             }
 
@@ -201,7 +206,7 @@ class RollbackOrchestrator:
             return {"success": True, "action": action}
         except Exception as e:
             self._logger.error(f"resolve_sync_conflict({rom_id}, {filename}, {action}) failed: {e}")
-            return {"success": False, "message": str(e)}
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": str(e)}
 
     def _validate_filename(self, rom_id: int, action: str, filename: str) -> dict[str, Any] | None:
         """Reject non-basename filenames; ``None`` if the filename is safe.
@@ -220,14 +225,14 @@ class RollbackOrchestrator:
                 action,
                 e,
             )
-            return {"success": False, "message": "Invalid filename"}
+            return {"success": False, "reason": "invalid_filename", "message": "Invalid filename"}
         if sanitized != filename:
             self._logger.warning(
                 "resolve_sync_conflict(rom_id=%d, action=%s) rejected non-basename filename",
                 rom_id,
                 action,
             )
-            return {"success": False, "message": "Invalid filename"}
+            return {"success": False, "reason": "invalid_filename", "message": "Invalid filename"}
         return None
 
     def _resolve_conflict_use_server(

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from lib.list_result import ErrorCode
+
 if TYPE_CHECKING:
     import logging
 
@@ -74,7 +76,7 @@ class SettingsService:
             return {"success": True, "message": "Settings saved"}
         except Exception as e:
             self._logger.error(f"Failed to save settings: {e}")
-            return {"success": False, "message": f"Save failed: {e}"}
+            return {"success": False, "reason": "save_failed", "message": f"Save failed: {e}"}
 
     def get_settings(self) -> dict[str, Any]:
         """Return the read-shape settings dict for the frontend.
@@ -99,7 +101,7 @@ class SettingsService:
     def save_log_level(self, level: str) -> dict[str, Any]:
         """Validate and persist the runtime log level."""
         if level not in _VALID_LOG_LEVELS:
-            return {"success": False, "message": "Invalid log level"}
+            return {"success": False, "reason": "invalid_log_level", "message": "Invalid log level"}
         self._settings["log_level"] = level
         self._settings_persister.save_settings()
         return {"success": True}
@@ -126,7 +128,7 @@ class SettingsService:
     def save_steam_input_setting(self, mode: str) -> dict[str, Any]:
         """Validate and persist the Steam Input mode preference."""
         if mode not in _VALID_STEAM_INPUT_MODES:
-            return {"success": False, "message": f"Invalid mode: {mode}"}
+            return {"success": False, "reason": "invalid_mode", "message": f"Invalid mode: {mode}"}
         self._settings["steam_input_mode"] = mode
         self._settings_persister.save_settings()
         return {"success": True}
@@ -143,7 +145,7 @@ class SettingsService:
             return {"success": True, "message": f"Steam Input set to '{mode}' for {len(app_ids)} shortcuts"}
         except Exception as e:
             self._logger.error(f"Failed to apply Steam Input setting: {e}")
-            return {"success": False, "message": "Operation failed"}
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": "Operation failed"}
 
     # ── RetroArch input driver ──────────────────────────────────────────
 
@@ -168,9 +170,17 @@ class SettingsService:
         cannot corrupt the on-disk shape.
         """
         if not isinstance(disabled_defaults, list) or not all(isinstance(s, str) for s in disabled_defaults):
-            return {"success": False, "message": "disabled_defaults must be a list of strings"}
+            return {
+                "success": False,
+                "reason": "invalid_whitelist",
+                "message": "disabled_defaults must be a list of strings",
+            }
         if not isinstance(custom_names, list) or not all(isinstance(s, str) for s in custom_names):
-            return {"success": False, "message": "custom_names must be a list of strings"}
+            return {
+                "success": False,
+                "reason": "invalid_whitelist",
+                "message": "custom_names must be a list of strings",
+            }
         self._settings["whitelist_disabled_defaults"] = disabled_defaults
         self._settings["whitelist_custom_names"] = custom_names
         self._settings_persister.save_settings()

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.platform_names import decode_platform_names
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import asyncio
@@ -88,7 +89,13 @@ class ShortcutRemovalService:
             return await self._loop.run_in_executor(None, self._remove_platform_shortcuts_io, platform_slug)
         except Exception as e:
             self._logger.error(f"Failed to get platform shortcuts: {e}")
-            return {"success": False, "message": f"Failed: {e}", "app_ids": [], "rom_ids": []}
+            return {
+                "success": False,
+                "reason": ErrorCode.UNKNOWN.value,
+                "message": f"Failed: {e}",
+                "app_ids": [],
+                "rom_ids": [],
+            }
 
     def _remove_platform_shortcuts_io(self, platform_slug: str) -> dict[str, Any]:
         with self._uow_factory() as uow:

--- a/py_modules/services/steamgrid.py
+++ b/py_modules/services/steamgrid.py
@@ -27,6 +27,7 @@ from domain.sgdb_artwork import (
     to_signed_app_id,
 )
 from lib.errors import SgdbApiError, SteamGridDirMissingError
+from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
     import logging
@@ -247,20 +248,31 @@ class SteamGridService:
         """Search SGDB by name and enrich the top candidates with thumbnails.
 
         Returns ``{"success": bool, "games": [{"id", "name",
-        "release_year", "thumb_url"}]}``. Returns an empty, unsuccessful
-        result when no API key is configured. Network failures are
-        logged and surfaced as ``{"success": False, "games": []}`` — the
-        callable never raises.
+        "release_year", "thumb_url"}]}`` plus a ``reason`` slug on failure.
+        Returns an empty, unsuccessful result (``reason="no_api_key"``) when
+        no API key is configured. Network failures are logged and surfaced
+        as ``{"success": False, "reason": "server_unreachable", "games":
+        []}`` — the callable never raises.
         """
         if not self._settings.get("steamgriddb_api_key"):
-            return {"success": False, "games": []}
+            return {
+                "success": False,
+                "reason": "no_api_key",
+                "message": "No SteamGridDB API key configured",
+                "games": [],
+            }
         try:
             path = build_autocomplete_path(str(term))
             payload = await self._loop.run_in_executor(None, self._sgdb_api.request, path)
             candidates = parse_autocomplete_results(payload)
         except Exception as e:
             self._logger.warning(f"SGDB name search failed for term={term!r}: {e}")
-            return {"success": False, "games": []}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": f"SteamGridDB search failed: {e}",
+                "games": [],
+            }
 
         capped = candidates[:6]
         thumb_futures = [
@@ -362,20 +374,32 @@ class SteamGridService:
         if not api_key or api_key == "••••":
             api_key = self._settings.get("steamgriddb_api_key", "")
         if not api_key:
-            return {"success": False, "message": "No API key configured"}
+            return {"success": False, "reason": "no_api_key", "message": "No API key configured"}
         try:
             data = await self._loop.run_in_executor(None, self._sgdb_api.verify_api_key, api_key)
             if data.get("success"):
                 return {"success": True, "message": "API key is valid"}
-            return {"success": False, "message": "API key rejected by SteamGridDB"}
+            return {
+                "success": False,
+                "reason": ErrorCode.AUTH_FAILED.value,
+                "message": "API key rejected by SteamGridDB",
+            }
         except SgdbApiError as e:
             self._logger.warning(f"SGDB API key verification HTTP error: {e.status_code}")
             if e.status_code in (401, 403):
-                return {"success": False, "message": "Invalid API key"}
-            return {"success": False, "message": f"SteamGridDB error: HTTP {e.status_code}"}
+                return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": "Invalid API key"}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": f"SteamGridDB error: HTTP {e.status_code}",
+            }
         except Exception as e:
             self._logger.error(f"SGDB API key verification failed: {e}")
-            return {"success": False, "message": f"Connection failed: {e}"}
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": f"Connection failed: {e}",
+            }
 
     def save_sgdb_api_key(self, api_key):
         if api_key and api_key != "••••":
@@ -453,7 +477,7 @@ class SteamGridService:
             icon_bytes = base64.b64decode(icon_base64)
         except Exception as e:
             self._logger.error(f"Failed to decode icon base64: {e}")
-            return {"success": False}
+            return {"success": False, "reason": "invalid_payload", "message": "Failed to decode icon data"}
 
         success = await self._loop.run_in_executor(None, self._save_icon_to_grid, app_id, icon_bytes)
         return {"success": success}

--- a/scripts/check_failure_shape.py
+++ b/scripts/check_failure_shape.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Failure-shape dialect gate — canonical-response enforcement.
+
+Decky callables that return a plain ``dict`` and can fail use the canonical
+failure shape ``{"success": False, "reason": ErrorCode | str, "message": str}``
+(plus per-callable payload extras). The convention — documented in
+``py_modules/lib/list_result.py`` and ``CLAUDE.md`` → "Callable response shapes"
+— forbids a second ``error`` field and the legacy ``error_code`` key.
+
+This check walks ``py_modules/services/`` and classifies every failure-shaped
+``return`` against a **required-key rule**: a failure shape must carry both
+``reason`` and ``message`` and must NOT carry ``error`` or ``error_code``.
+
+Classification of each failure-shaped return (a ``return`` of a dict literal
+with a falsy ``success`` entry):
+
+  * CANONICAL — has ``reason`` and ``message``, no ``error`` / ``error_code``.
+    (Extra/additive payload keys are allowed.)
+  * ERROR_CODE_DIALECT — carries the forbidden ``error_code`` key.
+  * ERROR_KEY_DIALECT — carries the forbidden ``error`` key.
+  * AD_HOC — ``success: False`` but missing ``reason`` and/or ``message``
+    (an extra-keys-only or message-only stray with no routing slug).
+  * CARVE_OUT_CANDIDATE — a documented carve-out shape, pattern-exempt and
+    never flagged: a discriminated-status union (``status`` discriminant, no
+    ``success``) or a partial-success payload (a full data payload alongside
+    an additive failure flag from :data:`PARTIAL_SUCCESS_FLAGS`).
+
+Two modes:
+
+  * report (default) — print every site grouped by classification with a count
+    summary, then exit 0. Report mode never fails; it is the inventory.
+  * ``--check`` — enforce mode. Exit 1 on any ERROR_CODE_DIALECT,
+    ERROR_KEY_DIALECT, or AD_HOC finding (the three collapsed dialects).
+    CANONICAL and the pattern-exempt CARVE_OUT_CANDIDATE sites pass.
+
+The dict-literal heuristic is intentionally conservative: it only inspects
+``return {...}`` literals. A failure dict built across several statements
+(``resp = {...}; resp["x"] = y; return resp``) or returned from a helper is not
+caught — a guardrail, not a prover. A ``**spread`` or computed key hides the
+full key set; such returns are flagged for manual review (AD_HOC) unless they
+look like a carve-out, so the heuristic never silently passes an unknown shape.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SERVICES_DIR = REPO_ROOT / "py_modules" / "services"
+
+REASON_KEY = "reason"
+MESSAGE_KEY = "message"
+SUCCESS_KEY = "success"
+STATUS_KEY = "status"
+ERROR_CODE_KEY = "error_code"
+ERROR_KEY = "error"
+
+# Classification labels (also the report group order).
+CANONICAL = "CANONICAL"
+ERROR_CODE_DIALECT = "ERROR_CODE_DIALECT"
+ERROR_KEY_DIALECT = "ERROR_KEY_DIALECT"
+CARVE_OUT_CANDIDATE = "CARVE_OUT_CANDIDATE"
+AD_HOC = "AD_HOC"
+
+REPORT_ORDER = (
+    ERROR_CODE_DIALECT,
+    ERROR_KEY_DIALECT,
+    AD_HOC,
+    CARVE_OUT_CANDIDATE,
+    CANONICAL,
+)
+
+# Findings in these classifications fail enforce mode (``--check``).
+VIOLATION_CLASSES = frozenset({ERROR_CODE_DIALECT, ERROR_KEY_DIALECT, AD_HOC})
+
+# Additive failure-flag keys that mark a partial-success payload (carve-out 2).
+# A return carrying one of these alongside a full payload keeps the flag.
+PARTIAL_SUCCESS_FLAGS = frozenset({"server_query_failed", "recommended_action"})
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One failure-shaped return site and its classification."""
+
+    path: Path
+    lineno: int
+    classification: str
+    keys: tuple[str, ...]
+    detail: str
+
+    @property
+    def rel(self) -> str:
+        return str(self.path.relative_to(REPO_ROOT))
+
+    def render(self) -> str:
+        key_set = "{" + ", ".join(self.keys) + "}" if self.keys else "{}"
+        suffix = f" — {self.detail}" if self.detail else ""
+        return f"{self.rel}:{self.lineno}  {key_set}{suffix}"
+
+
+def _is_falsy_success(value: ast.expr) -> bool:
+    """Return True when *value* is a literal falsy ``success`` value (False/0/None)."""
+    if isinstance(value, ast.Constant):
+        return value.value in (False, 0, None)
+    return False
+
+
+def _literal_keys(node: ast.Dict) -> list[str] | None:
+    """Return the string keys of a dict literal, or None if any key is non-constant.
+
+    A ``**spread`` entry (key is None) or a computed key means the literal's full
+    key set is unknown at parse time — return None so the caller treats it as
+    unclassifiable-by-keys rather than guessing.
+    """
+    keys: list[str] = []
+    for key in node.keys:
+        if key is None:  # ``**other`` spread
+            return None
+        if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+            return None
+        keys.append(key.value)
+    return keys
+
+
+def _classify_keys(keys: list[str]) -> str:
+    """Classify a failure-shaped dict literal by its key set (required-key rule).
+
+    Precondition: the caller has already confirmed this dict is failure-shaped
+    (a falsy ``success`` entry, a ``status`` discriminant, or a partial-success
+    flag). Order matters: carve-outs are recognised first so they never fall
+    through to the dialect/ad-hoc checks.
+    """
+    key_set = set(keys)
+
+    # Carve-out 1: discriminated-status union (status discriminant, no success).
+    if STATUS_KEY in key_set and SUCCESS_KEY not in key_set:
+        return CARVE_OUT_CANDIDATE
+    # Carve-out 2: partial-success payload (additive failure flag).
+    if key_set & PARTIAL_SUCCESS_FLAGS:
+        return CARVE_OUT_CANDIDATE
+
+    # Forbidden keys — the two legacy dialects.
+    if ERROR_CODE_KEY in key_set:
+        return ERROR_CODE_DIALECT
+    if ERROR_KEY in key_set:
+        return ERROR_KEY_DIALECT
+
+    # Required-key rule: a canonical failure carries both reason and message.
+    if REASON_KEY in key_set and MESSAGE_KEY in key_set:
+        return CANONICAL
+
+    # success: False but missing reason and/or message — an ad-hoc stray.
+    return AD_HOC
+
+
+def _has_falsy_success_entry(node: ast.Dict) -> bool:
+    """Return True when the dict literal has a ``"success"`` key with a falsy value."""
+    for key, value in zip(node.keys, node.values, strict=True):
+        if isinstance(key, ast.Constant) and key.value == SUCCESS_KEY and _is_falsy_success(value):
+            return True
+    return False
+
+
+def _has_status_entry(node: ast.Dict) -> bool:
+    """Return True when the dict literal has a literal ``"status"`` key."""
+    return any(isinstance(key, ast.Constant) and key.value == STATUS_KEY for key in node.keys)
+
+
+def _has_partial_success_flag(node: ast.Dict) -> bool:
+    """Return True when the dict literal carries an additive partial-success flag."""
+    return any(isinstance(key, ast.Constant) and key.value in PARTIAL_SUCCESS_FLAGS for key in node.keys)
+
+
+def _finding_for_return(path: Path, node: ast.Return) -> Finding | None:
+    """Classify one ``return`` statement. None = not a failure-shaped return."""
+    value = node.value
+    if not isinstance(value, ast.Dict):
+        return None
+
+    keys = _literal_keys(value)
+    is_failure = _has_falsy_success_entry(value)
+    is_status = _has_status_entry(value)
+    is_partial = _has_partial_success_flag(value)
+
+    if not (is_failure or is_status or is_partial):
+        return None
+
+    if keys is None:
+        # A ``**spread`` or computed key hid the full key set. Flag it so a
+        # reviewer can eyeball it; treat an obvious carve-out shape as exempt,
+        # everything else as AD_HOC (an unknown shape never silently passes).
+        looks_like_carve_out = (is_status and not is_failure) or is_partial
+        classification = CARVE_OUT_CANDIDATE if looks_like_carve_out else AD_HOC
+        return Finding(
+            path=path,
+            lineno=node.lineno,
+            classification=classification,
+            keys=("<dynamic keys>",),
+            detail="dict with spread/computed keys — verify by hand",
+        )
+
+    classification = _classify_keys(keys)
+    return Finding(
+        path=path,
+        lineno=node.lineno,
+        classification=classification,
+        keys=tuple(keys),
+        detail="",
+    )
+
+
+def scan_file(path: Path) -> list[Finding]:
+    """Parse *path* and return every failure-shaped return finding in it."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Return):
+            finding = _finding_for_return(path, node)
+            if finding is not None:
+                findings.append(finding)
+    return findings
+
+
+def collect_findings(services_dir: Path = SERVICES_DIR) -> list[Finding]:
+    """Walk *services_dir* and return every failure-shape finding."""
+    findings: list[Finding] = []
+    if services_dir.is_dir():
+        for path in sorted(services_dir.rglob("*.py")):
+            findings.extend(scan_file(path))
+    return findings
+
+
+def _group_by_class(findings: list[Finding]) -> dict[str, list[Finding]]:
+    by_class: dict[str, list[Finding]] = {label: [] for label in REPORT_ORDER}
+    for finding in findings:
+        by_class.setdefault(finding.classification, []).append(finding)
+    return by_class
+
+
+def _print_report(findings: list[Finding]) -> None:
+    """Print findings grouped by classification with a count summary."""
+    by_class = _group_by_class(findings)
+
+    for label in REPORT_ORDER:
+        group = by_class.get(label, [])
+        print(f"=== {label} ({len(group)}) ===")
+        for finding in group:
+            print(f"  {finding.render()}")
+        print()
+
+    print("=== SUMMARY ===")
+    for label in REPORT_ORDER:
+        print(f"  {label}: {len(by_class.get(label, []))}")
+    print(f"  TOTAL: {len(findings)}")
+
+
+def _print_violations(findings: list[Finding]) -> None:
+    """Print only the enforce-mode violations, grouped, with a fix hint."""
+    violations = [f for f in findings if f.classification in VIOLATION_CLASSES]
+    by_class = _group_by_class(violations)
+    for label in REPORT_ORDER:
+        group = by_class.get(label, [])
+        if not group:
+            continue
+        print(f"=== {label} ({len(group)}) ===")
+        for finding in group:
+            print(f"  {finding.render()}")
+        print()
+    print(
+        "ERROR: failure-shaped returns in py_modules/services/ must carry "
+        "'reason' + 'message' and must not carry 'error' / 'error_code' "
+        "(CLAUDE.md → Callable response shapes; lib/list_result.py)."
+    )
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+
+    enforce = "--check" in argv
+    findings = collect_findings(SERVICES_DIR)
+
+    if enforce:
+        violations = [f for f in findings if f.classification in VIOLATION_CLASSES]
+        if violations:
+            _print_violations(findings)
+            return 1
+        print(f"OK: no failure-shape dialect violations in {SERVICES_DIR.relative_to(REPO_ROOT)}.")
+        return 0
+
+    _print_report(findings)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -44,7 +44,7 @@ import type {
 export interface BackendResult {
   success: boolean;
   message: string;
-  error_code?: RommErrorCode;
+  reason?: RommErrorCode;
   romm_version?: string;
   /** Set when a callable was rejected because a RetroDECK migration is pending. */
   blocked_by_migration?: boolean;
@@ -127,7 +127,7 @@ export const savePlatformSync = callable<[number, boolean], { success: boolean; 
 export const setAllPlatformsSync = callable<[boolean], { success: boolean; message: string }>("set_all_platforms_sync");
 export const getCollections = callable<
   [],
-  { success: boolean; collections: CollectionSyncSetting[]; message?: string; error_code?: RommErrorCode }
+  { success: boolean; collections: CollectionSyncSetting[]; message?: string; reason?: RommErrorCode }
 >("get_collections");
 export const saveCollectionSync = callable<[string, CollectionKind, boolean], { success: boolean; message?: string }>(
   "save_collection_sync",
@@ -314,7 +314,7 @@ export const syncAllSaves = callable<
 >("sync_all_saves");
 export const resolveSyncConflict = callable<
   [number, string, number, "keep_local" | "use_server"],
-  { success: boolean; message?: string; error_code?: "stale_conflict"; action?: "keep_local" | "use_server" }
+  { success: boolean; message?: string; reason?: "stale_conflict"; action?: "keep_local" | "use_server" }
 >("resolve_sync_conflict");
 export const recordSessionStart = callable<[number], { success: boolean }>("record_session_start");
 export const getSaveSyncSettings = callable<[], SaveSyncSettings>("get_save_sync_settings");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -451,11 +451,11 @@ describe("MainPage", () => {
       setVerSpy.mockRestore();
     });
 
-    it("testConnection error_code='version_error' surfaces r.message via setVersionError", async () => {
+    it("testConnection reason='version_error' surfaces r.message via setVersionError", async () => {
       vi.mocked(backend.testConnection).mockResolvedValue({
         success: false,
         message: "server out of date",
-        error_code: "version_error",
+        reason: "version_error",
       });
       const setVerSpy = vi.spyOn(connectionState, "setVersionError");
       render(<MainPage onNavigate={vi.fn()} />);

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -206,7 +206,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     testConnection()
       .then((r) => {
         setConnected(r.success);
-        setVersionError(r.error_code === "version_error" ? r.message : null);
+        setVersionError(r.reason === "version_error" ? r.message : null);
       })
       .catch((e) => logError(`Failed to test connection: ${e}`));
     getSettings()

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -728,11 +728,11 @@ describe("RomMPlaySection", () => {
       expect(vi.mocked(connectionState.setRommConnectionState)).toHaveBeenCalledWith("offline");
     });
 
-    it("on error_code=version_error → calls setVersionError and stays offline", async () => {
+    it("on reason=version_error → calls setVersionError and stays offline", async () => {
       vi.mocked(backend.testConnection).mockResolvedValue({
         success: false,
         message: "Update required",
-        error_code: "version_error",
+        reason: "version_error",
       });
       render(<RomMPlaySection appId={testAppId} />);
       await flushAsync();

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -414,7 +414,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       try {
         const result = await Promise.race([testConnection(), timeoutMs(5000)]);
         if (cancelled) return;
-        if (result.error_code === "version_error") {
+        if (result.reason === "version_error") {
           setVersionError(result.message);
           setRommConnectionState("offline");
           setConnectionState("offline");

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -420,24 +420,31 @@ describe("SettingsPage", () => {
       expect(queryByTestId("devices-section")).toBeNull();
     });
 
-    it("surfaces an error from listDevices via devicesError + empty list", async () => {
+    it("surfaces the human-readable message (not the slug) from listDevices via devicesError + empty list", async () => {
       vi.mocked(backend.getSaveSyncSettings).mockResolvedValue({
         ...defaultSaveSyncSettings(),
         save_sync_enabled: true,
       });
+      // Canonical failure shape: the routing slug lives on `reason`, the
+      // human-readable text on `message`. The UI must render `message`, never
+      // the raw slug (the #972 user-visible bug: "Could not load devices —
+      // list_failed" leaked the slug).
       vi.mocked(backend.listDevices).mockResolvedValue({
         success: false,
         devices: [],
-        error: "auth failed",
+        reason: "server_unreachable",
+        message: "Could not load devices",
       });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();
       const d = capturedDevices[capturedDevices.length - 1];
-      expect(d?.devicesError).toBe("auth failed");
+      expect(d?.devicesError).toBe("Could not load devices");
+      // The raw slug must NOT surface to the user.
+      expect(d?.devicesError).not.toBe("server_unreachable");
       expect(d?.registeredDevices).toEqual([]);
     });
 
-    it("falls back to a generic message when error is absent on a failed response", async () => {
+    it("falls back to a generic message when message is absent on a failed response", async () => {
       vi.mocked(backend.getSaveSyncSettings).mockResolvedValue({
         ...defaultSaveSyncSettings(),
         save_sync_enabled: true,
@@ -573,7 +580,7 @@ describe("SettingsPage", () => {
       expect(conn?.hasToken).toBe(true);
     });
 
-    it("surfaces the failure message without setting hasToken (e.g. forbidden_error)", async () => {
+    it("surfaces the failure message without setting hasToken (e.g. 403 auth_failed)", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         has_token: false,
@@ -581,7 +588,7 @@ describe("SettingsPage", () => {
       vi.mocked(backend.connectWithCredentials).mockResolvedValue({
         success: false,
         message: "This account cannot create API tokens.",
-        error_code: "forbidden_error",
+        reason: "auth_failed",
       });
       render(<SettingsPage onBack={vi.fn()} />);
       await flushAsync();

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -145,7 +145,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         } else if (result.disabled) {
           setRegisteredDevices(null);
         } else {
-          setDevicesError(result.error ?? "Failed to load devices");
+          setDevicesError(result.message ?? "Failed to load devices");
           setRegisteredDevices([]);
         }
       })

--- a/src/components/SyncConflictModal.test.tsx
+++ b/src/components/SyncConflictModal.test.tsx
@@ -208,7 +208,7 @@ describe("SyncConflictModal", () => {
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
       vi.mocked(backend.resolveSyncConflict).mockResolvedValue({
         success: false,
-        error_code: "stale_conflict",
+        reason: "stale_conflict",
         message: "out of date",
       });
 
@@ -239,7 +239,7 @@ describe("SyncConflictModal", () => {
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
       vi.mocked(backend.resolveSyncConflict).mockResolvedValue({
         success: false,
-        error_code: "stale_conflict",
+        reason: "stale_conflict",
       });
 
       const conflict = makeConflict();

--- a/src/components/SyncConflictModal.tsx
+++ b/src/components/SyncConflictModal.tsx
@@ -163,7 +163,7 @@ const SyncConflictModalHost: FC<SyncConflictModalHostProps> = ({ conflict, close
     try {
       const result = await resolveSyncConflict(conflict.rom_id, conflict.filename, conflict.server_save_id, action);
       if (!result.success) {
-        if (result.error_code === "stale_conflict") {
+        if (result.reason === "stale_conflict") {
           const staleMsg =
             "The server save has been updated by another device. Please cancel and retry sync to get the latest version.";
           logError(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -187,7 +187,7 @@ export default definePlugin(() => {
     (async () => {
       try {
         const result = await withTimeout(testConnection(), CALLABLE_TIMEOUT);
-        if (result.error_code === "version_error") {
+        if (result.reason === "version_error") {
           setVersionError(result.message);
         } else if (result.success) {
           setVersionError(null);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -5,22 +5,24 @@
  * (sync, saves, firmware, downloads, achievements) live in their own files.
  */
 
+/**
+ * Canonical failure-`reason` slugs the backend emits on the `{success: false,
+ * reason, message}` shape (see py_modules/lib/list_result.py `ErrorCode` + the
+ * gate scripts/check_failure_shape.py). The Lean enum plus the bespoke
+ * plain-string reasons the frontend actually routes on. Transport failures
+ * collapse onto `server_unreachable`; 401/403 onto `auth_failed` (distinguished
+ * by `message`, not slug).
+ */
 export type RommErrorCode =
-  | "auth_error"
-  | "forbidden_error"
-  | "connection_error"
-  | "timeout_error"
-  | "ssl_error"
-  | "server_error"
-  | "not_found_error"
-  | "unsupported_error"
+  | "server_unreachable"
+  | "auth_failed"
+  | "not_found"
+  | "unsupported"
+  | "unknown"
   | "version_error"
-  | "config_error"
-  | "disk_error"
-  | "api_error"
   | "stale_conflict"
   | "stale_preview"
-  | "unknown_error";
+  | "config_error";
 
 export interface InstalledRom {
   rom_id: number;

--- a/src/types/devices.ts
+++ b/src/types/devices.ts
@@ -26,5 +26,6 @@ export interface ListDevicesResponse {
   success: boolean;
   devices: RegisteredDevice[];
   disabled?: boolean;
-  error?: string;
+  reason?: string;
+  message?: string;
 }

--- a/src/utils/connectionState.ts
+++ b/src/utils/connectionState.ts
@@ -7,7 +7,7 @@ export function setRommConnectionState(s: "checking" | "connected" | "offline") 
   _state = s;
 }
 
-/** Version mismatch error — set when server returns error_code: "version_error" */
+/** Version mismatch error — set when server returns reason: "version_error" */
 let _versionError: string | null = null;
 const versionErrorListeners = new Set<(err: string | null) => void>();
 

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -901,7 +901,7 @@ class TestRetryLogic:
 
 
 class TestTestConnectionErrors:
-    """test_connection returns structured error_code in responses."""
+    """test_connection returns a canonical ``reason`` slug in failure responses."""
 
     @pytest.mark.asyncio
     async def test_config_error_when_url_empty(self, plugin):
@@ -909,7 +909,7 @@ class TestTestConnectionErrors:
         plugin.settings["romm_url"] = ""
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "config_error"
+        assert result["reason"] == "config_error"
         assert "No server URL" in result["message"]
 
     @pytest.mark.asyncio
@@ -924,7 +924,7 @@ class TestTestConnectionErrors:
         plugin._romm_api.list_platforms.side_effect = RommAuthError("401")
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "auth_error"
+        assert result["reason"] == "auth_failed"
         assert "Authentication failed" in result["message"]
 
     @pytest.mark.asyncio
@@ -937,7 +937,7 @@ class TestTestConnectionErrors:
         plugin._romm_api.heartbeat.side_effect = RommConnectionError("refused")
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "connection_error"
+        assert result["reason"] == "server_unreachable"
         assert "unreachable" in result["message"].lower()
 
     @pytest.mark.asyncio
@@ -950,7 +950,7 @@ class TestTestConnectionErrors:
         plugin._romm_api.heartbeat.side_effect = RommSSLError("cert fail")
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "ssl_error"
+        assert result["reason"] == "server_unreachable"
         assert "SSL" in result["message"]
 
     @pytest.mark.asyncio
@@ -979,7 +979,7 @@ class TestTestConnectionErrors:
         plugin._romm_api.list_platforms.side_effect = RommServerError("500", status_code=500)
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "server_error"
+        assert result["reason"] == "server_unreachable"
         assert "Server reachable but API request failed" in result["message"]
 
 
@@ -1010,7 +1010,7 @@ class TestVersionDetection:
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
         assert result["romm_version"] == "4.5.0"
 
     @pytest.mark.asyncio
@@ -1024,7 +1024,7 @@ class TestVersionDetection:
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
 
     @pytest.mark.asyncio
     async def test_47_version_rejected(self, plugin):
@@ -1037,7 +1037,7 @@ class TestVersionDetection:
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
 
     @pytest.mark.asyncio
     async def test_48_minimum_version_accepted(self, plugin):
@@ -1062,7 +1062,7 @@ class TestVersionDetection:
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
 
     @pytest.mark.asyncio
     async def test_development_version_accepted(self, plugin):
@@ -1113,7 +1113,7 @@ class TestVersionDetection:
         plugin._romm_api.heartbeat.side_effect = RommTimeoutError("timed out")
         result = await plugin.test_connection()
         assert result["success"] is False
-        assert result["error_code"] == "timeout_error"
+        assert result["reason"] == "server_unreachable"
 
 
 # ── Tests for uncovered HTTP adapter methods ──────────

--- a/tests/contract/test_saves_read.py
+++ b/tests/contract/test_saves_read.py
@@ -169,10 +169,10 @@ async def test_get_slot_delete_info_happy_shape(harness):
 
 
 async def test_get_slot_delete_info_not_installed_failure_shape(harness):
-    """Documented guard: sync on but not installed → {success: False, reason: not_installed}."""
+    """Documented guard: sync on but not installed → canonical {success: False, reason, message}."""
     enable_save_sync(harness)
     result = await harness.plugin.get_slot_delete_info(42, "main")
-    assert result == {"success": False, "reason": "not_installed"}
+    assert result == {"success": False, "reason": "not_installed", "message": "ROM is not installed"}
 
 
 async def test_get_slot_delete_info_server_failure_shape(harness):

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -10,16 +10,12 @@ delegation. Covered here:
 - ``get_collections`` (happy + server-failure)
 - ``get_registry_platforms``
 
-Note on the failure shape: ``get_platforms`` / ``get_collections`` return
-``{success: False, message, error_code}`` — the *legacy* failure shape that
-predates the canonical ``{success, reason, message}`` used by the save
-callables. These contract tests assert the shape the backend *actually*
-returns (``error_code``, not ``reason``); pinning the real divergence is the
-point of this tier. ``error_code`` is the ``classify_error`` slug
-(``"connection_error"`` for a ``RommConnectionError``). When #972 (collapse
-the failure-shape dialects onto the canonical shape) lands, these assertions
-will break — that is the intended coupling; update them to the unified shape
-as part of that fix.
+Note on the failure shape: ``get_platforms`` / ``get_collections`` now return
+the canonical ``{success: False, reason, message}`` shape used across the
+callable surface. The ``reason`` slug is ``"server_unreachable"`` for a
+``RommConnectionError``. The earlier legacy divergence (``error_code`` under a
+separate key) has been collapsed onto the unified shape, so these assertions
+pin ``reason``, not ``error_code``.
 """
 
 from __future__ import annotations
@@ -96,16 +92,17 @@ async def test_get_platforms_happy_shape(harness):
 
 
 async def test_get_platforms_server_failure_shape(harness):
-    """Server unreachable → legacy failure shape: success False + message + error_code."""
+    """Server unreachable → canonical failure shape: success False + reason + message."""
     harness.romm.list_platforms_side_effect = RommConnectionError("offline")
     result = await harness.plugin.get_platforms()
     assert result["success"] is False
     assert "platforms" not in result
     assert isinstance(result["message"], str)
     assert result["message"]  # non-empty
-    # error_code is classify_error's slug (NOT a `reason` field) — the legacy shape.
-    assert result["error_code"] == "connection_error"
-    assert "reason" not in result
+    # reason is the canonical slug for a RommConnectionError.
+    assert result["reason"] == "server_unreachable"
+    assert "error_code" not in result
+    assert "error" not in result
 
 
 # ── get_collections ──────────────────────────────────────────────────────
@@ -127,15 +124,16 @@ async def test_get_collections_happy_shape(harness):
 
 
 async def test_get_collections_server_failure_shape(harness):
-    """User-collection fetch failure → legacy failure shape."""
+    """User-collection fetch failure → canonical failure shape."""
     harness.romm.list_collections_side_effect = RommConnectionError("offline")
     result = await harness.plugin.get_collections()
     assert result["success"] is False
     assert "collections" not in result
     assert isinstance(result["message"], str)
     assert result["message"]
-    assert result["error_code"] == "connection_error"
-    assert "reason" not in result
+    assert result["reason"] == "server_unreachable"
+    assert "error_code" not in result
+    assert "error" not in result
 
 
 # ── get_registry_platforms ───────────────────────────────────────────────

--- a/tests/lib/test_errors.py
+++ b/tests/lib/test_errors.py
@@ -164,69 +164,69 @@ class TestClassifyError:
 
     def test_auth_error(self):
         code, msg = classify_error(RommAuthError("401"))
-        assert code == "auth_error"
+        assert code == "auth_failed"
         assert "Authentication failed" in msg
 
     def test_forbidden_error(self):
         code, msg = classify_error(RommForbiddenError("403"))
-        assert code == "forbidden_error"
+        assert code == "auth_failed"
         assert "Access denied" in msg
 
     def test_ssl_error(self):
         code, msg = classify_error(RommSSLError("cert fail"))
-        assert code == "ssl_error"
+        assert code == "server_unreachable"
         assert "SSL certificate error" in msg
 
     def test_timeout_error(self):
         code, msg = classify_error(RommTimeoutError("timed out"))
-        assert code == "timeout_error"
+        assert code == "server_unreachable"
         assert "timed out" in msg.lower()
 
     def test_connection_error(self):
         code, msg = classify_error(RommConnectionError("refused"))
-        assert code == "connection_error"
+        assert code == "server_unreachable"
         assert "unreachable" in msg.lower()
 
     def test_server_error(self):
         code, msg = classify_error(RommServerError("500", status_code=500))
-        assert code == "server_error"
+        assert code == "server_unreachable"
         assert "500" in msg
 
     def test_server_error_502(self):
         code, msg = classify_error(RommServerError("bad gateway", status_code=502))
-        assert code == "server_error"
+        assert code == "server_unreachable"
         assert "502" in msg
 
     def test_not_found_error(self):
         code, msg = classify_error(RommNotFoundError("missing"))
-        assert code == "not_found_error"
+        assert code == "not_found"
         assert "not found" in msg.lower()
 
     def test_unsupported_error(self):
         code, msg = classify_error(RommUnsupportedError("save content download", "4.7.0"))
-        assert code == "unsupported_error"
+        assert code == "unsupported"
         assert "4.7.0" in msg
         assert "requires RomM" in msg
 
     def test_generic_api_error(self):
         code, msg = classify_error(RommApiError("some API issue"))
-        assert code == "api_error"
+        assert code == "server_unreachable"
         assert msg == "some API issue"
 
     def test_conflict_error_is_api_error(self):
         """RommConflictError is a subclass of RommApiError, not specifically handled."""
         code, msg = classify_error(RommConflictError("conflict"))
-        assert code == "api_error"
+        assert code == "server_unreachable"
         assert msg == "conflict"
 
     def test_unknown_exception_value_error(self):
         code, msg = classify_error(ValueError("bad value"))
-        assert code == "unknown_error"
+        assert code == "unknown"
         assert msg == "bad value"
 
     def test_unknown_exception_runtime_error(self):
         code, msg = classify_error(RuntimeError("something broke"))
-        assert code == "unknown_error"
+        assert code == "unknown"
         assert msg == "something broke"
 
     def test_messages_are_user_friendly_not_tracebacks(self):
@@ -243,54 +243,56 @@ class TestClassifyError:
             assert "File " not in msg
 
     def test_subclass_ordering_auth_before_api(self):
-        """RommAuthError (subclass of RommApiError) should be classified as auth_error, not api_error."""
+        """RommAuthError (subclass of RommApiError) should be classified as auth_failed, not server_unreachable."""
         code, _ = classify_error(RommAuthError("auth fail"))
-        assert code == "auth_error"
+        assert code == "auth_failed"
 
     def test_subclass_ordering_ssl_before_connection(self):
-        """RommSSLError should be classified as ssl_error even though it's a RommApiError."""
+        """RommSSLError should be classified as server_unreachable even though it's a RommApiError."""
         code, _ = classify_error(RommSSLError("cert fail"))
-        assert code == "ssl_error"
+        assert code == "server_unreachable"
 
 
 class TestErrorResponse:
-    """error_response returns a proper {success, message, error_code} dict."""
+    """error_response returns a proper {success, reason, message} dict."""
 
     def test_structure(self):
         resp = error_response(RommAuthError("401"))
         assert resp["success"] is False
         assert "message" in resp
-        assert "error_code" in resp
+        assert "reason" in resp
+        assert "error_code" not in resp
+        assert "error" not in resp
 
     def test_auth_error_code(self):
         resp = error_response(RommAuthError("unauthorized"))
-        assert resp["error_code"] == "auth_error"
+        assert resp["reason"] == "auth_failed"
         assert resp["success"] is False
 
     def test_connection_error_code(self):
         resp = error_response(RommConnectionError("refused"))
-        assert resp["error_code"] == "connection_error"
+        assert resp["reason"] == "server_unreachable"
 
     def test_ssl_error_code(self):
         resp = error_response(RommSSLError("cert fail"))
-        assert resp["error_code"] == "ssl_error"
+        assert resp["reason"] == "server_unreachable"
 
     def test_timeout_error_code(self):
         resp = error_response(RommTimeoutError("timed out"))
-        assert resp["error_code"] == "timeout_error"
+        assert resp["reason"] == "server_unreachable"
 
     def test_server_error_code(self):
         resp = error_response(RommServerError("500", status_code=500))
-        assert resp["error_code"] == "server_error"
+        assert resp["reason"] == "server_unreachable"
 
     def test_unknown_error_code(self):
         resp = error_response(ValueError("bad"))
-        assert resp["error_code"] == "unknown_error"
+        assert resp["reason"] == "unknown"
 
     def test_fallback_message_override(self):
         resp = error_response(RommAuthError("401"), fallback_message="Custom message")
         assert resp["message"] == "Custom message"
-        assert resp["error_code"] == "auth_error"
+        assert resp["reason"] == "auth_failed"
 
     def test_fallback_message_none_uses_default(self):
         resp = error_response(RommAuthError("401"), fallback_message=None)
@@ -298,16 +300,16 @@ class TestErrorResponse:
 
     def test_not_found_error_response(self):
         resp = error_response(RommNotFoundError("missing"))
-        assert resp["error_code"] == "not_found_error"
+        assert resp["reason"] == "not_found"
         assert resp["success"] is False
 
     def test_forbidden_error_response(self):
         resp = error_response(RommForbiddenError("forbidden"))
-        assert resp["error_code"] == "forbidden_error"
+        assert resp["reason"] == "auth_failed"
         assert "Access denied" in resp["message"]
 
     def test_unsupported_error_response(self):
         resp = error_response(RommUnsupportedError("save content download", "4.7.0"))
-        assert resp["error_code"] == "unsupported_error"
+        assert resp["reason"] == "unsupported"
         assert resp["success"] is False
         assert "4.7.0" in resp["message"]

--- a/tests/scripts/test_check_failure_shape.py
+++ b/tests/scripts/test_check_failure_shape.py
@@ -1,0 +1,305 @@
+"""Tests for ``scripts/check_failure_shape.py``.
+
+The check is loaded via ``importlib`` because ``scripts/`` is not on
+``sys.path`` (and is excluded from ruff/basedpyright). Fixtures use
+``tmp_path`` to lay out a small ``py_modules/services/`` tree the check
+walks, monkeypatching the script's ``SERVICES_DIR`` / ``REPO_ROOT``
+constants for the duration of the test.
+
+Coverage centres on the required-key rule (a ``success: False`` failure
+return must carry both ``reason`` and ``message`` and must not carry
+``error`` / ``error_code``) and the two pattern-exempt carve-outs
+(discriminated-status unions and partial-success payloads).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_failure_shape.py"
+
+
+def _load_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_failure_shape", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_check_module()
+
+
+def _make_services_tree(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Build a fake ``py_modules/services/`` tree: ``name -> source``."""
+    services_dir = tmp_path / "py_modules" / "services"
+    services_dir.mkdir(parents=True)
+    for name, source in files.items():
+        path = services_dir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return services_dir
+
+
+def _wrap_return(body: str) -> str:
+    """Wrap a single ``return {...}`` body in a tiny function module."""
+    return f"def f():\n    return {body}\n"
+
+
+def _classify_single(tmp_path: Path, body: str) -> str:
+    """Scan a one-return module and return that return's classification."""
+    services_dir = _make_services_tree(tmp_path, {"mod.py": _wrap_return(body)})
+    findings = check.collect_findings(services_dir)
+    assert len(findings) == 1, f"expected exactly one finding, got {findings}"
+    return findings[0].classification
+
+
+# ── Required-key rule: classification ────────────────────────────────────
+
+
+class TestCanonicalShape:
+    def test_reason_and_message_is_canonical(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"success": False, "reason": "x", "message": "m"}') == check.CANONICAL
+
+    def test_reason_message_plus_extras_is_canonical(self, tmp_path: Path):
+        body = '{"success": False, "reason": "x", "message": "m", "synced": 0, "files": []}'
+        assert _classify_single(tmp_path, body) == check.CANONICAL
+
+    def test_key_order_does_not_matter(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"message": "m", "success": False, "reason": "x"}') == check.CANONICAL
+
+    def test_falsy_success_none_still_classified(self, tmp_path: Path):
+        # ``success: None`` is falsy — still a failure shape under the rule.
+        assert _classify_single(tmp_path, '{"success": None, "reason": "x", "message": "m"}') == check.CANONICAL
+
+
+class TestForbiddenKeys:
+    def test_error_code_key_is_dialect(self, tmp_path: Path):
+        body = '{"success": False, "message": "m", "error_code": "x"}'
+        assert _classify_single(tmp_path, body) == check.ERROR_CODE_DIALECT
+
+    def test_error_key_is_dialect(self, tmp_path: Path):
+        body = '{"success": False, "message": "m", "error": "x"}'
+        assert _classify_single(tmp_path, body) == check.ERROR_KEY_DIALECT
+
+    def test_error_code_flagged_even_with_reason_present(self, tmp_path: Path):
+        # A forbidden key is a violation regardless of whether reason/message exist.
+        body = '{"success": False, "reason": "x", "message": "m", "error_code": "x"}'
+        assert _classify_single(tmp_path, body) == check.ERROR_CODE_DIALECT
+
+
+class TestAdHoc:
+    def test_message_only_no_reason_is_ad_hoc(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"success": False, "message": "m"}') == check.AD_HOC
+
+    def test_reason_only_no_message_is_ad_hoc(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"success": False, "reason": "x"}') == check.AD_HOC
+
+    def test_success_only_is_ad_hoc(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"success": False}') == check.AD_HOC
+
+    def test_extras_only_no_reason_no_message_is_ad_hoc(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"success": False, "synced": 0, "errors": []}') == check.AD_HOC
+
+
+# ── Carve-outs (pattern-exempt) ──────────────────────────────────────────
+
+
+class TestDiscriminatedStatusCarveOut:
+    def test_status_without_success_is_carve_out(self, tmp_path: Path):
+        body = '{"status": "server_unreachable", "message": "m"}'
+        assert _classify_single(tmp_path, body) == check.CARVE_OUT_CANDIDATE
+
+    def test_status_with_only_versions_is_carve_out(self, tmp_path: Path):
+        assert _classify_single(tmp_path, '{"status": "ok", "versions": []}') == check.CARVE_OUT_CANDIDATE
+
+    def test_status_with_success_false_is_not_carve_out(self, tmp_path: Path):
+        # A dict carrying BOTH status and a falsy success is not the union shape —
+        # it falls through to the required-key rule (AD_HOC here, no reason/message).
+        assert _classify_single(tmp_path, '{"success": False, "status": "x"}') == check.AD_HOC
+
+
+class TestPartialSuccessCarveOut:
+    def test_server_query_failed_flag_is_carve_out(self, tmp_path: Path):
+        body = '{"total_seconds": 0, "session_count": 0, "server_query_failed": True}'
+        assert _classify_single(tmp_path, body) == check.CARVE_OUT_CANDIDATE
+
+    def test_recommended_action_flag_is_carve_out(self, tmp_path: Path):
+        body = '{"has_local_saves": False, "recommended_action": "server_unreachable"}'
+        assert _classify_single(tmp_path, body) == check.CARVE_OUT_CANDIDATE
+
+    def test_partial_flag_wins_over_falsy_success(self, tmp_path: Path):
+        # Partial-success payloads may carry success: False alongside the flag;
+        # the carve-out still applies (the flag is checked before the dialects).
+        body = '{"success": False, "server_query_failed": True, "data": []}'
+        assert _classify_single(tmp_path, body) == check.CARVE_OUT_CANDIDATE
+
+
+# ── Non-failure returns are ignored ──────────────────────────────────────
+
+
+class TestNonFailureReturnsIgnored:
+    def test_success_true_dict_not_a_finding(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, {"mod.py": _wrap_return('{"success": True, "message": "ok"}')})
+        assert check.collect_findings(services_dir) == []
+
+    def test_non_dict_return_not_a_finding(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, {"mod.py": "def f():\n    return []\n"})
+        assert check.collect_findings(services_dir) == []
+
+    def test_bare_return_not_a_finding(self, tmp_path: Path):
+        services_dir = _make_services_tree(tmp_path, {"mod.py": "def f():\n    return\n"})
+        assert check.collect_findings(services_dir) == []
+
+
+# ── Dynamic-key heuristic (spread / computed keys) ───────────────────────
+
+
+class TestDynamicKeys:
+    def test_spread_failure_dict_flagged_ad_hoc(self, tmp_path: Path):
+        # A ``**base`` spread hides the full key set on a falsy-success dict —
+        # flagged AD_HOC for manual review (never silently passed).
+        body = '{**base, "success": False}'
+        services_dir = _make_services_tree(tmp_path, {"mod.py": f"def f(base):\n    return {body}\n"})
+        findings = check.collect_findings(services_dir)
+        assert len(findings) == 1
+        assert findings[0].classification == check.AD_HOC
+
+    def test_spread_status_union_flagged_carve_out(self, tmp_path: Path):
+        body = '{**base, "status": "ok"}'
+        services_dir = _make_services_tree(tmp_path, {"mod.py": f"def f(base):\n    return {body}\n"})
+        findings = check.collect_findings(services_dir)
+        assert len(findings) == 1
+        assert findings[0].classification == check.CARVE_OUT_CANDIDATE
+
+
+# ── Robustness ───────────────────────────────────────────────────────────
+
+
+class TestScanRobustness:
+    def test_syntax_error_file_skipped(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        services_dir = _make_services_tree(
+            tmp_path,
+            {
+                "broken.py": "def(\n",
+                "good.py": _wrap_return('{"success": False, "message": "m"}'),
+            },
+        )
+        findings = check.collect_findings(services_dir)
+        assert len(findings) == 1
+        assert findings[0].rel.endswith("good.py")
+
+    def test_missing_services_dir_returns_empty(self, tmp_path: Path):
+        assert check.collect_findings(tmp_path / "nope") == []
+
+    def test_nested_package_files_scanned(self, tmp_path: Path):
+        services_dir = _make_services_tree(
+            tmp_path,
+            {"saves/sync_engine/devices.py": _wrap_return('{"success": False, "error": "list_failed"}')},
+        )
+        findings = check.collect_findings(services_dir)
+        assert len(findings) == 1
+        assert findings[0].classification == check.ERROR_KEY_DIALECT
+
+
+# ── main() entry point ───────────────────────────────────────────────────
+
+
+class TestMainEntryPoint:
+    def test_help_flag_returns_zero(self, capsys: pytest.CaptureFixture[str]):
+        rc = check.main(["--help"])
+        assert rc == 0
+        assert "Failure-shape dialect gate" in capsys.readouterr().out
+
+    def test_short_help_flag_returns_zero(self):
+        assert check.main(["-h"]) == 0
+
+    def test_real_repo_report_is_clean(self, capsys: pytest.CaptureFixture[str]):
+        # Report mode never fails; it prints the inventory + summary.
+        rc = check.main([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "=== SUMMARY ===" in out
+
+    def test_real_repo_enforce_is_clean(self, capsys: pytest.CaptureFixture[str]):
+        # The real services/ tree must be fully collapsed onto the canonical
+        # shape — enforce mode passes (the whole point of the migration).
+        rc = check.main(["--check"])
+        assert rc == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_enforce_fails_on_dialect(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        services_dir = _make_services_tree(
+            tmp_path,
+            {"mod.py": _wrap_return('{"success": False, "message": "m", "error_code": "x"}')},
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        rc = check.main(["--check"])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "ERROR:" in out
+        assert "error_code" not in out or "mod.py" in out
+
+    def test_enforce_fails_on_ad_hoc(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        services_dir = _make_services_tree(
+            tmp_path,
+            {"mod.py": _wrap_return('{"success": False, "message": "m"}')},
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        rc = check.main(["--check"])
+        assert rc == 1
+        assert "ERROR:" in capsys.readouterr().out
+
+    def test_enforce_passes_on_canonical_and_carve_outs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        services_dir = _make_services_tree(
+            tmp_path,
+            {
+                "canonical.py": _wrap_return('{"success": False, "reason": "x", "message": "m"}'),
+                "status.py": _wrap_return('{"status": "server_unreachable", "message": "m"}'),
+                "partial.py": _wrap_return('{"data": [], "server_query_failed": True}'),
+                "ok.py": _wrap_return('{"success": True, "message": "ok"}'),
+            },
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        rc = check.main(["--check"])
+        assert rc == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_report_groups_and_summarises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        services_dir = _make_services_tree(
+            tmp_path,
+            {
+                "a.py": _wrap_return('{"success": False, "reason": "x", "message": "m"}'),
+                "b.py": _wrap_return('{"success": False, "error": "x"}'),
+            },
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+        rc = check.main([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert f"=== {check.CANONICAL} (1) ===" in out
+        assert f"=== {check.ERROR_KEY_DIALECT} (1) ===" in out
+        assert "TOTAL: 2" in out

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -113,7 +113,7 @@ class TestGetPlatforms:
 
         result = await plugin._sync_service.get_platforms()
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
 
     @pytest.mark.asyncio
     async def test_unexpected_response_type(self, plugin):
@@ -125,7 +125,7 @@ class TestGetPlatforms:
 
         result = await plugin._sync_service.get_platforms()
         assert result["success"] is False
-        assert result["error_code"] == "api_error"
+        assert result["reason"] == "server_unreachable"
 
 
 class TestSavePlatformSync:
@@ -324,7 +324,7 @@ class TestGetCollections:
         result = await plugin._sync_service.get_collections()
 
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
         assert "message" in result
 
     @pytest.mark.asyncio
@@ -636,7 +636,7 @@ class TestSetAllCollectionsSync:
         result = await plugin._sync_service.set_all_collections_sync(True)
 
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
 
     @pytest.mark.asyncio
     async def test_smart_scope_api_error_returns_error_response(self, plugin):
@@ -646,7 +646,7 @@ class TestSetAllCollectionsSync:
         result = await plugin._sync_service.set_all_collections_sync(True, scope="smart")
 
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
         assert "message" in result
         # Settings must not be mutated when the single-scope fetch fails.
         assert plugin._sync_service._settings["enabled_collections"]["smart"] == {}
@@ -659,7 +659,7 @@ class TestSetAllCollectionsSync:
         result = await plugin._sync_service.set_all_collections_sync(True, scope="franchise")
 
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
         assert "message" in result
         # Settings must not be mutated when the single-scope fetch fails.
         assert plugin._sync_service._settings["enabled_collections"]["franchise"] == {}

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -452,14 +452,14 @@ class TestSyncApplyDelta:
         self._setup_pending_delta(plugin, "correct-id")
         result = await plugin.sync_apply_delta("wrong-id")
         assert result["success"] is False
-        assert result["error_code"] == "stale_preview"
+        assert result["reason"] == "stale_preview"
 
     @pytest.mark.asyncio
     async def test_rejects_when_no_pending_delta(self, plugin):
         assert plugin._sync_service._pending_delta is None
         result = await plugin.sync_apply_delta("any-id")
         assert result["success"] is False
-        assert result["error_code"] == "stale_preview"
+        assert result["reason"] == "stale_preview"
 
     @pytest.mark.asyncio
     async def test_rejects_when_preview_older_than_max_age(self, plugin):
@@ -476,7 +476,7 @@ class TestSyncApplyDelta:
         result = await plugin.sync_apply_delta("preview-abc")
 
         assert result["success"] is False
-        assert result["error_code"] == "stale_preview"
+        assert result["reason"] == "stale_preview"
         assert "30 minutes" in result["message"]
         # Stale delta is cleared so a repeat apply can't pick it up.
         assert plugin._sync_service._pending_delta is None
@@ -695,7 +695,7 @@ class TestSyncPreviewErrorHandling:
 
         result = await plugin._sync_service.sync_preview()
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
         assert plugin._sync_service._sync_state == SyncState.IDLE
         # Error path evicts any pending delta.
         assert plugin._sync_service._pending_delta is None

--- a/tests/services/saves/sync_engine/test_rollback.py
+++ b/tests/services/saves/sync_engine/test_rollback.py
@@ -431,7 +431,7 @@ class TestResolveSyncConflictStaleConflict:
         )
 
         assert result["success"] is False
-        assert result["error_code"] == "stale_conflict"
+        assert result["reason"] == "stale_conflict"
         assert result["message"]
         # No PUT/POST fired against the head save — the whole point of the guard.
         assert not any(c[0] == "upload_save" for c in fake.call_log)
@@ -471,7 +471,7 @@ class TestResolveSyncConflictStaleConflict:
         )
 
         assert result["success"] is False
-        assert result["error_code"] == "stale_conflict"
+        assert result["reason"] == "stale_conflict"
         # Local file untouched — no silent download of the wrong server save.
         assert save_path.read_bytes() == b"local-stale"
         # State unchanged.

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -88,7 +88,7 @@ class TestDeviceRegistrationServer:
 
         result = await svc.ensure_device_registered()
         assert result["success"] is False
-        assert result.get("error") == "registration_failed"
+        assert result["reason"] == "server_unreachable"
         assert _get_device_id(svc) is None
 
     @pytest.mark.asyncio
@@ -263,7 +263,8 @@ class TestListDevices:
 
         result = await svc.list_devices()
 
-        assert result == {"success": False, "devices": [], "disabled": True}
+        assert result["disabled"] is True
+        assert result["reason"] == "sync_disabled"
 
     @pytest.mark.asyncio
     async def test_list_devices_adapter_error(self, tmp_path):
@@ -275,7 +276,8 @@ class TestListDevices:
         fake.fail_on_next(Exception("server unavailable"))
         result = await svc.list_devices()
 
-        assert result == {"success": False, "devices": [], "error": "list_failed"}
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
 
     @pytest.mark.asyncio
     async def test_list_devices_no_own_id_all_false(self, tmp_path):

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -1439,7 +1439,7 @@ class TestDeleteSlot:
         result = await svc.delete_slot(42, "save1")
 
         assert result["success"] is False
-        assert result["reason"] == "server_error"
+        assert result["reason"] == "server_unreachable"
         # Slot NOT removed from state (rollback on failure)
         assert "save1" in _require_save_state(svc, 42).slots
 

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -89,8 +89,8 @@ class TestTestConnectionBadPath:
         result = event_loop.run_until_complete(service.test_connection())
         assert result == {
             "success": False,
+            "reason": "config_error",
             "message": "No server URL configured",
-            "error_code": "config_error",
         }
         romm_api.heartbeat.assert_not_called()
 
@@ -99,7 +99,7 @@ class TestTestConnectionBadPath:
         settings: dict[str, Any] = {}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
-        assert result["error_code"] == "config_error"
+        assert result["reason"] == "config_error"
 
     def test_no_token_returns_config_error_without_probing(self, event_loop, romm_api, logger):
         """A configured URL but no minted token short-circuits before any network
@@ -109,8 +109,8 @@ class TestTestConnectionBadPath:
         result = event_loop.run_until_complete(service.test_connection())
         assert result == {
             "success": False,
+            "reason": "config_error",
             "message": "Not signed in — sign in to RomM first",
-            "error_code": "config_error",
         }
         romm_api.heartbeat.assert_not_called()
         romm_api.list_platforms.assert_not_called()
@@ -121,7 +121,7 @@ class TestTestConnectionBadPath:
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is False
-        assert result["error_code"] == "connection_error"
+        assert result["reason"] == "server_unreachable"
         romm_api.set_version.assert_called_once_with(None)
         romm_api.list_platforms.assert_not_called()
 
@@ -132,7 +132,7 @@ class TestTestConnectionBadPath:
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is False
-        assert result["error_code"] == "server_error"
+        assert result["reason"] == "server_unreachable"
         assert result["message"].startswith("Server reachable but API request failed: ")
 
     def test_list_platforms_auth_error_not_prefixed(self, event_loop, romm_api, logger):
@@ -142,7 +142,7 @@ class TestTestConnectionBadPath:
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is False
-        assert result["error_code"] == "auth_error"
+        assert result["reason"] == "auth_failed"
         assert not result["message"].startswith("Server reachable")
 
 
@@ -153,7 +153,7 @@ class TestTestConnectionVersionGate:
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
         assert result["romm_version"] == "4.5.0"
         assert "4.8.1" in result["message"]
         assert "4.5.0" in result["message"]
@@ -164,7 +164,7 @@ class TestTestConnectionVersionGate:
         romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.0"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
 
     def test_development_version_bypasses_gate(self, event_loop, romm_api, logger):
         """``development`` version string skips the minimum-version check."""
@@ -221,7 +221,7 @@ class TestTestConnectionEdgeCases:
             min_required_version=(5, 1, 0),
         )
         result = event_loop.run_until_complete(service.test_connection())
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
         assert "5.1.0" in result["message"]
 
 
@@ -330,7 +330,7 @@ class TestEstablishTokenBadPath:
     def test_empty_url_returns_config_error(self, event_loop, romm_api, logger):
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("", "u", "p"))
-        assert result == {"success": False, "message": "No server URL configured", "error_code": "config_error"}
+        assert result == {"success": False, "reason": "config_error", "message": "No server URL configured"}
         romm_api.mint_client_token.assert_not_called()
 
     def test_unreachable_returns_connection_error_no_mint(self, event_loop, romm_api, logger):
@@ -338,7 +338,7 @@ class TestEstablishTokenBadPath:
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "connection_error"
+        assert result["reason"] == "server_unreachable"
         romm_api.mint_client_token.assert_not_called()
 
     def test_version_too_old_returns_version_error_no_mint(self, event_loop, romm_api, logger):
@@ -346,7 +346,7 @@ class TestEstablishTokenBadPath:
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "version_error"
+        assert result["reason"] == "version_error"
         romm_api.mint_client_token.assert_not_called()
 
     def test_forbidden_mint_returns_actionable_message(self, event_loop, romm_api, logger):
@@ -354,7 +354,7 @@ class TestEstablishTokenBadPath:
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "forbidden_error"
+        assert result["reason"] == "auth_failed"
         assert "cannot create API tokens" in result["message"]
 
     def test_auth_error_mint_returns_auth_error(self, event_loop, romm_api, logger):
@@ -362,21 +362,21 @@ class TestEstablishTokenBadPath:
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "auth_error"
+        assert result["reason"] == "auth_failed"
 
     def test_missing_raw_token_returns_api_error(self, event_loop, romm_api, logger):
         romm_api.mint_client_token.return_value = {"id": 42}  # no raw_token
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "api_error"
+        assert result["reason"] == "server_unreachable"
 
     def test_missing_id_returns_api_error(self, event_loop, romm_api, logger):
         romm_api.mint_client_token.return_value = {"raw_token": "rmm_x"}  # no id
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "api_error"
+        assert result["reason"] == "server_unreachable"
 
     def test_persist_failure_returns_error_and_does_not_raise(self, event_loop, romm_api, logger, settings_persister):
         settings_persister.save_settings.side_effect = OSError("disk full")
@@ -389,7 +389,7 @@ class TestEstablishTokenBadPath:
         )
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         assert result["success"] is False
-        assert result["error_code"] == "unknown_error"
+        assert result["reason"] == "unknown"
         assert "disk full" in result["message"]
 
 

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -215,7 +215,7 @@ class TestStartDownload:
 
         result = await plugin.start_download(9999)
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
 
     @pytest.mark.asyncio
     async def test_checks_disk_space(self, plugin, tmp_path):

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -576,7 +576,7 @@ class TestDownloadFirmware:
             result = await fw.download_firmware(10)
 
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
 
 
 class TestDownloadAllFirmware:
@@ -2290,7 +2290,7 @@ class TestDownloadFirmwareErrors:
 
         # Canonical failure shape, no exception escaped.
         assert result["success"] is False
-        assert "error_code" in result
+        assert "reason" in result
         assert "Invalid firmware metadata" in result["message"]
         # The renamed/downloaded file was cleaned up — nothing left dangling.
         assert not os.path.exists(os.path.join(str(bios_dir), "orphan.bin"))

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -513,7 +513,9 @@ class TestSearchSgdbGames:
     async def test_no_api_key(self, plugin):
         plugin._sgdb_service._loop = asyncio.get_event_loop()
         result = await plugin.search_sgdb_games("mario")
-        assert result == {"success": False, "games": []}
+        assert result["success"] is False
+        assert result["games"] == []
+        assert result["reason"] == "no_api_key"
 
     @pytest.mark.asyncio
     async def test_network_error_returns_failure(self, plugin, fake_steamgrid_db_api):
@@ -523,7 +525,9 @@ class TestSearchSgdbGames:
 
         result = await plugin.search_sgdb_games("mario")
 
-        assert result == {"success": False, "games": []}
+        assert result["success"] is False
+        assert result["games"] == []
+        assert result["reason"] == "server_unreachable"
 
     @pytest.mark.asyncio
     async def test_caps_at_six_candidates(self, plugin, fake_steamgrid_db_api):


### PR DESCRIPTION
Closes #972.

Three failure-shape dialects coexisted behind the documented-but-unenforced canonical `{success: False, reason, message}`:
- `error_response()` → `{success, message, error_code}` (different key + `*_error` slug set) — firmware/downloads/connection
- `devices.py` → the forbidden `{error: ...}` key (`registration_failed`/`list_failed`)
- ad-hoc shapes with no routing slug (`engine.py` `{success: False, message, offline: True}`)

The frontend had to know per-callable which dialect it got, and the mess was user-visible — `SettingsPage` rendered the raw slug ("Could not load devices — list_failed").

## Fix

**Lean `ErrorCode` (8 members)** — the slug job is frontend routing, and the frontend routes on exactly two families (version/stale); transport diagnostics live in the human `message`, not the routing layer:
`SERVER_UNREACHABLE`, `AUTH_FAILED`, `NOT_FOUND`, `UNSUPPORTED`, `UNKNOWN`, `VERSION_ERROR`, `STALE_CONFLICT`, `STALE_PREVIEW`. Bespoke non-transport failures stay plain-string `reason` (the `reason: ErrorCode | str` union allows it).

### Slug mapping (old → new)

| old (`error_code`/`error`) | new (`reason`) | note |
|---|---|---|
| `auth_error` | `auth_failed` | 401 |
| `forbidden_error` | `auth_failed` | 403 — **distinct message kept** (Cloudflare bot-fight ≠ bad creds) |
| `connection_error`, `timeout_error`, `ssl_error`, `server_error`, `api_error` | `server_unreachable` | detail in `message` |
| `not_found_error` | `not_found` | reconciled with plain `not_found` literals |
| `unsupported_error` | `unsupported` | |
| `unknown_error` | `unknown` | also the fallback slug |
| `version_error`, `stale_conflict`, `stale_preview` | unchanged slug | key `error_code`→`reason`; frontend routes on these |
| `config_error` | `config_error` | bespoke plain-string |
| `disk_error` | removed | backend never emitted it |
| `error: list_failed`/`registration_failed` (devices) | `reason: server_unreachable` + readable `message` | the user-visible bug |

Ad-hoc no-slug failures get a `reason` additively (flags like `offline`/`blocked_by_migration` stay → zero frontend churn): `offline`→`server_unreachable`, `disabled`→`sync_disabled`, else `unknown`.

## Enforced, not documented

`scripts/check_failure_shape.py` (required-key rule): any `success: False` return in `services/` must carry `reason`+`message` and must not carry `error`/`error_code`. The two carve-outs (discriminated-status unions, partial-success flags) are pattern-exempt. Wired into `mise run lint` + CI. **Gate green = all three dialects collapsed** (report: 0 dialect/ad-hoc violations). 33 gate tests.

## One artifact, no skew

Backend collapse + every frontend consumer in the same PR (`RommErrorCode` union → Lean, `error_code`→`reason` keys, all routing comparisons migrated). **Grep proof:** zero old slug literals or `.error_code` reads survive in `src/` routing code. The #1027 contract pins that captured the legacy shape flip to canonical (the harness at work). `SettingsPage` renders the human `message` now, with a non-vacuous frontend test.

**Note:** touches `.github/workflows/ci.yml` (gate wiring) → needs merging via the GitHub UI (my CLI token lacks `workflow` scope).

docs: updated — `lib/list_result.py` docstring, `CLAUDE.md` (Callable response shapes + Code Quality), `backend-architecture.md`, `development.md`, `save-file-sync-architecture.md`.