### PR TITLE
fix(library): re-confirm launch_options before a Play-button launch (#1150)

### DIFF
--- a/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
+++ b/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
@@ -59,9 +59,12 @@ whose own `-e "..."` quoting must survive verbatim. `launch_options` carries:
 
 - the **full command** for an installed ROM, written at **sync** (for ROMs already on disk), at **download-complete**
   (the moment a ROM becomes installed), **re-resolved on RetroDECK-home migration** (a new `migration_relaunch_options`
-  event rewrites every installed+bound shortcut to the relocated path), and **re-confirmed at every plugin load** by a
+  event rewrites every installed+bound shortcut to the relocated path), **re-confirmed at every plugin load** by a
   startup pull-reconcile (the frontend pulls `get_installed_relaunch_options` once the backend is reachable and
-  confirm-sets each installed+bound shortcut's command, healing any drift to `""` left by a missed bake);
+  confirm-sets each installed+bound shortcut's command, healing any drift to `""` left by a missed bake), and
+  **re-confirmed once more just before a Play-button launch** by a single-ROM pull (the funnel pulls
+  `get_rom_relaunch_options(rom_id)` and confirm-sets the shortcut's command before `RunGame`, healing mid-session drift
+  on the most common launch path between plugin loads — best-effort, a failed re-confirm still launches; #1150);
 - the **empty string `""`** (placeholder) for an uninstalled ROM, until it is downloaded.
 
 The `romm:<rom_id>` marker is **gone**. Two bindings that previously rode on it move off `launch_options`:
@@ -116,6 +119,14 @@ storage + precedence + bake-site model is [ADR-0011](0011-per-game-core-override
   it once the backend is proven reachable and confirm-sets each entry. The pass is **idempotent and appId-safe**:
   re-confirming a correct command matches the read-back instantly, and `launch_options` is not part of the appId CRC32,
   so the shortcut identity, artwork, and collections survive. It heals drift from every cause at the next plugin load.
+- Because the startup reconcile only runs at plugin load, drift that appears **mid-session** (e.g. a `download-complete`
+  confirm-set that timed out) survives until the next reload. The **Play-button funnel** closes that gap for the common
+  launch path: it runs and `await`s **before** `RunGame`, so it pulls `get_rom_relaunch_options(rom_id)` (the single-ROM
+  build over the same active-core/disc seams) and confirm-sets the shortcut's command just before launch — best-effort,
+  a failed or `None` re-confirm still launches, no worse than today
+  ([#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)). The **direct-Steam-launch watcher path stays
+  uncovered**: it must decide synchronously before `CancelGameAction` with no pre-warmed state, so it can't afford the
+  extra round-trip; that path still relies on the startup reconcile.
 - **Breaking for existing shortcuts: a re-sync is required.** Shortcuts created under the `romm:<rom_id>` model carry
   the old marker and no baked command; they are detected by exe but recreated by re-sync to pick up the baked
   `launch_options`. Accepted as a **pre-release** breaking change.

--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -107,6 +107,13 @@ local file to `.romm-backup`, so there is no silent data loss. "Unknown because 
   launch is flicker-free and that a deep link is caught.
 - **One gate** to maintain instead of two divergent ones; the double-gate's redundant `list_saves` is gone.
 - The skip-set adds a little state; its lifetime self-heals (check-and-delete at entry).
+- **The Play-button funnel re-confirms `launch_options` just before `RunGame`** (in `dispatchLaunch`, after the verdict
+  approves and on every launching branch): it pulls `get_rom_relaunch_options(rom_id)` and confirm-sets the shortcut's
+  command, healing mid-session drift on the common launch path between plugin loads
+  ([ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md),
+  [#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)). Best-effort — a failed or `None` re-confirm
+  still launches. The **watcher path is not covered**: it decides synchronously before `CancelGameAction` and can't
+  afford the round-trip, so it relies on the startup reconcile.
 - **On-device verification required** (cannot be unit-tested): the cancel-relaunch flicker, modal focus after cancel,
   slow-server feel, and the suspend hooks.
 

--- a/main.py
+++ b/main.py
@@ -124,6 +124,7 @@ class Plugin:
         self._startup_healing_service = services["startup_healing_service"]
         self._launch_gate_service = services["launch_gate_service"]
         self._session_lifecycle_service = services["session_lifecycle_service"]
+        self._relaunch_options_resolver = services["relaunch_options_resolver"]
 
         # ── 4b. Legacy credential migration ─────────────────────────────────
         # Upgrade a stored-password install to a Client API Token. The
@@ -349,6 +350,15 @@ class Plugin:
 
     async def check_local_drift(self, rom_id):
         return await self._launch_gate_service.check_local_drift(rom_id)
+
+    async def get_rom_relaunch_options(self, rom_id):
+        """Return ``{app_id, launch_options}`` for one installed+bound ROM, or None.
+
+        The Play-button funnel re-confirms the shortcut's launch command from
+        this just before launch to heal mid-session ``launch_options`` drift
+        (#1150). Read-only — no migration gate, no canonical failure shape.
+        """
+        return await self.loop.run_in_executor(None, self._relaunch_options_resolver.relaunch_item_for_rom, int(rom_id))
 
     async def probe_reachability(self):
         return await self._connection_service.probe_reachability()

--- a/py_modules/bootstrap.py
+++ b/py_modules/bootstrap.py
@@ -765,4 +765,5 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
         "startup_healing_service": startup_healing_service,
         "launch_gate_service": launch_gate_service,
         "session_lifecycle_service": session_lifecycle_service,
+        "relaunch_options_resolver": relaunch_options_resolver,
     }

--- a/py_modules/services/relaunch_options_resolver.py
+++ b/py_modules/services/relaunch_options_resolver.py
@@ -31,6 +31,8 @@ from typing import TYPE_CHECKING, Any
 from domain.shortcut_data import build_launch_options, resolve_emulator_invocation
 
 if TYPE_CHECKING:
+    from domain.rom import Rom
+    from domain.rom_install import RomInstall
     from services.protocols import (
         ActiveCoreReader,
         DiscResolver,
@@ -62,14 +64,30 @@ class RelaunchOptionsResolver:
         self._active_core = config.active_core
         self._disc_resolver = config.disc_resolver
 
+    def _resolve_item(self, rom: Rom, install: RomInstall) -> dict[str, Any]:
+        """Compose one ``{app_id, launch_options}`` item for an installed+bound ROM.
+
+        The single resolve body shared by the batch and single-ROM entry points.
+        Resolves the ROM's active core and selected disc — through the same
+        ``active_core`` / ``disc_resolver`` seams every other launch-bake site
+        uses — outside any open Unit of Work (``active_core_for_rom`` opens its
+        own, and the per-connection write lock is not re-entrant; #1154). A
+        multi-disc ROM bakes its selected disc's path, a single-disc ROM its own
+        ``file_path``.
+        """
+        core_so, _label = self._active_core.active_core_for_rom(rom.rom_id)
+        invocation = resolve_emulator_invocation({"id": rom.rom_id}, core_so)
+        bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
+        return {
+            "app_id": rom.shortcut_app_id,
+            "launch_options": build_launch_options(invocation, bake_path),
+        }
+
     def installed_relaunch_items(self) -> list[dict[str, Any]]:
         """Return one ``{app_id, launch_options}`` item per installed+bound ROM.
 
         Snapshots the installed+bound ``(rom, install)`` pairs in one short read
-        UoW, closes it, then resolves each ROM's active core and selected disc
-        outside any open UoW and composes the launch command. A multi-disc ROM
-        re-resolves its selected disc against its install directory (a
-        single-disc ROM resolves to its own ``file_path``, unchanged).
+        UoW, closes it, then resolves each item outside any open UoW.
         Uninstalled or unbound ROMs are skipped by construction.
 
         The iteration UoW is closed before the resolve loop runs because
@@ -84,15 +102,24 @@ class RelaunchOptionsResolver:
                 if (rom := uow.roms.get(install.rom_id)) is not None and rom.shortcut_app_id is not None
             ]
 
-        items: list[dict[str, Any]] = []
-        for rom, install in bound_installs:
-            core_so, _label = self._active_core.active_core_for_rom(rom.rom_id)
-            invocation = resolve_emulator_invocation({"id": rom.rom_id}, core_so)
-            bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
-            items.append(
-                {
-                    "app_id": rom.shortcut_app_id,
-                    "launch_options": build_launch_options(invocation, bake_path),
-                }
-            )
-        return items
+        return [self._resolve_item(rom, install) for rom, install in bound_installs]
+
+    def relaunch_item_for_rom(self, rom_id: int) -> dict[str, Any] | None:
+        """Resolve the ``{app_id, launch_options}`` for one installed+bound ROM.
+
+        Returns ``None`` when the ROM has no install row or no bound shortcut —
+        there is no installed launch command to re-confirm. Snapshots the
+        rom/install in one short read UoW, closes it, then resolves outside —
+        same non-reentrant-write-lock reason as the batch path (#1154).
+
+        The Play-button funnel re-confirms the shortcut's launch command from
+        this just before launch, healing mid-session ``launch_options`` drift on
+        the most common launch path (#1150).
+        """
+        with self._uow_factory() as uow:
+            install = uow.rom_installs.get(rom_id)
+            rom = uow.roms.get(rom_id) if install is not None else None
+            if install is None or rom is None or rom.shortcut_app_id is None:
+                return None
+            pair = (rom, install)
+        return self._resolve_item(*pair)

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -122,6 +122,9 @@ export const getDownloadQueue = callable<[], { downloads: DownloadItem[] }>("get
 export const getInstalledRom = callable<[number], InstalledRom | null>("get_installed_rom");
 export const evaluateLaunch = callable<[number], LaunchVerdict>("evaluate_launch");
 export const checkLocalDrift = callable<[number], { drifted: boolean; rom_id: number }>("check_local_drift");
+export const getRomRelaunchOptions = callable<[number], { app_id: number; launch_options: string } | null>(
+  "get_rom_relaunch_options",
+);
 export const probeReachability = callable<[], { online: boolean }>("probe_reachability");
 export const refreshSaveStatus = callable<[number], { success: boolean }>("refresh_save_status");
 export const removeRom = callable<[number], BackendResult>("remove_rom");

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1371,3 +1371,130 @@ describe("CustomPlayButton — F7 background save-status refresh on settle-to-pl
     expect(await findByText("Play")).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1150 — the Play-button pre-launch relaunch re-confirm. dispatchLaunch pulls
+// getRomRelaunchOptions and confirm-sets the shortcut's launch_options BEFORE
+// RunGame, healing mid-session drift on the common launch path. Best-effort:
+// a None item skips the set, and a rejection logs + still launches.
+// ---------------------------------------------------------------------------
+describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
+  const RELAUNCH_COMMAND = 'flatpak run net.retrodeck.retrodeck "/roms/gba/pokemon.gba"';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consumeLaunchSkip(100);
+    // Allow-path gate predecessors: online, tracking configured, no core change,
+    // clean pre-launch sync → the gate returns "allow" → dispatchLaunch runs.
+    vi.mocked(getMigrationState).mockReturnValue({ pending: false });
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
+    vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
+    vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({ success: true, message: "", synced: 0, conflicts: [] });
+    vi.mocked(setLaunchOptionsConfirmed).mockResolvedValue(true);
+
+    vi.stubGlobal("SteamClient", { Apps: { RunGame: vi.fn() } });
+    vi.stubGlobal("appStore", {
+      GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
+      allApps: [],
+    });
+  });
+
+  async function clickPlay(): Promise<void> {
+    mockCachedDetail();
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+      // Drain the gate chain + the dispatchLaunch re-confirm awaits.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("re-confirms launch_options (getRomRelaunchOptions → setLaunchOptionsConfirmed) BEFORE RunGame", async () => {
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 100, launch_options: RELAUNCH_COMMAND });
+
+    await clickPlay();
+
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+    // The re-confirm pulled this ROM's resolved command and confirm-set it onto
+    // the shortcut's appId with that exact command.
+    expect(vi.mocked(backend.getRomRelaunchOptions)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledWith(100, RELAUNCH_COMMAND);
+    // Order: getRomRelaunchOptions → setLaunchOptionsConfirmed → RunGame.
+    const getOrder = vi.mocked(backend.getRomRelaunchOptions).mock.invocationCallOrder[0]!;
+    const setOrder = vi.mocked(setLaunchOptionsConfirmed).mock.invocationCallOrder[0]!;
+    const runOrder = vi.mocked(SteamClient.Apps.RunGame).mock.invocationCallOrder[0]!;
+    expect(getOrder).toBeLessThan(setOrder);
+    expect(setOrder).toBeLessThan(runOrder);
+  });
+
+  it("a null item skips setLaunchOptionsConfirmed but still launches", async () => {
+    // No install/binding to re-confirm → backend returns null → the set is
+    // skipped, but the launch must still proceed (nothing to heal, no block).
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue(null);
+
+    await clickPlay();
+
+    expect(vi.mocked(backend.getRomRelaunchOptions)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+  });
+
+  it("a rejected re-confirm logs the pre-launch message AND still launches (non-vacuous catch)", async () => {
+    const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    vi.mocked(backend.getRomRelaunchOptions).mockRejectedValue(new Error("offline"));
+
+    await clickPlay();
+
+    // Post-catch state: the failure was logged with the #1150 message AND the
+    // launch still fired (best-effort — a failed re-confirm is no worse than today).
+    await waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("pre-launch relaunch re-confirm failed")),
+    );
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+
+    logSpy.mockRestore();
+  });
+
+  it("a hung getRomRelaunchOptions falls through to the launch after the timeout (button never trapped)", async () => {
+    // The Decky callable bridge can hang forever on a wedged backend. The fetch
+    // is bounded by a 3s Promise.race; on timeout the re-confirm is skipped and
+    // the launch still fires — the button must not stay stuck on "Launching…".
+    // RTL's findBy* deadlocks under fake timers, so render + settle to "Play"
+    // under REAL timers, then switch to fake timers right before the click so the
+    // 3s re-confirm timeout fires without a real wait (kept fast).
+    const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    // Never resolves — simulates a wedged backend / hung bridge.
+    vi.mocked(backend.getRomRelaunchOptions).mockReturnValue(new Promise<never>(() => {}));
+
+    try {
+      mockCachedDetail();
+      const { findByText } = render(<CustomPlayButton appId={100} />);
+      const playBtn = await findByText("Play");
+
+      vi.useFakeTimers();
+      await act(async () => {
+        playBtn.click();
+        // The gate chain up to dispatchLaunch is microtask-driven (no setTimeout);
+        // advancing past 3000ms flushes those microtasks and fires the re-confirm
+        // timeout that unblocks the hung fetch.
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      // The hung fetch timed out → re-confirm skipped (no set), logged, and the
+      // launch STILL fired. RunGame is the proof the button escaped "Launching…".
+      expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("pre-launch relaunch re-confirm failed"));
+      expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
+    } finally {
+      vi.useRealTimers();
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -33,6 +33,7 @@ import {
   probeReachability,
   checkLocalDrift,
   refreshSaveStatus,
+  getRomRelaunchOptions,
 } from "../api/backend";
 import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
@@ -447,10 +448,31 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   };
 
   // Final launch step — set state and hand off to Steam. Marks the appId in the
-  // shared skip-set FIRST so this RunGame does NOT re-enter the global watcher
-  // and re-gate a launch that already ran the funnel (the double-gate fix C1).
-  const dispatchLaunch = (gameId: string) => {
+  // shared skip-set immediately before RunGame so this RunGame does NOT re-enter
+  // the global watcher and re-gate a launch that already ran the funnel (the
+  // double-gate fix C1).
+  const dispatchLaunch = async (gameId: string) => {
     setState("launching");
+    // Heal any mid-session launch_options drift on this shortcut before launch
+    // (#1150). Best-effort: a failed re-confirm still launches — no worse than today.
+    // The Decky callable bridge can hang indefinitely if the backend is wedged, so
+    // bound the read with a timeout (mirrors index.tsx's withTimeout and the
+    // funnel's preLaunchSync Promise.race) — a hang must fall through to the launch,
+    // never trap the button on "Launching…". setLaunchOptionsConfirmed has its own
+    // 2s internal timeout, so only the fetch needs bounding here.
+    if (romId) {
+      try {
+        const item = await Promise.race([
+          getRomRelaunchOptions(romId),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("get_rom_relaunch_options timed out")), 3000),
+          ),
+        ]);
+        if (item) await setLaunchOptionsConfirmed(appId, item.launch_options);
+      } catch (e) {
+        logError(`CustomPlayButton: pre-launch relaunch re-confirm failed (launching anyway): ${e}`);
+      }
+    }
     markLaunchSkipped(appId);
     SteamClient.Apps.RunGame(gameId, "", -1, 100);
   };
@@ -493,7 +515,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
     // Non-RomM / unresolved ROM — nothing to gate, launch straight through.
     if (!romId) {
-      dispatchLaunch(gameId);
+      await dispatchLaunch(gameId);
       return;
     }
 
@@ -526,7 +548,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const actOnVerdict = async (verdict: GateVerdict, gameId: string, rid: number): Promise<"done" | "retry"> => {
     switch (verdict.decision) {
       case "allow":
-        dispatchLaunch(gameId);
+        await dispatchLaunch(gameId);
         return "done";
       case "abort":
       case "block":
@@ -543,13 +565,13 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         }
         // Conflicts resolved — notify sibling components to refresh, then launch.
         globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: rid } }));
-        dispatchLaunch(gameId);
+        await dispatchLaunch(gameId);
         return "done";
       }
       case "offline_drift": {
         const choice = await showOfflineDriftModal();
         if (choice === "start_anyway") {
-          dispatchLaunch(gameId);
+          await dispatchLaunch(gameId);
           return "done";
         }
         if (choice === "retry") {
@@ -565,7 +587,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       case "sync_failed": {
         const proceed = await showFallbackLaunchModal(verdict.message);
         if (proceed) {
-          dispatchLaunch(gameId);
+          await dispatchLaunch(gameId);
           return "done";
         }
         setState("play");

--- a/tests/contract/_harness.py
+++ b/tests/contract/_harness.py
@@ -82,6 +82,7 @@ _BOUND_SERVICE_ATTRS = {
     "_startup_healing_service": "startup_healing_service",
     "_launch_gate_service": "launch_gate_service",
     "_session_lifecycle_service": "session_lifecycle_service",
+    "_relaunch_options_resolver": "relaunch_options_resolver",
 }
 
 

--- a/tests/contract/test_rom_relaunch_options.py
+++ b/tests/contract/test_rom_relaunch_options.py
@@ -1,0 +1,46 @@
+"""Contract test for ``get_rom_relaunch_options`` over the real nesting.
+
+``Plugin.get_rom_relaunch_options(rom_id)`` is the single-ROM re-confirm seam
+the Play-button funnel pulls just before launch to heal mid-session
+``launch_options`` drift (#1150). It resolves through the real
+:class:`RelaunchOptionsResolver`, whose ``active_core_for_rom`` opens its **own**
+Unit of Work — the same non-reentrant ``BEGIN IMMEDIATE`` write-lock nesting the
+batch path guards against (#1154). The unit tests inject a fake UoW; this tier
+drives the real callable over the real file-based SQLite UoW the harness wires.
+
+Called positionally as the frontend does, and pinned against the TS shape:
+``{ app_id: number; launch_options: string } | null`` — a literal ``None`` where
+the TS union says ``null``.
+"""
+
+from __future__ import annotations
+
+from ._seed import seed_install, seed_rom
+
+
+async def test_installed_bound_rom_returns_item(harness):
+    """An installed+bound ROM → ``{app_id, launch_options}`` with a real command."""
+    seed_install(harness, 42, system="gba", platform_slug="gba", file_name="pokemon.gba")
+
+    item = await harness.plugin.get_rom_relaunch_options(42)
+
+    assert item is not None
+    assert set(item.keys()) == {"app_id", "launch_options"}
+    assert item["app_id"] == 42
+    assert isinstance(item["launch_options"], str)
+    assert item["launch_options"]  # non-empty — the full launch command
+
+
+async def test_bound_rom_with_no_install_returns_none(harness):
+    """A bound-but-uninstalled ROM (no install row) → literal None (TS ``null``)."""
+    seed_rom(harness, 7, platform_slug="gba", shortcut_app_id=7)
+
+    item = await harness.plugin.get_rom_relaunch_options(7)
+
+    assert item is None
+
+
+async def test_unknown_rom_returns_none(harness):
+    """A rom_id with no rows at all → None — nothing to re-confirm."""
+    item = await harness.plugin.get_rom_relaunch_options(999)
+    assert item is None

--- a/tests/services/test_relaunch_options_resolver.py
+++ b/tests/services/test_relaunch_options_resolver.py
@@ -1,10 +1,13 @@
 """Tests for RelaunchOptionsResolver — the shared installed+bound relaunch seam.
 
-The single (deadlock-free) build of the ``{app_id, launch_options}`` list both
-the RetroDECK-home migration and the startup launch-options reconcile delegate
-to. These cases pin the resolution behavior — empty, skip-on-missing-rom,
-skip-unbound, default core, ``-e`` core-override form, multiple installs, and
-the multi-disc pin — over the fake active-core / disc seams and the fake UoW.
+The single (deadlock-free) build of the ``{app_id, launch_options}`` items the
+RetroDECK-home migration, the startup launch-options reconcile, and the
+Play-button pre-launch re-confirm (#1150) all delegate to. These cases pin the
+resolution behavior — empty, skip-on-missing-rom, skip-unbound, default core,
+``-e`` core-override form, multiple installs, and the multi-disc pin — over the
+fake active-core / disc seams and the fake UoW, for both the batch
+(``installed_relaunch_items``) and single-ROM (``relaunch_item_for_rom``)
+entry points that share the one resolve body.
 """
 
 from __future__ import annotations
@@ -206,3 +209,78 @@ def test_multi_disc_unpinned_defaults_to_disc_1():
     resolver = _make_resolver(uow=uow, disc_resolver=_multi_disc_resolver())
     items = resolver.installed_relaunch_items()
     assert items[0]["launch_options"] == f'flatpak run net.retrodeck.retrodeck "{_DISC1_PATH}"'
+
+
+# ── relaunch_item_for_rom — the single-ROM re-confirm seam (#1150) ──────────
+
+
+def test_single_rom_installed_bound_default_core():
+    """One installed+bound ROM (no core override) → its plain launch command."""
+    uow = FakeUnitOfWork()
+    file_path = "/roms/n64/zelda.z64"
+    _seed_install(uow, 1, file_path=file_path, shortcut_app_id=4242)
+    resolver = _make_resolver(uow=uow)
+    assert resolver.relaunch_item_for_rom(1) == {
+        "app_id": 4242,
+        "launch_options": f'flatpak run net.retrodeck.retrodeck "{file_path}"',
+    }
+
+
+def test_single_rom_core_override_bakes_e_form():
+    """A resolved core .so produces the RetroDECK -e override for the single ROM."""
+    uow = FakeUnitOfWork()
+    file_path = "/roms/n64/mario.z64"
+    _seed_install(uow, 1, file_path=file_path, shortcut_app_id=7)
+    active_core = FakeActiveCoreResolver(per_rom={1: ("mupen64plus_next", "Mupen64Plus-Next")})
+    resolver = _make_resolver(uow=uow, active_core=active_core)
+    assert resolver.relaunch_item_for_rom(1) == {
+        "app_id": 7,
+        "launch_options": (
+            "flatpak run net.retrodeck.retrodeck -e "
+            '"%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/mupen64plus_next.so %ROM%" '
+            f'"{file_path}"'
+        ),
+    }
+    assert active_core.calls == [1]
+
+
+def test_single_rom_no_install_row_returns_none():
+    """A ROM with no rom_installs row (uninstalled) → None, nothing to confirm."""
+    uow = FakeUnitOfWork()
+    with uow:
+        uow.roms.save(_make_rom(1, shortcut_app_id=99))
+    resolver = _make_resolver(uow=uow)
+    assert resolver.relaunch_item_for_rom(1) is None
+
+
+def test_single_rom_unbound_returns_none():
+    """An installed ROM with shortcut_app_id=None (unbound) → None."""
+    uow = FakeUnitOfWork()
+    _seed_install(uow, 1, file_path="/roms/n64/a.z64", shortcut_app_id=None)
+    resolver = _make_resolver(uow=uow)
+    assert resolver.relaunch_item_for_rom(1) is None
+
+
+def test_single_rom_missing_rom_returns_none(monkeypatch):
+    """An install whose ``roms.get`` yields None (defensive) → None.
+
+    The schema FK keeps this from happening on disk, so the branch is forced by
+    stubbing the lookup rather than orphaning the install (the FK-modelling fake
+    rejects an orphan at commit).
+    """
+    uow = FakeUnitOfWork()
+    _seed_install(uow, 1, file_path="/roms/n64/a.z64", shortcut_app_id=99)
+    monkeypatch.setattr(uow.roms, "get", lambda _rom_id: None)
+    resolver = _make_resolver(uow=uow)
+    assert resolver.relaunch_item_for_rom(1) is None
+
+
+def test_single_rom_multi_disc_pin_bakes_selected_disc_path():
+    """A multi-disc ROM pinned to disc 2 → its single-ROM item bakes disc 2."""
+    uow = FakeUnitOfWork()
+    _seed_multi_disc(uow, rom_id=1, selected_disc=_DISC2, app_id=555)
+    resolver = _make_resolver(uow=uow, disc_resolver=_multi_disc_resolver())
+    assert resolver.relaunch_item_for_rom(1) == {
+        "app_id": 555,
+        "launch_options": f'flatpak run net.retrodeck.retrodeck "{_DISC2_PATH}"',
+    }

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -346,7 +346,7 @@ class TestWireServices:
     def test_returns_expected_services(self, tmp_path):
         deps = self._make_deps(tmp_path)
         result = wire_services(self._make_config(deps))
-        assert len(result) == 20
+        assert len(result) == 21
         assert "migration_service" in result
         assert "game_detail_service" in result
         assert "rom_removal_service" in result
@@ -359,6 +359,7 @@ class TestWireServices:
         assert "startup_healing_service" in result
         assert "launch_gate_service" in result
         assert "session_lifecycle_service" in result
+        assert "relaunch_options_resolver" in result
         deps["loop"].close()
 
     def test_pending_sync_binding_observes_library_rebinds(self, tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -755,11 +755,13 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_installed_rom",
     "evaluate_launch",
     # Launch-gate offline funnel: a local-only drift hash check, a version-free
-    # reachability heartbeat, and a fire-and-forget read-only save-status
-    # refresh. None mutate RetroDECK state, so all stay callable mid-migration.
+    # reachability heartbeat, a fire-and-forget read-only save-status refresh,
+    # and the pre-launch relaunch re-confirm read (#1150). None mutate RetroDECK
+    # state, so all stay callable mid-migration.
     "check_local_drift",
     "probe_reachability",
     "refresh_save_status",
+    "get_rom_relaunch_options",
     # End-of-session orchestration — composes record_session_end (whitelisted),
     # post_exit_sync (decorator-gated, but SessionLifecycleService applies its
     # own ``is_retrodeck_migration_pending`` check internally so the
@@ -953,6 +955,7 @@ class TestMainStartupOrdering:
             "startup_healing_service": startup_healing_service,
             "launch_gate_service": MagicMock(),
             "session_lifecycle_service": MagicMock(),
+            "relaunch_options_resolver": MagicMock(),
         }
 
         bootstrap_result = BootstrapResult(


### PR DESCRIPTION
Closes #1150.

## Problem

`launch_options` drift that happens **mid-session** (a `download_complete` confirm-set that timed out at `setLaunchOptionsConfirmed`'s 2 s deadline, etc.) heals only on the next plugin reload via the #1043 startup reconcile. Until then the shortcut can carry the empty `""` placeholder and the game flashes Play → `exit 1`.

## Fix

Close it for the most common launch path: the plugin **Play-button funnel** now re-confirms the shortcut's resolved launch command just before launch.

- **Backend:** `RelaunchOptionsResolver` gains a single-ROM seam `relaunch_item_for_rom(rom_id)` — sharing the batch path's *one* resolve body via a factored `_resolve_item` (no new duplication), same snapshot-then-resolve-outside-UoW shape as #1154. Exposed as the `get_rom_relaunch_options(rom_id)` callable (read-only, not migration-gated).
- **Frontend:** `dispatchLaunch` (the single chokepoint every Play-initiated launch goes through) fetches the expected command and `setLaunchOptionsConfirmed(appId, …)` before `RunGame`. **Best-effort** — a failed, empty, or timed-out read still launches (no worse than today). The fetch is bounded by a 3 s `Promise.race` so a wedged backend can't trap the button on "Launching…"; `markLaunchSkipped` stays immediately before `RunGame` so the watcher double-gate fix is preserved.

## Scope — watcher path intentionally uncovered

The direct-Steam-launch path (library grid / Big Picture, handled by the `launchInterceptor.ts` watcher) is **not** covered: the watcher must decide synchronously *before* `CancelGameAction`, with no pre-warmed in-memory state, so it can't await a per-ROM resolve. The #1043 startup reconcile remains its safety net. Documented in ADR-0015.

## Tests

- Resolver (`test_relaunch_options_resolver.py`): `relaunch_item_for_rom` — default-core + `-e` override forms; None for no-install / unbound / missing-rom.
- Contract (`test_rom_relaunch_options.py`): real `get_rom_relaunch_options` — `{app_id, launch_options}` shape for installed+bound, literal `None` for bound-without-install.
- Frontend (`CustomPlayButton.test.tsx`): re-confirm runs before `RunGame` (order asserted); a rejected read logs and **still** launches (non-vacuous); a `null` item skips the set but still launches; a **hung** read falls through after the 3 s timeout and still launches (button never trapped).

## Docs

ADR-0009 (the Play-button pre-launch re-confirm joins the launch_options write paths) and ADR-0015 (the funnel re-confirm step + the uncovered watcher path), updated in this PR.

## On-device

- Force a mid-session drift (blank an installed ROM's `launch_options`), press Play → command healed, game launches, no flicker.
- Normal Play press: no perceptible extra delay, no double-gate, button never stuck on "Launching…".
