### PR TITLE
fix(connection): bind stored token to its minting server origin (#1015, #1038, #1039)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,16 @@ silent omission. The CI check enforces this.
   event). See [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md).
 - **RomM minimum version**: Requires RomM >= 4.8.1. Hard-rejected in `test_connection()` — plugin is inert until server
   is updated. `_MIN_REQUIRED_VERSION` tuple in `main.py`.
+- **Token-host binding**: A Client API Token is bound to the server origin it was minted against
+  (`romm_api_token_origin` — canonical `scheme://host[:port]` via `lib/url_host`; `https://h` and `http://h` are
+  different origins). The bearer is sent only when `romm_url`'s origin matches; a mismatch raises
+  `TokenHostMismatchError` in `RommHttpAdapter.auth_header` (non-retryable → `config_error`, "sign in again"), so a
+  wrong/hostile host never receives the credential. Sign-in (`establish_token`) validates the URL, holds the candidate
+  URL in memory while probing (the old token is cleared in memory first so it never leaks to the candidate host), and
+  persists URL+SSL+token+id+origin in a single atomic save only on success — a failed sign-in restores the previous
+  working state, never clobbering disk. The old-token DELETE on re-auth is fired only when the old origin matches the
+  new one (#1038). A legacy token with origin `None` is un-bound: attached, never blocked, until the next sign-in stamps
+  it. See [ConnectionService notes](docs/architecture/backend-architecture.md#connectionservice-notes).
 - **Decky callables must be async**: Even if the method body is synchronous, Decky's callable framework requires
   `async def`. Do not remove `async` from callable methods in main.py.
 

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -123,7 +123,7 @@ the rest are single modules. A service over ~700 LOC is the decomposition signal
 | `metadata.py`             | MetadataService — ROM metadata reads from `rom_metadata` (7-day TTL), app_id mapping                                                                                                                                                                                                                                   |
 | `launch_gate.py`          | LaunchGateService — pre-launch gate (rom lookup, install check, save status)                                                                                                                                                                                                                                           |
 | `startup_healing.py`      | StartupHealingService — prunes stale `rom_installs` rows against disk on load (via the UoW) + reconciles orphaned `running` SyncRuns (a hard crash leaves a `running` row → marked errored)                                                                                                                            |
-| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials)                                                                                                                                                                                          |
+| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials, host-bound to the minting origin; see [ConnectionService notes](#connectionservice-notes))                                                                                               |
 | `protocols/`              | Protocol interfaces grouped by concern (see [Protocol Interfaces](#protocol-interfaces))                                                                                                                                                                                                                               |
 
 #### LibraryService decomposition (`services/library/`)
@@ -209,6 +209,38 @@ GameCube/Wii (Dolphin) are never bin/cue and do not reliably launch from a singl
 arrive as single-file downloads that never reach the extraction path, so they get no playlist.
 
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
+
+#### ConnectionService notes
+
+**A Client API Token is bound to the server it was minted against.** When the token is minted, the canonical origin of
+`romm_url` (full `scheme://host[:port]`, default ports folded out, path/query dropped — `lib/url_host.normalize_origin`)
+is stored alongside it as `romm_api_token_origin`. `RommHttpAdapter.auth_header()` attaches the bearer **only** when
+that stored origin matches the current `romm_url` origin; on a mismatch it raises `TokenHostMismatchError` instead of
+sending the credential to a host the token was not minted for. The error is non-retryable and maps to a `config_error`
+failure (`Your saved RomM login is for a different server. Sign in again to continue.`), so every data flow fails fast
+until the user re-signs-in. `https://h` and `http://h` are deliberately **different** origins — a plaintext downgrade is
+a different destination, not the same one. A legacy token minted before origin stamping carries
+`romm_api_token_origin =
+None` and is treated as un-bound: it is still attached (never blocked) so existing installs
+keep working until their next sign-in stamps the origin.
+
+**Sign-in ordering: validate → probe → mint → persist (one atomic save).** `establish_token` trims the entered URL and
+rejects a non-http(s) value before any network call. It then holds the candidate URL in memory only — clearing the
+stored token in memory first so the version probe never carries the old server's bearer to the candidate host — and
+persists nothing until the mint succeeds. On any failure (probe unreachable, version too old, forbidden/error mint, no
+usable token, or a disk error) the in-memory auth state is rolled back to the previous working URL + token, and because
+disk was never touched the prior working credentials survive a failed sign-in. Only a successful mint commits
+`romm_url` + SSL flag + token + id + origin to disk in a single `save_settings()` call.
+
+**The old-token DELETE is origin-guarded.** RomM scopes a Client API Token to the account, and re-auth deletes the
+device's previous token. That DELETE is only fired when the old token's stored origin matches the new URL's origin
+(same-server re-auth) — replaying it against a different server would delete an unrelated token there, so the DELETE is
+skipped (and logged) when the origins differ or the old origin is unknown. The DELETE uses Basic auth from the one-time
+credentials, unaffected by the cleared bearer.
+
+The no-sign-in URL change path (`SettingsService.save_server_url`) deliberately does not touch the token, so pointing
+the URL at a different origin leaves the stored token's origin mismatched and the auth-header guard makes subsequent
+data flows fail fast with `config_error` until the user signs in again.
 
 **Server-supplied paths are validated, fail-stop on traversal**: every server-supplied path component — the firmware
 `file_name`, the ROM platform slug, and post-extraction URL-decoded ZIP member names — is checked through

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -13,7 +13,7 @@ import logging
 import os
 from typing import Any
 
-_SETTINGS_VERSION = 7
+_SETTINGS_VERSION = 8
 _LOCK_EXT = ".lock"
 
 DEFAULT_SETTINGS: dict[str, Any] = {
@@ -22,6 +22,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "romm_pass": "",
     "romm_api_token": None,
     "romm_api_token_id": None,
+    "romm_api_token_origin": None,
     "enabled_platforms": {},
     "enabled_collections": {"user": {}, "smart": {}, "franchise": {}},
     "collection_create_platform_groups": False,

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -29,7 +29,9 @@ from lib.errors import (
     RommServerError,
     RommSSLError,
     RommTimeoutError,
+    TokenHostMismatchError,
 )
+from lib.url_host import same_origin
 
 
 class RommHttpAdapter:
@@ -117,13 +119,26 @@ class RommHttpAdapter:
     def auth_header(self) -> str | None:
         """Bearer auth header value, or ``None`` when no Client API Token is stored.
 
+        The token is host-bound: it is sent only to the server it was minted
+        against. When a token is stored together with its minting origin
+        (``romm_api_token_origin``) and that origin no longer matches the
+        current ``romm_url`` origin, a :class:`TokenHostMismatchError` is raised
+        instead of leaking the bearer to a wrong/hostile host (#1039). A legacy
+        token minted before origin stamping (origin ``None``) is still attached,
+        so existing installs keep working until their next sign-in stamps it.
+
         Returning ``None`` lets callers omit the ``Authorization`` header on
         unauthenticated probes (fresh setup, before a token is minted). An empty
         ``Bearer `` value is malformed and some RomM versions 500 on it, which
         would deadlock first-time connection setup.
         """
         token = self._settings.get("romm_api_token") or ""
-        return f"Bearer {token}" if token else None
+        if not token:
+            return None
+        origin = self._settings.get("romm_api_token_origin")
+        if origin is not None and not same_origin(origin, self._settings.get("romm_url")):
+            raise TokenHostMismatchError("Stored token was minted for a different server than the configured URL")
+        return f"Bearer {token}"
 
     def _apply_default_headers(self, req: urllib.request.Request) -> None:
         """Attach the standard outgoing headers: ``User-Agent`` always, and
@@ -195,6 +210,8 @@ class RommHttpAdapter:
     @staticmethod
     def is_retryable(exc: Exception) -> bool:
         """Check if an exception is a transient error worth retrying."""
+        # TokenHostMismatchError is intentionally absent: a wrong-origin token
+        # can never become right by retrying, so with_retry re-raises it at once.
         if isinstance(exc, RommServerError | RommConnectionError | RommTimeoutError):
             return True
         # Backward compat for non-RomM exceptions

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -29,6 +29,8 @@ def migrate_settings(data: dict[str, Any]) -> dict[str, Any]:
         new_data = _migrate_v5_to_v6(new_data)
     if version < 7:
         new_data = _migrate_v6_to_v7(new_data)
+    if version < 8:
+        new_data = _migrate_v7_to_v8(new_data)
     return new_data
 
 
@@ -191,4 +193,18 @@ def _migrate_v6_to_v7(data: dict[str, Any]) -> dict[str, Any]:
     """
     data.setdefault("platform_cores", {})
     data["version"] = 7
+    return data
+
+
+def _migrate_v7_to_v8(data: dict[str, Any]) -> dict[str, Any]:
+    """v<8 → v8: seed the token's minting origin slot.
+
+    Introduces ``romm_api_token_origin`` as a ``None`` placeholder so
+    post-migration reads find the key. ``None`` means "origin unknown" — a
+    token minted before host-binding — and is treated as legacy by the auth
+    guard (still attached, never blocked). The origin is stamped on the next
+    sign-in; no existing token's origin is inferred here.
+    """
+    data.setdefault("romm_api_token_origin", None)
+    data["version"] = 8
     return data

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -91,6 +91,15 @@ class RommUnsupportedError(RommApiError):
         )
 
 
+class TokenHostMismatchError(RommApiError):
+    """Stored token's minting origin does not match the current ``romm_url``.
+
+    Raised before any request carries the bearer token to a host the token was
+    not minted for, so the credential never leaks to a wrong/hostile server.
+    Non-retryable: replaying it cannot succeed, only re-signing-in can.
+    """
+
+
 def classify_error(exc):
     """Return ``(reason, user_friendly_message)`` for an exception.
 
@@ -129,6 +138,8 @@ def classify_error(exc):
         return ErrorCode.NOT_FOUND.value, "Resource not found on server"
     if isinstance(exc, RommUnsupportedError):
         return ErrorCode.UNSUPPORTED.value, f"This feature requires RomM {exc.min_version} or newer"
+    if isinstance(exc, TokenHostMismatchError):
+        return "config_error", "Your saved RomM login is for a different server. Sign in again to continue."
     if isinstance(exc, RommApiError):
         return ErrorCode.SERVER_UNREACHABLE.value, str(exc)
     return ErrorCode.UNKNOWN.value, str(exc)

--- a/py_modules/lib/url_host.py
+++ b/py_modules/lib/url_host.py
@@ -1,0 +1,77 @@
+"""Canonical server-origin derivation and comparison for server-identity binding.
+
+A stored Client API Token is minted against one RomM server and must never be
+replayed against another. The comparison key is the **full origin** — scheme,
+host, and (non-default) port — so this module turns an arbitrary user-entered
+URL into that canonical key and answers whether two URLs name the same server.
+``https://h`` and ``http://h`` are deliberately distinct origins: a downgrade to
+plaintext is a different (and hostile) destination, not the same one.
+
+Anything that needs to decide "is this URL the same server as that one?" or
+"is this a usable http(s) server URL?" belongs here. Stdlib-only (``urllib``);
+no I/O, no network — purely lexical normalization.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def normalize_origin(url: str) -> str | None:
+    """Return the canonical ``scheme://host[:port]`` origin of *url*, or ``None``.
+
+    Scheme and host are lowercased; the default port for the scheme (``443``
+    for https, ``80`` for http) is folded out; any path, query, fragment, or
+    trailing slash is dropped. An IPv6 literal keeps its brackets
+    (``https://[::1]:8080``) and a trailing FQDN root dot is normalized away
+    (``host.com.`` → ``host.com``), so the result always re-parses through this
+    function unchanged. Returns ``None`` when *url* has no scheme, no host, or a
+    scheme other than ``http`` / ``https`` — i.e. it is not a usable server
+    origin and cannot serve as a comparison key.
+    """
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        return None
+    scheme = parts.scheme.lower()
+    if scheme not in _DEFAULT_PORTS:
+        return None
+    host = (parts.hostname or "").lower()
+    if not host:
+        return None
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    # urlsplit().hostname strips IPv6 brackets and never trims the FQDN root dot.
+    # Re-bracket an IPv6 literal (any host containing ``:``) so the origin
+    # re-parses, and drop a single trailing dot so ``host.com.`` == ``host.com``.
+    host = host.rstrip(".") or host
+    host_part = f"[{host}]" if ":" in host else host
+    if port is None or port == _DEFAULT_PORTS[scheme]:
+        return f"{scheme}://{host_part}"
+    return f"{scheme}://{host_part}:{port}"
+
+
+def same_origin(a: str | None, b: str | None) -> bool:
+    """Return True iff *a* and *b* normalize to the same non-``None`` origin.
+
+    A ``None`` (or otherwise unparseable) origin on either side is never equal
+    to anything — fail closed: an unknown origin is not "the same server".
+    """
+    origin_a = normalize_origin(a) if a is not None else None
+    origin_b = normalize_origin(b) if b is not None else None
+    return origin_a is not None and origin_a == origin_b
+
+
+def is_valid_server_url(url: str) -> bool:
+    """Return True iff *url* (after stripping surrounding whitespace) names an http(s) origin.
+
+    The validation guard for user-entered server URLs: a value is valid when it
+    carries an ``http`` / ``https`` scheme and a host. Path / port / query are
+    allowed (they are dropped by :func:`normalize_origin`); a scheme-less,
+    hostless, or non-http(s) value is rejected.
+    """
+    return normalize_origin(url.strip()) is not None

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from domain.version import meets_min_version
 from lib.errors import RommForbiddenError, error_response
 from lib.list_result import ErrorCode
+from lib.url_host import is_valid_server_url, normalize_origin, same_origin
 
 if TYPE_CHECKING:
     import asyncio
@@ -115,36 +116,58 @@ class ConnectionService:
     ) -> dict[str, Any]:
         """Mint a Client API Token from one-time credentials and store it.
 
-        Writes the server URL (and optional SSL flag), confirms the
-        server is reachable and recent enough, deletes any token this
-        device previously minted, mints a fresh scoped token, and
-        persists ``romm_api_token`` / ``romm_api_token_id``. The
-        username/password are never persisted. Returns the same
-        ``success`` / ``reason`` / ``message`` shape as
-        :meth:`test_connection`.
+        Validates the server URL, probes the server, and only on a successful
+        mint commits ``romm_url`` / SSL flag / token / id / minting origin to
+        disk in a single atomic save. Nothing is persisted before the mint
+        succeeds, so a failed sign-in leaves the previous working URL and token
+        untouched (#1015). The candidate URL is held only in memory while
+        probing, and the old token is cleared in memory first so it never
+        leaks to the candidate host (#1039). The username/password are never
+        persisted. Returns the same ``success`` / ``reason`` / ``message``
+        shape as :meth:`test_connection`.
         """
         if not romm_url:
             return {"success": False, "reason": "config_error", "message": "No server URL configured"}
+        trimmed = romm_url.strip()
+        if not is_valid_server_url(trimmed):
+            return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
 
-        self._settings["romm_url"] = romm_url
+        snapshot = self._snapshot_auth_state()
+        old_token_id = snapshot["romm_api_token_id"]
+        old_token_origin = snapshot["romm_api_token_origin"]
+
+        # Hold the candidate URL in memory only; clear the stored token so the
+        # version probe never carries the old server's bearer to this host (and
+        # the auth-header origin guard stays quiet during sign-in).
+        self._settings["romm_url"] = trimmed
         if allow_insecure_ssl is not None:
             self._settings["romm_allow_insecure_ssl"] = bool(allow_insecure_ssl)
-        try:
-            self._settings_persister.save_settings()
-        except Exception as e:
-            return error_response(e)
+        self._settings["romm_api_token"] = None
+        self._settings["romm_api_token_id"] = None
+        self._settings["romm_api_token_origin"] = None
 
         try:
             version = await self._loop.run_in_executor(None, self._probe_version)
         except Exception as e:
+            self._restore_auth_state(snapshot)
             self._romm_api.set_version(None)
             return error_response(e)
 
         version_error = self._version_gate_error(version)
         if version_error is not None:
+            self._restore_auth_state(snapshot)
             return version_error
 
-        await self._delete_existing_token(username, password)
+        # #1038: only replay the DELETE against the same server the old token
+        # was minted on. A different (or unknown) origin would delete an
+        # unrelated token on the new host, so skip it.
+        if old_token_id is not None and same_origin(old_token_origin, trimmed):
+            await self._delete_existing_token(username, password, old_token_id)
+        elif old_token_id is not None:
+            self._logger.info(
+                "Previous token was minted for a different/unknown server; "
+                "skipping DELETE to avoid replaying it against the current server"
+            )
 
         try:
             minted = await self._loop.run_in_executor(None, self._mint, username, password)
@@ -152,13 +175,16 @@ class ConnectionService:
             # 403 on token mint: same AUTH_FAILED slug as a 401, but a distinct
             # message — the account lacks token-creation permission (or a
             # Cloudflare bot-fight 403 at the edge), not wrong credentials.
+            self._restore_auth_state(snapshot)
             return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _FORBIDDEN_TOKEN_MESSAGE}
         except Exception as e:
+            self._restore_auth_state(snapshot)
             return error_response(e)
 
         raw_token = minted.get("raw_token")
         token_id = minted.get("id")
         if not raw_token or token_id is None:
+            self._restore_auth_state(snapshot)
             return {
                 "success": False,
                 "reason": ErrorCode.SERVER_UNREACHABLE.value,
@@ -166,8 +192,9 @@ class ConnectionService:
             }
 
         try:
-            self._persist_token(raw_token, token_id)
+            self._persist_token(raw_token, token_id, origin=normalize_origin(trimmed))
         except Exception as e:
+            self._restore_auth_state(snapshot)
             return error_response(e)
 
         return self._success_result(version)
@@ -201,7 +228,7 @@ class ConnectionService:
             return
 
         try:
-            self._persist_token(raw_token, token_id)
+            self._persist_token(raw_token, token_id, origin=normalize_origin(self._settings.get("romm_url") or ""))
         except Exception as e:
             self._logger.warning(f"Legacy credential migration failed: {e}")
             return
@@ -209,15 +236,38 @@ class ConnectionService:
 
     # ── Internal helpers ─────────────────────────────────────────────────
 
-    def _persist_token(self, raw_token: str, token_id: int) -> None:
+    _AUTH_STATE_KEYS = (
+        "romm_url",
+        "romm_allow_insecure_ssl",
+        "romm_api_token",
+        "romm_api_token_id",
+        "romm_api_token_origin",
+    )
+
+    def _snapshot_auth_state(self) -> dict[str, Any]:
+        """Capture the in-memory auth-relevant settings for restore-on-failure."""
+        return {key: self._settings.get(key) for key in self._AUTH_STATE_KEYS}
+
+    def _restore_auth_state(self, snapshot: dict[str, Any]) -> None:
+        """Restore the in-memory auth-relevant settings from *snapshot*.
+
+        Disk is untouched (no ``save_settings``), so a failed sign-in rolls the
+        live dict back to the previous working URL + token without clobbering
+        the on-disk state.
+        """
+        for key, value in snapshot.items():
+            self._settings[key] = value
+
+    def _persist_token(self, raw_token: str, token_id: int, *, origin: str | None) -> None:
         """Persist a freshly minted token and retire the legacy credentials.
 
-        Stores the token + its id, drops any stored ``romm_user`` /
-        ``romm_pass`` (a token fully supersedes them — nothing reads the
-        stored credentials at runtime once a token exists), and saves.
+        Stores the token + its id + its minting *origin*, drops any stored
+        ``romm_user`` / ``romm_pass`` (a token fully supersedes them — nothing
+        reads the stored credentials at runtime once a token exists), and saves.
         """
         self._settings["romm_api_token"] = raw_token
         self._settings["romm_api_token_id"] = token_id
+        self._settings["romm_api_token_origin"] = origin
         self._settings.pop("romm_user", None)
         self._settings.pop("romm_pass", None)
         self._settings_persister.save_settings()
@@ -267,17 +317,16 @@ class ConnectionService:
             result["romm_version"] = version
         return result
 
-    async def _delete_existing_token(self, username: str, password: str) -> None:
-        """Best-effort delete of a token this device previously minted.
+    async def _delete_existing_token(self, username: str, password: str, token_id: int) -> None:
+        """Best-effort delete of the token this device previously minted on this server.
 
-        Runs on the executor thread. Failures are logged and swallowed so
-        re-establishing auth never fails on a stale-token cleanup.
+        Runs on the executor thread via Basic auth (unaffected by the cleared
+        bearer). Failures are logged and swallowed so re-establishing auth
+        never fails on a stale-token cleanup. The caller is responsible for the
+        same-origin guard (#1038) — this only fires the request.
         """
-        old_id = self._settings.get("romm_api_token_id")
-        if old_id is None:
-            return
         try:
-            await self._loop.run_in_executor(None, self._delete, username, password, old_id)
+            await self._loop.run_in_executor(None, self._delete, username, password, token_id)
         except Exception as e:
             self._logger.warning(f"Failed to delete previous Client API Token: {e}")
 

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from lib.list_result import ErrorCode
+from lib.url_host import is_valid_server_url
 
 if TYPE_CHECKING:
     import logging
@@ -62,14 +63,24 @@ class SettingsService:
     # ── Server connection settings ───────────────────────────────────────
 
     def save_server_url(self, romm_url: str, allow_insecure_ssl: bool | None = None) -> dict[str, Any]:
-        """Persist the server URL and optional SSL flag.
+        """Persist the trimmed server URL and optional SSL flag.
 
+        Rejects a blank or non-http(s) URL without writing anything.
         Credentials and tokens are never touched here — minting and
         storing the Client API Token is ``ConnectionService``'s job.
         ``allow_insecure_ssl=None`` leaves the SSL flag unchanged.
+
+        This path deliberately does not re-stamp the stored token's origin, so
+        pointing the URL at a different origin leaves the token's origin
+        mismatched — the auth-header guard then fails data flows fast with
+        ``config_error`` until the user signs in again (the intended #1039
+        behavior for the no-sign-in URL-change path).
         """
+        trimmed = romm_url.strip()
+        if not is_valid_server_url(trimmed):
+            return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
         try:
-            self._settings["romm_url"] = romm_url
+            self._settings["romm_url"] = trimmed
             if allow_insecure_ssl is not None:
                 self._settings["romm_allow_insecure_ssl"] = bool(allow_insecure_ssl)
             self._settings_persister.save_settings()

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -500,6 +500,37 @@ describe("SettingsPage", () => {
       expect(pendingEdits.url).toBeUndefined();
     });
 
+    it("rejects an invalid URL inline without calling saveServerUrl", async () => {
+      vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      const conn = capturedConnection[capturedConnection.length - 1];
+
+      await act(async () => {
+        conn?.onUrlChange("romm.local"); // no scheme
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.saveServerUrl)).not.toHaveBeenCalled();
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
+        "Enter a valid http:// or https:// server URL",
+      );
+    });
+
+    it("trims the URL before persisting", async () => {
+      vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      const conn = capturedConnection[capturedConnection.length - 1];
+
+      await act(async () => {
+        conn?.onUrlChange("  https://new.url  ");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.saveServerUrl)).toHaveBeenCalledWith("https://new.url", false);
+    });
+
     it("does not delete the pending URL edit when saveServerUrl rejects (status fallback wired)", async () => {
       vi.mocked(backend.saveServerUrl).mockRejectedValue(new Error("nope"));
       pendingEdits.url = "draft";
@@ -601,6 +632,26 @@ describe("SettingsPage", () => {
       const conn = capturedConnection[capturedConnection.length - 1];
       expect(conn?.status).toBe("This account cannot create API tokens.");
       expect(conn?.hasToken).toBe(false);
+    });
+
+    it("rejects an invalid URL inline without calling connectWithCredentials", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        romm_url: "romm.local", // scheme-less — invalid
+        has_token: false,
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnect("daniel", "hunter2");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.connectWithCredentials)).not.toHaveBeenCalled();
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
+        "Enter a valid http:// or https:// server URL",
+      );
     });
 
     it("sets status='Sign-in failed' when connectWithCredentials throws", async () => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -31,6 +31,7 @@ import {
 } from "../utils/saveSortMigrationStore";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
+import { trimServerUrl, isValidServerUrl } from "../utils/serverUrl";
 import type { SaveSyncSettings as SaveSyncSettingsType, RetroArchInputCheck } from "../types";
 import { pendingEdits } from "./settings/TextInputModal";
 import { SaveSortMigrationSection } from "./settings/SaveSortMigrationSection";
@@ -267,9 +268,14 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
 
   // --- Connection handlers wired into ConnectionSection ---
   const handleUrlChange = async (value: string) => {
-    setUrl(value);
+    const trimmed = trimServerUrl(value);
+    setUrl(trimmed);
+    if (!isValidServerUrl(trimmed)) {
+      setStatus("Enter a valid http:// or https:// server URL");
+      return;
+    }
     try {
-      await saveServerUrl(value, allowInsecureSsl);
+      await saveServerUrl(trimmed, allowInsecureSsl);
       delete pendingEdits.url;
     } catch {
       setStatus("Failed to save settings");
@@ -284,8 +290,13 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   };
   const handleConnect = async (username: string, password: string) => {
     setStatus("");
+    const trimmed = trimServerUrl(url);
+    if (!isValidServerUrl(trimmed)) {
+      setStatus("Enter a valid http:// or https:// server URL");
+      return;
+    }
     try {
-      const result = await connectWithCredentials(url, username, password, allowInsecureSsl);
+      const result = await connectWithCredentials(trimmed, username, password, allowInsecureSsl);
       setStatus(result.message);
       if (result.success) {
         setHasToken(true);

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -186,6 +186,17 @@ describe("ConnectionSection", () => {
       expect(toggleCaptured.items).toHaveLength(1);
     });
 
+    it("trims a leading space so a padded https URL still shows the toggle", () => {
+      // Regression: untrimmed startsWith("https") hid the toggle for "  https://...".
+      render(<ConnectionSection {...defaultProps({ url: "  https://romm.local" })} />);
+      expect(toggleCaptured.items).toHaveLength(1);
+    });
+
+    it("stays hidden for a padded http URL", () => {
+      render(<ConnectionSection {...defaultProps({ url: "  http://romm.local" })} />);
+      expect(toggleCaptured.items).toHaveLength(0);
+    });
+
     it("reflects allowInsecureSsl in checked state", () => {
       render(<ConnectionSection {...defaultProps({ url: "https://romm.local", allowInsecureSsl: true })} />);
       expect(toggleCaptured.items[0]?.checked).toBe(true);

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -9,6 +9,7 @@ import { FC } from "react";
 import { PanelSection, PanelSectionRow, ButtonItem, DialogButton, Field, showModal, ToggleField } from "@decky/ui";
 import { TextInputModal } from "./TextInputModal";
 import { ConnectModal } from "./ConnectModal";
+import { isHttpsUrl } from "../../utils/serverUrl";
 
 interface ConnectionSectionProps {
   url: string;
@@ -57,7 +58,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
           </DialogButton>
         </Field>
       </PanelSectionRow>
-      {url.toLowerCase().startsWith("https") && (
+      {isHttpsUrl(url) && (
         <PanelSectionRow>
           <ToggleField
             label="Allow Insecure SSL"

--- a/src/utils/serverUrl.test.ts
+++ b/src/utils/serverUrl.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { trimServerUrl, isValidServerUrl, isHttpsUrl } from "./serverUrl";
+
+describe("trimServerUrl", () => {
+  it("strips surrounding whitespace", () => {
+    expect(trimServerUrl("  https://romm.local  ")).toBe("https://romm.local");
+  });
+
+  it("leaves a clean URL unchanged", () => {
+    expect(trimServerUrl("https://romm.local")).toBe("https://romm.local");
+  });
+
+  it("strips tabs and newlines", () => {
+    expect(trimServerUrl("\t https://romm.local \n")).toBe("https://romm.local");
+  });
+});
+
+describe("isValidServerUrl", () => {
+  it.each(["http://romm.local", "https://romm.local", "https://romm.local:8443/romm", "  http://romm.local  "])(
+    "accepts %s",
+    (url) => {
+      expect(isValidServerUrl(url)).toBe(true);
+    },
+  );
+
+  it.each(["romm.local", "ftp://romm.local", "", "   ", "https://", "http://"])("rejects %s", (url) => {
+    expect(isValidServerUrl(url)).toBe(false);
+  });
+
+  it("is case-insensitive on the scheme", () => {
+    expect(isValidServerUrl("HTTPS://romm.local")).toBe(true);
+  });
+});
+
+describe("isHttpsUrl", () => {
+  it("is true for https URLs", () => {
+    expect(isHttpsUrl("https://romm.local")).toBe(true);
+  });
+
+  it("is false for http URLs", () => {
+    expect(isHttpsUrl("http://romm.local")).toBe(false);
+  });
+
+  it("trims before checking, so a leading space does not hide it", () => {
+    expect(isHttpsUrl("  https://romm.local")).toBe(true);
+  });
+
+  it("is false for empty input", () => {
+    expect(isHttpsUrl("")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isHttpsUrl("HTTPS://romm.local")).toBe(true);
+  });
+});

--- a/src/utils/serverUrl.ts
+++ b/src/utils/serverUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * Client-side RomM server-URL validation + normalization.
+ *
+ * Mirrors the backend `lib.url_host` guard: a usable server URL carries an
+ * `http://` or `https://` scheme. The frontend trims and rejects scheme-less /
+ * empty input before calling the backend so a bad URL never reaches a network
+ * round-trip (and a leading space never hides the "Allow Insecure SSL" toggle).
+ */
+
+/** Trim surrounding whitespace from a user-entered server URL. */
+export function trimServerUrl(url: string): string {
+  return url.trim();
+}
+
+/** True iff the trimmed *url* starts with an `http://` or `https://` scheme. */
+export function isValidServerUrl(url: string): boolean {
+  const trimmed = trimServerUrl(url);
+  return /^https?:\/\/.+/i.test(trimmed);
+}
+
+/** True iff the trimmed *url* is an `https://` URL (drives the SSL toggle visibility). */
+export function isHttpsUrl(url: string): boolean {
+  return trimServerUrl(url).toLowerCase().startsWith("https://");
+}

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -22,6 +22,7 @@ from lib.errors import (
     RommServerError,
     RommSSLError,
     RommTimeoutError,
+    TokenHostMismatchError,
 )
 
 # conftest.py patches decky before this import
@@ -160,6 +161,55 @@ class TestRommAuthHeader:
         plugin.settings["romm_api_token"] = None
         header = plugin._http_adapter.auth_header()
         assert header is None
+
+    def test_attaches_token_when_origin_none_legacy(self, plugin):
+        """A token minted before host-binding (origin None) is still attached — never blocked."""
+        plugin.settings["romm_url"] = "https://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_legacy"
+        plugin.settings["romm_api_token_origin"] = None
+        assert plugin._http_adapter.auth_header() == "Bearer rmm_legacy"
+
+    def test_attaches_token_when_origin_matches(self, plugin):
+        plugin.settings["romm_url"] = "https://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_bound"
+        plugin.settings["romm_api_token_origin"] = "https://romm.local"
+        assert plugin._http_adapter.auth_header() == "Bearer rmm_bound"
+
+    def test_origin_match_folds_default_port_and_path(self, plugin):
+        """The bound origin equals the current URL even with a default port / path."""
+        plugin.settings["romm_url"] = "https://romm.local:443/romm/"
+        plugin.settings["romm_api_token"] = "rmm_bound"
+        plugin.settings["romm_api_token_origin"] = "https://romm.local"
+        assert plugin._http_adapter.auth_header() == "Bearer rmm_bound"
+
+    def test_raises_on_origin_mismatch(self, plugin):
+        """#1039: the bearer is never sent to a host the token was not minted for."""
+        plugin.settings["romm_url"] = "https://evil.host"
+        plugin.settings["romm_api_token"] = "rmm_bound"
+        plugin.settings["romm_api_token_origin"] = "https://romm.local"
+        with pytest.raises(TokenHostMismatchError):
+            plugin._http_adapter.auth_header()
+
+    def test_raises_on_scheme_downgrade(self, plugin):
+        """http vs https are different origins — a downgrade is a mismatch."""
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_bound"
+        plugin.settings["romm_api_token_origin"] = "https://romm.local"
+        with pytest.raises(TokenHostMismatchError):
+            plugin._http_adapter.auth_header()
+
+    def test_no_raise_without_token_even_if_origin_set(self, plugin):
+        """No token → no header, no raise (the guard only applies when a token exists)."""
+        plugin.settings["romm_url"] = "https://evil.host"
+        plugin.settings.pop("romm_api_token", None)
+        plugin.settings["romm_api_token_origin"] = "https://romm.local"
+        assert plugin._http_adapter.auth_header() is None
+
+
+class TestTokenHostMismatchRetry:
+    def test_token_host_mismatch_is_not_retryable(self):
+        """A wrong-origin token can never succeed by retrying — must stay non-retryable."""
+        assert RommHttpAdapter.is_retryable(TokenHostMismatchError("mismatch")) is False
 
 
 class TestRommBasicAuthRequest:

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -82,12 +82,13 @@ class TestLocking:
 class TestSettingsSchema:
     """Schema-level expectations for the settings defaults + version stamp."""
 
-    def test_settings_version_is_7(self):
-        assert _SETTINGS_VERSION == 7
+    def test_settings_version_is_8(self):
+        assert _SETTINGS_VERSION == 8
 
     def test_default_settings_carry_token_slots(self):
         assert DEFAULT_SETTINGS["romm_api_token"] is None
         assert DEFAULT_SETTINGS["romm_api_token_id"] is None
+        assert DEFAULT_SETTINGS["romm_api_token_origin"] is None
 
     def test_default_settings_carry_empty_platform_cores(self):
         assert DEFAULT_SETTINGS["platform_cores"] == {}
@@ -96,6 +97,7 @@ class TestSettingsSchema:
         result = adapter.load_settings()
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
+        assert result["romm_api_token_origin"] is None
 
 
 class TestVersionStampingOnSave:
@@ -105,7 +107,7 @@ class TestVersionStampingOnSave:
         with open(settings_path) as f:
             loaded = json.load(f)
         assert loaded["version"] == _SETTINGS_VERSION
-        assert loaded["version"] == 7
+        assert loaded["version"] == 8
 
 
 # ── Loading edge cases ─────────────────────────────────────────────────────────

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -5,6 +5,7 @@ from typing import Any
 from domain.state_migrations import (
     _migrate_v5_to_v6,
     _migrate_v6_to_v7,
+    _migrate_v7_to_v8,
     fold_legacy_save_sync_settings,
     migrate_settings,
 )
@@ -16,28 +17,28 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
         assert "disable_steam_input" not in result
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_disable_steam_input_false(self):
         data = {"version": 0, "disable_steam_input": False}
         result = migrate_settings(data)
         assert "disable_steam_input" not in result
         assert "steam_input_mode" not in result  # False → no override set
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_debug_logging_true(self):
         data = {"version": 0, "debug_logging": True}
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_debug_logging_false(self):
         data = {"version": 0, "debug_logging": False}
         result = migrate_settings(data)
         assert "debug_logging" not in result
         assert "log_level" not in result  # False → no log_level override set
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_both_deprecated(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -46,48 +47,51 @@ class TestMigrateSettings:
         assert result["log_level"] == "debug"
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_no_deprecated_keys(self):
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_url"] == "http://example.com"
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v3_advances_through_token_seeding(self):
-        """v3 → v7: version stamp advances and the token slots are seeded.
+        """v3 → v8: version stamp advances and the token slots are seeded.
 
         The cross-file save-sync fold (v3 → v4) is orchestrated in
         bootstrap, not here, so this step only bumps the version; the
         v4 → v5 step seeds the two ``romm_api_token*`` placeholders; the
         v5 → v6 step is a no-op here because no token is set; the v6 → v7
-        step seeds the empty ``platform_cores`` map.
+        step seeds the empty ``platform_cores`` map; the v7 → v8 step seeds
+        the ``romm_api_token_origin`` slot.
         """
         data = {"version": 3, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 7,
+            "version": 8,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
             "romm_api_token_id": None,
             "platform_cores": {},
+            "romm_api_token_origin": None,
         }
 
     def test_migrate_settings_v4_seeds_token_slots(self):
         data = {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 7,
+            "version": 8,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
             "romm_api_token_id": None,
             "platform_cores": {},
+            "romm_api_token_origin": None,
         }
 
     def test_migrate_settings_v5_only_bumps_version(self):
-        """v5 → v7 with a token but no legacy creds advances the version + seeds platform_cores."""
+        """v5 → v8 with a token but no legacy creds advances the version + seeds the new slots."""
         data = {
             "version": 5,
             "romm_url": "http://example.com",
@@ -97,16 +101,17 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 7,
+            "version": 8,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {},
+            "romm_api_token_origin": None,
         }
 
     def test_migrate_settings_v6_seeds_platform_cores(self):
-        """v6 → v7 seeds the empty per-platform core map and bumps the version."""
+        """v6 → v8 seeds the per-platform core map + token origin and bumps the version."""
         data = {
             "version": 6,
             "romm_url": "http://example.com",
@@ -116,15 +121,17 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 7,
+            "version": 8,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {},
+            "romm_api_token_origin": None,
         }
 
-    def test_migrate_settings_v7_no_change(self):
+    def test_migrate_settings_v7_seeds_token_origin(self):
+        """v7 → v8 seeds the ``romm_api_token_origin`` slot and bumps the version."""
         data = {
             "version": 7,
             "romm_url": "http://example.com",
@@ -132,6 +139,27 @@ class TestMigrateSettings:
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {"snes": "bsnes"},
+        }
+        result = migrate_settings(data)
+        assert result == {
+            "version": 8,
+            "romm_url": "http://example.com",
+            "log_level": "warn",
+            "romm_api_token": "rmm_existing",
+            "romm_api_token_id": 7,
+            "platform_cores": {"snes": "bsnes"},
+            "romm_api_token_origin": None,
+        }
+
+    def test_migrate_settings_v8_no_change(self):
+        data = {
+            "version": 8,
+            "romm_url": "http://example.com",
+            "log_level": "warn",
+            "romm_api_token": "rmm_existing",
+            "romm_api_token_id": 7,
+            "platform_cores": {"snes": "bsnes"},
+            "romm_api_token_origin": "http://example.com",
         }
         result = migrate_settings(data)
         assert result == data
@@ -142,7 +170,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] == "rmm_keep"
         assert result["romm_api_token_id"] == 3
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_v0_to_v5_seeds_token_slots(self):
         """A pre-versioning file runs the whole chain and ends with token slots."""
@@ -150,12 +178,12 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_fresh_empty(self):
         data = {}
         result = migrate_settings(data)
-        assert result["version"] == 7
+        assert result["version"] == 8
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
 
@@ -163,7 +191,7 @@ class TestMigrateSettings:
         data = {"romm_url": "http://example.com", "disable_steam_input": True}
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_debug_logging_true_overrides_log_level(self):
         """When debug_logging=True is being migrated, log_level is set to 'debug' unconditionally.
@@ -175,7 +203,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_migrate_settings_idempotent(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -198,7 +226,7 @@ class TestMigrateSettingsV5Token:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_idempotent_across_two_runs(self):
         data = {"version": 4, "romm_url": "x"}
@@ -273,7 +301,7 @@ class TestMigrateSettingsV6LegacyCredentials:
         """
         data = {"version": 4, "romm_url": "http://example.com", "romm_user": "alice", "romm_pass": "secret"}
         result = migrate_settings(data)
-        assert result["version"] == 7
+        assert result["version"] == 8
         assert result["romm_api_token"] is None
         assert result["romm_user"] == "alice"
         assert result["romm_pass"] == "secret"
@@ -317,6 +345,50 @@ class TestMigrateSettingsV7PlatformCores:
         assert result["platform_cores"] == {}
 
 
+class TestMigrateSettingsV8TokenOrigin:
+    """v7 → v8 migration: seed the ``romm_api_token_origin`` slot as ``None``."""
+
+    def test_seeds_origin_as_none(self):
+        data = {"version": 7}
+        result = _migrate_v7_to_v8(data)
+        assert result["romm_api_token_origin"] is None
+        assert result["version"] == 8
+
+    def test_does_not_overwrite_existing_origin(self):
+        """An already-present origin is preserved (setdefault), never re-seeded."""
+        data = {"version": 7, "romm_api_token_origin": "https://romm.local"}
+        result = _migrate_v7_to_v8(data)
+        assert result["romm_api_token_origin"] == "https://romm.local"
+        assert result["version"] == 8
+
+    def test_does_not_infer_origin_from_url(self):
+        """A token present without an origin stays origin-``None`` (legacy) — no inference."""
+        data = {"version": 7, "romm_url": "https://romm.local", "romm_api_token": "rmm_x"}
+        result = _migrate_v7_to_v8(data)
+        assert result["romm_api_token_origin"] is None
+
+    def test_preserves_unrelated_keys(self):
+        data = {"version": 7, "romm_url": "http://example.com", "log_level": "warn"}
+        result = _migrate_v7_to_v8(data)
+        assert result["romm_url"] == "http://example.com"
+        assert result["log_level"] == "warn"
+        assert result["romm_api_token_origin"] is None
+
+    def test_full_chain_seeds_origin(self):
+        """A pre-versioning file runs the whole chain and ends with the origin slot."""
+        data = {"version": 0, "romm_url": "http://example.com"}
+        result = migrate_settings(data)
+        assert result["romm_api_token_origin"] is None
+        assert result["version"] == 8
+
+    def test_idempotent_via_full_chain(self):
+        data = {"version": 7, "romm_api_token_origin": "https://romm.local"}
+        once = migrate_settings(data.copy())
+        twice = migrate_settings(once.copy())
+        assert once == twice
+        assert once["romm_api_token_origin"] == "https://romm.local"
+
+
 class TestMigrateSettingsV3Collections:
     """v<3 → v3 migration: split flat ``enabled_collections`` into 3 buckets."""
 
@@ -328,7 +400,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_base64_keys_move_to_franchise_bucket(self):
         b64 = "eyJuYW1lIjogIkFuIFRoZSBNYXJpbyJ9"
@@ -350,7 +422,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {b64: True},
         }
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_smart_bucket_always_starts_empty(self):
         """Pre-v3 users had no smart collections — bucket must start empty."""
@@ -368,7 +440,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "romm_url": "x"}
         result = migrate_settings(data)
         assert "enabled_collections" not in result
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_already_nested_value_passes_through_unchanged(self):
         """Defensive: a half-stamped v3-shaped value must not be re-split."""
@@ -380,7 +452,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "enabled_collections": already_nested}
         result = migrate_settings(data)
         assert result["enabled_collections"] == already_nested
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_partial_nested_value_normalized_with_missing_buckets(self):
         """A partial-nested value (only one bucket present) is normalized to all three buckets."""
@@ -391,7 +463,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_partial_nested_two_buckets_fills_missing_third(self):
         """Partial-nested with two bucket keys — missing bucket is filled empty."""
@@ -405,7 +477,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {"abc": True},
         }
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_v0_to_v3_runs_both_steps(self):
         """A v0 file with both deprecated keys AND old enabled_collections gets both migrations."""
@@ -422,7 +494,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_negative_numeric_string_keys_go_to_user(self):
         """``key.lstrip('-').isdigit()`` accepts ``-1`` as a numeric id."""
@@ -438,7 +510,7 @@ class TestMigrateSettingsV3Collections:
         }
         result = migrate_settings(data)
         assert result["enabled_collections"] == {"user": {"1": True}, "smart": {}, "franchise": {}}
-        assert result["version"] == 7
+        assert result["version"] == 8
 
     def test_v3_migration_does_not_mutate_caller_dict(self):
         data = {"version": 1, "enabled_collections": {"1": True, "abc": True}}

--- a/tests/lib/test_errors.py
+++ b/tests/lib/test_errors.py
@@ -11,6 +11,7 @@ from lib.errors import (
     RommSSLError,
     RommTimeoutError,
     RommUnsupportedError,
+    TokenHostMismatchError,
     classify_error,
     error_response,
 )
@@ -213,6 +214,14 @@ class TestClassifyError:
         assert code == "server_unreachable"
         assert msg == "some API issue"
 
+    def test_token_host_mismatch_maps_to_config_error(self):
+        """TokenHostMismatchError routes to config_error with a re-sign-in message —
+        NOT server_unreachable, even though it subclasses RommApiError."""
+        code, msg = classify_error(TokenHostMismatchError("origin mismatch"))
+        assert code == "config_error"
+        assert "different server" in msg
+        assert "Sign in again" in msg
+
     def test_conflict_error_is_api_error(self):
         """RommConflictError is a subclass of RommApiError, not specifically handled."""
         code, msg = classify_error(RommConflictError("conflict"))
@@ -313,3 +322,11 @@ class TestErrorResponse:
         assert resp["reason"] == "unsupported"
         assert resp["success"] is False
         assert "4.7.0" in resp["message"]
+
+    def test_token_host_mismatch_error_response(self):
+        resp = error_response(TokenHostMismatchError("mismatch"))
+        assert resp["success"] is False
+        assert resp["reason"] == "config_error"
+        assert "different server" in resp["message"]
+        assert "error" not in resp
+        assert "error_code" not in resp

--- a/tests/lib/test_url_host.py
+++ b/tests/lib/test_url_host.py
@@ -1,0 +1,181 @@
+"""Tests for lib/url_host.py — canonical origin derivation + comparison."""
+
+import pytest
+
+from lib.url_host import is_valid_server_url, normalize_origin, same_origin
+
+
+class TestNormalizeOrigin:
+    def test_basic_https(self):
+        assert normalize_origin("https://romm.local") == "https://romm.local"
+
+    def test_basic_http(self):
+        assert normalize_origin("http://romm.local") == "http://romm.local"
+
+    def test_default_https_port_folded_out(self):
+        assert normalize_origin("https://romm.local:443") == "https://romm.local"
+
+    def test_default_http_port_folded_out(self):
+        assert normalize_origin("http://romm.local:80") == "http://romm.local"
+
+    def test_non_default_port_kept(self):
+        assert normalize_origin("https://romm.local:8443") == "https://romm.local:8443"
+
+    def test_scheme_lowercased(self):
+        assert normalize_origin("HTTPS://romm.local") == "https://romm.local"
+
+    def test_host_lowercased(self):
+        assert normalize_origin("https://RomM.Local") == "https://romm.local"
+
+    def test_trailing_slash_dropped(self):
+        assert normalize_origin("https://romm.local/") == "https://romm.local"
+
+    def test_path_dropped(self):
+        assert normalize_origin("https://romm.local/romm/") == "https://romm.local"
+
+    def test_query_and_fragment_dropped(self):
+        assert normalize_origin("https://romm.local/x?y=1#frag") == "https://romm.local"
+
+    def test_scheme_sensitivity(self):
+        """https and http are DIFFERENT origins (no downgrade folding)."""
+        assert normalize_origin("https://romm.local") != normalize_origin("http://romm.local")
+
+    def test_port_sensitivity(self):
+        assert normalize_origin("https://romm.local:8080") != normalize_origin("https://romm.local:9090")
+
+    def test_path_origin_equals_bare_origin(self):
+        assert normalize_origin("https://romm.local/romm/") == normalize_origin("https://romm.local")
+
+    # ── IPv6 literals ────────────────────────────────────────────────────────
+
+    def test_ipv6_with_port_keeps_brackets(self):
+        assert normalize_origin("https://[::1]:8080") == "https://[::1]:8080"
+
+    def test_ipv6_with_port_round_trips(self):
+        """The normalized IPv6 origin must re-parse through normalize_origin unchanged."""
+        once = normalize_origin("https://[::1]:8080")
+        assert once is not None
+        assert normalize_origin(once) == once
+
+    def test_ipv6_default_portless_keeps_brackets(self):
+        assert normalize_origin("https://[::1]") == "https://[::1]"
+
+    def test_ipv6_default_port_folded_out(self):
+        assert normalize_origin("https://[::1]:443") == "https://[::1]"
+
+    def test_ipv6_with_path_strips_path(self):
+        assert normalize_origin("https://[::1]:8080/romm") == "https://[::1]:8080"
+
+    def test_ipv6_full_address_lowercased(self):
+        assert normalize_origin("https://[2001:DB8::1]:8080") == "https://[2001:db8::1]:8080"
+
+    # ── trailing-dot FQDN ─────────────────────────────────────────────────────
+
+    def test_trailing_dot_stripped(self):
+        assert normalize_origin("https://host.com.") == "https://host.com"
+
+    def test_trailing_dot_with_port_stripped(self):
+        assert normalize_origin("https://host.com.:8443") == "https://host.com:8443"
+
+    # ── rejects ────────────────────────────────────────────────────────────
+
+    def test_no_scheme_rejected(self):
+        assert normalize_origin("romm.local") is None
+
+    def test_no_host_rejected(self):
+        assert normalize_origin("https://") is None
+
+    def test_non_http_scheme_rejected(self):
+        assert normalize_origin("ftp://romm.local") is None
+
+    def test_empty_rejected(self):
+        assert normalize_origin("") is None
+
+    def test_whitespace_only_rejected(self):
+        # normalize_origin itself does not strip; a whitespace-only value has no scheme.
+        assert normalize_origin("   ") is None
+
+    def test_invalid_port_rejected(self):
+        assert normalize_origin("https://romm.local:notaport") is None
+
+
+class TestSameOrigin:
+    def test_identical_true(self):
+        assert same_origin("https://romm.local", "https://romm.local") is True
+
+    def test_default_port_vs_bare_true(self):
+        assert same_origin("https://romm.local:443", "https://romm.local") is True
+
+    def test_path_vs_bare_true(self):
+        assert same_origin("https://romm.local/romm/", "https://romm.local") is True
+
+    def test_different_host_false(self):
+        assert same_origin("https://a.local", "https://b.local") is False
+
+    def test_different_scheme_false(self):
+        assert same_origin("https://romm.local", "http://romm.local") is False
+
+    def test_different_port_false(self):
+        assert same_origin("https://romm.local:8080", "https://romm.local:9090") is False
+
+    def test_none_left_false(self):
+        assert same_origin(None, "https://romm.local") is False
+
+    def test_none_right_false(self):
+        assert same_origin("https://romm.local", None) is False
+
+    def test_both_none_false(self):
+        assert same_origin(None, None) is False
+
+    def test_unparseable_left_false(self):
+        assert same_origin("not-a-url", "https://romm.local") is False
+
+    def test_two_unparseable_false(self):
+        """Two unparseable (None-origin) inputs are never 'the same server'."""
+        assert same_origin("nope", "also-nope") is False
+
+    # ── IPv6 + trailing-dot equivalence (regression: bracket corruption) ──────
+
+    def test_ipv6_same_self_true(self):
+        """An IPv6 origin must equal itself — the round-trip the bracket bug broke."""
+        assert same_origin("https://[::1]:8080", "https://[::1]:8080") is True
+
+    def test_ipv6_path_vs_bare_true(self):
+        assert same_origin("https://[::1]:8080/romm", "https://[::1]:8080") is True
+
+    def test_ipv6_default_portless_vs_explicit_port_false(self):
+        """[::1] (default port) and [::1]:8080 are different origins."""
+        assert same_origin("https://[::1]", "https://[::1]:8080") is False
+
+    def test_ipv6_default_port_vs_bare_true(self):
+        assert same_origin("https://[::1]:443", "https://[::1]") is True
+
+    def test_ipv6_does_not_collide_with_flattened_host(self):
+        """A bracketed [::1]:8080 must NOT collide with a host literally named '::1:8080'.
+
+        The bug flattened the former to the latter; they must stay distinct
+        (the flattened form is unparseable → None → never equal).
+        """
+        assert same_origin("https://[::1]:8080", "https://::1:8080") is False
+
+    def test_trailing_dot_vs_dotless_true(self):
+        assert same_origin("https://host.com.", "https://host.com") is True
+
+
+class TestIsValidServerUrl:
+    @pytest.mark.parametrize(
+        "url",
+        ["http://romm.local", "https://romm.local", "https://romm.local:8443/romm", "  http://romm.local  "],
+    )
+    def test_valid(self, url):
+        assert is_valid_server_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        ["romm.local", "ftp://romm.local", "", "   ", "https://", "://nohost"],
+    )
+    def test_invalid(self, url):
+        assert is_valid_server_url(url) is False
+
+    def test_trims_before_validating(self):
+        assert is_valid_server_url("\t https://romm.local \n") is True

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -240,8 +240,10 @@ class TestEstablishTokenHappyPath:
         assert result["romm_version"] == "4.8.1"
         assert settings["romm_api_token"] == "rmm_minted"
         assert settings["romm_api_token_id"] == 42
-        # URL persisted + token persisted → at least two saves.
-        assert settings_persister.save_settings.call_count >= 2
+        # The token's minting origin is stamped from the trimmed URL.
+        assert settings["romm_api_token_origin"] == "http://romm.local"
+        # url + ssl + token + id + origin commit in a SINGLE atomic save (#1015).
+        assert settings_persister.save_settings.call_count == 1
 
     def test_mints_with_no_preexisting_token(self, event_loop, romm_api, logger):
         """``establish_token`` is the path that mints the first token — it must
@@ -278,8 +280,8 @@ class TestEstablishTokenHappyPath:
         assert settings["romm_api_token_id"] == 42
         assert "romm_user" not in settings
         assert "romm_pass" not in settings
-        # The token-persist step saves after wiping the credentials.
-        assert settings_persister.save_settings.call_count >= 2
+        # The single token-persist save commits after wiping the credentials.
+        assert settings_persister.save_settings.call_count == 1
 
     def test_token_name_uses_device_name(self, event_loop, romm_api, logger):
         settings = {"device_name": "MyDeck"}
@@ -303,12 +305,37 @@ class TestEstablishTokenHappyPath:
 
 
 class TestEstablishTokenOldTokenDeletion:
-    def test_deletes_old_token_before_mint(self, event_loop, romm_api, logger):
-        settings = {"romm_api_token_id": 99}
+    def test_deletes_old_token_when_origin_matches(self, event_loop, romm_api, logger):
+        """Same-server re-auth (#1038): the old token is revoked on its origin."""
+        settings = {"romm_api_token_id": 99, "romm_api_token_origin": "http://romm.local"}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
         romm_api.delete_client_token.assert_called_once_with("u", "p", token_id=99)
         assert settings["romm_api_token_id"] == 42
+
+    def test_origin_match_ignores_trailing_slash_and_default_port(self, event_loop, romm_api, logger):
+        """Origin comparison folds path / default port — still the same server."""
+        settings = {"romm_api_token_id": 99, "romm_api_token_origin": "https://romm.local"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_token("https://romm.local:443/romm/", "u", "p"))
+        romm_api.delete_client_token.assert_called_once_with("u", "p", token_id=99)
+
+    def test_skips_delete_when_origin_differs(self, event_loop, romm_api, logger):
+        """#1038: an old token from a DIFFERENT origin is NOT replayed as a DELETE."""
+        settings = {"romm_api_token_id": 99, "romm_api_token_origin": "https://old.server"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["success"] is True
+        romm_api.delete_client_token.assert_not_called()
+        # The new token still mints + persists.
+        assert settings["romm_api_token"] == "rmm_minted"
+
+    def test_skips_delete_when_old_origin_unknown(self, event_loop, romm_api, logger):
+        """A legacy token with no stored origin is not DELETE-replayed against the new host."""
+        settings = {"romm_api_token_id": 99}  # no romm_api_token_origin
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
+        romm_api.delete_client_token.assert_not_called()
 
     def test_no_delete_when_no_old_token(self, event_loop, romm_api, logger):
         settings: dict[str, Any] = {}
@@ -317,7 +344,7 @@ class TestEstablishTokenOldTokenDeletion:
         romm_api.delete_client_token.assert_not_called()
 
     def test_delete_failure_is_ignored(self, event_loop, romm_api, logger):
-        settings = {"romm_api_token_id": 99}
+        settings = {"romm_api_token_id": 99, "romm_api_token_origin": "http://romm.local"}
         romm_api.delete_client_token.side_effect = RommServerError("boom", status_code=500)
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
@@ -332,6 +359,24 @@ class TestEstablishTokenBadPath:
         result = event_loop.run_until_complete(service.establish_token("", "u", "p"))
         assert result == {"success": False, "reason": "config_error", "message": "No server URL configured"}
         romm_api.mint_client_token.assert_not_called()
+
+    @pytest.mark.parametrize("bad_url", ["romm.local", "ftp://romm.local", "   ", "https://"])
+    def test_invalid_url_returns_config_error_without_probing(self, event_loop, romm_api, logger, bad_url):
+        """A scheme-less / non-http(s) / hostless URL is rejected before any network call (#1015)."""
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_token(bad_url, "u", "p"))
+        assert result == {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+        romm_api.heartbeat.assert_not_called()
+        romm_api.mint_client_token.assert_not_called()
+
+    def test_url_is_trimmed_before_use(self, event_loop, romm_api, logger):
+        """Surrounding whitespace is stripped; the trimmed URL is what gets persisted."""
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_token("  http://romm.local  ", "u", "p"))
+        assert result["success"] is True
+        assert settings["romm_url"] == "http://romm.local"
+        assert settings["romm_api_token_origin"] == "http://romm.local"
 
     def test_unreachable_returns_connection_error_no_mint(self, event_loop, romm_api, logger):
         romm_api.heartbeat.side_effect = RommConnectionError("refused")
@@ -393,9 +438,130 @@ class TestEstablishTokenBadPath:
         assert "disk full" in result["message"]
 
 
+def _working_settings() -> dict[str, Any]:
+    """A settings dict already signed in against the OLD server."""
+    return {
+        "romm_url": "https://old.server",
+        "romm_allow_insecure_ssl": False,
+        "romm_api_token": "rmm_old",
+        "romm_api_token_id": 7,
+        "romm_api_token_origin": "https://old.server",
+    }
+
+
+class TestEstablishTokenSnapshotRestore:
+    """#1015: a failed sign-in must not clobber the previous working state.
+
+    Nothing is persisted before the mint succeeds, and the in-memory dict is
+    rolled back to the previous URL + token on any failure.
+    """
+
+    def _assert_old_state_intact(self, settings: dict[str, Any]) -> None:
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_id"] == 7
+        assert settings["romm_api_token_origin"] == "https://old.server"
+
+    def test_probe_failure_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_version_gate_failure_restores_old_state_and_never_saves(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["reason"] == "version_error"
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_mint_failure_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.mint_client_token.side_effect = RommForbiddenError("403")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["reason"] == "auth_failed"
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_persist_failure_restores_old_state(self, event_loop, romm_api, logger, settings_persister):
+        settings_persister.save_settings.side_effect = OSError("disk full")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+
+    def test_clears_old_token_before_probe(self, event_loop, romm_api, logger):
+        """The version probe must run with NO bearer — the old token is cleared first (#1039)."""
+        seen: dict[str, Any] = {}
+
+        def _capture_heartbeat():
+            seen["token_during_probe"] = settings.get("romm_api_token")
+            seen["origin_during_probe"] = settings.get("romm_api_token_origin")
+            return {"SYSTEM": {"VERSION": "4.8.1"}}
+
+        romm_api.heartbeat.side_effect = _capture_heartbeat
+        settings = _working_settings()
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert seen["token_during_probe"] is None
+        assert seen["origin_during_probe"] is None
+
+    def test_successful_signin_to_new_origin_stamps_and_persists_once(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("https://new.server", "u", "p"))
+        assert result["success"] is True
+        assert settings["romm_url"] == "https://new.server"
+        assert settings["romm_api_token"] == "rmm_minted"
+        assert settings["romm_api_token_id"] == 42
+        assert settings["romm_api_token_origin"] == "https://new.server"
+        settings_persister.save_settings.assert_called_once_with()
+
+
 class TestMigrateLegacyCredentials:
     def test_mints_and_wipes_credentials(self, event_loop, romm_api, logger, settings_persister):
-        settings = {"romm_user": "alice", "romm_pass": "secret"}
+        settings = {"romm_url": "https://romm.local", "romm_user": "alice", "romm_pass": "secret"}
         service = _make_service(
             settings=settings,
             romm_api=romm_api,
@@ -406,6 +572,8 @@ class TestMigrateLegacyCredentials:
         event_loop.run_until_complete(service.migrate_legacy_credentials())
         assert settings["romm_api_token"] == "rmm_minted"
         assert settings["romm_api_token_id"] == 42
+        # The origin is stamped from the configured URL at migration time.
+        assert settings["romm_api_token_origin"] == "https://romm.local"
         assert "romm_user" not in settings
         assert "romm_pass" not in settings
         settings_persister.save_settings.assert_called_once_with()

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -108,6 +108,23 @@ class TestSaveServerUrl:
         assert result["success"] is False
         assert "disk full" in result["message"]
 
+    def test_trims_url_before_persisting(self, service, settings, settings_persister):
+        result = service.save_server_url("  https://romm.local  ")
+        assert result["success"] is True
+        assert settings["romm_url"] == "https://romm.local"
+        settings_persister.save_settings.assert_called_once_with()
+
+    @pytest.mark.parametrize("bad_url", ["", "   ", "romm.local", "ftp://romm.local", "https://"])
+    def test_invalid_url_rejected_without_writing(self, service, settings, settings_persister, bad_url):
+        result = service.save_server_url(bad_url)
+        assert result == {
+            "success": False,
+            "reason": "config_error",
+            "message": "Enter a valid http(s):// server URL",
+        }
+        assert "romm_url" not in settings
+        settings_persister.save_settings.assert_not_called()
+
 
 # ── get_settings ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Binds the stored RomM credential to the server that issued it, so changing `romm_url` can no longer send the old server's token to a new host, replay a stale `token_id` against the wrong server, or clobber a working URL on a failed sign-in. Closes #1015, #1038, #1039 (the connection-flow half of the server-binding cluster; #1037's identity/save-state reset is a separate follow-up).

## The three bugs

- **#1039** — the persisted bearer carried no minting host, so `auth_header()` (reads settings live) sent it to whatever `romm_url` pointed at, including the no-sign-in `save_server_url` path. A mistyped or hostile host received a valid credential for the user's real server.
- **#1038** — `_delete_existing_token` ran after `romm_url` already pointed at the new server, sending `DELETE /api/client-tokens/{id}` with an old-server `token_id` against the **new** server (RomM ids are small auto-increments → could delete an unrelated token there), while the old token stayed valid forever.
- **#1015** — `establish_token` wrote `romm_url` to disk *before* the version check / mint, so a typo on a failed sign-in clobbered the previous working URL; no URL trim/scheme validation existed on either end.

## How

- **`lib/url_host.py`** (new, stdlib-only): `normalize_origin(url)` → canonical `scheme://host[:port]` (scheme + host lowercased, default ports folded, IPv6 literals kept bracketed, trailing FQDN dot stripped, path/query/fragment dropped, non-http(s) → `None`); `same_origin(a, b)` (fails closed on `None`); `is_valid_server_url(url)`.
- **`romm_api_token_origin`** settings field (default `None`, schema migration v7→v8) stamped at mint time.
- **#1039** — `auth_header()` raises `TokenHostMismatchError` → `config_error` when a stored token's origin ≠ the current `romm_url` origin (fail-fast: the request never leaves, no leak; plugin is inert until re-sign-in, like the version gate). Legacy tokens (no stored origin) attach as before until their next sign-in stamps an origin.
- **#1015** — `establish_token` now validates+trims the URL, holds the candidate **in memory**, clears the stored token so the version probe never carries a foreign credential, and calls `save_settings()` **once** on success; every failure path restores the previous in-memory state and leaves disk untouched.
- **#1038** — the old token is DELETEd only when its stored origin matches the server being signed into (same-server re-auth); a different/unknown origin skips the DELETE rather than replaying it against the new server.
- **Frontend** — `serverUrl.ts` trims + scheme-validates before `saveServerUrl`/`connectWithCredentials`; the "Allow Insecure SSL" toggle trims first (fixes a leading space hiding the toggle).

## Tests

`tests/lib/test_url_host.py` (55, incl. IPv6 round-trip / no-collision, default-port folding, scheme sensitivity, trailing-dot, userinfo not leaked), failure-shape mapping + non-retryability, `auth_header` raise-on-mismatch / legacy-attach / match-attach, the full `establish_token` snapshot/restore matrix (every failure path restores and never saves), the #1038 origin-gated DELETE matrix, `save_server_url` validation, the v7→v8 migration, and the frontend `serverUrl`/`SettingsPage`/`ConnectionSection` cases. Full backend suite 3361 passed / 1 xfailed; frontend green.

## Docs

`CLAUDE.md` (token-host-binding constraint), `docs/architecture/backend-architecture.md` (ConnectionService notes: validate→probe→mint→persist ordering, the binding, the DELETE guard, legacy-token handling).
