### PR TITLE
fix(plugin): remove the inert _root flag from plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,9 +2,7 @@
   "name": "RomM Sync",
   "version": "0.23.0",
   "author": "danielcopper",
-  "flags": [
-    "_root"
-  ],
+  "flags": [],
   "api_version": 1,
   "publish": {
     "tags": [


### PR DESCRIPTION
## Summary

Removes the `_root` flag from `plugin.json` (`"flags": ["_root"]` → `"flags": []`).

Decky Loader only honors the exact flag string `"root"` for elevated execution:

```python
setuid(UserType.EFFECTIVE_USER if "root" in self.flags else UserType.HOST_USER)
```

`"root" in ["_root"]` is `False`, so `_root` is an unrecognized no-op — the plugin already runs as the `deck` user (UID 1000), not root. The flag has been present since the Phase-1 skeleton commit and grants nothing; it is a template carryover that needlessly invites store-reviewer scrutiny.

## On-device verification (Steam Deck, Decky Loader v3.2.5-pre1)

After deploying `flags: []` and restarting the plugin loader:

- RomM Sync process runs as **UID 1000 (deck)** — unchanged.
- Plugin bootstraps cleanly: `RomM Sync plugin loaded`, backend connected to RomM 4.9.2, frontend `App ID init succeeded` / `Session manager initialized`.
- No tracebacks, errors, or permission-denied in the plugin log.

The write paths (download / save sync / BIOS / grid art) already executed as `deck` in production, so they cannot regress from removing a no-op flag.

docs: N/A — removes an inert manifest flag; no user-facing, architectural, or flow change.

Closes #1157
