### PR TITLE
fix(sync): post-sync toast shows the true created/removed delta (#744)

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -18,7 +18,9 @@ games appear in the Steam Library with cover art, metadata, and organized into c
 1. Open the QAM and navigate to the plugin
 2. Tap **Sync Library** on the main page
 3. A progress bar shows the sync status
-4. When complete, a summary appears (e.g. "Added 42 games from 5 platforms")
+4. When complete, a toast reports what actually changed — the true delta, not the total in your library. It shows the
+   number of shortcuts added and/or removed this run (e.g. "Sync complete — 42 added, 3 removed."), omitting a part that
+   is zero. If nothing changed, it reads "Library up to date."
 
 ![RomM Sync QAM panel with connection status and the Sync Library button](../assets/screenshot-qam.jpg)
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -17,7 +17,8 @@ import { toaster } from "@decky/api";
 import { emitDeckyEvent, deckyEventListenerCount } from "./test-utils/decky-api-mock";
 import { getSettingsResetNotice, getAllPlaytime, getAppIdRomIdMap } from "./api/backend";
 import { getSettingsResetState, setSettingsResetState } from "./utils/settingsResetStore";
-import type { DownloadCompleteEvent, SyncStaleData } from "./types";
+import { recordSyncCreated, resetSyncDelta } from "./utils/syncDeltaStore";
+import type { DownloadCompleteEvent, SyncPlanData, SyncStaleData } from "./types";
 
 vi.mock("./patches/gameDetailPatch", () => ({
   registerGameDetailPatch: vi.fn(),
@@ -423,6 +424,162 @@ describe("index.tsx — sync_complete stale-collection cleanup (#1040)", () => {
     // The additive create/update path is NOT gated on cancel — the platforms
     // that DID complete still get their collections.
     expect(createOrUpdateCollections).toHaveBeenCalledWith({ "Nintendo 64": [1] });
+    plugin.onDismount();
+  });
+});
+
+describe("index.tsx — sync_complete toast shows the true delta (#744)", () => {
+  // total_games is intentionally MISLEADING in these payloads (the bug): the
+  // toast must ignore it and report the real created/removed delta tracked by
+  // syncDeltaStore. created is seeded via recordSyncCreated (the mocked
+  // syncManager would do this on the create path); removed flows through the
+  // real sync_stale listener.
+  type SyncCompletePayload = {
+    platform_app_ids: Record<string, number[]>;
+    romm_collection_app_ids?: Record<string, number[]>;
+    total_games: number;
+    cancelled?: boolean;
+  };
+
+  function lastToastBody(): string | undefined {
+    const calls = vi.mocked(toaster.toast).mock.calls;
+    if (calls.length === 0) return undefined;
+    const last = calls[calls.length - 1]![0] as { body?: string };
+    return last.body;
+  }
+
+  beforeEach(() => {
+    vi.mocked(toaster.toast).mockClear();
+    logError.mockClear();
+    vi.mocked(applyAllPlaytime).mockResolvedValue(undefined);
+    vi.mocked(getAllPlaytime).mockResolvedValue({ playtime: {} });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({});
+    // No RomM collections so the stale-cleanup detach is a no-op for these tests.
+    vi.stubGlobal("collectionStore", { userCollections: [] });
+    resetSyncDelta();
+  });
+
+  it("reports 'X added, Y removed' when both are non-zero (ignores total_games)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 2, total_roms: 2 });
+    });
+    // Two distinct shortcuts created this run (what the syncManager create path records).
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    // One shortcut removed via the real sync_stale listener.
+    act(() => {
+      emitDeckyEvent<[SyncStaleData]>("sync_stale", { remove: [{ rom_id: 7, app_id: 700 }] });
+    });
+
+    // total_games=53 is the misleading total — the toast must NOT use it.
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 53 });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync complete — 2 added, 1 removed.");
+    plugin.onDismount();
+  });
+
+  it("omits the zero part — only removals → 'Sync complete — N removed.'", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 1, total_roms: 0 });
+    });
+    act(() => {
+      emitDeckyEvent<[SyncStaleData]>("sync_stale", {
+        remove: [
+          { rom_id: 7, app_id: 700 },
+          { rom_id: 8, app_id: 800 },
+        ],
+      });
+    });
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 53 });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync complete — 2 removed.");
+    plugin.onDismount();
+  });
+
+  it("reports 'Library up to date.' when nothing changed (the #744 repro)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 1, total_roms: 53 });
+    });
+    // No creates, no removes — but total_games=53 (the old toast wrongly said
+    // "53 games added"). The fixed toast must say the library is up to date.
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 53 });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Library up to date.");
+    plugin.onDismount();
+  });
+
+  it("dedups a shortcut created in two units (platform + collection) — counted once", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 2, total_roms: 1 });
+    });
+    // Same appId surfaces in its platform unit and a collection unit; the Set
+    // in the store collapses it to one "added".
+    recordSyncCreated(100);
+    recordSyncCreated(100);
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", { platform_app_ids: {}, total_games: 1 });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync complete — 1 added.");
+    plugin.onDismount();
+  });
+
+  it("on cancel with partial work → 'Sync cancelled — … so far.'", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 3, total_roms: 10 });
+    });
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    recordSyncCreated(300);
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 53,
+        cancelled: true,
+      });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync cancelled — 3 added so far.");
+    plugin.onDismount();
+  });
+
+  it("on cancel before any work → 'Sync cancelled.' (no delta)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 3, total_roms: 10 });
+    });
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 53,
+        cancelled: true,
+      });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync cancelled.");
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,7 @@ import {
 } from "./utils/collections";
 import { setMigrationStatus } from "./utils/migrationStore";
 import { fetchSettingsResetState } from "./utils/settingsResetStore";
+import { resetSyncDelta, recordSyncRemoved, getSyncDelta } from "./utils/syncDeltaStore";
 import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
@@ -270,12 +271,26 @@ export default definePlugin(() => {
     cancelled?: boolean;
   }) => {
     logInfo(`sync_complete received: ${data.total_games} games, cancelled=${data.cancelled ?? false}`);
-    toaster.toast({
-      title: "RomM Sync",
-      body: data.cancelled
-        ? `Sync cancelled. ${data.total_games} games processed.`
-        : `Sync complete! ${data.total_games} games added.`,
-    });
+
+    // Report the TRUE delta, not the total processed set. The library applies
+    // whole platforms, so total_games is not a real delta — the exact, honest
+    // counts are the shortcuts the frontend actually created and removed this
+    // run (tracked in syncDeltaStore, deduplicated across platform/collection
+    // units). Omit a zero part; "Library up to date." when nothing changed.
+    const { added, removed } = getSyncDelta();
+    const parts: string[] = [];
+    if (added > 0) parts.push(`${added} added`);
+    if (removed > 0) parts.push(`${removed} removed`);
+    const summary = parts.join(", ");
+    let body: string;
+    if (data.cancelled) {
+      body = summary ? `Sync cancelled — ${summary} so far.` : "Sync cancelled.";
+    } else {
+      body = summary ? `Sync complete — ${summary}.` : "Library up to date.";
+    }
+    toaster.toast({ title: "RomM Sync", body });
+    // Defensive reset; sync_plan also resets at the start of the next run.
+    resetSyncDelta();
 
     // Update RomM app ID set with newly synced shortcuts
     for (const appIds of Object.values(data.platform_app_ids)) {
@@ -375,6 +390,9 @@ export default definePlugin(() => {
   // ``sync_plan`` arrives once per run with the full work queue (info only
   // for now — future PR adds a per-platform progress view).
   const syncPlanListener = addEventListener<[SyncPlanData]>("sync_plan", (data: SyncPlanData) => {
+    // sync_plan fires once per run, before any unit — reset the per-run delta
+    // so the terminal toast counts only this run's created/removed shortcuts.
+    resetSyncDelta();
     logInfo(`sync_plan received: ${data.total_units} units, ${data.total_roms} ROMs total`);
   });
 
@@ -385,7 +403,12 @@ export default definePlugin(() => {
   const syncStaleListener = addEventListener<[SyncStaleData]>("sync_stale", (data: SyncStaleData) => {
     if (!Array.isArray(data.remove) || data.remove.length === 0) return;
     for (const { app_id } of data.remove) {
-      if (app_id) removeShortcut(app_id);
+      if (app_id) {
+        removeShortcut(app_id);
+        // Record the removal as a real "removed" delta. The store dedups across
+        // the per-unit sync_stale emits so a shortcut removed once is counted once.
+        recordSyncRemoved(app_id);
+      }
     }
     logInfo(`sync_stale: removed ${data.remove.length} stale shortcuts`);
   });

--- a/src/utils/syncDeltaStore.test.ts
+++ b/src/utils/syncDeltaStore.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Exercises the per-run sync delta store: record/get/reset, dedup of repeated
+ * appIds, and independence of the created vs removed sets. The store is
+ * module-level state, so each test resets it first.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { resetSyncDelta, recordSyncCreated, recordSyncRemoved, getSyncDelta } from "./syncDeltaStore";
+
+describe("syncDeltaStore", () => {
+  beforeEach(() => {
+    resetSyncDelta();
+  });
+
+  it("starts empty", () => {
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 0 });
+  });
+
+  it("counts each distinct created appId once", () => {
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    recordSyncCreated(300);
+    expect(getSyncDelta()).toEqual({ added: 3, removed: 0 });
+  });
+
+  it("counts each distinct removed appId once", () => {
+    recordSyncRemoved(900);
+    recordSyncRemoved(800);
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 2 });
+  });
+
+  it("dedups a created appId recorded twice (multi-unit overlap counts once)", () => {
+    recordSyncCreated(100);
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    expect(getSyncDelta()).toEqual({ added: 2, removed: 0 });
+  });
+
+  it("dedups a removed appId recorded twice across per-unit sync_stale emits", () => {
+    recordSyncRemoved(900);
+    recordSyncRemoved(900);
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 1 });
+  });
+
+  it("tracks created and removed independently", () => {
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    recordSyncRemoved(900);
+    expect(getSyncDelta()).toEqual({ added: 2, removed: 1 });
+  });
+
+  it("clears both sets on reset", () => {
+    recordSyncCreated(100);
+    recordSyncRemoved(900);
+    resetSyncDelta();
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 0 });
+  });
+});

--- a/src/utils/syncDeltaStore.ts
+++ b/src/utils/syncDeltaStore.ts
@@ -1,0 +1,44 @@
+/**
+ * Module-level per-run sync delta — the TRUE created/removed counts for one
+ * sync run, so the post-sync toast reports what actually changed rather than
+ * the total processed set.
+ *
+ * The library applies whole platforms (not per-ROM deltas), so an "applied
+ * count" is not a real delta. The only exact, meaningful deltas are the
+ * shortcuts the frontend actually created (`addShortcut` calls) and removed
+ * (`sync_stale` app_ids). A ROM can appear in multiple units (its platform unit
+ * plus a collection unit like Favorites), so the counts are Sets of appIds —
+ * the same shortcut created/removed across units is counted once.
+ *
+ * Updated by:
+ *   - syncManager create path (recordSyncCreated on a fresh addShortcut appId)
+ *   - sync_stale listener in index.tsx (recordSyncRemoved per removed app_id)
+ *   - sync_plan listener in index.tsx (resetSyncDelta at run start)
+ *
+ * Read by:
+ *   - onSyncComplete in index.tsx (getSyncDelta for the terminal toast)
+ */
+
+const created = new Set<number>();
+const removed = new Set<number>();
+
+/** Clear both sets at the start of a run (sync_plan fires once per run). */
+export function resetSyncDelta(): void {
+  created.clear();
+  removed.clear();
+}
+
+/** Record a newly created shortcut's appId (real addShortcut call). */
+export function recordSyncCreated(appId: number): void {
+  created.add(appId);
+}
+
+/** Record a removed shortcut's appId (a sync_stale entry). */
+export function recordSyncRemoved(appId: number): void {
+  removed.add(appId);
+}
+
+/** The deduplicated created/removed counts for the current run. */
+export function getSyncDelta(): { added: number; removed: number } {
+  return { added: created.size, removed: removed.size };
+}

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { act } from "@testing-library/react";
 import * as backend from "../api/backend";
 import { emitDeckyEvent } from "../test-utils/decky-api-mock";
+import { resetSyncDelta, getSyncDelta } from "./syncDeltaStore";
 import type { SyncApplyUnitData } from "../types";
 
 const setLaunchOptionsConfirmed = vi.fn().mockResolvedValue(true);
@@ -119,5 +120,61 @@ describe("syncManager — once-per-run existing-shortcut scan cache", () => {
 
     // A new run_id is a cache miss → fresh scan.
     expect(getExistingRomMShortcuts).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("syncManager — records created shortcuts into the per-run delta store", () => {
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    resetSyncDelta();
+  });
+
+  it("records a freshly created shortcut's appId as an 'added' delta", async () => {
+    // rom 42 has no existing appId → create path → addShortcut returns 6000.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    addShortcut.mockResolvedValue(6000);
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-create"));
+      await flush(120);
+    });
+
+    expect(addShortcut).toHaveBeenCalledTimes(1);
+    expect(getSyncDelta()).toEqual({ added: 1, removed: 0 });
+  });
+
+  it("does NOT record the update path (existing shortcut) as a delta", async () => {
+    // rom 42 already maps to appId 5000 → update path, never addShortcut.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[42, 5000]]));
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-update"));
+      await flush(120);
+    });
+
+    expect(addShortcut).not.toHaveBeenCalled();
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 0 });
+  });
+
+  it("does NOT record when addShortcut fails to resolve an appId (null)", async () => {
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    addShortcut.mockResolvedValue(null);
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-create-fail"));
+      await flush(120);
+    });
+
+    expect(addShortcut).toHaveBeenCalledTimes(1);
+    expect(getSyncDelta()).toEqual({ added: 0, removed: 0 });
   });
 });

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -3,6 +3,7 @@ import type { SyncAddItem, SyncApplyUnitData } from "../types";
 import { getArtworkBase64, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
 import { getExistingRomMShortcuts, addShortcut, setLaunchOptionsConfirmed } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
+import { recordSyncCreated } from "./syncDeltaStore";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 const HEARTBEAT_INTERVAL_MS = 10_000;
@@ -48,7 +49,11 @@ async function resolveShortcutAppId(item: SyncAddItem, existing: Map<number, num
     await setLaunchOptionsConfirmed(existingAppId, item.launch_options);
     return existingAppId;
   }
-  return (await addShortcut(item)) ?? undefined;
+  // Create path: a fresh shortcut. Record its appId as a real "added" delta —
+  // the update path above is excluded (the shortcut already existed).
+  const createdAppId = (await addShortcut(item)) ?? undefined;
+  if (createdAppId) recordSyncCreated(createdAppId);
+  return createdAppId;
 }
 
 /**


### PR DESCRIPTION
## Problem

The post-sync toast hardcoded `Sync complete! {total_games} games added.` regardless of what actually happened. Because the library applies whole **platforms** (not per-ROM deltas), `total_games` is the processed/enabled set — not a real delta.

On-device repro (#744): deactivate one platform, sync → 52 removed, 0 added, 53 unchanged → toast wrongly says **"53 games added."**

## Fix (frontend-only)

Track the only exact, meaningful deltas frontend-side:

- **created** — real `addShortcut` calls (new appIds), known in `syncManager`.
- **removed** — the `sync_stale` app_id list.

A ROM can appear in multiple units (its platform unit + a collection unit like Favorites), so a new per-run `src/utils/syncDeltaStore.ts` uses **Sets of appIds** — a shortcut created/removed across units is counted **once**. Reset on `sync_plan` (fires once per run, before any unit), read on `sync_complete`.

New toast wording:

| Situation | Body |
| --- | --- |
| added + removed | `Sync complete — 42 added, 3 removed.` |
| only one non-zero | `Sync complete — 42 added.` (zero part omitted) |
| nothing changed | `Library up to date.` |
| cancelled, partial | `Sync cancelled — 3 added so far.` |
| cancelled, nothing yet | `Sync cancelled.` |

No apply-model change, **no backend / event / callable changes**. `total_games` stays in the payload type and is still logged — it just no longer drives the toast. No "updated" count (whole-platform re-apply is not a meaningful delta).

## Tests (non-vacuous)

- `src/utils/syncDeltaStore.test.ts` — record/get/reset, dedup (same appId twice → counted once), created/removed independence.
- `src/utils/syncManager.test.ts` — the create path records the new appId; the update path (existing appId) does **not**; a failed `addShortcut` (null) records nothing.
- `src/index.test.tsx` — via the `emitDeckyEvent` harness: emit `sync_plan` → `sync_stale` → `sync_complete` and assert the **actual toast body string** for every case above, plus the end-to-end dedup (one appId created in two units → "1 added") and the `total_games`-is-misleading repro (53 → "Library up to date.").

## Validation (all green)

| Command | Result |
| --- | --- |
| `pnpm test` (vitest) | 57 files, **1220 passed** |
| `pnpm typecheck` (tsc) | clean |
| `pnpm lint` (eslint) | 0 errors (2 pre-existing warnings in untouched files: `DownloadQueue.tsx`, `SlotSetupWizard.tsx`) |
| `pnpm build` (rollup) | succeeds |

New-code coverage: `syncDeltaStore.ts` fully exercised; the new `syncManager.ts` create-path lines covered; the new `index.tsx` delta branch covered by 6 toast tests — comfortably above the 80% Sonar gate.

## Docs

Updated `docs/user-guide/syncing-your-library.md` — the post-sync summary description now reflects the true-delta wording instead of the old "Added 42 games from 5 platforms" example.

Closes #744