### PR TITLE
fix(library): reset shortcut launch_options to the uninstalled placeholder on uninstall (#1051)

### DIFF
--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -39,7 +39,15 @@ vi.mock("../utils/connectionState", () => ({
   getRommConnectionState: () => "connected",
 }));
 
+// Uninstall resets the shortcut's launch_options via setLaunchOptionsConfirmed
+// (#1051) — mock it so the test asserts the call without touching SteamClient.
+vi.mock("../utils/steamShortcuts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/steamShortcuts")>()),
+  setLaunchOptionsConfirmed: vi.fn().mockResolvedValue(true),
+}));
+
 import { getCachedGameDetail } from "../utils/cachedGameDetailStore";
+import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 
 function mockCachedDetail(overrides: Partial<CachedGameDetail> = {}): void {
   vi.mocked(getCachedGameDetail).mockResolvedValue({
@@ -573,5 +581,62 @@ describe("CustomPlayButton — pre-launch savefiles_in_content_dir benign skip (
     expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
     // No fallback-launch confirm modal was opened (would mean we treated it as failure).
     expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42);
+  });
+});
+
+describe("CustomPlayButton — uninstall resets launch_options (#1051)", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(toaster.toast).mockReset();
+    vi.mocked(showContextMenu).mockReset();
+    vi.mocked(setLaunchOptionsConfirmed).mockReset();
+    vi.mocked(setLaunchOptionsConfirmed).mockResolvedValue(true);
+    vi.mocked(backend.removeRom).mockResolvedValue({ success: true, message: "" });
+  });
+
+  // Open the play-state "RomM Actions" menu (the chevron next to Play) and click
+  // its Uninstall item — mirrors the download-actions menu-driving pattern above.
+  async function clickUninstall(container: HTMLElement): Promise<void> {
+    const chevron = container.querySelector(".romm-btn-dropdown") as HTMLElement | null;
+    if (!chevron) throw new Error("dropdown chevron not rendered");
+    act(() => {
+      chevron.click();
+    });
+    const calls = vi.mocked(showContextMenu).mock.calls;
+    const menu = calls[calls.length - 1]![0] as ReactElement;
+    const { findByText } = render(menu);
+    const uninstallItem = await findByText("Uninstall");
+    await act(async () => {
+      uninstallItem.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("clears the shortcut launch command to the uninstalled placeholder on a successful uninstall", async () => {
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { container, findByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    await clickUninstall(container);
+
+    // Reset to "" for the shortcut's appId so a raced-past not_installed can't
+    // exec a stale command into the deleted path (#1051).
+    expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledWith(100, "");
+    expect(vi.mocked(backend.removeRom)).toHaveBeenCalledWith(42);
+  });
+
+  it("does not reset launch_options when the uninstall fails", async () => {
+    vi.mocked(backend.removeRom).mockResolvedValue({ success: false, message: "boom" });
+    mockCachedDetail({ rom_id: 42, installed: true });
+    const { container, findByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    await clickUninstall(container);
+
+    // The reset lives in the success branch — a failed uninstall leaves the
+    // command untouched (the shortcut is still installed).
+    expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
   });
 });

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -41,6 +41,7 @@ import { showSyncConflictModal } from "./SyncConflictModal";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent, SyncConflict } from "../types";
 import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
 import { detach } from "../utils/detach";
+import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 
 type PlayButtonState =
   | "loading"
@@ -586,6 +587,11 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     try {
       const result = await removeRom(romId);
       if (result.success) {
+        // Reset the now-stale launch command to the uninstalled "" placeholder so a
+        // raced-past not_installed launch execs `bin/rom-launcher` with no args (clean
+        // exit 1) instead of a stale `flatpak run … "<deleted path>"` (#1051). Best-effort:
+        // a launch-options hiccup must not turn a successful uninstall into an error.
+        await setLaunchOptionsConfirmed(appId, "").catch(() => false);
         globalThis.dispatchEvent(new CustomEvent("romm_rom_uninstalled", { detail: { rom_id: romId } }));
         toaster.toast({ title: "RomM Sync", body: `${romName || "ROM"} uninstalled` });
         // Dark pulse transition before showing Download button


### PR DESCRIPTION
**Part 1 of #1051** (the `not_installed`-stale hardening). The launch-gate race itself and the Start Anyway / Cancel / Retry modal land in a follow-up PR.

## Problem

A single-ROM uninstall (`CustomPlayButton.handleUninstall`) drops the install record + files but leaves the Steam shortcut's `launch_options` holding the full launch command, still pointing at the now-deleted ROM path. The launch gate's `not_installed` verdict can be **raced past** (it awaits a network read, so `CancelGameAction` must win a race against the actual launch) → the shortcut execs a stale `flatpak run … "<deleted path>"` → Play flashes and dies with a bogus 0-second session.

## Fix

`handleUninstall` resets `launch_options` to the uninstalled `""` placeholder via the existing `setLaunchOptionsConfirmed` seam, **best-effort** (a launch-options hiccup must not turn a successful uninstall into an error toast). A raced-past launch then execs `bin/rom-launcher` with no args — a clean exit — instead of a stale command into a deleted path. This is the defense-in-depth that makes the race harmless even when the gate doesn't win.

## Tests

`CustomPlayButton.test.tsx` — uninstall via the play-state "RomM Actions" menu → `setLaunchOptionsConfirmed(appId, "")` is called; a failed uninstall leaves it untouched (the reset lives in the success branch). Full frontend suite green (1259 tests).

## Known gap

The bulk uninstall-all path (`DangerZone` → `uninstall_all_roms`) has the same latent issue, but the callable returns no app ids to reset per kept shortcut — left for a follow-up.

## Docs

`docs: N/A` — internal robustness; no user-facing flow change.

Part of #1051
