### PR TITLE
fix(downloads): wave 1 cancel/cleanup cluster — data loss, transfer-stop, concurrency, UI

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -106,7 +106,7 @@ the rest are single modules. A service over ~700 LOC is the decomposition signal
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `library/`                | LibraryService façade — fetch ROMs, preview/apply sync, per-unit shortcut delivery, `roms`/`SyncRun` writes + queries (decomposed; see below)                                                                                                                                                                          |
 | `saves/`                  | SaveService aggregate — `.srm` upload/download, conflict detection, slots, versions (decomposed; see below)                                                                                                                                                                                                            |
-| `downloads.py`            | DownloadService — ZIP extraction, M3U, fcntl-locked queue, progress                                                                                                                                                                                                                                                    |
+| `downloads.py`            | DownloadService — ZIP extraction, M3U, progress, bounded-concurrency download queue (Semaphore(2) + reserved-bytes pre-flight); cancel/cleanup never deletes a live install                                                                                                                                            |
 | `firmware.py`             | FirmwareService — BIOS registry, downloads, per-core filtering; `get_firmware_status` ships per-platform `bios_level` (ok/partial/missing via `domain.bios.compute_bios_level`) + `required_count`/`required_downloaded`/`server_count`/`local_count` so the System page reads the decision off the payload (#461)     |
 | `session_lifecycle.py`    | SessionLifecycleService — post-exit orchestration (playtime + post-exit save sync + achievement sync + migration refresh)                                                                                                                                                                                              |
 | `migration.py`            | MigrationService — RetroDECK path-change detection + file migration, save-sort change detection + conflict resolution                                                                                                                                                                                                  |
@@ -223,6 +223,24 @@ GameCube/Wii (Dolphin) are never bin/cue and do not reliably launch from a singl
 arrive as single-file downloads that never reach the extraction path, so they get no playlist.
 
 Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
+
+**Bounded concurrency + reserved-bytes pre-flight**: at most **two** ROMs transfer at once, gated by an
+`asyncio.Semaphore(2)` around the transfer + post-IO critical section. `start_download` enters the queue with status
+**`queued`** and reserves the download's required bytes in `_reserved_bytes[rom_id]`; `_do_download` flips the status to
+`downloading` only once it acquires the semaphore (emitting a `download_progress` `status: "queued"` frame first if it
+has to wait), and releases the reservation in its `finally`. The disk pre-flight accounts for siblings' outstanding
+reservations (`free_space - sum(reserved) < required`) so two concurrent downloads that each fit alone but not together
+can't both pass — the second is rejected with an `insufficient_space` failure.
+
+**Cancel reaches the UI and never destroys a live install**: cancelling a download emits a terminal `download_progress`
+`status: "cancelled"` frame so the frontend resets the button out of its downloading state (the cancel path used to be
+silent). Because executor threads run to completion regardless of cancellation, a cancel that **loses the race** to a
+just-committed install is reconciled (`_reconcile_post_io` awaits the in-flight post-IO future): if the install
+committed, the download is surfaced as **completed** (launch options baked, `download_complete` emitted) rather than
+torn down. `_cleanup_partial_download` removes **only** the transient transfer artifacts (`.zip.tmp` / `.tmp`) and, for
+a multi-file ROM that did **not** commit, the extract dir(s) this download created — it **never** deletes the bare
+`target_path`, so a re-download that fails mid-stream (or a cancel that lost the race) cannot destroy a pre-existing or
+just-committed install.
 
 #### ConnectionService notes
 

--- a/docs/user-guide/managing-games.md
+++ b/docs/user-guide/managing-games.md
@@ -27,7 +27,11 @@ Games appear as shortcuts in your library even before the ROM file is downloaded
 
 <!-- Screenshot: Game detail page during a download with progress bar -->
 
-You can also tap **Cancel** to abort a download in progress. Partial files are cleaned up automatically.
+You can also abort a download in progress — tap the **X** that appears on the right of the download button on the game's
+detail page, or use **Cancel** in the QAM download queue. Only the partial transfer files are cleaned up — an
+already-installed copy of the game is never removed, so cancelling a re-download (or a download that fails partway)
+leaves your existing install intact. If the cancel happens to land just as the download finishes, the game is kept as
+**Installed** rather than torn down.
 
 Downloaded ROMs are stored in your RetroDECK roms directory (e.g. `~/retrodeck/roms/gba/`).
 
@@ -94,6 +98,10 @@ The **Downloads** page (accessible from the main QAM panel) shows all active and
 - Active downloads with progress bars and cancel buttons
 - Completed, failed, and cancelled downloads with status details
 - **Clear Completed** button to clean up the list
+
+At most **two** ROMs download at the same time. If you start more, the extra ones wait their turn and begin
+automatically as soon as a slot frees up. Before a download starts, the plugin checks there's enough free disk space for
+everything already in flight, so a batch of downloads won't overcommit the SD card.
 
 <!-- Screenshot: Download Queue page with an active download and completed entries -->
 

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -50,6 +50,22 @@ _ZIP_TMP_EXT = ".zip.tmp"
 _TMP_EXT = ".tmp"
 
 
+class _CancelToken:
+    """Per-download cancellation flag. Set on the event-loop thread by
+    ``cancel_download``; polled on the executor worker thread by the progress
+    callback, which raises to abort the in-flight HTTP transfer (#144).
+
+    A plain bool — not ``threading.Event`` — because the import-linter
+    ``no-stdlib-io-in-services`` contract forbids ``threading`` in services, and
+    under the GIL a one-way set-once bool flip needs no synchronisation.
+    """
+
+    __slots__ = ("cancelled",)
+
+    def __init__(self) -> None:
+        self.cancelled = False
+
+
 @dataclass(frozen=True)
 class DownloadServiceConfig:
     """Frozen wiring bundle handed to ``DownloadService.__init__``.
@@ -95,6 +111,17 @@ class DownloadService:
         self._download_in_progress: set[int] = set()
         self._download_queue: dict[int, dict[str, Any]] = {}
         self._download_tasks: dict[int, asyncio.Task[None]] = {}
+        # Bounded concurrency: at most two ROMs transfer at once. Excess
+        # downloads enter the queue with status "queued" and acquire the
+        # semaphore in FIFO order inside ``_do_download``.
+        self._download_semaphore = asyncio.Semaphore(2)
+        # Reserved bytes per in-flight ROM, so the disk pre-flight accounts for
+        # siblings already committed to download but not yet written to disk.
+        self._reserved_bytes: dict[int, int] = {}
+        # Per-download cooperative-cancel tokens. The progress callback polls its
+        # captured token on the executor thread; ``cancel_download`` flips it on
+        # the loop thread to abort the in-flight transfer (#144).
+        self._cancel_tokens: dict[int, _CancelToken] = {}
 
     async def shutdown(self) -> None:
         """Cancel in-flight per-ROM download tasks on plugin unload.
@@ -184,63 +211,85 @@ class DownloadService:
         platform_fs_slug = rom_detail.get("platform_fs_slug")
         system = self._resolve_system(platform_slug, platform_fs_slug)
 
-        roms_path = self._retrodeck_paths.roms_path()
+        # Path building, directory creation, and the disk pre-flight can raise
+        # (SD card unmounted → OSError; ``roms_path()`` returning None → TypeError
+        # in the join). Any raise here must release the in-progress flag so the
+        # ROM isn't stuck "Already downloading" until a plugin reload (#1048).
+        # The explicit early-return guards inside still ``return`` (not raise)
+        # and discard the flag themselves; a ``return`` does not trip the except.
         try:
-            # ``system`` may be an unmapped server slug passed through verbatim
-            # (ADR-0010). Validate it stays under roms_path BEFORE any make_dirs
-            # so a slug like "../../etc" cannot create or write outside roms.
-            roms_dir = safe_join(roms_path, system)
-        except PathTraversalError as e:
-            self._download_in_progress.discard(rom_id)
-            self._logger.error(f"Rejected download for ROM {rom_id}: unsafe platform slug {system!r}: {e}")
-            await self._emit(
-                "download_failed",
-                {
-                    "rom_id": rom_id,
-                    "rom_name": rom_detail.get("name", ""),
-                    "platform_name": rom_detail.get("platform_name", platform_slug),
-                    "error_message": "Server sent an unsafe platform path — download aborted",
-                },
-            )
-            return {
-                "success": False,
-                "reason": "path_traversal",
-                "message": "Server sent an unsafe platform path — download aborted",
-            }
-        file_name, files_missing = resolve_local_file_name(rom_detail)
-        if files_missing:
-            self._logger.warning(
-                f"has_nested_single_file=true but files list is empty; falling back to fs_name='{file_name}'"
-            )
-        # Fix 1: Sanitize fs_name to prevent path traversal
-        safe_name = os.path.basename(file_name)
-        if safe_name != file_name:
-            self._logger.warning(f"Sanitized fs_name from '{file_name}' to '{safe_name}'")
-            file_name = safe_name
-        file_size = rom_detail.get("fs_size_bytes", 0)
+            roms_path = self._retrodeck_paths.roms_path()
+            try:
+                # ``system`` may be an unmapped server slug passed through verbatim
+                # (ADR-0010). Validate it stays under roms_path BEFORE any make_dirs
+                # so a slug like "../../etc" cannot create or write outside roms.
+                roms_dir = safe_join(roms_path, system)
+            except PathTraversalError as e:
+                self._download_in_progress.discard(rom_id)
+                self._logger.error(f"Rejected download for ROM {rom_id}: unsafe platform slug {system!r}: {e}")
+                await self._emit(
+                    "download_failed",
+                    {
+                        "rom_id": rom_id,
+                        "rom_name": rom_detail.get("name", ""),
+                        "platform_name": rom_detail.get("platform_name", platform_slug),
+                        "error_message": "Server sent an unsafe platform path — download aborted",
+                    },
+                )
+                return {
+                    "success": False,
+                    "reason": "path_traversal",
+                    "message": "Server sent an unsafe platform path — download aborted",
+                }
+            file_name, files_missing = resolve_local_file_name(rom_detail)
+            if files_missing:
+                self._logger.warning(
+                    f"has_nested_single_file=true but files list is empty; falling back to fs_name='{file_name}'"
+                )
+            # Fix 1: Sanitize fs_name to prevent path traversal
+            safe_name = os.path.basename(file_name)
+            if safe_name != file_name:
+                self._logger.warning(f"Sanitized fs_name from '{file_name}' to '{safe_name}'")
+                file_name = safe_name
+            file_size = rom_detail.get("fs_size_bytes", 0)
 
-        # Check disk space: multi-file ROMs need space for ZIP + extracted contents
-        self._download_file_store.make_dirs(roms_dir)
-        free_space = self._download_file_store.disk_free(roms_dir)
-        buffer = 100 * 1024 * 1024
-        required = file_size * 2 + buffer if is_multi_file_download(rom_detail) else file_size + buffer
-        if file_size and free_space < required:
-            self._download_in_progress.discard(rom_id)
-            free_mb = free_space // (1024 * 1024)
-            need_mb = required // (1024 * 1024)
-            return {
-                "success": False,
-                "reason": "insufficient_space",
-                "message": f"Not enough disk space ({free_mb}MB free, need {need_mb}MB)",
-            }
+            # Check disk space: multi-file ROMs need space for ZIP + extracted contents
+            self._download_file_store.make_dirs(roms_dir)
+            free_space = self._download_file_store.disk_free(roms_dir)
+            buffer = 100 * 1024 * 1024
+            required = file_size * 2 + buffer if is_multi_file_download(rom_detail) else file_size + buffer
+            # Account for siblings already reserved but not yet written to disk,
+            # so two concurrent downloads can't each pass a pre-flight that only
+            # one of them actually fits (#1053).
+            reserved_total = sum(self._reserved_bytes.values())
+            if file_size and free_space - reserved_total < required:
+                self._download_in_progress.discard(rom_id)
+                free_mb = max(free_space - reserved_total, 0) // (1024 * 1024)
+                need_mb = required // (1024 * 1024)
+                return {
+                    "success": False,
+                    "reason": "insufficient_space",
+                    "message": f"Not enough disk space ({free_mb}MB free, need {need_mb}MB)",
+                }
 
-        target_path = os.path.join(roms_dir, file_name)
+            target_path = os.path.join(roms_dir, file_name)
+        except Exception as e:
+            self._download_in_progress.discard(rom_id)
+            self._logger.error(f"Failed to prepare download for ROM {rom_id}: {e}")
+            return {"success": False, "reason": ErrorCode.UNKNOWN.value, "message": "Failed to start download"}
 
         rom_name = rom_detail.get("name", file_name)
         platform_name = rom_detail.get("platform_name", platform_slug)
 
+        # Create the cancel token BEFORE the task so the closure captured inside
+        # ``_do_download``'s progress callback polls this exact object. A later
+        # re-download installs a fresh token, leaving the zombie's callback bound
+        # to the cancelled one (#144).
+        cancel_token = _CancelToken()
         try:
-            task = self._loop.create_task(self._do_download(rom_id, rom_detail, target_path, system, file_name))
+            task = self._loop.create_task(
+                self._do_download(rom_id, rom_detail, target_path, system, file_name, cancel_token)
+            )
         except Exception as e:
             self._download_in_progress.discard(rom_id)
             self._logger.error(f"Failed to start download task for ROM {rom_id}: {e}")
@@ -251,12 +300,20 @@ class DownloadService:
             "rom_name": rom_name,
             "platform_name": platform_name,
             "file_name": file_name,
-            "status": "downloading",
+            # Honest initial status: the task hasn't acquired the concurrency
+            # semaphore yet. ``_do_download`` flips this to "downloading" once it
+            # enters the critical section (#1053).
+            "status": "queued",
             "progress": 0,
             "bytes_downloaded": 0,
             "total_bytes": file_size,
         }
         self._download_tasks[rom_id] = task
+        # Reserve this download's required bytes so a concurrent sibling's
+        # pre-flight sees the outstanding claim (released in ``_do_download``'s
+        # ``finally``).
+        self._reserved_bytes[rom_id] = required
+        self._cancel_tokens[rom_id] = cancel_token
         return {"success": True, "message": "Download started"}
 
     def _record_install_io(self, *, rom_id, rom_detail, file_path, rom_dir, system, cleanup):
@@ -394,12 +451,19 @@ class DownloadService:
         core_so, _label = self._active_core.active_core_for_rom(int(rom_id))
         return (rom.shortcut_app_id, core_so)
 
-    def _make_progress_callback(self, rom_id, rom_name, platform_name, file_name):
+    def _make_progress_callback(self, rom_id, rom_name, platform_name, file_name, cancel_token=None):
         """Build a throttled progress callback for a download."""
+        if cancel_token is None:
+            cancel_token = _CancelToken()
         last_emit = [0.0]  # mutable container for closure
         last_log = [0.0]
 
         def progress_callback(downloaded, total):
+            if cancel_token.cancelled:
+                # Abort the in-flight transfer thread (#144). CancelledError is a
+                # BaseException, so it propagates untouched through the adapter's
+                # Exception-only retry/translate — no retry, no error translation.
+                raise asyncio.CancelledError()
             now = self._clock.monotonic()
             if now - last_log[0] >= 30.0:
                 last_log[0] = now
@@ -411,98 +475,197 @@ class DownloadService:
                 return
             last_emit[0] = now
             progress = downloaded / total if total else 0
-            self._download_queue[rom_id].update(
-                {
-                    "progress": progress,
-                    "bytes_downloaded": downloaded,
-                    "total_bytes": total,
-                }
-            )
-            self._loop.call_soon_threadsafe(
-                self._loop.create_task,
-                self._emit(
+
+            # This callback runs on a ``run_in_executor`` worker thread. Both the
+            # queue-dict mutation and the emit-scheduling must happen on the loop
+            # thread, guarded by ``.get`` — if the entry was evicted between ticks
+            # we must not resurrect it or raise KeyError off-thread (#973).
+            def _apply_progress() -> None:
+                entry = self._download_queue.get(rom_id)
+                if entry is None:
+                    return  # evicted mid-download — do not resurrect or emit
+                entry.update(
+                    {
+                        "progress": progress,
+                        "bytes_downloaded": downloaded,
+                        "total_bytes": total,
+                    }
+                )
+                self._loop.create_task(
+                    self._emit(
+                        "download_progress",
+                        {
+                            "rom_id": rom_id,
+                            "rom_name": rom_name,
+                            "platform_name": platform_name,
+                            "file_name": file_name,
+                            "status": "downloading",
+                            "progress": progress,
+                            "bytes_downloaded": downloaded,
+                            "total_bytes": total,
+                        },
+                    )
+                )
+
+            self._loop.call_soon_threadsafe(_apply_progress)
+
+        return progress_callback
+
+    async def _finalize_download_complete(self, rom_id, rom_detail, final_path, rom_name, platform_name):
+        """Mark the queue entry completed and emit ``download_complete``.
+
+        Resolves the bound Steam ``shortcut_app_id`` for this rom_id (or ``None``
+        when the ROM hasn't been synced yet) plus the ROM's full active core
+        (resolved ``.so`` or ``None``) so the frontend confirm-sets launch options
+        on the exact shortcut without a full-library scan to re-resolve
+        rom_id→app_id, and the re-bake keeps the per-game/per-platform core across
+        uninstall → reinstall. Called from the normal success path and from the
+        cancel handler when the install committed before the cancel landed (#1049).
+        """
+        self._download_queue[rom_id]["status"] = "completed"
+        self._download_queue[rom_id]["progress"] = 1.0
+        app_id, active_core_so = await self._loop.run_in_executor(None, self._resolve_bound_app_id, rom_id)
+        await self._emit(
+            "download_complete",
+            {
+                "rom_id": rom_id,
+                "rom_name": rom_name,
+                "platform_name": platform_name,
+                "file_path": final_path,
+                "app_id": app_id,
+                "launch_options": build_launch_options(
+                    resolve_emulator_invocation(rom_detail, active_core_so), final_path
+                ),
+            },
+        )
+        self._logger.info(f"Download complete: {rom_name} -> {final_path}")
+
+    async def _reconcile_post_io(self, post_io_future):
+        """After a cancel, wait for an in-flight post-IO commit and report whether
+        the install committed. Executor threads run to completion regardless of
+        cancellation, so awaiting the future here lets a race-committed install be
+        honored instead of torn down. Returns (final_path, committed: bool).
+        """
+        if post_io_future is None:
+            return (None, False)  # cancel landed before the post-IO phase started
+        try:
+            final_path, post_io_error = await post_io_future
+        except asyncio.CancelledError:
+            return (None, False)  # executor work was cancelled before it ran — nothing committed
+        except Exception:
+            return (None, False)  # commit failed its invariant
+        if post_io_error is None and final_path is not None:
+            return (final_path, True)
+        return (None, False)
+
+    async def _do_download(self, rom_id, rom_detail, target_path, system, file_name, cancel_token=None):
+        if cancel_token is None:
+            cancel_token = _CancelToken()
+        rom_name = rom_detail.get("name", file_name)
+        platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
+        has_multiple = is_multi_file_download(rom_detail)
+        progress_callback = self._make_progress_callback(rom_id, rom_name, platform_name, file_name, cancel_token)
+        # Tracks the resolved launch path once extraction returns it, so a
+        # failure AFTER the ES-DE collapse rename cleans up the *renamed* dir
+        # (``os.path.dirname(final_path)``) — not just the staging name.
+        final_path: str | None = None
+        # The post-IO commit future, declared before the try so the cancel
+        # handler can reconcile a race-committed install (#1049). Stays ``None``
+        # while waiting on the concurrency semaphore or during the transfer.
+        post_io_future: asyncio.Future[tuple[str | None, str | None]] | None = None
+
+        try:
+            self._logger.info(f"Download starting: {rom_name} (rom_id={rom_id}, multi={has_multiple}) -> {target_path}")
+
+            # Bounded concurrency (#1053): only two ROMs transfer at once. If the
+            # semaphore is already held, surface an honest "queued" frame so the
+            # UI shows the wait instead of a stalled "downloading" bar.
+            if self._download_semaphore.locked():
+                self._download_queue[rom_id]["status"] = "queued"
+                await self._emit(
                     "download_progress",
                     {
                         "rom_id": rom_id,
                         "rom_name": rom_name,
                         "platform_name": platform_name,
                         "file_name": file_name,
-                        "status": "downloading",
-                        "progress": progress,
-                        "bytes_downloaded": downloaded,
-                        "total_bytes": total,
+                        "status": "queued",
+                        "progress": 0,
+                        "bytes_downloaded": 0,
+                        "total_bytes": rom_detail.get("fs_size_bytes", 0),
                     },
-                ),
-            )
-
-        return progress_callback
-
-    async def _do_download(self, rom_id, rom_detail, target_path, system, file_name):
-        rom_name = rom_detail.get("name", file_name)
-        platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
-        has_multiple = is_multi_file_download(rom_detail)
-        progress_callback = self._make_progress_callback(rom_id, rom_name, platform_name, file_name)
-        # Tracks the resolved launch path once extraction returns it, so a
-        # failure AFTER the ES-DE collapse rename cleans up the *renamed* dir
-        # (``os.path.dirname(final_path)``) — not just the staging name.
-        final_path: str | None = None
-
-        try:
-            self._logger.info(f"Download starting: {rom_name} (rom_id={rom_id}, multi={has_multiple}) -> {target_path}")
-
-            if has_multiple:
-                # Multi-file ROM: API returns ZIP, download to temp then extract
-                tmp_zip = target_path + _ZIP_TMP_EXT
-                await self._loop.run_in_executor(
-                    None, self._romm_api.download_rom_content, rom_id, file_name, tmp_zip, progress_callback
-                )
-                final_path, post_io_error = await self._loop.run_in_executor(
-                    None, self._post_download_multi_io, rom_id, rom_detail, target_path, file_name, system
-                )
-            else:
-                tmp_path = target_path + _TMP_EXT
-                await self._loop.run_in_executor(
-                    None, self._romm_api.download_rom_content, rom_id, file_name, tmp_path, progress_callback
-                )
-                final_path, post_io_error = await self._loop.run_in_executor(
-                    None, self._post_download_single_io, rom_id, rom_detail, target_path, system
                 )
 
-            if post_io_error is not None or final_path is None:
-                # The download succeeded but the install record failed its
-                # invariant; the artifact was already cleaned up by the worker.
-                # ``final_path is None`` always coincides with a non-None error
-                # — the guard narrows the type for the launch-command build below.
-                raise ValueError(post_io_error or "install record produced no launch path")
+            async with self._download_semaphore:
+                self._download_queue[rom_id]["status"] = "downloading"
 
-            self._download_queue[rom_id]["status"] = "completed"
-            self._download_queue[rom_id]["progress"] = 1.0
-            # Resolve the bound Steam ``shortcut_app_id`` for this rom_id (or
-            # ``None`` when the ROM hasn't been synced yet) plus the ROM's full
-            # active core (resolved ``.so`` or ``None``) so the frontend
-            # confirm-sets launch options on the exact shortcut without a
-            # full-library scan to re-resolve rom_id→app_id, and the re-bake keeps
-            # the per-game/per-platform core across uninstall → reinstall.
-            app_id, active_core_so = await self._loop.run_in_executor(None, self._resolve_bound_app_id, rom_id)
-            await self._emit(
-                "download_complete",
-                {
-                    "rom_id": rom_id,
-                    "rom_name": rom_name,
-                    "platform_name": platform_name,
-                    "file_path": final_path,
-                    "app_id": app_id,
-                    "launch_options": build_launch_options(
-                        resolve_emulator_invocation(rom_detail, active_core_so), final_path
-                    ),
-                },
-            )
-            self._logger.info(f"Download complete: {rom_name} -> {final_path}")
+                if has_multiple:
+                    # Multi-file ROM: API returns ZIP, download to temp then extract
+                    tmp_zip = target_path + _ZIP_TMP_EXT
+                    await self._loop.run_in_executor(
+                        None, self._romm_api.download_rom_content, rom_id, file_name, tmp_zip, progress_callback
+                    )
+                    post_io_future = self._loop.run_in_executor(
+                        None, self._post_download_multi_io, rom_id, rom_detail, target_path, file_name, system
+                    )
+                    # Shield the commit await: a cancel here must propagate to this
+                    # coroutine WITHOUT cancelling the underlying future, so
+                    # ``_reconcile_post_io`` can re-await it for the real result. A
+                    # bare ``await`` cancels the asyncio future (the executor thread
+                    # still commits), so the re-await would raise CancelledError and
+                    # the committed install would be mis-reported as not committed
+                    # → torn down (#1049).
+                    final_path, post_io_error = await asyncio.shield(post_io_future)
+                else:
+                    tmp_path = target_path + _TMP_EXT
+                    await self._loop.run_in_executor(
+                        None, self._romm_api.download_rom_content, rom_id, file_name, tmp_path, progress_callback
+                    )
+                    post_io_future = self._loop.run_in_executor(
+                        None, self._post_download_single_io, rom_id, rom_detail, target_path, system
+                    )
+                    # Shielded so a racing cancel leaves the future intact for
+                    # ``_reconcile_post_io`` to re-await (see the multi-file branch).
+                    final_path, post_io_error = await asyncio.shield(post_io_future)
+
+                if post_io_error is not None or final_path is None:
+                    # The download succeeded but the install record failed its
+                    # invariant; the artifact was already cleaned up by the worker.
+                    # ``final_path is None`` always coincides with a non-None error
+                    # — the guard narrows the type for the launch-command build below.
+                    raise ValueError(post_io_error or "install record produced no launch path")
+
+                await self._finalize_download_complete(rom_id, rom_detail, final_path, rom_name, platform_name)
 
         except asyncio.CancelledError:
-            self._download_queue[rom_id]["status"] = "cancelled"
-            self._cleanup_partial_download(target_path, has_multiple, file_name, final_path)
-            self._logger.info(f"Download cancelled: {rom_name}")
+            # The cancel may have raced a committing install. Executor threads run
+            # to completion, so wait for the post-IO future before deciding (#1049).
+            committed_path, committed = await self._reconcile_post_io(post_io_future)
+            if committed:
+                # The ROM IS installed — surface completed, don't tear it down.
+                # This also bakes launch_options for the just-committed install.
+                await self._finalize_download_complete(rom_id, rom_detail, committed_path, rom_name, platform_name)
+                self._logger.info(f"Download cancelled after install committed; surfaced as complete: {rom_name}")
+            else:
+                entry = self._download_queue[rom_id]
+                entry["status"] = "cancelled"
+                self._cleanup_partial_download(target_path, has_multiple, file_name, final_path)
+                # #1017: emit a terminal frame so the frontend resets the button
+                # out of its downloading state (the global cancel path was silent).
+                await self._emit(
+                    "download_progress",
+                    {
+                        "rom_id": rom_id,
+                        "rom_name": rom_name,
+                        "platform_name": platform_name,
+                        "file_name": file_name,
+                        "status": "cancelled",
+                        "progress": entry.get("progress", 0),
+                        "bytes_downloaded": entry.get("bytes_downloaded", 0),
+                        "total_bytes": entry.get("total_bytes", 0),
+                    },
+                )
+                self._logger.info(f"Download cancelled: {rom_name}")
             raise
 
         except Exception as e:
@@ -523,6 +686,12 @@ class DownloadService:
         finally:
             self._download_tasks.pop(rom_id, None)
             self._download_in_progress.discard(rom_id)
+            self._reserved_bytes.pop(rom_id, None)
+            # A re-download overwrites the dict entry with a fresh token; only
+            # delete OUR registration so a zombie's finally never evicts the
+            # newer download's token (#144).
+            if self._cancel_tokens.get(rom_id) is cancel_token:
+                del self._cancel_tokens[rom_id]
             self._prune_download_queue()
 
     def _maybe_generate_m3u_io(self, extract_dir: str, rom_detail: dict[str, Any]) -> None:
@@ -562,6 +731,19 @@ class DownloadService:
     def _cleanup_partial_download(self, target_path, has_multiple, file_name, final_path=None):
         """Clean up partial download files. Each step is independent so one failure doesn't block others.
 
+        Only ever called for a download that did NOT commit an install (the
+        failure path and the cancel-without-commit path); a cancel that loses the
+        race to a committed install routes to ``_finalize_download_complete``
+        instead and never reaches here.
+
+        Removes ONLY the transient transfer artifacts (``.zip.tmp`` / ``.tmp``)
+        and, for a multi-file ROM, the extract dir(s) this download created. The
+        bare ``target_path`` is NEVER removed: a single-file transfer writes to
+        ``target_path + .tmp`` and only renames to ``target_path`` on success, so
+        deleting the bare path would destroy a PRE-EXISTING install (a re-download
+        that fails mid-stream) or a just-committed one (a cancel race) — the #1049
+        data-loss bug.
+
         For a multi-file ROM the extract dir may have been renamed for ES-DE
         collapse after extraction. *final_path* (the resolved launch file,
         ``None`` until extraction returns it) lets cleanup tear down whichever
@@ -571,7 +753,6 @@ class DownloadService:
         paths_to_remove = [
             target_path + _ZIP_TMP_EXT,
             target_path + _TMP_EXT,
-            target_path,
         ]
         for path in paths_to_remove:
             try:
@@ -594,6 +775,9 @@ class DownloadService:
         task = self._download_tasks.get(rom_id)
         if not task:
             return {"success": False, "reason": "no_active_download", "message": "No active download for this ROM"}
+        token = self._cancel_tokens.get(rom_id)
+        if token is not None:
+            token.cancelled = True  # stop the executor transfer thread, not just the asyncio wrapper (#144)
         task.cancel()
         return {"success": True, "message": "Download cancelled"}
 

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -541,19 +541,22 @@ class DownloadService:
         self._logger.info(f"Download complete: {rom_name} -> {final_path}")
 
     async def _reconcile_post_io(self, post_io_future):
-        """After a cancel, wait for an in-flight post-IO commit and report whether
+        """After a cancel, settle an in-flight post-IO commit and report whether
         the install committed. Executor threads run to completion regardless of
-        cancellation, so awaiting the future here lets a race-committed install be
-        honored instead of torn down. Returns (final_path, committed: bool).
+        cancellation, so letting the future settle here lets a race-committed
+        install be honored instead of torn down. Returns (final_path, committed).
         """
         if post_io_future is None:
             return (None, False)  # cancel landed before the post-IO phase started
-        try:
-            final_path, post_io_error = await post_io_future
-        except asyncio.CancelledError:
-            return (None, False)  # executor work was cancelled before it ran — nothing committed
-        except Exception:
-            return (None, False)  # commit failed its invariant
+        # Let the (shielded) executor future settle WITHOUT awaiting it directly:
+        # ``asyncio.wait`` reports completion through the future's own state, so a
+        # cancelled or failed commit is inspected here, never swallowed — the
+        # caller's ``except asyncio.CancelledError`` keeps ownership of the re-raise.
+        await asyncio.wait({post_io_future})
+        if post_io_future.cancelled() or post_io_future.exception() is not None:
+            # Executor work was cancelled before it ran, or the commit raised.
+            return (None, False)
+        final_path, post_io_error = post_io_future.result()
         if post_io_error is None and final_path is not None:
             return (final_path, True)
         return (None, False)

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -21,7 +21,7 @@ import { CustomPlayButton } from "./CustomPlayButton";
 import { emitDeckyEvent, deckyEventListenerCount } from "../test-utils/decky-api-mock";
 import * as backend from "../api/backend";
 import type { CachedGameDetail } from "../api/backend";
-import type { DownloadFailedEvent } from "../types";
+import type { DownloadFailedEvent, DownloadProgressEvent } from "../types";
 
 // Stub the cached-detail store: synchronous Promise.resolve so the initial
 // useEffect settles within a single waitFor tick. The default test-setup
@@ -119,6 +119,152 @@ describe("CustomPlayButton — download_failed listener", () => {
 
     unmount();
     expect(deckyEventListenerCount("download_failed")).toBe(0);
+  });
+});
+
+describe("CustomPlayButton — download_progress cancelled listener (#1017)", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+  });
+
+  it("transitions out of its downloading state when a matching cancelled frame arrives", async () => {
+    // The cancel terminal frame the backend now emits (#1017) — the button's
+    // download_progress listener resets to "download" on status "cancelled",
+    // exactly as it does for "failed".
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    act(() => {
+      const event: DownloadProgressEvent = {
+        rom_id: 42,
+        rom_name: "Test ROM",
+        platform_name: "PSX",
+        file_name: "test.chd",
+        status: "cancelled",
+        progress: 0.3,
+        bytes_downloaded: 300,
+        total_bytes: 1000,
+      };
+      emitDeckyEvent<[DownloadProgressEvent]>("download_progress", event);
+    });
+
+    // Post-state: the Download label is shown and Play is gone — the visible
+    // side-effect of setState("download") on the cancelled frame.
+    await findByText("Download");
+    expect(queryByText("Play")).toBeNull();
+  });
+
+  it("ignores a cancelled frame for a different rom_id", async () => {
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    act(() => {
+      emitDeckyEvent<[DownloadProgressEvent]>("download_progress", {
+        rom_id: 999, // mismatched — listener no-ops
+        rom_name: "Other",
+        platform_name: "PSX",
+        file_name: "other.chd",
+        status: "cancelled",
+        progress: 0,
+        bytes_downloaded: 0,
+        total_bytes: 0,
+      });
+    });
+
+    // Button stays in "play" — the cancelled frame for another ROM is ignored.
+    expect(await findByText("Play")).toBeInTheDocument();
+    expect(queryByText("Download")).toBeNull();
+  });
+});
+
+describe("CustomPlayButton — cancel X on active download (#1049)", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+    // startDownload resolves success so handleDownload leaves actionPending
+    // true (it only resets actionPending on !success). A subsequent
+    // download_progress "downloading" frame then sets dlProgress, making
+    // `downloading` truthy and rendering the cancel X.
+    vi.mocked(backend.startDownload).mockResolvedValue({ success: true, message: "" });
+    vi.mocked(backend.cancelDownload).mockResolvedValue({ success: true, message: "" });
+  });
+
+  // Drive the button into its active-download render: cache says not installed
+  // (→ "download" state), click Download (→ actionPending), then a matching
+  // "downloading" progress frame sets dlProgress (→ downloading truthy).
+  async function renderDownloading(romId = 42) {
+    mockCachedDetail({ rom_id: romId, installed: false });
+    const utils = render(<CustomPlayButton appId={100} />);
+    const downloadBtn = await utils.findByText("Download");
+
+    await act(async () => {
+      downloadBtn.click();
+      // Drain handleDownload (startDownload resolve → actionPending stays true).
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      const event: DownloadProgressEvent = {
+        rom_id: romId,
+        rom_name: "Test ROM",
+        platform_name: "PSX",
+        file_name: "test.chd",
+        status: "downloading",
+        progress: 0.3,
+        bytes_downloaded: 300,
+        total_bytes: 1000,
+      };
+      emitDeckyEvent<[DownloadProgressEvent]>("download_progress", event);
+    });
+
+    return utils;
+  }
+
+  it("renders the cancel X while a download is actively running", async () => {
+    const { findByLabelText } = await renderDownloading(42);
+    // The icon-only cancel button is identified by its aria-label/title.
+    expect(await findByLabelText("Cancel download")).toBeInTheDocument();
+  });
+
+  it("does NOT render the cancel X in the idle Download state", async () => {
+    mockCachedDetail({ rom_id: 42, installed: false });
+    const { findByText, queryByLabelText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Download");
+    // No download in flight → no cancel control.
+    expect(queryByLabelText("Cancel download")).toBeNull();
+  });
+
+  it("clicking the cancel X calls cancelDownload with the rom_id", async () => {
+    const { findByLabelText } = await renderDownloading(42);
+    const cancelX = await findByLabelText("Cancel download");
+
+    await act(async () => {
+      cancelX.click();
+      // Let the detached cancelDownload().catch chain settle.
+      await Promise.resolve();
+    });
+
+    // Non-vacuous: assert the exact rom_id was passed.
+    expect(backend.cancelDownload).toHaveBeenCalledWith(42);
+  });
+
+  it("swallows a cancelDownload rejection without crashing the button", async () => {
+    vi.mocked(backend.cancelDownload).mockRejectedValue(new Error("nope"));
+    const { findByLabelText } = await renderDownloading(42);
+    const cancelX = await findByLabelText("Cancel download");
+
+    await act(async () => {
+      cancelX.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Post-catch state: the X is still rendered (button did not crash); the
+    // backend cancellation frame, not this catch, is what tears the row down.
+    expect(backend.cancelDownload).toHaveBeenCalledWith(42);
+    expect(await findByLabelText("Cancel download")).toBeInTheDocument();
   });
 });
 

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -18,6 +18,7 @@ import { hasAnySaveConflict } from "../utils/saveStatus";
 import {
   getCachedGameDetail,
   startDownload,
+  cancelDownload,
   removeRom,
   debugLog,
   preLaunchSync,
@@ -496,6 +497,14 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     }
   };
 
+  // Cancel an in-flight download. Fire-and-forget: the backend emits a
+  // cancelled download_progress frame that the progress listener reacts to
+  // (resets to "download"). The inline .catch keeps the click non-throwing.
+  const handleCancelDownload = () => {
+    if (romId == null) return;
+    detach(cancelDownload(romId).catch(() => {}));
+  };
+
   const handleUninstall = async () => {
     if (!romId) return;
     detach(debugLog(`CustomPlayButton: uninstalling romId=${romId}`));
@@ -540,7 +549,8 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   }
   detach(debugLog(`CustomPlayButton: rendering state=${state}`));
 
-  // Dropdown arrow button style
+  // Dropdown arrow button style. Shared shape for the play-state chevron and
+  // the download-state cancel X — both are 36px side actions on the right.
   const dropdownArrowStyle: React.CSSProperties = {
     height: "48px",
     width: "36px",
@@ -631,37 +641,79 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       baseBg = "linear-gradient(to right, #1a9fff, #0078d4)";
     }
 
+    // While a download is actively running, the main button shares the row
+    // with a right-side action section (the cancel X). Square off its right
+    // edge so it butts cleanly against that section; idle/starting keeps the
+    // full pill radius.
+    const downloadBtn = (
+      <DialogButton
+        className={[appActionButtonClasses?.PlayButton, "romm-btn-download", downloading && "romm-dl-active"]
+          .filter(Boolean)
+          .join(" ")}
+        style={
+          {
+            ...mainBtnStyle,
+            borderRadius: downloading ? "2px 0 0 2px" : "2px",
+            background: baseBg,
+            "--romm-pulse-color": pulseColor,
+          } as React.CSSProperties
+        }
+        onClick={() => {
+          detach(handleDownload());
+        }}
+        disabled={actionPending || isOffline}
+      >
+        {/* Progress fill bar */}
+        {downloading && (
+          <div
+            className="romm-dl-fill"
+            style={{
+              width: `${t * 100}%`,
+              background: fillColor,
+            }}
+          />
+        )}
+        <span className="romm-dl-label">{dlLabel}</span>
+      </DialogButton>
+    );
+
+    if (!downloading) {
+      // Idle ("Download") or "Starting..." — single full-width button, no X.
+      return (
+        <Focusable ref={containerRef} className={appActionButtonClasses?.PlayButtonContainer} style={btnContainerStyle}>
+          {downloadBtn}
+        </Focusable>
+      );
+    }
+
+    // Active download: button + a right-side action section. The section is a
+    // flex sub-container so a second action (Pause, follow-up #1049) can join
+    // next to the X later without restructuring the row.
     return (
       <Focusable ref={containerRef} className={appActionButtonClasses?.PlayButtonContainer} style={btnContainerStyle}>
-        <DialogButton
-          className={[appActionButtonClasses?.PlayButton, "romm-btn-download", downloading && "romm-dl-active"]
-            .filter(Boolean)
-            .join(" ")}
-          style={
-            {
-              ...mainBtnStyle,
-              borderRadius: "2px",
-              background: baseBg,
-              "--romm-pulse-color": pulseColor,
-            } as React.CSSProperties
-          }
-          onClick={() => {
-            detach(handleDownload());
-          }}
-          disabled={actionPending || isOffline}
-        >
-          {/* Progress fill bar */}
-          {downloading && (
-            <div
-              className="romm-dl-fill"
-              style={{
-                width: `${t * 100}%`,
-                background: fillColor,
-              }}
-            />
-          )}
-          <span className="romm-dl-label">{dlLabel}</span>
-        </DialogButton>
+        {downloadBtn}
+        <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>
+          <DialogButton
+            className="romm-btn-cancel"
+            aria-label="Cancel download"
+            title="Cancel download"
+            style={{
+              ...dropdownArrowStyle,
+              background: "linear-gradient(to right, #0a3a5a, #062a45)",
+              color: "#fff",
+            }}
+            onClick={handleCancelDownload}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M1 1L11 11M11 1L1 11"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </DialogButton>
+        </div>
       </Focusable>
     );
   }

--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -26,8 +26,11 @@ import * as backend from "../api/backend";
 import { setDownloads, getDownloadState } from "../utils/downloadStore";
 import type { DownloadItem } from "../types";
 
-// Local @decky/ui mock adds ProgressBarWithInfo (not in the global stub) and
-// exposes per-prop testids so we can assert progress bar wiring directly.
+// Local @decky/ui mock adds ProgressBar (not in the global stub) and exposes
+// per-prop testids so we can assert progress bar wiring directly. The active
+// download caption now lives in a sibling div (the #751 full-width fix), so the
+// rom name / bytes are read from the component's own dl-caption / dl-bytes
+// testids rather than from the bar's props.
 vi.mock("@decky/ui", async () => {
   type AnyProps = Record<string, unknown> & { children?: unknown };
   const { createElement: ce } = await import("react");
@@ -44,19 +47,15 @@ vi.mock("@decky/ui", async () => {
         ce("span", { "data-testid": "field-label" }, p.label as never),
         ce("span", { "data-testid": "field-desc" }, p.description as never),
       ),
-    ProgressBarWithInfo: (
+    ProgressBar: (
       p: AnyProps & {
         nProgress?: number;
         indeterminate?: boolean;
-        sOperationText?: string;
-        sTimeRemaining?: string;
       },
     ) =>
       ce(
         "div",
         { "data-testid": "progress" },
-        ce("span", { "data-testid": "progress-op" }, p.sOperationText as never),
-        ce("span", { "data-testid": "progress-remaining" }, p.sTimeRemaining as never),
         ce("span", { "data-testid": "progress-progress" }, String(p.nProgress)),
         ce("span", { "data-testid": "progress-indeterminate" }, String(p.indeterminate)),
       ),
@@ -128,9 +127,9 @@ describe("DownloadQueue", () => {
 
       // Store was seeded — verifies setDownloads(result.downloads) ran.
       expect(getDownloadState()).toEqual([item]);
-      // Local state rendered — progress bar present for the active item.
-      const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toBe("Item7 (Genesis)");
+      // Local state rendered — caption present for the active item.
+      const caption = container.querySelector('[data-testid="dl-caption"]');
+      expect(caption?.textContent).toBe("Item7 (Genesis)");
     });
 
     it("rejection falls back to current getDownloadState() store contents", async () => {
@@ -143,8 +142,8 @@ describe("DownloadQueue", () => {
       const { container } = render(<DownloadQueue onBack={() => {}} />);
       await flushMount();
 
-      const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toBe("Fallback (Genesis)");
+      const caption = container.querySelector('[data-testid="dl-caption"]');
+      expect(caption?.textContent).toBe("Fallback (Genesis)");
       // Store unchanged by the catch branch.
       expect(getDownloadState()).toEqual([fallback]);
     });
@@ -168,8 +167,8 @@ describe("DownloadQueue", () => {
         await vi.advanceTimersByTimeAsync(500);
       });
 
-      const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toBe("Ticked (Genesis)");
+      const caption = container.querySelector('[data-testid="dl-caption"]');
+      expect(caption?.textContent).toBe("Ticked (Genesis)");
     });
 
     it("interval is cleared on unmount — clearInterval is invoked with the pollRef id", async () => {
@@ -246,9 +245,9 @@ describe("DownloadQueue", () => {
       });
 
       // unclearRestarted removed rom_id 42 from `cleared`, so the active
-      // progress bar is rendered again.
-      const op = container.querySelector('[data-testid="progress-op"]');
-      expect(op?.textContent).toBe("Restart (Genesis)");
+      // download caption is rendered again.
+      const caption = container.querySelector('[data-testid="dl-caption"]');
+      expect(caption?.textContent).toBe("Restart (Genesis)");
     });
 
     it("a cleared rom_id whose download restarts as 'queued' also becomes visible", async () => {
@@ -274,7 +273,7 @@ describe("DownloadQueue", () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(500);
       });
-      expect(container.querySelector('[data-testid="progress-op"]')?.textContent).toBe("Queued (Genesis)");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Queued (Genesis)");
     });
 
     it("if no cleared rom_id matches, cleared Set stays the same instance (no needless re-set)", async () => {
@@ -340,7 +339,7 @@ describe("DownloadQueue", () => {
         await Promise.resolve();
       });
       // Component still rendered normally — the catch swallowed cleanly.
-      expect(container.querySelector('[data-testid="progress-op"]')?.textContent).toBe("Cancellable (Genesis)");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Cancellable (Genesis)");
     });
   });
 
@@ -391,7 +390,7 @@ describe("DownloadQueue", () => {
       expect(labelsAfter).not.toContain("Done");
       expect(labelsAfter).not.toContain("Broke");
       expect(labelsAfter).not.toContain("Stopped");
-      expect(container.querySelector('[data-testid="progress-op"]')?.textContent).toBe("Active (Genesis)");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Active (Genesis)");
       // Clear Completed button is gone (no finished items remain).
       expect(buttonByExactText(container, "Clear Completed")).toBeNull();
     });
@@ -425,8 +424,8 @@ describe("DownloadQueue", () => {
       // 512 / 2048 * 100 = 25
       expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("25");
       expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("false");
-      expect(container.querySelector('[data-testid="progress-remaining"]')?.textContent).toBe("512 B / 2.0 KB");
-      expect(container.querySelector('[data-testid="progress-op"]')?.textContent).toBe("Det (Genesis)");
+      expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("512 B / 2.0 KB");
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Det (Genesis)");
     });
 
     it("active item with total_bytes === 0: nProgress=undefined, indeterminate=true, sTimeRemaining = formatBytes(bytes_downloaded)", async () => {
@@ -445,7 +444,7 @@ describe("DownloadQueue", () => {
       // String(undefined) → "undefined".
       expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("undefined");
       expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("true");
-      expect(container.querySelector('[data-testid="progress-remaining"]')?.textContent).toBe("700 B");
+      expect(container.querySelector('[data-testid="dl-bytes"]')?.textContent).toBe("700 B");
     });
 
     it("finished list: completed → 'Completed — <bytes>'", async () => {

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, Field, ProgressBarWithInfo } from "@decky/ui";
+import { PanelSection, PanelSectionRow, ButtonItem, Field, ProgressBar } from "@decky/ui";
 import { getDownloadQueue, cancelDownload } from "../api/backend";
 import { getDownloadState, setDownloads } from "../utils/downloadStore";
 import { formatBytes } from "../utils/formatters";
@@ -121,16 +121,38 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
           <>
             {active.map((item) => (
               <PanelSectionRow key={item.rom_id}>
-                <ProgressBarWithInfo
-                  {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
-                  indeterminate={item.total_bytes === 0}
-                  sOperationText={`${item.rom_name} (${item.platform_name})`}
-                  sTimeRemaining={
-                    item.total_bytes > 0
-                      ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
-                      : formatBytes(item.bytes_downloaded)
-                  }
-                />
+                {/* Own the caption in a full-width row and use the bare ProgressBar.
+                    ProgressBarWithInfo is a Steam Field (label column | bar column);
+                    with the rom name in sOperationText the empty bar column gets
+                    squeezed into the right half and clips (#751). The bare
+                    ProgressBar is just the bar and spans the full panel width
+                    (mirrors the sync-progress fix in MainPage). */}
+                <div style={{ width: "100%" }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      fontSize: "12px",
+                      marginBottom: "4px",
+                    }}
+                  >
+                    <span
+                      data-testid="dl-caption"
+                      style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                    >
+                      {item.rom_name} ({item.platform_name})
+                    </span>
+                    <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
+                      {item.total_bytes > 0
+                        ? `${formatBytes(item.bytes_downloaded)} / ${formatBytes(item.total_bytes)}`
+                        : formatBytes(item.bytes_downloaded)}
+                    </span>
+                  </div>
+                  <ProgressBar
+                    indeterminate={item.total_bytes === 0}
+                    {...(item.total_bytes > 0 ? { nProgress: (item.bytes_downloaded / item.total_bytes) * 100 } : {})}
+                  />
+                </div>
               </PanelSectionRow>
             ))}
             {active.map((item) => (

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -64,8 +64,27 @@ vi.mock("@decky/ui", () => {
   return {
     ConfirmModal: passthrough("div"),
     ModalRoot: passthrough("div"),
-    DialogButton: ({ children, onClick, disabled }: AnyProps & { disabled?: boolean }) =>
-      createElement("button", { onClick, disabled }, children as never),
+    DialogButton: ({
+      children,
+      onClick,
+      disabled,
+      className,
+      ...rest
+    }: AnyProps & { disabled?: boolean; className?: string }) =>
+      // Forward className + the a11y/identity attrs (aria-label, title, …) so
+      // icon-only buttons (no text child) stay queryable in tests. style and
+      // the FooterLegend-only props are dropped — no DOM effect under happy-dom.
+      createElement(
+        "button",
+        {
+          onClick,
+          disabled,
+          className,
+          "aria-label": rest["aria-label"],
+          title: rest.title,
+        },
+        children as never,
+      ),
     DialogButtonPrimary: ({ children, onClick }: AnyProps) => createElement("button", { onClick }, children as never),
     ButtonItem: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
       createElement("button", { onClick, disabled }, children as never),

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -51,6 +51,9 @@ export function hideNativePlaySection(playSectionClass: string) {
 .romm-btn-dropdown:hover, .romm-btn-dropdown.gpfocus {
   filter: brightness(1.3);
 }
+.romm-btn-cancel:hover, .romm-btn-cancel.gpfocus {
+  filter: brightness(1.4);
+}
 [data-romm] .gpfocus {
   outline: 2px solid #1a9fff;
   outline-offset: 2px;

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import sqlite3
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,8 +21,9 @@ from adapters.rom_files import RomFileAdapter
 from adapters.steam_config import SteamConfigAdapter
 from domain.rom import Rom
 from domain.rom_install import RomInstall
+from lib.list_result import ErrorCode
 from services.active_core_resolver import ActiveCoreResolver, ActiveCoreResolverConfig
-from services.downloads import DownloadService, DownloadServiceConfig
+from services.downloads import DownloadService, DownloadServiceConfig, _CancelToken
 from services.library import LibraryService, LibraryServiceConfig
 from services.rom_removal import RomRemovalService, RomRemovalServiceConfig
 
@@ -196,8 +198,13 @@ class TestStartDownload:
 
         assert result["success"] is True
         assert 42 in plugin._download_service._download_queue
-        assert plugin._download_service._download_queue[42]["status"] == "downloading"
+        # The initial status is "queued" (#1053) — the task flips it to
+        # "downloading" only once it acquires the concurrency semaphore.
+        assert plugin._download_service._download_queue[42]["status"] == "queued"
         assert len(_create_task_calls) == 1
+        # The download's required bytes are reserved so a sibling's pre-flight
+        # accounts for the outstanding claim.
+        assert 42 in plugin._download_service._reserved_bytes
 
     @pytest.mark.asyncio
     async def test_rejects_already_downloading(self, plugin):
@@ -2531,7 +2538,8 @@ class TestStartDownloadReDownload:
         result = await plugin.start_download(42)
 
         assert result["success"] is True
-        assert plugin._download_service._download_queue[42]["status"] == "downloading"
+        # Re-download re-enters the queue as "queued" (#1053).
+        assert plugin._download_service._download_queue[42]["status"] == "queued"
 
 
 class TestMaybeGenerateM3uMixedFormats:
@@ -3148,8 +3156,28 @@ class TestMakeProgressCallback:
         }
         fake_clock = FakeClock()
         plugin._download_service._clock = fake_clock
+        # The queue mutation now happens inside the function marshaled onto the
+        # loop thread via call_soon_threadsafe (#973), so run it eagerly to
+        # observe the in-place update; create_task just consumes the coroutine.
         plugin._download_service._loop = MagicMock()
-        plugin._download_service._emit = MagicMock(return_value=None)
+        plugin._download_service._loop.call_soon_threadsafe = lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        plugin._download_service._loop.create_task = lambda coro: coro.close() or MagicMock()
+        call_soon_count = [0]
+        _orig_css = plugin._download_service._loop.call_soon_threadsafe
+
+        def _counting_css(fn, *args, **kwargs):
+            call_soon_count[0] += 1
+            return _orig_css(fn, *args, **kwargs)
+
+        plugin._download_service._loop.call_soon_threadsafe = _counting_css
+
+        def _record_emit(_event, _payload):
+            async def _noop():
+                return None
+
+            return _noop()
+
+        plugin._download_service._emit = _record_emit
 
         cb = plugin._download_service._make_progress_callback(8, "Game", "Plat", "game.bin")
 
@@ -3158,14 +3186,14 @@ class TestMakeProgressCallback:
         # 0.5 AND downloaded < total) returns early. No update.
         cb(100, 1000)
         assert plugin._download_service._download_queue[8]["bytes_downloaded"] == 0
-        assert plugin._download_service._loop.call_soon_threadsafe.call_count == 0
+        assert call_soon_count[0] == 0
 
         # Final call: downloaded == total bypasses the throttle even
         # when no time elapsed — the closure always emits the final
         # completion frame.
         cb(1000, 1000)
         assert plugin._download_service._download_queue[8]["bytes_downloaded"] == 1000
-        assert plugin._download_service._loop.call_soon_threadsafe.call_count == 1
+        assert call_soon_count[0] == 1
 
     def test_progress_callback_handles_zero_total(self, plugin):
         """total == 0 must not divide-by-zero — pct/progress fall back to 0."""
@@ -3211,22 +3239,25 @@ class TestCleanupPartialDownloadFailureInjection:
 
         fake = FakeDownloadFileStore()
         target = "/roms/n64/game.z64"
-        # Stage all three candidate paths so each remove call has
-        # something to act on; mark the .tmp variant as failing.
+        # Stage the two transient candidates plus a pre-existing install at the
+        # bare target. Cleanup must remove only the transients (the .tmp variant
+        # is marked failing) and NEVER the bare target (#1049 data-loss guard).
         fake.files[target + _ZIP_TMP_EXT_LITERAL] = b"junk1"
         fake.files[target + _TMP_EXT_LITERAL] = b"junk2"
-        fake.files[target] = b"junk3"
+        fake.files[target] = b"preexisting install"
         fake.remove_failures.add(target + _TMP_EXT_LITERAL)
         plugin._download_service._download_file_store = fake
 
         with caplog.at_level(logging.WARNING, logger="test_romm"):
             plugin._download_service._cleanup_partial_download(target, False, "game.z64")
 
-        # The failing path is still in the fake (remove raised); the
-        # other two were successfully removed.
+        # The failing transient is still in the fake (remove raised); the
+        # other transient was successfully removed.
         assert (target + _TMP_EXT_LITERAL) in fake.files
         assert (target + _ZIP_TMP_EXT_LITERAL) not in fake.files
-        assert target not in fake.files
+        # The bare target is NEVER touched — a re-download that fails mid-stream
+        # must not destroy a pre-existing (or just-committed) install.
+        assert target in fake.files
         # Warning mentions the failing path.
         assert any(
             "Cleanup failed for" in rec.message and (target + _TMP_EXT_LITERAL) in rec.message for rec in caplog.records
@@ -3257,6 +3288,821 @@ class TestCleanupPartialDownloadFailureInjection:
         assert any(
             "Cleanup failed for directory" in rec.message and extract_dir in rec.message for rec in caplog.records
         )
+
+
+class TestStartDownloadInProgressLeak:
+    """#1048: an early exception in start_download must release the in-progress flag.
+
+    Before the fix, a raise between ``_download_in_progress.add`` and the
+    create_task block left the ROM stuck "Already downloading" until a plugin
+    reload (SD card unmounted → OSError in make_dirs / disk_free; roms_path()
+    returning None → TypeError in the path join).
+    """
+
+    def _wire(self, plugin, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_make_dirs_oserror_releases_flag(self, plugin, tmp_path):
+        from unittest.mock import AsyncMock
+
+        self._wire(plugin, tmp_path)
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "fs_size_bytes": 1024,
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+        }
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
+
+        def _boom(_path):
+            raise OSError("SD card unmounted")
+
+        plugin._download_service._download_file_store.make_dirs = _boom
+
+        result = await plugin.start_download(42)
+
+        # Canonical failure shape.
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.UNKNOWN.value
+        assert "Failed to start download" in result["message"]
+        # The flag is released — the ROM is not stuck "Already downloading".
+        assert 42 not in plugin._download_service._download_in_progress
+        # A second attempt is not rejected as already-downloading; it fails the
+        # same way (make_dirs still boom) — proving the flag was discarded.
+        result2 = await plugin.start_download(42)
+        assert result2["success"] is False
+        assert "Already downloading" not in result2["message"]
+
+    @pytest.mark.asyncio
+    async def test_disk_free_oserror_releases_flag(self, plugin, tmp_path):
+        from unittest.mock import AsyncMock
+
+        self._wire(plugin, tmp_path)
+        rom_detail = {
+            "id": 43,
+            "name": "Mario",
+            "fs_name": "mario.z64",
+            "fs_size_bytes": 1024,
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+        }
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
+
+        def _boom(_path):
+            raise OSError("statvfs failed: SD card gone")
+
+        plugin._download_service._download_file_store.disk_free = _boom
+
+        result = await plugin.start_download(43)
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.UNKNOWN.value
+        assert 43 not in plugin._download_service._download_in_progress
+
+    @pytest.mark.asyncio
+    async def test_roms_path_none_releases_flag(self, plugin, tmp_path):
+        from unittest.mock import AsyncMock
+
+        # roms_path() returns None → the os.path.realpath inside safe_join raises
+        # a TypeError that must be caught and the flag released.
+        paths = FakeRetroDeckPaths(roms="", bios="")
+        paths.roms_path = lambda: None  # type: ignore[method-assign,return-value]
+        plugin._download_service._retrodeck_paths = paths
+        rom_detail = {
+            "id": 44,
+            "name": "DK",
+            "fs_name": "dk.z64",
+            "fs_size_bytes": 1024,
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+        }
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
+
+        result = await plugin.start_download(44)
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.UNKNOWN.value
+        assert "Failed to start download" in result["message"]
+        assert 44 not in plugin._download_service._download_in_progress
+
+
+class TestProgressCallbackEvictionSafe:
+    """#973: the progress callback must not KeyError if the entry was evicted.
+
+    The dict mutation now runs on the loop thread via call_soon_threadsafe and
+    is guarded by ``.get`` — an evicted rom_id is a no-op (the entry is neither
+    resurrected nor mutated, and no emit is scheduled), never a KeyError off the
+    executor thread.
+    """
+
+    def _eager_loop(self, plugin):
+        """Make call_soon_threadsafe run its target synchronously so the marshaled
+        ``_apply_progress`` executes in-test; create_task consumes the coroutine.
+        Returns the recorded emit calls list.
+        """
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.call_soon_threadsafe = lambda fn, *a, **k: fn(*a, **k)
+        plugin._download_service._loop.create_task = lambda coro: coro.close() or MagicMock()
+        emit_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _record_emit(event, payload):
+            emit_calls.append((event, payload))
+
+            async def _noop():
+                return None
+
+            return _noop()
+
+        plugin._download_service._emit = _record_emit
+        return emit_calls
+
+    def test_evicted_entry_progress_tick_is_noop(self, plugin):
+        emit_calls = self._eager_loop(plugin)
+        fake_clock = FakeClock()
+        fake_clock.advance(60)  # clear both throttles
+        plugin._download_service._clock = fake_clock
+
+        # No queue entry for rom_id 99 — the callback's _apply_progress hits the
+        # ``.get`` guard. Before the #973 fix this was ``self._download_queue[99]
+        # .update(...)`` on the worker thread → KeyError.
+        cb = plugin._download_service._make_progress_callback(99, "Ghost", "N64", "ghost.z64")
+        cb(256, 512)  # must NOT raise
+
+        # The entry is not resurrected and no emit was scheduled for it.
+        assert 99 not in plugin._download_service._download_queue
+        assert emit_calls == []
+
+    def test_present_entry_still_updates(self, plugin):
+        """Control: a present entry is still updated + an emit scheduled (the guard
+        only suppresses the evicted case)."""
+        emit_calls = self._eager_loop(plugin)
+        fake_clock = FakeClock()
+        fake_clock.advance(60)
+        plugin._download_service._clock = fake_clock
+        plugin._download_service._download_queue[7] = {
+            "rom_id": 7,
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+        }
+
+        cb = plugin._download_service._make_progress_callback(7, "Mario", "N64", "mario.z64")
+        cb(512, 1024)
+
+        entry = plugin._download_service._download_queue[7]
+        assert entry["bytes_downloaded"] == 512
+        assert entry["total_bytes"] == 1024
+        assert len(emit_calls) == 1
+        assert emit_calls[0][0] == "download_progress"
+        assert emit_calls[0][1]["rom_id"] == 7
+
+
+class TestDoDownloadRedownloadPreservesExisting:
+    """#1049 scenario 2: a re-download that fails mid-transfer must NOT delete the existing install."""
+
+    @pytest.mark.asyncio
+    async def test_failed_redownload_keeps_preexisting_file(self, plugin, tmp_path):
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+        # A pre-existing, fully-installed ROM at the bare target_path.
+        with open(target_path, "wb") as f:
+            f.write(b"REAL INSTALLED ROM DATA")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        def fake_download(_rom_id, _filename, _dest, _progress_callback=None):
+            raise OSError("network died mid-redownload")
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
+
+        # The pre-existing install must SURVIVE — this was the data-loss bug.
+        assert os.path.exists(target_path)
+        with open(target_path, "rb") as f:
+            assert f.read() == b"REAL INSTALLED ROM DATA"
+        assert plugin._download_service._download_queue[42]["status"] == "failed"
+
+
+class TestDoDownloadCancelReconcile:
+    """#1049 scenario 1: a cancel that loses the race to a committed install is
+    surfaced as COMPLETED, never torn down.
+
+    These use a REAL ``run_in_executor`` with a commit that blocks until the test
+    releases it, so the asyncio future-cancellation semantics are faithful: a
+    cancel delivered while awaiting the post-IO future CANCELS that future, so a
+    plain re-await raises ``CancelledError`` (not the value) — which is exactly
+    why the post-IO await must be ``asyncio.shield``-ed. A non-faithful awaitable
+    that returns its value on re-await would green-light the un-shielded bug.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_commit_surfaces_completed_single_file(self, plugin, tmp_path):
+        import threading
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        _seed_rom(plugin._uow, 42)
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+        }
+
+        def fake_transfer(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(b"\x00" * 512)
+
+        # The post-IO commit blocks until released, so the test can deliver the
+        # cancel while the commit is genuinely in-flight (the #1049 race window),
+        # then let the real rename + DB save run to completion.
+        started = threading.Event()
+        release = threading.Event()
+        real_post_io = plugin._download_service._post_download_single_io
+
+        def blocking_post_io(*args):
+            started.set()
+            release.wait(timeout=5)
+            return real_post_io(*args)
+
+        with (
+            patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_transfer),
+            patch.object(plugin._download_service, "_post_download_single_io", side_effect=blocking_post_io),
+        ):
+            task = asyncio.ensure_future(
+                plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
+            )
+            while not started.is_set():
+                await asyncio.sleep(0.01)
+            task.cancel()
+            await asyncio.sleep(0)  # let the cancel reach the (shielded) post-IO await
+            release.set()  # let the real commit finish (rename + DB save)
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # Committed before the cancel landed → surfaced COMPLETED, file kept, row saved.
+        assert plugin._download_service._download_queue[42]["status"] == "completed"
+        assert os.path.exists(target_path)
+        installed = plugin._uow.rom_installs.get(42)
+        assert installed is not None
+        assert installed.file_path == target_path
+        assert [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
+        assert not [c for c in decky.emit.call_args_list if c[0][0] == "download_failed"]
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_commit_keeps_committed_install_multi_file(self, plugin, tmp_path):
+        """The data-loss path: a committed multi-file extract dir must SURVIVE a
+        racing cancel — cleanup would otherwise ``remove_tree`` the live install."""
+        import threading
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "psx"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "game.zip")
+        file_name = "game.zip"
+        # The extract dir the cleanup would target on a (mis-)cancelled multi-file.
+        committed_dir = os.path.join(os.path.dirname(target_path), "game")
+
+        rom_detail = {
+            "id": 77,
+            "name": "Game",
+            "fs_name": "game.zip",
+            "platform_slug": "psx",
+            "platform_name": "PlayStation",
+            "has_multiple_files": True,
+            "files": [{"file_name": "a.bin"}, {"file_name": "b.bin"}],
+        }
+
+        _seed_rom(plugin._uow, 77, platform_slug="psx")
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[77] = {
+            "rom_id": 77,
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+        }
+
+        def fake_transfer(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(b"PK\x05\x06" + b"\x00" * 18)  # zip-ish bytes; the stubbed post-IO never reads them
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_post_io_multi(rom_id, _detail, tpath, fname, system):
+            # Faithful post-condition of a committed multi-file install: an extract
+            # dir with a launch file + a saved RomInstall row.
+            started.set()
+            release.wait(timeout=5)
+            rom_dir = os.path.join(os.path.dirname(tpath), os.path.splitext(fname)[0])
+            os.makedirs(rom_dir, exist_ok=True)
+            launch_file = os.path.join(rom_dir, "game.m3u")
+            with open(launch_file, "wb") as f:
+                f.write(b"playlist")
+            with plugin._download_service._uow_factory() as uow:
+                uow.rom_installs.save(
+                    RomInstall.mark_installed(
+                        rom_id=rom_id,
+                        file_path=launch_file,
+                        rom_dir=rom_dir,
+                        platform_slug="psx",
+                        system=system,
+                        installed_at="2026-01-01T00:00:00+00:00",
+                    )
+                )
+            return (launch_file, None)
+
+        with (
+            patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_transfer),
+            patch.object(plugin._download_service, "_post_download_multi_io", side_effect=blocking_post_io_multi),
+        ):
+            task = asyncio.ensure_future(
+                plugin._download_service._do_download(77, rom_detail, target_path, "psx", file_name)
+            )
+            while not started.is_set():
+                await asyncio.sleep(0.01)
+            task.cancel()
+            await asyncio.sleep(0)
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # The committed extract dir + its launch file SURVIVE (data-loss regression).
+        assert os.path.isdir(committed_dir)
+        assert os.path.exists(os.path.join(committed_dir, "game.m3u"))
+        # Surfaced as completed, install row present, download_complete emitted.
+        assert plugin._download_service._download_queue[77]["status"] == "completed"
+        assert plugin._uow.rom_installs.get(77) is not None
+        assert [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
+
+
+class TestDoDownloadCancelEmitsEvent:
+    """#1017: a clean cancel must emit a terminal download_progress(cancelled) frame."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_emits_cancelled_progress_event(self, plugin, tmp_path):
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        def fake_download_cancel(_rom_id, _filename, _dest, _progress_callback=None):
+            raise asyncio.CancelledError()
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "status": "downloading",
+            "progress": 0.3,
+            "bytes_downloaded": 300,
+            "total_bytes": 1000,
+        }
+
+        with (
+            patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download_cancel),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
+
+        # A terminal cancelled frame reached the frontend (was silent before #1017).
+        cancelled = [
+            c
+            for c in decky.emit.call_args_list
+            if c[0][0] == "download_progress" and c[0][1].get("status") == "cancelled"
+        ]
+        assert len(cancelled) == 1
+        payload = cancelled[0][0][1]
+        assert payload["rom_id"] == 42
+        assert payload["progress"] == pytest.approx(0.3)
+        assert payload["bytes_downloaded"] == 300
+        assert payload["total_bytes"] == 1000
+        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+
+
+class TestConcurrencyReservation:
+    """#1053: bounded concurrency + reserved-bytes preflight + queued status."""
+
+    def _wire(self, plugin, tmp_path):
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_reservation_blocks_sibling_that_fits_alone(self, plugin, tmp_path):
+        from unittest.mock import AsyncMock
+
+        self._wire(plugin, tmp_path)
+
+        # Each ROM is 400MB (+100MB buffer = 500MB required). Free space is
+        # 900MB: one fits, two do not (1000MB required, but only 900 free once
+        # the first is reserved).
+        file_size = 400 * 1024 * 1024
+
+        def _detail(rom_id):
+            return {
+                "id": rom_id,
+                "name": f"Game {rom_id}",
+                "fs_name": f"game{rom_id}.z64",
+                "fs_size_bytes": file_size,
+                "platform_slug": "n64",
+                "platform_name": "Nintendo 64",
+            }
+
+        plugin._download_service._loop = MagicMock()
+
+        def _close_coro_task(coro):
+            coro.close()
+            return MagicMock()
+
+        plugin._download_service._loop.create_task = _close_coro_task
+        plugin._download_service._download_file_store.disk_free = lambda _path: 900 * 1024 * 1024
+
+        # First download: fits (900 free, needs 500) → reserved.
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=_detail(1))
+        r1 = await plugin.start_download(1)
+        assert r1["success"] is True
+        assert plugin._download_service._reserved_bytes[1] == 500 * 1024 * 1024
+
+        # Second download: 900 free - 500 reserved = 400 < 500 needed → rejected.
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=_detail(2))
+        r2 = await plugin.start_download(2)
+        assert r2["success"] is False
+        assert r2["reason"] == "insufficient_space"
+        assert "disk space" in r2["message"].lower()
+        # The rejected ROM holds no reservation and no in-progress flag.
+        assert 2 not in plugin._download_service._reserved_bytes
+        assert 2 not in plugin._download_service._download_in_progress
+
+    @pytest.mark.asyncio
+    async def test_reservation_released_after_download(self, plugin, tmp_path):
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(b"\x00" * 512)
+
+        _seed_rom(plugin._uow, 42)
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._reserved_bytes[42] = 999
+        plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "queued", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64")
+
+        assert plugin._download_service._download_queue[42]["status"] == "completed"
+        # The reservation is released in the finally.
+        assert 42 not in plugin._download_service._reserved_bytes
+
+    @pytest.mark.asyncio
+    async def test_third_download_emits_queued_while_two_run(self, plugin, tmp_path):
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+
+        # Hold the semaphore so it is fully locked, forcing the third download to
+        # emit a "queued" frame before it can acquire.
+        sem = plugin._download_service._download_semaphore
+        await sem.acquire()
+        await sem.acquire()
+        assert sem.locked()
+
+        rom_detail = {
+            "id": 3,
+            "name": "Third",
+            "fs_name": "third.z64",
+            "fs_size_bytes": 1000,
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+        target_path = str(roms_dir / "third.z64")
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None):
+            with open(dest, "wb") as f:
+                f.write(b"\x00" * 64)
+
+        _seed_rom(plugin._uow, 3)
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[3] = {"rom_id": 3, "status": "queued", "progress": 0}
+
+        # Run the third download as a task — it must emit "queued" then block on
+        # the semaphore (which we hold).
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            task = asyncio.ensure_future(
+                plugin._download_service._do_download(3, rom_detail, target_path, "n64", "third.z64")
+            )
+            # Let it reach the semaphore wait.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            # It emitted a queued frame and is still waiting (status queued).
+            queued = [
+                c
+                for c in decky.emit.call_args_list
+                if c[0][0] == "download_progress" and c[0][1].get("status") == "queued"
+            ]
+            assert len(queued) == 1
+            assert queued[0][0][1]["rom_id"] == 3
+            assert plugin._download_service._download_queue[3]["status"] == "queued"
+
+            # Release the semaphore so the third can proceed and finish.
+            sem.release()
+            sem.release()
+            await task
+
+        assert plugin._download_service._download_queue[3]["status"] == "completed"
+
+
+class TestCooperativeCancel:
+    """#144: cooperative cancellation — a per-attempt token the progress
+    callback polls on the executor thread, raising ``CancelledError`` to abort
+    the in-flight HTTP transfer. ``task.cancel()`` alone cannot interrupt the
+    executor worker thread; the token is what really stops the bytes.
+    """
+
+    def test_progress_callback_raises_once_token_cancelled(self, plugin):
+        """The callback runs clean while the token is unset; raises after it flips."""
+        token = _CancelToken()
+        # The queue entry the callback would update if it didn't bail early.
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+        }
+        fake_clock = FakeClock()
+        plugin._download_service._clock = fake_clock
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.call_soon_threadsafe = lambda fn, *a, **k: fn(*a, **k)
+        plugin._download_service._loop.create_task = lambda coro: coro.close() or MagicMock()
+
+        def _record_emit(_event, _payload):
+            async def _noop():
+                return None
+
+            return _noop()
+
+        plugin._download_service._emit = _record_emit
+
+        cb = plugin._download_service._make_progress_callback(42, "Zelda", "N64", "zelda.z64", token)
+
+        # Unset token: a normal tick proceeds (no raise). Advance so the
+        # final-frame throttle bypass fires and the queue entry updates.
+        cb(1024, 1024)
+        assert plugin._download_service._download_queue[42]["bytes_downloaded"] == 1024
+
+        # Flip the token; the very next tick aborts the transfer thread.
+        token.cancelled = True
+        with pytest.raises(asyncio.CancelledError):
+            cb(2048, 4096)
+
+    @pytest.mark.asyncio
+    async def test_transfer_loop_aborts_when_token_cancelled_mid_stream(self, plugin, tmp_path):
+        """A real transfer LOOP stops once its token flips — the bytes really halt.
+
+        Models ``download_rom_content`` as a 500-iteration loop calling
+        ``progress_callback`` each tick (faking it as instantaneous is exactly
+        why the original tests missed #144). At tick 3 the token is cancelled;
+        the callback then raises and the loop never reaches 500.
+        """
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "zelda.z64")
+
+        rom_detail = {
+            "id": 42,
+            "name": "Zelda",
+            "fs_name": "zelda.z64",
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+            "has_multiple_files": False,
+        }
+
+        token = _CancelToken()
+        plugin._download_service._cancel_tokens[42] = token
+        captured: list[int] = []
+
+        def fake_transfer(_rom_id, _filename, _dest, progress_callback=None):
+            assert progress_callback is not None  # _do_download always threads a real callback
+            for i in range(1, 500):
+                captured.append(i)
+                if i == 3:
+                    token.cancelled = True
+                # The callback raises CancelledError once the token is set, so
+                # the loop never runs to completion — the transfer aborts.
+                progress_callback(i, 500)
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
+
+        with (
+            patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_transfer),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await plugin._download_service._do_download(42, rom_detail, target_path, "n64", "zelda.z64", token)
+
+        # The loop stopped near tick 3/4 — nowhere near 500. The transfer
+        # really halted instead of running to completion.
+        assert len(captured) <= 5
+        assert plugin._download_service._download_queue[42]["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_download_sets_token_and_cancels_task(self, plugin):
+        """``cancel_download`` flips the token AND cancels the asyncio task."""
+        loop = asyncio.get_event_loop()
+        token = _CancelToken()
+        plugin._download_service._cancel_tokens[42] = token
+
+        async def _never_ending():
+            await asyncio.Event().wait()
+
+        task = loop.create_task(_never_ending())
+        await asyncio.sleep(0)  # let it start waiting
+        plugin._download_service._download_tasks[42] = task
+
+        result = await plugin.cancel_download(42)
+        assert result["success"] is True
+        # The token is flipped so the executor transfer thread aborts (#144) —
+        # not just the asyncio wrapper.
+        assert token.cancelled is True
+        assert task.cancelled() or task.cancelling()
+
+        # Drain the cancelled task so it doesn't leak as pending.
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    def test_per_attempt_token_isolation(self, plugin):
+        """A zombie's callback (old token) aborts; a fresh download's continues.
+
+        Each callback closes over its OWN token. A re-download installs a NEW
+        token, so the zombie's cancelled token raises while the fresh token's
+        callback runs clean — no parallel-download flicker.
+        """
+        plugin._download_service._download_queue[42] = {
+            "rom_id": 42,
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+        }
+        fake_clock = FakeClock()
+        plugin._download_service._clock = fake_clock
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.call_soon_threadsafe = lambda fn, *a, **k: fn(*a, **k)
+        plugin._download_service._loop.create_task = lambda coro: coro.close() or MagicMock()
+
+        def _record_emit(_event, _payload):
+            async def _noop():
+                return None
+
+            return _noop()
+
+        plugin._download_service._emit = _record_emit
+
+        old_token = _CancelToken()
+        old_token.cancelled = True  # the cancelled zombie's token
+        new_token = _CancelToken()  # the fresh re-download's token
+
+        cb_old = plugin._download_service._make_progress_callback(42, "Zelda", "N64", "zelda.z64", old_token)
+        cb_new = plugin._download_service._make_progress_callback(42, "Zelda", "N64", "zelda.z64", new_token)
+
+        # The zombie's callback aborts; the fresh download's proceeds.
+        with pytest.raises(asyncio.CancelledError):
+            cb_old(512, 1024)
+        cb_new(1024, 1024)  # no raise
+        assert plugin._download_service._download_queue[42]["bytes_downloaded"] == 1024
 
 
 # Internal constants — re-declared so the test file doesn't reach into


### PR DESCRIPTION
## Summary

Wave 1 of the v1 download-robustness work (#1121) — the destructive and availability bugs in the download path, plus the cancel UX they exposed.

### Data loss / correctness
- **#1049** — cancel/failure cleanup could delete a live install. Cleanup no longer removes the bare target file (a transfer writes to a `.tmp` and only renames on success), and the post-IO commit is `asyncio.shield`-ed so a cancel that races a committing install is reconciled and surfaced as **completed** rather than torn down. The multi-file extract dir had the same exposure and is covered too.

### Availability / cancel actually working
- **#144** — cancel now stops the actual HTTP transfer. `task.cancel()` alone left the executor worker thread downloading; on-device this showed up as a zombie transfer that kept the UI "downloading" after cancel and ran in parallel with a re-download (flickering byte counts). A per-download cancel token, polled by the progress callback on the worker thread, aborts the in-flight stream.
- **#1017** — the cancel path now emits a terminal `download_progress` (`status: cancelled`) frame so the frontend leaves its downloading state.
- **#1048** — `start_download` releases the in-progress flag on any early failure (unmounted SD card, missing roms path) so a ROM can't get stuck "Already downloading".
- **#973** — progress updates are marshalled onto the loop thread with a guarded lookup, fixing a `KeyError` race when a queue entry is evicted mid-download.
- **#1053** — bounded concurrency (semaphore of 2) + a reserved-bytes disk pre-flight so two large downloads can't both pass a check only one fits; waiting downloads show an honest `queued` status.

### UI
- A cancel **X** on the game-detail download button while a download is in flight (#1049), in addition to the QAM queue. The right-side action area is factored so a pause control can join later.
- Fixes the QAM download progress bar clipping on the right (#751) using the full-width caption + bare `ProgressBar` pattern already used for sync progress.

## Testing
- Full backend suite + all CI gates green; full frontend suite + build green.
- New faithful unit tests model the transfer as a cancellable loop (the original tests faked it as instantaneous, which is why #144 went unnoticed) and cover the cancel-race reconcile, the data-loss preservation, and the concurrency/reservation paths.
- On-device testing on the Steam Deck surfaced #144 (the original cancel left the transfer thread running); the fix is unit-covered and pending an on-device re-check.

## Notes
- Pause/resume is a separate follow-up: single-file ROMs are byte-resumable (RomM serves them as a static file → HTTP Range/206); multi-file ROMs are zipped on the fly and are not resumable, and a Cloudflare Tunnel can strip Range — so it needs runtime detection, out of scope here.

Closes #1049, #1017, #1048, #973, #1053, #144
