### PR TITLE
fix(saves): order save versions chronologically + persist rollback preflight on raise (#1014, #1012)

### DIFF
--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
+from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_slot import save_in_slot, slot_query_param
@@ -144,7 +145,11 @@ class SetupWizard:
 
         server_slots = []
         for slot_key, saves in slots_map.items():
-            latest = max((s.get("updated_at", "") for s in saves), default=None)
+            latest = max(
+                (s.get("updated_at", "") for s in saves),
+                key=lambda u: parse_iso_to_epoch(u) or 0.0,
+                default=None,
+            )
             server_slots.append(
                 {
                     "slot": slot_key,

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -15,6 +15,7 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from domain.iso_time import parse_iso_to_epoch
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_slot import save_in_slot, slot_query_param
@@ -177,7 +178,7 @@ class VersionsService:
             if s.get("id") != tracked_id and save_in_slot(s, slot)
         ]
 
-        versions.sort(key=lambda v: v["updated_at"], reverse=True)
+        versions.sort(key=lambda v: parse_iso_to_epoch(v["updated_at"]) or 0.0, reverse=True)
         return {"status": "ok", "versions": versions}
 
     def _rollback_to_version_io(
@@ -394,18 +395,23 @@ class VersionsService:
             # _rollback_to_version_io rather than rolling back cross-slot.
             server_saves = [s for s in server_saves if save_in_slot(s, slot)]
 
-            result = await self._loop.run_in_executor(
-                None,
-                self._rollback_to_version_io,
-                rom_id,
-                save_state,
-                device_id,
-                core_so,
-                save_id,
-                info,
-                server_saves,
-            )
-
-            await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
+            try:
+                result = await self._loop.run_in_executor(
+                    None,
+                    self._rollback_to_version_io,
+                    rom_id,
+                    save_state,
+                    device_id,
+                    core_so,
+                    save_id,
+                    info,
+                    server_saves,
+                )
+            finally:
+                # The pre-flight ``do_sync_rom_saves`` already performed real
+                # uploads/downloads whose baselines/tracked-ids live only in the
+                # in-memory aggregate; persist them regardless of how the switch
+                # ends, or the next sync mis-classifies (#1012).
+                await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
 
             return result

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -367,6 +367,36 @@ class TestGetSaveSetupInfo:
         assert slot_names == {"default", "desktop"}
 
     @pytest.mark.asyncio
+    async def test_latest_updated_at_uses_epoch_not_lexical_order(self, tmp_path):
+        """#1014: a slot's latest_updated_at is the truly-newest instant.
+
+        With mixed ISO shapes (trailing ``Z`` vs explicit offset) a raw
+        ``max()`` over the strings returns the lexically-greatest value, which
+        can be an EARLIER instant. The slot's latest_updated_at must reflect
+        chronological order, so the value compared by epoch but returned as the
+        original ISO string.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "dev-1")
+        _install_rom(svc, tmp_path)
+
+        # Both saves in one slot. The truly-newest instant is 12:00Z (12:00 UTC);
+        # the 13:00+02:00 string is lexically greater but is 11:00 UTC (older).
+        fake.saves[1] = _server_save(save_id=1, slot="default", updated_at="2024-01-01T12:00:00Z")
+        fake.saves[2] = _server_save(
+            save_id=2, slot="default", filename="pokemon.srm", updated_at="2024-01-01T13:00:00+02:00"
+        )
+
+        result = await svc.get_save_setup_info(42)
+
+        assert len(result["server_slots"]) == 1
+        slot = result["server_slots"][0]
+        assert slot["slot"] == "default"
+        # Epoch-newest ISO string, NOT the lexically-greatest "...13:00:00+02:00".
+        assert slot["latest_updated_at"] == "2024-01-01T12:00:00Z"
+
+    @pytest.mark.asyncio
     async def test_server_error_recommends_server_unreachable_not_auto_confirm(self, tmp_path):
         """Server API failure MUST NOT be misread as "server has no saves".
 

--- a/tests/services/saves/test_versions.py
+++ b/tests/services/saves/test_versions.py
@@ -145,6 +145,33 @@ class TestListFileVersions:
         assert versions[1]["id"] == 30
 
     @pytest.mark.asyncio
+    async def test_sorted_by_epoch_not_lexically(self, tmp_path):
+        """#1014: versions are ordered chronologically, not by raw string compare.
+
+        RomM has emitted mixed ISO shapes across versions (trailing ``Z`` vs
+        explicit offset). A raw lexical reverse-sort puts the lexically-greater
+        ``+02:00`` string first even though it represents an EARLIER instant —
+        so the user could roll back to the wrong version. Ordering by epoch
+        fixes it.
+        """
+        svc, fake = make_service(tmp_path)
+
+        # id=200 is truly newest: 12:00Z == 12:00 UTC.
+        fake.saves[200] = _server_save(save_id=200, rom_id=42, slot="default", updated_at="2024-01-01T12:00:00Z")
+        # id=300 is truly OLDER: 13:00+02:00 == 11:00 UTC, but its string is
+        # lexically GREATER than "2024-01-01T12:00:00Z" — a raw sort ranks it first.
+        fake.saves[300] = _server_save(save_id=300, rom_id=42, slot="default", updated_at="2024-01-01T13:00:00+02:00")
+        self._setup_state(svc, tracked_id=None)
+
+        result = await svc.list_file_versions(42, "default", "pokemon.srm")
+
+        assert result["status"] == "ok"
+        ids_in_order = [v["id"] for v in result["versions"]]
+        # Epoch order: 12:00 UTC (200) before 11:00 UTC (300). A lexical sort
+        # would yield [300, 200] — the bug.
+        assert ids_in_order == [200, 300]
+
+    @pytest.mark.asyncio
     async def test_empty_when_no_older_versions(self, tmp_path):
         """Returns empty list when there are no versions other than the tracked one."""
         svc, fake = make_service(tmp_path)
@@ -802,6 +829,53 @@ class TestRollbackToVersion:
         # State updated
         file_state = _require_save_state(svc, 42).files["pokemon.srm"]
         assert file_state.tracked_save_id == 50
+
+    @pytest.mark.asyncio
+    async def test_preflight_state_persisted_when_switch_raises(self, tmp_path):
+        """#1012: a raising switch still persists the pre-flight's state mutations.
+
+        The pre-flight ``do_sync_rom_saves`` performs REAL uploads/downloads
+        whose baselines/tracked-ids live only in the in-memory aggregate. If the
+        destructive switch (``_rollback_to_version_io``) raises, the exception
+        must propagate AND the persist must still run — otherwise the next sync
+        re-uploads as new or raises a false conflict. The try/finally guarantees
+        the write regardless of how the switch ends.
+        """
+        svc, fake = make_service(tmp_path)
+
+        _create_save(tmp_path)
+        local_hash = _file_md5(str(tmp_path / "saves" / "gba" / "pokemon.srm"))
+        self._setup_state(svc, tmp_path, tracked_id=100, last_sync_hash=local_hash)
+        fake.saves[100] = self._tracked_save(100)
+        fake.saves[50] = _server_save(save_id=50, rom_id=42, slot="default", updated_at="2026-02-01T10:00:00Z")
+
+        # rollback_to_version is delegated to the VersionsService sub-service,
+        # which owns _write_save_state and _rollback_to_version_io.
+        versions = svc._versions
+
+        # Spy on the persist so the finally-branch write is observable. Make the
+        # switch raise AFTER the clean pre-flight to model the #1012 hazard.
+        original_write = versions._write_save_state
+        write_calls: list[int] = []
+
+        def spy_write(rom_id, save_state):
+            write_calls.append(rom_id)
+            return original_write(rom_id, save_state)
+
+        def raising_io(*args, **kwargs):
+            raise RuntimeError("switch I/O exploded")
+
+        versions._write_save_state = spy_write  # type: ignore[method-assign]
+        versions._rollback_to_version_io = raising_io  # type: ignore[method-assign]
+
+        try:
+            with pytest.raises(RuntimeError, match="switch I/O exploded"):
+                await svc.rollback_to_version(42, "default", 50)
+        finally:
+            versions._write_save_state = original_write  # type: ignore[method-assign]
+
+        # Non-vacuous: the persist actually fired for rom 42 despite the raise.
+        assert 42 in write_calls
 
     @pytest.mark.asyncio
     async def test_rollback_to_already_tracked_save_is_idempotent(self, tmp_path):


### PR DESCRIPTION
## Wave 1 — saves rollback correctness (#1121)

Two coupled correctness fixes in the save-version rollback path.

### #1014 — version timestamps sorted lexicographically
`updated_at` was sorted/compared as a raw string at two sites: the version-history list (`versions.py`) and the wizard's per-slot `latest_updated_at` (`slots/setup.py`). RomM has emitted mixed ISO-8601 shapes (trailing `Z` vs `+00:00` vs non-UTC offset vs microseconds) across versions, so lexical order diverges from chronological order — the "Previous Versions" list mis-orders and a user could pick the labelled-newest entry and roll back to the wrong version. Both sites now order by `parse_iso_to_epoch(...) or 0.0` (the idiom every other site already uses). `latest_updated_at` stays the original ISO string (`max(..., key=...)`); only the comparison changed.

### #1012 — rollback skipped persisting preflight state on raise
`rollback_to_version` ran the destructive switch in `_rollback_to_version_io`, then persisted `save_state`. Only `do_upload_save` was try-wrapped inside the switch; if `do_download_save` (or the backup/rename I/O) raised, the exception propagated and the persist never ran — yet the pre-flight `do_sync_rom_saves` had already performed real uploads/downloads whose baselines/tracked-ids existed only in the discarded in-memory aggregate, so the next sync mis-classified (re-upload as new, or false conflict). The persist now runs in a `try/finally` around the switch; the exception still propagates.

### Tests
- `test_sorted_by_epoch_not_lexically` — version list ordered chronologically given a lexical-vs-chronological timestamp mismatch.
- `test_latest_updated_at_uses_epoch_not_lexical_order` — wizard slot's `latest_updated_at` picks the truly-newest ISO string, not the lexically-greatest.
- `test_preflight_state_persisted_when_switch_raises` — persist fires (and the exception still propagates) when the switch raises.

All three fail on the un-fixed code. Full suite green (3596 passed), ruff + basedpyright clean, all CI gates kept.

docs: N/A — correctness fixes (version ordering + rollback preflight persistence), no architecture/flow/UI change

Closes #1014
Closes #1012
