### PR TITLE
docs(security): reflect token-based auth and current safeguards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,13 +28,23 @@ You should receive a response within 7 days.
 
 This plugin handles:
 
-- **RomM server credentials** (URL, username, password) stored in Decky's settings directory
-- **SteamGridDB API keys** stored in the same settings file
+- **A scoped RomM Client API Token** stored in the plugin's settings file (`settings.json`) in Decky's settings
+  directory. Your RomM username and password are used **once, in memory only**, to mint that token at sign-in and are
+  then discarded — they are never written to disk. The plugin stores only the server URL, the minted token (plus its
+  server-side id and the origin it was minted against), and the SSL-verification flag.
+- **An optional SteamGridDB API key** stored in the same `settings.json`
 - **HTTP requests** to self-hosted RomM servers (optionally with SSL verification disabled for self-signed certificates)
 
 ### Known security considerations
 
-- Settings files are stored with `0600` permissions (owner-only read/write)
-- Credentials are never logged — masked in all log output
+- The settings file is stored with `0600` permissions (owner-only read/write); the plugin actively migrates an older
+  world-readable `0644` file to `0600` on load.
+- Credentials and tokens are never logged — masked in all log output.
+- The RomM Client API Token is **bound to the origin it was minted against** (`scheme://host[:port]`) and is only ever
+  sent to that exact origin. If the configured server URL no longer matches, the bearer is withheld rather than sent — a
+  changed or hostile host never receives the credential.
+- Path components supplied by the RomM server (filenames, ROM and save paths) are validated against path traversal
+  before they are used to build local filesystem paths, so a compromised or malicious server cannot write outside the
+  plugin's directories.
 - The `allow_insecure_ssl` option disables certificate verification for self-hosted servers with self-signed
   certificates. This is an opt-in user setting with a warning in the UI.


### PR DESCRIPTION
Updates the security policy, which still described the pre-token credential model.

## What changed

- **Scope** — replaced "URL + username + password stored on disk" with the real model: the RomM username/password are used **once, in memory only** to mint a scoped Client API Token and are then discarded. Only the server URL, the minted token (+ id + origin it was minted against), the SteamGridDB key, and the SSL flag are persisted in `settings.json`.
- Fixed the dangling "the same settings file" reference (the first bullet now names `settings.json`).
- Documented three existing safeguards that weren't listed:
  - **Token-host binding** — the bearer is only ever sent to the origin the token was minted against; a changed/hostile host never receives it.
  - **Path-traversal validation** of server-supplied path components (filenames, ROM/save paths).
  - The active **`0644`→`0600`** permission migration on the settings file.

docs: N/A — this PR *is* the documentation change. `SECURITY.md` is a root policy file, not under `docs/`, so it isn't covered by the docs-check skip list.