### PR TITLE
fix(shortcuts): escape quotes in build_launch_options — argv injection via ROM filename

### DIFF
--- a/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
+++ b/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
@@ -51,8 +51,11 @@ per-game emulator/core override, and which) is a **service-layer DB read** —
 [ADR-0011](0011-per-game-core-override-in-db-applied-via-e-flag.md)'s `ActiveCoreResolver.active_core_for_rom(rom_id)`,
 backed by `roms.emulator_override` — that resolves the core and passes it into the seam. The seam only turns the chosen
 core into a command string. Multi-emulator support ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129))
-extends this single seam, not the launcher. The ROM path is quoted so paths with spaces survive `exec "$@"`.
-`launch_options` carries:
+extends this single seam, not the launcher. The ROM path is double-quoted so paths with spaces survive `exec "$@"`, and
+any embedded `\` and `"` in the path are backslash-escaped (backslash first, then quote) so a server-controlled ROM
+filename cannot break out of the quoted token and inject extra argv elements into the emulator invocation through
+Steam's launch-options tokenizer. Only the path is escaped — the emulator invocation itself is trusted build-time text
+whose own `-e "..."` quoting must survive verbatim. `launch_options` carries:
 
 - the **full command** for an installed ROM, written at **sync** (for ROMs already on disk), at **download-complete**
   (the moment a ROM becomes installed), and **re-resolved on RetroDECK-home migration** (a new

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -58,9 +58,15 @@ def label_to_core_so(available_cores: list[dict[str, Any]], label: str) -> str |
 def build_launch_options(invocation: str, path: str) -> str:
     """Compose the Steam shortcut launch command from *invocation* and ROM *path*.
 
-    The path is quoted so paths with spaces survive the launcher's ``exec "$@"``.
+    The path is double-quoted so paths with spaces survive the launcher's
+    ``exec "$@"``. Embedded ``\\`` and ``"`` in the path are backslash-escaped
+    (backslash first, then quote) so a server-controlled ROM filename cannot
+    break out of the quoted token and inject extra argv elements into the
+    emulator invocation. Only the path is escaped — *invocation* is trusted
+    build-time text whose own ``-e "..."`` quoting must survive verbatim.
     """
-    return f'{invocation} "{path}"'
+    escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{invocation} "{escaped}"'
 
 
 def build_shortcuts_data(

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -1,6 +1,7 @@
 """Tests for domain/shortcut_data.py pure functions."""
 
 import os
+import shlex
 
 from domain.shortcut_data import (
     RETRODECK_INVOCATION,
@@ -106,6 +107,73 @@ class TestBuildLaunchOptions:
 
     def test_empty_path_still_quoted(self):
         assert build_launch_options(RETRODECK_INVOCATION, "") == 'flatpak run net.retrodeck.retrodeck ""'
+
+    # The tests below use shlex.split(posix=True) as a reference POSIX /
+    # ``\"``-honoring tokenizer: it proves the escaping is internally correct (a
+    # server-controlled ROM filename round-trips to exactly ONE final argv token).
+    # Parity with Steam's actual (closed-source) launch-time tokenizer is verified
+    # on-device, not here.
+
+    def test_quote_in_path_round_trips_to_one_arg(self):
+        path = '/roms/gba/Game".gba'
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        assert shlex.split(result, posix=True) == [
+            "flatpak",
+            "run",
+            "net.retrodeck.retrodeck",
+            path,
+        ]
+
+    def test_argv_injection_attempt_is_neutralized(self):
+        path = '/roms/gba/evil" --inject-flag --foo.gba'
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        tokens = shlex.split(result, posix=True)
+        # The 3 invocation tokens + exactly ONE final token equal to the original
+        # path: --inject-flag / --foo never become separate argv elements.
+        assert tokens == ["flatpak", "run", "net.retrodeck.retrodeck", path]
+
+    def test_backslash_in_path_round_trips(self):
+        path = "/roms/gba/a\\b.gba"  # one literal backslash
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        tokens = shlex.split(result, posix=True)
+        assert tokens[-1] == path
+        assert tokens == ["flatpak", "run", "net.retrodeck.retrodeck", path]
+
+    def test_trailing_backslash_does_not_eat_closing_quote(self):
+        path = "/roms/gba/dir\\"  # ends in one literal backslash
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        tokens = shlex.split(result, posix=True)
+        # Without escaping, the trailing \ would escape the closing " and merge
+        # the token with whatever follows; backslash-escaping keeps it one arg.
+        assert tokens[-1] == path
+        assert tokens == ["flatpak", "run", "net.retrodeck.retrodeck", path]
+
+    def test_combined_backslash_and_quote_round_trips(self):
+        path = '/roms/gba/a\\"b.gba'  # one backslash followed by a quote
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        tokens = shlex.split(result, posix=True)
+        assert tokens[-1] == path
+        assert tokens == ["flatpak", "run", "net.retrodeck.retrodeck", path]
+
+    def test_path_is_just_a_quote(self):
+        path = '"'  # filename consisting of a single double-quote
+        result = build_launch_options(RETRODECK_INVOCATION, path)
+        assert shlex.split(result, posix=True) == [
+            "flatpak",
+            "run",
+            "net.retrodeck.retrodeck",
+            path,
+        ]
+
+    def test_override_invocation_is_preserved_unescaped(self):
+        invocation = resolve_emulator_invocation({"id": 1}, "mgba")
+        path = '/roms/gba/Game".gba'
+        result = build_launch_options(invocation, path)
+        # The invocation's own -e "..." quoting is part of the trusted prefix and
+        # is NOT escaped — it survives verbatim in the launch string.
+        assert '-e "%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/mgba.so %ROM%"' in result
+        # The path still round-trips to a single final argv token under shlex.
+        assert shlex.split(result, posix=True)[-1] == path
 
 
 class TestBuildShortcutsData:


### PR DESCRIPTION
## What

`build_launch_options` composed the Steam shortcut launch command as `f'{invocation} "{path}"'` with no escaping. The ROM path derives from the server-controlled `fs_name` (basenamed, but otherwise unfiltered). The shortcut's exe is `bin/rom-launcher` — a pure `exec "$@"` wrapper with no shell — so Steam tokenizes the launch-options string straight into argv. A filename containing a `"` closes the quoted token early and injects extra argv elements into the flatpak/RetroDECK invocation (e.g. a ROM named `Game" --foo .gba` smuggles `--foo` in as a separate argument). No shell is involved, so this is argv injection / broken launches, not shell RCE — but the filename is server-controlled.

## Fix

Backslash-escape the path before quoting: `\` → `\\` first, then `"` → `\"` (backslash first, so the second pass can't double-escape the backslash it just added). Only the **path** is escaped — the emulator invocation is trusted build-time text whose own `-e "..."` quoting must survive verbatim. This is the `\\` / `\"` C/POSIX-standard scheme, which is also Steam's own convention (it writes `"` → `\"` in `screenshots.vdf`).

All four `launch_options` producers route through this one function (sync, download-complete, core-override rebake, RetroDECK-home relaunch), so the escape covers every path that reaches a shortcut.

## Tests

`tests/domain/test_shortcut_data.py` gains round-trip tests that tokenize the result with `shlex.split` (a POSIX / `\"`-honoring reference tokenizer) and assert it parses back to exactly the invocation tokens **plus one** ROM argument equal to the original unescaped path: embedded quote, a crafted injection attempt, single/trailing/combined backslash, a filename that is only a quote, and that the core-override invocation's own quotes are preserved unescaped.

## Docs

ADR-0009 (`docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md`) updated to record the path escaping in the launch-options model.

## Verification note

Steam's launch-time tokenizer is closed-source, so the `shlex` tests prove the escaping is internally correct for a POSIX/`\"`-honoring tokenizer; parity with Steam's actual tokenizer is confirmed on-device by launching a ROM whose filename contains a `"`. The escape scheme matches Steam's documented `\"` convention, which is the strongest available signal short of that on-device check.
