### PR TITLE
chore(ci): gate locked pins against source constraints; lint deps via uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-dev.lock
+
+      # uv is the project's canonical Python package manager (mise pins 0.10.2;
+      # `mise run setup` installs via uv). Use it in CI too for parity + speed,
+      # and so the lock-sync check below can run `uv pip compile`.
+      - uses: astral-sh/setup-uv@v8
+        with:
+          version: "0.10.2"
 
       - name: Install lint dependencies
-        run: pip install -r requirements-dev.lock
+        run: uv pip install --system -r requirements-dev.lock
 
       - name: Ruff check
         run: ruff check .
@@ -142,6 +147,9 @@ jobs:
 
       - name: Check settings-owner confinement
         run: python scripts/check_settings_owner.py
+
+      - name: Check dependency locks satisfy their source constraints
+        run: python scripts/check_lock_sync.py
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       # uv is the project's canonical Python package manager (mise pins 0.10.2;
       # `mise run setup` installs via uv). Use it in CI too for parity + speed,
       # and so the lock-sync check below can run `uv pip compile`.
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.10.2"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,12 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
   `success: False` return in `services/` is missing the canonical `reason` + `message` keys or carries the forbidden
   `error` / `error_code` key. The two documented carve-outs (discriminated-status unions, partial-success payloads) are
   pattern-exempt. Enforces the "Callable response shapes" convention below.
+- **Lockfile constraint gate**: `scripts/check_lock_sync.py` — asserts every direct dependency pinned in
+  `requirements-*.lock` satisfies the version constraint declared in its `requirements-*.txt` source (and that every
+  source dep is present in the lock). A constraint bump that isn't followed by `mise run lock-update` is inert (CI +
+  `mise run setup` install from the lock) and can leave the lock silently violating the source (the #1113/#1114/#1115
+  drift); this gate forces the regeneration into the same PR. It checks satisfaction, not "is it the newest", so it is
+  deterministic and offline — an unrelated transitive upstream release never flaps it.
 - **pytest-cov**: Branch coverage reported to SonarCloud.
 
 ## Invariant register — cross-cutting safety rules
@@ -161,6 +167,7 @@ green, and a real drift is a finding to triage, never an exemption. `[ours]`
 | Service-independence contract list stays complete                                                      | check              | `scripts/check_service_independence_contract.py`                                                                                                                                                                                                    |
 | Layer import direction (services ↛ adapters, adapters ↛ services, …)                                   | check              | `.importlinter` (`lint-imports`)                                                                                                                                                                                                                    |
 | No bare `# type: ignore` / blanket suppressions                                                        | check              | `scripts/check_no_bare_ignores.sh`                                                                                                                                                                                                                  |
+| Every pinned version in `requirements-*.lock` satisfies its `requirements-*.txt` source constraint     | check              | `scripts/check_lock_sync.py`                                                                                                                                                                                                                        |
 | Server-supplied path components pass `safe_join` (`lib/path_safety.py`)                                | test + prompt-only | traversal tests per path builder; new call sites are prompt-only                                                                                                                                                                                    |
 | No sentinel objects on the wire — explicit JSON-representable tagged values only                       | prompt-only        | mechanize with #1032 (after tagged values replace the sentinels)                                                                                                                                                                                    |
 | Every destructive op has backup-or-confirm; never delete data that exists nowhere else                 | prompt-only        | save-file removals route through `MatrixExecutor.quarantine_local_file` (the `.romm-backup` funnel — #965/#1058 done); mechanize the rest via the #794 delete-path fixes (#974 / #1005 / #1062)                                                     |

--- a/mise.toml
+++ b/mise.toml
@@ -51,6 +51,7 @@ run = [
     "python scripts/check_failure_shape.py --check",
     "python scripts/check_event_parity.py",
     "python scripts/check_settings_owner.py",
+    "python scripts/check_lock_sync.py",
 ]
 
 [tasks.deploy]

--- a/scripts/check_lock_sync.py
+++ b/scripts/check_lock_sync.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Lockfile constraint gate.
+
+``requirements-*.lock`` are compiled from ``requirements-*.txt`` via
+``uv pip compile`` (``mise run lock-update``). CI and ``mise run setup`` install
+from the LOCK, so a bump to a ``.txt`` constraint that does not regenerate the
+lock is INERT (the old pin keeps getting installed) and can leave the lock
+VIOLATING its source constraint, silently and green — the failure mode behind
+#1113 / #1114 / #1115.
+
+This gate asserts that every DIRECT dependency pinned in the lock SATISFIES the
+version constraint declared in its ``.txt`` source (and that every source dep is
+present in the lock). It deliberately does NOT recompile-and-diff against the
+live package index: a fresh ``uv pip compile`` resolves to the newest versions
+available *at compile time*, so an unrelated transitive upstream release (or a
+different uv index-cache state) would make recompile-and-diff flap red with no
+source change. Checking *satisfaction* — not "is it the newest" — targets
+exactly the harmful drift and stays deterministic and offline.
+
+Out of scope (not constrained by the source, so not checked): transitive pins
+and lock-only orphans.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+PAIRS = [
+    ("requirements-dev.txt", "requirements-dev.lock"),
+    ("requirements-docs.txt", "requirements-docs.lock"),
+]
+
+# A pinned line in a uv-compiled lock: `name==version` at column 0 (the `# via`
+# provenance lines are indented, the header lines start with `#`).
+_PIN_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==(.+?)\s*$")
+
+
+def parse_sources(path: Path) -> list[Requirement]:
+    """Parse a requirements ``.txt`` into its declared direct requirements."""
+    reqs: list[Requirement] = []
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):  # blank/comment or -r/-c include
+            continue
+        reqs.append(Requirement(line))
+    return reqs
+
+
+def parse_lock_pins(path: Path) -> dict[str, str]:
+    """Map canonical package name -> pinned version from a compiled lock."""
+    pins: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        m = _PIN_RE.match(raw)
+        if m:
+            pins[canonicalize_name(m.group(1))] = m.group(2)
+    return pins
+
+
+def main() -> int:
+    errors: list[str] = []
+    for src_name, lock_name in PAIRS:
+        src, lock = Path(src_name), Path(lock_name)
+        if not src.is_file():
+            errors.append(f"missing source {src_name}")
+            continue
+        if not lock.is_file():
+            errors.append(f"missing lock {lock_name}")
+            continue
+
+        pins = parse_lock_pins(lock)
+        for req in parse_sources(src):
+            pinned = pins.get(canonicalize_name(req.name))
+            if pinned is None:
+                errors.append(f"{src_name}: '{req.name}' is declared but not pinned in {lock_name}")
+            elif not req.specifier.contains(pinned, prereleases=True):
+                errors.append(
+                    f"{lock_name}: '{req.name}' is pinned at {pinned}, "
+                    f"which violates the '{req}' constraint in {src_name}"
+                )
+
+    if errors:
+        print("ERROR: dependency lock(s) out of sync with their sources — run 'mise run lock-update' and commit:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("OK: every locked pin satisfies its source constraint.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two dependency-tooling fixes, surfaced by the #1113 / #1114 / #1115 dependabot bumps.

### 1. Lock-constraint gate (`scripts/check_lock_sync.py`)

Those bumps changed `requirements-dev.txt` constraints but not the lock. CI and `mise run setup` install from the **lock**, so the bumps were inert — and the lock pins actually *violated* the new constraints (`pytest==9.0.3` vs `>=9.1.1`), silently and green, because nothing checked it.

The new gate asserts every direct dependency pinned in `requirements-*.lock` satisfies its `requirements-*.txt` constraint (and that every source dep is present in the lock). Wired into the CI lint job, `mise run lint`, and the Invariant register.

It checks **satisfaction, not "is it the newest"** — deliberately *not* recompile-and-diff: a fresh `uv pip compile` resolves to the newest versions available at compile time, so an unrelated transitive upstream release (or a different uv index-cache state) would flap recompile-and-diff red with no source change. Constraint-satisfaction is deterministic + offline and targets exactly the harmful drift.

### 2. Lint job uses uv

uv is the project's canonical Python package manager (mise pins 0.10.2; `mise run setup` installs via uv), but the CI lint job used `pip`. Switched it to `astral-sh/setup-uv@v8` (pinned 0.10.2) + `uv pip install --system` for parity + speed.

## Validation

- `check_lock_sync.py`: ruff + basedpyright clean; happy path OK; verified it fails on an injected unsatisfiable constraint (`pytest>=99` → "pinned at 9.1.1 violates …") and passes again after restore.

docs: N/A (CI tooling — lock-constraint gate + uv in the lint job; no user-facing or `docs/` change)
