### PR TITLE
fix(saves): skip launch-gate conflict round-trip when save sync is disabled (#1056)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1098,11 +1098,12 @@ names and constraints.
 The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
 `autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this aggregate.
 `save_sync_enabled` is the master feature toggle — when it is off, the universal launch gate
-(`LaunchGateService.evaluate`) skips the save-status round-trip and never blocks a launch on a save conflict, so a stale
-server-side conflict (e.g. another device moved the save) can't render a game unplayable while the feature is disabled
-and its SAVES tab is hidden. `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs;
-`default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on
-the server (10).
+(`LaunchGateService.evaluate`) skips the save-status round-trip, and `get_save_status` itself returns an empty
+`conflicts` array, so no consumer (the launch gate, the play button, the `save_status_updated` push that `index.tsx`
+forwards) surfaces a conflict the user has no UI to resolve — the SAVES tab where one would resolve it is hidden while
+disabled. A stale server-side conflict (e.g. another device moved the save) therefore can't render a game unplayable.
+`sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs; `default_slot` is the slot new
+games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on the server (10).
 
 Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom_saves` and `_get_save_status_io` and
 surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1097,9 +1097,12 @@ names and constraints.
 
 The save-sync feature toggles (`save_sync_enabled`, `sync_before_launch`, `sync_after_exit`, `default_slot`,
 `autocleanup_limit`) and the device label (`device_name`) live in `settings.json` (ADR-0003), not in this aggregate.
-`save_sync_enabled` is the master feature toggle; `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch
-/ post-exit syncs; `default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save
-versions per slot on the server (10).
+`save_sync_enabled` is the master feature toggle — when it is off, the universal launch gate
+(`LaunchGateService.evaluate`) skips the save-status round-trip and never blocks a launch on a save conflict, so a stale
+server-side conflict (e.g. another device moved the save) can't render a game unplayable while the feature is disabled
+and its SAVES tab is hidden. `sync_before_launch` / `sync_after_exit` gate the automatic pre-launch / post-exit syncs;
+`default_slot` is the slot new games adopt (`"default"`); `autocleanup_limit` caps retained save versions per slot on
+the server (10).
 
 Conflicts are no longer persisted. They are returned ephemerally from `_sync_rom_saves` and `_get_save_status_io` and
 surfaced via the modal at the moment of the sync. If the user dismisses the modal (Cancel), the conflict re-fires on the

--- a/py_modules/services/launch_gate.py
+++ b/py_modules/services/launch_gate.py
@@ -38,8 +38,9 @@ class LaunchVerdict:
     """Outcome of a pre-launch evaluation for a single Steam app id.
 
     ``action="allow"`` means the launch may proceed (the ROM is either
-    not a RomM ROM, is installed with no save conflict, or the save
-    status check failed for a ROM with no tracked saves). ``action="warn"``
+    not a RomM ROM, is installed with save-sync disabled, is installed
+    with no save conflict, or the save status check failed for a ROM
+    with no tracked saves). ``action="warn"``
     means the launch may proceed but the frontend should surface a
     soft toast — used when ``get_save_status`` failed for a ROM that
     *does* have tracked saves, where silent allow would risk data loss
@@ -108,6 +109,7 @@ class LaunchGateService:
         -------
         LaunchVerdict
             ``allow`` when the app is not a RomM ROM, when the ROM is
+            installed but save-sync is disabled, when the ROM is
             installed with no save conflict, or when the save-status
             read failed for a ROM with no tracked saves. ``warn`` with
             ``reason="save_status_failed"`` when the save-status read
@@ -131,6 +133,15 @@ class LaunchGateService:
                 toast_title=_TOAST_TITLE_NOT_INSTALLED,
                 toast_body=_TOAST_BODY_NOT_INSTALLED,
             )
+
+        # Save-sync off → there is no conflict state to gate on. Allow the
+        # launch and skip the get_save_status round-trip entirely. Otherwise a
+        # stale server-side conflict (e.g. another device moved the save while
+        # sync was disabled) would block every launch with no way to resolve
+        # it — the Saves tab is hidden while the feature is off — leaving the
+        # game permanently unplayable.
+        if not self._save_status_reader.is_save_sync_enabled():
+            return LaunchVerdict(action="allow")
 
         try:
             save_status = await self._save_status_reader.get_save_status(rom_id)

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -148,13 +148,18 @@ class LaunchGateSaveStatusReader(Protocol):
     """Save-status surface consumed by LaunchGateService.
 
     The composition root satisfies this with ``SaveService``. The gate
-    calls ``get_save_status`` for the canonical conflict signal (a
-    non-empty ``conflicts`` array blocks the launch) and falls back to
-    the synchronous ``has_tracked_save`` in-memory check to decide
+    first consults ``is_save_sync_enabled`` — when the feature toggle is
+    off there is no conflict state to gate on, so the gate allows the
+    launch and skips the ``get_save_status`` round-trip entirely. With
+    save-sync on, it calls ``get_save_status`` for the canonical conflict
+    signal (a non-empty ``conflicts`` array blocks the launch) and falls
+    back to the synchronous ``has_tracked_save`` in-memory check to decide
     whether a ``get_save_status`` failure should be soft-warned (ROM has
     tracked saves — silent allow would risk data loss) or silently
     allowed (no tracked saves — nothing to corrupt).
     """
+
+    def is_save_sync_enabled(self) -> bool: ...
 
     async def get_save_status(self, rom_id: int) -> dict[str, Any]: ...
 

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -254,6 +254,16 @@ class StatusService:
         playtime_dict = _playtime_to_dict(playtime)
         last_sync_check_at = save_state.last_sync_check_at if save_state else None
 
+        # Save sync disabled → suppress the conflict signal at the source. Every
+        # consumer (launch gate, the play button, the save_status_updated emit
+        # that index.tsx forwards) reads this single ``conflicts`` array, and the
+        # SAVES tab that would resolve a conflict is hidden while disabled — so a
+        # surfaced conflict is one the user has no UI to clear (#1056). The launch
+        # gate already short-circuits before calling here; this closes the same
+        # hole for any other caller.
+        if not save_sync_enabled(self._settings):
+            conflicts = []
+
         # When saves go to the content dir, override the display with a clear
         # "not supported" status — no local files were probed, so the normal
         # computation would report a misleading "No saves" (#239).

--- a/tests/contract/test_launch_gate.py
+++ b/tests/contract/test_launch_gate.py
@@ -1,0 +1,58 @@
+"""Contract tests for the ``evaluate_launch`` launch-gate callable.
+
+Driven frontend-shaped per ``src/api/backend.ts``: ``evaluate_launch`` takes a
+single positional Steam app id and returns the ``LaunchVerdict`` dict
+(``action`` / ``reason`` / ``toast_title`` / ``toast_body``).
+
+The save-sync-disabled cases are the #1056 regression guard: with the feature
+off, an installed ROM must launch (``action="allow"``) and the gate must not
+perform a RomM ``list_saves`` round-trip — even when a server save exists that
+would otherwise surface as a conflict. The enabled case is the control proving
+the round-trip is a real, toggle-driven difference, not an unconditional skip.
+"""
+
+from __future__ import annotations
+
+from ._seed import enable_save_sync, seed_install, seed_rom, seed_server_save
+
+
+def _call_names(harness) -> list[str]:
+    return [entry[0] for entry in harness.romm.call_log]
+
+
+async def test_evaluate_launch_disabled_allows_and_skips_round_trip(harness):
+    """Save-sync off + installed ROM → allow, and no ``list_saves`` round-trip."""
+    harness.plugin.settings["save_sync_enabled"] = False
+    seed_install(harness, 1)  # rom_id=1; shortcut_app_id defaults to rom_id, so app id 1 maps
+    # A server save that the gate WOULD read (and could surface as a conflict)
+    # if it ran the status round-trip — it must not.
+    seed_server_save(harness, save_id=10, rom_id=1)
+
+    verdict = await harness.plugin.evaluate_launch(1)
+
+    assert verdict["action"] == "allow"
+    assert verdict["reason"] is None
+    assert "list_saves" not in _call_names(harness)
+
+
+async def test_evaluate_launch_disabled_still_blocks_not_installed(harness):
+    """The disabled-allow is gated behind the not-installed check — uninstalled still blocks."""
+    harness.plugin.settings["save_sync_enabled"] = False
+    seed_rom(harness, 1, shortcut_app_id=1)  # bound shortcut, but NOT installed
+
+    verdict = await harness.plugin.evaluate_launch(1)
+
+    assert verdict["action"] == "block"
+    assert verdict["reason"] == "not_installed"
+    assert "list_saves" not in _call_names(harness)
+
+
+async def test_evaluate_launch_enabled_performs_round_trip(harness):
+    """Control: save-sync on + installed → the gate DOES read save status (list_saves called)."""
+    enable_save_sync(harness)
+    seed_install(harness, 1)
+
+    verdict = await harness.plugin.evaluate_launch(1)
+
+    assert verdict["action"] in {"allow", "warn", "block"}
+    assert "list_saves" in _call_names(harness)

--- a/tests/services/saves/test_status.py
+++ b/tests/services/saves/test_status.py
@@ -211,6 +211,49 @@ class TestGetSaveStatusComputeAction:
         assert c["server_save_id"] == 100
         assert "created_at" in c
 
+    def test_get_save_status_suppresses_conflicts_when_save_sync_disabled(self, tmp_path):
+        """#1056: with save sync disabled, the conflict signal is empty at the source.
+
+        Every consumer (launch gate, play button, the ``save_status_updated``
+        emit that index.tsx forwards) reads this single ``conflicts`` array, and
+        the SAVES tab that would resolve a conflict is hidden while disabled.
+        Non-vacuous: the identical setup is conflict-producing while enabled, so
+        the toggle is the only thing that changes the outcome.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc)
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"diverged local")
+
+        ss = _server_save_with_syncs(
+            device_syncs=[{"device_id": "device-1", "is_current": False}],
+        )
+        fake.saves[100] = ss
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "files": {
+                    "pokemon.srm": {
+                        "tracked_save_id": 100,
+                        "last_sync_hash": "0" * 32,
+                        "last_sync_server_updated_at": "2025-01-01T00:00:00Z",
+                    }
+                }
+            },
+        )
+
+        # Sanity: the identical setup is conflict-producing while save sync is on.
+        assert len(svc._status._get_save_status_io(42, [ss])["conflicts"]) == 1
+
+        # Disable save sync → the conflict array is empty; the rest of the
+        # payload is still produced (only the conflict signal is gated).
+        svc._config.settings["save_sync_enabled"] = False
+        result = svc._status._get_save_status_io(42, [ss])
+        assert result["conflicts"] == []
+        assert result["rom_id"] == 42
+        assert "files" in result
+
     def test_get_save_status_status_field_mapping(self, tmp_path):
         """Skip→synced, Upload→upload, Download→download, Conflict→conflict."""
         svc, fake = make_service(tmp_path)

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -56,12 +56,17 @@ class FakeSaveStatusReader:
         payload: dict[str, Any] | None = None,
         side_effect: BaseException | None = None,
         tracked_rom_ids: set[int] | None = None,
+        save_sync_enabled: bool = True,
     ) -> None:
         self.payload: dict[str, Any] = payload if payload is not None else {"conflicts": []}
         self.side_effect = side_effect
         self.tracked_rom_ids: set[int] = tracked_rom_ids if tracked_rom_ids is not None else set()
+        self.save_sync_enabled = save_sync_enabled
         self.calls: list[int] = []
         self.tracked_calls: list[int] = []
+
+    def is_save_sync_enabled(self) -> bool:
+        return self.save_sync_enabled
 
     async def get_save_status(self, rom_id: int) -> dict[str, Any]:
         self.calls.append(rom_id)
@@ -319,3 +324,52 @@ class TestEvaluateEdgeCases:
         verdict = event_loop.run_until_complete(service.evaluate(42))
 
         assert verdict == LaunchVerdict(action="allow")
+
+
+class TestEvaluateSaveSyncDisabled:
+    def test_disabled_installed_allows_and_skips_status_round_trip(self, event_loop, logger):
+        """Save-sync off + installed → allow, even with a server-side conflict, and ``get_save_status`` is never called.
+
+        Regression for #1056: a stale conflict (another device moved the save
+        while sync was disabled) must not block the launch, and the gate must
+        not perform a RomM round-trip on every direct launch while the feature
+        is off.
+        """
+        rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99, "name": "Game"}})
+        installed_checker = FakeInstalledChecker(installed={99: _installed_rom(99)})
+        save_status_reader = FakeSaveStatusReader(
+            payload={"conflicts": [{"type": "sync_conflict", "rom_id": 99, "filename": "game.srm"}]},
+            save_sync_enabled=False,
+        )
+        service = _make_service(
+            rom_lookup=rom_lookup,
+            installed_checker=installed_checker,
+            save_status_reader=save_status_reader,
+            logger=logger,
+        )
+
+        verdict = event_loop.run_until_complete(service.evaluate(42))
+
+        assert verdict == LaunchVerdict(action="allow")
+        assert installed_checker.calls == [99]
+        # The conflict round-trip must be skipped entirely while save-sync is off.
+        assert save_status_reader.calls == []
+        assert save_status_reader.tracked_calls == []
+
+    def test_disabled_still_blocks_not_installed(self, event_loop, logger):
+        """The save-sync-disabled allow is gated behind the not-installed check — uninstalled still blocks."""
+        rom_lookup = FakeRomLookup(mapping={42: {"rom_id": 99}})
+        installed_checker = FakeInstalledChecker(installed={})  # not installed
+        save_status_reader = FakeSaveStatusReader(save_sync_enabled=False)
+        service = _make_service(
+            rom_lookup=rom_lookup,
+            installed_checker=installed_checker,
+            save_status_reader=save_status_reader,
+            logger=logger,
+        )
+
+        verdict = event_loop.run_until_complete(service.evaluate(42))
+
+        assert verdict.action == "block"
+        assert verdict.reason == "not_installed"
+        assert save_status_reader.calls == []


### PR DESCRIPTION
## Problem

`LaunchGateService.evaluate` had no `save_sync_enabled` check — the conflict matrix ran and the gate blocked on conflicts regardless of whether save sync was on. Scenario: track saves → disable sync → keep playing while another device moves the server save → every launch (including the interceptor path) is cancelled with "open game page to resolve". But the SAVES tab is hidden when save sync is off, so there is no resolution UI: the game is unplayable until the user guesses to re-enable save sync. Side effect: every direct launch performs a RomM round-trip even with the feature off.

## Fix

Two guards, both keyed on `save_sync_enabled` — exactly what #1056's fix section asked for ("launch gate **and** `get_save_status`'s conflict arm treat save-sync-disabled as allow/skip"):

1. **Launch gate** (`launch_gate.py`): a guard in `evaluate`, after the not-installed check and before the `get_save_status` read — when save sync is disabled, return `allow` and skip the round-trip entirely. The not-installed block is unaffected. The guard reads a new `is_save_sync_enabled()` method on the `LaunchGateSaveStatusReader` cross-service seam, already satisfied by `SaveService` — so `bootstrap` wiring is unchanged.

2. **Conflict signal at the source** (`saves/status/service.py`): `_get_save_status_io` returns an empty `conflicts` array when save sync is disabled. Every consumer reads this single array — the launch gate, the play button (`CustomPlayButton`), and the `save_status_updated` emit that `index.tsx` forwards — so suppressing it at the source closes the path where a conflict could surface while the SAVES tab (the only place to resolve one) is hidden. Defense-in-depth complementing guard 1.

## Tests

- `tests/services/test_launch_gate.py` — disabled + installed (with a would-be conflict) → `allow`, and `get_save_status` is never called; disabled still blocks not-installed.
- `tests/contract/test_launch_gate.py` (new) — real-bootstrap `evaluate_launch`: disabled allows with no `list_saves` round-trip, disabled still blocks not-installed, plus an enabled control proving the round-trip otherwise happens.
- `tests/services/saves/test_status.py` — the identical conflict-producing setup yields 1 conflict while enabled and 0 while disabled (the toggle is the only thing that changes).

## Docs

`docs/architecture/save-file-sync-architecture.md` — the master-toggle paragraph documents that disabling save sync skips the launch-gate round-trip **and** empties `get_save_status`'s conflict array, so no consumer surfaces an unresolvable conflict.

## On-device verification

Verified on a Steam Deck: with save sync disabled and a real two-sided conflict present (a server-side save that isn't ours as the slot head + a diverged local `.srm`), Golden Sun (GBA) launched normally and ran a full session — the gate allowed instead of the old permanent block. The play button correctly showed **Play** (not a conflict/Resolve state) while disabled.

Closes #1056
