### PR TITLE
fix(downloads): show extraction progress + Steam-native cancel controls

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -234,7 +234,12 @@ domain functions (`needs_m3u`, `detect_launch_file`) take `m3u_supported`, never
 bundled `.m3u` is left inert on disk, never deleted. When `es_systems.xml` cannot be found the answer defaults to
 `False` (safe: a missing playlist only degrades disc-switching, a wrong one breaks the launch).
 
-Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected.
+Filesystem writes go through `DownloadFileAdapter`. ZIP extraction is ZIP-slip protected and streamed: `extract_zip`
+copies each member in chunks and reports byte progress through an optional callback, so a multi-file ROM emits
+`download_progress` frames with `status: "extracting"` (`bytes_downloaded`/`total_bytes` over the **uncompressed**
+total, `resumable: false`) after the transfer hits 100%. The frontend reuses the same event — no new event name — to
+switch the download button and QAM queue into the non-cancellable **Extracting…** phase. Single-file downloads never
+emit it.
 
 **Bounded concurrency + reserved-bytes pre-flight**: at most **two** ROMs transfer at once, gated by an
 `asyncio.Semaphore(2)` around the transfer + post-IO critical section. `start_download` enters the queue with status

--- a/docs/user-guide/managing-games.md
+++ b/docs/user-guide/managing-games.md
@@ -58,6 +58,11 @@ Some games ship as more than one file — multi-disc PS1 titles, a base game plu
 downloads these as a single ZIP, which the plugin extracts automatically. You just download and play; the layout is
 handled for you.
 
+After the byte transfer finishes, the download button and the QAM queue show a brief **Extracting…** phase with its own
+progress (the percentage climbs back from 0 as the archive unpacks — a large Switch or disc image takes a moment). The
+extraction can't be cancelled, so the cancel/pause controls are replaced by a spinner until it's done; the game then
+flips to **Installed** as usual. Single-file ROMs download as a bare file and skip this phase entirely.
+
 The plugin gives the extracted game its own folder and names that folder after the real **launch file** (including the
 extension, e.g. `Final Fantasy VII (USA).m3u/` or `Halo 3 (USA).iso/`) so that ES-DE collapses it into a single game
 entry instead of showing a folder plus loose files.

--- a/py_modules/adapters/download_file.py
+++ b/py_modules/adapters/download_file.py
@@ -14,8 +14,14 @@ import os
 import shutil
 import urllib.parse
 import zipfile
+from typing import TYPE_CHECKING
 
 from lib.path_safety import safe_path_component
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_EXTRACT_CHUNK = 1024 * 1024
 
 
 class DownloadFileAdapter:
@@ -81,23 +87,50 @@ class DownloadFileAdapter:
             matches.extend(os.path.join(root, filename) for filename in files if filename.endswith(suffixes))
         return matches
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
+    def extract_zip(
+        self,
+        archive_path: str,
+        dest_dir: str,
+        safe_root: str,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> None:
         """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
 
         Resolves both *dest_dir* and *safe_root* via ``os.path.realpath``
         and verifies that every ZIP member resolves within both before
-        extracting. Raises ``ValueError`` on any escape attempt.
+        writing any byte. Raises ``ValueError`` on any escape attempt.
+
+        When *progress_callback* is supplied it is invoked with
+        ``(extracted, total)`` uncompressed byte counts after each chunk
+        write — ``total`` is the sum of every member's uncompressed size,
+        ``extracted`` is the running total written so far. With
+        *progress_callback* left ``None`` the extraction is silent and the
+        output files are byte-identical to a plain ``extractall``.
         """
         real_dest = os.path.realpath(dest_dir)
         real_safe = os.path.realpath(safe_root)
         if not (real_dest == real_safe or real_dest.startswith(real_safe + os.sep)):
             raise ValueError(f"Extract directory would be outside safe root: {dest_dir}")
         with zipfile.ZipFile(archive_path, "r") as zf:
-            for member in zf.namelist():
-                member_path = os.path.realpath(os.path.join(real_dest, member))
+            members = zf.infolist()
+            for member in members:
+                member_path = os.path.realpath(os.path.join(real_dest, member.filename))
                 if not (member_path == real_dest or member_path.startswith(real_dest + os.sep)):
-                    raise ValueError(f"ZIP member {member} would extract outside target directory")
-            zf.extractall(real_dest)
+                    raise ValueError(f"ZIP member {member.filename} would extract outside target directory")
+            total = sum(member.file_size for member in members)
+            extracted = 0
+            for member in members:
+                target = os.path.join(real_dest, member.filename)
+                if member.is_dir():
+                    os.makedirs(target, exist_ok=True)
+                    continue
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                with zf.open(member) as src, open(target, "wb") as dst:
+                    while chunk := src.read(_EXTRACT_CHUNK):
+                        dst.write(chunk)
+                        extracted += len(chunk)
+                        if progress_callback is not None:
+                            progress_callback(extracted, total)
 
     def decode_url_encoded_names(self, directory: str) -> None:
         """Rename URL-encoded files and directories under *directory* in place.

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -413,7 +413,10 @@ class DownloadService:
         tmp_zip = target_path + _ZIP_TMP_EXT
         # ZIP-slip protection: adapter validates members resolve within extract_dir
         # AND that extract_dir itself resolves within roms_base.
-        self._download_file_store.extract_zip(tmp_zip, extract_dir, roms_base)
+        rom_name = rom_detail.get("name", file_name)
+        platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
+        extract_cb = self._make_extract_callback(rom_id, rom_name, platform_name, file_name)
+        self._download_file_store.extract_zip(tmp_zip, extract_dir, roms_base, progress_callback=extract_cb)
         self._download_file_store.remove_file(tmp_zip)
         self._download_file_store.decode_url_encoded_names(extract_dir)
         # Whether ES-DE lists .m3u for this system (gates both M3U generation and
@@ -583,6 +586,89 @@ class DownloadService:
                     "bytes_downloaded": downloaded,
                     "total_bytes": total,
                     "resumable": entry.get("resumable", False),
+                },
+            )
+        )
+
+    def _make_extract_callback(self, rom_id, rom_name, platform_name, file_name):
+        """Build a throttled extraction-progress callback for a multi-file ROM.
+
+        Mirrors ``_make_progress_callback`` but for the post-transfer ZIP
+        extraction. ``last_emit`` starts at 0.0 so the FIRST tick emits
+        immediately — the UI switches to the "extracting" phase promptly once
+        the byte transfer finishes. Emits are then throttled to 0.5s and a
+        human-readable log line to ~30s. Unlike the download callback this does
+        NOT poll the cancel/pause token: extraction is not cancellable this
+        iteration. Runs on the executor worker thread, so the queue mutation
+        and emit-scheduling are marshaled to the loop thread via
+        ``call_soon_threadsafe`` (#973).
+        """
+        last_emit = [0.0]  # mutable container for closure
+        last_log = [0.0]
+
+        def extract_callback(extracted, total):
+            now = self._clock.monotonic()
+            if now - last_log[0] >= 30.0:
+                last_log[0] = now
+                self._log_extract_progress(rom_name, extracted, total)
+            if now - last_emit[0] < 0.5 and extracted < total:
+                return
+            last_emit[0] = now
+            progress = extracted / total if total else 0
+            self._loop.call_soon_threadsafe(
+                self._apply_extract_progress,
+                rom_id,
+                rom_name,
+                platform_name,
+                file_name,
+                progress,
+                extracted,
+                total,
+            )
+
+        return extract_callback
+
+    def _log_extract_progress(self, rom_name, extracted, total):
+        """Log a throttled one-line human-readable extraction summary (MB + %)."""
+        mb_done = extracted / (1024 * 1024)
+        mb_total = total / (1024 * 1024) if total else 0
+        pct = (extracted / total * 100) if total else 0
+        self._logger.info(f"Extract progress: {rom_name} — {mb_done:.1f}/{mb_total:.1f} MB ({pct:.0f}%)")
+
+    def _apply_extract_progress(self, rom_id, rom_name, platform_name, file_name, progress, extracted, total):
+        """Update the live queue entry and schedule an ``extracting`` ``download_progress`` emit.
+
+        Runs on the loop thread (marshaled from the executor worker via
+        ``call_soon_threadsafe``). Guarded by ``.get`` — if the entry was evicted
+        between ticks we must not resurrect it or raise KeyError off-thread (#973).
+        Mirrors ``_apply_download_progress`` but flips the entry to the
+        "extracting" phase and reports ``resumable: False`` (extraction is never
+        resumable).
+        """
+        entry = self._download_queue.get(rom_id)
+        if entry is None:
+            return  # evicted mid-extraction — do not resurrect or emit
+        entry.update(
+            {
+                "status": "extracting",
+                "progress": progress,
+                "bytes_downloaded": extracted,
+                "total_bytes": total,
+            }
+        )
+        self._loop.create_task(
+            self._emit(
+                "download_progress",
+                {
+                    "rom_id": rom_id,
+                    "rom_name": rom_name,
+                    "platform_name": platform_name,
+                    "file_name": file_name,
+                    "status": "extracting",
+                    "progress": progress,
+                    "bytes_downloaded": extracted,
+                    "total_bytes": total,
+                    "resumable": False,
                 },
             )
         )

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -12,7 +12,10 @@ context offload via ``loop.run_in_executor``.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class CoverArtFileStore(Protocol):
@@ -120,13 +123,24 @@ class DownloadFileStore(Protocol):
         """
         ...
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
+    def extract_zip(
+        self,
+        archive_path: str,
+        dest_dir: str,
+        safe_root: str,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> None:
         """Extract *archive_path* into *dest_dir* with ZIP-slip protection.
 
         *safe_root* is the boundary outside of which extraction is
         rejected. Implementations resolve both *dest_dir* and *safe_root*
         via ``os.path.realpath`` and verify that every member resolves
         within *safe_root* before extracting.
+
+        When *progress_callback* is supplied it is invoked with
+        ``(extracted, total)`` uncompressed byte counts as members stream
+        out; with it left ``None`` the extraction is silent and produces
+        byte-identical output.
         """
         ...
 

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -428,6 +428,97 @@ describe("CustomPlayButton — pause/resume on active download (#1124)", () => {
   });
 });
 
+describe("CustomPlayButton — extraction phase on a multi-file download", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(backend.startDownload).mockResolvedValue({ success: true, message: "" });
+    vi.mocked(backend.cancelDownload).mockResolvedValue({ success: true, message: "" });
+    vi.mocked(backend.getDownloadQueue).mockResolvedValue({ downloads: [] });
+  });
+
+  // Drive the button into its active-download render, then optionally hand it a
+  // follow-up frame (an extracting frame, here). Mirrors renderDownloading/
+  // renderActive above but parameterised on the second frame.
+  async function renderWithFrames(frames: DownloadProgressEvent[]): Promise<ReturnType<typeof render>> {
+    mockCachedDetail({ rom_id: 42, installed: false });
+    const utils = render(<CustomPlayButton appId={100} />);
+    const downloadBtn = await utils.findByText("Download");
+
+    await act(async () => {
+      downloadBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    for (const frame of frames) {
+      act(() => {
+        emitDeckyEvent<[DownloadProgressEvent]>("download_progress", frame);
+      });
+    }
+
+    return utils;
+  }
+
+  const downloadingFrame: DownloadProgressEvent = {
+    rom_id: 42,
+    rom_name: "Test ROM",
+    platform_name: "PSX",
+    file_name: "game.zip",
+    status: "downloading",
+    progress: 1,
+    bytes_downloaded: 1000,
+    total_bytes: 1000,
+    resumable: false,
+  };
+
+  const extractingFrame: DownloadProgressEvent = {
+    rom_id: 42,
+    rom_name: "Test ROM",
+    platform_name: "PSX",
+    file_name: "game.zip",
+    status: "extracting",
+    progress: 0.42,
+    bytes_downloaded: 4200,
+    total_bytes: 10000,
+    resumable: false,
+  };
+
+  it("shows 'Extracting… N%' (N from extracted bytes/total) once an extracting frame arrives", async () => {
+    const { findByText } = await renderWithFrames([downloadingFrame, extractingFrame]);
+    // 4200 / 10000 = 42% — the label reads the uncompressed-byte fraction.
+    expect(await findByText("Extracting… 42%")).toBeInTheDocument();
+  });
+
+  it("removes the cancel control during extraction and surfaces a disabled throbber instead", async () => {
+    const { findByLabelText, queryByLabelText } = await renderWithFrames([downloadingFrame, extractingFrame]);
+
+    // The disabled throbber is the only right-side action while extracting.
+    const throbber = await findByLabelText("Extracting");
+    expect(throbber).toBeInTheDocument();
+    expect(throbber).toBeDisabled();
+
+    // No cancel X and no pause/resume dropdown during extraction.
+    expect(queryByLabelText("Cancel download")).toBeNull();
+    expect(queryByLabelText("Download actions")).toBeNull();
+  });
+
+  it("keeps the (neutral-restyled) cancel X in the normal downloading phase", async () => {
+    // The normal downloading phase still carries the cancel X — now restyled to
+    // the Steam-native translucent-white look. The @decky/ui mock drops inline
+    // `style`, so the colour itself isn't observable here; assert the control
+    // renders and is enabled (cancellable) — the contrast with the extracting
+    // phase's disabled throbber is what the restyle test pair guards.
+    const { findByLabelText, queryByLabelText } = await renderWithFrames([downloadingFrame]);
+    const cancelX = await findByLabelText("Cancel download");
+
+    expect(cancelX).toBeInTheDocument();
+    expect(cancelX).toHaveClass("romm-btn-cancel");
+    expect(cancelX).not.toBeDisabled();
+    // While downloading (not extracting) there's no throbber action.
+    expect(queryByLabelText("Extracting")).toBeNull();
+  });
+});
+
 describe("CustomPlayButton — pre-launch savefiles_in_content_dir benign skip (#239)", () => {
   beforeEach(() => {
     vi.mocked(getCachedGameDetail).mockReset();

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -9,7 +9,7 @@
  * with action: Uninstall.
  */
 
-import { useState, useEffect, useRef, FC } from "react";
+import { useState, useEffect, useRef, FC, ReactElement } from "react";
 import { addEventListener, removeEventListener, toaster } from "@decky/api";
 import { Focusable, DialogButton, ConfirmModal, Menu, MenuItem, showContextMenu, showModal } from "@decky/ui";
 import { appActionButtonClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
@@ -70,6 +70,13 @@ interface DownloadProgress {
   resumable: boolean;
   /** True once a paused frame arrives; the transfer is frozen, awaiting Resume. */
   paused: boolean;
+  /**
+   * True once an `extracting` frame arrives — the byte transfer is done and the
+   * multi-file ZIP is being unpacked. The transfer is not cancellable here, so
+   * the right-side action becomes a disabled throbber instead of the cancel X /
+   * Pause-Resume chevron.
+   */
+  extracting: boolean;
 }
 
 function lerpColor(a: [number, number, number], b: [number, number, number], t: number): string {
@@ -156,13 +163,20 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       // No post-await `cancelled` guard needed: React 18 no-ops a setState on an
       // unmounted component, and a remount keeps its own state.
       const entry = queue.downloads.find((d) => d.rom_id === rid);
-      if (entry && (entry.status === "downloading" || entry.status === "queued" || entry.status === "paused")) {
+      if (
+        entry &&
+        (entry.status === "downloading" ||
+          entry.status === "queued" ||
+          entry.status === "paused" ||
+          entry.status === "extracting")
+      ) {
         setActionPending(true);
         setDlProgress({
           bytesDownloaded: entry.bytes_downloaded,
           totalBytes: entry.total_bytes,
-          resumable: entry.resumable,
+          resumable: entry.status === "extracting" ? false : entry.resumable,
           paused: entry.status === "paused",
+          extracting: entry.status === "extracting",
         });
       }
     } catch (e) {
@@ -232,11 +246,15 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         } else {
           // A frame that omits resumable (older shape / progress tick before
           // the headers land) keeps the prior verdict instead of resetting it.
+          // The post-transfer `extracting` phase carries resumable:false and is
+          // never paused — its bytes climb 0→100 again over the uncompressed total.
+          const extracting = evt.status === "extracting";
           setDlProgress((prev) => ({
             bytesDownloaded: evt.bytes_downloaded,
             totalBytes: evt.total_bytes,
-            resumable: evt.resumable ?? prev?.resumable ?? false,
-            paused: evt.status === "paused",
+            resumable: extracting ? false : (evt.resumable ?? prev?.resumable ?? false),
+            paused: extracting ? false : evt.status === "paused",
+            extracting,
           }));
         }
       },
@@ -695,17 +713,31 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     const downloading = actionPending && dlProgress;
     const paused = downloading ? dlProgress.paused : false;
     const resumable = downloading ? dlProgress.resumable : false;
+    // Post-transfer ZIP unpack for a multi-file ROM — bytes climb 0→100 again
+    // over the uncompressed total. Not cancellable: the right-side action is a
+    // disabled throbber rather than the cancel X / Pause-Resume chevron.
+    const extracting = downloading ? dlProgress.extracting : false;
 
-    // Fill color shifts from blue to green as download progresses
-    const fillColor = downloading
-      ? `linear-gradient(to right, ${lerpColor(BLUE_LEFT, GREEN_LEFT, t)}, ${lerpColor(BLUE_RIGHT, GREEN_RIGHT, t)})`
-      : "linear-gradient(to right, #1a9fff, #0078d4)";
+    // Fill color shifts from blue to green as download progresses. Extraction
+    // begins right after the transfer hit 100% green, so it keeps the solid
+    // green fill for visual continuity.
+    let fillColor: string;
+    if (extracting) {
+      fillColor = `linear-gradient(to right, rgb(${GREEN_LEFT.join(",")}), rgb(${GREEN_RIGHT.join(",")}))`;
+    } else if (downloading) {
+      fillColor = `linear-gradient(to right, ${lerpColor(BLUE_LEFT, GREEN_LEFT, t)}, ${lerpColor(BLUE_RIGHT, GREEN_RIGHT, t)})`;
+    } else {
+      fillColor = "linear-gradient(to right, #1a9fff, #0078d4)";
+    }
 
     // Pulse color shifts from blue to green with progress; a paused download
     // freezes to a dim amber so the whole group reads as "halted, not running".
+    // Extraction holds the green pulse — it just finished the transfer.
     let pulseColor: string;
     if (paused) {
       pulseColor = "rgba(212,167,44,0.7)";
+    } else if (extracting) {
+      pulseColor = `rgb(${GREEN_LEFT.join(", ")})`;
     } else if (downloading) {
       pulseColor = lerpColor(BLUE_LEFT, GREEN_LEFT, t);
     } else {
@@ -713,7 +745,9 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     }
 
     let dlLabel: string;
-    if (paused) {
+    if (extracting) {
+      dlLabel = `Extracting… ${Math.round(t * 100)}%`;
+    } else if (paused) {
       dlLabel = "Paused";
     } else if (downloading) {
       dlLabel = formatProgress(dlProgress.bytesDownloaded, dlProgress.totalBytes);
@@ -723,10 +757,13 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       dlLabel = "Download";
     }
 
-    // Unfilled portion: darker shade of the current fill color
+    // Unfilled portion: darker shade of the current fill color. Extraction
+    // keeps a dim green base (the transfer just completed green).
     let baseBg: string;
     if (isOffline) {
       baseBg = "linear-gradient(to right, #6b7b8b, #5a6a7a)";
+    } else if (extracting) {
+      baseBg = "linear-gradient(to right, #1a4d1a, #0f3320)";
     } else if (downloading) {
       baseBg = `linear-gradient(to right, ${lerpColor([10, 50, 90], [5, 35, 65], t)}, ${lerpColor([5, 35, 65], [5, 50, 30], t)})`;
     } else {
@@ -782,7 +819,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         title="Cancel download"
         style={{
           ...dropdownArrowStyle,
-          background: "linear-gradient(to right, #0a3a5a, #062a45)",
+          background: "rgba(255, 255, 255, 0.15)",
           color: "#fff",
         }}
         onClick={handleCancelDownload}
@@ -809,9 +846,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         title="Download actions"
         style={{
           ...dropdownArrowStyle,
-          background: paused
-            ? "linear-gradient(to right, #6b5a1f, #4d4015)"
-            : "linear-gradient(to right, #0a3a5a, #062a45)",
+          background: "rgba(255, 255, 255, 0.15)",
           color: "#fff",
         }}
         onClick={(e: MouseEvent) => showDownloadActionsMenu(e, paused)}
@@ -828,9 +863,36 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       </DialogButton>
     );
 
+    // Extraction is not cancellable — the right-side action is a disabled
+    // throbber (same 36px slot, squared-left/rounded-right) so the control reads
+    // "working, can't stop" rather than offering a cancel/pause it can't honour.
+    const extractThrobber = (
+      <DialogButton
+        className="romm-btn-cancel"
+        aria-label="Extracting"
+        title="Extracting"
+        style={{
+          ...dropdownArrowStyle,
+          background: "rgba(255, 255, 255, 0.15)",
+          color: "#fff",
+        }}
+        disabled
+      >
+        <span className={`${appActionButtonClasses?.Throbber || ""} romm-throbber`.trim()} />
+      </DialogButton>
+    );
+
     // Active download: button + a right-side action section. The section is a
-    // flex sub-container so the dropdown-vs-X choice is a clean conditional.
-    // The pulse runs on the container so it spans the whole group.
+    // flex sub-container so the throbber-vs-dropdown-vs-X choice is a clean
+    // conditional. The pulse runs on the container so it spans the whole group.
+    let rightAction: ReactElement;
+    if (extracting) {
+      rightAction = extractThrobber;
+    } else if (resumable) {
+      rightAction = dropdown;
+    } else {
+      rightAction = cancelX;
+    }
     return (
       <Focusable
         ref={containerRef}
@@ -838,7 +900,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         style={{ ...btnContainerStyle, "--romm-pulse-color": pulseColor } as React.CSSProperties}
       >
         {downloadBtn}
-        <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>{resumable ? dropdown : cancelX}</div>
+        <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>{rightAction}</div>
       </Focusable>
     );
   }

--- a/src/components/DownloadQueue.test.tsx
+++ b/src/components/DownloadQueue.test.tsx
@@ -400,6 +400,53 @@ describe("DownloadQueue", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // extracting (post-transfer ZIP unpack)
+  // ---------------------------------------------------------------------------
+  describe("extracting", () => {
+    it("renders an extracting item in the active section with the 'Extracting…' caption and the extracted fraction", async () => {
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({
+        downloads: [
+          makeItem({
+            rom_id: 91,
+            rom_name: "Chrono",
+            status: "extracting",
+            bytes_downloaded: 4200,
+            total_bytes: 10000,
+            resumable: false,
+          }),
+        ],
+      });
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+
+      // Caption carries the Extracting marker; the bar reads the 42% fraction.
+      expect(container.querySelector('[data-testid="dl-caption"]')?.textContent).toBe("Chrono (Genesis) — Extracting…");
+      expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("42");
+    });
+
+    it("offers no Pause / Resume / Cancel control while extracting", async () => {
+      vi.mocked(backend.getDownloadQueue).mockResolvedValue({
+        downloads: [
+          makeItem({
+            rom_id: 92,
+            rom_name: "Trigger",
+            status: "extracting",
+            bytes_downloaded: 5000,
+            total_bytes: 10000,
+            resumable: false,
+          }),
+        ],
+      });
+      const { container } = render(<DownloadQueue onBack={() => {}} />);
+      await flushMount();
+
+      expect(buttonByText(container, "Pause Trigger")).toBeNull();
+      expect(buttonByText(container, "Resume Trigger")).toBeNull();
+      expect(buttonByText(container, "Cancel Trigger")).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // handleClearCompleted
   // ---------------------------------------------------------------------------
   describe("handleClearCompleted", () => {

--- a/src/components/DownloadQueue.tsx
+++ b/src/components/DownloadQueue.tsx
@@ -37,7 +37,9 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
     (current: DownloadItem[]) =>
     (prev: Set<number>): Set<number> => {
       const restarted = current.filter(
-        (d) => (d.status === "downloading" || d.status === "queued" || d.status === "paused") && prev.has(d.rom_id),
+        (d) =>
+          (d.status === "downloading" || d.status === "queued" || d.status === "paused" || d.status === "extracting") &&
+          prev.has(d.rom_id),
       );
       if (restarted.length === 0) return prev;
       const next = new Set(prev);
@@ -107,9 +109,12 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
   };
 
   const visible = downloads.filter((d) => !cleared.has(d.rom_id));
-  // Paused downloads stay in the active section — they're not finished, the
-  // partial transfer is held for resume.
-  const active = visible.filter((d) => d.status === "queued" || d.status === "downloading" || d.status === "paused");
+  // Paused and extracting downloads stay in the active section — they're not
+  // finished. Paused holds the partial transfer for resume; extracting is the
+  // post-transfer ZIP unpack (not cancellable, no pause/resume offered).
+  const active = visible.filter(
+    (d) => d.status === "queued" || d.status === "downloading" || d.status === "paused" || d.status === "extracting",
+  );
   const finished = visible.filter((d) => d.status === "completed" || d.status === "failed" || d.status === "cancelled");
   const hasFinished = downloads.some(
     (d) => !cleared.has(d.rom_id) && (d.status === "completed" || d.status === "failed" || d.status === "cancelled"),
@@ -159,6 +164,7 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
                       style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
                     >
                       {item.rom_name} ({item.platform_name}){item.status === "paused" ? " — Paused" : ""}
+                      {item.status === "extracting" ? " — Extracting…" : ""}
                     </span>
                     <span data-testid="dl-bytes" style={{ flexShrink: 0 }}>
                       {item.total_bytes > 0
@@ -173,44 +179,49 @@ export const DownloadQueue: FC<DownloadQueueProps> = ({ onBack }) => {
                 </div>
               </PanelSectionRow>
             ))}
-            {active.map((item) => (
-              <Fragment key={`actions-${item.rom_id}`}>
-                {item.status === "downloading" && item.resumable && (
+            {active.map((item) =>
+              // Extraction is not cancellable and can't pause/resume — the
+              // post-transfer unpack runs to completion. Offer no action row,
+              // matching the game-detail button's disabled throbber.
+              item.status === "extracting" ? null : (
+                <Fragment key={`actions-${item.rom_id}`}>
+                  {item.status === "downloading" && item.resumable && (
+                    <PanelSectionRow>
+                      <ButtonItem
+                        layout="below"
+                        onClick={() => {
+                          detach(handlePause(item.rom_id));
+                        }}
+                      >
+                        Pause {item.rom_name}
+                      </ButtonItem>
+                    </PanelSectionRow>
+                  )}
+                  {item.status === "paused" && (
+                    <PanelSectionRow>
+                      <ButtonItem
+                        layout="below"
+                        onClick={() => {
+                          detach(handleResume(item.rom_id));
+                        }}
+                      >
+                        Resume {item.rom_name}
+                      </ButtonItem>
+                    </PanelSectionRow>
+                  )}
                   <PanelSectionRow>
                     <ButtonItem
                       layout="below"
                       onClick={() => {
-                        detach(handlePause(item.rom_id));
+                        detach(handleCancel(item.rom_id));
                       }}
                     >
-                      Pause {item.rom_name}
+                      Cancel {item.rom_name}
                     </ButtonItem>
                   </PanelSectionRow>
-                )}
-                {item.status === "paused" && (
-                  <PanelSectionRow>
-                    <ButtonItem
-                      layout="below"
-                      onClick={() => {
-                        detach(handleResume(item.rom_id));
-                      }}
-                    >
-                      Resume {item.rom_name}
-                    </ButtonItem>
-                  </PanelSectionRow>
-                )}
-                <PanelSectionRow>
-                  <ButtonItem
-                    layout="below"
-                    onClick={() => {
-                      detach(handleCancel(item.rom_id));
-                    }}
-                  >
-                    Cancel {item.rom_name}
-                  </ButtonItem>
-                </PanelSectionRow>
-              </Fragment>
-            ))}
+                </Fragment>
+              ),
+            )}
 
             {finished.map((item) => (
               <PanelSectionRow key={item.rom_id}>

--- a/src/types/downloads.ts
+++ b/src/types/downloads.ts
@@ -8,7 +8,7 @@ export interface DownloadItem {
   rom_name: string;
   platform_name: string;
   file_name: string;
-  status: "queued" | "downloading" | "completed" | "failed" | "cancelled" | "paused";
+  status: "queued" | "downloading" | "extracting" | "completed" | "failed" | "cancelled" | "paused";
   progress: number;
   bytes_downloaded: number;
   total_bytes: number;

--- a/src/utils/styleInjector.ts
+++ b/src/utils/styleInjector.ts
@@ -51,8 +51,8 @@ export function hideNativePlaySection(playSectionClass: string) {
 .romm-btn-dropdown:hover, .romm-btn-dropdown.gpfocus {
   filter: brightness(1.3);
 }
-.romm-btn-cancel:hover, .romm-btn-cancel.gpfocus {
-  filter: brightness(1.4);
+.romm-btn-cancel:hover, .romm-btn-cancel.gpfocus, .romm-btn-cancel:focus {
+  background: rgba(255, 255, 255, 0.25) !important;
 }
 [data-romm] .gpfocus {
   outline: 2px solid #1a9fff;

--- a/tests/adapters/test_download_file.py
+++ b/tests/adapters/test_download_file.py
@@ -211,6 +211,112 @@ class TestExtractZip:
         assert result is None
         assert (tmp_path / "a.bin").read_bytes() == b"x"
 
+    def test_progress_callback_reports_monotonic_to_total(self, adapter, tmp_path):
+        archive = tmp_path / "src.zip"
+        members = {"a.bin": b"A" * 1500, "b.bin": b"B" * 2500}
+        self._make_zip(archive, members)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        adapter.extract_zip(str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t)))
+
+        total = sum(len(data) for data in members.values())
+        # Every tick carries the same total.
+        assert all(t == total for _e, t in calls)
+        # extracted is non-decreasing and ends exactly at total.
+        extracted_seq = [e for e, _t in calls]
+        assert extracted_seq == sorted(extracted_seq)
+        assert extracted_seq[-1] == total
+        # Files extracted with identical bytes.
+        assert (dest / "a.bin").read_bytes() == members["a.bin"]
+        assert (dest / "b.bin").read_bytes() == members["b.bin"]
+
+    def test_progress_callback_chunks_large_member(self, adapter, tmp_path):
+        # A member larger than _EXTRACT_CHUNK (1 MiB) yields multiple ticks,
+        # each a chunk-sized step, climbing to the member's full size.
+        archive = tmp_path / "big.zip"
+        big = b"\x00" * (1024 * 1024 + 7)  # 1 MiB + a partial chunk
+        self._make_zip(archive, {"rom.bin": big})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        adapter.extract_zip(str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t)))
+
+        assert len(calls) >= 2  # at least one full chunk + the remainder
+        assert [e for e, _t in calls] == sorted(e for e, _t in calls)
+        assert calls[-1] == (len(big), len(big))
+        assert (dest / "rom.bin").read_bytes() == big
+
+    def test_progress_callback_nested_dirs(self, adapter, tmp_path):
+        archive = tmp_path / "nested.zip"
+        members = {
+            "base.nsp": b"\x01" * 100,
+            "update/upd.nsp": b"\x02" * 200,
+            "dlc/extra.nsp": b"\x03" * 300,
+        }
+        self._make_zip(archive, members)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        adapter.extract_zip(str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t)))
+
+        total = sum(len(d) for d in members.values())
+        assert calls[-1] == (total, total)
+        assert (dest / "base.nsp").read_bytes() == members["base.nsp"]
+        assert (dest / "update" / "upd.nsp").read_bytes() == members["update/upd.nsp"]
+        assert (dest / "dlc" / "extra.nsp").read_bytes() == members["dlc/extra.nsp"]
+
+    def test_progress_callback_zip_slip_still_raises(self, adapter, tmp_path):
+        archive = tmp_path / "evil.zip"
+        self._make_zip(archive, {"../escape.txt": b"bad"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        with pytest.raises(ValueError, match="outside"):
+            adapter.extract_zip(
+                str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t))
+            )
+        # Validation runs BEFORE any write, so the callback never fired.
+        assert calls == []
+        assert not (tmp_path.parent / "escape.txt").exists()
+
+    def test_none_callback_is_back_compatible(self, adapter, tmp_path):
+        # progress_callback=None (the default) extracts byte-identically and
+        # invokes no callback — back-compat with the old extractall.
+        archive = tmp_path / "src.zip"
+        members = {"a.bin": b"AAA", "sub/b.bin": b"BBBB"}
+        self._make_zip(archive, members)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        result = adapter.extract_zip(str(archive), str(dest), str(tmp_path))
+        assert result is None
+        assert (dest / "a.bin").read_bytes() == b"AAA"
+        assert (dest / "sub" / "b.bin").read_bytes() == b"BBBB"
+
+    def test_empty_zip_no_callbacks(self, adapter, tmp_path):
+        archive = tmp_path / "empty.zip"
+        self._make_zip(archive, {})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        adapter.extract_zip(str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t)))
+        # No members → no writes → no progress callbacks.
+        assert calls == []
+
+    def test_zero_byte_member(self, adapter, tmp_path):
+        archive = tmp_path / "mix.zip"
+        members = {"empty.bin": b"", "data.bin": b"X" * 50}
+        self._make_zip(archive, members)
+        dest = tmp_path / "out"
+        dest.mkdir()
+        calls: list[tuple[int, int]] = []
+        adapter.extract_zip(str(archive), str(dest), str(tmp_path), progress_callback=lambda e, t: calls.append((e, t)))
+        # The zero-byte member writes no chunk (no tick); the 50-byte member
+        # produces the final tick at total.
+        assert (dest / "empty.bin").read_bytes() == b""
+        assert (dest / "data.bin").read_bytes() == members["data.bin"]
+        assert calls[-1] == (50, 50)
+
 
 class TestDecodeUrlEncodedNames:
     def test_renames_url_encoded_file(self, adapter, tmp_path):

--- a/tests/fakes/fake_download_file_store.py
+++ b/tests/fakes/fake_download_file_store.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import os
 import urllib.parse
+from typing import TYPE_CHECKING
 
 from lib.path_safety import safe_path_component
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class FakeDownloadFileStore:
@@ -121,7 +125,13 @@ class FakeDownloadFileStore:
                 matches.append(stored)
         return matches
 
-    def extract_zip(self, archive_path: str, dest_dir: str, safe_root: str) -> None:
+    def extract_zip(
+        self,
+        archive_path: str,
+        dest_dir: str,
+        safe_root: str,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> None:
         self.extract_calls.append((archive_path, dest_dir, safe_root))
         if archive_path not in self.files:
             raise FileNotFoundError(archive_path)
@@ -131,9 +141,17 @@ class FakeDownloadFileStore:
         # Fake-mode: derive extracted entries from a paired dict the test set.
         members = getattr(self, "_zip_members", {}).get(archive_path, {})
         self.make_dirs(dest_dir)
+        # Drive the progress callback with running (extracted, total) byte
+        # counts so service tests can observe the "extracting" frames the
+        # real adapter emits per member chunk.
+        total = sum(len(data) for data in members.values())
+        extracted = 0
         for name, data in members.items():
             full = os.path.join(dest_dir, name)
             self.files[full] = data
+            extracted += len(data)
+            if progress_callback is not None:
+                progress_callback(extracted, total)
 
     def set_zip_members(self, archive_path: str, members: dict[str, bytes]) -> None:
         if not hasattr(self, "_zip_members"):

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -1339,6 +1339,93 @@ class TestDoDownloadMultiFile:
         assert not extract_dir.exists()
         assert plugin._download_service._download_queue[99]["status"] == "failed"
 
+    @pytest.mark.asyncio
+    async def test_multi_file_emits_extracting_progress(self, plugin, tmp_path):
+        """A multi-file download emits ``download_progress`` ``status:"extracting"``
+        frames after the byte transfer, then ``download_complete`` after.
+
+        Drives the real adapter's streaming extraction through the fake store so
+        the passed extract callback fires per member; the final tick (extracted
+        == total) always bypasses the throttle, so at least one extracting frame
+        lands regardless of the fake clock.
+        """
+        from unittest.mock import patch
+
+        import decky
+        from fakes.fake_download_file_store import FakeDownloadFileStore
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        decky.emit.reset_mock()
+
+        roms_base = str(tmp_path / "retrodeck" / "roms")
+        target_path = os.path.join(roms_base, "psx", "FF7.zip")
+        tmp_zip = target_path + ".zip.tmp"
+
+        fake = FakeDownloadFileStore()
+        fake.make_dirs(roms_base)
+        # The ZIP the fake "extracts": two members so total > any single member.
+        fake.set_zip_members(tmp_zip, {"disc1.bin": b"\x00" * 600, "disc2.bin": b"\x00" * 400})
+        plugin._download_service._download_file_store = fake
+
+        rom_detail = {
+            "id": 55,
+            "name": "Final Fantasy VII",
+            "fs_name": "FF7.zip",
+            "fs_name_no_ext": "FF7",
+            "platform_slug": "psx",
+            "platform_name": "PlayStation",
+            "has_multiple_files": True,
+        }
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None, *, resume=False, on_meta=None):
+            # Populate the fake store's virtual filesystem with the tmp zip so
+            # the subsequent extract_zip finds it and drives the callback.
+            fake.files[dest] = b"ZIPDATA"
+
+        _seed_rom(plugin._uow, 55, platform_slug="psx")
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[55] = {
+            "rom_id": 55,
+            "rom_name": "Final Fantasy VII",
+            "platform_name": "PlayStation",
+            "file_name": "FF7.zip",
+            "status": "downloading",
+            "progress": 0,
+            "bytes_downloaded": 0,
+            "total_bytes": 0,
+            "resumable": False,
+        }
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(55, rom_detail, target_path, "psx", "FF7.zip")
+
+        # Drain the create_task-scheduled emits marshaled onto the loop.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        progress_calls = [c for c in decky.emit.call_args_list if c[0][0] == "download_progress"]
+        extracting = [c[0][1] for c in progress_calls if c[0][1].get("status") == "extracting"]
+        assert extracting, "expected at least one extracting download_progress frame"
+        frame = extracting[-1]
+        total = 1000
+        assert frame["status"] == "extracting"
+        assert frame["resumable"] is False
+        assert frame["bytes_downloaded"] == total
+        assert frame["total_bytes"] == total
+        assert frame["progress"] == 1.0
+        assert frame["rom_id"] == 55
+        assert frame["file_name"] == "FF7.zip"
+
+        # The queue entry reflects the extracting phase's last tick.
+        # download_complete still fires after extraction.
+        complete = [c for c in decky.emit.call_args_list if c[0][0] == "download_complete"]
+        assert len(complete) == 1
+        assert plugin._download_service._download_queue[55]["status"] == "completed"
+
 
 class TestDoDownloadBundledM3uPlatformGate:
     """#1111: a RomM-bundled .m3u must not drive launch/collapse on non-m3u systems.


### PR DESCRIPTION
## Problem
Multi-file ROM downloads arrive as a single ZIP the plugin extracts after the byte transfer. The UI used to freeze at "100% / stale green bar / blue cancel-X" during that extraction — a 7.5 GB Switch `.xci` takes real time — with no feedback that anything was still happening.

## Changes
- **Backend**: `extract_zip` streams each member in 1 MB chunks and reports uncompressed bytes; the service emits `download_progress` with `status: "extracting"` (reusing the existing event), carrying extracted/total bytes. ZIP-slip validation is unchanged — every member is validated before any write.
- **Frontend**: the game-detail download button and the QAM download queue show an **"Extracting… N%"** phase after the byte transfer; cancel is disabled during extraction (a throbber replaces the X). The cancel-X and pause/resume chevron now use Steam's native neutral (translucent white) secondary style instead of the custom blue gradient.

## Validation
Exercised on-device (Steam Deck / RetroDECK) with a large multi-file download: the Extracting… phase shows live progress after the byte transfer instead of a frozen 100%, and the neutral cancel controls render Steam-native.

## Out of scope
Extraction is not cancellable. Multi-file *download* resume (per-file `file_ids` reassembly) stays tracked for v2 in #1124 — RomM serves multi-file ROMs via on-the-fly `mod_zip`, which disables HTTP Range.

## Docs
`docs/user-guide/managing-games.md`, `docs/architecture/backend-architecture.md`.
