### PR TITLE
fix(saves): check confirmSlotChoice success in the automated setup paths (#1009)

### DIFF
--- a/src/utils/saveSetup.test.ts
+++ b/src/utils/saveSetup.test.ts
@@ -99,6 +99,30 @@ describe("applyLaunchGateSetupOutcome", () => {
     expect(deps.dispatchSavesTab).not.toHaveBeenCalled();
   });
 
+  it("aborts and routes to the saves tab when confirmSlotChoice resolves success:false", async () => {
+    // #1009: a resolved failure (not a throw) must not let the launch proceed
+    // with save tracking unconfigured. The backend returns {success:false}
+    // without throwing, so only this branch catches it.
+    const deps = makeLaunchGateDeps({
+      confirmSlotChoice: vi.fn().mockResolvedValue({ success: false, message: "slot taken" }),
+    });
+    const result = await applyLaunchGateSetupOutcome({ kind: "auto_confirm", slot: "main" }, deps);
+    expect(result).toBe("abort");
+    expect(deps.confirmSlotChoice).toHaveBeenCalledWith(42, "main", false, null);
+    expect(deps.toast).toHaveBeenCalledWith("slot taken");
+    expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the generic toast when confirmSlotChoice fails without a message", async () => {
+    const deps = makeLaunchGateDeps({
+      confirmSlotChoice: vi.fn().mockResolvedValue({ success: false }),
+    });
+    const result = await applyLaunchGateSetupOutcome({ kind: "auto_confirm", slot: "main" }, deps);
+    expect(result).toBe("abort");
+    expect(deps.toast).toHaveBeenCalledWith(expect.stringContaining("Couldn't configure save sync"));
+    expect(deps.dispatchSavesTab).toHaveBeenCalledOnce();
+  });
+
   it("toasts the configure-in-saves-tab copy, dispatches the tab switch, and aborts on needs_user_choice", async () => {
     const deps = makeLaunchGateDeps();
     const result = await applyLaunchGateSetupOutcome({ kind: "needs_user_choice" }, deps);
@@ -192,6 +216,23 @@ describe("applyWizardInitialSetupResult", () => {
     await applyWizardInitialSetupResult(result, deps);
     expect(deps.setError).toHaveBeenCalledWith(expect.stringContaining("Auto-setup failed:"));
     expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining("SlotSetupWizard auto-confirm failed:"));
+    expect(deps.setConfirming).toHaveBeenNthCalledWith(1, true);
+    expect(deps.setConfirming).toHaveBeenNthCalledWith(2, false);
+    expect(deps.setInfo).toHaveBeenCalledWith(result);
+    expect(deps.onComplete).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a resolved success:false confirm without calling onComplete", async () => {
+    // #1009: a {success:false} that does NOT throw is exactly what the backend
+    // returns on a failed confirm — the automated path must treat it like the
+    // manual path (SlotSetupWizard), not complete with tracking unconfigured.
+    const deps = makeWizardDeps({
+      confirmSlotChoice: vi.fn().mockResolvedValue({ success: false, message: "slot taken" }),
+    });
+    const result = makeInfo({ recommended_action: "auto_confirm_default", default_slot: "alpha" });
+    await applyWizardInitialSetupResult(result, deps);
+    expect(deps.setError).toHaveBeenCalledWith(expect.stringContaining("slot taken"));
+    expect(deps.logError).toHaveBeenCalledWith(expect.stringContaining("success=false"));
     expect(deps.setConfirming).toHaveBeenNthCalledWith(1, true);
     expect(deps.setConfirming).toHaveBeenNthCalledWith(2, false);
     expect(deps.setInfo).toHaveBeenCalledWith(result);

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -48,6 +48,10 @@ export const SERVER_UNREACHABLE_TOAST_BODY =
 
 const NEEDS_USER_CHOICE_TOAST_BODY = "Configure save sync in the Saves tab first";
 
+/** Fallback toast body when `confirmSlotChoice` resolves to `success: false`
+ *  without a message — used by both automated setup paths. */
+const CONFIRM_FAILED_TOAST_BODY = "Couldn't configure save sync — open the Saves tab to finish setup.";
+
 /** Side-effect bundle for the launch-gate handler. The component supplies
  *  Decky's `toaster.toast` and the global event dispatch; tests pass spies. */
 export interface LaunchGateSetupDeps {
@@ -59,7 +63,7 @@ export interface LaunchGateSetupDeps {
     slot: string | null,
     migrate: boolean,
     migrateFrom: string | null,
-  ) => Promise<unknown>;
+  ) => Promise<{ success?: boolean; message?: string } | undefined>;
   /** Shows a Decky toast — wrapped as a callback so the helper is dispatch-agnostic. */
   toast: (body: string) => void;
   /** Switches to the Saves tab — wrapped as a callback so the helper is
@@ -81,7 +85,15 @@ export async function applyLaunchGateSetupOutcome(
   }
   if (outcome.kind === "auto_confirm") {
     // Auto-confirm of a named/default slot — never migrate.
-    await deps.confirmSlotChoice(deps.rid, outcome.slot, false, null);
+    const result = await deps.confirmSlotChoice(deps.rid, outcome.slot, false, null);
+    if (result?.success === false) {
+      // A resolved failure (not a throw) must not let the launch proceed with
+      // save tracking unconfigured — route to the Saves tab like the other
+      // abort branches (#1009).
+      deps.toast(result.message || CONFIRM_FAILED_TOAST_BODY);
+      deps.dispatchSavesTab();
+      return "abort";
+    }
     return "proceed";
   }
   // Server has saves — user must configure in saves tab.
@@ -100,7 +112,7 @@ export interface WizardSetupDeps {
     slot: string | null,
     migrate: boolean,
     migrateFrom: string | null,
-  ) => Promise<{ success?: boolean } | undefined>;
+  ) => Promise<{ success?: boolean; message?: string } | undefined>;
   setError: (message: string | null) => void;
   setConfirming: (confirming: boolean) => void;
   setInfo: (info: SaveSetupInfo) => void;
@@ -128,8 +140,19 @@ export async function applyWizardInitialSetupResult(result: SaveSetupInfo, deps:
     deps.setConfirming(true);
     try {
       // Auto-confirm of the default slot — never migrate.
-      await deps.confirmSlotChoice(deps.romId, result.default_slot, false, null);
-      if (!deps.isCancelled()) deps.onComplete();
+      const confirmResult = await deps.confirmSlotChoice(deps.romId, result.default_slot, false, null);
+      if (deps.isCancelled()) return;
+      if (confirmResult?.success === false) {
+        // Resolved failure (not a throw): mirror the catch branch — surface the
+        // error and re-hydrate the wizard rather than completing with save
+        // tracking unconfigured (#1009).
+        deps.setError(`Auto-setup failed: ${confirmResult.message || "could not confirm slot"}`);
+        deps.logError(`SlotSetupWizard auto-confirm returned success=false: ${confirmResult.message ?? ""}`);
+        deps.setConfirming(false);
+        deps.setInfo(result);
+        return;
+      }
+      deps.onComplete();
     } catch (e) {
       if (!deps.isCancelled()) {
         deps.setError(`Auto-setup failed: ${e}`);


### PR DESCRIPTION
## Problem

The two **automated** slot-setup paths in `src/utils/saveSetup.ts` — `applyLaunchGateSetupOutcome` and `applyWizardInitialSetupResult` — `await confirmSlotChoice(...)` and proceed (`return "proceed"` / `onComplete()`) without inspecting `result.success`. The backend returns a resolved `{success: false, message}` on a failed confirm (no throw), so only a transport error hits the `catch`. A failed confirm therefore lets the game launch / the wizard complete with **save tracking unconfigured** — exactly the state the wizard exists to prevent. The manual path (`SlotSetupWizard.tsx:132`) already checks `result.success`; the two automated paths didn't.

## Fix

Both automated paths now branch on `result?.success === false`:

- **Launch gate** (`applyLaunchGateSetupOutcome`): toast the backend `message` (or a generic fallback) + route to the Saves tab + return `"abort"` — the same shape as the existing abort branches.
- **Wizard** (`applyWizardInitialSetupResult`): surface the error, re-hydrate the wizard via `setInfo`, reset `setConfirming(false)`, and skip `onComplete()` — mirroring the existing `catch` branch.

The DI `confirmSlotChoice` types are tightened from `Promise<unknown>` / `{success?: boolean}` to carry `{success?: boolean; message?: string}` so the message can be surfaced.

## Tests

`src/utils/saveSetup.test.ts` — resolved-failure cases (a `{success:false}` that does **not** throw, which is what the backend actually returns) for both paths: the launch gate aborts and toasts the message (plus a generic-fallback case), and the wizard surfaces the error and does not call `onComplete`. Resolved-failure is precisely the gap the existing exception-only tests missed. Full frontend suite stays green (1257 tests).

## Docs

`docs: N/A` — internal robustness fix. No user-facing flow change (a failed setup now surfaces an error / aborts the launch instead of silently proceeding with broken tracking); no backend change, no architecture shift.

Closes #1009
