### PR TITLE
fix(persistence): crash-safe settings writes + corrupt-file quarantine (#1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,14 @@ silent omission. The CI check enforces this.
   it. See [ConnectionService notes](docs/architecture/backend-architecture.md#connectionservice-notes).
 - **Decky callables must be async**: Even if the method body is synchronous, Decky's callable framework requires
   `async def`. Do not remove `async` from callable methods in main.py.
+- **Settings durability**: `settings.json` is written crash-safe — write-tmp → `fsync(tmp)` → `os.replace()` →
+  `fsync(dir)` (the Steam Deck's ext4 can otherwise leave a truncated file on power loss, and boot rewrites the file
+  every run). A corrupt/unparseable `settings.json` is **never silently factory-reset**: it is logged loudly, backed up
+  to `settings.json.corrupt-<ts>` (`<ts>` from the injected `Clock`), and the user is toasted (via the
+  `consume_settings_reset_notice` callable, drained once per process) before defaults are written — so the user knows to
+  re-enter the server URL and sign in, and the original bytes survive for recovery. The settings `version` is stamped
+  `max(stored, _SETTINGS_VERSION)` on write — a file from a newer plugin is **never down-stamped**. `PersistenceAdapter`
+  takes an injected `clock` (bootstrap threads the shared `SystemClock`).
 
 ## Current State
 

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -282,8 +282,26 @@ Adapters own all I/O and implement the Protocols defined in `services/protocols/
   writes from corrupting state.
 - **Schema versioning**: every state file written includes a `version` field. On read, a mismatch causes the file to be
   treated as absent (cache discarded, state reset to defaults) rather than loading incompatible data.
-- **Atomic writes**: data is written to a temporary file in the same directory, then renamed into place with
-  `os.replace()`, so a crash mid-write never leaves a partial file.
+- **Crash-safe atomic writes**: `settings.json` is written with the durable write-tmp → `fsync(tmp)` → `os.replace()` →
+  `fsync(dir)` recipe. The temp file's bytes are forced to disk **before** the rename, and the directory entry the
+  rename creates is forced to disk **after** it. This closes the power-loss window on the Steam Deck's ext4: without the
+  fsyncs, a crash after the rename but before the kernel flushed could leave a truncated or empty `settings.json` —
+  which boot rewrites every run, so the window recurred. The directory fsync is best-effort: on the rare filesystem that
+  rejects it, the error is logged at debug and swallowed (the content is already durable via the temp-file fsync).
+- **Corrupt-file quarantine (never silently factory-reset)**: a `FileNotFoundError` on read is a legitimate first run —
+  defaults are returned silently, no backup, no flag. An **unparseable** `settings.json` (a `JSONDecodeError`, e.g. a
+  truncated file from a prior crash) is the data-loss hazard: returning defaults silently would let the immediate
+  bootstrap save overwrite the corrupt file, wiping the user's RomM URL, API token, SGDB key, and platform/collection
+  selections with no trace. Instead the adapter logs the corruption loudly at error level, renames the unparseable file
+  aside to `settings.json.corrupt-<ts>` (the `<ts>` is the injected `Clock`'s epoch seconds — filesystem-safe), and sets
+  a transient in-memory `_corrupt_reset` flag (never persisted) before returning defaults. If the backup rename itself
+  fails (e.g. permissions), the error is logged and defaults are still returned so boot never crashes. The flag is
+  surfaced to the frontend through the `consume_settings_reset_notice` callable (drains once per process), which toasts
+  the user that their settings were reset and where the backup landed so they can re-enter the server URL and sign in.
+- **Version never down-stamps**: on write, the `version` field is stamped to `max(stored_version, _SETTINGS_VERSION)`. A
+  file written by a **newer** plugin (stored version > current) is preserved as-is rather than down-stamped, so a later
+  re-upgrade does not re-run migrations against down-stamped data. An absent or older version is stamped up to the
+  current `_SETTINGS_VERSION`.
 
 ### Domain (`py_modules/domain/`)
 

--- a/main.py
+++ b/main.py
@@ -75,6 +75,10 @@ class Plugin:
         )
         self.settings = result.stores.settings
         self._debug_logger = result.handles.debug_logger
+        # Persistence adapter — held directly so consume_settings_reset_notice
+        # can drain the one-shot corrupt-settings-reset flag (a transient
+        # bootstrap signal, not service state) for the frontend toast.
+        self._persistence = result.handles.persistence
         # RetroDECK path resolver — held directly so the get_retrodeck_status
         # callable can read the resolution health without routing through a
         # service (it's a pure adapter read, no orchestration).
@@ -513,3 +517,14 @@ class Plugin:
 
     async def refresh_migration_state(self):
         return await self._migration_service.refresh_state()
+
+    async def consume_settings_reset_notice(self):
+        """Drain the one-shot corrupt-settings-reset notice for the frontend.
+
+        Returns ``{"reset": bool, "backed_up_to": str | None}``. When a
+        corrupt ``settings.json`` was backed up and reset at boot, the first
+        call returns ``reset: True`` with the backup filename; the flag is
+        cleared on read so the toast fires at most once per process. A clean
+        boot returns ``{"reset": False, "backed_up_to": None}``.
+        """
+        return self._persistence.consume_settings_reset_notice()

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -11,10 +11,28 @@ import fcntl
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Protocol
+
+from adapters.system_clock import SystemClock
 
 _SETTINGS_VERSION = 8
 _LOCK_EXT = ".lock"
+
+
+class _ClockPort(Protocol):
+    """Minimal wall-clock port the persistence adapter consumes.
+
+    Adapters must not import ``services.protocols`` (import-linter forbids
+    ``adapters -> services``), so this declares the single Clock method the
+    adapter needs — ``time()`` for the corrupt-file backup stamp. The
+    production ``adapters.system_clock.SystemClock`` and the test
+    ``FakeClock`` both satisfy it structurally.
+    """
+
+    def time(self) -> float:
+        """Return the current Unix timestamp in seconds since the epoch."""
+        ...
+
 
 DEFAULT_SETTINGS: dict[str, Any] = {
     "romm_url": "",
@@ -56,20 +74,50 @@ class PersistenceAdapter:
         (typically ``decky.DECKY_PLUGIN_RUNTIME_DIR``).
     logger:
         A standard-library ``logging.Logger`` instance.
+    clock:
+        Wall-clock source for the corrupt-file backup stamp. Keyword-only;
+        defaults to a real :class:`adapters.system_clock.SystemClock` so the
+        many existing 3-arg construction sites need no change. Bootstrap
+        passes the shared instance so the whole composition root reads one
+        clock.
     """
 
-    def __init__(self, settings_dir: str, runtime_dir: str, logger: logging.Logger) -> None:
+    def __init__(
+        self,
+        settings_dir: str,
+        runtime_dir: str,
+        logger: logging.Logger,
+        *,
+        clock: _ClockPort | None = None,
+    ) -> None:
         self._settings_dir = settings_dir
         self._runtime_dir = runtime_dir
         self._logger = logger
+        self._clock: _ClockPort = clock if clock is not None else SystemClock()
+        # Transient, never-persisted record of a corrupt-settings reset that
+        # happened on the last ``load_settings``. ``None`` means no reset;
+        # otherwise ``{"backed_up_to": <basename>}``. The frontend drains this
+        # once per process via ``consume_settings_reset_notice`` to toast the
+        # user; it is never written to ``settings.json``.
+        self._corrupt_reset: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
     def _locked_write(self, path: str, data: dict[str, Any]) -> None:
-        """Atomic write of *data* to *path* under an exclusive file lock."""
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        """Crash-safe atomic write of *data* to *path* under an exclusive lock.
+
+        Uses the standard write-tmp → fsync(tmp) → rename → fsync(dir) recipe so
+        a power loss (a real hazard on the Steam Deck) can never leave a
+        truncated or empty ``settings.json``: the tmp file's bytes are forced to
+        disk *before* the rename, and the directory entry the rename creates is
+        forced to disk *after* it. The directory fsync is best-effort — on the
+        rare filesystem where it raises, the error is logged and swallowed so it
+        never fails an otherwise-successful write.
+        """
+        dirname = os.path.dirname(path)
+        os.makedirs(dirname, exist_ok=True)
         tmp_path = path + ".tmp"
         lock_fd = os.open(path + _LOCK_EXT, os.O_WRONLY | os.O_CREAT, 0o600)
         try:
@@ -78,11 +126,23 @@ class PersistenceAdapter:
             try:
                 with os.fdopen(fd, "w") as f:
                     json.dump(data, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
                 os.replace(tmp_path, path)
             except Exception:
                 with contextlib.suppress(OSError):
                     os.unlink(tmp_path)
                 raise
+            # fsync the directory so the rename's directory-entry update is
+            # durable. Best-effort: some filesystems reject a dir fsync.
+            try:
+                dir_fd = os.open(dirname, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError as exc:
+                self._logger.debug("directory fsync after settings write failed (non-fatal): %s", exc)
         finally:
             os.close(lock_fd)
 
@@ -97,12 +157,28 @@ class PersistenceAdapter:
         included here — that belongs in ``domain/state_migrations.py``.
         If the ``version`` key is absent the returned dict has ``version: 0``
         to signal a pre-versioning file to callers.
+
+        A missing file is a legitimate first run — defaults are returned
+        silently with no backup and no reset flag. An *unparseable* file is
+        the data-loss hazard: rather than silently returning defaults (which
+        the immediate bootstrap save would then write over the corrupt file,
+        destroying the user's server URL, token, and selections), the
+        unparseable file is backed up to ``settings.json.corrupt-<ts>`` and a
+        transient :attr:`_corrupt_reset` flag is set so the frontend can toast
+        the user. The error is logged loudly. If the backup rename itself
+        fails, the error is logged and defaults are still returned so boot
+        never crashes.
         """
         settings_path = os.path.join(self._settings_dir, "settings.json")
         try:
             with open(settings_path) as f:
                 settings = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError:
+            # Legitimate first run: no file, no backup, no reset flag.
+            settings = {}
+        except json.JSONDecodeError:
+            self._logger.error("settings.json is corrupt/unparseable — backing up and resetting to defaults")
+            self._quarantine_corrupt_settings(settings_path)
             settings = {}
 
         for key, default in DEFAULT_SETTINGS.items():
@@ -119,9 +195,63 @@ class PersistenceAdapter:
 
         return settings
 
+    def _quarantine_corrupt_settings(self, settings_path: str) -> None:
+        """Rename an unparseable ``settings.json`` aside and record the reset.
+
+        The backup name is ``settings.json.corrupt-<ts>`` where ``<ts>`` is the
+        injected clock's epoch seconds (an int — filesystem-safe, no ``:``), so
+        the original bytes survive for manual recovery while the immediate
+        bootstrap save writes fresh defaults to ``settings.json``. If that name
+        is already taken (two corruptions in the same wall-clock second, or a
+        clock rollback onto an existing stamp) a ``-<n>`` suffix disambiguates
+        so an older backup is never clobbered. Sets :attr:`_corrupt_reset` so
+        the frontend can toast the user once. A failed rename (e.g. perms) is
+        logged and swallowed — boot must not crash.
+        """
+        stamp = int(self._clock.time())
+        backup_name = f"settings.json.corrupt-{stamp}"
+        backup_path = os.path.join(self._settings_dir, backup_name)
+        n = 1
+        while os.path.exists(backup_path):
+            backup_name = f"settings.json.corrupt-{stamp}-{n}"
+            backup_path = os.path.join(self._settings_dir, backup_name)
+            n += 1
+        try:
+            os.replace(settings_path, backup_path)
+        except OSError as exc:
+            self._logger.error("could not back up corrupt settings.json to %s: %s", backup_name, exc)
+            return
+        self._corrupt_reset = {"backed_up_to": backup_name}
+
+    def consume_settings_reset_notice(self) -> dict[str, Any]:
+        """Drain the one-shot corrupt-settings-reset notice for the frontend.
+
+        Returns ``{"reset": bool, "backed_up_to": str | None}`` and clears the
+        transient flag so the toast fires at most once per process. On a clean
+        boot (no corruption) returns ``{"reset": False, "backed_up_to": None}``.
+        """
+        notice = self._corrupt_reset
+        self._corrupt_reset = None
+        if notice is None:
+            return {"reset": False, "backed_up_to": None}
+        return {"reset": True, "backed_up_to": notice["backed_up_to"]}
+
     def save_settings(self, data: dict[str, Any]) -> None:
-        """Atomic write of *data* to ``settings.json`` with flock, stamping version."""
-        data["version"] = _SETTINGS_VERSION
+        """Atomic write of *data* to ``settings.json`` with flock, stamping version.
+
+        The version stamp never *down*-stamps: ``data["version"]`` is set to
+        ``max(stored_version, _SETTINGS_VERSION)``. A file written by a newer
+        plugin (stored version > current) is preserved as-is so a later
+        re-upgrade does not re-run migrations against down-stamped data;
+        an absent or older version is stamped up to ``_SETTINGS_VERSION``.
+        A non-numeric stored version (e.g. a hand-edited ``"abc"``) coerces to
+        ``0`` rather than raising — the stamp must never crash the boot-time save.
+        """
+        try:
+            stored = int(data.get("version", 0) or 0)
+        except (TypeError, ValueError):
+            stored = 0
+        data["version"] = max(stored, _SETTINGS_VERSION)
         settings_path = os.path.join(self._settings_dir, "settings.json")
         self._locked_write(settings_path, data)
 

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -185,13 +185,15 @@ class BootstrapHandles:
     """Bootstrap outputs ``main.py`` needs that don't fit the wiring bundles.
 
     Anything ``Plugin`` itself binds (not the services) lives here:
-    the debug logger forwarded by ``Plugin._log_debug``. The bundles
-    already cover everything passed to ``wire_services``; this struct
-    keeps those Plugin-only handles typed instead of returning them
-    via the untyped dict shape of yore.
+    the debug logger forwarded by ``Plugin._log_debug`` and the
+    persistence adapter ``Plugin`` reads the one-shot corrupt-settings
+    reset notice from. The bundles already cover everything passed to
+    ``wire_services``; this struct keeps those Plugin-only handles typed
+    instead of returning them via the untyped dict shape of yore.
     """
 
     debug_logger: DebugLogger
+    persistence: PersistenceAdapter
 
 
 @dataclass(frozen=True)
@@ -291,7 +293,11 @@ def bootstrap(
         logger=logger,
     )
 
-    persistence = PersistenceAdapter(settings_dir, runtime_dir, logger)
+    # SystemClock is dependency-free; construct it here so the single shared
+    # instance threads into PersistenceAdapter (corrupt-settings backup stamp)
+    # and every later seam (uuid_gen/sleeper neighbours, runtime bundle).
+    clock = SystemClock()
+    persistence = PersistenceAdapter(settings_dir, runtime_dir, logger, clock=clock)
     settings = persistence.load_settings()
     # One-time JSON→JSON lift (ADR-0003): fold the legacy save-sync knobs +
     # device_name out of save_sync_state.json before the schema bump stamps
@@ -323,7 +329,6 @@ def bootstrap(
     rom_file_store = RomFileAdapter()
     save_file_store = SaveFileAdapter()
     path_probe = PathProbeAdapter()
-    clock = SystemClock()
     uuid_gen = SystemUuidGen()
     sleeper = AsyncioSleeper()
     hostname_provider = HostnameAdapter()
@@ -365,7 +370,7 @@ def bootstrap(
         hostname_provider=hostname_provider,
         machine_id_provider=machine_id_provider,
     )
-    handles = BootstrapHandles(debug_logger=debug_logger)
+    handles = BootstrapHandles(debug_logger=debug_logger, persistence=persistence)
 
     return BootstrapResult(
         adapters=adapters,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -374,6 +374,14 @@ export const refreshMigrationState = callable<[], { retrodeck: MigrationStatus; 
   "refresh_migration_state",
 );
 
+// One-shot corrupt-settings-reset notice. When settings.json was unparseable
+// at boot it is backed up to settings.json.corrupt-<ts> and reset to defaults;
+// the first call returns reset:true with the backup filename, then clears so
+// the toast fires once per process.
+export const consumeSettingsResetNotice = callable<[], { reset: boolean; backed_up_to: string | null }>(
+  "consume_settings_reset_notice",
+);
+
 // End-of-session orchestration — collapses recordSessionEnd + syncAchievementsAfterSession
 // + postExitSync + refreshMigrationState into a single backend round-trip.
 // See SessionLifecycleService in py_modules/services/session_lifecycle.py.

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -13,7 +13,9 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act } from "@testing-library/react";
+import { toaster } from "@decky/api";
 import { emitDeckyEvent, deckyEventListenerCount } from "./test-utils/decky-api-mock";
+import { consumeSettingsResetNotice } from "./api/backend";
 import type { DownloadCompleteEvent, SyncStaleData } from "./types";
 
 vi.mock("./patches/gameDetailPatch", () => ({
@@ -243,5 +245,49 @@ describe("index.tsx — migration_relaunch_options listener", () => {
 
     plugin.onDismount();
     expect(deckyEventListenerCount("migration_relaunch_options")).toBe(0);
+  });
+});
+
+describe("index.tsx — corrupt-settings reset notice", () => {
+  beforeEach(() => {
+    vi.mocked(toaster.toast).mockClear();
+    logError.mockClear();
+    vi.mocked(consumeSettingsResetNotice).mockReset();
+  });
+
+  it("toasts the backup path when the boot notice reports a reset", async () => {
+    vi.mocked(consumeSettingsResetNotice).mockResolvedValue({
+      reset: true,
+      backed_up_to: "settings.json.corrupt-1781697600",
+    });
+    const plugin = pluginFactory();
+    await flush();
+
+    expect(toaster.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "RomM Sync",
+        body: expect.stringContaining("settings.json.corrupt-1781697600"),
+      }),
+    );
+    plugin.onDismount();
+  });
+
+  it("does not toast when the boot notice reports no reset", async () => {
+    vi.mocked(consumeSettingsResetNotice).mockResolvedValue({ reset: false, backed_up_to: null });
+    const plugin = pluginFactory();
+    await flush();
+
+    expect(toaster.toast).not.toHaveBeenCalled();
+    plugin.onDismount();
+  });
+
+  it("surfaces a logError when the reset-notice check rejects", async () => {
+    vi.mocked(consumeSettingsResetNotice).mockRejectedValue(new Error("boom"));
+    const plugin = pluginFactory();
+    await flush();
+
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining("Failed to check settings reset notice"));
+    expect(toaster.toast).not.toHaveBeenCalled();
+    plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ import {
   getAllPlaytime,
   getMigrationStatus,
   getSaveSortMigrationStatus,
+  consumeSettingsResetNotice,
   testConnection,
   logError,
   logInfo,
@@ -227,6 +228,25 @@ export default definePlugin(() => {
         }
       } catch (e) {
         logError(`Failed to check save sort migration status: ${e}`);
+      }
+    })(),
+  );
+
+  // Surface a corrupt-settings reset that happened at boot. The backend backs
+  // up an unparseable settings.json to settings.json.corrupt-<ts> and resets to
+  // defaults; the notice drains once per process so the toast fires only once.
+  detach(
+    (async () => {
+      try {
+        const notice = await consumeSettingsResetNotice();
+        if (notice.reset) {
+          toaster.toast({
+            title: "RomM Sync",
+            body: `Your settings file was corrupt and has been reset. A backup was saved to ${notice.backed_up_to}. Please re-enter your server URL and sign in again.`,
+          });
+        }
+      } catch (e) {
+        logError(`Failed to check settings reset notice: ${e}`);
       }
     })(),
   );

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -4,8 +4,10 @@ import json
 import logging
 import os
 import threading
+from datetime import UTC, datetime
 
 import pytest
+from fakes.system_time import FakeClock
 
 from adapters.persistence import (
     _SETTINGS_VERSION,
@@ -170,6 +172,276 @@ class TestLoadingEdgeCases:
         settings_path = os.path.join(adapter._settings_dir, "settings.json")
         mode = os.stat(settings_path).st_mode & 0o777
         assert mode == 0o600
+
+
+# ── Crash-safe write: fsync(tmp) before rename, fsync(dir) after ─────────────────
+
+
+class TestCrashSafeWrite:
+    def test_fsync_called_on_file_then_dir_around_replace(self, adapter, monkeypatch):
+        """fsync must hit the tmp file fd BEFORE os.replace and the directory fd
+        AFTER it, so both the tmp bytes and the rename's directory entry are
+        durable on power loss."""
+        events: list[str] = []
+        real_fsync = os.fsync
+        real_replace = os.replace
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+
+        def spy_fsync(fd):
+            # A directory fd is not writable; distinguish it from the file fd by
+            # checking whether the fd refers to a directory.
+            kind = "dir" if os.path.isdir(f"/proc/self/fd/{fd}") else "file"
+            events.append(f"fsync_{kind}")
+            return real_fsync(fd)
+
+        def spy_replace(src, dst):
+            events.append("replace")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "fsync", spy_fsync)
+        monkeypatch.setattr(os, "replace", spy_replace)
+
+        adapter.save_settings({"romm_url": "http://example.com"})
+
+        assert events == ["fsync_file", "replace", "fsync_dir"], events
+        # Content is actually on disk and valid.
+        with open(settings_path) as f:
+            assert json.load(f)["romm_url"] == "http://example.com"
+
+    def test_dir_fsync_failure_is_swallowed(self, adapter, monkeypatch):
+        """A directory fsync that raises OSError must NOT fail the write — the
+        content is already durable via the tmp-file fsync + rename."""
+        real_fsync = os.fsync
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+
+        def flaky_fsync(fd):
+            if os.path.isdir(f"/proc/self/fd/{fd}"):
+                raise OSError("dir fsync unsupported")
+            return real_fsync(fd)
+
+        monkeypatch.setattr(os, "fsync", flaky_fsync)
+
+        # Must not raise.
+        adapter.save_settings({"romm_url": "http://example.com"})
+        with open(settings_path) as f:
+            assert json.load(f)["romm_url"] == "http://example.com"
+
+    def test_write_failure_cleans_up_tmp_and_raises(self, adapter, monkeypatch):
+        """A failure inside the write (before rename) must unlink the tmp file
+        and re-raise, leaving no half-written settings.json."""
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        tmp_path = settings_path + ".tmp"
+
+        def boom(*_a, **_k):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(json, "dump", boom)
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            adapter.save_settings({"romm_url": "http://example.com"})
+        assert not os.path.exists(tmp_path)
+        assert not os.path.exists(settings_path)
+
+
+# ── Version stamping never down-stamps ───────────────────────────────────────────
+
+
+class TestVersionNoDownStamp:
+    def _saved(self, adapter):
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path) as f:
+            return json.load(f)
+
+    def test_newer_version_preserved(self, adapter):
+        """A settings dict from a NEWER plugin (version > current) is preserved,
+        never down-stamped to _SETTINGS_VERSION."""
+        future = _SETTINGS_VERSION + 5
+        adapter.save_settings({"romm_url": "http://example.com", "version": future})
+        assert self._saved(adapter)["version"] == future
+
+    def test_older_version_stamped_up(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com", "version": 1})
+        assert self._saved(adapter)["version"] == _SETTINGS_VERSION
+
+    def test_absent_version_stamped_to_current(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com"})
+        assert self._saved(adapter)["version"] == _SETTINGS_VERSION
+
+    def test_equal_version_unchanged(self, adapter):
+        adapter.save_settings({"romm_url": "http://example.com", "version": _SETTINGS_VERSION})
+        assert self._saved(adapter)["version"] == _SETTINGS_VERSION
+
+    @pytest.mark.parametrize("bad_version", [None, "", "abc", "v8", "8.0", [], {}])
+    def test_malformed_version_coerced(self, adapter, bad_version):
+        """A non-int / non-numeric-truthy / falsy stored version must NOT raise —
+        it coerces to 0, then stamps up to current. The truthy-string cases
+        (``"abc"``, ``"v8"``) are the regression guard: ``int("abc")`` raises
+        ValueError, which would crash the boot-time save."""
+        adapter.save_settings({"romm_url": "http://example.com", "version": bad_version})
+        assert self._saved(adapter)["version"] == _SETTINGS_VERSION
+
+
+# ── Corrupt-file quarantine + one-shot reset notice ──────────────────────────────
+
+
+class TestCorruptQuarantine:
+    def _make_adapter(self, tmp_path, logger, clock):
+        settings_dir = str(tmp_path / "settings")
+        runtime_dir = str(tmp_path / "runtime")
+        os.makedirs(settings_dir, exist_ok=True)
+        os.makedirs(runtime_dir, exist_ok=True)
+        return PersistenceAdapter(settings_dir=settings_dir, runtime_dir=runtime_dir, logger=logger, clock=clock)
+
+    def test_corrupt_file_backed_up_with_clock_stamp(self, tmp_path, logger):
+        clock = FakeClock(now=datetime(2026, 6, 13, 12, 0, 0, tzinfo=UTC))
+        adapter = self._make_adapter(tmp_path, logger, clock)
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            f.write("TRUNCATED{{{")
+
+        result = adapter.load_settings()
+
+        expected_stamp = int(clock.time())
+        backup_name = f"settings.json.corrupt-{expected_stamp}"
+        backup_path = os.path.join(adapter._settings_dir, backup_name)
+        # Original unparseable file moved aside (gone from its original name).
+        assert not os.path.exists(settings_path)
+        assert os.path.exists(backup_path)
+        with open(backup_path) as f:
+            assert f.read() == "TRUNCATED{{{"
+        # Defaults returned.
+        for key, default_value in DEFAULT_SETTINGS.items():
+            assert result[key] == default_value
+        # Transient flag set with the backup name.
+        assert adapter._corrupt_reset == {"backed_up_to": backup_name}
+
+    def test_two_corruptions_same_clock_second_keep_both_backups(self, tmp_path, logger):
+        """Two corruptions at the same wall-clock second must NOT clobber each
+        other — the second backup gets a ``-<n>`` suffix and the first survives
+        with its distinct original contents."""
+        clock = FakeClock(now=datetime(2026, 6, 13, 12, 0, 0, tzinfo=UTC))
+        adapter = self._make_adapter(tmp_path, logger, clock)
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        stamp = int(clock.time())
+
+        # First corruption.
+        with open(settings_path, "w") as f:
+            f.write("FIRST_CORRUPT{{{")
+        adapter.load_settings()
+        first_backup = os.path.join(adapter._settings_dir, f"settings.json.corrupt-{stamp}")
+
+        # Second corruption at the SAME clock second (FakeClock not advanced).
+        with open(settings_path, "w") as f:
+            f.write("SECOND_CORRUPT{{{")
+        adapter.load_settings()
+        second_backup = os.path.join(adapter._settings_dir, f"settings.json.corrupt-{stamp}-1")
+
+        # Both backups exist with their distinct original bytes — the first is
+        # NOT overwritten by the second.
+        assert os.path.exists(first_backup)
+        assert os.path.exists(second_backup)
+        with open(first_backup) as f:
+            assert f.read() == "FIRST_CORRUPT{{{"
+        with open(second_backup) as f:
+            assert f.read() == "SECOND_CORRUPT{{{"
+        # The notice points at the most recent backup.
+        assert adapter._corrupt_reset == {"backed_up_to": f"settings.json.corrupt-{stamp}-1"}
+
+    def test_corrupt_file_logs_error(self, tmp_path, logger, caplog):
+        adapter = self._make_adapter(tmp_path, logger, FakeClock())
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            f.write("{{{not json")
+        with caplog.at_level(logging.ERROR):
+            adapter.load_settings()
+        assert any("corrupt" in r.message.lower() for r in caplog.records)
+
+    def test_first_run_missing_file_no_backup_no_flag(self, tmp_path, logger):
+        adapter = self._make_adapter(tmp_path, logger, FakeClock())
+        result = adapter.load_settings()
+        # No .corrupt- file created.
+        assert not any(n.startswith("settings.json.corrupt-") for n in os.listdir(adapter._settings_dir))
+        assert adapter._corrupt_reset is None
+        assert result["romm_url"] == ""
+
+    def test_valid_file_no_flag(self, tmp_path, logger):
+        adapter = self._make_adapter(tmp_path, logger, FakeClock())
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump({"romm_url": "http://ok.com"}, f)
+        os.chmod(settings_path, 0o600)
+        result = adapter.load_settings()
+        assert result["romm_url"] == "http://ok.com"
+        assert adapter._corrupt_reset is None
+        assert not any(n.startswith("settings.json.corrupt-") for n in os.listdir(adapter._settings_dir))
+
+    def test_failed_backup_rename_still_returns_defaults(self, tmp_path, logger, monkeypatch):
+        """If the backup rename fails (e.g. perms), boot must not crash — defaults
+        are returned and the flag is NOT set."""
+        adapter = self._make_adapter(tmp_path, logger, FakeClock())
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            f.write("CORRUPT{{{")
+
+        def boom(_src, _dst):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(os, "replace", boom)
+        result = adapter.load_settings()
+        for key, default_value in DEFAULT_SETTINGS.items():
+            assert result[key] == default_value
+        assert adapter._corrupt_reset is None
+
+    def test_corrupt_perms_still_enforced_on_backup_path(self, tmp_path, logger):
+        """The fresh defaults written after a reset must still land at 0600 on the
+        next save — quarantine does not relax permission enforcement."""
+        adapter = self._make_adapter(tmp_path, logger, FakeClock())
+        settings_path = os.path.join(adapter._settings_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            f.write("CORRUPT{{{")
+        defaults = adapter.load_settings()
+        adapter.save_settings(defaults)
+        assert os.stat(settings_path).st_mode & 0o777 == 0o600
+
+
+class TestResetNotice:
+    def test_clean_boot_returns_reset_false(self, adapter):
+        assert adapter.consume_settings_reset_notice() == {"reset": False, "backed_up_to": None}
+
+    def test_after_corruption_returns_reset_true_then_clears(self, tmp_path, logger):
+        clock = FakeClock(now=datetime(2026, 6, 13, 12, 0, 0, tzinfo=UTC))
+        settings_dir = str(tmp_path / "settings")
+        runtime_dir = str(tmp_path / "runtime")
+        os.makedirs(settings_dir, exist_ok=True)
+        os.makedirs(runtime_dir, exist_ok=True)
+        adapter = PersistenceAdapter(settings_dir=settings_dir, runtime_dir=runtime_dir, logger=logger, clock=clock)
+        with open(os.path.join(settings_dir, "settings.json"), "w") as f:
+            f.write("CORRUPT{{{")
+        adapter.load_settings()
+
+        first = adapter.consume_settings_reset_notice()
+        assert first["reset"] is True
+        assert first["backed_up_to"] == f"settings.json.corrupt-{int(clock.time())}"
+        # Drains once: a second read is clean.
+        assert adapter.consume_settings_reset_notice() == {"reset": False, "backed_up_to": None}
+
+
+class TestClockInjection:
+    def test_default_clock_used_when_not_injected(self, tmp_path, logger):
+        """Constructing without an explicit clock must not crash and the corrupt
+        backup name carries an integer stamp from the real SystemClock."""
+        settings_dir = str(tmp_path / "settings")
+        runtime_dir = str(tmp_path / "runtime")
+        os.makedirs(settings_dir, exist_ok=True)
+        os.makedirs(runtime_dir, exist_ok=True)
+        adapter = PersistenceAdapter(settings_dir=settings_dir, runtime_dir=runtime_dir, logger=logger)
+        with open(os.path.join(settings_dir, "settings.json"), "w") as f:
+            f.write("CORRUPT{{{")
+        adapter.load_settings()
+        backups = [n for n in os.listdir(settings_dir) if n.startswith("settings.json.corrupt-")]
+        assert len(backups) == 1
+        stamp = backups[0].rsplit("-", 1)[1]
+        assert stamp.isdigit()
 
 
 # ── Save-sync state (legacy read — consumed only by the settings fold) ───────────

--- a/tests/contract/_harness.py
+++ b/tests/contract/_harness.py
@@ -193,6 +193,7 @@ def build_contract_harness(tmp_path: Any) -> ContractHarness:
     plugin.loop = loop
     plugin.settings = result.stores.settings
     plugin._debug_logger = result.handles.debug_logger
+    plugin._persistence = result.handles.persistence
     plugin._retrodeck_paths = result.callbacks.retrodeck_paths
     for attr, key in _BOUND_SERVICE_ATTRS.items():
         setattr(plugin, attr, services[key])

--- a/tests/contract/test_settings_reset_notice.py
+++ b/tests/contract/test_settings_reset_notice.py
@@ -1,0 +1,19 @@
+"""Contract test for the corrupt-settings-reset notice callable.
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``consumeSettingsResetNotice = callable<[], {reset: boolean; backed_up_to: string | null}>``.
+
+The corruption path itself is hard to drive cleanly through the real
+bootstrap (it writes fresh defaults over a quarantined file), so the
+adapter unit tests are the primary coverage. This pins the clean-boot
+shape over the real Plugin: a non-corrupt boot returns ``reset: False``
+with ``backed_up_to: None`` (literal None → JS null).
+"""
+
+from __future__ import annotations
+
+
+async def test_consume_settings_reset_notice_clean_boot_shape(harness):
+    result = await harness.plugin.consume_settings_reset_notice()
+    assert result == {"reset": False, "backed_up_to": None}
+    assert result["backed_up_to"] is None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -464,6 +464,38 @@ class TestInsecureSslSetting:
         assert plugin.settings["romm_allow_insecure_ssl"] is False
 
 
+class TestConsumeSettingsResetNotice:
+    """The consume_settings_reset_notice callable drains the adapter's one-shot
+    corrupt-settings-reset flag and clears it after the first read."""
+
+    @pytest.mark.asyncio
+    async def test_clean_boot_returns_reset_false(self, plugin, tmp_path):
+        import decky
+
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+        result = await plugin.consume_settings_reset_notice()
+        assert result == {"reset": False, "backed_up_to": None}
+
+    @pytest.mark.asyncio
+    async def test_after_corruption_returns_reset_true_then_clears(self, plugin, tmp_path):
+        import decky
+        from fakes.system_time import FakeClock
+
+        settings_dir = str(tmp_path)
+        clock = FakeClock()
+        plugin._persistence = PersistenceAdapter(settings_dir, settings_dir, decky.logger, clock=clock)
+        with open(os.path.join(settings_dir, "settings.json"), "w") as f:
+            f.write("CORRUPT{{{")
+        plugin._persistence.load_settings()
+
+        first = await plugin.consume_settings_reset_notice()
+        assert first["reset"] is True
+        assert first["backed_up_to"] == f"settings.json.corrupt-{int(clock.time())}"
+        # Drains once per process.
+        second = await plugin.consume_settings_reset_notice()
+        assert second == {"reset": False, "backed_up_to": None}
+
+
 class TestSettingsFilePermissions:
     def test_save_settings_creates_file_with_0600(self, plugin, tmp_path):
         import decky
@@ -643,6 +675,8 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_whitelist_settings",
     "update_whitelist_settings",
     "save_collection_platform_groups",
+    # Read-only one-shot corrupt-settings-reset notice drain (frontend toast).
+    "consume_settings_reset_notice",
     # Read-only RetroDECK path-resolution health probe (for the frontend banner).
     "get_retrodeck_status",
     # Cancel operations — must remain callable mid-operation when migration
@@ -901,7 +935,7 @@ class TestMainStartupOrdering:
                 hostname_provider=MagicMock(),
                 machine_id_provider=MagicMock(),
             ),
-            handles=BootstrapHandles(debug_logger=MagicMock()),
+            handles=BootstrapHandles(debug_logger=MagicMock(), persistence=MagicMock()),
         )
 
         with (


### PR DESCRIPTION
## What

`settings.json` persistence had three compounding holes that could silently wipe the user's config (RomM URL, API token, SGDB key, platform/collection selections) — a real Steam Deck risk on power loss. Closes #1010.

## Fixes

- **Crash-safe write** — `_locked_write` now `flush()` + `os.fsync`es the temp file *before* `os.replace`, then `os.fsync`es the containing directory *after* (write-tmp → fsync → rename → fsync-dir). `os.replace` only makes the rename atomic; without the fsyncs ext4 can leave a truncated `settings.json` on power loss, and settings are rewritten every boot.
- **Corrupt-file quarantine** — `load_settings` now distinguishes a missing file (silent defaults — legit first run) from an unparseable one: a corrupt `settings.json` is logged loudly and renamed to `settings.json.corrupt-<ts>` (disambiguated with `-<n>` if the stamp collides) **before** defaults are written, instead of being silently overwritten. The user keeps a recoverable backup.
- **No version down-stamp** — `save_settings` uses `max(stored, _SETTINGS_VERSION)`, so settings written by a newer plugin version aren't down-stamped (which would re-run migrations against newer-shaped data on a later re-upgrade). A non-numeric stored version coerces to `0` rather than crashing the write.
- **Clock injected** into `PersistenceAdapter` for a deterministic backup timestamp (the `SystemClock` construction moves above the adapter build in `bootstrap`; one shared instance).

## UI notice

A corruption reset is surfaced once via a new `consume_settings_reset_notice` callable → a mount-time toast ("settings were reset, a backup was saved to `<path>`, please re-enter your server URL and sign in"). The flag is transient (never persisted) and drained on read.

## Tests

Regression guards pin each bug: corrupt-file quarantine (backed up, not overwritten; first-run no backup; failed-rename still defaults), no-downstamp incl. the non-numeric-version no-crash cases, fsync ordering (`file → replace → dir`), same-second double-corruption keeps both backups, and the reset notice (backend callable + contract shape + frontend toast, non-vacuous). **100% new-code coverage** on `persistence.py` (114/114 statements, 12/12 branches).

## Docs

`CLAUDE.md` (settings-durability constraint) + `docs/architecture/backend-architecture.md`.

Closes #1010.
