### PR TITLE
fix(saves): group the matrix local-file loop by canonical target (#1006)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -183,7 +183,9 @@ The algorithm is `compute_sync_action` in `py_modules/domain/sync_action.py`. Th
 
 Server-only saves (no matching local file) are grouped by their target local filename (`rom_name.<ext>`) before being
 passed to `compute_sync_action`. The algorithm picks the newest in the group, so older stacked versions in the same slot
-are not separately surfaced.
+are not separately surfaced. The same grouping applies to local files: each local file is matrix-evaluated only against
+the server saves sharing its canonical target, so a multi-file save set (e.g. `Game.srm` + `Game.rtc`) never
+cross-contaminates extensions — `Game.srm` is never resolved against a newer `Game.rtc` server record.
 
 ## Decision Matrix
 

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -552,9 +552,15 @@ class MatrixExecutor:
                 else None
             )
             local_size = self._save_file_store.get_size(local_path) if local_exists else None
+            # Group server saves to this file's own canonical target — symmetric
+            # with the server-only loop below — so a multi-file save set never
+            # cross-contaminates extensions (#1006). Without this, a sibling
+            # extension's newer server record would win max(updated_at) and the
+            # file would be evaluated/dispatched against the wrong save.
+            group = [ss for ss in server_in_slot if local_save_target(ss, rom_name) == filename]
             action = compute_sync_action(
                 local_file=self._build_local_input(local_path, filename),
-                server_saves_in_slot=server_in_slot,
+                server_saves_in_slot=group,
                 files_state=_file_state_to_dict(file_state),
                 device_id=device_id_str,
                 local_hash=local_hash,
@@ -567,7 +573,7 @@ class MatrixExecutor:
                 local_mtime_iso=local_mtime_iso,
                 local_size=local_size,
                 file_state=file_state,
-                server_candidates=server_in_slot,
+                server_candidates=group,
             )
 
         # Group server saves by canonical local target filename. Server-only

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -699,6 +699,103 @@ class TestOlderVersionSkipping:
         assert len(download_calls) == 0
 
 
+class TestMultiFileSaveSetGrouping:
+    """Regression for #1006.
+
+    A multi-file save set (e.g. GBA ``Game.srm`` + ``Game.rtc``) must be
+    matrix-evaluated extension-by-extension: each local file is compared only
+    against the server saves sharing its canonical target. Before the fix the
+    local-file loop handed ``compute_sync_action`` the whole slot, so
+    ``Game.srm`` was evaluated against ``Game.rtc``'s (newer) server record —
+    cross-extension corruption.
+    """
+
+    def test_each_local_file_evaluated_only_against_its_own_target(self, tmp_path):
+        """Each local file's outcome carries only the server saves whose canonical
+        target is that file — and the resolved chosen server is the same-extension
+        record, never the newer save of a sibling extension."""
+        from domain.save_status_builders import resolve_chosen_server
+
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+        # Two-extension save set: .srm + .rtc both present on disk.
+        srm_path = _create_save(tmp_path, content=b"srm bytes", ext=".srm")
+        rtc_path = _create_save(tmp_path, content=b"rtc bytes", ext=".rtc")
+        srm_hash = _file_md5(str(srm_path))
+        rtc_hash = _file_md5(str(rtc_path))
+
+        # .srm server record: canonical target pokemon.srm, OLDER. is_current so
+        # the matrix picks Skip(synced) → chosen-server falls back to candidates.
+        srm_ss = _server_save_with_syncs(
+            save_id=10,
+            filename="pokemon [old].srm",
+            updated_at="2026-03-24T10:00:00",
+            slot="default",
+            device_syncs=[{"device_id": "dev-1", "is_current": True}],
+        )
+        srm_ss["file_extension"] = "srm"
+        # .rtc server record: canonical target pokemon.rtc, slot-wide NEWEST.
+        rtc_ss = _server_save_with_syncs(
+            save_id=20,
+            filename="pokemon [new].rtc",
+            updated_at="2026-03-24T15:00:00",
+            slot="default",
+            device_syncs=[{"device_id": "dev-1", "is_current": True}],
+        )
+        rtc_ss["file_extension"] = "rtc"
+
+        # Per-file baselines matching each local hash → both resolve to Skip(synced).
+        save_state = rom_save_state_from_dict(
+            {
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 10,
+                        "last_sync_hash": srm_hash,
+                        "last_sync_server_updated_at": "2026-03-24T10:00:00",
+                    },
+                    "pokemon.rtc": {
+                        "tracked_save_id": 20,
+                        "last_sync_hash": rtc_hash,
+                        "last_sync_server_updated_at": "2026-03-24T15:00:00",
+                    },
+                },
+            }
+        )
+        info = svc._sync_engine._rom_info.get_rom_save_info(42)
+        assert info is not None
+
+        outcomes = {
+            o.filename: o
+            for o in svc._sync_engine._matrix.iter_matrix_outcomes(
+                42,
+                [srm_ss, rtc_ss],
+                save_state=save_state,
+                device_id="dev-1",
+                info=info,
+            )
+        }
+
+        # Each canonical target appears, evaluated against ITS OWN server record only.
+        srm_outcome = outcomes["pokemon.srm"]
+        assert [s["id"] for s in srm_outcome.server_candidates] == [10]
+        # The chosen server (consumed at dispatch/status time) is the .srm record,
+        # NOT the slot-wide newest .rtc one.
+        chosen_srm = resolve_chosen_server(srm_outcome.action, srm_outcome.server_candidates)
+        assert chosen_srm is not None
+        assert chosen_srm["id"] == 10
+
+        rtc_outcome = outcomes["pokemon.rtc"]
+        assert [s["id"] for s in rtc_outcome.server_candidates] == [20]
+        chosen_rtc = resolve_chosen_server(rtc_outcome.action, rtc_outcome.server_candidates)
+        assert chosen_rtc is not None
+        assert chosen_rtc["id"] == 20
+
+
 class TestOwnUploadIds:
     """Tests for own_upload_ids tracking and the uploaded_by_us flag."""
 


### PR DESCRIPTION
## Problem

`iter_matrix_outcomes` (sync matrix) had an asymmetry: the **server-only loop** grouped server saves by `local_save_target`, but the **local-file loop** passed the **whole slot** to both `compute_sync_action` (`server_saves_in_slot`) and `MatrixOutcome.server_candidates`. So `compute_sync_action` picked `max(updated_at)` across the whole slot regardless of extension.

For a multi-file save set (GBA `.srm` + `.rtc`, Saturn `.bkr`/`.bcr`/`.smpc`, …): a sibling extension's newer server record won, so `Game.srm` could be evaluated/dispatched against `Game.rtc`'s save — PUTting srm bytes over the rtc record (and the mirror download). The `server_candidates` half mattered too: it feeds `resolve_chosen_server` (status) and the dispatch PUT lookup, so fixing only `compute_sync_action` would have left the corruption at dispatch/status time.

## Fix

In the local-file loop, filter to the file's own canonical-target group and use it for **both** call sites — symmetric with the server-only loop:

```python
group = [ss for ss in server_in_slot if local_save_target(ss, rom_name) == filename]
```

A new `test_matrix.py` case with a two-extension save set asserts each file resolves against its own record (and exercises the `resolve_chosen_server` fallback path, the real corruption vector). Doc updated to state the grouping symmetry.

## On-device test

This is a real-hardware save-integrity change worth verifying on the Deck: take a system with a **multi-file save set** (e.g. a GBA game under VBA-M producing `Game.srm` + `Game.rtc`), play a session that changes both, then sync twice across two devices/slots. Expected: each file stays tracked against its own server record — no extension cross-contamination (`.srm` content never lands on the `.rtc` record or vice versa).

Closes #1006
