### PR TITLE
test(contract): callable-manifest parity gate (#1027 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Check service-independence contract is complete
         run: python scripts/check_service_independence_contract.py
 
+      - name: Check callable-manifest parity (frontend ↔ backend)
+        run: python scripts/check_callable_manifest.py
+
       - name: Check Cosmic Python call bans
         run: bash scripts/check_cosmic_call_bans.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Service-independence contract self-check**: `scripts/check_service_independence_contract.py` — derives the expected
   service list from `py_modules/services/` and fails CI if `.importlinter`'s `service-independence` contract omits a
   service or carries a stale entry, keeping the hand-maintained `modules` list self-healing.
+- **Callable-manifest parity gate**: `scripts/check_callable_manifest.py` — derives the frontend callable surface from
+  every `callable<[Args], Return>("name")` in `src/**/*.ts` and the backend surface from the public `async def` methods
+  on the `Plugin` class in `main.py`, and fails CI if they diverge: a name on one side only (either direction) or a
+  matching name whose arity (positional param count) differs. Arg TYPES are out of scope — Python signatures carry no
+  hints, so arity is the only mechanically checkable shape (the contract tier exercises types by driving real values).
 - **Failure-shape dialect gate**: `scripts/check_failure_shape.py --check` — AST check that fails CI if any
   `success: False` return in `services/` is missing the canonical `reason` + `message` keys or carries the forbidden
   `error` / `error_code` key. The two documented carve-outs (discriminated-status unions, partial-success payloads) are
@@ -427,9 +432,15 @@ Rules for this tier:
 - A wiring drift (a renamed/added service) fails the fixture loudly via the bound-attribute assert, not as a confusing
   mid-test `AttributeError`.
 
-Phase 2 — a `backend.ts` manifest gate that parses the `callable<[Args], Return>("name")` declarations into an artifact
-the pytest side consumes (so a renamed callable or changed default breaks CI) — is a forthcoming separate PR; it is not
-built yet.
+Phase 2 — the callable-manifest parity gate — is built: `scripts/check_callable_manifest.py` derives the frontend
+surface from every `callable<[Args], Return>("name")` in `src/**/*.ts` (not just `backend.ts` — one declaration lives in
+`utils/cachedGameDetailStore.ts`) and the backend surface from the public `async def` methods on `Plugin` in `main.py`,
+then fails on any divergence: a name declared on only one side (either direction) or a matching name whose arity
+(positional-param count, `self` dropped) differs. Arg TYPES stay out of scope — Python method signatures carry no hints,
+so arity is the only mechanically checkable shape. The gate runs standalone in CI (`mise run lint` + a CI step) and is
+also surfaced inside the pytest run by `tests/contract/test_callable_manifest.py`, which imports the same two parser
+functions and asserts live parity — so a renamed/added/removed callable or an arity drift breaks both the lint gate and
+the test run.
 
 ### Frontend component tests — `@decky/api` event harness
 

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -143,6 +143,14 @@ in `services/` is missing the canonical `reason` + `message` keys or carries the
 collapsing the failure-shape dialects onto one vocabulary (the two documented carve-outs are pattern-exempt). Run it
 without `--check` for a report-mode inventory.
 
+`mise run lint` (and CI) also runs `scripts/check_callable_manifest.py`, which pins the frontend↔backend callable
+surface to one source of truth: it derives the frontend names + arities from every `callable<[Args], Return>("name")` in
+`src/**/*.ts` and the backend surface from the public `async def` methods on the `Plugin` class in `main.py`, then fails
+if they diverge — a callable declared on only one side (either direction) or a matching name whose arity (positional
+param count) differs. Arg types stay out of scope (Python signatures carry no hints), so arity is the only mechanically
+checkable shape. The same parity assertion is surfaced inside the pytest run by
+`tests/contract/test_callable_manifest.py`.
+
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality

--- a/mise.toml
+++ b/mise.toml
@@ -46,6 +46,7 @@ depends = ["lint:md"]
 run = [
     "PYTHONPATH=py_modules lint-imports",
     "python scripts/check_service_independence_contract.py",
+    "python scripts/check_callable_manifest.py",
     "bash scripts/check_cosmic_call_bans.sh",
     "python scripts/check_failure_shape.py --check",
 ]

--- a/scripts/check_callable_manifest.py
+++ b/scripts/check_callable_manifest.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Frontend↔backend callable-manifest parity gate.
+
+The Decky callable surface is declared twice: once on the frontend as
+``callable<[Args], Return>("wire_name")`` (TypeScript) and once on the backend
+as a public ``async def`` method on the ``Plugin`` class in ``main.py``. Nothing
+ties the two together at build time — a renamed/added/removed callable on either
+side, or an arg-count change that the other side doesn't follow, only surfaces as
+a runtime "method not found" / wrong-arity failure once the plugin is loaded.
+
+This check derives both surfaces from source and fails when they diverge, so the
+wire stays one source of truth. It is the static sibling of the
+``tests/contract/`` tier: the contract tests drive the *real* callables
+frontend-shaped; this gate pins that the two *declarations* agree before any
+callable is driven.
+
+What it guarantees (and what it deliberately does not):
+
+  * Every frontend ``callable("name")`` has a matching backend ``async def name``
+    and vice versa — no orphan on either side.
+  * Where a name exists on both sides, the **arity** (positional parameter count,
+    ``self`` dropped on the backend) matches. Python method signatures carry no
+    type hints, so arity is the only mechanically checkable shape — arg TYPES are
+    out of scope (the contract tier exercises those by driving real values).
+  * A backend method that takes ``*args`` has a variable arity; its name is still
+    checked, but the arity comparison is skipped for it.
+
+``EXEMPT`` holds wire names deliberately kept out of the parity check. It is
+empty today; an entry here is a conscious "this name is intentionally declared on
+only one side" decision — never a lever to silence a real drift. A genuine drift
+is a finding to triage, not to exempt.
+
+Exit 0 when the two surfaces match, 1 (one line per discrepancy) otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src"
+MAIN_PY = REPO_ROOT / "main.py"
+
+# Wire names deliberately excluded from the parity check. Empty today; add an
+# entry only as a conscious decision (see the module docstring). Do NOT add a
+# name here to silence a real drift — a drift is a finding to triage.
+EXEMPT: frozenset[str] = frozenset()
+
+# Brackets that open/close a balance-tracked region inside a ``callable<...>``.
+_OPENERS = {"<": ">", "[": "]", "{": "}", "(": ")"}
+_CLOSERS = frozenset(_OPENERS.values())
+_QUOTES = frozenset({'"', "'", "`"})
+
+
+def _skip_string(text: str, start: int) -> int:
+    """Return the index just past the string/template literal opening at *start*.
+
+    *start* must index a quote character. Handles backslash escapes; a template
+    literal's ``${...}`` interpolation is treated as opaque body text (its inner
+    brackets never reach the depth tracker because the whole literal is skipped).
+    """
+    quote = text[start]
+    i = start + 1
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == quote:
+            return i + 1
+        i += 1
+    return n
+
+
+def _strip_comments(text: str) -> str:
+    """Return *text* with TS ``//`` and ``/* */`` comments blanked out.
+
+    Comment spans are replaced with a single space (preserving token separation
+    and source length is unnecessary — the parser is whitespace-tolerant), so a
+    comment containing an apostrophe, a ``<``/``>``, an unbalanced bracket, or a
+    whole commented-out ``callable<...>("dead")`` declaration cannot corrupt the
+    downstream bracket-depth tracking or be mistaken for a live callable.
+
+    String and template literals are preserved verbatim — a ``//`` or ``/*``
+    inside ``"http://x"`` or `` `a/*b` `` is part of the string, not a comment.
+    Scans char by char so a comment-opener inside a literal is never honoured.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTES:
+            end = _skip_string(text, i)
+            out.append(text[i:end])
+            i = end
+            continue
+        if ch == "/" and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt == "/":
+                end = text.find("\n", i + 2)
+                # Keep the newline so line structure (and any line comment a
+                # later scan relies on) survives; blank only the comment body.
+                if end == -1:
+                    out.append(" ")
+                    return "".join(out)
+                out.append(" \n")
+                i = end + 1
+                continue
+            if nxt == "*":
+                end = text.find("*/", i + 2)
+                out.append(" ")
+                i = len(text) if end == -1 else end + 2
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _is_arrow(text: str, i: int) -> bool:
+    """Return True when *i* indexes the ``=`` of a ``=>`` arrow token.
+
+    The ``>`` in ``=>`` (arrow-function return type, e.g. ``(a: number) => void``)
+    is not a closing angle bracket and must not decrement bracket depth. The
+    scanners treat ``=>`` as an opaque two-char token so the ``>`` never reaches
+    the depth/closer logic.
+    """
+    return text[i] == "=" and i + 1 < len(text) and text[i + 1] == ">"
+
+
+def _capture_generic(text: str, lt_index: int) -> tuple[str, int] | None:
+    """Capture the balanced ``<...>`` body starting at the ``<`` at *lt_index*.
+
+    Returns ``(inner, end)`` where *inner* is the text between the outer angle
+    brackets and *end* indexes just past the closing ``>``. String/template
+    literals are skipped so brackets/commas inside them never affect the depth
+    count, and a ``=>`` arrow's ``>`` does not close a generic. (Comments are
+    already removed upstream by :func:`_strip_comments`.) Returns None if the
+    angle brackets never balance (truncated source).
+    """
+    depth = 0
+    i = lt_index
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTES:
+            i = _skip_string(text, i)
+            continue
+        if _is_arrow(text, i):
+            i += 2
+            continue
+        if ch in _OPENERS:
+            depth += 1
+            i += 1
+            continue
+        if ch in _CLOSERS:
+            depth -= 1
+            if depth == 0 and ch == ">":
+                return text[lt_index + 1 : i], i + 1
+            i += 1
+            continue
+        i += 1
+    return None
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split *text* on TOP-LEVEL commas, respecting nesting and string literals.
+
+    Nested generics (``Record<string, number>``), tuples, objects, string
+    literals and ``=>`` arrows do not split — only commas at bracket depth 0 do.
+    (Comments are already removed upstream by :func:`_strip_comments`.) A wholly
+    empty *text* yields ``[]``; a single trailing comma (``number, string,``)
+    drops the empty final fragment so it does not inflate the element count.
+    """
+    if not text.strip():
+        return []
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTES:
+            i = _skip_string(text, i)
+            continue
+        if _is_arrow(text, i):
+            i += 2
+            continue
+        if ch in _OPENERS:
+            depth += 1
+        elif ch in _CLOSERS:
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(text[start:i])
+            start = i + 1
+        i += 1
+    parts.append(text[start:])
+    # Drop a single trailing empty fragment from a trailing comma (``a, b,``);
+    # an all-empty *text* already returned [] above, so this only trims the
+    # spurious final element, never a legitimate one.
+    if len(parts) > 1 and not parts[-1].strip():
+        parts.pop()
+    return parts
+
+
+def _args_arity(args_fragment: str) -> int:
+    """Return the arity of the leading ``[...]`` args tuple of a callable generic.
+
+    *args_fragment* is the first top-level element of the ``callable<...>``
+    generic — a tuple type like ``[number, string]``. Arity is the count of
+    top-level comma-separated elements inside the brackets (``[]`` -> 0). Nested
+    generics, unions and object literals inside an element do not inflate it.
+    """
+    inner = args_fragment.strip()
+    if inner.startswith("[") and inner.endswith("]"):
+        inner = inner[1:-1]
+    return len(_split_top_level(inner))
+
+
+def _trailing_call_name(text: str, after: int) -> str | None:
+    """Return the string literal in the ``("name")`` immediately following *after*.
+
+    *after* indexes just past the closing ``>`` of the ``callable<...>`` generic.
+    Skips whitespace, expects ``(`` then a quoted string literal.
+    """
+    i = after
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n or text[i] != "(":
+        return None
+    i += 1
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n or text[i] not in _QUOTES:
+        return None
+    quote = text[i]
+    end = _skip_string(text, i)
+    # end indexes just past the closing quote; the literal body excludes quotes.
+    body = text[i + 1 : end - 1]
+    return body if quote != "`" or "${" not in body else None
+
+
+def parse_frontend_callables(src_dir: Path) -> dict[str, int]:
+    """Parse every ``callable<[Args], Return>("name")`` under *src_dir*.
+
+    Scans all ``.ts``/``.tsx`` files as text (declarations may span multiple
+    lines). Comments are stripped first (:func:`_strip_comments`) so a comment
+    inside a ``callable<...>`` block can't corrupt the bracket tracker and a
+    commented-out declaration isn't mistaken for a live one. Returns
+    ``{wire_name: arity}`` where arity is the number of top-level elements in the
+    ``[Args]`` tuple. A wire name declared more than once maps to a sentinel
+    arity of ``-1`` so the diff surfaces the duplicate.
+    """
+    result: dict[str, int] = {}
+    if not src_dir.is_dir():
+        return result
+    files = sorted(p for p in src_dir.rglob("*") if p.suffix in (".ts", ".tsx") and p.is_file())
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        _parse_text_into(_strip_comments(text), result)
+    return result
+
+
+def _parse_text_into(text: str, result: dict[str, int]) -> None:
+    """Find every ``callable<...>("name")`` in *text* and record name -> arity."""
+    needle = "callable"
+    i = 0
+    n = len(text)
+    while True:
+        idx = text.find(needle, i)
+        if idx == -1:
+            return
+        i = idx + len(needle)
+        # The ``<`` of the generic must follow ``callable`` (allowing whitespace).
+        j = i
+        while j < n and text[j].isspace():
+            j += 1
+        if j >= n or text[j] != "<":
+            continue
+        captured = _capture_generic(text, j)
+        if captured is None:
+            continue
+        inner, end = captured
+        elements = _split_top_level(inner)
+        if not elements:
+            continue
+        name = _trailing_call_name(text, end)
+        if name is None:
+            continue
+        arity = _args_arity(elements[0])
+        # A second declaration of the same name is itself a finding.
+        result[name] = -1 if name in result else arity
+        i = end
+
+
+def parse_backend_callables(main_py: Path) -> dict[str, int]:
+    """Parse the public ``async def`` methods of the ``Plugin`` class in *main_py*.
+
+    Uses ``ast`` (never imports ``main.py`` — it needs a decky runtime). Returns
+    ``{method_name: arity}`` for every ``AsyncFunctionDef`` on ``Plugin`` whose
+    name does not start with ``_`` (those are internal lifecycle, not callables).
+    Arity counts positional parameters only — ``posonlyargs`` + ``args`` minus
+    ``self``; a method with ``*args`` has variable arity, recorded as ``None``
+    (name still checked). Keyword-only args (``*, c``) and ``**kwargs`` are NOT
+    part of positional arity: the frontend's positional ``[Args]`` tuple can't
+    fill them, so they're excluded by design (a non-occurring corner on this
+    callable surface).
+    """
+    result: dict[str, int | None] = {}
+    source = main_py.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(main_py))
+    plugin = next(
+        (node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Plugin"),
+        None,
+    )
+    if plugin is None:
+        return {}
+    for node in plugin.body:
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name.startswith("_"):
+            continue
+        args = node.args
+        if args.vararg is not None:
+            result[node.name] = None
+            continue
+        # posonly + regular positional params, minus ``self``. Defaults still
+        # occupy a positional slot the frontend fills (e.g. ``null``).
+        result[node.name] = len(args.posonlyargs) + len(args.args) - 1
+    return result
+
+
+def find_discrepancies(
+    frontend: dict[str, int],
+    backend: dict[str, int | None],
+    exempt: frozenset[str],
+) -> list[str]:
+    """Diff the two callable surfaces. One human-readable line per discrepancy.
+
+    Reports: (a) a name on the frontend but not the backend, (b) a name on the
+    backend but not the frontend, (c) a name on both whose arity differs, and
+    (d) a frontend name declared twice (arity sentinel ``-1``). ``exempt`` names
+    are skipped for the name-presence checks (a)/(b).
+    """
+    findings: list[str] = [
+        f"{name}: declared more than once on the frontend "
+        f"(src/**/*.ts callable<...>) — remove the duplicate declaration."
+        for name in sorted(frontend)
+        if frontend[name] == -1
+    ]
+
+    frontend_names = set(frontend) - exempt
+    backend_names = set(backend) - exempt
+
+    findings.extend(
+        f'{name}: frontend declares callable("{name}") but main.py has no public '
+        f"async def {name} on Plugin — add the backend method, fix a rename, or "
+        f"add it to EXEMPT in this script if it is intentionally frontend-only."
+        for name in sorted(frontend_names - backend_names)
+    )
+    findings.extend(
+        f"{name}: main.py exposes public async def {name} on Plugin but no frontend "
+        f'callable("{name}") declares it — add the frontend declaration, fix a '
+        f"rename, or add it to EXEMPT in this script if it is intentionally backend-only."
+        for name in sorted(backend_names - frontend_names)
+    )
+
+    for name in sorted(frontend_names & backend_names):
+        fe_arity = frontend[name]
+        be_arity = backend[name]
+        if fe_arity == -1 or be_arity is None:
+            # Duplicate frontend name already flagged above; ``*args`` backend
+            # method has variable arity — name checked, arity skipped.
+            continue
+        if fe_arity != be_arity:
+            findings.append(
+                f"{name}: arity mismatch — frontend declares {fe_arity} arg(s) "
+                f"(callable<[...]>) but main.py async def {name} takes {be_arity} "
+                f"(self dropped). Align the argument count on one side."
+            )
+
+    return sorted(findings)
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+    frontend = parse_frontend_callables(SRC_DIR)
+    backend = parse_backend_callables(MAIN_PY)
+    findings = find_discrepancies(frontend, backend, EXEMPT)
+    if findings:
+        for line in findings:
+            print(line)
+        print()
+        print(
+            "ERROR: the frontend (src/**/*.ts callable declarations) and backend "
+            "(Plugin async methods in main.py) callable surfaces have drifted. Every "
+            "callable must be declared on both sides with matching arity (or be "
+            "explicitly EXEMPT) so the frontend↔backend wire stays one source of truth."
+        )
+        return 1
+    matched = len(set(frontend) & set(backend))
+    print(f"OK: frontend↔backend callable manifest matches ({matched} callables).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/contract/test_callable_manifest.py
+++ b/tests/contract/test_callable_manifest.py
@@ -1,0 +1,45 @@
+"""Frontend↔backend callable-manifest parity, surfaced inside the pytest run.
+
+This pins the exact contract the CI gate (``scripts/check_callable_manifest.py``)
+enforces: every ``callable<[Args], Return>("name")`` declared on the frontend
+(``src/**/*.ts``) has a matching public ``async def name`` on the ``Plugin``
+class in ``main.py``, in both directions, with matching arity. It is the
+static-parity sibling of the rest of ``tests/contract/`` — those tests *drive*
+the real callables frontend-shaped; this one asserts the two *declarations*
+agree before any callable is driven, so a renamed/added/removed callable or an
+arity drift breaks the pytest run, not just the standalone lint gate.
+
+The parser functions are imported from the gate script (loaded via ``importlib``
+because ``scripts/`` is not on ``sys.path``), so the test and the CI gate share
+one implementation — they can never disagree about what "matches" means.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_callable_manifest.py"
+_SRC_DIR = _REPO_ROOT / "src"
+_MAIN_PY = _REPO_ROOT / "main.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("check_callable_manifest", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_gate = _load_gate()
+
+
+def test_frontend_backend_callable_manifest_matches():
+    frontend = _gate.parse_frontend_callables(_SRC_DIR)
+    backend = _gate.parse_backend_callables(_MAIN_PY)
+    discrepancies = _gate.find_discrepancies(frontend, backend, _gate.EXEMPT)
+    assert discrepancies == []

--- a/tests/scripts/test_check_callable_manifest.py
+++ b/tests/scripts/test_check_callable_manifest.py
@@ -1,0 +1,394 @@
+"""Tests for ``scripts/check_callable_manifest.py``.
+
+Loaded via ``importlib`` because ``scripts/`` is not on ``sys.path`` (and is
+excluded from ruff/basedpyright). Parser edge cases feed synthetic ``.ts`` /
+``main.py`` files under ``tmp_path``; the happy-path test asserts the real repo
+tree is clean (the regression that protects the live frontend↔backend wire).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_callable_manifest.py"
+
+
+def _load_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_callable_manifest", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load_check_module()
+
+
+def _write_ts(tmp_path: Path, name: str, body: str) -> Path:
+    """Write a ``.ts`` file under a fake ``src/`` tree and return the src dir."""
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    (src / name).write_text(body, encoding="utf-8")
+    return src
+
+
+def _write_main(tmp_path: Path, body: str) -> Path:
+    """Write a synthetic ``main.py`` with a ``Plugin`` class body and return its path."""
+    path = tmp_path / "main.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestParseFrontendCallables:
+    def test_empty_args_is_arity_zero(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'const x = callable<[], Foo>("get_settings");')
+        assert check.parse_frontend_callables(src) == {"get_settings": 0}
+
+    def test_single_arg_is_arity_one(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[number], Foo>("start_download");')
+        assert check.parse_frontend_callables(src) == {"start_download": 1}
+
+    def test_three_args_with_union(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[number, string, string | null], Foo>("f");')
+        assert check.parse_frontend_callables(src) == {"f": 3}
+
+    def test_nested_generic_comma_not_counted(self, tmp_path: Path):
+        # Record<string, number> is ONE element — the inner comma must not inflate.
+        src = _write_ts(tmp_path, "a.ts", 'callable<[Record<string, number>], Foo>("report_unit_results");')
+        assert check.parse_frontend_callables(src) == {"report_unit_results": 1}
+
+    def test_union_with_string_literals_is_arity_two(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[boolean, "my" | "smart" | null], Foo>("g");')
+        assert check.parse_frontend_callables(src) == {"g": 2}
+
+    def test_object_literal_return_does_not_split_args(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[number], { a: number; b: string }>("h");')
+        assert check.parse_frontend_callables(src) == {"h": 1}
+
+    def test_multiline_declaration(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            export const setAllCollectionsSync = callable<
+              [boolean, "my" | "smart" | "franchise" | null],
+              { success: boolean; message?: string }
+            >("set_all_collections_sync");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        assert check.parse_frontend_callables(src) == {"set_all_collections_sync": 2}
+
+    def test_string_literal_containing_bracket_and_comma(self, tmp_path: Path):
+        # A string literal in the args tuple must not be parsed as structure.
+        src = _write_ts(tmp_path, "a.ts", 'callable<["a, b]", number], Foo>("weird");')
+        assert check.parse_frontend_callables(src) == {"weird": 2}
+
+    def test_scans_tsx_and_nested_dirs(self, tmp_path: Path):
+        src = tmp_path / "src"
+        (src / "utils").mkdir(parents=True)
+        (src / "api.ts").write_text('callable<[], A>("a");', encoding="utf-8")
+        (src / "utils" / "store.tsx").write_text('callable<[number], B>("b");', encoding="utf-8")
+        assert check.parse_frontend_callables(src) == {"a": 0, "b": 1}
+
+    def test_duplicate_name_marked_sentinel(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[], A>("dup");\ncallable<[number], B>("dup");')
+        assert check.parse_frontend_callables(src) == {"dup": -1}
+
+    def test_missing_src_returns_empty(self, tmp_path: Path):
+        assert check.parse_frontend_callables(tmp_path / "nope") == {}
+
+
+class TestParserHardening:
+    """Regression cases for the adversarial blind spots: TS comments, arrow-typed
+    args, trailing commas, and string-literal preservation of comment-like text.
+    Each test below fails against the pre-hardening parser."""
+
+    def test_comment_with_apostrophe_inside_generic(self, tmp_path: Path):
+        # A line comment carrying an apostrophe inside the multiline <...> block
+        # must not corrupt depth tracking — the callable is still captured.
+        body = textwrap.dedent(
+            """\
+            export const x = callable<
+              [number],
+              // it's a tricky comment
+              R
+            >("has_apostrophe");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        assert check.parse_frontend_callables(src) == {"has_apostrophe": 1}
+
+    def test_comment_with_brackets_and_angles_inside_generic(self, tmp_path: Path):
+        # A comment with an unbalanced bracket and a stray > must be ignored.
+        body = textwrap.dedent(
+            """\
+            export const y = callable<
+              [number, string],
+              // compares x > y and references app_ids[]
+              R
+            >("noisy_comment");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        assert check.parse_frontend_callables(src) == {"noisy_comment": 2}
+
+    def test_block_comment_inside_generic(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            export const z = callable<
+              [number, /* inline 's apostrophe, < > [ */ string],
+              R
+            >("block_comment");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        assert check.parse_frontend_callables(src) == {"block_comment": 2}
+
+    def test_real_shape_multiline_with_apostrophe_comment(self, tmp_path: Path):
+        # Mirrors the remove_platform_shortcuts declaration: a multiline generic
+        # whose Return carries inline comments with apostrophes.
+        body = textwrap.dedent(
+            """\
+            export const removePlatformShortcuts = callable<
+              [string],
+              {
+                success: boolean;
+                // The success path returns success/app_ids/rom_ids; the
+                // @migration_blocked gate short-circuits, so it's path-dependent.
+                app_ids?: number[];
+                rom_ids?: (string | number)[];
+                message?: string;
+              }
+            >("remove_platform_shortcuts");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        assert check.parse_frontend_callables(src) == {"remove_platform_shortcuts": 1}
+
+    def test_commented_out_declaration_not_counted(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            // const dead = callable<[number], R>("dead");
+            const live = callable<[], R>("alive");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        result = check.parse_frontend_callables(src)
+        assert "dead" not in result
+        assert result == {"alive": 0}
+
+    def test_block_commented_out_declaration_not_counted(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            /* const dead = callable<[number], R>("dead2"); */
+            const live = callable<[number], R>("alive2");
+            """
+        )
+        src = _write_ts(tmp_path, "a.ts", body)
+        result = check.parse_frontend_callables(src)
+        assert "dead2" not in result
+        assert result == {"alive2": 1}
+
+    def test_arrow_function_typed_arg_is_arity_one(self, tmp_path: Path):
+        # The > in => must not unbalance the generic's depth.
+        src = _write_ts(tmp_path, "a.ts", 'callable<[(a: number, b: number) => void], R>("arrow_arg");')
+        assert check.parse_frontend_callables(src) == {"arrow_arg": 1}
+
+    def test_trailing_comma_does_not_inflate_arity(self, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[number, string,], R>("trailing_comma");')
+        assert check.parse_frontend_callables(src) == {"trailing_comma": 2}
+
+    def test_comment_like_text_in_string_literal_preserved(self, tmp_path: Path):
+        # A // or /* inside a string literal is part of the string, NOT a comment.
+        src = _write_ts(tmp_path, "a.ts", 'callable<["http://x.com/*nope", number], R>("url_in_string");')
+        assert check.parse_frontend_callables(src) == {"url_in_string": 2}
+
+
+class TestParseBackendCallables:
+    def test_public_methods_with_arity(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def get_settings(self):
+                    ...
+                async def start_download(self, rom_id):
+                    ...
+                async def switch_slot(self, rom_id, new_slot):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {
+            "get_settings": 0,
+            "start_download": 1,
+            "switch_slot": 2,
+        }
+
+    def test_underscore_internal_excluded(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def _main(self):
+                    ...
+                async def _unload(self):
+                    ...
+                async def test_connection(self):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"test_connection": 0}
+
+    def test_default_param_counts_as_positional_slot(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def connect_with_credentials(self, url, user, pw, allow_insecure_ssl=None):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"connect_with_credentials": 4}
+
+    def test_vararg_method_has_none_arity_name_recorded(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def flexible(self, *args):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"flexible": None}
+
+    def test_sync_methods_ignored(self, tmp_path: Path):
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                def helper(self):
+                    ...
+                async def real_callable(self):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"real_callable": 0}
+
+    def test_no_plugin_class_returns_empty(self, tmp_path: Path):
+        main_py = _write_main(tmp_path, "class Other:\n    async def foo(self):\n        ...\n")
+        assert check.parse_backend_callables(main_py) == {}
+
+    def test_keyword_only_args_excluded_from_positional_arity(self, tmp_path: Path):
+        # ``*, c`` is keyword-only — a positional frontend tuple can't fill it,
+        # so arity counts only the positional params (a, b) -> 2.
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def m(self, a, b, *, c):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"m": 2}
+
+    def test_kwargs_only_yields_positional_arity(self, tmp_path: Path):
+        # **kwargs is not positional — the two positional params still count as 2.
+        body = textwrap.dedent(
+            """\
+            class Plugin:
+                async def m(self, a, b, **kwargs):
+                    ...
+            """
+        )
+        main_py = _write_main(tmp_path, body)
+        assert check.parse_backend_callables(main_py) == {"m": 2}
+
+
+class TestFindDiscrepancies:
+    def test_matching_surfaces_no_findings(self):
+        fe = {"a": 0, "b": 1}
+        be: dict[str, int | None] = {"a": 0, "b": 1}
+        assert check.find_discrepancies(fe, be, frozenset()) == []
+
+    def test_frontend_only_name_flagged(self):
+        findings = check.find_discrepancies({"a": 0, "ghost": 1}, {"a": 0}, frozenset())
+        assert len(findings) == 1
+        assert "ghost" in findings[0]
+        assert "no public" in findings[0]
+
+    def test_backend_only_name_flagged(self):
+        findings = check.find_discrepancies({"a": 0}, {"a": 0, "orphan": 1}, frozenset())
+        assert len(findings) == 1
+        assert "orphan" in findings[0]
+        assert "no frontend" in findings[0]
+
+    def test_arity_mismatch_shows_both_numbers(self):
+        findings = check.find_discrepancies({"f": 2}, {"f": 3}, frozenset())
+        assert len(findings) == 1
+        assert "arity mismatch" in findings[0]
+        assert "2 arg" in findings[0]
+        assert "takes 3" in findings[0]
+
+    def test_vararg_backend_skips_arity_check(self):
+        # Name matches; backend is *args (None) -> no arity finding.
+        assert check.find_discrepancies({"f": 5}, {"f": None}, frozenset()) == []
+
+    def test_duplicate_frontend_name_flagged(self):
+        findings = check.find_discrepancies({"dup": -1}, {"dup": 1}, frozenset())
+        assert any("more than once" in line for line in findings)
+
+    def test_exempt_name_not_flagged_for_presence(self):
+        # Frontend-only name, but EXEMPT -> no presence finding.
+        assert check.find_discrepancies({"a": 0, "fe_only": 1}, {"a": 0}, frozenset({"fe_only"})) == []
+
+
+class TestMainEntryPoint:
+    def test_help_flag_returns_zero(self, capsys: pytest.CaptureFixture[str]):
+        rc = check.main(["--help"])
+        assert rc == 0
+        assert "callable-manifest parity gate" in capsys.readouterr().out
+
+    def test_short_help_flag_returns_zero(self):
+        assert check.main(["-h"]) == 0
+
+    def test_real_repo_run_is_clean(self, capsys: pytest.CaptureFixture[str]):
+        # Locks the actual src/**/*.ts callable declarations in sync with the
+        # Plugin async methods in main.py. If this fails, a callable was
+        # added/renamed/removed on one side only, or an arity drifted.
+        rc = check.main([])
+        assert rc == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_drift_reports_and_returns_one(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[], A>("present");\ncallable<[number], B>("frontend_only");')
+        main_py = _write_main(
+            tmp_path,
+            "class Plugin:\n    async def present(self):\n        ...\n",
+        )
+        monkeypatch.setattr(check, "SRC_DIR", src)
+        monkeypatch.setattr(check, "MAIN_PY", main_py)
+        monkeypatch.setattr(check, "EXEMPT", frozenset())
+        rc = check.main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "frontend_only" in out
+        assert "ERROR:" in out
+
+    def test_in_sync_fake_repo_returns_zero(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        src = _write_ts(tmp_path, "a.ts", 'callable<[number], A>("match");')
+        main_py = _write_main(tmp_path, "class Plugin:\n    async def match(self, rom_id):\n        ...\n")
+        monkeypatch.setattr(check, "SRC_DIR", src)
+        monkeypatch.setattr(check, "MAIN_PY", main_py)
+        monkeypatch.setattr(check, "EXEMPT", frozenset())
+        assert check.main([]) == 0


### PR DESCRIPTION
## What

Phase 2 of the contract-test tier (#1027). Phase 1 (#1079) built the harness that drives the real callables; this pins the frontend↔backend callable **surface** so a renamed/added/removed callable or an arity drift breaks CI instead of a user's save files (the #1017/#1008 bug class).

## How

`scripts/check_callable_manifest.py` (stdlib-only, mirrors the `check_service_independence_contract.py` self-check pattern — no committed artifact, the parser is the single source of truth):

- derives the **frontend** surface from every `callable<[Args], Return>("name")` across `src/**/*.ts(x)` (one declaration lives outside `backend.ts`, in `utils/cachedGameDetailStore.ts` — picked up by the src-wide scan)
- derives the **backend** surface from the public `async def` methods on the `Plugin` class in `main.py` (AST, no import)
- fails on any divergence: a name on one side only (either direction), or a matching name whose **arity** (positional param count, `self` dropped) differs

Arg **types** are out of scope — Python method signatures carry no hints, so arity is the only mechanically checkable shape; the contract tier exercises types by driving real values. The current surface is clean: **99 callables, identical both ways**, `EXEMPT` empty.

The TS parser strips `//` and `/* */` comments (preserving `//`/`/*` inside string/template literals) and treats `=>` as an opaque token, so a comment or an arrow-function-typed arg inside a multiline `callable<...>` block can't silently drop a declaration from the manifest (a parser blind spot would make the parity a false match).

Runs standalone in CI (`mise run lint` + a CI step, next to the other self-checks) and is mirrored inside the pytest run by `tests/contract/test_callable_manifest.py`, which imports the same two parser functions and asserts live parity.

## Tests

41 unit tests in `tests/scripts/test_check_callable_manifest.py` (arity edge cases — nested generics, unions, object/arrow types, trailing comma; comment-hardening; backend AST extraction; drift detection proven non-vacuous) + the live-parity contract test.

## Docs

`CLAUDE.md` (Code-Quality self-check bullet + the Contract-tests section's Phase 2 paragraph flipped from "not built yet" to built), `docs/contributing/development.md`.

Closes #1027.
