### PR TITLE
fix(security): reject path traversal in firmware/download joins via lib safe_join

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -210,6 +210,16 @@ arrive as single-file downloads that never reach the extraction path, so they ge
 
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
 
+**Server-supplied paths are validated, fail-stop on traversal**: every server-supplied path component — the firmware
+`file_name`, the ROM platform slug, and post-extraction URL-decoded ZIP member names — is checked through
+`lib/path_safety` (`safe_join` for realpath containment, `safe_path_component` for single-component names) before any
+write. A traversal attempt (`../`, an absolute path, or a `%2e%2e%2f`-encoded ZIP member that decodes to `../` after the
+pre-decode ZIP-slip check passes) **aborts the whole download** rather than skipping the offending entry:
+already-extracted members are cleaned up (no half-installed ROM), a canonical
+`{"success": false, "reason": "path_traversal", "message": ...}` failure is returned, and the `download_failed` event
+fires so the UI doesn't hang on "downloading". Firmware downloads surface the same canonical failure from
+`download_firmware`.
+
 ### Adapters (`py_modules/adapters/`)
 
 Adapters own all I/O and implement the Protocols defined in `services/protocols/`. Selected adapters:

--- a/py_modules/adapters/download_file.py
+++ b/py_modules/adapters/download_file.py
@@ -15,6 +15,8 @@ import shutil
 import urllib.parse
 import zipfile
 
+from lib.path_safety import safe_path_component
+
 
 class DownloadFileAdapter:
     """Synchronous filesystem operations for ROM download files.
@@ -95,15 +97,27 @@ class DownloadFileAdapter:
 
         Walks bottom-up so nested encoded directories are handled
         correctly. A no-op when the decoded name equals the original.
+
+        ``os.walk`` yields each name as a single basename, so a clean
+        decode always stays a single component (e.g. ``Game%20Title.cue``
+        → ``Game Title.cue``). A crafted member like ``%2e%2e%2fevil.sh``
+        passes the pre-decode ZIP-slip check as one safe component, then
+        decodes to ``../evil.sh`` — a traversal. ``safe_path_component``
+        catches that: a decoded name that is not a single safe component
+        raises :class:`PathTraversalError` and the whole extraction
+        aborts (fail-stop) rather than ``os.replace``-ing the file outside
+        the extraction directory.
         """
         for root, dirs, files in os.walk(directory, topdown=False):
             for fname in files:
                 decoded = urllib.parse.unquote(fname)
                 if decoded != fname:
+                    safe_path_component(decoded)
                     os.replace(os.path.join(root, fname), os.path.join(root, decoded))
             for dname in dirs:
                 decoded = urllib.parse.unquote(dname)
                 if decoded != dname:
+                    safe_path_component(decoded)
                     os.replace(os.path.join(root, dname), os.path.join(root, decoded))
 
     def scan_files_with_sizes(self, directory: str) -> list[tuple[str, int]]:

--- a/py_modules/lib/path_safety.py
+++ b/py_modules/lib/path_safety.py
@@ -7,11 +7,90 @@ this is not pure compute (``realpath`` is an ``lstat`` syscall) and
 belongs in ``lib/`` rather than ``domain/``. The source of the
 configured root (e.g. the ``RetroDeckPaths`` Protocol) stays in
 ``services/``; this module only consumes the resolved string.
+
+Two guards live here for server-supplied path components:
+
+- :func:`safe_path_component` — lexical (no I/O). Validates that an
+  untrusted string is a single safe filename component before it is
+  joined onto a base.
+- :func:`safe_join` — realpath containment. Joins untrusted parts onto a
+  trusted base and confirms the result resolves strictly below the base
+  (the same semantics as :func:`is_safe_rom_path`), so a multi-component
+  registry path or a symlink cannot escape.
+
+Both raise :class:`PathTraversalError` on a violation so call sites can
+fail closed (abort the operation, surface a canonical failure) rather
+than silently writing outside the configured root.
 """
 
 from __future__ import annotations
 
 import os
+
+
+class PathTraversalError(ValueError):
+    """Raised when an untrusted path component escapes its base directory.
+
+    A :class:`ValueError` subclass so existing ``except ValueError`` write
+    paths still catch it, while call sites that want the distinct
+    ``path_traversal`` failure slug can catch this type first.
+    """
+
+
+def safe_path_component(name: str) -> str:
+    """Validate that *name* is a single safe filesystem component. Lexical, no I/O.
+
+    A defence for server-supplied names that must stay a single component
+    (e.g. a decoded ZIP member basename). Unlike
+    ``domain.save_path.sanitize_save_filename`` — which silently reduces a
+    name to its basename — this rejects anything that is not already a
+    clean single component, so a traversal attempt aborts the operation
+    rather than being quietly defanged.
+
+    Rejects (raising :class:`PathTraversalError`):
+
+    - a NUL byte anywhere in *name*
+    - the empty string, ``"."`` or ``".."``
+    - an absolute path
+    - any value containing a path separator, or whose ``os.path.normpath``
+      introduces or retains a ``..`` segment or separator (a single
+      component must normalize to itself)
+
+    Returns *name* unchanged when it is already a valid single component.
+    """
+    if "\x00" in name:
+        raise PathTraversalError("path component contains a NUL byte")
+    if name in ("", ".", ".."):
+        raise PathTraversalError(f"not a valid path component: {name!r}")
+    if os.path.isabs(name) or os.sep in name or (os.altsep and os.altsep in name):
+        raise PathTraversalError(f"path component must not contain a separator: {name!r}")
+    # normpath collapses ``a/../b`` → ``b`` and ``./x`` → ``x``; a clean
+    # single component is a fixed point. Anything that changes — or that
+    # normalizes to a ``..`` escape — is rejected.
+    if os.path.normpath(name) != name:
+        raise PathTraversalError(f"path component is not normalized: {name!r}")
+    return name
+
+
+def safe_join(base: str, *parts: str) -> str:
+    """Join *parts* onto *base* and return the realpath, or raise on escape.
+
+    Realpath-containment guard for server-supplied path components: the
+    joined path must resolve **strictly below** ``base`` — equality with
+    the base is rejected, matching :func:`is_safe_rom_path`. Symlinks are
+    resolved (``realpath``), so a symlink planted under ``base`` that
+    points outside cannot be used to escape.
+
+    Legitimate multi-component parts (e.g. the registry ``dc/dc_boot.bin``)
+    are allowed as long as the resolved path stays under ``base``. Raises
+    :class:`PathTraversalError` otherwise; returns the resolved absolute
+    path on success.
+    """
+    real_base = os.path.realpath(base)
+    real_joined = os.path.realpath(os.path.join(base, *parts))
+    if not real_joined.startswith(real_base + os.sep):
+        raise PathTraversalError(f"path escapes base directory: {os.path.join(base, *parts)!r} not under {base!r}")
+    return real_joined
 
 
 def is_safe_rom_path(path: str, roms_base: str) -> bool:

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -26,6 +26,7 @@ from domain.rom_install import RomInstall
 from domain.shortcut_data import build_launch_options, resolve_emulator_invocation
 from lib.errors import error_response
 from lib.list_result import ErrorCode
+from lib.path_safety import PathTraversalError, safe_join
 
 if TYPE_CHECKING:
     import logging
@@ -183,7 +184,29 @@ class DownloadService:
         platform_fs_slug = rom_detail.get("platform_fs_slug")
         system = self._resolve_system(platform_slug, platform_fs_slug)
 
-        roms_dir = os.path.join(self._retrodeck_paths.roms_path(), system)
+        roms_path = self._retrodeck_paths.roms_path()
+        try:
+            # ``system`` may be an unmapped server slug passed through verbatim
+            # (ADR-0010). Validate it stays under roms_path BEFORE any make_dirs
+            # so a slug like "../../etc" cannot create or write outside roms.
+            roms_dir = safe_join(roms_path, system)
+        except PathTraversalError as e:
+            self._download_in_progress.discard(rom_id)
+            self._logger.error(f"Rejected download for ROM {rom_id}: unsafe platform slug {system!r}: {e}")
+            await self._emit(
+                "download_failed",
+                {
+                    "rom_id": rom_id,
+                    "rom_name": rom_detail.get("name", ""),
+                    "platform_name": rom_detail.get("platform_name", platform_slug),
+                    "error_message": "Server sent an unsafe platform path — download aborted",
+                },
+            )
+            return {
+                "success": False,
+                "reason": "path_traversal",
+                "message": "Server sent an unsafe platform path — download aborted",
+            }
         file_name, files_missing = resolve_local_file_name(rom_detail)
         if files_missing:
             self._logger.warning(

--- a/py_modules/services/firmware.py
+++ b/py_modules/services/firmware.py
@@ -22,6 +22,7 @@ from domain.bios_file import BiosFile
 from domain.firmware_cache import FirmwareCacheEntry
 from lib.errors import error_response
 from lib.list_result import ErrorCode
+from lib.path_safety import PathTraversalError, safe_join
 
 if TYPE_CHECKING:
     import asyncio
@@ -155,13 +156,77 @@ class FirmwareService:
         Uses firmware_path from bios_registry.json for correct subdirectory
         placement (e.g. dc/dc_boot.bin). Falls back to flat in bios root
         for files not in the registry.
+
+        Both branches go through ``safe_join`` so a server-supplied
+        ``file_name`` (and, defensively, the static registry path) cannot
+        escape the BIOS directory via ``..`` or an absolute path. Raises
+        :class:`PathTraversalError` on an escape attempt — the write path
+        (``download_firmware``) turns that into a canonical failure; the
+        read paths skip the poisoned entry.
         """
         bios_base = self._retrodeck_paths.bios_path()
         file_name = firmware.get("file_name", "")
         reg_entry = self.bios_files_index.get(file_name)
         if reg_entry and reg_entry.get("firmware_path"):
-            return os.path.join(bios_base, reg_entry["firmware_path"])
-        return os.path.join(bios_base, file_name)
+            return safe_join(bios_base, reg_entry["firmware_path"])
+        return safe_join(bios_base, file_name)
+
+    def _safe_firmware_dest_path(self, firmware) -> str | None:
+        """Read-path wrapper for ``_firmware_dest_path`` — ``None`` on a poisoned entry.
+
+        The status queries (``check_platform_bios``, the System-page group)
+        only need to know whether a firmware file is downloaded; a server
+        entry whose ``file_name`` attempts path traversal cannot be on
+        disk, so it is logged and dropped from the listing instead of
+        crashing the whole panel. The write path keeps the raising
+        ``_firmware_dest_path`` so a download attempt fails closed.
+        """
+        try:
+            return self._firmware_dest_path(firmware)
+        except PathTraversalError as e:
+            self._logger.warning(f"Skipping firmware with unsafe file name: {e}")
+            return None
+
+    def _safe_registry_dest_path(self, firmware_path: str) -> str | None:
+        """Containment-check a registry-relative BIOS path — ``None`` on a poisoned entry.
+
+        The registry read paths (``_group_registry_firmware`` and the
+        offline System-page fallback) resolve a ``firmware_path`` that
+        falls back to the server-supplied ``file_name`` when absent, so the
+        raw join can be steered outside the BIOS directory by a compromised
+        server. These are existence-check reads (not writes), so a rejected
+        path is logged and skipped — the panel stays up minus the poisoned
+        entry, mirroring ``_safe_firmware_dest_path``.
+        """
+        bios_base = self._retrodeck_paths.bios_path()
+        try:
+            return safe_join(bios_base, firmware_path)
+        except PathTraversalError as e:
+            self._logger.warning(f"Skipping registry firmware with unsafe path: {e}")
+            return None
+
+    def _build_firmware_status_items(self, firmware_iter) -> list[dict[str, Any]]:
+        """Build ``collect_firmware_status`` items, dropping traversal-poisoned entries.
+
+        Each item carries the resolved ``dest`` and its ``downloaded``
+        flag. A firmware entry whose ``file_name`` fails the path-safety
+        check resolves to ``None`` and is skipped (logged in
+        ``_safe_firmware_dest_path``) so a single malicious entry cannot
+        crash the status query.
+        """
+        items: list[dict[str, Any]] = []
+        for fw in firmware_iter:
+            dest = self._safe_firmware_dest_path(fw)
+            if dest is None:
+                continue
+            items.append(
+                {
+                    "file_name": fw.get("file_name", ""),
+                    "downloaded": self._firmware_file_store.exists(dest),
+                    "dest": dest,
+                }
+            )
+        return items
 
     # ── Firmware list cache ─────────────────────────────────
 
@@ -295,15 +360,9 @@ class FirmwareService:
         for slug in fw_slugs:
             registry_platform.update(self._bios_registry.get("platforms", {}).get(slug, {}))
 
-        items = [
-            {
-                "file_name": fw.get("file_name", ""),
-                "downloaded": self._firmware_file_store.exists(self._firmware_dest_path(fw)),
-                "dest": self._firmware_dest_path(fw),
-            }
-            for fw in self._firmware_cache
-            if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
-        ]
+        items = self._build_firmware_status_items(
+            fw for fw in self._firmware_cache if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
+        )
         files = collect_firmware_status(items, registry_platform, active_core_so)
 
         if not files:
@@ -336,9 +395,11 @@ class FirmwareService:
         platforms_map = {}
         for fw in firmware_list:
             platform_slug = firmware_paths.parse_firmware_slug(fw.get("file_path", "")) or "unknown"
+            dest = self._safe_firmware_dest_path(fw)
+            if dest is None:
+                continue
             if platform_slug not in platforms_map:
                 platforms_map[platform_slug] = {"platform_slug": platform_slug, "files": []}
-            dest = self._firmware_dest_path(fw)
             platforms_map[platform_slug]["files"].append(
                 {
                     "id": fw.get("id"),
@@ -352,14 +413,15 @@ class FirmwareService:
 
     def _group_registry_firmware(self):
         """Build platform map from bios registry (offline fallback)."""
-        bios_base = self._retrodeck_paths.bios_path()
         platforms_map = {}
         for reg_slug, reg_files in self._bios_registry.get("platforms", {}).items():
             if reg_slug not in platforms_map:
                 platforms_map[reg_slug] = {"platform_slug": reg_slug, "files": []}
             for file_name, reg_entry in reg_files.items():
                 firmware_path = reg_entry.get("firmware_path", file_name)
-                dest = os.path.join(bios_base, firmware_path)
+                dest = self._safe_registry_dest_path(firmware_path)
+                if dest is None:
+                    continue
                 platforms_map[reg_slug]["files"].append(
                     {
                         "id": None,
@@ -515,7 +577,15 @@ class FirmwareService:
             return error_response(e)
 
         file_name = fw.get("file_name", "")
-        dest = self._firmware_dest_path(fw)
+        try:
+            dest = self._firmware_dest_path(fw)
+        except PathTraversalError as e:
+            self._logger.error(f"Rejected firmware with unsafe file name {file_name!r}: {e}")
+            return {
+                "success": False,
+                "reason": "path_traversal",
+                "message": "Server sent an unsafe firmware file name — download aborted",
+            }
         tmp_path = dest + ".tmp"
 
         try:
@@ -558,8 +628,8 @@ class FirmwareService:
         downloaded = 0
         errors = []
         for fw in platform_firmware:
-            dest = self._firmware_dest_path(fw)
-            if self._firmware_file_store.exists(dest):
+            dest = self._safe_firmware_dest_path(fw)
+            if dest is not None and self._firmware_file_store.exists(dest):
                 continue
             result = await self.download_firmware(fw["id"])
             if result.get("success"):
@@ -586,8 +656,8 @@ class FirmwareService:
         downloaded = 0
         errors = []
         for fw in platform_firmware:
-            dest = self._firmware_dest_path(fw)
-            if self._firmware_file_store.exists(dest):
+            dest = self._safe_firmware_dest_path(fw)
+            if dest is not None and self._firmware_file_store.exists(dest):
                 continue
             result = await self.download_firmware(fw["id"])
             if result.get("success"):
@@ -647,32 +717,27 @@ class FirmwareService:
 
         try:
             firmware_list = await self._loop.run_in_executor(None, self._get_firmware_list)
-            items = [
-                {
-                    "file_name": fw.get("file_name", ""),
-                    "downloaded": self._firmware_file_store.exists(self._firmware_dest_path(fw)),
-                    "dest": self._firmware_dest_path(fw),
-                }
-                for fw in firmware_list
-                if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
-            ]
+            items = self._build_firmware_status_items(
+                fw for fw in firmware_list if firmware_paths.parse_firmware_slug(fw.get("file_path", "")) in fw_slugs
+            )
             files = collect_firmware_status(items, registry_platform, active_core_so)
         except Exception:
             if not registry_platform:
                 return {
                     "needs_bios": False,
                 }
-            bios_base = self._retrodeck_paths.bios_path()
-            registry_items = [
-                {
-                    "file_name": file_name,
-                    "downloaded": self._firmware_file_store.exists(
-                        os.path.join(bios_base, reg_entry.get("firmware_path", file_name))
-                    ),
-                    "dest": os.path.join(bios_base, reg_entry.get("firmware_path", file_name)),
-                }
-                for file_name, reg_entry in registry_platform.items()
-            ]
+            registry_items = []
+            for file_name, reg_entry in registry_platform.items():
+                dest = self._safe_registry_dest_path(reg_entry.get("firmware_path", file_name))
+                if dest is None:
+                    continue
+                registry_items.append(
+                    {
+                        "file_name": file_name,
+                        "downloaded": self._firmware_file_store.exists(dest),
+                        "dest": dest,
+                    }
+                )
             files = collect_firmware_status(registry_items, registry_platform, active_core_so)
 
         if not files:

--- a/tests/adapters/test_download_file.py
+++ b/tests/adapters/test_download_file.py
@@ -244,6 +244,44 @@ class TestDecodeUrlEncodedNames:
         # Must not raise
         adapter.decode_url_encoded_names(str(tmp_path))
 
+    def test_rejects_decoded_traversal_member(self, adapter, tmp_path):
+        """#968: a ``%2e%2e%2f``-encoded member name fails-stop, file not moved out."""
+        from lib.path_safety import PathTraversalError
+
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+        # A single literal basename containing no real separator — it passed the
+        # pre-decode ZIP-slip check as one safe component. unquote() turns it
+        # into "../evil.sh".
+        encoded = "%2e%2e%2fevil.sh"
+        (extract_dir / encoded).write_text("payload")
+
+        with pytest.raises(PathTraversalError):
+            adapter.decode_url_encoded_names(str(extract_dir))
+
+        # The file was NOT moved outside the extraction dir.
+        assert not (tmp_path / "evil.sh").exists()
+        # The original encoded file is still present (no partial os.replace).
+        assert (extract_dir / encoded).exists()
+
+    def test_legit_multi_file_subdir_decodes_correctly(self, adapter, tmp_path):
+        """A real multi-file ROM with an encoded name inside a real subdir still extracts.
+
+        ``os.walk`` yields each name as a single basename, so a member inside a
+        real ``update/`` subfolder decodes per-basename and stays valid — the
+        #968 fix must not break legitimate nested ROM layouts.
+        """
+        extract_dir = tmp_path / "extract"
+        sub = extract_dir / "update"
+        sub.mkdir(parents=True)
+        (sub / "Zelda%20Update.nsp").write_bytes(b"\x00" * 10)
+        (extract_dir / "Zelda%20Base.nsp").write_bytes(b"\x00" * 10)
+
+        adapter.decode_url_encoded_names(str(extract_dir))
+
+        assert (extract_dir / "Zelda Base.nsp").exists()
+        assert (extract_dir / "update" / "Zelda Update.nsp").exists()
+
 
 class TestScanFilesWithSizes:
     def test_returns_paths_and_sizes(self, adapter, tmp_path):

--- a/tests/fakes/fake_download_file_store.py
+++ b/tests/fakes/fake_download_file_store.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import urllib.parse
 
+from lib.path_safety import safe_path_component
+
 
 class FakeDownloadFileStore:
     """In-memory ``DownloadFileStore`` for tests.
@@ -145,10 +147,21 @@ class FakeDownloadFileStore:
             if not stored.startswith(prefix):
                 continue
             rel = stored[len(prefix) :]
-            decoded = urllib.parse.unquote(rel)
-            if decoded != rel:
-                new_path = prefix + decoded
-                self.files[new_path] = self.files.pop(stored)
+            # The real adapter walks the tree and decodes each name as a single
+            # basename, so a legitimate multi-component ``rel`` (e.g.
+            # ``update/Game%20.bin``) is decoded segment-by-segment. Mirror that
+            # here — decode + safe-check each component — so the fake is not
+            # spuriously stricter than the adapter on legit nested layouts,
+            # while still failing-stop on a ``%2e%2e%2f`` → ``..`` segment.
+            segments = rel.split("/")
+            decoded_segments = [urllib.parse.unquote(seg) for seg in segments]
+            if decoded_segments == segments:
+                continue
+            for seg, decoded_seg in zip(segments, decoded_segments, strict=True):
+                if decoded_seg != seg:
+                    safe_path_component(decoded_seg)
+            new_path = prefix + "/".join(decoded_segments)
+            self.files[new_path] = self.files.pop(stored)
 
     def scan_files_with_sizes(self, directory: str) -> list[tuple[str, int]]:
         prefix = directory.rstrip("/") + "/"

--- a/tests/lib/test_path_safety.py
+++ b/tests/lib/test_path_safety.py
@@ -2,7 +2,111 @@
 
 import os
 
-from lib.path_safety import is_safe_rom_path
+import pytest
+
+from lib.path_safety import (
+    PathTraversalError,
+    is_safe_rom_path,
+    safe_join,
+    safe_path_component,
+)
+
+
+class TestSafePathComponent:
+    def test_accepts_clean_name(self):
+        assert safe_path_component("game.z64") == "game.z64"
+
+    def test_accepts_name_with_spaces_and_parens(self):
+        # Decoded ZIP basenames commonly carry these — must stay valid.
+        assert safe_path_component("Final Fantasy VII (USA).cue") == "Final Fantasy VII (USA).cue"
+
+    def test_rejects_parent_dir(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component("..")
+
+    def test_rejects_current_dir(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component(".")
+
+    def test_rejects_empty(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component("")
+
+    def test_rejects_nul_byte(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component("evil\x00.sh")
+
+    def test_rejects_absolute_path(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component("/etc/passwd")
+
+    def test_rejects_separator(self):
+        # A single component must stay a single component.
+        with pytest.raises(PathTraversalError):
+            safe_path_component("a/b")
+
+    def test_rejects_decoded_traversal(self):
+        # ``%2e%2e%2fevil.sh`` decodes to this — the #968 attack vector.
+        with pytest.raises(PathTraversalError):
+            safe_path_component("../evil.sh")
+
+    def test_rejects_embedded_traversal_segment(self):
+        with pytest.raises(PathTraversalError):
+            safe_path_component("sub/../../evil")
+
+
+class TestSafeJoin:
+    def test_accepts_legit_single_component(self, tmp_path):
+        base = str(tmp_path / "bios")
+        os.makedirs(base)
+        result = safe_join(base, "scph5501.bin")
+        assert result == os.path.realpath(os.path.join(base, "scph5501.bin"))
+
+    def test_accepts_legit_multi_component(self, tmp_path):
+        # The registry ``dc/dc_boot.bin`` shape must pass.
+        base = str(tmp_path / "bios")
+        os.makedirs(base)
+        result = safe_join(base, "dc/dc_boot.bin")
+        assert result == os.path.realpath(os.path.join(base, "dc", "dc_boot.bin"))
+
+    def test_rejects_parent_traversal(self, tmp_path):
+        base = str(tmp_path / "bios")
+        os.makedirs(base)
+        with pytest.raises(PathTraversalError):
+            safe_join(base, "../evil.desktop")
+
+    def test_rejects_deep_traversal(self, tmp_path):
+        base = str(tmp_path / "retrodeck" / "roms")
+        os.makedirs(base)
+        with pytest.raises(PathTraversalError):
+            safe_join(base, "../../etc/passwd")
+
+    def test_rejects_absolute_second_arg(self, tmp_path):
+        # os.path.join resets to an absolute part — must be caught.
+        base = str(tmp_path / "bios")
+        os.makedirs(base)
+        with pytest.raises(PathTraversalError):
+            safe_join(base, "/home/deck/.config/autostart/evil.desktop")
+
+    def test_rejects_equality_with_base(self, tmp_path):
+        # Strictly-below semantics: resolving exactly to base is rejected.
+        base = str(tmp_path / "bios")
+        os.makedirs(base)
+        with pytest.raises(PathTraversalError):
+            safe_join(base, ".")
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        # A symlink planted UNDER base pointing OUTSIDE must not be a usable
+        # escape — realpath resolves it, lexical normalization would not.
+        base = tmp_path / "bios"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.bin").write_bytes(b"x")
+        # base/link -> ../outside
+        (base / "link").symlink_to(outside)
+        with pytest.raises(PathTraversalError):
+            safe_join(str(base), "link/secret.bin")
 
 
 class TestIsSafeRomPath:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -1983,6 +1983,59 @@ class TestPathTraversalFsName:
         assert ".." not in queue_entry["file_name"]
 
 
+class TestPathTraversalPlatformSlug:
+    """#967: an unmapped server platform slug must not escape roms_path."""
+
+    @pytest.mark.asyncio
+    async def test_traversal_slug_rejected_before_make_dirs(self, plugin, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        roms_root = tmp_path / "retrodeck" / "roms"
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(roms_root),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        rom_detail = {
+            "id": 77,
+            "name": "Evil ROM",
+            "fs_name": "game.z64",
+            "fs_size_bytes": 1024,
+            # Unmapped slug passes through resolve_system verbatim (ADR-0010).
+            "platform_slug": "../../etc",
+            "platform_name": "Nintendo 64",
+        }
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+
+        # Track make_dirs to prove the slug is rejected BEFORE any directory work.
+        made_dirs: list[str] = []
+        plugin._download_service._download_file_store.make_dirs = lambda p: made_dirs.append(p)
+
+        from unittest.mock import patch
+
+        with patch.object(plugin._romm_api, "get_rom", return_value=rom_detail):
+            result = await plugin._download_service.start_download(77)
+
+        # Canonical path_traversal failure shape.
+        assert result["success"] is False
+        assert result["reason"] == "path_traversal"
+        assert "message" in result
+        # Rejected before any make_dirs.
+        assert made_dirs == []
+        # No directory created outside the roms root.
+        escape_dir = tmp_path / "etc"
+        assert not escape_dir.exists()
+        # The rom is no longer marked in-progress (cleaned up on rejection).
+        assert 77 not in plugin._download_service._download_in_progress
+        # download_failed event fired so the UI doesn't hang on "downloading".
+        failed = [c for c in decky.emit.call_args_list if c[0][0] == "download_failed"]
+        assert len(failed) == 1
+        assert failed[0][0][1]["rom_id"] == 77
+
+
 class TestCleanupPartialDownload:
     """Tests for _cleanup_partial_download — all paths."""
 
@@ -2125,6 +2178,144 @@ class TestDoDownloadZipFailure:
         assert plugin._download_service._download_queue[66]["status"] == "failed"
         # .zip.tmp should be cleaned up
         assert not os.path.exists(target_path + ".zip.tmp")
+
+
+class TestDoDownloadPostDecodeTraversal:
+    """#968: a ZIP member that passes the ZIP-slip check but decodes to a traversal."""
+
+    @pytest.mark.asyncio
+    async def test_decoded_traversal_aborts_cleans_up_and_emits(self, plugin, tmp_path):
+        import zipfile as zf
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "psx"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "Evil.zip")
+
+        # A ZIP whose member name is a single literal basename with NO real
+        # separator (the %2e/%2f are literal chars), so it passes the pre-decode
+        # ZIP-slip realpath check and extracts inside the dir — plus a legit
+        # member so we can prove the already-extracted file is cleaned up.
+        zip_content_path = tmp_path / "source.zip"
+        with zf.ZipFile(str(zip_content_path), "w") as z:
+            z.writestr("legit.bin", b"\x00" * 50)
+            z.writestr("%2e%2e%2fevil.sh", b"payload")
+        zip_bytes = zip_content_path.read_bytes()
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(zip_bytes)
+
+        rom_detail = {
+            "id": 88,
+            "name": "Evil Multi",
+            "fs_name": "Evil.zip",
+            "fs_name_no_ext": "Evil",
+            "platform_slug": "psx",
+            "platform_name": "PlayStation",
+            "has_multiple_files": True,
+        }
+
+        _seed_rom(plugin._uow, 88, platform_slug="psx")
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[88] = {"rom_id": 88, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(88, rom_detail, target_path, "psx", "Evil.zip")
+
+        # The traversal target must NOT exist anywhere outside the extraction dir.
+        assert not (roms_dir / "evil.sh").exists()
+        assert not (tmp_path / "retrodeck" / "roms" / "evil.sh").exists()
+        assert not (tmp_path / "evil.sh").exists()
+        # Already-extracted members are cleaned up — no half-installed ROM dir.
+        assert not (roms_dir / "Evil").exists()
+        assert not (roms_dir / "Evil.zip").is_dir()
+        # .zip.tmp cleaned up.
+        assert not os.path.exists(target_path + ".zip.tmp")
+        # Nothing persisted.
+        assert plugin._uow.rom_installs.get(88) is None
+        # Queue marked failed.
+        assert plugin._download_service._download_queue[88]["status"] == "failed"
+        # download_failed fired (UI doesn't hang); offending name surfaced.
+        failed = [c for c in decky.emit.call_args_list if c[0][0] == "download_failed"]
+        assert len(failed) == 1
+        assert failed[0][0][1]["rom_id"] == 88
+        assert "evil.sh" in failed[0][0][1]["error_message"]
+        # No download_complete.
+        assert not [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
+
+    @pytest.mark.asyncio
+    async def test_legit_multi_file_subdir_still_extracts(self, plugin, tmp_path):
+        """The #968 fix must not break a legitimate nested-subdir multi-file ROM."""
+        import zipfile as zf
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "switch"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "Game.nsp")
+
+        # Real nested layout with URL-encoded basenames inside a real subdir.
+        zip_content_path = tmp_path / "source.zip"
+        with zf.ZipFile(str(zip_content_path), "w") as z:
+            z.writestr("Game%20Base.nsp", b"\x00" * 100)
+            z.writestr("update/Game%20Update.nsp", b"\x00" * 50)
+        zip_bytes = zip_content_path.read_bytes()
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(zip_bytes)
+
+        rom_detail = {
+            "id": 91,
+            "name": "Game",
+            "fs_name": "Game.nsp",
+            "fs_name_no_ext": "Game",
+            "platform_slug": "switch",
+            "platform_name": "Nintendo Switch",
+            "has_multiple_files": True,
+        }
+
+        _seed_rom(plugin._uow, 91, platform_slug="switch")
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[91] = {"rom_id": 91, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(91, rom_detail, target_path, "switch", "Game.nsp")
+
+        # The encoded names decoded correctly (per-basename) and the install
+        # succeeded — the legit nested ROM is intact.
+        assert plugin._download_service._download_queue[91]["status"] == "completed"
+        install = plugin._uow.rom_installs.get(91)
+        assert install is not None
+        rom_dir = install.rom_dir
+        assert rom_dir is not None
+        assert os.path.exists(os.path.join(rom_dir, "Game Base.nsp"))
+        assert os.path.exists(os.path.join(rom_dir, "update", "Game Update.nsp"))
+        assert [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
 
 
 class TestDoDownloadFailureEmit:

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -512,6 +512,62 @@ class TestGetFirmwareStatusBiosAggregates:
         assert plat["server_count"] == 3
         assert plat["local_count"] == 1
 
+    @pytest.mark.asyncio
+    async def test_offline_fallback_skips_registry_entry_with_unsafe_firmware_path(self, plugin, fw, tmp_path):
+        """#966 NIT2: a poisoned registry/fallback ``firmware_path`` is skipped, not joined.
+
+        The registry read paths fall back to the server-supplied ``file_name``
+        when ``firmware_path`` is absent, so a traversal value must be dropped
+        (log-and-skip) rather than steering an ``exists()`` read outside the
+        BIOS sandbox.
+        """
+        bios_dir = tmp_path / "retrodeck" / "bios"
+        bios_dir.mkdir(parents=True, exist_ok=True)
+        (bios_dir / "good.bin").write_bytes(b"\x00" * 100)
+        # A file planted OUTSIDE the bios dir that the traversal would reach.
+        escape_target = tmp_path / "retrodeck" / "evil.bin"
+        escape_target.write_bytes(b"\x00" * 100)
+
+        fw._bios_registry = {
+            "platforms": {
+                "dc": {
+                    "good.bin": {"description": "Good", "required": True, "md5": "", "firmware_path": "good.bin"},
+                    # firmware_path absent → falls back to the (poisoned) file_name key.
+                    "../evil.bin": {"description": "Evil", "required": True, "md5": ""},
+                },
+            },
+        }
+        fw._bios_files_index = {
+            "good.bin": {"description": "Good", "required": True, "md5": "", "platform": "dc"},
+        }
+        fw._loop = asyncio.get_event_loop()
+
+        # Track exists() calls so we can prove none escapes the bios dir.
+        real_exists = fw._firmware_file_store.exists
+        checked: list[str] = []
+
+        def _tracking_exists(path):
+            checked.append(path)
+            return real_exists(path)
+
+        fw._firmware_file_store.exists = _tracking_exists
+
+        with (
+            patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")),
+            patch.object(fw, "_retrodeck_paths", FakeRetroDeckPaths(bios=str(bios_dir))),
+        ):
+            result = await fw.get_firmware_status()
+
+        plat = next(p for p in result["platforms"] if p["platform_slug"] == "dc")
+        file_names = {f["file_name"] for f in plat["files"]}
+        # The poisoned entry was dropped; only the clean file remains.
+        assert "../evil.bin" not in file_names
+        assert file_names == {"good.bin"}
+        # No exists() read was steered outside the bios sandbox.
+        real_bios = os.path.realpath(str(bios_dir))
+        for path in checked:
+            assert os.path.realpath(path).startswith(real_bios + os.sep)
+
 
 class TestDownloadFirmware:
     @pytest.mark.asyncio
@@ -577,6 +633,49 @@ class TestDownloadFirmware:
 
         assert result["success"] is False
         assert "reason" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_traversal_in_server_file_name(self, plugin, fw, tmp_path):
+        """#966: a server ``file_name`` of ``../evil.desktop`` is rejected, nothing written outside BIOS."""
+        bios_dir = tmp_path / "retrodeck" / "bios"
+        bios_dir.mkdir(parents=True)
+        # The traversal target lives a sibling of the bios dir.
+        escape_target = tmp_path / "retrodeck" / "evil.desktop"
+
+        fw_detail = {
+            "id": 10,
+            "file_name": "../evil.desktop",
+            "file_path": "bios/n64/evil.desktop",
+            "file_size_bytes": 10,
+            "md5_hash": "",
+        }
+
+        fw._retrodeck_paths = FakeRetroDeckPaths(bios=str(bios_dir))
+        fw._loop = asyncio.get_event_loop()
+
+        download_called = []
+
+        def fake_download(firmware_id, filename, dest):
+            download_called.append(dest)
+            with open(dest, "wb") as f:
+                f.write(b"evil")
+
+        with (
+            patch.object(plugin._romm_api, "get_firmware", return_value=fw_detail),
+            patch.object(plugin._romm_api, "download_firmware", side_effect=fake_download),
+        ):
+            result = await fw.download_firmware(10)
+
+        # Canonical path_traversal failure shape.
+        assert result["success"] is False
+        assert result["reason"] == "path_traversal"
+        assert "message" in result
+        # No download was ever attempted (rejected before make_dirs / fetch).
+        assert download_called == []
+        # Nothing written outside the BIOS directory.
+        assert not escape_target.exists()
+        # No BIOS record persisted.
+        assert plugin._uow.bios_files.get("n64", "../evil.desktop") is None
 
 
 class TestDownloadAllFirmware:


### PR DESCRIPTION
Closes #966, closes #967, closes #968.

Three sites joined **server-supplied** path components into write targets with no containment — each let a malicious (or broken) RomM server write outside the sandbox:

- **#966** — `firmware._firmware_dest_path`: server `file_name` → BIOS path, then `rename`. `file_name = "../../.config/autostart/evil.desktop"` writes attacker bytes anywhere the user can.
- **#967** — `downloads.start_download`: server `platform_slug` → `roms_dir` (`resolve_system` passes unmapped slugs verbatim), then `make_dirs` + write.
- **#968** — `download_file.decode_url_encoded_names`: a URL-encoded member (`%2e%2e%2f…`) **passes** the pre-decode ZIP-slip check, then the decode step runs *after* it and `os.replace` moves the file out of the extraction dir.

## Fix

A `lib/path_safety` security helper (stdlib-only, importable by services + adapters — alongside the existing `is_safe_rom_path`):
- `safe_path_component(name)` — lexical: rejects `..`, separators, absolute paths, NUL, empty/`.`/`..`.
- `safe_join(base, *parts)` — **realpath** containment, mirroring `is_safe_rom_path`: result must be **strictly below** `base` (equality rejected); defeats `..`-collapse, absolute-second-arg (the `os.path.join` base-discard trap), and **symlink escapes** (a planted symlink under base → outside is caught). Fail-closed via `PathTraversalError(ValueError)`.

Every server-influenced join routes through it. **Write paths fail-STOP**: a traversal attempt aborts the whole operation, cleans up any partial extraction (no half-installed ROM), and surfaces the canonical `{success: False, reason: "path_traversal", message}` **plus the `download_failed` event** (so the UI doesn’t hang — the #1017 class). The offending name goes in the log + message. The #968 decode is now the **last gate** — each decoded basename is validated before the rename. Firmware *read* paths (existence checks) log-and-skip a poisoned entry rather than crash the BIOS panel.

`reason: "path_traversal"` is a bespoke plain-string slug (frontend shows the message; the #972 gate accepts `reason: str`).

## Verification

Adversarial review threw ~40 bypass inputs at the helper (absolute, symlink, prefix-collision, equality-with-base, NUL, multi-`..`) — all rejected. Each fail-stop test asserts **post-state** (target absent, partial extraction cleaned up, failure shape returned, event fired) — non-vacuous (proven by breaking the fix → tests fail). A legit nested multi-file ROM (`subdir/file.bin`) still extracts. Full suite green (3222), `lint-imports` clean (lib stays stdlib-only), the #972 failure-shape gate green.

**Scope note:** #969 (argv-injection / quote-escaping in `build_launch_options`) is deliberately **out** — it is shell-quoting, not a path join; separate small PR.

docs: updated — `backend-architecture.md` (fail-stop traversal behavior).