### PR TITLE
fix(persistence): use BEGIN IMMEDIATE in the UoW to avoid un-retried SQLITE_BUSY_SNAPSHOT (#1011)

### DIFF
--- a/docs/adr/0004-sync-sqlite-unit-of-work.md
+++ b/docs/adr/0004-sync-sqlite-unit-of-work.md
@@ -47,7 +47,17 @@ Unchanged from epic #271 (these were never the contested part): connection **per
 (thin `main.py` callables don't see the factory); **one UoW per platform unit** for library sync (a crash loses only the
 in-flight unit); repositories **return domain aggregates**, not TypedDicts. Runtime per-connection PRAGMAs:
 `foreign_keys=ON`, `synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY`, `isolation_level=None` (the UoW
-issues explicit `BEGIN`/`COMMIT`/`ROLLBACK`); `journal_mode=WAL` is persistent and already set by the #781 runner.
+issues an explicit `BEGIN IMMEDIATE` and an explicit `COMMIT`/`ROLLBACK`); `journal_mode=WAL` is persistent and already
+set by the #781 runner.
+
+**Transaction start is `BEGIN IMMEDIATE`, universally.** Every UoW opens with `BEGIN IMMEDIATE`, never a deferred
+`BEGIN` — the write lock is taken at transaction start. A read-then-write UoW opened deferred takes a read snapshot
+first and then upgrades read → write on its first write; under WAL, if another connection commits in between, that
+upgrade fails immediately with `SQLITE_BUSY_SNAPSHOT`, which `busy_timeout` does **not** retry — so the operation errors
+spuriously. Holding the write lock from the start removes the read → write upgrade entirely; concurrent writers
+serialize on `busy_timeout` instead. The rule is universal (no read-only/write distinction): across the ~116 UoW call
+sites in this single-user, short-DB-op workload, one rule is the safe one-liner with no mislabeling footgun, and the
+only cost — read-only UoWs also taking the write lock — is negligible here.
 
 ## Consequences
 

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -390,9 +390,21 @@ introduce a second I/O paradigm alongside the established `run_in_executor` idio
 **Shape.** `SqliteUnitOfWork(db_path)` is a synchronous context manager. `__enter__` opens one connection
 (`isolation_level=None`, `row_factory = sqlite3.Row`), applies the per-connection PRAGMAs (`foreign_keys=ON`,
 `synchronous=NORMAL`, `busy_timeout=5000`, `temp_store=MEMORY` — `journal_mode=WAL` is already persistent from the
-runner), issues an explicit `BEGIN`, builds the nine repositories over that shared connection, and returns itself.
-`__exit__` commits on a clean exit, rolls back on an exception (then re-raises), and always closes the connection. One
-UoW therefore equals one transaction; writes across several repositories commit or roll back together.
+runner), issues an explicit `BEGIN IMMEDIATE`, builds the nine repositories over that shared connection, and returns
+itself. `__exit__` commits on a clean exit, rolls back on an exception (then re-raises), and always closes the
+connection. One UoW therefore equals one transaction; writes across several repositories commit or roll back together.
+
+**Transaction policy — `BEGIN IMMEDIATE` for every UoW.** The UoW starts its transaction with `BEGIN IMMEDIATE`, not a
+deferred `BEGIN`, so the write lock is acquired at transaction start. The reason: a read-then-write UoW (e.g. the
+reporter's per-rom upsert does a `roms.get` then an `INSERT` in a loop) opened with a deferred `BEGIN` takes a read
+snapshot first, then tries to _upgrade_ read → write on the first `INSERT`. Under WAL, if another connection commits a
+write in between, that upgrade fails **immediately** with `SQLITE_BUSY_SNAPSHOT` — and `busy_timeout` does **not** retry
+a snapshot-upgrade failure, so the operation errors spuriously. `BEGIN IMMEDIATE` holds the write lock from the start,
+so there is no read → write upgrade and no snapshot to invalidate; concurrent writers serialize on `busy_timeout=5000`
+instead of failing. The decision is **universal** — _all_ UoWs use `BEGIN IMMEDIATE`, with no read-only/write
+distinction: across ~116 call sites in a single-user, short-DB-op workload, the universal rule is the safe one-liner
+with no mislabeling footgun. The accepted tradeoff is that read-only UoWs also take the write lock (and so serialize
+against each other) — negligible for this workload.
 
 **Thread affinity.** A `sqlite3` connection is single-thread by default (`check_same_thread=True`, left at its safe
 default). Services run the whole `with uow_factory() as uow:` block inside their synchronous `run_in_executor` worker

--- a/py_modules/adapters/repositories/unit_of_work.py
+++ b/py_modules/adapters/repositories/unit_of_work.py
@@ -1,11 +1,19 @@
 """The synchronous SQLite Unit of Work — the transactional boundary for one operation.
 
 Opens one ``sqlite3`` connection per operation, applies the runtime
-per-connection PRAGMAs, issues an explicit ``BEGIN``, exposes the nine
+per-connection PRAGMAs, issues an explicit ``BEGIN IMMEDIATE``, exposes the nine
 repositories over that shared connection, and commits / rolls back on exit. Used
 as a synchronous context manager from a service's ``run_in_executor`` worker so
 the connection never escapes its worker thread (ADR-0004 — sync ``sqlite3`` over
 ``aiosqlite``, thread-affinity by connection-per-operation).
+
+Every UoW opens with ``BEGIN IMMEDIATE`` (not a deferred ``BEGIN``) so the write
+lock is held from transaction start. A read-then-write UoW therefore never
+upgrades a read snapshot to a write mid-transaction — the upgrade that raises
+``SQLITE_BUSY_SNAPSHOT`` (which ``busy_timeout`` does not retry) when another
+connection commits in between under WAL. Concurrent writers serialize on
+``busy_timeout`` instead. The accepted tradeoff is that read-only UoWs also take
+the write lock — negligible for this single-user, short-DB-op workload.
 
 ``SqliteUnitOfWork`` returns concrete ``SqliteXxxRepository`` instances and never
 imports the ``services``-layer Protocols; it structurally satisfies the
@@ -70,7 +78,13 @@ class SqliteUnitOfWork:
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=5000")
         conn.execute("PRAGMA temp_store=MEMORY")
-        conn.execute("BEGIN")
+        # BEGIN IMMEDIATE acquires the write lock at transaction start, so a
+        # read-then-write UoW never hits SQLITE_BUSY_SNAPSHOT under concurrent
+        # WAL commits (busy_timeout does not retry a snapshot-upgrade failure);
+        # concurrent writers serialize on busy_timeout=5000 instead. Tradeoff:
+        # read-only UoWs also take the write lock (fine for this single-user,
+        # short-DB-op workload).
+        conn.execute("BEGIN IMMEDIATE")
         self._conn = conn
 
         self.roms = SqliteRomRepository(conn)

--- a/tests/adapters/repositories/test_unit_of_work.py
+++ b/tests/adapters/repositories/test_unit_of_work.py
@@ -1,14 +1,19 @@
-"""Tests for ``SqliteUnitOfWork`` — PRAGMA application, commit, and rollback."""
+"""Tests for ``SqliteUnitOfWork`` — PRAGMA application, BEGIN mode, commit, and rollback."""
 
 from __future__ import annotations
 
 import sqlite3
+from typing import TYPE_CHECKING
 
 import pytest
 
 from adapters.repositories.unit_of_work import SqliteUnitOfWork
 from domain.rom import Rom
 from domain.rom_install import RomInstall
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
 
 
 def _rom(rom_id: int) -> Rom:
@@ -122,3 +127,159 @@ class TestRepositoryWiring:
         uow.roms.save(_rom(1))
         uow.rom_installs  # noqa: B018 — touch the peer repo
         assert uow.roms.count() == 1
+
+
+class _RecordingConnection:
+    """Wraps a real ``sqlite3.Connection`` and records every ``execute`` SQL string.
+
+    Delegates all attribute access to the wrapped connection so the UoW behaves
+    exactly as it would against a raw connection, while ``executed`` accumulates
+    the SQL the UoW issued — letting a test assert the transaction-start
+    statement non-vacuously.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self.executed: list[str] = []
+
+    def execute(self, sql: str, parameters: Sequence[object] = ()) -> sqlite3.Cursor:
+        self.executed.append(sql)
+        return self._conn.execute(sql, parameters)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._conn, name)
+
+
+class TestBeginImmediate:
+    """The UoW must start its transaction with ``BEGIN IMMEDIATE``, not a deferred ``BEGIN``."""
+
+    def test_enter_issues_begin_immediate_not_plain_begin(self, db: str, monkeypatch: pytest.MonkeyPatch):
+        recorded: list[str] = []
+        real_connect = sqlite3.connect
+
+        def spy_connect(*args: object, **kwargs: object) -> _RecordingConnection:
+            conn = real_connect(*args, **kwargs)  # type: ignore[arg-type]
+            wrapper = _RecordingConnection(conn)
+            recorded.append(wrapper)  # type: ignore[arg-type]
+            return wrapper
+
+        monkeypatch.setattr(sqlite3, "connect", spy_connect)
+
+        with SqliteUnitOfWork(db) as unit:
+            unit.roms.save(_rom(1))
+
+        assert len(recorded) == 1
+        statements = recorded[0].executed  # type: ignore[attr-defined]
+        # The write lock is taken up front with BEGIN IMMEDIATE ...
+        assert "BEGIN IMMEDIATE" in statements
+        # ... and a plain deferred BEGIN (the SNAPSHOT-prone start) is NOT issued.
+        assert "BEGIN" not in statements
+
+
+def _wal_connection(db_path: str, *, busy_timeout: int = 5000) -> sqlite3.Connection:
+    """Open a raw connection in WAL mode, mirroring the UoW's runtime PRAGMAs.
+
+    ``journal_mode=WAL`` is persistent in the database file once set; the first
+    connection to a fresh standalone DB stamps it (production gets it from the
+    migration runner). Setting it on every connection is idempotent and keeps
+    these standalone-DB tests self-contained.
+    """
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(f"PRAGMA busy_timeout={busy_timeout}")
+    conn.execute("PRAGMA temp_store=MEMORY")
+    return conn
+
+
+class TestBusySnapshotRegression:
+    """Deterministic proof of the #1011 SNAPSHOT failure mode and that the fix avoids it.
+
+    Both tests drive two real connections against one WAL database with manual
+    lock ordering on a single thread, so there is no timing race.
+    """
+
+    def test_deferred_begin_read_then_write_raises_under_concurrent_commit(self, tmp_path: Path):
+        # (a) Pin the bug with a *deferred* BEGIN on raw connections (NOT the UoW):
+        # conn1 takes a read snapshot, conn2 commits a write, conn1's later write
+        # upgrade fails IMMEDIATELY with OperationalError — the SQLITE_BUSY_SNAPSHOT
+        # that busy_timeout does not retry.
+        db_path = str(tmp_path / "snapshot.db")
+        seed = _wal_connection(db_path)
+        seed.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)")
+        seed.execute("INSERT INTO t (id, n) VALUES (1, 1)")
+        seed.close()
+
+        # A short busy_timeout on conn1 so a (non-snapshot) lock contention would
+        # also fail fast rather than hang the test.
+        conn1 = _wal_connection(db_path, busy_timeout=100)
+        conn2 = _wal_connection(db_path)
+        try:
+            conn1.execute("BEGIN")  # deferred — no lock taken yet
+            conn1.execute("SELECT n FROM t WHERE id = 1").fetchone()  # take the snapshot
+
+            conn2.execute("BEGIN IMMEDIATE")
+            conn2.execute("UPDATE t SET n = 2 WHERE id = 1")
+            conn2.execute("COMMIT")  # snapshot conn1 holds is now stale
+
+            with pytest.raises(sqlite3.OperationalError):
+                # read -> write upgrade against a stale snapshot: SQLITE_BUSY_SNAPSHOT
+                conn1.execute("UPDATE t SET n = 3 WHERE id = 1")
+        finally:
+            conn1.close()
+            conn2.close()
+
+    def test_uow_immediate_read_then_write_survives_concurrent_writer(self, tmp_path: Path):
+        # (b) Same lock ordering, but conn1 is the real SqliteUnitOfWork. Its
+        # BEGIN IMMEDIATE takes the write lock at transaction start, so the
+        # contending writer (conn2) cannot commit in between; conn2 instead fails
+        # fast with "database is locked" on its own short busy_timeout. The UoW's
+        # read-then-write completes and commits cleanly — no SNAPSHOT error.
+        db_path = str(tmp_path / "immediate.db")
+        apply = _wal_connection(db_path)
+        apply.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)")
+        apply.execute("INSERT INTO t (id, n) VALUES (1, 1)")
+        apply.close()
+
+        contender = _wal_connection(db_path, busy_timeout=100)
+        try:
+            with SqliteUnitOfWork(db_path) as unit:
+                conn = unit._conn
+                assert conn is not None
+                # Read first (this is the read-then-write shape that broke with deferred BEGIN).
+                row = conn.execute("SELECT n FROM t WHERE id = 1").fetchone()
+                assert row[0] == 1
+
+                # A second writer contends now; with the UoW holding the write lock
+                # from BEGIN IMMEDIATE, the contender cannot slip a commit in — it
+                # fails fast on its short busy_timeout instead.
+                with pytest.raises(sqlite3.OperationalError, match="locked"):
+                    contender.execute("BEGIN IMMEDIATE")
+                    contender.execute("UPDATE t SET n = 99 WHERE id = 1")
+
+                # The UoW's own read-then-write proceeds without a SNAPSHOT error.
+                conn.execute("UPDATE t SET n = 2 WHERE id = 1")
+            # __exit__ committed cleanly.
+
+            verify = _wal_connection(db_path)
+            try:
+                assert verify.execute("SELECT n FROM t WHERE id = 1").fetchone()[0] == 2
+            finally:
+                verify.close()
+        finally:
+            contender.close()
+
+    def test_two_sequential_immediate_write_uows_serialize(self, db: str):
+        # A simpler serialization guard: two sequential write UoWs both succeed
+        # and the second sees the first's committed write.
+        with SqliteUnitOfWork(db) as first:
+            first.roms.save(_rom(1))
+
+        with SqliteUnitOfWork(db) as second:
+            assert second.roms.get(1) is not None
+            second.roms.save(_rom(2))
+
+        with SqliteUnitOfWork(db) as third:
+            assert third.roms.count() == 2


### PR DESCRIPTION
## What

The SQLite Unit-of-Work opened transactions with a deferred `BEGIN`, so a read-then-write UoW (e.g. `reporter._upsert_acked_rom` does `roms.get` then INSERT in a loop) upgrades a read snapshot to a write mid-transaction. Under WAL, if another executor thread (download-complete / sync-commit / playtime session-end all run concurrently) commits in between, the upgrade fails **immediately** with `SQLITE_BUSY_SNAPSHOT` — which `busy_timeout` does **not** retry — and the operation rolls back and errors spuriously. No corruption (connection-per-op + WAL); just avoidable failures. Closes #1011.

## Fix

`BEGIN IMMEDIATE` acquires the write lock at transaction start, so the read→write upgrade never happens and concurrent writers serialize on `busy_timeout=5000` instead of failing.

Applied **universally** (no read-only/write distinction): the safe choice across all ~116 UoW call sites with zero mislabeling footgun. The only tradeoff — read-only UoWs also take the write lock — is negligible for this single-user, short-DB-op workload (verified the heaviest write UoW, the sync-commit batch, is a bounded in-memory loop well under the 5s timeout).

## Tests

`tests/adapters/repositories/test_unit_of_work.py`: asserts `BEGIN IMMEDIATE` is issued (not plain `BEGIN`); a deterministic two-connection regression that **pins the bug** with deferred `BEGIN` (read-then-write under a concurrent commit raises `OperationalError`) and **shows the UoW survives** it with `BEGIN IMMEDIATE`; plus a writer-serialization guard. Proven non-vacuous (reverting to deferred `BEGIN` fails exactly the fix-dependent tests). Full suite green, no regression.

## Docs

`docs/architecture/database-design.md` (transaction policy) + `docs/adr/0004-sync-sqlite-unit-of-work.md`.