### PR TITLE
fix(build): always chown the deploy dir recursively before syncing files

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -60,9 +60,13 @@ depends = ["build"]
 raw = true
 run = """
 DEST="$HOME/homebrew/plugins/decky-romm-sync"
-if [ -d "$DEST" ] && [ "$(stat -c '%U' "$DEST")" != "$USER" ]; then
-  sudo chown -R "$USER:$USER" "$DEST"
-fi
+# Decky's root plugin_loader can re-own individual files inside the plugin dir
+# (e.g. plugin.json) while the dir itself stays user-owned. A guard that checks
+# only the dir's owner then skips the chown, and the rsync/cp below hits
+# "permission denied" on the root-owned file. Always chown recursively when the
+# dir exists; the dev task's `sudo -v` keeps the password cached, so it costs no
+# extra prompt.
+[ -d "$DEST" ] && sudo chown -R "$USER:$USER" "$DEST"
 mkdir -p "$DEST/dist" "$DEST/bin" "$DEST/defaults" "$DEST/py_modules"
 rsync -a --delete dist/ "$DEST/dist/"
 rsync -a --delete bin/ "$DEST/bin/"


### PR DESCRIPTION
## Problem

`mise run dev` (and `mise run deploy`) intermittently fails with:

```
cp: das Entfernen von '.../homebrew/plugins/decky-romm-sync/plugin.json' ist nicht möglich: Keine Berechtigung
```

The deploy task only chowned the plugin dir when the **dir's own owner** differed from `$USER`. Decky's root `plugin_loader` can re-own individual files inside the dir (e.g. `plugin.json`, after the `systemctl restart plugin_loader` that `dev` itself triggers) while the dir itself stays user-owned — so the guard skips the chown and the next deploy's `rsync`/`cp` hits "permission denied" on the now-root-owned file. That's the intermittent "sometimes it happens" behaviour.

## Fix

Always chown the deploy dir **recursively** when it exists, rather than gating on the dir's own owner. The `dev` task already runs `sudo -v`, so the cached credential means no extra prompt.

docs: N/A — build/deploy tooling change, no user-facing or architecture impact.
