### PR TITLE
fix(sync): skip stale-collection cleanup on cancelled sync (#1040)

### DIFF
--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -126,6 +126,23 @@ quotes internally.
 
 See: `py_modules/adapters/steam_config.py`
 
+## Collection management
+
+Steam collections are managed entirely on the frontend via `collectionStore`, not by writing the shortcut's `tags` VDF
+field. The plugin owns machine-scoped collections named `RomM: <platform> (<hostname>)` for platforms and
+`RomM: [<name>] (<hostname>)` for synced RomM collections. The `sync_complete` event carries `platform_app_ids` and
+`romm_collection_app_ids` maps; `onSyncComplete` (`src/index.tsx`) creates/updates the collections for the maps it
+receives and then runs a **stale-collection cleanup** that deletes any `RomM: …` collection for this machine whose
+platform/collection name is absent from those maps.
+
+The cleanup is **gated on a completed (non-cancelled) sync** (`!data.cancelled`). On a cancelled run the maps are
+**partial** — they list only the platforms the run reached before the cancel (empty if the cancel fired before the first
+unit), because the backend builds `platform_app_ids` from the cross-unit accumulator of reached platforms. Treating a
+partial map as the authoritative active-set would delete the collections for unreached platforms — an early cancel would
+wipe the entire library organization. The additive create/update path stays ungated, so the platforms that did complete
+still get their collections; only the destructive deletion is skipped on cancel. Steam collections are not backed up, so
+the safe behavior on a partial/cancelled run is to delete nothing.
+
 ## App IDs and Artwork
 
 `SteamClient.Apps.AddShortcut()` returns the real `appId`, so the plugin does **not** compute shortcut app IDs itself —

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -24,7 +24,9 @@ games appear in the Steam Library with cover art, metadata, and organized into c
 
 <!-- Screenshot: Sync in progress with progress bar -->
 
-You can tap **Cancel Sync** to stop mid-sync. Games already added will remain.
+You can tap **Cancel Sync** to stop mid-sync. Games already added will remain. A cancelled sync never removes any Steam
+collections — stale-collection cleanup only runs after a sync finishes in full, so cancelling can never wipe the
+collections for platforms the run did not reach.
 
 ## Per-Platform Toggles
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act } from "@testing-library/react";
 import { toaster } from "@decky/api";
 import { emitDeckyEvent, deckyEventListenerCount } from "./test-utils/decky-api-mock";
-import { getSettingsResetNotice } from "./api/backend";
+import { getSettingsResetNotice, getAllPlaytime, getAppIdRomIdMap } from "./api/backend";
 import { getSettingsResetState, setSettingsResetState } from "./utils/settingsResetStore";
 import type { DownloadCompleteEvent, SyncStaleData } from "./types";
 
@@ -41,6 +41,19 @@ vi.mock("./utils/syncManager", () => ({
   initUnitSyncManager: vi.fn(() => () => {}),
 }));
 
+// Observe the collection create/update + stale-cleanup calls fired by
+// onSyncComplete. getHostname resolves a fixed hostname so the machine-scoped
+// `RomM: <platform> (steamdeck)` suffix is deterministic.
+const createOrUpdateCollections = vi.fn().mockResolvedValue(undefined);
+const createOrUpdateRomMCollections = vi.fn().mockResolvedValue(undefined);
+const clearPlatformCollection = vi.fn().mockResolvedValue(undefined);
+vi.mock("./utils/collections", () => ({
+  createOrUpdateCollections: (...args: unknown[]) => createOrUpdateCollections(...args),
+  createOrUpdateRomMCollections: (...args: unknown[]) => createOrUpdateRomMCollections(...args),
+  clearPlatformCollection: (...args: unknown[]) => clearPlatformCollection(...args),
+  getHostname: vi.fn().mockResolvedValue("steamdeck"),
+}));
+
 // Observe the launch-options confirm-poll.
 const setLaunchOptionsConfirmed = vi.fn().mockResolvedValue(true);
 const removeShortcut = vi.fn();
@@ -60,6 +73,7 @@ vi.mock("./api/backend", async () => {
   };
 });
 
+import { applyAllPlaytime } from "./patches/metadataPatches";
 import definePluginResult from "./index";
 
 // `definePlugin` is stubbed in test-setup to return its factory unchanged, so
@@ -293,6 +307,122 @@ describe("index.tsx — corrupt-settings reset notice", () => {
 
     expect(logError).toHaveBeenCalledWith(expect.stringContaining("Failed to check settings reset notice"));
     expect(toaster.toast).not.toHaveBeenCalled();
+    plugin.onDismount();
+  });
+});
+
+describe("index.tsx — sync_complete stale-collection cleanup (#1040)", () => {
+  // A SNES platform collection and a [Faves] RomM smart-collection, both
+  // machine-scoped to "steamdeck" (the getHostname mock). Delete is a vi.fn so
+  // the smart-collection delete is observable; the platform collection is
+  // removed via the mocked clearPlatformCollection, so only its presence in
+  // userCollections matters for the stale filter.
+  function seedCollections(): {
+    snes: { Delete: ReturnType<typeof vi.fn> };
+    faves: { Delete: ReturnType<typeof vi.fn> };
+  } {
+    const snes = { id: "snes-id", displayName: "RomM: Super Nintendo (steamdeck)", Delete: vi.fn() };
+    const faves = { id: "faves-id", displayName: "RomM: [Faves] (steamdeck)", Delete: vi.fn() };
+    vi.stubGlobal("collectionStore", { userCollections: [snes, faves] });
+    return { snes, faves };
+  }
+
+  type SyncCompletePayload = {
+    platform_app_ids: Record<string, number[]>;
+    romm_collection_app_ids?: Record<string, number[]>;
+    total_games: number;
+    cancelled?: boolean;
+  };
+
+  function emitSyncComplete(payload: SyncCompletePayload): void {
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", payload);
+    });
+  }
+
+  beforeEach(() => {
+    createOrUpdateCollections.mockClear();
+    createOrUpdateRomMCollections.mockClear();
+    clearPlatformCollection.mockClear();
+    vi.mocked(applyAllPlaytime).mockClear();
+    vi.mocked(applyAllPlaytime).mockResolvedValue(undefined);
+    vi.mocked(toaster.toast).mockClear();
+    logError.mockClear();
+    // Give the playtime re-apply detach a well-shaped payload so it reaches
+    // applyAllPlaytime instead of throwing on a destructure of undefined.
+    vi.mocked(getAllPlaytime).mockResolvedValue({ playtime: {} });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({});
+  });
+
+  it("runs the stale cleanup on a completed (non-cancelled) sync", async () => {
+    const { faves } = seedCollections();
+    const plugin = pluginFactory();
+
+    // Only "Nintendo 64" is active — SNES and [Faves] are stale and removed.
+    emitSyncComplete({ platform_app_ids: { "Nintendo 64": [1] }, total_games: 1 });
+    await flush();
+
+    expect(clearPlatformCollection).toHaveBeenCalledWith("Super Nintendo");
+    expect(faves.Delete).toHaveBeenCalledTimes(1);
+    plugin.onDismount();
+  });
+
+  it("skips the stale cleanup on a cancelled sync with a partial map (regression)", async () => {
+    const { snes, faves } = seedCollections();
+    const plugin = pluginFactory();
+
+    // Cancel reached only "Nintendo 64"; SNES + [Faves] must SURVIVE.
+    emitSyncComplete({ platform_app_ids: { "Nintendo 64": [1] }, total_games: 1, cancelled: true });
+    await flush();
+
+    expect(clearPlatformCollection).not.toHaveBeenCalled();
+    expect(snes.Delete).not.toHaveBeenCalled();
+    expect(faves.Delete).not.toHaveBeenCalled();
+    plugin.onDismount();
+  });
+
+  it("skips the stale cleanup on an early cancel with an empty map (full-wipe case)", async () => {
+    const { snes, faves } = seedCollections();
+    const plugin = pluginFactory();
+
+    // Cancel fired before unit 1 — the map is empty. Treating it as the active
+    // set would wipe EVERY RomM collection; nothing must be deleted.
+    emitSyncComplete({ platform_app_ids: {}, total_games: 0, cancelled: true });
+    await flush();
+
+    expect(clearPlatformCollection).not.toHaveBeenCalled();
+    expect(snes.Delete).not.toHaveBeenCalled();
+    expect(faves.Delete).not.toHaveBeenCalled();
+    plugin.onDismount();
+  });
+
+  it("still fires the cancelled toast and re-applies playtime on a cancelled sync", async () => {
+    seedCollections();
+    const plugin = pluginFactory();
+    // The factory's own init runs one initial playtime apply; clear it so the
+    // assertion counts only the apply triggered by sync_complete.
+    await flush();
+    vi.mocked(applyAllPlaytime).mockClear();
+    vi.mocked(toaster.toast).mockClear();
+
+    emitSyncComplete({ platform_app_ids: { "Nintendo 64": [1] }, total_games: 1, cancelled: true });
+    await flush();
+
+    expect(toaster.toast).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining("cancelled") }));
+    expect(applyAllPlaytime).toHaveBeenCalledTimes(1);
+    plugin.onDismount();
+  });
+
+  it("still creates/updates the reached platforms' collections on a cancelled sync", async () => {
+    seedCollections();
+    const plugin = pluginFactory();
+
+    emitSyncComplete({ platform_app_ids: { "Nintendo 64": [1] }, total_games: 1, cancelled: true });
+    await flush();
+
+    // The additive create/update path is NOT gated on cancel — the platforms
+    // that DID complete still get their collections.
+    expect(createOrUpdateCollections).toHaveBeenCalledWith({ "Nintendo 64": [1] });
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -297,7 +297,15 @@ export default definePlugin(() => {
             await createOrUpdateRomMCollections(data.romm_collection_app_ids);
           }
 
-          if (typeof collectionStore !== "undefined") {
+          // Stale-collection cleanup deletes any RomM collection not in
+          // data.platform_app_ids / romm_collection_app_ids. On a cancelled run
+          // those maps are PARTIAL (only the platforms reached before the cancel,
+          // empty if the cancel fired before unit 1), so treating them as the
+          // authoritative active-set would delete collections for unreached
+          // platforms — wiping library organization. Only run cleanup on a
+          // completed sync. The additive create/update above stays safe on a
+          // partial run. (#1040)
+          if (!data.cancelled && typeof collectionStore !== "undefined") {
             const hostname = await getHostname();
             const suffix = ` (${hostname})`;
 


### PR DESCRIPTION
Closes #1040

## Problem

A cancelled sync destroyed Steam collections (data loss). Under the **default** setting `collection_create_platform_groups=False`:

- On cancel, the backend's `SyncReporter.finalize_per_unit_run` still emits `sync_complete` — correctly — with a **partial** `platform_app_ids` map listing only the platforms reached before the cancel (empty if the cancel fired before the first unit).
- The frontend `onSyncComplete` ran its stale-collection cleanup with **no `cancelled` guard**. It treated that partial map as the authoritative active-set and deleted every `RomM: <platform> (<host>)` / `RomM: [<name>] (<host>)` collection for this machine not in it.

So cancelling mid-run wiped the collections for unreached platforms — and an **early cancel** (empty map) wiped the **entire** library organization. The bug was masked by `collection_create_platform_groups=True`, where the map is always complete.

## Fix

Frontend-only, surgical. Gate **only** the destructive stale-cleanup block behind `!data.cancelled` (`src/index.tsx`). Everything else in the handler is preserved on cancel:

- The cancelled toast still fires.
- `registerRomMAppId` for completed units still runs.
- The **additive** `createOrUpdateCollections` / `createOrUpdateRomMCollections` still run — the platforms that did complete still get their collections (no deletion).
- Playtime re-apply still runs.

Steam collections are not backed up, so deleting nothing is the safe behavior on a partial/cancelled run.

## Tests

Added a `sync_complete` stale-collection cleanup block to `src/index.test.tsx` (driven through the `@decky/api` event harness):

- Completed (non-cancelled) sync → cleanup still runs (`clearPlatformCollection` + smart-collection `Delete` fire).
- **Cancelled with a partial map (regression)** → no cleanup, no deletes.
- **Cancelled with an empty map (early-cancel full-wipe case)** → nothing deleted.
- Cancelled sync → still fires the cancelled toast and re-applies playtime.
- Cancelled sync → still creates/updates the reached platforms' collections (additive path ungated).

The two regression-guard tests were verified to FAIL without the one-line fix (non-vacuous).

## Validation

- `pnpm test` — 1204 passed (56 files)
- `pnpm typecheck` — clean
- `pnpm lint` — no new warnings/errors (2 pre-existing warnings in untouched `DownloadQueue.tsx` / `SlotSetupWizard.tsx`)
- `pnpm build` — clean
- `scripts/check_callable_manifest.py` + `scripts/check_event_parity.py` — pass (no callable/emit change)

## Docs

Updated in the same PR:

- `docs/user-guide/syncing-your-library.md` — a cancelled sync removes no collections.
- `docs/architecture/steam-non-steam-shortcuts.md` — new Collection management section documenting the cancel-gated cleanup.

## On-device testing (CI cannot cover)

- Multi-platform sync, default `collection_create_platform_groups=OFF`, let unit 1 complete, cancel mid-run → unreached platforms' collections survive.
- Immediate cancel before unit 1 (empty map) → the entire `RomM:` collection set survives.
- Normal full sync after disabling a previously-synced platform → stale cleanup still removes that platform's collection (legitimate path intact).
- After a cancel: cancelled toast appears and playtime renders correctly.