### PR TITLE
fix(saves): branch-6 conflicts on baseline divergence instead of silent download (#1059)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -201,23 +201,26 @@ Dimensions:
 - **Local mtime vs server `updated_at`** — only consulted in the `never touched` branch where the algorithm has no other
   ordering signal.
 
-| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                 |
-| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                          |
-| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                          |
-| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                               |
-| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                         |
-| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                         |
-| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                           |
-| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                               |
-| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                           |
-| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected |
-| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                     |
-| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                            |
-| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                             |
-| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                  |
+| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                   |
+| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                            |
+| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                            |
+| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                 |
+| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                           |
+| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                           |
+| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                             |
+| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                 |
+| 6c | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059) |
+| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                             |
+| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected   |
+| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                       |
+| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                              |
+| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                               |
+| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                    |
 
-Conflict happens in exactly one row (#12). Every other row resolves silently to a Skip, Upload, or Download.
+Conflict happens in two rows — #12 (we already hold an entry on the picked save) and #6c (we hold a baseline from a
+prior sync but no entry on the picked head). Both are the same situation: the server moved to content we never synced
+while our local diverged from baseline. Every other row resolves silently to a Skip, Upload, or Download.
 
 ### Why row 6a posts instead of overwriting
 
@@ -226,6 +229,15 @@ picked server save and our local mtime is at-or-after the server's `updated_at`.
 (`last_sync_hash`), so we cannot prove drift either way; we also have no claim on the picked save (no `device_syncs`
 entry for our id). POSTing a brand-new save preserves both files: the original picked save stays intact, and our local
 content lands as a separate entry that becomes the new newest. Subsequent syncs pick our save naturally.
+
+### Why row 6c conflicts instead of downloading
+
+Row 6c is the never-touched sibling of row 12. We hold a baseline (`last_sync_hash`) from a prior sync, but the picked
+head is a save we have no `device_syncs` entry for — another timeline became newest while our local diverged from the
+baseline (`local_hash != last_sync_hash`). That is the same "both sides moved independently" situation as row 12, so it
+takes the same exit: a `Conflict` the user resolves, never a silent `Download` that would discard the diverged local
+progress (whose only surviving copy would be the `.romm-backup`). When there is no baseline, or local still matches it,
+we cannot claim divergence — rows 6a/6b apply and the mtime heuristic breaks the tie.
 
 ### Why row 11 downloads instead of uploading
 
@@ -539,9 +551,10 @@ frontend no longer fetches or checks capability flags.
 
 ## Conflict Resolution
 
-A `Conflict` outcome from `compute_sync_action` (matrix row 12) is the only surface that shows a modal. It fires when
-the server has moved forward (`device_syncs[me].is_current=false`) and the local file has diverged from the recorded
-baseline (`local_hash != last_sync_hash`) — both sides have unsynced changes that cannot be silently merged.
+A `Conflict` outcome from `compute_sync_action` (matrix rows 12 and 6c) is the only surface that shows a modal. It fires
+when the local file has diverged from the recorded baseline (`local_hash != last_sync_hash`) while the server moved to
+content we never synced — either on a save we already have an entry for (`device_syncs[me].is_current=false`, row 12) or
+on a new head we have no entry for (row 6c). Both sides have unsynced changes that cannot be silently merged.
 
 ### The modal
 
@@ -553,7 +566,7 @@ side by side, each with size and timestamp. Three actions:
 - **Use Server** → `resolveSyncConflict(rom_id, filename, "use_server")` → backend downloads the picked server save and
   overwrites local.
 - **Cancel** → pure UI close, no callable, no state mutation. The conflict re-fires on the next sync as long as the
-  underlying state still produces matrix row 12.
+  underlying state still produces matrix row 12 or 6c.
 
 The modal is shown by `CustomPlayButton` during pre-launch sync, and by `VersionHistoryPanel.handleRestore` (in
 `SavesTab`) when a version-restore pre-flight returns `conflict_blocked`. Both call `showSyncConflictModal(conflict)`

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -30,9 +30,12 @@ still tracked on the server but the local copy disappeared. We download to
 recover the canonical content.
 
 When our device has never touched the picked save (no entry in
-``device_syncs``) and the local file is present, we fall back to comparing
-local mtime against ``server.updated_at``: local-newer-or-equal means
-``Upload`` (POST a new save), older means ``Download``.
+``device_syncs``) and the local file is present: if we hold a baseline
+(``last_sync_hash``) and local has diverged from it, both sides moved — the
+chosen head is a save we never synced — so that is a ``Conflict``, the same as
+branch 5. Otherwise we fall back to comparing local mtime against
+``server.updated_at``: local-newer-or-equal means ``Upload`` (POST a new save),
+older means ``Download``.
 
 No I/O. No imports from services or adapters. Stdlib only.
 """
@@ -148,10 +151,16 @@ def _decide_when_not_current(
     return Download(server_save=server)
 
 
-def _decide_when_no_entry(server: dict[str, Any], local_file: dict[str, Any] | None) -> SyncAction:
+def _decide_when_no_entry(
+    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
+) -> SyncAction:
     """Branch 6: no ``device_syncs`` entry for our device on the chosen save."""
     if local_file is None:
         return Download(server_save=server)
+    if last_sync_hash and local_hash and local_hash != last_sync_hash:
+        # Both sides moved — the chosen head is a save we never synced while
+        # local diverged from the baseline. Mirrors branch 5: a true Conflict.
+        return Conflict(server_save=server)
     if _local_mtime_ge_server_updated_at(local_file, server):
         # POST our local as a new save in the slot.
         return Upload(target_save_id=None)
@@ -197,4 +206,4 @@ def compute_sync_action(
         return _decide_when_is_current(server, local_file, local_hash, last_sync_hash)
     if our_entry is not None:
         return _decide_when_not_current(server, local_file, local_hash, last_sync_hash)
-    return _decide_when_no_entry(server, local_file)
+    return _decide_when_no_entry(server, local_file, local_hash, last_sync_hash)

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -339,6 +339,124 @@ def test_no_device_entry_local_mtime_equals_server_epoch_returns_upload_post():
     assert result == Upload(target_save_id=None)
 
 
+def test_no_device_entry_baseline_diverged_server_newer_returns_conflict():
+    """Branch 6 / #1059 — no entry for our device on the newest server save, but
+    we hold a baseline and local has diverged from it. The chosen head is a save
+    we never synced (a NEW save id became the slot head while we played offline),
+    so both sides moved → Conflict, mirroring branch 5. Today branch 6 does
+    mtime-only and Downloads here, silently replacing the diverged local.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch - 3600),  # local older → today Downloads
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_no_device_entry_baseline_diverged_local_newer_returns_conflict():
+    """Branch 6 / #1059 — same divergence-from-baseline case, but local mtime is
+    newer than the server save. Divergence beats mtime: both sides moved → Conflict,
+    not Upload. Today branch 6 does mtime-only and Uploads here.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),  # local newer → today Uploads
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_no_device_entry_baseline_matches_preserves_mtime_behavior():
+    """Branch 6 / #1059 — no entry, baseline present, local_hash == last_sync_hash
+    (no divergence). The Conflict guard must NOT fire; the existing mtime split is
+    preserved: Download when local older, Upload(None) when local newer-or-equal.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+
+    # local older → Download
+    server_a = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result_older = compute_sync_action(
+        local_file=_local(mtime=server_epoch - 3600),
+        server_saves_in_slot=[server_a],
+        files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="abc",  # matches baseline → no divergence
+    )
+    assert result_older == Download(server_save=server_a)
+
+    # local newer-or-equal → Upload(None) (POST)
+    server_b = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result_newer = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),
+        server_saves_in_slot=[server_b],
+        files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="abc",  # matches baseline → no divergence
+    )
+    assert result_newer == Upload(target_save_id=None)
+
+
+def test_no_device_entry_no_baseline_preserves_mtime_behavior():
+    """Branch 6 / #1059 — no entry, NO baseline (last_sync_hash absent). Without a
+    baseline we cannot claim drift, so the Conflict guard must NOT fire and the
+    mtime path is unchanged: Download when local older, Upload(None) when newer.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+
+    # local older → Download
+    server_a = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result_older = compute_sync_action(
+        local_file=_local(mtime=server_epoch - 3600),
+        server_saves_in_slot=[server_a],
+        files_state={},  # no baseline
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result_older == Download(server_save=server_a)
+
+    # local newer-or-equal → Upload(None) (POST)
+    server_b = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    result_newer = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),
+        server_saves_in_slot=[server_b],
+        files_state={},  # no baseline
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result_newer == Upload(target_save_id=None)
+
+
 def test_no_device_entry_garbled_server_updated_at_returns_download():
     """Parse-failure path: unparseable server `updated_at` → server effectively
     wins (Download), per the conservative-fallthrough contract.

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -23,6 +23,8 @@ Invariants encoded here:
 - Inv4 (#1013): same inputs replayed → same action (pure determinism), and
   after a first-sync ``Upload(None)`` baseline is adopted the next run is
   ``Skip("synced")`` — never another POST.
+- Inv5 (#1059): branch-6 divergence from a held baseline is always a
+  ``Conflict`` — never a silent ``Download``/``Upload``.
 """
 
 from __future__ import annotations
@@ -294,6 +296,39 @@ def test_idempotent_after_branch6_upload_and_baseline_adoption(
     }
     step2 = _action(local_file, [adopted_server], {"last_sync_hash": local_hash}, local_hash)
     assert step2 == Skip(reason="synced")
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 (#1059): branch-6 divergence from baseline is always a Conflict.
+# ---------------------------------------------------------------------------
+
+
+@given(local_file=_local_files(), server_epoch=_epochs, local_hash=_hashes, baseline=_hashes)
+def test_no_entry_diverged_baseline_is_conflict(
+    local_file: dict[str, Any],
+    server_epoch: float,
+    local_hash: str,
+    baseline: str,
+) -> None:
+    """Branch 6 / #1059 — when the newest server save has no ``device_syncs``
+    entry for our device, we hold a baseline (``last_sync_hash``), and the
+    present local file has diverged from that baseline
+    (``local_hash != last_sync_hash``), the kernel returns ``Conflict`` — never
+    a silent ``Download`` (server replaces diverged local) or ``Upload`` (local
+    replaces a head we never synced). Both sides moved: the chosen head is a
+    save we never synced while local drifted offline. Holds regardless of the
+    mtime ordering between local and the server save.
+    """
+    assume(local_hash != baseline)
+    server = {
+        "id": 7,
+        "slot": 0,
+        "updated_at": _epoch_to_iso(server_epoch, zulu=False, micros=False),
+        "file_extension": "srm",
+        "device_syncs": [{"device_id": OTHER_DEVICE_ID, "is_current": True}],
+    }
+    result = _action(local_file, [server], {"last_sync_hash": baseline}, local_hash)
+    assert result == Conflict(server_save=server)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Problem

`compute_sync_action` branch 6 ("no `device_syncs` entry for our device on the chosen newest server save") ignored the baseline. When our device held a baseline (`last_sync_hash`) and local had diverged from it while a **new** save became the slot head, branch 6 fell back to an mtime-only comparison → `Download`, **silently replacing diverged offline progress** (its only surviving copy being the `.romm-backup`). Branch 5 (`_decide_when_not_current`) already treats the identical "both sides moved independently" case as a `Conflict`.

## Fix

Mirror branch 5: in branch 6, when a baseline exists and `local_hash != last_sync_hash`, return `Conflict` so the user resolves it (preserving both copies) instead of a silent overwrite.

- `py_modules/domain/sync_action.py` — thread `local_hash` + `last_sync_hash` into `_decide_when_no_entry`; add the divergence guard before the mtime check (pure; no I/O).
- Unit cases for both mtime orderings + the matching-baseline / no-baseline / no-local paths.
- New property (Inv5): diverged local in branch 6 is never a silent `Download`/`Upload` — proven non-vacuous (fails on revert).
- Docs: new decision-matrix row **6c** + corrected "Conflict happens in two rows" + Conflict-Resolution section.

## Out of scope (deliberately split)

The **duplicate-POST** arm of the same branch (#1013 — byte-identical content with no device entry) needs a slow-path server-hash (download + MD5) that a pure decision function can't do; it'll land as a dispatch-time dedup in a focused follow-up. Its xfail-pinned property stays xfailed here.

Closes #1059
