### PR TITLE
fix(library): re-confirm launch_options after a sync to heal skipped-platform drift (#1151)

### DIFF
--- a/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
+++ b/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
@@ -64,7 +64,9 @@ whose own `-e "..."` quoting must survive verbatim. `launch_options` carries:
   confirm-sets each installed+bound shortcut's command, healing any drift to `""` left by a missed bake), and
   **re-confirmed once more just before a Play-button launch** by a single-ROM pull (the funnel pulls
   `get_rom_relaunch_options(rom_id)` and confirm-sets the shortcut's command before `RunGame`, healing mid-session drift
-  on the most common launch path between plugin loads — best-effort, a failed re-confirm still launches; #1150);
+  on the most common launch path between plugin loads — best-effort, a failed re-confirm still launches; #1150), and
+  **re-confirmed after every sync** by the same startup-reconcile pass on `sync_complete` (a normal sync skips unchanged
+  platforms, so the post-sync reconcile heals their drift without waiting for a reload or a launch; #1151);
 - the **empty string `""`** (placeholder) for an uninstalled ROM, until it is downloaded.
 
 The `romm:<rom_id>` marker is **gone**. Two bindings that previously rode on it move off `launch_options`:
@@ -127,6 +129,11 @@ storage + precedence + bake-site model is [ADR-0011](0011-per-game-core-override
   ([#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)). The **direct-Steam-launch watcher path stays
   uncovered**: it must decide synchronously before `CancelGameAction` with no pre-warmed state, so it can't afford the
   extra round-trip; that path still relies on the startup reconcile.
+- The startup reconcile also runs **on `sync_complete`**. A normal sync skips unchanged platforms (no per-unit
+  `sync_apply_unit` emit), so a shortcut whose command drifted on an unchanged platform is otherwise never re-applied by
+  the sync — only by a later reload or Play press. Re-running the same idempotent pass after every sync heals it then
+  and there, which is also when the user expects "Sync" to make the library whole
+  ([#1151](https://github.com/danielcopper/decky-romm-sync/issues/1151)).
 - **Breaking for existing shortcuts: a re-sync is required.** Shortcuts created under the `romm:<rom_id>` model carry
   the old marker and no baked command; they are detected by exe but recreated by re-sync to pick up the baked
   `launch_options`. Accepted as a **pre-release** breaking change.

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -327,6 +327,97 @@ describe("index.tsx — startup launch-options reconcile (#1043)", () => {
   });
 });
 
+describe("index.tsx — sync_complete launch-options reconcile (#1151)", () => {
+  type SyncCompletePayload = {
+    platform_app_ids: Record<string, number[]>;
+    total_games: number;
+    cancelled?: boolean;
+  };
+
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    logError.mockClear();
+    vi.mocked(getAllPlaytime).mockResolvedValue({ playtime: {} });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({});
+    vi.mocked(getSettingsResetNotice).mockResolvedValue({ pending: false, backed_up_to: null });
+    // The startup reconcile fires on factory init; default it to an empty set
+    // so each test isolates the sync_complete-triggered reconcile below.
+    vi.mocked(getInstalledRelaunchOptions).mockReset();
+    vi.mocked(getInstalledRelaunchOptions).mockResolvedValue([]);
+  });
+
+  it("re-confirms launch options for every installed+bound ROM after a sync", async () => {
+    const plugin = pluginFactory();
+    await flush(); // settle the startup reconcile (empty set)
+    setLaunchOptionsConfirmed.mockClear();
+    vi.mocked(getInstalledRelaunchOptions).mockClear();
+    vi.mocked(getInstalledRelaunchOptions).mockResolvedValue([
+      { app_id: 100, launch_options: 'flatpak run net.retrodeck.retrodeck "/roms/a.bin"' },
+    ]);
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 0,
+        cancelled: false,
+      });
+    });
+    await flush();
+
+    expect(getInstalledRelaunchOptions).toHaveBeenCalled();
+    expect(setLaunchOptionsConfirmed).toHaveBeenCalledWith(100, 'flatpak run net.retrodeck.retrodeck "/roms/a.bin"');
+    expect(logError).not.toHaveBeenCalledWith(expect.stringContaining("sync_reconcile"));
+    plugin.onDismount();
+  });
+
+  it("reconciles even when the sync was cancelled", async () => {
+    const plugin = pluginFactory();
+    await flush();
+    setLaunchOptionsConfirmed.mockClear();
+    vi.mocked(getInstalledRelaunchOptions).mockClear();
+    vi.mocked(getInstalledRelaunchOptions).mockResolvedValue([
+      { app_id: 200, launch_options: 'flatpak run net.retrodeck.retrodeck "/roms/b.bin"' },
+    ]);
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 0,
+        cancelled: true,
+      });
+    });
+    await flush();
+
+    expect(setLaunchOptionsConfirmed).toHaveBeenCalledWith(200, 'flatpak run net.retrodeck.retrodeck "/roms/b.bin"');
+    plugin.onDismount();
+  });
+
+  it("surfaces a sync_reconcile-prefixed logError when the pull callable rejects", async () => {
+    const plugin = pluginFactory();
+    await flush();
+    setLaunchOptionsConfirmed.mockClear();
+    logError.mockClear();
+    vi.mocked(getInstalledRelaunchOptions).mockReset();
+    vi.mocked(getInstalledRelaunchOptions).mockRejectedValue(new Error("pull failed"));
+
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 0,
+        cancelled: false,
+      });
+    });
+    await flush();
+
+    expect(setLaunchOptionsConfirmed).not.toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("sync_reconcile: failed to reconcile launch options"),
+    );
+    plugin.onDismount();
+  });
+});
+
 describe("index.tsx — corrupt-settings reset notice", () => {
   beforeEach(() => {
     vi.mocked(toaster.toast).mockClear();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,6 +312,23 @@ export default definePlugin(() => {
       }
     }
 
+    // Re-confirm launch_options for every installed+bound ROM after a sync. A
+    // normal sync skips unchanged platforms (no per-unit sync_apply_unit emit),
+    // so a shortcut whose launch_options drifted on an unchanged platform is
+    // otherwise healed only on the next plugin reload (startup reconcile) or
+    // Play press — never by the sync itself (#1151). Reuse the startup-reconcile
+    // mechanism: idempotent + appId-safe, runs regardless of cancellation.
+    detach(
+      (async () => {
+        try {
+          const items = await getInstalledRelaunchOptions();
+          await batchConfirmLaunchOptions(items, "sync_reconcile");
+        } catch (e) {
+          logError(`sync_reconcile: failed to reconcile launch options: ${e}`);
+        }
+      })(),
+    );
+
     // Create/update platform and RomM Steam collections + clean stale ones
     detach(
       (async () => {


### PR DESCRIPTION
Closes #1151.

## Problem

The per-unit incremental skip in library sync (`fetcher.py` → `sync_orchestrator.py`, `if skipped: return`) short-circuits **before** emitting `sync_apply_unit` for unchanged platforms — that's the whole point of the optimization ("skip = no full FE roundtrip"). The side effect: a shortcut whose `launch_options` already drifted to `""` on an unchanged platform is **never re-applied by a normal sync**. It heals only on the next plugin reload (#1043 startup reconcile) or Play press (#1150) — so a user who syncs frequently but doesn't reload or launch via the plugin keeps a broken shortcut, and a **direct Steam-grid launch** (the watcher path #1150 doesn't cover) of that ROM fails until a reload.

## Fix

Rather than re-plumb the carefully-optimized skip path (and risk its invariant), reuse the existing idempotent launch_options reconcile — already built for #1043 — on `sync_complete`: pull `get_installed_relaunch_options` and confirm-set every installed+bound shortcut.

- **Pure frontend**, no backend change, no new event/callable, **the skip path is untouched** — the "skip = no full FE roundtrip" per-unit invariant is fully preserved. This is a separate post-sync sweep, not a per-unit roundtrip.
- **Idempotent + appId-safe**: re-confirming a correct command matches the read-back instantly; `launch_options` isn't part of the appId CRC32, so identity/artwork/collections survive.
- **Best-effort**: wrapped in its own detached try/catch, so a failed pull/confirm never disturbs the sync's toast, collection management, or app-id registration. Runs regardless of cancellation.
- Heals skipped-platform drift (and any other drift) exactly when the user presses "Sync" and expects the library to be made whole.

## Cost

Re-confirms all installed+bound ROMs (≤~200) on each `sync_complete`, including ones a full sync just applied via `sync_apply_unit` — redundant but idempotent (instant read-back match). Gating it on "a platform was skipped" would require plumbing skip state from the backend skip path into the `sync_complete` payload — exactly the skip-path surgery this avoids. The bounded idempotent pass is the right trade for zero backend change.

## Tests

`src/index.test.tsx`: after `sync_complete`, the reconcile pulls + confirm-sets each installed+bound item; reconciles even on a cancelled sync; a rejected pull surfaces a `sync_reconcile`-prefixed `logError` and confirm-set is never called (non-vacuous). The startup reconcile that also fires on init is isolated (defaulted to an empty set, mocks reset before the `sync_complete` emit).

## Docs

ADR-0009 updated: the post-sync reconcile joins the launch_options heal paths, with the skip-path rationale.
