### PR TITLE
ci(release): smoke-test flattened defaults path, unblock asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,11 +88,14 @@ jobs:
           BUILT_ZIP=$(ls /tmp/output/*.zip | head -1)
           echo "Checking $BUILT_ZIP for required entries..."
           # bootstrap RAISES without 001_initial.sql (plugin fully inert), and the
-          # default registries' packaging rides on Decky-CLI defaults/ handling —
-          # the most fatal omissions, previously uncovered by this smoke test.
+          # default registries are the most fatal omissions, previously uncovered
+          # by this smoke test. The Decky CLI FLATTENS the repo's defaults/ dir
+          # into the plugin root at package time, so the registries ship as
+          # core_defaults.json / bios_registry.json (no defaults/ prefix) — which
+          # is exactly where the runtime reads them (es_de_config.py / firmware.py).
           for required in main.py plugin.json package.json dist/index.js py_modules/bootstrap.py bin/rom-launcher \
               py_modules/db/migrations/001_initial.sql py_modules/db/migrations/002_add_emulator_override.sql \
-              defaults/core_defaults.json defaults/bios_registry.json; do
+              core_defaults.json bios_registry.json; do
             if ! unzip -l "$BUILT_ZIP" | grep -qE "/$required\b"; then
               echo "ERROR: release zip is missing $required"
               unzip -l "$BUILT_ZIP"


### PR DESCRIPTION
## What

The v0.22.0 release published a tag + GitHub Release but **0 assets** — no plugin zip. Root cause: the release-zip smoke test (added in #1068, first run live on 0.22.0) requires `defaults/core_defaults.json` and `defaults/bios_registry.json`, but the Decky CLI **flattens** the repo's `defaults/` directory into the plugin root at package time. The registries ship as `core_defaults.json` / `bios_registry.json` (no `defaults/` prefix) — exactly where the runtime reads them (`es_de_config.py:302`, `firmware.py:109`). The `/defaults/...` grep never matched, the smoke test failed, and the `Upload release asset` step was skipped.

## Fix

Check the flattened root names (`core_defaults.json` / `bios_registry.json`). This also makes the smoke test verify the **real production/runtime location** rather than a path that never exists in a packaged plugin.

The plugin zip itself was always correct — only the (mistaken) guard blocked the upload.

## Recovery

After merge, the Release workflow is dispatched manually (`workflow_dispatch`) to rebuild and attach the zip to the existing **v0.22.0** release via `gh release upload --clobber`. No version bump — the plugin code is unchanged.

docs: N/A (CI-only smoke-test path fix, no user-visible change)
