### PR TITLE
fix(ui): per-game BIOS panel ignores bios change-events for other platforms

### DIFF
--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -132,7 +132,6 @@ vi.mock("../utils/saveSortMigrationStore", () => ({
   }),
 }));
 import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
-import { detach } from "../utils/detach";
 
 // ----- @decky/ui — global stub from test-setup.ts covers Focusable +
 // DialogButton. Pass-through is enough for this panel.
@@ -905,22 +904,25 @@ describe("RomMGameInfoPanel", () => {
       expect(vi.mocked(backend.debugLog)).not.toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
     });
 
-    it("bios: detail.platform_slug provided → calls checkPlatformBios; updates biosStatus when needs_bios=true", async () => {
-      await mountWithRomId(60);
+    it("bios: matching platform_slug → calls checkPlatformBios; updates biosStatus when needs_bios=true", async () => {
+      // Panel's own platform is snes; a matching-platform bios event must be
+      // applied (the positive case for the #1082 guard).
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 60,
+        platform_slug: "snes",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
       vi.mocked(backend.checkPlatformBios).mockResolvedValue({
         needs_bios: true,
         server_count: 2,
         local_count: 2,
         all_downloaded: true,
       });
-      const { container } = await new Promise<{
-        container: HTMLElement;
-      }>((resolve) => {
-        // Already rendered via mountWithRomId — get container via re-render?
-        // Use a fresh render that uses the new mock.
-        const view = render(<RomMGameInfoPanel appId={testAppId} />);
-        detach(flushAsync().then(() => resolve({ container: view.container })));
-      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
       await act(async () => {
         globalThis.dispatchEvent(
           new CustomEvent("romm_data_changed", {
@@ -938,7 +940,14 @@ describe("RomMGameInfoPanel", () => {
       // The check_platform_bios refresh path now ships bios_level straight from
       // the backend (compute_bios_level) — the handler threads it through, never
       // re-deriving from counts. amber (#d4a72c) is the observable side effect.
-      await mountWithRomId(60);
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 60,
+        platform_slug: "snes",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
       vi.mocked(backend.checkPlatformBios).mockResolvedValue({
         needs_bios: true,
         server_count: 5,
@@ -982,10 +991,20 @@ describe("RomMGameInfoPanel", () => {
     });
 
     it("bios: checkPlatformBios rejection → falls back to { needs_bios: false } (non-vacuous .catch)", async () => {
-      // Mount without bios_status so biosStatus starts null and the BIOS
-      // tab is NOT visible — the assertion that it STAYS hidden after the
-      // rejection is the fallback-state observable.
-      const { container } = await mountWithRomId(60);
+      // Mount on the snes platform (so the #1082 guard lets the matching
+      // event through) without bios_status, so biosStatus starts null and
+      // the BIOS tab is NOT visible — the assertion that it STAYS hidden
+      // after the rejection is the fallback-state observable.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 60,
+        platform_slug: "snes",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
       expect(container.textContent).not.toContain("BIOS");
       vi.mocked(backend.checkPlatformBios).mockRejectedValue(new Error("net"));
       await act(async () => {
@@ -1003,6 +1022,95 @@ describe("RomMGameInfoPanel", () => {
       // BIOS tab remains hidden.
       expect(vi.mocked(backend.debugLog)).not.toHaveBeenCalledWith(expect.stringContaining("onDataChanged error"));
       expect(container.textContent).not.toContain("BIOS");
+    });
+
+    it("bios: cross-platform event (#1082) → ignored; no fetch, foreign BIOS list never bleeds in", async () => {
+      // Regression for #1082: bios events fan out to every mounted panel.
+      // A gba panel must ignore a psx bios event (e.g. a psx BIOS bulk
+      // download) instead of repainting itself with the psx BIOS list.
+      // Mount a gba panel WITHOUT bios_status, so the BIOS tab starts hidden.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 70,
+        platform_slug: "gba",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("BIOS");
+
+      // The psx event would, if applied, repaint this panel with a needs_bios
+      // psx status (surfacing the BIOS tab + a psx-specific marker). Make the
+      // assertion non-vacuous: a distinct psx payload that must NOT appear.
+      vi.mocked(backend.checkPlatformBios).mockClear();
+      vi.mocked(backend.checkPlatformBios).mockResolvedValue({
+        needs_bios: true,
+        server_count: 1,
+        local_count: 1,
+        all_downloaded: true,
+        files: [
+          {
+            file_name: "PSX_BLEED_MARKER.bin",
+            description: "PSX BIOS",
+            classification: "required",
+            downloaded: true,
+          },
+        ],
+      } as never);
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "bios", platform_slug: "psx" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Guard returns BEFORE the fetch — checkPlatformBios("psx") never runs.
+      expect(vi.mocked(backend.checkPlatformBios)).not.toHaveBeenCalled();
+      // BIOS tab stayed hidden; the psx marker never bled into this gba panel.
+      expect(container.textContent).not.toContain("BIOS");
+      expect(container.innerHTML).not.toContain("PSX_BLEED_MARKER.bin");
+    });
+
+    it("bios: matching-platform event (#1082) → still applied (guard not over-broad)", async () => {
+      // The guard must reject other platforms WITHOUT blocking the panel's own.
+      // Mount a gba panel and feed it a gba bios event — it must update.
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 70,
+        platform_slug: "gba",
+        save_sync_enabled: true,
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      const { container } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(container.textContent).not.toContain("BIOS");
+
+      vi.mocked(backend.checkPlatformBios).mockClear();
+      vi.mocked(backend.checkPlatformBios).mockResolvedValue({
+        needs_bios: true,
+        server_count: 1,
+        local_count: 1,
+        all_downloaded: true,
+      });
+      await act(async () => {
+        globalThis.dispatchEvent(
+          new CustomEvent("romm_data_changed", {
+            detail: { type: "bios", platform_slug: "gba" },
+          }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Own-platform event flows through: fetch fired and BIOS tab surfaced.
+      expect(vi.mocked(backend.checkPlatformBios)).toHaveBeenCalledWith("gba");
+      expect(container.textContent).toContain("BIOS");
     });
 
     it("core_changed: invalidates cache + re-fetches getCachedGameDetail and updates biosStatus state", async () => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -285,6 +285,7 @@ async function loadData(
   appId: number,
   cancelled: () => boolean,
   romIdRef: React.MutableRefObject<number | null>,
+  platformSlugRef: React.MutableRefObject<string>,
   setter: React.Dispatch<React.SetStateAction<PanelState>>,
 ): Promise<void> {
   try {
@@ -302,6 +303,7 @@ async function loadData(
     const platformSlug = cached.platform_slug || "";
 
     romIdRef.current = romId;
+    platformSlugRef.current = platformSlug;
 
     const biosStatus = biosStatusFromCache(cached.bios_status);
     // bios_level is computed by the backend (`compute_bios_level`) and shipped on
@@ -387,6 +389,10 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     slotsLoading: false,
   });
   const romIdRef = useRef<number | null>(null);
+  // Tracks the panel's own platform so the broadcast `bios` data-changed
+  // handler can reject events for other platforms without a stale closure
+  // (mirrors romIdRef). bios events fan out to every mounted panel (#1082).
+  const platformSlugRef = useRef<string>("");
   const [migration, setMigration] = useState(getMigrationState());
   const [saveSortPending, setSaveSortPending] = useState(getSaveSortMigrationState().pending);
 
@@ -411,7 +417,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
   useEffect(() => {
     let cancelled = false;
 
-    detach(loadData(appId, () => cancelled, romIdRef, setState));
+    detach(loadData(appId, () => cancelled, romIdRef, platformSlugRef, setState));
 
     // Listen for uninstall events to update state (uses ref to avoid stale closure)
     const onUninstall = (e: Event) => {
@@ -461,8 +467,13 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     };
 
     const handleBiosChange = async (detail: Extract<RommDataChangedDetail, { type: "bios" }>) => {
-      if (!detail.platform_slug) return;
+      // bios events fan out to every mounted panel — ignore platforms other
+      // than this panel's own, both to avoid cross-platform BIOS-list bleed
+      // and to skip the wasted checkPlatformBios fetch (#1082). Read via ref
+      // to avoid a stale closure.
+      if (!detail.platform_slug || detail.platform_slug !== platformSlugRef.current) return;
       const updated = await checkPlatformBios(detail.platform_slug).catch((): BiosStatus => ({ needs_bios: false }));
+      if (cancelled) return;
       const biosLevel = updated.needs_bios ? (updated.bios_level ?? null) : null;
       setState((prev) => ({ ...prev, biosStatus: updated.needs_bios ? updated : null, biosLevel }));
     };


### PR DESCRIPTION
Closes #1082. Surfaced during the on-device smoke of #966–968 (pre-existing frontend race, unrelated to that fix).

## Problem

`RomMGameInfoPanel`'s `handleBiosChange` — the broadcast `romm_data_changed` handler for `type: "bios"` — applied the **changed** platform's BIOS status (`detail.platform_slug`) to the panel's own state without checking it matched the panel's own game platform, and without the `cancelled` guard every other async path in the file uses. `bios` events fan out to all mounted panels, so a BIOS change for platform A (e.g. a bulk BIOS download) repainted an open panel on platform B with platform A's list.

Observed on device: with a `psx` BIOS download active, an open `gba` game's BIOS tab briefly rendered the `psx` BIOS list (self-corrects on the next refresh). Same mis-applied-cross-context-state class as #1004 / #1009.

## Fix

- `handleBiosChange` now guards on `platformSlugRef.current` (a ref mirroring the existing `romIdRef`, kept in sync in `loadData` — reads the panel's current platform without a stale closure) **before** the `checkPlatformBios` fetch: an event for any other platform is ignored (kills the bleed and the wasted call).
- Adds the `cancelled` guard after the await, matching the sibling handlers.

## Test

Regression test dispatches the `romm_data_changed` DOM event (per the CLAUDE.md harness note): a `gba` panel **ignores** a `psx` `bios` event (asserts `checkPlatformBios` not called, no bleed in the DOM) — non-vacuous (fails without the guard, re-proven in review). A matching `gba` event still applies (guard not over-broad). Three pre-existing bios tests were mounted with a matching `platform_slug` so they keep exercising the handler rather than silently early-returning.

docs: N/A — frontend race correction, no user-visible feature / architecture / flow change.