### PR TITLE
ci(release): migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5


### PR DESCRIPTION
Closes #1103.

## What

`release.yml` mints release-please's GitHub App token via
`actions/create-github-app-token@v3`, whose `app-id` input is deprecated. Swap it
for the supported `client-id`, fed by the new `RELEASE_PLEASE_APP_CLIENT_ID` secret
(the App's Client ID — a distinct value from the numeric App ID, already added).

## Why it matters

When a future major drops `app-id`, the token mint fails and release-please falls
back to `GITHUB_TOKEN`, whose pushes don't trigger workflows — leaving the release
PR's required checks stuck "Expected" and unmergeable. Just deprecation warnings
today; this is the pre-emptive fix.

docs: N/A — CI tooling, no user-facing change.