### PR TITLE
fix(saves): surface pre-launch and resolve-conflict failures without an errors array (#1050)

### DIFF
--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -776,4 +776,133 @@ describe("CustomPlayButton — pre-launch failure shapes without an errors array
     // Still in the conflict state — not dropped to "play".
     await findByText("Resolve Conflict");
   });
+
+  it("proceeds with the synced toast and no confirm on a clean pre-launch sync", async () => {
+    mockCachedDetail();
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 1,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled());
+    expect(vi.mocked(showModal)).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(expect.objectContaining({ body: "Saves synced with RomM" }));
+  });
+
+  it("falls back to the generic confirm when pre-launch sync throws (catch path)", async () => {
+    mockCachedDetail();
+    vi.mocked(backend.preLaunchSync).mockRejectedValue(new Error("network down"));
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(showModal)).toHaveBeenCalled());
+    // No backend message on a throw → the generic copy (the no-message branch).
+    expect(lastModalProps().strDescription).toContain("Couldn't sync saves with RomM server");
+    await act(async () => {
+      lastModalProps().onCancel?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a minimal failure shape with no reason or errors and launches on confirm", async () => {
+    mockCachedDetail();
+    // No reason / errors / synced — exercises the `reason ?? ""` and
+    // `errors?.join() ?? ""` fallbacks in the failure-debug log.
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({ success: false, message: "Save sync unavailable" });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(showModal)).toHaveBeenCalled());
+    expect(lastModalProps().strDescription).toContain("Save sync unavailable");
+    await act(async () => {
+      lastModalProps().onOK?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalled();
+  });
+
+  it("returns to the Play button when resolve-conflict sync succeeds", async () => {
+    mockCachedDetail();
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 42, has_conflict: true } }),
+      );
+    });
+    const resolveBtn = await findByText("Resolve Conflict");
+
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    await act(async () => {
+      resolveBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await findByText("Play");
+    expect(queryByText("Resolve Conflict")).toBeNull();
+  });
+
+  it("shows the generic resolve toast when the failed resolve carries no message", async () => {
+    mockCachedDetail();
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 42, has_conflict: true } }),
+      );
+    });
+    const resolveBtn = await findByText("Resolve Conflict");
+
+    // Empty message → the `|| "Couldn't resolve conflict…"` fallback body.
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: false,
+      message: "",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    await act(async () => {
+      resolveBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("Couldn't resolve conflict") }),
+    );
+    await findByText("Resolve Conflict");
+  });
 });

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -17,7 +17,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, waitFor, act } from "@testing-library/react";
 import { toaster } from "@decky/api";
-import { showContextMenu } from "@decky/ui";
+import { showContextMenu, showModal } from "@decky/ui";
 import type { ReactElement } from "react";
 import { CustomPlayButton } from "./CustomPlayButton";
 import { emitDeckyEvent, deckyEventListenerCount } from "../test-utils/decky-api-mock";
@@ -638,5 +638,142 @@ describe("CustomPlayButton — uninstall resets launch_options (#1051)", () => {
     // The reset lives in the success branch — a failed uninstall leaves the
     // command untouched (the shortcut is still installed).
     expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+  });
+});
+
+describe("CustomPlayButton — pre-launch failure shapes without an errors array (#1050)", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(toaster.toast).mockReset();
+    vi.mocked(showModal).mockClear();
+    vi.mocked(backend.preLaunchSync).mockReset();
+    // Gate predecessors so handlePlay reaches runPreLaunchSync.
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
+    vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
+    vi.stubGlobal("SteamClient", { Apps: { RunGame: vi.fn() } });
+    vi.stubGlobal("appStore", {
+      GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
+      allApps: [],
+    });
+  });
+
+  // success:false failures that carry NO errors array — the shapes that
+  // previously fell through to a silent "proceed".
+  const FAILURE_SHAPES = [
+    {
+      reason: "device_not_registered",
+      message: "Device is not registered with RomM. Open the Saves tab to set it up.",
+    },
+    { reason: "save_sort_changed", message: "RetroArch save sorting changed — migrate saves in Settings first" },
+    {
+      reason: "blocked_by_migration",
+      message: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+    },
+  ];
+
+  function lastModalProps(): { strDescription?: string; onOK?: () => void; onCancel?: () => void } {
+    const calls = vi.mocked(showModal).mock.calls;
+    const el = calls[calls.length - 1]?.[0] as
+      | ReactElement<{ strDescription?: string; onOK?: () => void; onCancel?: () => void }>
+      | undefined;
+    if (!el) throw new Error("showModal was not called");
+    return el.props;
+  }
+
+  it.each(FAILURE_SHAPES)(
+    "surfaces the fallback-launch confirm with the backend message on $reason instead of proceeding silently",
+    async ({ reason, message }) => {
+      mockCachedDetail();
+      vi.mocked(backend.preLaunchSync).mockResolvedValue({
+        success: false,
+        reason,
+        message,
+        synced: 0,
+        errors: [],
+        conflicts: [],
+      });
+
+      const { findByText } = render(<CustomPlayButton appId={100} />);
+      const playBtn = await findByText("Play");
+      await act(async () => {
+        playBtn.click();
+      });
+
+      // The fallback-launch confirm opened (not a silent launch) ...
+      await waitFor(() => expect(vi.mocked(showModal)).toHaveBeenCalled());
+      // ... and it surfaces the backend's specific message (e.g. save_sort_changed's
+      // "migrate saves in Settings first" — previously never shown).
+      expect(lastModalProps().strDescription).toContain(message);
+
+      // Cancelling the fallback must NOT launch.
+      await act(async () => {
+        lastModalProps().onCancel?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+    },
+  );
+
+  it("launches with local saves when the user confirms the fallback on a no-errors failure", async () => {
+    mockCachedDetail();
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: false,
+      reason: "device_not_registered",
+      message: "Device is not registered with RomM.",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+
+    await waitFor(() => expect(vi.mocked(showModal)).toHaveBeenCalled());
+    await act(async () => {
+      lastModalProps().onOK?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
+  });
+
+  it("stays in the conflict state and toasts the message when resolve-conflict sync fails without conflicts", async () => {
+    mockCachedDetail();
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+    // Drive the button into the conflict state via the backend push (DOM event).
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: 42, has_conflict: true } }),
+      );
+    });
+    const resolveBtn = await findByText("Resolve Conflict");
+
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: false,
+      reason: "device_not_registered",
+      message: "Device is not registered with RomM.",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+
+    await act(async () => {
+      resolveBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(toaster.toast)).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("Device is not registered") }),
+    );
+    // Still in the conflict state — not dropped to "play".
+    await findByText("Resolve Conflict");
   });
 });

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -401,10 +401,12 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   // Sync-error confirmation: ask the user whether to launch despite a failed
   // pre-launch sync. Centralises the toast strings so timeout vs result-errors
   // share copy.
-  const confirmFallbackLaunch = async (): Promise<boolean> => {
+  const confirmFallbackLaunch = async (message?: string): Promise<boolean> => {
     return showLaunchConfirmation(
       "Save Sync Unavailable",
-      "Couldn't sync saves with RomM server. Launch with local saves?",
+      message?.trim()
+        ? `${message} — launch with local saves?`
+        : "Couldn't sync saves with RomM server. Launch with local saves?",
     );
   };
 
@@ -447,9 +449,17 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: rid } }));
       }
 
-      if (!result.success && result.errors && result.errors.length > 0) {
-        detach(debugLog(`CustomPlayButton: pre-launch sync errors: ${result.errors.join(", ")}`));
-        const proceed = await confirmFallbackLaunch();
+      if (!result.success) {
+        detach(
+          debugLog(
+            `CustomPlayButton: pre-launch sync failed: reason=${result.reason ?? ""} errors=[${result.errors?.join(", ") ?? ""}] message=${result.message}`,
+          ),
+        );
+        // Any resolved failure must surface, not silently proceed. Failures with
+        // no errors array — DEVICE_NOT_REGISTERED, blocked_by_migration,
+        // save_sort_changed — still mean sync didn't run; without this the user
+        // plays on stale local saves believing pre-launch sync happened (#1050).
+        const proceed = await confirmFallbackLaunch(result.message);
         return proceed ? "proceed" : "abort";
       }
       if (result.synced && result.synced > 0) {
@@ -531,6 +541,18 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
           setState("conflict");
           return;
         }
+      }
+      // A resolved failure without conflicts (DEVICE_NOT_REGISTERED,
+      // save_sort_changed, blocked_by_migration) must not masquerade as
+      // "resolved" — surface it and stay in the conflict state instead of
+      // dispatching a refresh and dropping back to play (#1050).
+      if (!result.success) {
+        detach(
+          debugLog(`CustomPlayButton: resolve conflict sync failed: reason=${result.reason ?? ""} message=${result.message}`),
+        );
+        toaster.toast({ title: "RomM Save Sync", body: result.message || "Couldn't resolve conflict — try again." });
+        setState("conflict");
+        return;
       }
       // Resolved or no conflicts left — notify siblings and go back to play
       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));


### PR DESCRIPTION
## Problem

`runPreLaunchSync` (`CustomPlayButton.tsx`) only branched on `!result.success && result.errors?.length > 0`. Backend failures with `success: false` but **no `errors`** key fall through to `"proceed"` with zero user signal: `DEVICE_NOT_REGISTERED`, `save_sort_changed` (whose "migrate saves in Settings first" message was never shown), `blocked_by_migration`. The user plays on stale local saves believing pre-launch sync ran; post-exit then produces avoidable conflicts. `handleResolveConflict` had the same hole — it only branched on `conflicts`, so a `success: false` with no conflicts dispatched a refresh and dropped to `"play"` as if resolved.

## Fix

Both paths now branch on `!result.success`:

- **`runPreLaunchSync`**: any resolved failure routes through the existing fallback-launch confirm ("Launch with local saves?"). `confirmFallbackLaunch` takes an optional `message` so the backend's specific reason is surfaced — `save_sort_changed`'s "migrate saves in Settings first" is finally shown. The benign `savefiles_in_content_dir` skip still returns **early** (before the new branch), so it stays a silent no-op — no per-launch nag.
- **`handleResolveConflict`**: a `success: false` without conflicts stays in the conflict state and toasts the message, instead of masquerading as resolved.

## Tests

`CustomPlayButton.test.tsx` — for each no-errors shape (`device_not_registered` / `save_sort_changed` / `blocked_by_migration`): the fallback confirm opens (not a silent launch) and its description surfaces the backend message; cancelling does not launch (`RunGame` not called), confirming does. Plus a resolve-conflict test: `success:false` without conflicts → stays "Resolve Conflict" and toasts the message. Full frontend suite green (1262 tests).

## Docs

`docs: N/A` — internal robustness fix. A failed pre-launch/resolve now surfaces a confirm / toast instead of silently proceeding; no backend change, no new flow.

Closes #1050
