### PR TITLE
fix(saves): gate the in-place PUT against 0-byte / truncated local saves (#1062)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -206,13 +206,17 @@ unit-tested.
 Within `server_saves_in_slot`, the algorithm picks the **newest by `updated_at`** as the canonical save and decides
 against that one. Other saves in the slot are ignored — no foreign-save surfacing, no per-save dismiss state.
 
-Two discriminators drive the branch:
+Three discriminators drive the branch:
 
 1. **Our device's entry on the picked save**: `server.device_syncs[me]` may be missing (we never touched this save),
    `is_current=true` (server claims our last write/read is current), or `is_current=false` (someone else has moved this
    save forward since we last touched it).
 2. **Hash divergence vs. baseline**: `local_hash != files_state["last_sync_hash"]` means the local file has been edited
    since the last successful sync. Without a baseline (`last_sync_hash` is missing) we cannot claim divergence.
+3. **Size plausibility (upload guard only)**: in the one branch that PUTs in place (our device `is_current=true` + local
+   diverged, row 9), `local_file.size` is checked against the recorded `last_sync_local_size` baseline via
+   `domain/save_size.is_implausibly_shrunken`. A 0-byte or implausibly-shrunk local is a crash artifact, not an edit,
+   and diverts that branch to `Conflict` (row 9b) so RomM's in-place PUT never overwrites the only good copy (#1062).
 
 `is_current` is **computed server-side**, not stored — see [RomM Save Sync API Behaviour](#romm-save-sync-api-behaviour)
 below.
@@ -266,27 +270,30 @@ Dimensions:
 - **Content identity** — in the `never touched` branch, the server save's RomM-provided `content_hash` is compared to
   the local content hash first; a match short-circuits to row 6d before mtime/baseline are consulted.
 
-| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                                    |
-| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                                             |
-| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                                             |
-| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                                  |
-| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                                            |
-| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                                            |
-| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                                              |
-| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                                  |
-| 6c | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059)                  |
-| 6d | yes        | ≥1             | never touched | any               | any                  | `Skip(synced, adopt_baseline=true)` | `server.content_hash == local_hash` — byte-identical to an existing server save; adopt it, never POST a duplicate (#1013) |
-| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                                              |
-| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected                    |
-| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit — push our changes back onto the save the server still considers ours                                        |
-| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                               |
-| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                                                |
-| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                     |
+| #  | local file | server in slot | our entry     | local vs baseline | mtime vs server      | decision                            | reason                                                                                                                          |
+| -- | ---------- | -------------- | ------------- | ----------------- | -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 1  | no         | none           | n/a           | n/a               | n/a                  | `Skip(nothing_to_sync)`             | nothing local, nothing server                                                                                                   |
+| 2  | yes        | none           | n/a           | n/a               | n/a                  | `Upload(POST)`                      | first push for this save (or recovery after server-side wipe)                                                                   |
+| 3  | no         | ≥1             | never touched | n/a               | n/a                  | `Download(picked)`                  | no relation, pull newest                                                                                                        |
+| 4  | no         | ≥1             | current=true  | n/a               | n/a                  | `Download(picked)`                  | recovery — server still tracks our last version, local is gone                                                                  |
+| 5  | no         | ≥1             | current=false | n/a               | n/a                  | `Download(picked)`                  | server moved forward, nothing local to protect                                                                                  |
+| 6a | yes        | ≥1             | never touched | no baseline       | local mtime ≥ server | `Upload(POST)`                      | post our local as a new save in the slot — no overwrite risk                                                                    |
+| 6b | yes        | ≥1             | never touched | no baseline       | local mtime < server | `Download(picked)`                  | server is newer than our untracked local                                                                                        |
+| 6c | yes        | ≥1             | never touched | changed           | n/a                  | **`Conflict(picked)`**              | baseline held from a prior sync but the picked head is a save we never synced — both sides moved (#1059)                        |
+| 6d | yes        | ≥1             | never touched | any               | any                  | `Skip(synced, adopt_baseline=true)` | `server.content_hash == local_hash` — byte-identical to an existing server save; adopt it, never POST a duplicate (#1013)       |
+| 7  | yes        | ≥1             | current=true  | unchanged         | n/a                  | `Skip(synced)`                      | steady state                                                                                                                    |
+| 8  | yes        | ≥1             | current=true  | no baseline       | n/a                  | `Skip(synced, adopt_baseline=true)` | trust server's `is_current=true`, write `last_sync_hash := local_hash` so future drift can be detected                          |
+| 9  | yes        | ≥1             | current=true  | changed           | n/a                  | `Upload(PUT to picked.id)`          | offline edit (plausible size) — push our changes back onto the save the server still considers ours                             |
+| 9b | yes        | ≥1             | current=true  | changed           | n/a                  | **`Conflict(picked)`**              | diverged local is 0-byte or shrunk past the baseline (crash / full disk) — refuse the in-place PUT, let the user decide (#1062) |
+| 10 | yes        | ≥1             | current=false | unchanged         | n/a                  | `Download(picked)`                  | another device synced; we did nothing — adopt their version                                                                     |
+| 11 | yes        | ≥1             | current=false | no baseline       | n/a                  | `Download(picked)`                  | no baseline → cannot prove our local is newer; server wins                                                                      |
+| 12 | yes        | ≥1             | current=false | changed           | n/a                  | **`Conflict(picked)`**              | both sides changed independently — only true conflict                                                                           |
 
-Conflict happens in two rows — #12 (we already hold an entry on the picked save) and #6c (we hold a baseline from a
-prior sync but no entry on the picked head). Both are the same situation: the server moved to content we never synced
-while our local diverged from baseline. Every other row resolves silently to a Skip, Upload, or Download.
+Conflict happens in three rows — #12 (we already hold an entry on the picked save), #6c (we hold a baseline from a prior
+sync but no entry on the picked head), and #9b (we own the picked save and our local diverged, but the local file is
+0-byte / implausibly shrunk). #12 and #6c are the same "both sides moved to content we never synced" situation; #9b is a
+different hazard — protecting the server's only good copy from being overwritten in place by a corrupt-looking local
+file (#1062). Every other row resolves silently to a Skip, Upload, or Download.
 
 ### Why row 6d adopts instead of posting
 
@@ -318,6 +325,26 @@ baseline (`local_hash != last_sync_hash`). That is the same "both sides moved in
 takes the same exit: a `Conflict` the user resolves, never a silent `Download` that would discard the diverged local
 progress (whose only surviving copy would be the `.romm-backup`). When there is no baseline, or local still matches it,
 we cannot claim divergence — rows 6a/6b apply and the mtime heuristic breaks the tie.
+
+### Why row 9b conflicts instead of PUTting in place
+
+Row 9 is the steady offline-edit path: we own the picked save (`is_current=true`), our local diverged from the baseline,
+so we PUT the local content onto the existing save id. Row 9b is the same branch with one extra guard. A crashed
+emulator or a full disk can leave a **0-byte or truncated** save on disk — still a valid regular file, with a
+valid-but-wrong content hash, so it reads as a "diverged" edit and would take the row 9 PUT. But RomM's
+`PUT /api/saves/{id}` updates the save **in place** and creates a version only on **POST**, never on PUT — so that PUT
+would overwrite the only good server copy with the corrupt bytes and leave **no recoverable version**. This is the
+upload mirror of the [#965](https://github.com/danielcopper/decky-romm-sync/issues/965) backup-or-confirm invariant: the
+download-overwrite path already quarantines the local file into `.romm-backup` first, but the upload-overwrite PUT had
+no equivalent guard.
+
+The plausibility check is pure (`domain/save_size.is_implausibly_shrunken`, fed `local_file.size` and the recorded
+`last_sync_local_size` baseline): a new size of **0** fires unconditionally, and a non-empty new size below **50%** of
+the recorded baseline fires as a shrink. The threshold is a hard-coded conservative default — not a setting. When the
+guard fires, the kernel returns `Conflict(picked)` instead of `Upload(PUT)`, routing through the existing
+`SyncConflictModal` so the user decides: **Use Server** downloads the good server copy (quarantining the bad local
+first), **Keep Local** re-PUTs the corrupt file only after an explicit choice. A plausible-size divergent edit (or a
+save that grew) is unaffected and still PUTs in place (row 9).
 
 ### Why row 11 downloads instead of uploading
 
@@ -631,10 +658,13 @@ frontend no longer fetches or checks capability flags.
 
 ## Conflict Resolution
 
-A `Conflict` outcome from `compute_sync_action` (matrix rows 12 and 6c) is the only surface that shows a modal. It fires
-when the local file has diverged from the recorded baseline (`local_hash != last_sync_hash`) while the server moved to
-content we never synced — either on a save we already have an entry for (`device_syncs[me].is_current=false`, row 12) or
-on a new head we have no entry for (row 6c). Both sides have unsynced changes that cannot be silently merged.
+A `Conflict` outcome from `compute_sync_action` (matrix rows 12, 6c, and 9b) is the only surface that shows a modal. The
+common case fires when the local file has diverged from the recorded baseline (`local_hash != last_sync_hash`) while the
+server moved to content we never synced — either on a save we already have an entry for
+(`device_syncs[me].is_current=false`, row 12) or on a new head we have no entry for (row 6c). Both sides have unsynced
+changes that cannot be silently merged. Row 9b is the corrupt-local guard: we own the picked save and our local
+diverged, but the local file is 0-byte or implausibly shrunk, so the in-place PUT is refused and the user resolves it
+instead of the only good server copy being overwritten (#1062).
 
 ### The modal
 
@@ -646,7 +676,7 @@ side by side, each with size and timestamp. Three actions:
 - **Use Server** → `resolveSyncConflict(rom_id, filename, "use_server")` → backend downloads the picked server save and
   overwrites local.
 - **Cancel** → pure UI close, no callable, no state mutation. The conflict re-fires on the next sync as long as the
-  underlying state still produces matrix row 12 or 6c.
+  underlying state still produces matrix row 12, 6c, or 9b.
 
 The modal is shown by `CustomPlayButton` during pre-launch sync, and by `VersionHistoryPanel.handleRestore` (in
 `SavesTab`) when a version-restore pre-flight returns `conflict_blocked`. Both call `showSyncConflictModal(conflict)`

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -62,6 +62,22 @@ always overwrites your local save. Switch to "Newest Wins" or "Ask Me" if you pl
 
 Also make sure each person using RomM has their own account — shared accounts cause saves to overwrite each other.
 
+### Conflict prompt after a crash or power loss
+
+**Symptom**: After an emulator crash, a full disk, or a power loss mid-save, the next sync shows a conflict prompt
+instead of uploading — and the local save shown is 0 bytes or much smaller than expected.
+
+**Why**: A crash can leave a 0-byte or truncated save file on disk. The plugin refuses to upload it over your good
+server copy, because the server overwrites the existing save **in place** — there would be no older version left to
+recover. So instead of silently destroying your progress, it asks you to choose.
+
+**Fix**: In the conflict prompt, pick **Use Server** to restore the good copy from RomM (the bad local file is moved
+aside into the `.romm-backup` folder next to your saves first, so nothing is lost). Only pick **Keep Local** if you are
+certain the small/empty local file is the one you want to keep — that uploads it and replaces the server copy.
+
+If you need to recover a save by hand, look in the `.romm-backup` folder inside your saves directory (e.g.
+`<saves_path>/gba/.romm-backup/`): every file the plugin moves aside is timestamped there.
+
 ## Artwork Missing
 
 ### No SteamGridDB API key

--- a/py_modules/domain/save_size.py
+++ b/py_modules/domain/save_size.py
@@ -1,0 +1,47 @@
+"""Plausibility checks on a local save file's size before it overwrites a server copy.
+
+A crashed emulator or a full disk can leave a 0-byte or truncated save behind. Such a
+file is still a valid regular file with a valid (but wrong) content hash, so the
+newest-wins kernel would treat it as a legitimate offline edit and PUT it over the only
+good server copy — which RomM updates in place (versions only on POST, never on PUT). The
+predicates here let the kernel refuse that in-place overwrite and route the case to a
+user-resolved conflict instead.
+
+No I/O, no service/adapter/lib imports. Pure functions only.
+"""
+
+from __future__ import annotations
+
+# Maintainer-tunable safety threshold: a local save that has shrunk to below this
+# fraction of its recorded baseline size is treated as implausible (likely a partial /
+# truncated write). Not configurable at runtime — a dumb, conservative default.
+_DEFAULT_SHRINK_RATIO = 0.5
+
+
+def is_implausibly_shrunken(
+    new_size: int | None,
+    baseline_size: int | None,
+    *,
+    shrink_ratio: float = _DEFAULT_SHRINK_RATIO,
+) -> bool:
+    """Return True when *new_size* looks like a corrupt / truncated save.
+
+    Two independent triggers:
+
+    - *new_size* is exactly ``0`` — an empty save is never a plausible edit of a
+      real save, so this fires unconditionally (no baseline required).
+    - a positive *baseline_size* exists and *new_size* has dropped below
+      ``baseline_size * shrink_ratio`` — a dramatic shrink that signals a partial
+      write rather than a normal edit.
+
+    Returns False when *new_size* is ``None`` (unknown — nothing to judge), and
+    when there is no positive baseline to compare a non-empty *new_size* against
+    (a first sync, or a baseline of 0/None, never blocks a non-empty save).
+    """
+    if new_size is None:
+        return False
+    if new_size == 0:
+        return True
+    if baseline_size is None or baseline_size <= 0:
+        return False
+    return new_size < baseline_size * shrink_ratio

--- a/py_modules/domain/sync_action.py
+++ b/py_modules/domain/sync_action.py
@@ -19,7 +19,12 @@ When our device is flagged ``is_current=true`` but local diverges from the
 baseline, we emit ``Upload`` with a PUT target — the offline edit gets
 pushed at the decision point rather than being deferred to a later phase.
 No user prompt is needed because nobody else can have moved the server
-forward (we're still flagged current).
+forward (we're still flagged current). The one exception is a local save
+that looks corrupt — 0-byte or implausibly shrunk versus the recorded
+baseline size (a crashed emulator / full disk). RomM's PUT overwrites the
+save in place with no recoverable version, so rather than destroy the only
+good copy we route that case to ``Conflict`` for the user to resolve
+(``domain/save_size.is_implausibly_shrunken``).
 
 When ``is_current=false`` AND local diverges, both sides moved
 independently — that is the only true ``Conflict`` and it requires a user
@@ -54,6 +59,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from domain.iso_time import parse_iso_to_epoch
+from domain.save_size import is_implausibly_shrunken
 
 # ---------------------------------------------------------------------------
 # SyncAction variants
@@ -129,7 +135,11 @@ def _local_mtime_ge_server_updated_at(local_file: dict[str, Any], server: dict[s
 
 
 def _decide_when_is_current(
-    server: dict[str, Any], local_file: dict[str, Any] | None, local_hash: str | None, last_sync_hash: str | None
+    server: dict[str, Any],
+    local_file: dict[str, Any] | None,
+    local_hash: str | None,
+    last_sync_hash: str | None,
+    last_sync_local_size: int | None,
 ) -> SyncAction:
     """Branch 4: ``our_entry.is_current=True`` on the chosen save."""
     if local_file is None:
@@ -140,6 +150,11 @@ def _decide_when_is_current(
         # Pure state mutation, no I/O.
         return Skip(reason="synced", adopt_baseline=True)
     if local_hash and local_hash != last_sync_hash:
+        if is_implausibly_shrunken(local_file.get("size"), last_sync_local_size):
+            # 0-byte / truncated local (crashed emulator, full disk). A PUT
+            # would overwrite the only good server copy in place with no
+            # recoverable version — let the user decide instead (#1062).
+            return Conflict(server_save=server)
         # Played offline since last sync; server unchanged — PUT the diverged
         # local content against the existing save id.
         return Upload(target_save_id=server.get("id"))
@@ -214,9 +229,10 @@ def compute_sync_action(
     device_syncs = server.get("device_syncs") or []
     our_entry = next((ds for ds in device_syncs if ds.get("device_id") == device_id), None)
     last_sync_hash = files_state.get("last_sync_hash")
+    last_sync_local_size = files_state.get("last_sync_local_size")
 
     if our_entry and our_entry.get("is_current"):
-        return _decide_when_is_current(server, local_file, local_hash, last_sync_hash)
+        return _decide_when_is_current(server, local_file, local_hash, last_sync_hash, last_sync_local_size)
     if our_entry is not None:
         return _decide_when_not_current(server, local_file, local_hash, last_sync_hash)
     return _decide_when_no_entry(server, local_file, local_hash, last_sync_hash)

--- a/tests/domain/test_save_size.py
+++ b/tests/domain/test_save_size.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``domain.save_size.is_implausibly_shrunken``.
+
+Pins the plausibility-guard decision (#1062): a 0-byte or implausibly-shrunken
+local save must be flagged so the sync kernel refuses an in-place PUT over the
+only good server copy. Pure-domain only — no I/O.
+"""
+
+from __future__ import annotations
+
+from domain.save_size import _DEFAULT_SHRINK_RATIO, is_implausibly_shrunken
+
+
+class TestZeroByteGate:
+    """A 0-byte local save is never plausible — the unconditional trigger."""
+
+    def test_zero_with_baseline_is_implausible(self):
+        assert is_implausibly_shrunken(0, 8192) is True
+
+    def test_zero_with_no_baseline_is_implausible(self):
+        assert is_implausibly_shrunken(0, None) is True
+
+    def test_zero_with_zero_baseline_is_implausible(self):
+        assert is_implausibly_shrunken(0, 0) is True
+
+
+class TestShrinkGate:
+    """A dramatic shrink versus a positive baseline is implausible."""
+
+    def test_just_below_half_is_implausible(self):
+        # 4095 < 8192 * 0.5 (4096) → fires.
+        assert is_implausibly_shrunken(4095, 8192) is True
+
+    def test_exactly_half_is_plausible(self):
+        # 4096 is not < 8192 * 0.5 (4096) — boundary is NOT a shrink.
+        assert is_implausibly_shrunken(4096, 8192) is False
+
+    def test_just_above_half_is_plausible(self):
+        assert is_implausibly_shrunken(4097, 8192) is False
+
+    def test_far_below_half_is_implausible(self):
+        assert is_implausibly_shrunken(10, 8192) is True
+
+    def test_larger_than_baseline_is_plausible(self):
+        # Growth is always a plausible edit.
+        assert is_implausibly_shrunken(16384, 8192) is False
+
+    def test_equal_to_baseline_is_plausible(self):
+        assert is_implausibly_shrunken(8192, 8192) is False
+
+
+class TestNoBaseline:
+    """Without a positive baseline a non-empty save can't be judged a shrink."""
+
+    def test_none_baseline_with_nonzero_size_is_plausible(self):
+        assert is_implausibly_shrunken(1, None) is False
+
+    def test_zero_baseline_with_nonzero_size_is_plausible(self):
+        assert is_implausibly_shrunken(1, 0) is False
+
+    def test_negative_baseline_treated_as_no_baseline(self):
+        # A garbage negative baseline must not yield a bogus threshold.
+        assert is_implausibly_shrunken(1, -100) is False
+
+
+class TestUnknownSize:
+    """An unknown (None) new size cannot be judged — never flag it."""
+
+    def test_none_size_with_baseline_is_plausible(self):
+        assert is_implausibly_shrunken(None, 8192) is False
+
+    def test_none_size_with_no_baseline_is_plausible(self):
+        assert is_implausibly_shrunken(None, None) is False
+
+
+class TestCustomRatio:
+    """The threshold is overridable for callers that need a different cutoff."""
+
+    def test_custom_ratio_changes_threshold(self):
+        # With ratio 0.9, 5000 < 8192 * 0.9 (7372.8) → fires, even though it
+        # passes the default 0.5 gate.
+        assert is_implausibly_shrunken(5000, 8192) is False
+        assert is_implausibly_shrunken(5000, 8192, shrink_ratio=0.9) is True
+
+    def test_default_ratio_is_half(self):
+        assert _DEFAULT_SHRINK_RATIO == 0.5

--- a/tests/domain/test_sync_action.py
+++ b/tests/domain/test_sync_action.py
@@ -27,11 +27,11 @@ OTHER_DEVICE_ID = "device-xyz"
 # ---------------------------------------------------------------------------
 
 
-def _local(filename: str = "save.srm", mtime: float = 1_700_000_000.0) -> dict[str, Any]:
+def _local(filename: str = "save.srm", mtime: float = 1_700_000_000.0, size: int = 8192) -> dict[str, Any]:
     return {
         "filename": filename,
         "path": f"/tmp/{filename}",
-        "size": 8192,
+        "size": size,
         "mtime": mtime,
     }
 
@@ -101,6 +101,82 @@ def test_is_current_true_local_diverged_returns_upload_put():
         local_file=_local(),
         server_saves_in_slot=[server],
         files_state={"last_sync_hash": "abc"},
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result == Upload(target_save_id=42)
+
+
+def test_is_current_true_zero_byte_local_returns_conflict():
+    """Row 9b / #1062 — is_current=true + diverged local that is 0 bytes → Conflict,
+    NOT an in-place PUT. RomM versions only on POST, so a PUT of the empty file
+    would overwrite the only good server copy with no recoverable version.
+    """
+    server = _server_save(save_id=42, device_syncs=[_device_sync(DEVICE_ID, is_current=True)])
+    result = compute_sync_action(
+        local_file=_local(size=0),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc", "last_sync_local_size": 8192},
+        device_id=DEVICE_ID,
+        local_hash="EMPTY-HASH",  # diverges from baseline
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_is_current_true_zero_byte_local_no_baseline_size_returns_conflict():
+    """Row 9b / #1062 — the 0-byte gate is unconditional: even with no recorded
+    ``last_sync_local_size`` baseline, a diverged 0-byte local is a Conflict, not a PUT.
+    """
+    server = _server_save(save_id=42, device_syncs=[_device_sync(DEVICE_ID, is_current=True)])
+    result = compute_sync_action(
+        local_file=_local(size=0),
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc"},  # no last_sync_local_size
+        device_id=DEVICE_ID,
+        local_hash="EMPTY-HASH",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_is_current_true_shrunken_local_returns_conflict():
+    """Row 9b / #1062 — is_current=true + diverged local dramatically smaller than
+    the recorded baseline size (truncated / partial write) → Conflict, not PUT.
+    """
+    server = _server_save(save_id=42, device_syncs=[_device_sync(DEVICE_ID, is_current=True)])
+    result = compute_sync_action(
+        local_file=_local(size=100),  # < 50% of 8192
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc", "last_sync_local_size": 8192},
+        device_id=DEVICE_ID,
+        local_hash="TRUNCATED",
+    )
+    assert result == Conflict(server_save=server)
+
+
+def test_is_current_true_plausible_size_diverged_still_uploads_put():
+    """Row 9 / #1062 regression — is_current=true + diverged local of a plausible
+    size (no shrink) still PUTs in place. The guard must NOT fire on a normal edit.
+    """
+    server = _server_save(save_id=42, device_syncs=[_device_sync(DEVICE_ID, is_current=True)])
+    result = compute_sync_action(
+        local_file=_local(size=8000),  # ~same size as baseline
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc", "last_sync_local_size": 8192},
+        device_id=DEVICE_ID,
+        local_hash="DIFFERENT",
+    )
+    assert result == Upload(target_save_id=42)
+
+
+def test_is_current_true_grown_local_uploads_put():
+    """Row 9 / #1062 regression — a diverged local that GREW past the baseline is a
+    plausible edit → PUT, never Conflict.
+    """
+    server = _server_save(save_id=42, device_syncs=[_device_sync(DEVICE_ID, is_current=True)])
+    result = compute_sync_action(
+        local_file=_local(size=16384),  # larger than baseline
+        server_saves_in_slot=[server],
+        files_state={"last_sync_hash": "abc", "last_sync_local_size": 8192},
         device_id=DEVICE_ID,
         local_hash="DIFFERENT",
     )

--- a/tests/domain/test_sync_action_property.py
+++ b/tests/domain/test_sync_action_property.py
@@ -28,6 +28,9 @@ Invariants encoded here:
   enforced live (no longer xfail-pinned).
 - Inv5 (#1059): branch-6 divergence from a held baseline is always a
   ``Conflict`` — never a silent ``Download``/``Upload``.
+- Inv6 (#1062): branch-4 (is_current=true) never emits an in-place PUT for a
+  0-byte / implausibly-shrunken diverged local save — that would overwrite the
+  only good server copy with no recoverable version; it is a ``Conflict``.
 """
 
 from __future__ import annotations
@@ -38,6 +41,7 @@ from typing import Any
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
+from domain.save_size import is_implausibly_shrunken
 from domain.sync_action import (
     Conflict,
     Download,
@@ -113,7 +117,8 @@ def _server_saves(draw: st.DrawFn) -> dict[str, Any]:
 
 
 _server_lists = st.lists(_server_saves(), min_size=0, max_size=5)
-_files_states = st.fixed_dictionaries({}, optional={"last_sync_hash": _hashes})
+_sizes = st.integers(min_value=0, max_value=1_048_576)
+_files_states = st.fixed_dictionaries({}, optional={"last_sync_hash": _hashes, "last_sync_local_size": _sizes})
 
 
 def _action(
@@ -363,3 +368,58 @@ def test_no_entry_identical_content_does_not_duplicate(
     result = _action(local_file, [server], {}, local_hash)
     # Identical content already on the server → adopt it, never POST a duplicate.
     assert result == Skip(reason="synced", adopt_baseline=True)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6 (#1062): branch-4 never PUTs a 0-byte / shrunken local in place.
+# ---------------------------------------------------------------------------
+
+
+@given(
+    server_epoch=_epochs,
+    local_hash=_hashes,
+    baseline=_hashes,
+    new_size=st.integers(min_value=0, max_value=1_048_576),
+    baseline_size=st.one_of(st.none(), st.integers(min_value=0, max_value=1_048_576)),
+)
+def test_is_current_implausible_local_never_puts_in_place(
+    server_epoch: float,
+    local_hash: str,
+    baseline: str,
+    new_size: int,
+    baseline_size: int | None,
+) -> None:
+    """Branch 4 / #1062 — when our device is ``is_current=true`` on the picked
+    save, the present local has diverged from the held baseline, AND the local
+    size is implausible (0-byte or shrunk past the threshold versus the recorded
+    baseline size), the kernel returns ``Conflict`` — never ``Upload`` (an
+    in-place PUT that RomM applies with no recoverable version, destroying the
+    only good copy). The safety invariant stated directly: no in-place overwrite
+    of a server save with a corrupt-looking local file.
+    """
+    assume(local_hash != baseline)
+    local_file = {
+        "filename": "Game.srm",
+        "path": "/tmp/Game.srm",
+        "size": new_size,
+        "mtime": server_epoch,
+    }
+    files_state: dict[str, Any] = {"last_sync_hash": baseline}
+    if baseline_size is not None:
+        files_state["last_sync_local_size"] = baseline_size
+    server = {
+        "id": 7,
+        "slot": 0,
+        "updated_at": _epoch_to_iso(server_epoch, zulu=False, micros=False),
+        "file_extension": "srm",
+        "device_syncs": [{"device_id": DEVICE_ID, "is_current": True}],
+    }
+
+    result = _action(local_file, [server], files_state, local_hash)
+
+    if is_implausibly_shrunken(new_size, baseline_size):
+        # Corrupt-looking local → never an in-place PUT; route to the user.
+        assert result == Conflict(server_save=server)
+    else:
+        # Plausible divergent edit → the normal in-place PUT.
+        assert result == Upload(target_save_id=7)

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -1336,6 +1336,60 @@ class TestSyncRomSavesDispatch:
         file_state = _require_save_state(svc, 42).files["pokemon.srm"]
         assert file_state.last_sync_hash == local_hash
 
+    def test_sync_rom_saves_zero_byte_local_conflicts_no_put(self, tmp_path):
+        """#1062: is_current=true + a 0-byte diverged local → Conflict, NO PUT.
+
+        A crashed emulator / full disk left a 0-byte save. RomM PUTs in place
+        (no recoverable version), so the matrix must refuse the upload and surface
+        a conflict the user resolves instead of silently destroying the only good
+        server copy. The local 0-byte file is left untouched on disk.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        # Local save is 0 bytes (truncated by the crash).
+        save_path = _create_save(tmp_path, content=b"")
+        local_hash = _file_md5(str(save_path))
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": True}],
+        )
+        fake.saves[100] = ss
+
+        # Baseline recorded a healthy 8 KiB save; the divergent local is now empty.
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,  # baseline differs from current local
+                        "last_sync_server_updated_at": ss["updated_at"],
+                        "last_sync_local_size": 8192,
+                    }
+                }
+            },
+        )
+
+        synced, errors, conflicts = _do_sync(svc, 42)
+
+        assert synced == 0
+        assert errors == []
+        # NO upload (PUT) was issued — the destructive overwrite was refused.
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        # A conflict entry was surfaced for the user to resolve.
+        assert len(conflicts) == 1
+        c = conflicts[0]
+        assert c["type"] == "sync_conflict"
+        assert c["rom_id"] == 42
+        assert c["filename"] == "pokemon.srm"
+        assert c["server_save_id"] == 100
+        assert c["local_hash"] == local_hash
+        assert c["local_size"] == 0
+        # The 0-byte local file is left in place (not deleted by the refusal).
+        assert save_path.exists()
+
     def test_sync_rom_saves_skip_with_adopt_baseline_writes_hash(self, tmp_path):
         """is_current=true + local present + no baseline → Skip + adopt_baseline:
         no I/O but state.last_sync_hash gets recorded as local_hash."""


### PR DESCRIPTION
Closes #1062

## Problem

Branch 4 of the newest-wins sync kernel (`_decide_when_is_current` in `domain/sync_action.py`) emits an in-place `Upload` (PUT) whenever local content diverges from the recorded baseline while our device is `is_current=true`. A crashed emulator or a full disk can leave a **0-byte or truncated** local save — still a valid regular file with a valid-but-wrong content hash — which took the same PUT path.

RomM's `PUT /api/saves/{id}` updates the save **in place** and creates a version only on **POST**, never on PUT. So that PUT overwrote the only good server copy with the corrupt bytes and left **no recoverable version**. This is the upload mirror of the still-open #965 "every destructive op has backup-or-confirm" invariant: the download-overwrite path already quarantines the local file into `.romm-backup` first, but the upload-overwrite PUT had no equivalent guard.

A truncated-but-non-empty save is equally destructive, so a pure 0-byte gate would be a partial fix.

## Fix

Add a pure-domain plausibility guard in a new `domain/save_size.py`:

- `is_implausibly_shrunken(new_size, baseline_size)` — `True` when `new_size == 0` (unconditional 0-byte gate) or when a positive baseline exists and `new_size` is below 50% of it (`_DEFAULT_SHRINK_RATIO`). The threshold is a hard-coded conservative default, **not** a setting.

Branch 4 now calls it before the in-place PUT: when it fires, the kernel returns `Conflict(server_save)` instead of `Upload(PUT)`. The case routes through the **existing** `sync_conflict` modal — zero frontend/callable change:

- **Use Server** → downloads the good server copy (quarantining the bad local first).
- **Keep Local** → re-PUTs the corrupt file only after an explicit user choice.

The `last_sync_local_size` baseline already flows end-to-end (written at every successful sync, exposed by `_file_state_to_dict`), so there is **no new persistence** and no adapter/aggregate-method change — only the kernel and the size it consumes.

A plausible-size divergent edit (or a save that grew) is unaffected and still PUTs in place.

## Tests

- `tests/domain/test_save_size.py` (new) — happy/bad/edge for the helper: 0-byte (with/without baseline), exactly-50% (plausible), just-below-50% (implausible), larger/grown, None size, no/zero/negative baseline, custom ratio.
- `tests/domain/test_sync_action.py` — branch-4 cases: 0-byte → Conflict, 0-byte-no-baseline-size → Conflict, shrunken → Conflict, plausible/grown → Upload(PUT) unchanged.
- `tests/domain/test_sync_action_property.py` — Inv6 (#1062): branch 4 never emits an in-place PUT for an implausibly-shrunken/0-byte diverged local; `_files_states` extended to generate `last_sync_local_size`.
- `tests/services/saves/sync_engine/test_matrix.py` — dispatch test: a 0-byte divergent local under `is_current=true` issues **no** PUT, surfaces a conflict entry, and leaves the local file in place.

## Docs (same PR, CI-enforced)

- `docs/architecture/save-file-sync-architecture.md` — decision matrix split (row 9 / 9b), new "Why row 9b conflicts instead of PUTting in place" subsection, third discriminator (size plausibility), and the "Conflict happens in three rows" + Conflict-Resolution updates.
- `docs/user-guide/troubleshooting.md` — user-facing "Conflict prompt after a crash or power loss" entry covering the `.romm-backup` recovery.

## Validation (all green locally)

- `mise run test` — 3473 passed
- `ruff format --check` + `ruff check` — clean
- `basedpyright py_modules main.py tests` — 0 errors, 0 warnings
- `mise run lint` — lint-imports, service-independence, callable-manifest, cosmic-call-bans, failure-shape, event-parity, settings-owner, markdownlint — all OK
- Coverage on new lines: 100% line + branch on `domain/save_size.py` and `domain/sync_action.py`

## On-device (Steam Deck + real RomM) follow-up

Not coverable by unit/CI tests — needs hardware verification:

- Good server save + `is_current=true` baseline, then zero the local `.srm` and post-exit sync → confirm NO PUT, conflict modal appears, Use Server recovers + moves the bad local to `.romm-backup`, Keep Local re-PUTs only on explicit choice.
- Truncated non-empty local → confirm the ratio gate fires (conflict, not silent PUT).
- Legitimate plausible-size divergent edit → still PUTs in place (no false-positive regression).