### PR TITLE
chore(ci): invariant register + emit-parity and settings-owner gates (#1029)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,12 @@ jobs:
       - name: Check no bare ignores
         run: bash scripts/check_no_bare_ignores.sh
 
+      - name: Check emit↔listener event parity (backend ↔ frontend)
+        run: python scripts/check_event_parity.py
+
+      - name: Check settings-owner confinement
+        run: python scripts/check_settings_owner.py
+
   sonarcloud:
     runs-on: ubuntu-latest
     needs: [test, frontend-test]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,34 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
   pattern-exempt. Enforces the "Callable response shapes" convention below.
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
+## Invariant register — cross-cutting safety rules
+
+The audit's clearest pattern: every rule with a mechanical check held; every rule that lived in prose or in a reviewer's
+head drifted. This register is the single inventory of the cross-cutting safety rules — the ones that span files, so no
+diff-scoped review (human or agent) sees the whole rule — plus the current enforcement tier of each. It is a **map of
+the enforcement surface, not the enforcement itself**: a `check`/`test` rule is enforced by the named artifact; a
+`prompt-only` rule is not yet mechanized and is injected here so review carries it verbatim until a check exists. The
+moment a `prompt-only` rule gets a mechanical check it moves to the `check` tier — a rule is never weakened to stay
+green, and a real drift is a finding to triage, never an exemption. `[ours]`
+
+| Invariant                                                                              | Tier               | Enforced by                                                                                          |
+| -------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Callable failures use `{success, reason, message}` (never `error` / `error_code`)      | check              | `scripts/check_failure_shape.py --check`                                                             |
+| Frontend↔backend callable parity (names + arity)                                       | check              | `scripts/check_callable_manifest.py`                                                                 |
+| Every backend `emit` event name has a frontend listener, and vice versa                | check              | `scripts/check_event_parity.py`                                                                      |
+| `settings.json` is written only by its owner (`adapters/persistence.py`)               | check              | `scripts/check_settings_owner.py`                                                                    |
+| Aggregate state mutated only via verb-named methods (no field assignment)              | check              | `scripts/check_aggregate_field_assignment.py`                                                        |
+| Services never call clocks / sleep / uuid / random directly (inject the Protocol)      | check              | `scripts/check_cosmic_call_bans.sh`                                                                  |
+| Service-independence contract list stays complete                                      | check              | `scripts/check_service_independence_contract.py`                                                     |
+| Layer import direction (services ↛ adapters, adapters ↛ services, …)                   | check              | `.importlinter` (`lint-imports`)                                                                     |
+| No bare `# type: ignore` / blanket suppressions                                        | check              | `scripts/check_no_bare_ignores.sh`                                                                   |
+| Server-supplied path components pass `safe_join` (`lib/path_safety.py`)                | test + prompt-only | traversal tests per path builder; new call sites are prompt-only                                     |
+| No sentinel objects on the wire — explicit JSON-representable tagged values only       | prompt-only        | mechanize with #1032 (after tagged values replace the sentinels)                                     |
+| Every destructive op has backup-or-confirm; never delete data that exists nowhere else | prompt-only        | mechanize via a destructive-ops funnel with the #794 delete-path fixes (#965 / #974 / #1005 / #1062) |
+
+When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
+register is what that sweep checks against (see #1030).
+
 ## Architecture — Cosmic Python rules
 
 Cosmic Python ("Architecture Patterns with Python", Percival & Gregory) is our north star, adapted for a single-user

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -151,6 +151,16 @@ param count) differs. Arg types stay out of scope (Python signatures carry no hi
 checkable shape. The same parity assertion is surfaced inside the pytest run by
 `tests/contract/test_callable_manifest.py`.
 
+`mise run lint` (and CI) also runs `scripts/check_event_parity.py`, which fails if a backend `emit("name", ...)` event
+has no matching frontend `addEventListener("name", ...)` (or vice versa). The event names are bare string literals, so
+the gate matches the two surfaces by literal event name — the backend side parsed via AST (`emit` / `_emit` calls), the
+frontend side via a text scan of bare `addEventListener` calls. Static sibling of the callable-manifest gate, for the
+event channel. The same parity assertion is surfaced inside the pytest run by `tests/contract/test_event_parity.py`.
+
+`mise run lint` (and CI) also runs `scripts/check_settings_owner.py`, which fails if the `settings.json` filename
+literal appears anywhere except its owning adapter (`adapters/persistence.py`); confining the literal to one module
+keeps all settings writes in the single crash-safe owner.
+
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
 ## Code Quality

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,8 @@ run = [
     "python scripts/check_callable_manifest.py",
     "bash scripts/check_cosmic_call_bans.sh",
     "python scripts/check_failure_shape.py --check",
+    "python scripts/check_event_parity.py",
+    "python scripts/check_settings_owner.py",
 ]
 
 [tasks.deploy]

--- a/scripts/check_event_parity.py
+++ b/scripts/check_event_parity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Backend↔frontend emit-event parity gate.
+
+The realtime event channel is declared twice: the backend emits a named event
+via ``self._emit("name", payload)`` (Python) and the frontend subscribes to it
+via ``addEventListener<[Payload]>("name", handler)`` (TypeScript). Nothing ties
+the two together at build time — a renamed/added/removed event on either side
+only surfaces at runtime as an event that fires into the void (emit with no
+listener) or a listener that never wakes (listener with no emitter).
+
+This check derives both surfaces from source and fails when they diverge, so the
+event channel stays one source of truth. It is the static sibling of
+``scripts/check_callable_manifest.py``: the callable gate pins the request/reply
+surface, this gate pins the fire-and-forget event surface.
+
+What it guarantees (and what it deliberately does not):
+
+  * Every backend ``emit("name", ...)`` has a matching frontend
+    ``addEventListener("name", ...)`` and vice versa — no orphan on either side.
+  * Only **literal** event names are checked. A dynamic/variable event name
+    (``self._emit(some_var, ...)`` or ``addEventListener(name, ...)``) can't be
+    matched statically and is skipped — same limitation the callable gate has
+    with literal wire names.
+  * Only the bare ``@decky/api`` ``addEventListener(...)`` counts on the
+    frontend. ``globalThis.addEventListener`` / ``el.addEventListener`` are DOM
+    ``CustomEvent`` subscriptions, not backend emits, and are excluded.
+
+``EXEMPT`` holds event names deliberately kept out of the parity check. It is
+empty today; an entry here is a conscious "this event is intentionally declared
+on only one side" decision — never a lever to silence a real drift. A genuine
+drift is a finding to triage, not to exempt.
+
+Exit 0 when the two surfaces match, 1 (one line per discrepancy) otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PY_MODULES_DIR = REPO_ROOT / "py_modules"
+VENDOR_DIR = PY_MODULES_DIR / "_vendor"
+SRC_DIR = REPO_ROOT / "src"
+MAIN_PY = REPO_ROOT / "main.py"
+
+# Event names deliberately excluded from the parity check. Empty today; add an
+# entry only as a conscious decision (see the module docstring). Do NOT add a
+# name here to silence a real drift — a drift is a finding to triage.
+EXEMPT: frozenset[str] = frozenset()
+
+# Attribute names that name an emit call (``self.emit`` / ``self._emit``).
+_EMIT_ATTRS = frozenset({"emit", "_emit"})
+
+# Mirrors the TS-source helpers in check_callable_manifest.py (kept local:
+# scripts/ is not importable from the importlib-loaded contract tests).
+_QUOTES = frozenset({'"', "'", "`"})
+
+
+def _skip_string(text: str, start: int) -> int:
+    """Return the index just past the string/template literal opening at *start*.
+
+    *start* must index a quote character. Handles backslash escapes; a template
+    literal's ``${...}`` interpolation is treated as opaque body text (its inner
+    brackets never reach the depth tracker because the whole literal is skipped).
+    """
+    quote = text[start]
+    i = start + 1
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == quote:
+            return i + 1
+        i += 1
+    return n
+
+
+def _strip_comments(text: str) -> str:
+    """Return *text* with TS ``//`` and ``/* */`` comments blanked out.
+
+    Comment spans are replaced with a single space (preserving token separation
+    and source length is unnecessary — the parser is whitespace-tolerant), so a
+    comment containing an apostrophe, a ``<``/``>``, an unbalanced bracket, or a
+    whole commented-out ``addEventListener("dead", ...)`` call cannot corrupt the
+    downstream scanning or be mistaken for a live listener.
+
+    String and template literals are preserved verbatim — a ``//`` or ``/*``
+    inside ``"http://x"`` or `` `a/*b` `` is part of the string, not a comment.
+    Scans char by char so a comment-opener inside a literal is never honoured.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTES:
+            end = _skip_string(text, i)
+            out.append(text[i:end])
+            i = end
+            continue
+        if ch == "/" and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt == "/":
+                end = text.find("\n", i + 2)
+                # Keep the newline so line structure (and any line comment a
+                # later scan relies on) survives; blank only the comment body.
+                if end == -1:
+                    out.append(" ")
+                    return "".join(out)
+                out.append(" \n")
+                i = end + 1
+                continue
+            if nxt == "*":
+                end = text.find("*/", i + 2)
+                out.append(" ")
+                i = len(text) if end == -1 else end + 2
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _skip_generic(text: str, lt_index: int) -> int | None:
+    """Return the index just past the balanced ``<...>`` opening at *lt_index*.
+
+    *lt_index* must index a ``<``. Depth-counts ``<``/``>`` so a nested generic
+    (``addEventListener<[{ a: number }]>``) balances correctly; string literals
+    inside are skipped so brackets/quotes within them never affect the count.
+    Returns None if the angle brackets never balance (truncated source).
+    """
+    depth = 0
+    i = lt_index
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in _QUOTES:
+            i = _skip_string(text, i)
+            continue
+        if ch == "<":
+            depth += 1
+            i += 1
+            continue
+        if ch == ">":
+            depth -= 1
+            i += 1
+            if depth == 0:
+                return i
+            continue
+        i += 1
+    return None
+
+
+def _is_word_char(ch: str) -> bool:
+    """Return True for a JS identifier char ([A-Za-z0-9_$])."""
+    return ch.isalnum() or ch in {"_", "$"}
+
+
+def _listener_name(text: str, after: int) -> str | None:
+    """Return the event name of the ``addEventListener(...)`` call after *after*.
+
+    *after* indexes just past the ``addEventListener`` needle. Skips whitespace;
+    if a ``<`` follows, skips the balanced generic; then expects ``(``, optional
+    whitespace, and a quoted string literal — that literal is the event name. A
+    template literal with a ``${...}`` interpolation is not a static name and is
+    skipped (returns None).
+    """
+    i = after
+    n = len(text)
+    while i < n and text[i].isspace():
+        i += 1
+    if i < n and text[i] == "<":
+        skipped = _skip_generic(text, i)
+        if skipped is None:
+            return None
+        i = skipped
+        while i < n and text[i].isspace():
+            i += 1
+    if i >= n or text[i] != "(":
+        return None
+    i += 1
+    while i < n and text[i].isspace():
+        i += 1
+    if i >= n or text[i] not in _QUOTES:
+        return None
+    quote = text[i]
+    end = _skip_string(text, i)
+    # end indexes just past the closing quote; the literal body excludes quotes.
+    body = text[i + 1 : end - 1]
+    return body if quote != "`" or "${" not in body else None
+
+
+def parse_frontend_listeners(src_dir: Path) -> set[str]:
+    """Parse every bare ``addEventListener("name", ...)`` under *src_dir*.
+
+    Scans all ``.ts``/``.tsx`` files as text (calls may span multiple lines),
+    EXCLUDING test files (``*.test.*``), ``src/test-utils/`` and
+    ``src/test-setup.ts``. Comments are stripped first so a commented-out
+    listener isn't mistaken for a live one. Only the bare ``addEventListener``
+    needle counts: the char immediately before it must be neither ``.`` (rejects
+    ``globalThis.addEventListener`` / ``el.addEventListener`` — DOM CustomEvents,
+    not backend emits) nor an identifier char. Returns the set of literal event
+    names.
+    """
+    result: set[str] = set()
+    if not src_dir.is_dir():
+        return result
+    test_utils = src_dir / "test-utils"
+    test_setup = src_dir / "test-setup.ts"
+    files = sorted(p for p in src_dir.rglob("*") if p.suffix in (".ts", ".tsx") and p.is_file())
+    for path in files:
+        if ".test." in path.name or test_utils in path.parents or path == test_setup:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        _parse_text_into(_strip_comments(text), result)
+    return result
+
+
+def _parse_text_into(text: str, result: set[str]) -> None:
+    """Find every bare ``addEventListener("name", ...)`` in *text* and record it."""
+    needle = "addEventListener"
+    i = 0
+    while True:
+        idx = text.find(needle, i)
+        if idx == -1:
+            return
+        i = idx + len(needle)
+        # The char immediately before the needle must be neither ``.`` nor an
+        # identifier char — that rejects ``globalThis.addEventListener`` and any
+        # ``fooAddEventListener``-style member, keeping only the bare import.
+        if idx > 0:
+            prev = text[idx - 1]
+            if prev == "." or _is_word_char(prev):
+                continue
+        name = _listener_name(text, i)
+        if name is not None:
+            result.add(name)
+
+
+def _iter_backend_files() -> list[Path]:
+    """Every backend ``.py`` to scan: all of py_modules/ minus _vendor/, plus main.py."""
+    files = sorted(p for p in PY_MODULES_DIR.rglob("*.py") if VENDOR_DIR not in p.parents and p != VENDOR_DIR)
+    if MAIN_PY.is_file():
+        files.append(MAIN_PY)
+    return files
+
+
+def parse_backend_emits(files: list[Path] | None = None) -> set[str]:
+    """Parse every literal ``self.emit("name", ...)`` / ``self._emit("name", ...)``.
+
+    Uses ``ast`` (emits span multiple lines, so a regex would be brittle). Walks
+    every ``ast.Call`` whose ``func`` is an ``ast.Attribute`` with ``.attr`` in
+    ``{"emit", "_emit"}`` and a first positional arg that is a string constant —
+    that constant is the event name. Dynamic/variable event names can't be
+    matched statically and are skipped. Returns the set of literal event names.
+    """
+    if files is None:
+        files = _iter_backend_files()
+    result: set[str] = set()
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr in _EMIT_ATTRS):
+                continue
+            if not node.args:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                result.add(first.value)
+    return result
+
+
+def find_discrepancies(
+    backend: set[str],
+    frontend: set[str],
+    exempt: frozenset[str],
+) -> list[str]:
+    """Diff the two event surfaces. One human-readable line per discrepancy.
+
+    Reports: (a) an event emitted by the backend with no frontend listener, and
+    (b) a frontend listener for an event no backend emits. ``exempt`` names are
+    skipped in both directions.
+    """
+    backend_names = backend - exempt
+    frontend_names = frontend - exempt
+
+    findings: list[str] = [
+        f'{name}: backend emits "{name}" but no frontend addEventListener("{name}", ...) '
+        f"subscribes to it — add the frontend listener, fix a rename, or add it to EXEMPT "
+        f"in this script if the event is intentionally backend-only."
+        for name in sorted(backend_names - frontend_names)
+    ]
+    findings.extend(
+        f'{name}: frontend addEventListener("{name}", ...) subscribes but no backend '
+        f'emit("{name}", ...) fires it — add the backend emit, fix a rename, or add it to '
+        f"EXEMPT in this script if the listener is intentionally frontend-only."
+        for name in sorted(frontend_names - backend_names)
+    )
+    return sorted(findings)
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+    backend = parse_backend_emits()
+    frontend = parse_frontend_listeners(SRC_DIR)
+    findings = find_discrepancies(backend, frontend, EXEMPT)
+    if findings:
+        for line in findings:
+            print(line)
+        print()
+        print(
+            "ERROR: the backend (py_modules emit calls) and frontend (src/**/*.ts "
+            "addEventListener calls) event surfaces have drifted. Every emitted event "
+            "must have a frontend listener and vice versa (or be explicitly EXEMPT) so "
+            "the event channel stays one source of truth."
+        )
+        return 1
+    matched = len(backend & frontend)
+    print(f"OK: backend↔frontend event parity matches ({matched} events).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_settings_owner.py
+++ b/scripts/check_settings_owner.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Settings-owner confinement gate.
+
+``settings.json`` is written crash-safe by a single owner — the persistence
+adapter (``adapters/persistence.py``: write-tmp → fsync → ``os.replace`` →
+fsync-dir, plus corrupt-file quarantine). If any other module names the file by
+its literal filename, that module could read or write it directly, bypassing the
+crash-safe path and the version-stamping/quarantine invariants the owner holds.
+
+This check enforces a **proxy** for "all writes go through the owner": the
+string literal ``"settings.json"`` may appear ONLY in the owner module.
+Confining the filename literal to the owner means no other module can name —
+hence open or write — the file. This is name-confinement, NOT taint/dataflow
+analysis: it cannot catch a module that receives an already-constructed path
+from the owner and writes to it. It catches the common regression, which is a
+second module hardcoding the filename and writing its own copy.
+
+It scans every backend ``.py`` (all of ``py_modules/`` except ``_vendor/`` and
+except the owner, plus ``main.py``) via ``ast`` and flags any ``ast.Constant``
+whose value is exactly the str ``"settings.json"``. A docstring or comment that
+merely *mentions* settings.json in prose does not match — only an exact
+string-constant ``"settings.json"`` does (a docstring's constant value is the
+whole docstring text, not the bare filename). ``tests/`` is not scanned: tests
+legitimately reference the filename.
+
+Exit 0 when the literal is confined to the owner, 1 (one line per offending
+site) otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PY_MODULES_DIR = REPO_ROOT / "py_modules"
+VENDOR_DIR = PY_MODULES_DIR / "_vendor"
+MAIN_PY = REPO_ROOT / "main.py"
+
+# The single module allowed to name settings.json — its crash-safe owner.
+OWNER = REPO_ROOT / "py_modules" / "adapters" / "persistence.py"
+
+# The confined literal.
+SETTINGS_FILENAME = "settings.json"
+
+
+def _iter_scanned_files() -> list[Path]:
+    """Every backend ``.py`` to scan: py_modules/ minus _vendor/ and the owner, plus main.py."""
+    owner = OWNER.resolve()
+    files = sorted(
+        p
+        for p in PY_MODULES_DIR.rglob("*.py")
+        if VENDOR_DIR not in p.parents and p != VENDOR_DIR and p.resolve() != owner
+    )
+    if MAIN_PY.is_file():
+        files.append(MAIN_PY)
+    return files
+
+
+def find_violations(files: list[Path] | None = None) -> list[str]:
+    """Return one human-readable line per ``"settings.json"`` literal outside the owner.
+
+    Walks each file's AST for any ``ast.Constant`` whose value is exactly the str
+    ``"settings.json"``. Each occurrence outside the owner is a violation; the
+    line reports the repo-relative path, line number, and a fix hint.
+    """
+    if files is None:
+        files = _iter_scanned_files()
+    findings: list[str] = []
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(REPO_ROOT)
+        findings.extend(
+            f'{rel}:{node.lineno}: names the literal "settings.json" — settings.json '
+            f"is written crash-safe only by its owner (adapters/persistence.py). Route "
+            f"reads/writes through the owner instead of hardcoding the filename here."
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and node.value == SETTINGS_FILENAME
+        )
+    return sorted(findings)
+
+
+def main(argv: list[str]) -> int:
+    if any(a in {"-h", "--help"} for a in argv):
+        print(__doc__)
+        return 0
+    findings = find_violations()
+    if findings:
+        for line in findings:
+            print(line)
+        print()
+        print(
+            'ERROR: the literal "settings.json" must appear only in its owning adapter '
+            "(adapters/persistence.py), which writes the file crash-safe. Any other module "
+            "naming the file can bypass the crash-safe write path and version/quarantine "
+            "invariants — route through the owner instead."
+        )
+        return 1
+    print("OK: settings.json literal is confined to its owner (adapters/persistence.py).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/contract/test_event_parity.py
+++ b/tests/contract/test_event_parity.py
@@ -1,0 +1,43 @@
+"""Backend↔frontend emit-event parity, surfaced inside the pytest run.
+
+This pins the exact contract the CI gate (``scripts/check_event_parity.py``)
+enforces: every backend ``emit("name", ...)`` event has a matching frontend
+``addEventListener("name", ...)`` listener, in both directions. It is the
+static-parity sibling of the rest of ``tests/contract/`` — those tests *drive*
+the real callables frontend-shaped; this one asserts the two *declarations* of
+the event channel agree, so a renamed/added/removed event or an orphaned
+listener breaks the pytest run, not just the standalone lint gate.
+
+The parser functions are imported from the gate script (loaded via ``importlib``
+because ``scripts/`` is not on ``sys.path``), so the test and the CI gate share
+one implementation — they can never disagree about what "matches" means.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_event_parity.py"
+_SRC_DIR = _REPO_ROOT / "src"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("check_event_parity", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_gate = _load_gate()
+
+
+def test_backend_frontend_event_parity_matches():
+    backend = _gate.parse_backend_emits()
+    frontend = _gate.parse_frontend_listeners(_SRC_DIR)
+    discrepancies = _gate.find_discrepancies(backend, frontend, _gate.EXEMPT)
+    assert discrepancies == []


### PR DESCRIPTION
## What

Establishes the **invariant register** (#1029) — a single inventory in `CLAUDE.md` of the cross-cutting safety rules that span files (so no diff-scoped review sees the whole rule), each tagged with its enforcement tier: `check` (script), `test`, or `prompt-only`.

The audit's clearest pattern was that rules with a mechanical check held while rules living in prose drifted. So this PR also begins mechanizing the `prompt-only` rows with two new gates:

- **`scripts/check_event_parity.py`** — fails when a backend `emit("name", …)` event has no matching frontend `addEventListener("name", …)` (or vice versa). Backend parsed via AST, frontend via text scan; static sibling of the callable-manifest gate. Carries a contract-test mirror (`tests/contract/test_event_parity.py`).
- **`scripts/check_settings_owner.py`** — confines the `settings.json` filename literal to its crash-safe owner (`adapters/persistence.py`), so no other module can name — hence write — the file.

Both are wired into `mise run lint` and the CI `lint` job, and are green against the current tree (13 events on both sides; the literal appears only in the owner).

## Remaining prompt-only rows

Two rules stay `prompt-only` because their mechanization belongs with other work, and are parked there:

- **No sentinel objects on the wire** → #1032 (once tagged values replace the sentinels).
- **Backup-or-confirm before any destructive op** → the #794 destructive-op cluster (#965 / #974 / #1005 / #1062), via a destructive-ops funnel.

Each of those issues now carries a note describing the gate + register flip to do when it lands.

## Docs

`docs/contributing/development.md` documents both new gates alongside the existing lint checks.

Closes #1029
