### PR TITLE
fix(sync): finalize sync state on cancel during a unit's fetch phase (#1035)

### DIFF
--- a/py_modules/domain/sync_state.py
+++ b/py_modules/domain/sync_state.py
@@ -7,3 +7,29 @@ class SyncState(Enum):
     IDLE = "idle"
     RUNNING = "running"
     CANCELLING = "cancelling"
+
+
+class SyncCancelled(Exception):
+    """Cooperative cancel signal for the library sync subsystem.
+
+    Raised by ``LibraryFetcher._check_cancelling`` (mid per-unit
+    pagination) and the ``SyncOrchestrator.sync_preview`` per-unit
+    checkpoint once a user cancel has flipped ``sync_state`` to
+    ``CANCELLING``. Caught only by the cooperative handlers (the
+    orchestrator's unit-loop and ``sync_preview`` ``except
+    SyncCancelled``), which route it into the graceful finalize. It is a
+    DISTINCT type from ``asyncio.CancelledError`` so a cooperative sync
+    cancel is never conflated with a real ``asyncio`` task cancellation
+    (the sync task is never ``task.cancel()``'d — ``cancel_sync`` only
+    sets the state flag), and the real-cancel handlers
+    (``build_work_queue``, the wait-loop sleep) keep
+    ``except asyncio.CancelledError`` so a genuine cancel still
+    propagates.
+
+    A plain ``Exception`` (not ``BaseException``): the only generic
+    ``except Exception`` on its propagation path (the fetcher's
+    ``list_roms`` guard) re-raises and carries an explicit
+    ``except SyncCancelled: raise`` so a cancel is never logged as a
+    fetch failure — so the signal reaches the cooperative handlers
+    untouched without relying on ``BaseException`` propagation.
+    """

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -12,17 +12,17 @@ elsewhere (per applied unit) so a fetch never mutates the cache.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
-from domain.sync_state import SyncState
+from domain.sync_state import SyncCancelled, SyncState
 from domain.work_unit import CollectionKind, WorkUnit
 from lib.errors import classify_error
 from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
+    import asyncio
     import logging
     from collections.abc import Awaitable, Callable
 
@@ -367,9 +367,9 @@ class LibraryFetcher:
         return platforms
 
     def _check_cancelling(self):
-        """Raise CancelledError if sync is being cancelled."""
+        """Raise SyncCancelled if sync is being cancelled."""
         if self._sync_state.sync_state == SyncState.CANCELLING:
-            raise asyncio.CancelledError(_SYNC_CANCELLED)
+            raise SyncCancelled(_SYNC_CANCELLED)
 
     # ── Per-unit work queue ──────────────────────────────────────
 
@@ -573,6 +573,13 @@ class LibraryFetcher:
                     limit,
                     offset,
                 )
+            except SyncCancelled:
+                # A cooperative cancel signalled mid-pagination is NOT a fetch
+                # failure — let it reach the orchestrator's ``except SyncCancelled``
+                # untouched, never logged as an error. (In production the signal
+                # is raised by ``_check_cancelling`` above, outside this ``try``;
+                # this guard also covers a cancel raised from within ``list_roms``.)
+                raise
             except Exception:
                 # Re-raise so the orchestrator aborts before the stale-cleanup
                 # pass runs against a partial list. Swallowing here would

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -243,9 +243,13 @@ class SyncOrchestrator:
                 "preview_id": preview_id,
             }
         except asyncio.CancelledError:
+            # sync_preview is a Decky callable — the frontend awaits its return.
+            # Re-raising leaves that promise unsettled, so a user-initiated
+            # cancel mid-preview returns the canonical failure shape instead of
+            # propagating the CancelledError out of the callable (#1035).
             box.pending_delta = None
             await self._finish_sync(_SYNC_CANCELLED)
-            raise
+            return {"success": False, "reason": "cancelled", "message": _SYNC_CANCELLED}
         except Exception as e:
             import traceback
 
@@ -446,24 +450,33 @@ class SyncOrchestrator:
             # SyncRun.start — short write UoW for the planned counts.
             await self._loop.run_in_executor(None, self._open_sync_run, run_id, platforms_planned, total_roms_planned)
 
-            for unit_index, unit in enumerate(work_queue):
-                if box.is_cancelling():
-                    cancelled = True
-                    break
+            try:
+                for unit_index, unit in enumerate(work_queue):
+                    if box.is_cancelling():
+                        cancelled = True
+                        break
 
-                applied = await self._sync_one_unit(
-                    unit,
-                    unit_index=unit_index,
-                    total_units=total_units,
-                    synced_rom_ids=synced_rom_ids,
-                    collection_memberships=collection_memberships,
-                    platform_rom_ids=platform_rom_ids,
-                )
-                total_games_applied += applied
+                    applied = await self._sync_one_unit(
+                        unit,
+                        unit_index=unit_index,
+                        total_units=total_units,
+                        synced_rom_ids=synced_rom_ids,
+                        collection_memberships=collection_memberships,
+                        platform_rom_ids=platform_rom_ids,
+                    )
+                    total_games_applied += applied
 
-                if box.is_cancelling():
-                    cancelled = True
-                    break
+                    if box.is_cancelling():
+                        cancelled = True
+                        break
+            except asyncio.CancelledError:
+                # A cooperative cancel delivered mid-fetch (fetcher._check_cancelling
+                # raised inside _sync_one_unit) bypasses the is_cancelling()
+                # checkpoints. Route it into the same graceful finalize the
+                # checkpoint break uses, so the SyncRun is marked cancelled and
+                # sync_state is restored to IDLE instead of wedging until a plugin
+                # reload (#1035).
+                cancelled = True
 
             # Final phase: stale cleanup + Steam collections + sync_complete.
             # Surface a non-terminal finalizing snapshot before the terminal

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -31,7 +31,7 @@ from domain.sync_diff import (
 )
 from domain.sync_run import SyncRun
 from domain.sync_stage import SyncStage
-from domain.sync_state import SyncState
+from domain.sync_state import SyncCancelled, SyncState
 from lib.errors import classify_error
 from lib.list_result import ErrorCode
 
@@ -184,7 +184,7 @@ class SyncOrchestrator:
             total_units = len(work_queue)
             for unit_index, unit in enumerate(work_queue, 1):
                 if box.is_cancelling():
-                    raise asyncio.CancelledError(_SYNC_CANCELLED)
+                    raise SyncCancelled(_SYNC_CANCELLED)
                 await self.emit_progress(
                     SyncStage.FETCHING,
                     current=len(all_roms),
@@ -242,11 +242,14 @@ class SyncOrchestrator:
                 "changed_names": [s["name"] for s in changed[:10]],
                 "preview_id": preview_id,
             }
-        except asyncio.CancelledError:
+        except SyncCancelled:
             # sync_preview is a Decky callable — the frontend awaits its return.
             # Re-raising leaves that promise unsettled, so a user-initiated
             # cancel mid-preview returns the canonical failure shape instead of
-            # propagating the CancelledError out of the callable (#1035).
+            # propagating the cooperative cancel out of the callable (#1035).
+            # SyncCancelled is a BaseException (not Exception), so it skips the
+            # generic ``except Exception`` below and lands here as a distinct
+            # cooperative signal — never conflated with a real asyncio cancel.
             box.pending_delta = None
             await self._finish_sync(_SYNC_CANCELLED)
             return {"success": False, "reason": "cancelled", "message": _SYNC_CANCELLED}
@@ -469,13 +472,15 @@ class SyncOrchestrator:
                     if box.is_cancelling():
                         cancelled = True
                         break
-            except asyncio.CancelledError:
+            except SyncCancelled:
                 # A cooperative cancel delivered mid-fetch (fetcher._check_cancelling
-                # raised inside _sync_one_unit) bypasses the is_cancelling()
-                # checkpoints. Route it into the same graceful finalize the
-                # checkpoint break uses, so the SyncRun is marked cancelled and
-                # sync_state is restored to IDLE instead of wedging until a plugin
-                # reload (#1035).
+                # raised SyncCancelled inside _sync_one_unit) bypasses the
+                # is_cancelling() checkpoints. Route it into the same graceful
+                # finalize the checkpoint break uses, so the SyncRun is marked
+                # cancelled and sync_state is restored to IDLE instead of wedging
+                # until a plugin reload (#1035). SyncCancelled is a BaseException,
+                # so a REAL asyncio.CancelledError raised mid-fetch is NOT caught
+                # here — it propagates out, never swallowed into the finalize.
                 cancelled = True
 
             # Final phase: stale cleanup + Steam collections + sync_complete.

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -8,11 +8,9 @@ per-method ``*_side_effect`` attributes (persistent) — no
 ``run_in_executor`` patching, no ``MagicMock(romm_api)``.
 """
 
-import asyncio
-
 import pytest
 
-from domain.sync_state import SyncState
+from domain.sync_state import SyncCancelled, SyncState
 from domain.work_unit import WorkUnit
 
 
@@ -31,7 +29,10 @@ class TestCheckCancelling:
 
     def test_raises_when_cancelling(self, plugin):
         plugin._sync_service._sync_state = SyncState.CANCELLING
-        with pytest.raises(asyncio.CancelledError):
+        # The cooperative cancel signal is the dedicated ``SyncCancelled``
+        # BaseException — NOT ``asyncio.CancelledError`` — so a cooperative
+        # sync cancel is never conflated with a real asyncio task cancel.
+        with pytest.raises(SyncCancelled):
             plugin._sync_service._fetcher._check_cancelling()
 
     def test_noop_when_running(self, plugin):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -701,7 +701,15 @@ class TestSyncPreviewErrorHandling:
         assert plugin._sync_service._pending_delta is None
 
     @pytest.mark.asyncio
-    async def test_cancelled_error_reraises(self, plugin, fake_romm_api):
+    async def test_cancelled_error_returns_canonical_failure(self, plugin, fake_romm_api):
+        """A cancel delivered during sync_preview RETURNS the canonical failure
+        shape — it does NOT re-raise out of the Decky callable (#1035).
+
+        sync_preview is awaited by the frontend; re-raising would leave that
+        promise unsettled. The cooperative cancel must surface as
+        ``{success: False, reason: "cancelled", message: ...}`` and leave
+        sync_state IDLE with no pending delta.
+        """
         import decky
 
         decky.emit.reset_mock()
@@ -710,8 +718,9 @@ class TestSyncPreviewErrorHandling:
         fake_romm_api.list_platforms_side_effect = asyncio.CancelledError("cancelled")
         plugin.settings["enabled_platforms"] = {"1": True}
 
-        with pytest.raises(asyncio.CancelledError):
-            await plugin._sync_service.sync_preview()
+        result = await plugin._sync_service.sync_preview()
+
+        assert result == {"success": False, "reason": "cancelled", "message": "Sync cancelled"}
         assert plugin._sync_service._sync_state == SyncState.IDLE
         assert plugin._sync_service._pending_delta is None
 
@@ -2098,6 +2107,61 @@ class TestDoSyncPerUnitErrors:
         ]
         assert len(error_events) >= 1
         assert plugin._sync_service._sync_state == SyncState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_cancel_mid_unit_fetch_finalizes_gracefully(self, plugin, fake_romm_api):
+        """A cooperative cancel delivered MID per-unit fetch recovers all state (#1035).
+
+        The cancel arrives while ``_sync_one_unit`` is fetching the unit's
+        ROMs (``fetcher._check_cancelling`` raising ``CancelledError`` from
+        inside ``list_roms``) — NOT at an ``is_cancelling()`` checkpoint and
+        NOT during ``build_work_queue``. On the un-fixed code that
+        ``BaseException`` escapes the outer ``except Exception``, leaving
+        sync_state stuck CANCELLING, the SyncRun stuck ``running``, and
+        sync_progress stuck ``running: True`` until a plugin reload.
+
+        The fix routes that mid-fetch CancelledError into the same graceful
+        finalize the checkpoint break uses. This asserts all three recovery
+        post-conditions AND that ``_do_sync_per_unit`` does NOT propagate the
+        CancelledError (contrast with the build_work_queue path, which
+        re-raises).
+        """
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # One live-fetch platform (no last_sync, empty registry) so the unit
+        # takes the real per-unit fetch rather than the incremental-skip path.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        # The per-unit ROM fetch raises CancelledError mid-flight — exactly
+        # how ``fetcher._check_cancelling`` signals a cooperative cancel that
+        # landed after the platform listing but before the unit ack.
+        fake_romm_api.list_roms_side_effect = asyncio.CancelledError("Sync cancelled")
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-mid-fetch-cancel"
+
+        # Must NOT propagate the CancelledError — awaiting returns normally.
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # 1. sync_state restored to IDLE (not stuck CANCELLING).
+        assert plugin._sync_service._sync_state == SyncState.IDLE
+        # 2. The SyncRun row is marked cancelled (not left ``running``).
+        with plugin._uow as uow:
+            run = uow.sync_runs.get("run-mid-fetch-cancel")
+        assert run is not None
+        assert run.status == "cancelled"
+        assert run.finished_at is not None
+        # 3. The persisted progress snapshot is no longer running.
+        assert plugin._sync_service._orchestrator.get_sync_status()["running"] is False
 
     @pytest.mark.asyncio
     async def test_cancelling_state_before_first_unit_skips_processing(self, plugin, fake_romm_api):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -702,27 +702,37 @@ class TestSyncPreviewErrorHandling:
 
     @pytest.mark.asyncio
     async def test_cancelled_error_returns_canonical_failure(self, plugin, fake_romm_api):
-        """A cancel delivered during sync_preview RETURNS the canonical failure
+        """A cooperative cancel during sync_preview RETURNS the canonical failure
         shape — it does NOT re-raise out of the Decky callable (#1035).
 
         sync_preview is awaited by the frontend; re-raising would leave that
-        promise unsettled. The cooperative cancel must surface as
-        ``{success: False, reason: "cancelled", message: ...}`` and leave
-        sync_state IDLE with no pending delta.
+        promise unsettled. The cooperative cancel — now the dedicated
+        ``SyncCancelled`` BaseException, matching the production signal raised
+        by ``fetcher._check_cancelling`` and the per-unit checkpoint — must
+        surface as ``{success: False, reason: "cancelled", message: ...}`` and
+        leave sync_state IDLE with no pending delta. ``SyncCancelled`` skips the
+        generic ``except Exception`` and lands in ``except SyncCancelled``.
         """
         import decky
+
+        from domain.sync_state import SyncCancelled
 
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
-        fake_romm_api.list_platforms_side_effect = asyncio.CancelledError("cancelled")
+        fake_romm_api.list_platforms = MagicMock(side_effect=SyncCancelled("Sync cancelled"))
         plugin.settings["enabled_platforms"] = {"1": True}
+
+        # sync_preview only runs from IDLE — guard against a leaked non-IDLE state.
+        assert plugin._sync_service._sync_state == SyncState.IDLE
 
         result = await plugin._sync_service.sync_preview()
 
         assert result == {"success": False, "reason": "cancelled", "message": "Sync cancelled"}
         assert plugin._sync_service._sync_state == SyncState.IDLE
         assert plugin._sync_service._pending_delta is None
+        # The cooperative signal genuinely originated from the fetch.
+        fake_romm_api.list_platforms.assert_called()
 
 
 # ──────────────────────────────────────────────────────────────
@@ -2113,19 +2123,25 @@ class TestDoSyncPerUnitErrors:
         """A cooperative cancel delivered MID per-unit fetch recovers all state (#1035).
 
         The cancel arrives while ``_sync_one_unit`` is fetching the unit's
-        ROMs (``fetcher._check_cancelling`` raising ``CancelledError`` from
+        ROMs (``fetcher._check_cancelling`` raising ``SyncCancelled`` from
         inside ``list_roms``) — NOT at an ``is_cancelling()`` checkpoint and
-        NOT during ``build_work_queue``. On the un-fixed code that
-        ``BaseException`` escapes the outer ``except Exception``, leaving
-        sync_state stuck CANCELLING, the SyncRun stuck ``running``, and
-        sync_progress stuck ``running: True`` until a plugin reload.
+        NOT during ``build_work_queue``. ``SyncCancelled`` is a
+        ``BaseException`` (like ``asyncio.CancelledError``), so it unwinds
+        through the fetcher's ``except Exception`` re-raise around ``list_roms``
+        untouched and lands in ``_do_sync_per_unit``'s dedicated
+        ``except SyncCancelled``. On the un-fixed code (raising
+        ``asyncio.CancelledError`` and catching it) sonar's S7497 would flag the
+        swallow; the refactor uses a distinct cooperative type so the swallow is
+        scoped to the cooperative signal only.
 
-        The fix routes that mid-fetch CancelledError into the same graceful
+        The handler routes that mid-fetch SyncCancelled into the same graceful
         finalize the checkpoint break uses. This asserts all three recovery
         post-conditions AND that ``_do_sync_per_unit`` does NOT propagate the
-        CancelledError (contrast with the build_work_queue path, which
-        re-raises).
+        cooperative cancel (contrast with the build_work_queue path, which
+        re-raises a real asyncio cancel).
         """
+        from domain.sync_state import SyncCancelled
+
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -2140,17 +2156,28 @@ class TestDoSyncPerUnitErrors:
         )
         plugin.settings["enabled_platforms"] = {"1": True}
 
-        # The per-unit ROM fetch raises CancelledError mid-flight — exactly
-        # how ``fetcher._check_cancelling`` signals a cooperative cancel that
-        # landed after the platform listing but before the unit ack.
-        fake_romm_api.list_roms_side_effect = asyncio.CancelledError("Sync cancelled")
+        # The per-unit ROM fetch raises SyncCancelled mid-flight — exactly how
+        # ``fetcher._check_cancelling`` now signals a cooperative cancel that
+        # landed after the platform listing but before the unit ack. A tracked
+        # MagicMock (not just ``list_roms_side_effect``) lets us pin that the
+        # signal was raised FROM the per-unit fetch — not bypassed by an early
+        # ``is_cancelling()`` checkpoint or the incremental-skip path, which would
+        # finalize gracefully for the WRONG reason.
+        fake_romm_api.list_roms = MagicMock(side_effect=SyncCancelled("Sync cancelled"))
 
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._sync_state = SyncState.RUNNING
         plugin._sync_service._current_sync_id = "run-mid-fetch-cancel"
 
-        # Must NOT propagate the CancelledError — awaiting returns normally.
+        # Guard against cross-test state leakage: a stale CANCELLING at entry
+        # would break the unit loop before the fetch and pass for the wrong reason.
+        assert plugin._sync_service._sync_state == SyncState.RUNNING
+
+        # Must NOT propagate the cooperative cancel — awaiting returns normally.
         await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # The cooperative signal genuinely originated from the per-unit fetch.
+        fake_romm_api.list_roms.assert_called()
 
         # 1. sync_state restored to IDLE (not stuck CANCELLING).
         assert plugin._sync_service._sync_state == SyncState.IDLE
@@ -2162,6 +2189,98 @@ class TestDoSyncPerUnitErrors:
         assert run.finished_at is not None
         # 3. The persisted progress snapshot is no longer running.
         assert plugin._sync_service._orchestrator.get_sync_status()["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_real_asyncio_cancel_mid_fetch_is_not_swallowed(self, plugin, fake_romm_api):
+        """A REAL ``asyncio.CancelledError`` mid per-unit fetch PROPAGATES (#1035).
+
+        This is the key safety guard the SyncCancelled split buys: the
+        cooperative cancel signal is now a DISTINCT type (``SyncCancelled``),
+        so the unit-loop ``except SyncCancelled`` does NOT catch a genuine
+        ``asyncio.CancelledError`` (e.g. the sync task being cancelled by the
+        runtime). Were the handler still ``except asyncio.CancelledError`` (the
+        S7497-flagged pre-refactor shape), this real cancel would be swallowed
+        into the graceful finalize and the run wrongly marked ``cancelled`` —
+        masking a real task cancellation.
+
+        The real cancel is injected at the ``list_roms`` layer, unwinds through
+        the fetcher's ``except Exception`` re-raise, skips the unit-loop
+        ``except SyncCancelled`` AND the outer ``except Exception`` (both narrower
+        than ``BaseException``), and propagates straight out of
+        ``_do_sync_per_unit``. The SyncRun is left ``running`` — it is NOT marked
+        cancelled by the cooperative swallow path.
+        """
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "A"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        # A genuine asyncio task cancellation lands mid-fetch — NOT the
+        # cooperative SyncCancelled signal. A tracked MagicMock guarantees a
+        # 'DID NOT RAISE' can never be a silent fetch bypass: list_roms.assert_called()
+        # below pins that the real cancel originated from the per-unit fetch.
+        fake_romm_api.list_roms = MagicMock(side_effect=asyncio.CancelledError("real task cancel"))
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-real-cancel"
+
+        # Guard against cross-test state leakage (a stale CANCELLING would break
+        # the loop before the fetch and the cancel would never fire).
+        assert plugin._sync_service._sync_state == SyncState.RUNNING
+
+        # The real cancel must PROPAGATE OUT — the cooperative handler does not
+        # catch it.
+        with pytest.raises(asyncio.CancelledError):
+            await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # The cancel genuinely fired from the per-unit fetch (not a bypass).
+        fake_romm_api.list_roms.assert_called()
+
+        # The run is NOT marked cancelled by the swallow path — a real task
+        # cancel leaves the SyncRun ``running`` (never routed through the
+        # graceful cooperative finalize).
+        with plugin._uow as uow:
+            run = uow.sync_runs.get("run-real-cancel")
+        assert run is not None
+        assert run.status == "running"
+        assert run.finished_at is None
+
+    @pytest.mark.asyncio
+    async def test_real_asyncio_cancel_mid_preview_is_not_swallowed(self, plugin, fake_romm_api):
+        """A REAL ``asyncio.CancelledError`` mid sync_preview PROPAGATES (#1035).
+
+        Symmetric to the per-unit guard: ``sync_preview``'s
+        ``except SyncCancelled`` catches only the cooperative signal. A genuine
+        ``asyncio.CancelledError`` injected at the fetch layer skips it (and the
+        generic ``except Exception``) and propagates straight out of the
+        callable — it is NOT mapped onto the canonical ``cancelled`` failure
+        dict. The ``finally`` still restores sync_state to IDLE.
+        """
+        _use_fake_romm(plugin, fake_romm_api)
+
+        fake_romm_api.list_platforms = MagicMock(side_effect=asyncio.CancelledError("real task cancel"))
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        # sync_preview only runs from IDLE — guard against a leaked non-IDLE state
+        # that would short-circuit it to "sync_in_progress" before the fetch.
+        assert plugin._sync_service._sync_state == SyncState.IDLE
+
+        with pytest.raises(asyncio.CancelledError):
+            await plugin._sync_service.sync_preview()
+
+        # The cancel genuinely fired from the fetch, not a bypass.
+        fake_romm_api.list_platforms.assert_called()
+
+        # The ``finally`` block always restores IDLE, even on a propagated cancel.
+        assert plugin._sync_service._sync_state == SyncState.IDLE
 
     @pytest.mark.asyncio
     async def test_cancelling_state_before_first_unit_skips_processing(self, plugin, fake_romm_api):


### PR DESCRIPTION
## Wave 1 — sync cancel-state wedge (#1121)

`cancel_sync()` sets `sync_state = CANCELLING` cooperatively (it does **not** call `task.cancel()`; the sync task is fire-and-forget). Mid-unit-fetch, `fetcher._check_cancelling()` raises a cancel signal. In `_do_sync_per_unit` that signal bypassed the `is_cancelling()` checkpoints, escaped the outer `except Exception`, and there was no `finally` — leaving `sync_state` stuck `CANCELLING`, the `SyncRun` row stuck `running`, and `sync_progress` stuck `running: true`. User-visible: Cancel returns "No sync in progress", "Sync Library" returns "Sync already in progress" forever, and a reopened QAM re-seeds a phantom progress bar — recoverable only by a Steam/plugin restart.

### Fix
- The unit loop catches the cooperative cancel signal and routes into the **existing** `cancelled=True` finalize path — marking the `SyncRun` cancelled and restoring `sync_state` to IDLE via the reporter, exactly as the `is_cancelling()` checkpoint break already does.
- `sync_preview` (a Decky callable) re-raised the signal, leaving the frontend's awaited promise unsettled; it now returns the canonical failure shape `{success: False, reason: "cancelled", message}`.

### Cooperative cancel is its own signal type — `SyncCancelled`
The cooperative cancel was raised as `asyncio.CancelledError`, which SonarCloud S7497 (correctly) flags when swallowed without re-raise — but re-raising would re-wedge sync. The root cause is abusing `asyncio.CancelledError` as a non-cancellation signal. A dedicated `domain.sync_state.SyncCancelled` (a plain `Exception`) now carries the cooperative signal, a **distinct type** so a cooperative cancel is never conflated with a real asyncio task cancellation. `fetcher._check_cancelling` and the `sync_preview` checkpoint raise `SyncCancelled`; the unit-loop and `sync_preview` handlers catch it and finalize gracefully. The `build_work_queue` and wait-loop handlers keep `except asyncio.CancelledError` (real cancellation, re-raised — S7497-compliant), so a **genuine task cancel now propagates instead of being swallowed** (a latent bug the old shape carried).

The cooperative propagation path was audited to carry no swallowing `except Exception` (the orchestrator wrappers and `_sync_one_unit` have none; the fetcher's `list_roms` guard re-raises and carries an explicit `except SyncCancelled: raise` so a cancel is never logged as a fetch failure), so a plain `Exception` reaches the handlers untouched — no `BaseException` needed (which would trip Sonar S5709). No behavioural regression: only the matched exception type in the `except` clauses changed.

### Tests
- `test_cancel_mid_unit_fetch_finalizes_gracefully` — cooperative cancel injected mid-`_sync_one_unit` fetch; asserts all three recovery states + non-propagation, with a tracked fetch mock + entry-state assert proving the signal originated from the fetch (not a checkpoint/incremental-skip bypass).
- `test_real_asyncio_cancel_mid_fetch_is_not_swallowed` / `..._mid_preview_...` — a **real** `asyncio.CancelledError` propagates out (is NOT swallowed by the cooperative handler); the run is left `running`.
- `test_cancelled_error_returns_canonical_failure` — `sync_preview` cancel returns the canonical failure dict, state IDLE.
- `test_fetcher.py` `TestCheckCancelling` asserts `_check_cancelling` raises `SyncCancelled`.
- The real-asyncio-cancel tests for `build_work_queue` and the wait-loop sleep are unchanged and still pass.

All tests fail on the un-refactored code (proven by temporary revert). Full suite green (3596 passed), ruff + basedpyright clean, import-linter 8/8, cosmic call bans + failure-shape gate pass.

### On-device smoke — passed
Confirmed on a Steam Deck: sync a large library, Cancel mid-fetch → Cancel succeeds, the progress bar clears, a second "Sync Library" starts normally (no wedge), QAM reopen shows no phantom progress, all without a plugin reload.

docs: N/A — correctness fix (cancel-state finalization), no architecture/flow/UI change

Closes #1035

