### PR TITLE
fix(saves): adopt identical server save instead of POSTing a duplicate (#1013)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -206,35 +206,52 @@ Dimensions:
 - **Local vs `last_sync_hash`** — _unchanged_, _changed_, or _no baseline_ (key missing in state).
 - **Local mtime vs server `updated_at`** — only consulted in the `never touched` branch where the algorithm has no other
   ordering signal.
+- **Content identity** — in the `never touched` branch, the server save's RomM-provided `content_hash` is compared to
+  the local content hash first; a match short-circuits to row 6d before mtime/baseline are consulted.
 
-| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                   |
-| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                            |
-| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                            |
-| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                 |
-| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                           |
-| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                           |
-| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                             |
-| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                 |
-| 6c | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059) |
-| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                             |
-| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected   |
-| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                       |
-| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                              |
-| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                               |
-| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                    |
+| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                                    |
+| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                                             |
+| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                                             |
+| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                                  |
+| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                                            |
+| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                                            |
+| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                                              |
+| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                                  |
+| 6c | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059)                  |
+| 6d | yes        | ≥1             | never touched | any               | any                  | `Skip(synced, adopt_baseline=true)` | `server.content_hash == local_hash` — byte-identical to an existing server save; adopt it, never POST a duplicate (#1013) |
+| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                                              |
+| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected                    |
+| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                                        |
+| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                               |
+| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                                                |
+| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                     |
 
 Conflict happens in two rows — #12 (we already hold an entry on the picked save) and #6c (we hold a baseline from a
 prior sync but no entry on the picked head). Both are the same situation: the server moved to content we never synced
 while our local diverged from baseline. Every other row resolves silently to a Skip, Upload, or Download.
 
+### Why row 6d adopts instead of posting
+
+Row 6d fires when a local file exists, a server save also exists in the slot, our device has never touched the picked
+save, **and** the picked save's RomM-provided `content_hash` equals the local content hash — the bytes on disk are
+identical to bytes the server already holds. This is the copied-SD-card / restored-backup / fresh-reinstall case: the
+device looks brand-new to the server (no `device_syncs` entry) but the content is the same save. POSTing here would
+create a duplicate server save of identical bytes, inflating the slot and churning autocleanup. Instead we adopt the
+existing save as the baseline (`Skip(adopt_baseline=true)`, writing `last_sync_hash := local_hash`), so future drift is
+detected without ever duplicating. The check is pure — no download, no re-hash — because RomM stamps `content_hash` on
+every save. **Known fallback gap:** older / migrated server saves may lack `content_hash`; when it is absent the dedup
+check is skipped and the row 6a/6b mtime path applies (which can still POST a byte-identical duplicate). No slow-path
+content fetch is attempted (#1013).
+
 ### Why row 6a posts instead of overwriting
 
-Row 6a fires when a local file exists, a server save also exists in the slot, but our device has never touched the
-picked server save and our local mtime is at-or-after the server's `updated_at`. There is no baseline
-(`last_sync_hash`), so we cannot prove drift either way; we also have no claim on the picked save (no `device_syncs`
-entry for our id). POSTing a brand-new save preserves both files: the original picked save stays intact, and our local
-content lands as a separate entry that becomes the new newest. Subsequent syncs pick our save naturally.
+Row 6a fires when a local file exists, a server save also exists in the slot, our device has never touched the picked
+server save, the content hashes do **not** match (or `content_hash` is absent — see row 6d), and our local mtime is
+at-or-after the server's `updated_at`. There is no baseline (`last_sync_hash`), so we cannot prove drift either way; we
+also have no claim on the picked save (no `device_syncs` entry for our id). POSTing a brand-new save preserves both
+files: the original picked save stays intact, and our local content lands as a separate entry that becomes the new
+newest. Subsequent syncs pick our save naturally.
 
 ### Why row 6c conflicts instead of downloading
 

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -30,12 +30,20 @@ still tracked on the server but the local copy disappeared. We download to
 recover the canonical content.
 
 When our device has never touched the picked save (no entry in
-``device_syncs``) and the local file is present: if we hold a baseline
+``device_syncs``) and the local file is present: first, if the local content is
+byte-identical to that server save — RomM stamps each save with a
+``content_hash``, so ``server.content_hash == local_hash`` proves identity
+without any I/O — we adopt it as the baseline (``Skip(adopt_baseline=True)``)
+rather than POSTing a duplicate of bytes the server already holds (copied SD
+card, restored backup, fresh reinstall). Otherwise, if we hold a baseline
 (``last_sync_hash``) and local has diverged from it, both sides moved — the
 chosen head is a save we never synced — so that is a ``Conflict``, the same as
-branch 5. Otherwise we fall back to comparing local mtime against
+branch 5. Failing both, we fall back to comparing local mtime against
 ``server.updated_at``: local-newer-or-equal means ``Upload`` (POST a new save),
-older means ``Download``.
+older means ``Download``. Known fallback gap: when a server save lacks
+``content_hash`` (older / migrated saves), the dedup check is skipped and the
+mtime path can still POST a byte-identical duplicate — no slow-path content
+fetch is attempted here.
 
 No I/O. No imports from services or adapters. Stdlib only.
 """
@@ -157,6 +165,11 @@ def _decide_when_no_entry(
     """Branch 6: no ``device_syncs`` entry for our device on the chosen save."""
     if local_file is None:
         return Download(server_save=server)
+    # #1013: local content is byte-identical to this server save (RomM-provided
+    # content_hash) → adopt it as the baseline instead of POSTing a duplicate.
+    server_hash = server.get("content_hash")
+    if server_hash and local_hash and server_hash == local_hash:
+        return Skip(reason="synced", adopt_baseline=True)
     if last_sync_hash and local_hash and local_hash != last_sync_hash:
         # Both sides moved — the chosen head is a save we never synced while
         # local diverged from the baseline. Mirrors branch 5: a true Conflict.

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -457,6 +457,99 @@ def test_no_device_entry_no_baseline_preserves_mtime_behavior():
     assert result_newer == Upload(target_save_id=None)
 
 
+def test_no_device_entry_identical_content_returns_skip_adopt_baseline():
+    """Branch 6 / #1013 — no entry for our device, local present, and the picked
+    server save's ``content_hash`` equals ``local_hash`` (copied SD card, restored
+    backup, fresh reinstall). The local bytes already exist on the server, so adopt
+    that save as the baseline (``Skip(synced, adopt_baseline=True)``) instead of
+    POSTing a duplicate — even when local mtime is at-or-after the server's
+    ``updated_at`` (today branch 6 does mtime-only and returns ``Upload(None)``).
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    server["content_hash"] = "abc"
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),  # local newer → today Uploads
+        server_saves_in_slot=[server],
+        files_state={},
+        device_id=DEVICE_ID,
+        local_hash="abc",  # byte-identical to the server save
+    )
+    assert result == Skip(reason="synced", adopt_baseline=True)
+
+
+def test_no_device_entry_different_content_returns_upload_post():
+    """Branch 6 / #1013 — no entry, local present, server ``content_hash`` differs
+    from ``local_hash``, local mtime >= server. The dedup guard must NOT fire on a
+    hash mismatch; the existing mtime path is preserved → ``Upload(None)`` (POST).
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    server["content_hash"] = "server-hash"
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),
+        server_saves_in_slot=[server],
+        files_state={},
+        device_id=DEVICE_ID,
+        local_hash="local-hash",  # differs → not a duplicate
+    )
+    assert result == Upload(target_save_id=None)
+
+
+def test_no_device_entry_missing_content_hash_falls_back_to_mtime():
+    """Branch 6 / #1013 — no entry, local present, the server save carries NO
+    ``content_hash`` key (older / migrated saves may lack it). The dedup check is
+    skipped and the existing mtime path is unchanged: local mtime >= server →
+    ``Upload(None)`` (POST). The known fallback gap — no slow-path content fetch.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    # No "content_hash" key at all.
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),
+        server_saves_in_slot=[server],
+        files_state={},
+        device_id=DEVICE_ID,
+        local_hash="abc",
+    )
+    assert result == Upload(target_save_id=None)
+
+
+def test_no_device_entry_diverged_baseline_with_different_content_hash_returns_conflict():
+    """Branch 6 / #1059 regression with #1013 present — no entry, baseline held and
+    local diverged from it (``local_hash != last_sync_hash``), and the server's
+    ``content_hash`` differs from ``local_hash`` too. The dedup guard must not
+    swallow this: content differs from both baseline and head → ``Conflict``.
+    """
+    server_updated_at = "2024-01-01T12:00:00+00:00"
+    server_epoch = datetime.fromisoformat(server_updated_at).timestamp()
+    server = _server_save(
+        updated_at=server_updated_at,
+        device_syncs=[_device_sync(OTHER_DEVICE_ID, is_current=True)],
+    )
+    server["content_hash"] = "server-hash"  # != local, so dedup must not fire
+    result = compute_sync_action(
+        local_file=_local(mtime=server_epoch + 3600),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",  # diverged from baseline AND from server head
+    )
+    assert result == Conflict(server_save=server)
+
+
 def test_no_device_entry_garbled_server_updated_at_returns_download():
     """Parse-failure path: unparseable server `updated_at` → server effectively
     wins (Download), per the conservative-fallthrough contract.

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -20,9 +20,12 @@ Invariants encoded here:
   carried ``server_save`` being the recovery source.
 - Inv3 (#1014): the action is identical under semantically-equal
   ``updated_at`` / ``mtime`` ISO renderings.
-- Inv4 (#1013): same inputs replayed → same action (pure determinism), and
-  after a first-sync ``Upload(None)`` baseline is adopted the next run is
-  ``Skip("synced")`` — never another POST.
+- Inv4 (#1013): same inputs replayed → same action (pure determinism); after a
+  first-sync ``Upload(None)`` baseline is adopted the next run is
+  ``Skip("synced")`` — never another POST; and a branch-6 save whose
+  server-provided ``content_hash`` already equals the local content is adopted
+  as the baseline (``Skip(adopt_baseline=True)``) rather than re-POSTed. Now
+  enforced live (no longer xfail-pinned).
 - Inv5 (#1059): branch-6 divergence from a held baseline is always a
   ``Conflict`` — never a silent ``Download``/``Upload``.
 """
@@ -32,7 +35,6 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
@@ -331,10 +333,6 @@ def test_no_entry_diverged_baseline_is_conflict(
     assert result == Conflict(server_save=server)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#1013: branch 6 ignores content hashes — byte-identical content with no device entry POSTs a duplicate",
-)
 @given(local_file=_local_files(), server_epoch=_epochs, local_hash=_hashes)
 def test_no_entry_identical_content_does_not_duplicate(
     local_file: dict[str, Any],
@@ -350,13 +348,8 @@ def test_no_entry_identical_content_does_not_duplicate(
     the local mtime is at-or-after the server's ``updated_at``. The correct
     action adopts the existing server save as the baseline
     (``Skip(adopt_baseline=True)``); POSTing a second copy of identical bytes
-    creates a duplicate server save and churns autocleanup.
-
-    Today branch 6 (`_decide_when_no_entry`) compares only mtime and returns
-    ``Upload(target_save_id=None)`` — this property fails until #1013 threads
-    the server content hash into the decision. When the fix lands the property
-    XPASSes, ``strict=True`` flips the run red, the marker is removed, and the
-    property guards against the duplicate-POST regression thereafter.
+    creates a duplicate server save and churns autocleanup. Guards against the
+    duplicate-POST regression.
     """
     local_file = {**local_file, "mtime": server_epoch + 3600}
     server = {


### PR DESCRIPTION
## Problem

`compute_sync_action` branch 6 (no `device_syncs` entry for our device on the chosen save) compared only mtime. A device with **byte-identical** local content (copied SD card, restored backup, fresh reinstall) returned `Upload(target_save_id=None)` → **POSTed a duplicate** server save, churning autocleanup.

## Fix (pure kernel — option B)

RomM stamps every save with a `content_hash` (verified against the live API), so identity is detectable with **no I/O**. In `_decide_when_no_entry`, when `server["content_hash"] == local_hash`, return `Skip(reason="synced", adopt_baseline=True)` and adopt the existing save instead of POSTing.

- Checked **before** the #1059 divergence-Conflict arm: if local already equals the current head there's nothing to conflict about, even if it diverged from an older baseline.
- Composes with #1006 (the picked `server` is the file's own canonical-target group).
- The previously `xfail`-pinned property `test_no_entry_identical_content_does_not_duplicate` now passes → marker removed (strict-xfail → live regression guard).

> Supersedes my earlier note on #1013 that proposed a dispatch-time slow-path hash (option A). That assumed no server-side hash was available; RomM **does** provide `content_hash`, so the pure check is simpler and needs no I/O.

**Known fallback gap:** saves with no `content_hash` (older / migrated) skip the dedup and the mtime path can still POST a duplicate — no slow-path content fetch is attempted here. Documented in the kernel docstring + the decision-matrix doc; tracked for the broader multi-file audit (#1098).

## On-device test

Set up `local == server` for a game with no `device_syncs` entry (e.g. copy a save to a second device, or restore a `.romm-backup` while the server still holds the same bytes), then sync. Expected: **no new server save is POSTed** — the existing save is adopted (`Skip`, baseline recorded), and the slot save count stays flat.

Closes #1013
