### PR TITLE
fix(library): re-confirm launch_options on the watcher relaunch path too (#1152)

### DIFF
--- a/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
+++ b/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md
@@ -122,13 +122,16 @@ storage + precedence + bake-site model is [ADR-0011](0011-per-game-core-override
   re-confirming a correct command matches the read-back instantly, and `launch_options` is not part of the appId CRC32,
   so the shortcut identity, artwork, and collections survive. It heals drift from every cause at the next plugin load.
 - Because the startup reconcile only runs at plugin load, drift that appears **mid-session** (e.g. a `download-complete`
-  confirm-set that timed out) survives until the next reload. The **Play-button funnel** closes that gap for the common
-  launch path: it runs and `await`s **before** `RunGame`, so it pulls `get_rom_relaunch_options(rom_id)` (the single-ROM
-  build over the same active-core/disc seams) and confirm-sets the shortcut's command just before launch — best-effort,
-  a failed or `None` re-confirm still launches, no worse than today
-  ([#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)). The **direct-Steam-launch watcher path stays
-  uncovered**: it must decide synchronously before `CancelGameAction` with no pre-warmed state, so it can't afford the
-  extra round-trip; that path still relies on the startup reconcile.
+  confirm-set that timed out) survives until the next reload. **Both launch surfaces** close that gap via the shared
+  `reconfirmLaunchOptions` helper (`utils/launchOptionsReconcile.ts`): it pulls `get_rom_relaunch_options(rom_id)` (the
+  single-ROM build over the same active-core/disc seams, bounded by a 3s race) and confirm-sets the shortcut's command
+  just before launch — best-effort, a hang/`None`/failure still launches, no worse than today.
+  - The **Play-button funnel** runs it `await`-before-`RunGame` in `dispatchLaunch`
+    ([#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)).
+  - The **direct-Steam-launch watcher** runs it in its `relaunch` chokepoint, in the already-detached portion after
+    `CancelGameAction` + the gate ([#1152](https://github.com/danielcopper/decky-romm-sync/issues/1152)). This closes
+    the previously-uncovered watcher path; it is defense-in-depth (rarely reachable in current Gaming Mode) and
+    de-duplicates #1150's inline re-confirm into one helper.
 - The startup reconcile also runs **on `sync_complete`**. A normal sync skips unchanged platforms (no per-unit
   `sync_apply_unit` emit), so a shortcut whose command drifted on an unchanged platform is otherwise never re-applied by
   the sync — only by a later reload or Play press. Re-running the same idempotent pass after every sync heals it then

--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -107,13 +107,19 @@ local file to `.romm-backup`, so there is no silent data loss. "Unknown because 
   launch is flicker-free and that a deep link is caught.
 - **One gate** to maintain instead of two divergent ones; the double-gate's redundant `list_saves` is gone.
 - The skip-set adds a little state; its lifetime self-heals (check-and-delete at entry).
-- **The Play-button funnel re-confirms `launch_options` just before `RunGame`** (in `dispatchLaunch`, after the verdict
-  approves and on every launching branch): it pulls `get_rom_relaunch_options(rom_id)` and confirm-sets the shortcut's
-  command, healing mid-session drift on the common launch path between plugin loads
-  ([ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md),
-  [#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)). Best-effort — a failed or `None` re-confirm
-  still launches. The **watcher path is not covered**: it decides synchronously before `CancelGameAction` and can't
-  afford the round-trip, so it relies on the startup reconcile.
+- **Both launch surfaces re-confirm `launch_options` just before `RunGame`**, via the shared
+  `reconfirmLaunchOptions(romId, appId, context)` helper (in `utils/launchOptionsReconcile.ts`): it pulls
+  `get_rom_relaunch_options(rom_id)` (bounded by a 3s race) and confirm-sets the shortcut's command, healing mid-session
+  drift on the launch path between plugin loads ([ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md)).
+  Best-effort — a hang, a `None` item, or a failure still launches.
+  - The **Play-button funnel** runs it in `dispatchLaunch` (after the verdict approves, on every launching branch)
+    ([#1150](https://github.com/danielcopper/decky-romm-sync/issues/1150)).
+  - The **watcher** runs it in its `relaunch` chokepoint (after `CancelGameAction` + the gate, in the already-detached
+    async portion — so it adds only a bounded ≤3s wait to the cancel→relaunch window)
+    ([#1152](https://github.com/danielcopper/decky-romm-sync/issues/1152)). This closes the previously-uncovered watcher
+    path. It is **defense-in-depth** — in current Steam Gaming Mode a launch needs the game page + Play button, so the
+    direct-Steam-launch watcher path is rarely reachable; its concrete win is **de-duplicating** #1150's inline
+    re-confirm into the one shared helper.
 - **On-device verification required** (cannot be unit-tested): the cancel-relaunch flicker, modal focus after cancel,
   slow-server feel, and the suspend hooks.
 

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1452,10 +1452,13 @@ describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
 
     await clickPlay();
 
-    // Post-catch state: the failure was logged with the #1150 message AND the
-    // launch still fired (best-effort — a failed re-confirm is no worse than today).
+    // Post-catch state: the failure was logged with the shared-helper message
+    // (carrying the "CustomPlayButton" context) AND the launch still fired
+    // (best-effort — a failed re-confirm is no worse than today).
     await waitFor(() =>
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("pre-launch relaunch re-confirm failed")),
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("CustomPlayButton: launch_options re-confirm failed"),
+      ),
     );
     await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
 
@@ -1490,7 +1493,9 @@ describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
       // The hung fetch timed out → re-confirm skipped (no set), logged, and the
       // launch STILL fired. RunGame is the proof the button escaped "Launching…".
       expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("pre-launch relaunch re-confirm failed"));
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("CustomPlayButton: launch_options re-confirm failed"),
+      );
       expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100);
     } finally {
       vi.useRealTimers();

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -33,7 +33,6 @@ import {
   probeReachability,
   checkLocalDrift,
   refreshSaveStatus,
-  getRomRelaunchOptions,
 } from "../api/backend";
 import { getRommConnectionState } from "../utils/connectionState";
 import { scrollToTop } from "../utils/scrollHelpers";
@@ -51,6 +50,7 @@ import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent 
 import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
 import { detach } from "../utils/detach";
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
+import { reconfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 
 type PlayButtonState =
   | "loading"
@@ -454,25 +454,9 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const dispatchLaunch = async (gameId: string) => {
     setState("launching");
     // Heal any mid-session launch_options drift on this shortcut before launch
-    // (#1150). Best-effort: a failed re-confirm still launches — no worse than today.
-    // The Decky callable bridge can hang indefinitely if the backend is wedged, so
-    // bound the read with a timeout (mirrors index.tsx's withTimeout and the
-    // funnel's preLaunchSync Promise.race) — a hang must fall through to the launch,
-    // never trap the button on "Launching…". setLaunchOptionsConfirmed has its own
-    // 2s internal timeout, so only the fetch needs bounding here.
-    if (romId) {
-      try {
-        const item = await Promise.race([
-          getRomRelaunchOptions(romId),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("get_rom_relaunch_options timed out")), 3000),
-          ),
-        ]);
-        if (item) await setLaunchOptionsConfirmed(appId, item.launch_options);
-      } catch (e) {
-        logError(`CustomPlayButton: pre-launch relaunch re-confirm failed (launching anyway): ${e}`);
-      }
-    }
+    // (#1150) via the shared bounded-race re-confirm. Best-effort: a hang, a
+    // null item, or a failure still launches — no worse than today.
+    if (romId) await reconfirmLaunchOptions(romId, appId, "CustomPlayButton");
     markLaunchSkipped(appId);
     SteamClient.Apps.RunGame(gameId, "", -1, 100);
   };

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -8,6 +8,7 @@ import * as syncConflictModal from "../components/SyncConflictModal";
 import * as offlineDriftModal from "../components/OfflineDriftModal";
 import * as fallbackLaunchModal from "../components/FallbackLaunchModal";
 import * as coreChangeModal from "../components/CoreChangeModal";
+import * as steamShortcuts from "./steamShortcuts";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./launchInterceptor";
 import type { GateVerdict, LaunchGateOps } from "./launchGate";
 import type { SyncConflict } from "../types";
@@ -30,8 +31,18 @@ vi.mock("../api/backend", () => ({
   probeReachability: vi.fn(),
   preLaunchSync: vi.fn(),
   checkLocalDrift: vi.fn(),
+  // The shared reconcile helper (real module) pulls the single-ROM command here
+  // before each watcher relaunch (#1152).
+  getRomRelaunchOptions: vi.fn(),
   logInfo: vi.fn(),
   logError: vi.fn(),
+}));
+
+// The reconcile helper confirm-sets the resolved command onto the shortcut.
+// Mock just that surface so the watcher relaunch re-confirm is observable
+// without touching SteamClient's shortcut APIs.
+vi.mock("./steamShortcuts", () => ({
+  setLaunchOptionsConfirmed: vi.fn().mockResolvedValue(true),
 }));
 
 // Keep the real skip-set (markLaunchSkipped / consumeLaunchSkip) so the
@@ -138,6 +149,11 @@ describe("launchInterceptor — full funnel watcher", () => {
     // Skip-set empty by default — a marked appId is set per-test.
     vi.mocked(sessionManager.getAppIdRomIdMapSnapshot).mockReturnValue({ "1234": 42 });
     vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
+    // The shared relaunch re-confirm (#1152) runs on every relaunch; default it
+    // to a resolved command + a clean confirm-set so the existing verdict tests
+    // exercise the happy path without per-test wiring.
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 1234, launch_options: "flatpak run x" });
+    vi.mocked(steamShortcuts.setLaunchOptionsConfirmed).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -416,6 +432,110 @@ describe("launchInterceptor — full funnel watcher", () => {
 
       expect(toaster.toast).not.toHaveBeenCalled();
       expect(runGameMock()).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1152 — the watcher's relaunch path re-confirms launch_options just before
+  // RunGame, mirroring the Play-button funnel via the shared
+  // `reconfirmLaunchOptions` helper. Best-effort: a null/rejected/hung re-confirm
+  // still relaunches (the launch must never be trapped).
+  // ---------------------------------------------------------------------------
+  describe("relaunch launch_options re-confirm (#1152)", () => {
+    const RELAUNCH_COMMAND = 'flatpak run net.retrodeck.retrodeck "/roms/snes/g.rom"';
+
+    it("allow → re-confirms (getRomRelaunchOptions → setLaunchOptionsConfirmed) BEFORE RunGame", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
+      vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 1234, launch_options: RELAUNCH_COMMAND });
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(backend.getRomRelaunchOptions).toHaveBeenCalledWith(42);
+      expect(steamShortcuts.setLaunchOptionsConfirmed).toHaveBeenCalledWith(1234, RELAUNCH_COMMAND);
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+      // Order: getRomRelaunchOptions → setLaunchOptionsConfirmed → RunGame.
+      const getOrder = vi.mocked(backend.getRomRelaunchOptions).mock.invocationCallOrder[0]!;
+      const setOrder = vi.mocked(steamShortcuts.setLaunchOptionsConfirmed).mock.invocationCallOrder[0]!;
+      const runOrder = vi.mocked(SteamClient.Apps.RunGame).mock.invocationCallOrder[0]!;
+      expect(getOrder).toBeLessThan(setOrder);
+      expect(setOrder).toBeLessThan(runOrder);
+    });
+
+    it("markLaunchSkipped fires immediately before RunGame (re-confirm doesn't disturb the skip→run order)", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
+      vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 1234, launch_options: RELAUNCH_COMMAND });
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      // markLaunchSkipped(1234) ran before RunGame, so the relaunch is exempt:
+      // consuming the skip now returns true (the real skip-set carries it).
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+      expect(launchGate.consumeLaunchSkip(1234)).toBe(true);
+    });
+
+    it("a null item skips setLaunchOptionsConfirmed but STILL relaunches", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
+      vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue(null);
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(backend.getRomRelaunchOptions).toHaveBeenCalledWith(42);
+      expect(steamShortcuts.setLaunchOptionsConfirmed).not.toHaveBeenCalled();
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+    });
+
+    it("a rejected re-confirm logs with the Watcher context AND still relaunches (non-vacuous)", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
+      vi.mocked(backend.getRomRelaunchOptions).mockRejectedValue(new Error("offline"));
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      // Post-catch: no set, the failure was logged with the helper's Watcher
+      // prefix, and the relaunch still fired (best-effort).
+      expect(steamShortcuts.setLaunchOptionsConfirmed).not.toHaveBeenCalled();
+      expect(backend.logError).toHaveBeenCalledWith(
+        expect.stringContaining("Watcher: launch_options re-confirm failed"),
+      );
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+    });
+
+    it("conflict resolved → re-confirms then relaunches (shared path covers every relaunch branch)", async () => {
+      vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "conflict", conflicts: [conflict()] });
+      vi.mocked(syncConflictModal.handleConflicts).mockResolvedValue("resolved");
+      vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 1234, launch_options: RELAUNCH_COMMAND });
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(steamShortcuts.setLaunchOptionsConfirmed).toHaveBeenCalledWith(1234, RELAUNCH_COMMAND);
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+    });
+
+    it("unknown appId relaunches WITHOUT a re-confirm (no romId to resolve)", async () => {
+      vi.mocked(sessionManager.getAppIdRomIdMapSnapshot).mockReturnValue({});
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(backend.getRomRelaunchOptions).not.toHaveBeenCalled();
+      expect(steamShortcuts.setLaunchOptionsConfirmed).not.toHaveBeenCalled();
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
     });
   });
 

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -36,6 +36,7 @@ import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { getAppIdRomIdMapSnapshot } from "./sessionManager";
 import { runLaunchGate, markLaunchSkipped, consumeLaunchSkip } from "./launchGate";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "./launchGate";
+import { reconfirmLaunchOptions } from "./launchOptionsReconcile";
 import { applyLaunchGateSetupOutcome, resolveSaveSetupOutcome } from "./saveSetup";
 import { showCoreChangeModal } from "../components/CoreChangeModal";
 import { handleConflicts } from "../components/SyncConflictModal";
@@ -168,12 +169,25 @@ function makeWatcherOps(romId: number): LaunchGateOps {
   };
 }
 
-/** Relaunch a previously-cancelled, now-approved launch. Marks the appId as
- *  skipped FIRST so this RunGame doesn't re-enter the watcher and re-gate. */
-function relaunch(appId: number): void {
+/** Relaunch a previously-cancelled launch. Marks the appId as skipped FIRST so
+ *  this RunGame doesn't re-enter the watcher and re-gate. Used directly only for
+ *  the no-romId paths (unknown appId, error fallback) where there is nothing to
+ *  re-confirm; the gated path goes through {@link relaunch}. */
+function bareRelaunch(appId: number): void {
   markLaunchSkipped(appId);
   const gameId = appStore.GetAppOverviewByAppID(appId)?.GetGameID?.() ?? String(appId);
   SteamClient.Apps.RunGame(gameId, "", -1, 100);
+}
+
+/** Relaunch a previously-cancelled, now-approved launch. Heals any mid-session
+ *  `launch_options` drift on the shortcut first (shared bounded-race re-confirm,
+ *  best-effort — a hang/null/failure still relaunches), then marks the appId as
+ *  skipped immediately before this RunGame so it doesn't re-enter the watcher
+ *  and re-gate. The re-confirm runs in the already-detached post-cancel portion,
+ *  so it only adds a bounded (≤3s) wait to the cancel→relaunch window. */
+async function relaunch(appId: number, romId: number): Promise<void> {
+  await reconfirmLaunchOptions(romId, appId, "Watcher");
+  bareRelaunch(appId);
 }
 
 /**
@@ -188,7 +202,7 @@ function relaunch(appId: number): void {
 async function handleWatcherVerdict(verdict: GateVerdict, appId: number, romId: number): Promise<"done" | "retry"> {
   switch (verdict.decision) {
     case "allow":
-      relaunch(appId);
+      await relaunch(appId, romId);
       return "done";
     case "abort":
       // The user saw setup/core UI and declined — already cancelled, nothing to do.
@@ -203,18 +217,18 @@ async function handleWatcherVerdict(verdict: GateVerdict, appId: number, romId: 
       if (resolution === "cancel") return "done";
       // Conflicts resolved — notify sibling components to refresh, then relaunch.
       globalThis.dispatchEvent(new CustomEvent("romm_data_changed", { detail: { type: "save_sync", rom_id: romId } }));
-      relaunch(appId);
+      await relaunch(appId, romId);
       return "done";
     }
     case "offline_drift": {
       const choice = await showOfflineDriftModal();
-      if (choice === "start_anyway") relaunch(appId);
+      if (choice === "start_anyway") await relaunch(appId, romId);
       if (choice === "retry") return "retry";
       return "done";
     }
     case "sync_failed": {
       const proceed = await showFallbackLaunchModal(verdict.message);
-      if (proceed) relaunch(appId);
+      if (proceed) await relaunch(appId, romId);
       return "done";
     }
   }
@@ -295,7 +309,7 @@ export function registerLaunchInterceptor(): void {
             // unknown appId is not ours to gate — relaunch and bail.
             const romId = getAppIdRomIdMapSnapshot()[String(appId)];
             if (romId == null) {
-              relaunch(appId);
+              bareRelaunch(appId);
               return;
             }
 
@@ -312,8 +326,11 @@ export function registerLaunchInterceptor(): void {
             await runWatcherGate(appId, romId);
           } catch (e) {
             // Any unexpected error must NEVER trap the user's game — relaunch.
+            // Use the bare relaunch (no re-confirm): the failure may be the
+            // re-confirm's own dependency, and the priority here is escaping the
+            // cancelled state, not healing drift.
             logError(`Launch interceptor error: ${e}`);
-            relaunch(appId);
+            bareRelaunch(appId);
           }
         })(),
       );

--- a/src/utils/launchOptionsReconcile.test.ts
+++ b/src/utils/launchOptionsReconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { batchConfirmLaunchOptions } from "./launchOptionsReconcile";
+import { batchConfirmLaunchOptions, reconfirmLaunchOptions } from "./launchOptionsReconcile";
 import * as steamShortcuts from "./steamShortcuts";
 import * as backend from "../api/backend";
 
@@ -58,5 +58,75 @@ describe("batchConfirmLaunchOptions", () => {
     const msg = vi.mocked(backend.logError).mock.calls[0]![0];
     expect(msg).toContain("migration_relaunch_options: failed to set launch options for appId 2");
     expect(msg).toContain("boom");
+  });
+});
+
+describe("reconfirmLaunchOptions", () => {
+  const RELAUNCH_COMMAND = 'flatpak run net.retrodeck.retrodeck "/roms/gba/pokemon.gba"';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(steamShortcuts.setLaunchOptionsConfirmed).mockResolvedValue(true);
+  });
+
+  it("confirm-sets the resolved command onto the appId when an item is returned", async () => {
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue({ app_id: 100, launch_options: RELAUNCH_COMMAND });
+
+    await reconfirmLaunchOptions(42, 100, "CustomPlayButton");
+
+    expect(vi.mocked(backend.getRomRelaunchOptions)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(steamShortcuts.setLaunchOptionsConfirmed)).toHaveBeenCalledWith(100, RELAUNCH_COMMAND);
+    expect(vi.mocked(backend.logError)).not.toHaveBeenCalled();
+  });
+
+  it("skips the confirm-set on a null item but does not throw or log", async () => {
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue(null);
+
+    await expect(reconfirmLaunchOptions(42, 100, "Watcher")).resolves.toBeUndefined();
+
+    expect(vi.mocked(backend.getRomRelaunchOptions)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(steamShortcuts.setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.logError)).not.toHaveBeenCalled();
+  });
+
+  it("logs a non-vacuous error with the context prefix when the fetch rejects; never throws", async () => {
+    vi.mocked(backend.getRomRelaunchOptions).mockRejectedValue(new Error("offline"));
+
+    await expect(reconfirmLaunchOptions(42, 100, "Watcher")).resolves.toBeUndefined();
+
+    expect(vi.mocked(steamShortcuts.setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+    const msg = vi.mocked(backend.logError).mock.calls[0]![0];
+    expect(msg).toContain("Watcher: launch_options re-confirm failed");
+    expect(msg).toContain("offline");
+  });
+
+  it("carries the caller's context prefix (CustomPlayButton) into the failure log", async () => {
+    vi.mocked(backend.getRomRelaunchOptions).mockRejectedValue(new Error("boom"));
+
+    await reconfirmLaunchOptions(42, 100, "CustomPlayButton");
+
+    expect(vi.mocked(backend.logError)).toHaveBeenCalledWith(
+      expect.stringContaining("CustomPlayButton: launch_options re-confirm failed"),
+    );
+  });
+
+  it("a hung fetch falls through after the 3s timeout: no set, logged, resolves (never hangs the caller)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Never resolves — simulates a wedged backend / hung callable bridge.
+      vi.mocked(backend.getRomRelaunchOptions).mockReturnValue(new Promise<never>(() => {}));
+
+      const pending = reconfirmLaunchOptions(42, 100, "CustomPlayButton");
+      // Advancing past the 3s race fires the timeout reject without a real wait.
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(pending).resolves.toBeUndefined();
+
+      expect(vi.mocked(steamShortcuts.setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.logError)).toHaveBeenCalledWith(
+        expect.stringContaining("CustomPlayButton: launch_options re-confirm failed"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/utils/launchOptionsReconcile.ts
+++ b/src/utils/launchOptionsReconcile.ts
@@ -1,10 +1,38 @@
-import { logError } from "../api/backend";
+import { getRomRelaunchOptions, logError } from "../api/backend";
 import { setLaunchOptionsConfirmed } from "./steamShortcuts";
 
 // Apply in bounded-concurrency batches (mirrors getExistingRomMShortcuts) so a
 // reconcile touching many ROMs doesn't serialize worst-case per-shortcut
 // confirm-poll timeouts.
 const CONCURRENCY = 10;
+
+/** Bound on the single-ROM relaunch-options fetch before a launch. The Decky
+ *  callable bridge can hang indefinitely on a wedged backend, so the read is
+ *  raced against this timeout — a hang falls through to the launch instead of
+ *  trapping the caller (mirrors index.tsx's withTimeout). */
+const RECONFIRM_FETCH_TIMEOUT_MS = 3000;
+
+/**
+ * Heal any mid-session `launch_options` drift on one shortcut right before a
+ * launch: pull the ROM's resolved command (`get_rom_relaunch_options`) and
+ * confirm-set it onto the shortcut's appId. Best-effort — a hang (bounded by a
+ * 3s race), a `null` item, or a thrown error is logged via `logError` with the
+ * `context` prefix and never blocks the caller; the launch proceeds regardless.
+ * Shared by the Play-button funnel and the direct-launch watcher relaunch path.
+ */
+export async function reconfirmLaunchOptions(romId: number, appId: number, context: string): Promise<void> {
+  try {
+    const item = await Promise.race([
+      getRomRelaunchOptions(romId),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("get_rom_relaunch_options timed out")), RECONFIRM_FETCH_TIMEOUT_MS),
+      ),
+    ]);
+    if (item) await setLaunchOptionsConfirmed(appId, item.launch_options);
+  } catch (e) {
+    logError(`${context}: launch_options re-confirm failed (launching anyway): ${e}`);
+  }
+}
 
 /**
  * Confirm-set the launch command on every shortcut in `items`, batching the


### PR DESCRIPTION
Closes #1152.

Last of the launch_options-drift series. After #1043 (heal at plugin load), #1151 (heal on every sync), and #1150 (heal before a Play-button launch), the one launch surface still uncovered was the **direct-Steam-launch watcher** (`launchInterceptor.ts`) — a grid/Big-Picture launch that bypasses our Play button.

## Fix

Extract #1150's bounded-race re-confirm into a shared `reconfirmLaunchOptions(romId, appId, context)` helper and wire it into **both** launch surfaces:

- **Play button** (`CustomPlayButton.dispatchLaunch`) — replaces #1150's inline block (dedup; one copy of the re-confirm body now).
- **Watcher** (`launchInterceptor.relaunch`) — the previously-uncovered path. The re-confirm runs in the already-detached post-`CancelGameAction` portion, before the relaunch `RunGame`, so a direct launch also heals mid-session drift.

Both are **best-effort**: the helper bounds `get_rom_relaunch_options` with a 3 s `Promise.race`, so a hang/`null`/failure still relaunches — no worse than before. `markLaunchSkipped` stays immediately before `RunGame` in both paths, preserving the watcher double-gate. The two genuinely no-romId relaunch sites (unknown appId, gate error-fallback) use a `bareRelaunch` that skips the re-confirm.

## Honest scoping

This is **defense-in-depth**: in current Steam Gaming Mode there is no way to launch a game without opening its page and pressing Play, so the watcher path is rarely reachable in practice. The concrete wins are (1) closing the documented "watcher uncovered" carve-out, and (2) **de-duplicating** #1150's inline re-confirm into one shared helper.

## Tests

- `launchOptionsReconcile.test.ts`: the helper — item → set; `null` → skip; reject → non-vacuous `logError`; hung fetch → 3 s timeout (fake timers) → no set + logged + resolves; both `"CustomPlayButton"` and `"Watcher"` contexts.
- `launchInterceptor.test.ts`: watcher relaunch re-confirms before `RunGame` (order asserted); `markLaunchSkipped` stays immediately before `RunGame`; null/rejected/hung re-confirm still relaunches (non-vacuous); unknown-appId relaunches without a re-confirm.
- `CustomPlayButton.test.tsx`: #1150 order/null/reject/hang tests stay green through the helper (message-prefix assertions updated).

## Docs

ADR-0009 and ADR-0015 updated: both launch surfaces now re-confirm via the shared helper; the watcher carve-out is closed.
