### PR TITLE
fix(migration): fail loud when the migration_blocked gate is unwired (#970)

### DIFF
--- a/py_modules/lib/migration_gate.py
+++ b/py_modules/lib/migration_gate.py
@@ -1,11 +1,20 @@
 """Decorator that blocks Decky callables while a RetroDECK migration is pending.
 
 The decorated method must be ``async def`` (every Decky callable is). The wrapped
-method's owner class must expose a ``_migration_service`` attribute with an
-``is_retrodeck_migration_pending() -> bool`` method.
+method's owner class **must** expose a ``_migration_service`` attribute with an
+``is_retrodeck_migration_pending() -> bool`` method — this gate is a data-safety
+guard and refuses to run without it.
 
-Tests can introspect blocked callables via the
-``_migration_blocked`` attribute attached to the wrapper.
+A missing ``_migration_service`` is a wiring regression, not a tolerable state:
+the wrapper raises ``RuntimeError`` rather than silently skipping the gate. In
+correctly-wired production the attribute is always present (``main.py:_main``
+binds it; the contract harness binds the same set), so the raise never fires
+normally — but a regression that drops the wiring fails loud (and the contract
+tests, which drive gated callables over the real bootstrap, catch it in CI)
+instead of silently disabling the gate for every gated callable.
+
+Tests can introspect blocked callables via the ``_migration_blocked`` attribute
+attached to the wrapper.
 
 Lives in ``lib/`` to stay outside the services/adapters/domain dependency
 graph (per import-linter contracts).
@@ -18,14 +27,23 @@ from typing import Any
 
 
 def migration_blocked(method):
-    """Block this Decky callable when ``is_retrodeck_migration_pending()`` is True."""
+    """Block this Decky callable when ``is_retrodeck_migration_pending()`` is True.
+
+    Requires the owner to expose ``_migration_service``; raises ``RuntimeError``
+    if it is missing (a wiring regression) so the safety gate fails loud rather
+    than silently disabling itself for the gated callable.
+    """
 
     @functools.wraps(method)
     async def wrapper(self, *args: Any, **kwargs: Any):
-        # Defensive: skip the gate cleanly if _migration_service is missing
-        # (e.g. tests that haven't wired it). Prefer no-op over AttributeError.
         service = getattr(self, "_migration_service", None)
-        if service is not None and service.is_retrodeck_migration_pending():
+        if service is None:
+            raise RuntimeError(
+                f"@migration_blocked on {method.__name__!r}: _migration_service is unwired. "
+                "The migration safety gate is a hard requirement; refusing to run the gated "
+                "callable without it (this is a wiring regression, not a tolerable state)."
+            )
+        if service.is_retrodeck_migration_pending():
             return {
                 "success": False,
                 "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,9 +59,10 @@ def _make_testable_plugin():
     """Return a TestablePlugin instance with test-only attributes declared.
 
     Pre-populates ``_migration_service`` with a non-pending MagicMock so the
-    ``@migration_blocked`` decorator does not raise AttributeError in tests
-    that don't otherwise wire migration state. Tests that exercise the
-    block can override ``is_retrodeck_migration_pending`` per-test.
+    ``@migration_blocked`` decorator passes through (it requires the service and
+    raises RuntimeError if it is unwired) in tests that don't otherwise wire
+    migration state. Tests that exercise the block can override
+    ``is_retrodeck_migration_pending`` per-test.
 
     Also pre-wires a no-op ``_debug_logger`` so any service that consumes
     ``Plugin._log_debug`` (which forwards through ``_debug_logger``) works

--- a/tests/lib/test_migration_gate.py
+++ b/tests/lib/test_migration_gate.py
@@ -2,8 +2,10 @@
 
 The decorator wraps Decky callables on Plugin so they short-circuit with a
 blocked-dict whenever ``self._migration_service.is_retrodeck_migration_pending()``
-is True. Tests use a minimal fake class with a ``_migration_service`` attribute
-to keep them independent from the full Plugin.
+is True. ``_migration_service`` is a hard requirement: a missing/None service is
+a wiring regression and the wrapper raises ``RuntimeError`` rather than silently
+skipping the safety gate. Tests use a minimal fake class with a
+``_migration_service`` attribute to keep them independent from the full Plugin.
 """
 
 from __future__ import annotations
@@ -122,17 +124,57 @@ class TestMigrationBlockedDecorator:
         assert _FakeOwner.do_thing.__doc__ == ("Demo docstring used to verify @functools.wraps preservation.")
 
     @pytest.mark.asyncio
-    async def test_decorator_no_op_when_migration_service_missing(self):
-        """Defensive path: if _migration_service is absent, the wrapper must
-        still call through to the wrapped method instead of raising."""
+    async def test_raises_when_migration_service_attribute_absent(self):
+        """Regression guard for #970: the gate is a hard data-safety requirement.
+
+        If _migration_service is missing entirely (no attribute), the wrapper
+        must RAISE rather than silently call through — a wiring regression must
+        fail loud. (Non-vacuous: under the old no-op escape hatch this same
+        owner returned "ok" instead of raising.)
+        """
 
         class _OwnerWithoutService:
+            def __init__(self):
+                self.called = False
+
             @migration_blocked
             async def do(self):
+                self.called = True
                 return "ok"
 
-        result = await _OwnerWithoutService().do()
-        assert result == "ok"
+        owner = _OwnerWithoutService()
+        with pytest.raises(RuntimeError) as exc_info:
+            await owner.do()
+        # Message names the gated method and explains the unwired gate.
+        assert "do" in str(exc_info.value)
+        assert "_migration_service" in str(exc_info.value)
+        # The gated callable must NOT have run without the safety gate.
+        assert owner.called is False
+
+    @pytest.mark.asyncio
+    async def test_raises_when_migration_service_is_none(self):
+        """A present-but-None _migration_service is also unwired → raises.
+
+        Mirrors the absent-attribute case for the ``getattr(..., None)`` path:
+        an explicitly-None service is just as much a wiring regression.
+        """
+
+        class _OwnerWithNoneService:
+            def __init__(self):
+                self._migration_service = None
+                self.called = False
+
+            @migration_blocked
+            async def do(self):
+                self.called = True
+                return "ok"
+
+        owner = _OwnerWithNoneService()
+        with pytest.raises(RuntimeError) as exc_info:
+            await owner.do()
+        assert "do" in str(exc_info.value)
+        assert "_migration_service" in str(exc_info.value)
+        assert owner.called is False
 
     @pytest.mark.asyncio
     async def test_returns_blocked_dict_using_mock_service(self):


### PR DESCRIPTION
## What

The `@migration_blocked` gate guards 31 data-risky callables during a pending RetroDECK migration. It read `_migration_service` via `getattr(..., None)` and, when the attribute was missing, **silently skipped the gate** (a test-convenience no-op). A production wiring regression would therefore disable the safety gate for every gated callable with **zero signal** — gated operations could run against half-migrated paths. Closes #970.

## Fix

Remove the escape hatch: the wrapper now **raises `RuntimeError`** when `_migration_service` is unwired. In correctly-wired production the attribute is always present (`main.py:_main` + the contract harness bind it), so the raise never fires normally; a wiring regression instead **fails loud**, and the contract tests (which drive gated callables over the real `bootstrap()`) catch it in CI rather than it silently shipping. Raise is also data-safe — the gated op does not run.

## Tests

`tests/lib/test_migration_gate.py`: missing/`None` `_migration_service` → raises `RuntimeError` (message names the method + the unwired gate) **and the inner method is not invoked**; pending→True returns the blocked dict (inner not called); pending→False calls through. Non-vacuous: the same missing-service input call-through-passed under the old no-op. The test fixtures already wired a non-pending migration service; only the gate's own no-op test was replaced. Full suite green (3403 passed / 1 xfailed).

docs: N/A — internal safety-gate hardening (fail-loud on a wiring regression); no user-facing or flow change, behavior documented in the decorator docstring.