### PR TITLE
fix(library): materialize full enabled-platforms map so one un-toggle never disables others

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -37,6 +37,9 @@ individual platforms.
 4. Use **Enable All** / **Disable All** for bulk changes
 5. Only enabled platforms are included in the next sync
 
+All platforms are enabled by default until you change a toggle. Turning one platform off affects only that platform —
+every other platform stays enabled and keeps syncing.
+
 <!-- Screenshot: Platforms page with toggle switches and ROM counts -->
 
 ## Collections

--- a/py_modules/domain/platform_prefs.py
+++ b/py_modules/domain/platform_prefs.py
@@ -1,0 +1,37 @@
+"""Per-platform sync-enabled defaulting — the empty-map "all enabled" rule.
+
+Single source of truth for how an absent ``enabled_platforms`` entry is
+resolved, shared by the display path (``get_platforms``) and the filter
+path (``_fetch_enabled_platforms``) so the two can never drift. The empty
+map means "all platforms enabled by default"; once any platform is
+explicitly toggled, the map is the full per-platform preference set.
+
+Pure compute — no I/O, no state mutation.
+"""
+
+from __future__ import annotations
+
+
+def resolve_sync_enabled(stored: dict[str, bool], pid: str) -> bool:
+    """Resolve whether platform ``pid`` is sync-enabled given the stored map.
+
+    An absent id defaults to enabled **only while the map is empty** (the
+    "all enabled by default" sentinel). Once any preference is recorded, an
+    absent id resolves to disabled — so a complete map can be read literally.
+    """
+    return stored.get(pid, len(stored) == 0)
+
+
+def materialize_enabled_platforms(stored: dict[str, bool], platform_ids: list[str]) -> dict[str, bool] | None:
+    """Resolve the empty-map sentinel into an explicit all-True map.
+
+    Returns a full ``{pid: True}`` map when ``stored`` is the empty sentinel
+    and at least one platform id is given; otherwise ``None`` (no
+    materialization needed — the map already holds explicit preferences, or
+    there are no platforms to enumerate). The caller persists a non-``None``
+    result so every later single-key write is a true partial update of a
+    complete map, and "len == 1" can never be misread as "the rest disabled".
+    """
+    if stored or not platform_ids:
+        return None
+    return dict.fromkeys(platform_ids, True)

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -16,6 +16,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
 from domain.sync_state import SyncState
 from domain.work_unit import CollectionKind, WorkUnit
 from lib.errors import classify_error
@@ -122,7 +123,22 @@ class LibraryFetcher:
                 "message": "Invalid server response",
             }
 
+        # Only platforms with ROMs are shown (and thus toggleable), so the
+        # materialized map covers exactly the set the user can act on.
+        shown_ids = [str(p["id"]) for p in platforms if p.get("rom_count", 0) > 0]
+
+        # Self-heal the empty-map sentinel into an explicit all-True map at the
+        # first read with a live platform list, so every later single-key
+        # ``save_platform_sync`` write is a partial update of a complete map —
+        # a one-platform toggle can never again be misread as "rest disabled"
+        # (#1007). Idempotent: only fires while the map is the empty sentinel.
         enabled = self._settings.get("enabled_platforms", {})
+        materialized = materialize_enabled_platforms(enabled, shown_ids)
+        if materialized is not None:
+            self._settings["enabled_platforms"] = materialized
+            self._settings_persister.save_settings()
+            enabled = materialized
+
         result = []
         for p in platforms:
             rom_count = p.get("rom_count", 0)
@@ -135,7 +151,7 @@ class LibraryFetcher:
                     "name": p.get("name", ""),
                     "slug": p.get("slug", ""),
                     "rom_count": rom_count,
-                    "sync_enabled": enabled.get(pid, len(enabled) == 0),
+                    "sync_enabled": resolve_sync_enabled(enabled, pid),
                 }
             )
         return {"success": True, "platforms": result}
@@ -339,11 +355,15 @@ class LibraryFetcher:
             self._logger.error(f"Unexpected platforms response type: {type(platforms).__name__}")
             return []
 
+        # Empty map = "all platforms enabled" (the safety floor for a user who
+        # syncs without ever opening the Platforms page). ``get_platforms``
+        # materializes the full map on first view, so a partial map here always
+        # reflects explicit per-platform choices, never the sentinel (#1007).
         enabled = self._settings.get("enabled_platforms", {})
         no_prefs = len(enabled) == 0
         self._logger.info(f"Platform filter: {len(enabled)} prefs saved, no_prefs={no_prefs}")
         self._logger.info(f"Enabled platforms: {[k for k, v in enabled.items() if v]}")
-        platforms = [p for p in platforms if enabled.get(str(p["id"]), no_prefs)]
+        platforms = [p for p in platforms if resolve_sync_enabled(enabled, str(p["id"]))]
         self._logger.info(f"Syncing {len(platforms)} platforms: {[p['name'] for p in platforms]}")
         return platforms
 

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -360,8 +360,7 @@ class LibraryFetcher:
         # materializes the full map on first view, so a partial map here always
         # reflects explicit per-platform choices, never the sentinel (#1007).
         enabled = self._settings.get("enabled_platforms", {})
-        no_prefs = len(enabled) == 0
-        self._logger.info(f"Platform filter: {len(enabled)} prefs saved, no_prefs={no_prefs}")
+        self._logger.info(f"Platform filter: {len(enabled)} prefs saved, no_prefs={not enabled}")
         self._logger.info(f"Enabled platforms: {[k for k, v in enabled.items() if v]}")
         platforms = [p for p in platforms if resolve_sync_enabled(enabled, str(p["id"]))]
         self._logger.info(f"Syncing {len(platforms)} platforms: {[p['name'] for p in platforms]}")

--- a/tests/contract/test_library_callables.py
+++ b/tests/contract/test_library_callables.py
@@ -1,0 +1,96 @@
+"""Contract tests for the platform-toggle callables (#1007).
+
+Drives the real ``Plugin`` over the real ``bootstrap`` to pin the
+end-to-end behavior the data-loss fix restores: opening the Platforms page
+(``get_platforms``) materializes the full per-platform enabled map into the
+real ``settings.json``, and un-toggling exactly ONE platform
+(``save_platform_sync``) leaves every other platform enabled — both on disk
+and in the sync-time platform filter.
+
+Each callable is driven exactly as the frontend declares it in
+``src/api/backend.ts``: ``get_platforms()`` zero-arg, ``save_platform_sync``
+with ``(platform_id: number, enabled: boolean)``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+def _read_settings(harness) -> dict[str, Any]:
+    """Read the real on-disk ``settings.json`` the bootstrap wrote under tmp_path."""
+    path = os.path.join(str(harness.tmp_path / "settings"), "settings.json")
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+async def test_get_platforms_materializes_full_map_to_disk(harness):
+    """get_platforms over the empty default persists the full all-True map."""
+    harness.romm.platforms = [
+        {"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3},
+        {"id": 2, "name": "Nintendo 64", "slug": "n64", "rom_count": 4},
+        {"id": 3, "name": "Empty", "slug": "empty", "rom_count": 0},  # filtered out
+    ]
+
+    result = await harness.plugin.get_platforms()
+
+    assert result["success"] is True
+    assert [p["slug"] for p in result["platforms"]] == ["snes", "n64"]
+    assert all(p["sync_enabled"] is True for p in result["platforms"])
+
+    # The full all-True map round-trips through the real crash-safe write.
+    on_disk = _read_settings(harness)
+    assert on_disk["enabled_platforms"] == {"1": True, "2": True}
+
+
+async def test_one_off_toggle_leaves_other_platforms_enabled(harness):
+    """#1007: get_platforms → save_platform_sync(one, False) → others stay enabled.
+
+    Pins the fix across the real settings round-trip and the sync-time filter
+    that drives stale-ROM removal: before the fix, the single OFF write turned
+    the empty sentinel into a one-entry map and the filter dropped every other
+    platform, marking their bound ROMs stale.
+    """
+    harness.romm.platforms = [
+        {"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3},
+        {"id": 2, "name": "Nintendo 64", "slug": "n64", "rom_count": 4},
+        {"id": 3, "name": "Game Boy Advance", "slug": "gba", "rom_count": 5},
+    ]
+
+    # 1. Platforms page mount materializes the full map.
+    await harness.plugin.get_platforms()
+
+    # 2. Un-toggle exactly one platform (frontend: number id, bool enabled).
+    toggle_result = await harness.plugin.save_platform_sync(2, False)
+    assert toggle_result == {"success": True}
+
+    # 3. The on-disk map is a true partial update — only id 2 flipped.
+    on_disk = _read_settings(harness)
+    assert on_disk["enabled_platforms"] == {"1": True, "2": False, "3": True}
+
+    # 4. The sync-time filter keeps every OTHER platform.
+    filtered = await harness.plugin._sync_service._fetcher._fetch_enabled_platforms()
+    kept_slugs = {p["slug"] for p in filtered}
+    assert kept_slugs == {"snes", "gba"}
+    assert "n64" not in kept_slugs
+
+
+async def test_get_platforms_idempotent_after_materialization(harness):
+    """A second get_platforms over a now-explicit map does not re-write or clobber."""
+    harness.romm.platforms = [
+        {"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3},
+        {"id": 2, "name": "Nintendo 64", "slug": "n64", "rom_count": 4},
+    ]
+
+    await harness.plugin.get_platforms()
+    await harness.plugin.save_platform_sync(1, False)
+
+    # Re-opening the page reads the explicit map literally — no re-materialize.
+    result = await harness.plugin.get_platforms()
+    by_id = {p["id"]: p["sync_enabled"] for p in result["platforms"]}
+    assert by_id == {1: False, 2: True}
+
+    on_disk = _read_settings(harness)
+    assert on_disk["enabled_platforms"] == {"1": False, "2": True}

--- a/tests/domain/test_platform_prefs.py
+++ b/tests/domain/test_platform_prefs.py
@@ -1,0 +1,57 @@
+"""Tests for domain.platform_prefs — the per-platform "all enabled" defaulting.
+
+Hand-enumerated cases for the pure kernel shared by the display path
+(``get_platforms``) and the filter path (``_fetch_enabled_platforms``).
+The property-based companion lives in ``test_platform_prefs_property.py``.
+"""
+
+from __future__ import annotations
+
+from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
+
+
+class TestResolveSyncEnabled:
+    """resolve_sync_enabled — absent-id default depends on whether prefs exist."""
+
+    def test_absent_id_defaults_true_when_map_empty(self):
+        assert resolve_sync_enabled({}, "1") is True
+
+    def test_absent_id_defaults_false_when_map_non_empty(self):
+        # The #1007 bug condition: one explicit entry means every absent id is
+        # disabled — so a complete map can be read literally.
+        assert resolve_sync_enabled({"1": True}, "2") is False
+
+    def test_present_id_true_is_returned(self):
+        assert resolve_sync_enabled({"1": True}, "1") is True
+
+    def test_present_id_false_is_returned(self):
+        assert resolve_sync_enabled({"1": False}, "1") is False
+
+    def test_present_false_id_returned_even_when_others_present(self):
+        assert resolve_sync_enabled({"1": False, "2": True}, "1") is False
+
+
+class TestMaterializeEnabledPlatforms:
+    """materialize_enabled_platforms — empty-map sentinel → explicit all-True map."""
+
+    def test_empty_map_with_ids_yields_full_all_true_map(self):
+        assert materialize_enabled_platforms({}, ["1", "2", "3"]) == {
+            "1": True,
+            "2": True,
+            "3": True,
+        }
+
+    def test_non_empty_map_yields_none(self):
+        # Already holds explicit prefs — nothing to materialize.
+        assert materialize_enabled_platforms({"1": False}, ["1", "2"]) is None
+
+    def test_empty_map_with_no_ids_yields_none(self):
+        # No platforms to enumerate (e.g. server returned an empty / all-empty
+        # library) — leave the sentinel untouched so the safety floor survives.
+        assert materialize_enabled_platforms({}, []) is None
+
+    def test_non_empty_map_with_no_ids_yields_none(self):
+        assert materialize_enabled_platforms({"1": True}, []) is None
+
+    def test_single_id_empty_map_yields_single_true(self):
+        assert materialize_enabled_platforms({}, ["42"]) == {"42": True}

--- a/tests/domain/test_platform_prefs_property.py
+++ b/tests/domain/test_platform_prefs_property.py
@@ -1,0 +1,79 @@
+"""Property-based tests for ``domain.platform_prefs`` (#1007).
+
+The per-platform "all enabled" defaulting kernel is what stood between a
+single un-toggle and a silent mass-stale wipe. Hand-enumerated cases
+(``test_platform_prefs.py``) pin specific shapes; these properties state
+the *invariants* the kernel must hold across the whole id space.
+
+Property-test convention — pinning open bugs
+---------------------------------------------
+A property states the TRUE invariant. If it FAILS today, the invariant's
+bug is still open, so the property is pinned ``@pytest.mark.xfail(
+strict=True, reason="#<issue>: …")``. The fix in this PR closes #1007, so
+the properties below are expected to pass LIVE (regression guards), not
+xfail-pinned.
+
+Invariants encoded here:
+- Inv1: materialization is semantics-preserving for the initial all-True
+  state — resolving any id over the materialized map equals resolving it
+  over the empty sentinel (both True).
+- Inv2 (#1007): after materializing the full map, flipping ONE id to False
+  never changes any OTHER id's resolved value. This is exactly the
+  invariant the bug violated — a single write turned the empty sentinel
+  into a one-entry map and flipped every absent id to disabled.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
+
+# Platform ids are stringified ints on the wire; a small, distinct, non-empty
+# set keeps the search focused on the defaulting logic, not id formatting.
+_platform_ids = st.lists(
+    st.integers(min_value=1, max_value=999).map(str),
+    min_size=1,
+    max_size=12,
+    unique=True,
+)
+
+
+@given(platform_ids=_platform_ids)
+def test_materialization_preserves_initial_all_enabled(platform_ids: list[str]) -> None:
+    """Inv1: every shown id resolves True before and after materialization."""
+    materialized = materialize_enabled_platforms({}, platform_ids)
+    assert materialized is not None
+    for pid in platform_ids:
+        # Sentinel default and the explicit map agree: all enabled.
+        assert resolve_sync_enabled({}, pid) is True
+        assert resolve_sync_enabled(materialized, pid) is True
+
+
+@given(platform_ids=_platform_ids, flip_index=st.integers(min_value=0))
+def test_single_off_toggle_does_not_disable_others(platform_ids: list[str], flip_index: int) -> None:
+    """Inv2 (#1007): one un-toggle leaves every other platform's value intact."""
+    materialized = materialize_enabled_platforms({}, platform_ids)
+    assert materialized is not None
+
+    target = platform_ids[flip_index % len(platform_ids)]
+    # Single-key write exactly as ``save_platform_sync`` does it.
+    materialized[target] = False
+
+    for pid in platform_ids:
+        expected = pid != target
+        assert resolve_sync_enabled(materialized, pid) is expected
+
+
+@given(platform_ids=_platform_ids, flip_index=st.integers(min_value=0))
+def test_single_on_toggle_does_not_disable_others(platform_ids: list[str], flip_index: int) -> None:
+    """Inv2 (#1007): re-toggling one platform ON keeps every other enabled."""
+    materialized = materialize_enabled_platforms({}, platform_ids)
+    assert materialized is not None
+
+    target = platform_ids[flip_index % len(platform_ids)]
+    materialized[target] = True
+
+    for pid in platform_ids:
+        assert resolve_sync_enabled(materialized, pid) is True

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -86,6 +86,106 @@ class TestFetchEnabledPlatforms:
         assert result == []
 
 
+class TestGetPlatformsMaterialization:
+    """Tests for get_platforms() — the #1007 empty-map → full-map self-heal."""
+
+    @pytest.mark.asyncio
+    async def test_materializes_full_all_true_map_when_empty(self, plugin, fake_romm_api):
+        """Empty map + shown platforms → persisted full all-True map (one save)."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 3},
+            {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+        ]
+        plugin.settings["enabled_platforms"] = {}
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["success"] is True
+        assert plugin.settings["enabled_platforms"] == {"1": True, "2": True}
+        assert plugin._settings_persister.save_count == 1
+        assert all(p["sync_enabled"] is True for p in result["platforms"])
+
+    @pytest.mark.asyncio
+    async def test_excludes_zero_rom_platforms_from_materialized_map(self, plugin, fake_romm_api):
+        """A rom_count==0 platform is neither shown nor materialized."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 3},
+            {"id": 2, "name": "Empty", "slug": "empty", "rom_count": 0},
+        ]
+        plugin.settings["enabled_platforms"] = {}
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert plugin.settings["enabled_platforms"] == {"1": True}
+        assert [p["slug"] for p in result["platforms"]] == ["n64"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_materialize_when_map_non_empty(self, plugin, fake_romm_api):
+        """A non-empty stored map is read literally — no re-write, no save."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 3},
+            {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+        ]
+        plugin.settings["enabled_platforms"] = {"1": False}
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert plugin.settings["enabled_platforms"] == {"1": False}
+        assert plugin._settings_persister.save_count == 0
+        by_id = {p["id"]: p["sync_enabled"] for p in result["platforms"]}
+        # Absent id 2 resolves False once any pref exists (the literal-map read).
+        assert by_id == {1: False, 2: False}
+
+    @pytest.mark.asyncio
+    async def test_does_not_persist_when_no_shown_platforms(self, plugin, fake_romm_api):
+        """Empty map + zero shown platforms → sentinel survives, no save."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "Empty", "slug": "empty", "rom_count": 0},
+        ]
+        plugin.settings["enabled_platforms"] = {}
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["success"] is True
+        assert result["platforms"] == []
+        assert plugin.settings["enabled_platforms"] == {}
+        assert plugin._settings_persister.save_count == 0
+
+    @pytest.mark.asyncio
+    async def test_one_off_toggle_after_materialization_keeps_others_enabled(self, plugin, fake_romm_api):
+        """#1007 regression: get_platforms → save one OFF → other platforms still sync.
+
+        Reproduces the data-loss path end-to-end at the fetcher seam: open the
+        Platforms page (materialize), un-toggle exactly ONE platform, then run
+        the sync-time filter and assert every OTHER platform survives.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 3},
+            {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+            {"id": 3, "name": "GBA", "slug": "gba", "rom_count": 7},
+        ]
+        plugin.settings["enabled_platforms"] = {}
+
+        # 1. Platforms page mount materializes the full all-True map.
+        await plugin._sync_service._fetcher.get_platforms()
+        assert plugin.settings["enabled_platforms"] == {"1": True, "2": True, "3": True}
+
+        # 2. Un-toggle exactly one platform (single-key write).
+        plugin._sync_service._fetcher.save_platform_sync(2, False)
+
+        # 3. Sync-time filter: every OTHER platform must survive (pre-fix this
+        #    returned only the never-touched platforms, dropping the rest).
+        filtered = await plugin._sync_service._fetcher._fetch_enabled_platforms()
+        kept = {p["name"] for p in filtered}
+        assert kept == {"N64", "GBA"}
+        assert "SNES" not in kept
+
+
 class TestBuildWorkQueueErrorPaths:
     """Tests for build_work_queue() collection-list failure / filter branches."""
 


### PR DESCRIPTION
Closes #1007.

## The bug (data loss)

`enabled_platforms` defaulted to an empty dict, with "all platforms enabled" encoded as the **empty-map sentinel** — both the display path (`get_platforms`) and the sync-time filter (`_fetch_enabled_platforms`) derived `no_prefs = len(enabled) == 0` and defaulted absent ids to that value.

`save_platform_sync` writes **only the single toggled id**. So the first toggle turned the empty map into a one-entry map: `len` became 1, `no_prefs` became `False`, and the filter then defaulted **every un-listed platform to disabled**. One un-toggle (or one toggle-on) implicitly disabled every other platform. The frontend never re-fetches after a toggle, so the other platforms still **displayed** as enabled.

When at least one collection was also enabled, the work queue was non-empty and bypassed the `total_units == 0` early-return guard. `_scan_stale_roms` then returned every bound ROM outside the surviving selection, `sync_stale` fired, and the frontend removed those Steam shortcuts — silently destroying artwork bindings, collection memberships, and controller configs for platforms the UI still showed as enabled. (The DB rows survive per ADR-0007, so playtime/saves are recoverable on a corrected re-sync, but the Steam-side state is genuinely lost.)

## The fix

Materialize the full all-True map at the read point that already has the live platform list (`get_platforms`), persisting the completed map. After materialization `enabled_platforms` is always a complete per-platform map, so a single-key `save_platform_sync` write is a true partial update of an explicit map — "len == 1" can never again be misread as "the rest disabled".

A new pure kernel `domain/platform_prefs.py` is the **single source** of the "all enabled" default, shared by both the display path and the filter path so the two can never drift (previously each re-derived `no_prefs` inline). The empty-map safety floor is preserved for a user who syncs without ever opening the Platforms page.

The materialization is a one-time, idempotent self-heal write inside `get_platforms` — the network-free trade for fixing the root cause without making a settings toggle depend on a network roundtrip. The write goes through the existing `SettingsPersister` Protocol, so `settings.json`'s owner is unchanged.

## Tests

- `tests/domain/test_platform_prefs.py` — kernel happy/bad/edge cases.
- `tests/domain/test_platform_prefs_property.py` — Hypothesis properties: materialization is semantics-preserving for the initial all-enabled state, and a subsequent single-key flip never changes any other id's resolved value (the exact invariant the bug violated). Live regression guards, not xfail-pinned.
- `tests/services/library/test_fetcher.py` — `TestGetPlatformsMaterialization`, including the end-to-end #1007 regression (materialize → un-toggle one → filter keeps the others).
- `tests/contract/test_library_callables.py` — real `Plugin` over real `bootstrap`: `get_platforms` → `save_platform_sync(one, False)` round-trips the materialized map through real `settings.json` under `tmp_path` and the sync-time filter keeps the other platforms.

## Validation

- `python -m pytest tests/` — 3471 passed
- `domain/platform_prefs.py` 100% covered; `services/library/fetcher.py` 98% (changed lines covered)
- `ruff check` / `ruff format --check` — clean
- `basedpyright` — 0 errors
- `lint-imports` + all architecture gates (callable manifest, failure shape, event parity, settings owner, cosmic call bans, service independence) — pass
- `pnpm build` — succeeds

## On-device verification still needed

The silent-wipe path uses the real `SteamClient.Apps.RemoveShortcut`, which unit/CI tests can't exercise:

1. Multi-platform library + ≥1 enabled collection: clean sync, un-toggle one platform, Skip-Preview sync → confirm the other platforms' shortcuts/artwork/collections survive.
2. Fresh install (empty `settings.json`): open the Platforms page once → confirm `settings.json` holds a full all-True map; a user who never opens the page still syncs all platforms.
