### PR TITLE
fix(saves): classify heartbeat and registration errors instead of masking as offline

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -990,6 +990,27 @@ If the RomM server is unreachable when a sync runs:
 4. No data is lost. There is no separate retry queue because the algorithm is idempotent: re-running it after a
    transient failure converges on the same end state.
 
+### Heartbeat error classification (launch-time probe)
+
+`pre_launch_sync` and `post_exit_sync` pre-probe the server with a single `heartbeat` call before doing any sync work. A
+failure here is **classified by type**, not collapsed onto a blanket "Server offline"
+([#971](https://github.com/danielcopper/decky-romm-sync/issues/971)):
+
+- A genuine reachability failure (`RommConnectionError` / `RommTimeoutError`) returns the canonical `SERVER_UNREACHABLE`
+  shape with `message: "Server offline"` **plus** the additive `offline: true` flag the launch path routes on
+  (offline-drift check instead of a doomed round-trip).
+- Any other typed `RommApiError` flows through `lib/errors.py` `classify_error`, so the result carries its **own**
+  `reason` + `message`: a revoked token (401) surfaces `AUTH_FAILED` + "Authentication failed — check your username and
+  password", an SSL misconfig surfaces the SSL message, a 5xx surfaces the server-error message. These branches **omit**
+  the `offline` flag, so the UI never claims a reachable server is unreachable. The Play button's fallback launch modal
+  shows that backend `message` verbatim, so a user whose token expired sees "authentication failed" instead of being
+  told the server is offline forever.
+
+The raw exception is logged at debug in every branch, so the probe is no longer a silent swallow. The same
+classification applies to the device-registration failure path in `services/saves/sync_engine/devices.py`
+(`ensure_device_registered`): an auth/SSL failure during `register_device` produces its own classified `reason` +
+`message` rather than a generic "Could not register device" unreachable slug.
+
 ## Playtime Tracking
 
 ### Local delta-based accumulation

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -142,6 +142,12 @@ If the RomM server is unreachable when a sync is attempted:
   outcome — typically pushing your changes once the server is reachable again.
 - No save data is ever lost due to a failed sync.
 
+"Server offline" is reported **only** for a genuine reachability failure (the server can't be reached or times out). A
+sync that fails for another reason — for example an expired or revoked login token, or an SSL certificate problem —
+shows that specific reason instead (such as "Authentication failed — check your username and password"), so a working
+server is never mislabelled as offline. If you see an authentication message, re-enter your server URL and sign in again
+in the plugin settings.
+
 ## Playtime Tracking
 
 The plugin tracks playtime per game. Session start and end times are recorded, and device suspend/resume is accounted

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -145,8 +145,9 @@ If the RomM server is unreachable when a sync is attempted:
 "Server offline" is reported **only** for a genuine reachability failure (the server can't be reached or times out). A
 sync that fails for another reason — for example an expired or revoked login token, or an SSL certificate problem —
 shows that specific reason instead (such as "Authentication failed — check your username and password"), so a working
-server is never mislabelled as offline. If you see an authentication message, re-enter your server URL and sign in again
-in the plugin settings.
+server is never mislabelled as offline. This applies to both surfaces: the warning shown before launch and the "after
+exit" toast both name the actual cause rather than a generic "failed to sync" message. If you see an authentication
+message, re-enter your server URL and sign in again in the plugin settings.
 
 ## Playtime Tracking
 

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -9,7 +9,6 @@ RomM communication goes through ``RommPlaytimeApi``. No ``import decky``.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import sqlite3
 from dataclasses import dataclass
@@ -248,9 +247,13 @@ class PlaytimeService:
             self._log_debug(f"Failed to record session end for rom {rom_id}: {e}")
             return {"success": False, "reason": "unknown_rom", "message": "Unknown ROM"}
 
-        # Best-effort sync playtime to RomM server notes (outside the UoW).
-        with contextlib.suppress(Exception):
+        # Best-effort sync playtime to RomM server notes (outside the UoW). A
+        # failure here is non-fatal (the local total is already persisted), but
+        # log it at debug so the swallow leaves a breadcrumb (#971).
+        try:
             self._sync_playtime_to_romm_io(rom_id, duration)
+        except Exception as e:
+            self._log_debug(f"record_session_end: playtime-to-RomM sync failed (non-fatal) for rom {rom_id}: {e}")
 
         return {
             "success": True,

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING, Any
 
+from lib.errors import classify_error
 from lib.list_result import ErrorCode
 from services.saves._settings import save_sync_enabled
 
@@ -139,11 +140,16 @@ class DeviceRegistry:
         device_id = await loop.run_in_executor(None, self._get_device_id)
         if device_id:
             server_id_str = str(device_id)
-            with contextlib.suppress(Exception):
+            # Best-effort touch of the server-side client_version. A failure here
+            # is non-fatal (the device is already registered), but log it at debug
+            # so the swallow leaves a breadcrumb instead of vanishing silently.
+            try:
                 await loop.run_in_executor(
                     None,
                     lambda: self._romm_api.update_device(server_id_str, client_version=self._plugin_version),
                 )
+            except Exception as e:
+                self._log_debug(f"ensure_device_registered: update_device failed (non-fatal): {e}")
             return {
                 "success": True,
                 "device_id": device_id,
@@ -178,7 +184,19 @@ class DeviceRegistry:
                     "server_device_id": new_id,
                 }
         except Exception as e:
+            # Classify the failure so a revoked token (401 → AUTH_FAILED) or an
+            # SSL misconfig carries its OWN reason + message instead of every
+            # failure collapsing onto a generic "Could not register device"
+            # offline slug (#971).
             self._logger.warning(f"Server device registration failed: {e}")
+            reason, message = classify_error(e)
+            return {
+                "success": False,
+                "reason": reason,
+                "message": message,
+                "device_id": "",
+                "device_name": "",
+            }
 
         return {
             "success": False,

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from domain.rom_save_state import RomSaveState
 from domain.save_layout import ContentDir
+from lib.errors import RommConnectionError, RommTimeoutError, classify_error
 from lib.list_result import ErrorCode
 from services.saves._messages import (
     DEVICE_NOT_REGISTERED,
@@ -414,6 +415,38 @@ class SyncEngine:
             base["conflicts"] = []
         return base
 
+    def _heartbeat_failure_result(self, where: str, exc: Exception) -> dict[str, Any]:
+        """Build the sync-result dict for a heartbeat failure, classified by type.
+
+        Only a genuine reachability failure (``RommConnectionError`` /
+        ``RommTimeoutError``) is reported as "Server offline" with the additive
+        ``offline`` flag the launch path routes on. Any other typed error — a
+        revoked token (401 → ``AUTH_FAILED``), an SSL misconfig, a 5xx, etc. —
+        flows through :func:`classify_error` so the result carries its OWN
+        ``reason`` + ``message`` and the UI stops claiming the server is
+        unreachable when it is plainly reachable (#971). The raw exception is
+        always logged at debug so the offline branch is no longer a silent
+        swallow.
+        """
+        self._log_debug(f"{where}: heartbeat failed ({type(exc).__name__}: {exc})")
+        if isinstance(exc, (RommConnectionError, RommTimeoutError)):
+            self._logger.info("%s skipped: server offline", where)
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Server offline",
+                "synced": 0,
+                "offline": True,
+            }
+        reason, message = classify_error(exc)
+        self._logger.info("%s skipped: %s", where, message)
+        return {
+            "success": False,
+            "reason": reason,
+            "message": message,
+            "synced": 0,
+        }
+
     async def _run_rom_sync(self, rom_id: int) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Read inputs → sync in executor → persist, for one ROM under its lock.
 
@@ -480,20 +513,15 @@ class SyncEngine:
                 return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
 
             # Pre-probe reachability before any sync work — mirror post_exit_sync.
-            # When the server is offline, surface the canonical unreachable shape
-            # (plus the additive ``offline`` flag) so the launch path can warn on
-            # local drift instead of stalling on a doomed sync round-trip.
+            # A genuine reachability failure surfaces the canonical unreachable
+            # shape (plus the additive ``offline`` flag) so the launch path can
+            # warn on local drift instead of stalling on a doomed round-trip; an
+            # auth/SSL/server error instead carries its OWN classified reason so
+            # the UI stops lying about reachability (#971).
             try:
                 await self._loop.run_in_executor(None, self._romm_api.heartbeat)
-            except Exception:
-                self._logger.info("pre_launch_sync skipped: server offline")
-                return {
-                    "success": False,
-                    "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                    "message": "Server offline",
-                    "synced": 0,
-                    "offline": True,
-                }
+            except Exception as e:
+                return self._heartbeat_failure_result("pre_launch_sync", e)
 
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()
@@ -550,15 +578,8 @@ class SyncEngine:
 
             try:
                 await self._loop.run_in_executor(None, self._romm_api.heartbeat)
-            except Exception:
-                self._logger.info("post_exit_sync skipped: server offline")
-                return {
-                    "success": False,
-                    "reason": ErrorCode.SERVER_UNREACHABLE.value,
-                    "message": "Server offline",
-                    "synced": 0,
-                    "offline": True,
-                }
+            except Exception as e:
+                return self._heartbeat_failure_result("post_exit_sync", e)
 
             if not self.get_device_id():
                 reg = await self.ensure_device_registered()

--- a/py_modules/services/session_lifecycle.py
+++ b/py_modules/services/session_lifecycle.py
@@ -111,13 +111,20 @@ class SessionLifecycleServiceConfig:
     logger: logging.Logger
 
 
-def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> tuple[str | None, str | None]:
+def _render_sync_toast(
+    *, offline: bool, success: bool, synced: int | None, message: str | None = None
+) -> tuple[str | None, str | None]:
     """Map the raw post-exit-sync flags onto the (title, body) toast pair.
 
     Branching: offline wins over success, success-with-uploads renders
     the synced toast, a successful no-op produces no toast at all, and
     any non-success/non-offline state falls through to the failure
-    toast.
+    toast. ``message`` is the classified failure cause from the sync
+    result (e.g. "Authentication failed — sign in again", #971); when
+    present it names the cause in the failure body instead of the
+    generic fallback, keeping the post-exit toast consistent with the
+    pre-launch fallback modal. Only the failure body honours it — the
+    offline and success branches are unaffected.
     """
     if offline:
         return _TOAST_TITLE, _TOAST_BODY_OFFLINE
@@ -125,7 +132,7 @@ def _render_sync_toast(*, offline: bool, success: bool, synced: int | None) -> t
         return _TOAST_TITLE, _TOAST_BODY_SYNCED
     if success:
         return None, None
-    return _TOAST_TITLE, _TOAST_BODY_FAILED
+    return _TOAST_TITLE, message or _TOAST_BODY_FAILED
 
 
 def _render_conflicts_toast(conflicts: list[dict[str, Any]]) -> str | None:
@@ -264,6 +271,9 @@ class SessionLifecycleService:
             result = await self._post_exit_sync.post_exit_sync(rom_id)
         except Exception as e:
             self._logger.warning(f"SessionLifecycle post-exit sync failed for rom_id={rom_id}: {e}")
+            # No classified message on this path: the sync raised rather than
+            # returning a structured result, so there is no result["message"]
+            # to surface — fall back to the generic failure body.
             return SessionFinalizeSyncResult(
                 offline=False,
                 success=False,
@@ -294,8 +304,10 @@ class SessionLifecycleService:
         synced = raw_synced if isinstance(raw_synced, int) else None
         raw_conflicts = result.get("conflicts")
         conflicts: list[dict[str, Any]] = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
+        raw_message = result.get("message")
+        message = raw_message if isinstance(raw_message, str) else None
 
-        toast_title, toast_body = _render_sync_toast(offline=offline, success=success, synced=synced)
+        toast_title, toast_body = _render_sync_toast(offline=offline, success=success, synced=synced, message=message)
         conflicts_toast = _render_conflicts_toast(conflicts)
 
         return SessionFinalizeSyncResult(

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -9,7 +9,8 @@ import pytest
 from fakes.fake_hostname_reader import FakeHostnameReader
 from fakes.fake_machine_id_reader import FakeMachineIdReader
 
-from lib.errors import RommApiError
+from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError
+from lib.list_result import ErrorCode
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
@@ -152,3 +153,75 @@ class TestEnsureDeviceRegisteredFailurePaths:
         assert "Device" in result["message"] or "device" in result["message"]
         # No per-ROM sync ran.
         assert not any(c[0] == "list_saves" for c in fake.call_log)
+
+
+class TestEnsureDeviceRegisteredErrorClassification:
+    """When register_device raises, the returned dict carries the CLASSIFIED
+    reason + message (auth/SSL get their own slug) instead of every failure
+    collapsing onto a generic SERVER_UNREACHABLE "Could not register device"
+    (#971)."""
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_classifies_to_auth_failed(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        # Stamp a version so the pre-register heartbeat probe is skipped — the
+        # failure must land on register_device, not the non-fatal version probe.
+        fake.set_version("4.8.1")
+        # No device_id set → registration branch.
+        fake.fail_on_next(RommAuthError("401 Unauthorized"))
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.AUTH_FAILED.value
+        assert "uthentication failed" in result["message"]
+        assert result["message"] != "Could not register device"
+
+    @pytest.mark.asyncio
+    async def test_ssl_failure_classifies_with_ssl_message(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        fake.set_version("4.8.1")
+        fake.fail_on_next(RommSSLError("cert verify failed"))
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert "SSL" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_connection_failure_classifies_to_unreachable(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        fake.set_version("4.8.1")
+        fake.fail_on_next(RommConnectionError("Connection refused"))
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is False
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert "unreachable" in result["message"].lower()
+
+
+class TestEnsureDeviceRegisteredUpdateSwallowLogs:
+    """The best-effort update_device touch on an already-registered device is a
+    non-fatal swallow, but it logs at debug so it leaves a breadcrumb (#971)."""
+
+    @pytest.mark.asyncio
+    async def test_update_device_failure_logs_at_debug_and_still_succeeds(self, tmp_path):
+        debug_log: list[str] = []
+        svc, fake = make_service(tmp_path, log_debug=debug_log.append)
+        _enable_sync_with_device(svc, "server-uuid")
+        # Stamp a version so the pre-register heartbeat probe is skipped — the
+        # injected failure must land on the best-effort update_device touch.
+        fake.set_version("4.8.1")
+        fake.fail_on_next(RommConnectionError("boom"))
+
+        result = await svc.ensure_device_registered()
+
+        # The touch failed but registration still reports success.
+        assert result["success"] is True
+        assert result["device_id"] == "server-uuid"
+        assert any("update_device failed" in m and "boom" in m for m in debug_log)

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -11,7 +11,8 @@ import logging
 import pytest
 
 from domain.save_layout import ContentDir, InSaveDir
-from lib.errors import RommApiError
+from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError, RommTimeoutError
+from lib.list_result import ErrorCode
 from tests.services.saves._helpers import (
     _create_save,
     _do_sync,
@@ -560,42 +561,79 @@ class TestMigrationPendingGuards:
 
 
 class TestPostExitServerOfflineGuard:
-    """post_exit_sync probes heartbeat first; on failure returns offline=True
-    instead of attempting upload (engine.py lines 358-360)."""
+    """post_exit_sync probes heartbeat first. A genuine reachability failure
+    (connection/timeout) returns offline=True; an auth/SSL failure flows through
+    classify_error so it carries its OWN reason + message instead of masking the
+    reachable server as offline (#971)."""
 
     @pytest.mark.asyncio
-    async def test_post_exit_sync_returns_offline_when_heartbeat_raises(self, tmp_path):
+    async def test_post_exit_sync_returns_offline_when_connection_error(self, tmp_path):
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
         _install_rom(svc, tmp_path)
         _create_save(tmp_path, content=b"data")
-        fake.heartbeat_raises = RommApiError("Connection refused")
+        fake.heartbeat_raises = RommConnectionError("Connection refused")
 
         result = await svc.post_exit_sync(42)
 
         assert result["success"] is False
         assert result["offline"] is True
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert result["message"] == "Server offline"
         assert result["synced"] == 0
         # No upload was attempted after heartbeat failed.
         assert not any(c[0] == "upload_save" for c in fake.call_log)
 
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_returns_offline_when_timeout(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"data")
+        fake.heartbeat_raises = RommTimeoutError("timed out")
 
-class TestPreLaunchServerOfflineGuard:
-    """pre_launch_sync probes heartbeat first (F4); on failure returns the
-    canonical SERVER_UNREACHABLE shape + offline=True instead of attempting a
-    download, mirroring post_exit_sync."""
+        result = await svc.post_exit_sync(42)
+
+        assert result["offline"] is True
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert result["message"] == "Server offline"
 
     @pytest.mark.asyncio
-    async def test_pre_launch_sync_returns_offline_when_heartbeat_raises(self, tmp_path):
-        from lib.list_result import ErrorCode
+    async def test_post_exit_sync_auth_failure_is_not_offline(self, tmp_path):
+        """A revoked token (401) on the heartbeat must NOT read as offline."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"data")
+        fake.heartbeat_raises = RommAuthError("401 Unauthorized")
 
+        result = await svc.post_exit_sync(42)
+
+        assert result["success"] is False
+        assert "offline" not in result
+        assert result["reason"] == ErrorCode.AUTH_FAILED.value
+        assert "uthentication failed" in result["message"]
+        assert result["message"] != "Server offline"
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+
+
+class TestPreLaunchServerOfflineGuard:
+    """pre_launch_sync probes heartbeat first (F4). A reachability failure
+    returns the canonical SERVER_UNREACHABLE shape + offline=True; an auth/SSL
+    failure flows through classify_error to its OWN reason + DISTINCT message so
+    the UI stops claiming the server is unreachable (#971)."""
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_returns_offline_when_connection_error(self, tmp_path):
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
         _install_rom(svc, tmp_path)
         fake.saves[100] = _server_save()
-        fake.heartbeat_raises = RommApiError("Connection refused")
+        fake.heartbeat_raises = RommConnectionError("Connection refused")
 
         result = await svc.pre_launch_sync(42)
 
@@ -606,6 +644,77 @@ class TestPreLaunchServerOfflineGuard:
         assert result["synced"] == 0
         # No download/list was attempted after heartbeat failed.
         assert not any(c[0] in ("download_save", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_returns_offline_when_timeout(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        fake.saves[100] = _server_save()
+        fake.heartbeat_raises = RommTimeoutError("timed out")
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["offline"] is True
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert result["message"] == "Server offline"
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_auth_failure_is_classified_not_offline(self, tmp_path):
+        """A 401 on the heartbeat surfaces AUTH_FAILED with a distinct message,
+        never the misleading "Server offline" + offline flag (#971)."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        fake.saves[100] = _server_save()
+        fake.heartbeat_raises = RommAuthError("401 Unauthorized")
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["success"] is False
+        assert "offline" not in result
+        assert result["reason"] == ErrorCode.AUTH_FAILED.value
+        assert "uthentication failed" in result["message"]
+        assert result["message"] != "Server offline"
+        assert result["synced"] == 0
+        assert not any(c[0] in ("download_save", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_ssl_failure_keeps_unreachable_slug_distinct_message(self, tmp_path):
+        """An SSL misconfig classifies to SERVER_UNREACHABLE but with the SSL
+        message — NOT the literal "Server offline" and NO offline flag."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        fake.saves[100] = _server_save()
+        fake.heartbeat_raises = RommSSLError("cert verify failed")
+
+        result = await svc.pre_launch_sync(42)
+
+        assert result["success"] is False
+        assert "offline" not in result
+        assert result["reason"] == ErrorCode.SERVER_UNREACHABLE.value
+        assert "SSL" in result["message"]
+        assert result["message"] != "Server offline"
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_offline_branch_logs_at_debug(self, tmp_path):
+        """The offline branch is no longer a silent swallow — the raw exception
+        is logged via the injected DebugLogger (asserted non-vacuously)."""
+        debug_log: list[str] = []
+        svc, fake = make_service(tmp_path, log_debug=debug_log.append)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        fake.saves[100] = _server_save()
+        fake.heartbeat_raises = RommConnectionError("Connection refused")
+
+        await svc.pre_launch_sync(42)
+
+        assert any("heartbeat failed" in m and "Connection refused" in m for m in debug_log)
 
     @pytest.mark.asyncio
     async def test_pre_launch_sync_proceeds_when_heartbeat_ok(self, tmp_path):

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -13,6 +13,7 @@ from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_save_api import FakeSaveApi
 
 from domain.rom_save_state import FileSyncState, RomSaveState
+from lib.errors import RommConnectionError
 from services.saves._settings import sanitize_setting
 from tests.services.saves._helpers import (
     _create_save,
@@ -80,9 +81,10 @@ class TestDeviceRegistrationServer:
 
     @pytest.mark.asyncio
     async def test_returns_failure_on_server_error(self, tmp_path):
-        """If register_device fails, returns failure."""
+        """If register_device fails with a reachability error, returns the classified failure."""
         fake = FakeSaveApi()
-        fake.fail_on_next(Exception("server error"))
+        fake.set_version("4.8.1")  # skip the pre-register heartbeat probe
+        fake.fail_on_next(RommConnectionError("server error"))
         svc, _ = make_service(tmp_path, fake_api=fake)
         svc._config.settings["save_sync_enabled"] = True
 
@@ -368,9 +370,9 @@ class TestRetroDeckMigrationBlocksSaveSync:
 class TestPostExitSyncConnectivity:
     @pytest.mark.asyncio
     async def test_returns_offline_when_heartbeat_fails(self, tmp_path):
-        """post_exit_sync returns offline=True when server is unreachable."""
+        """post_exit_sync returns offline=True when the server is genuinely unreachable."""
         fake = FakeSaveApi()
-        fake.heartbeat_raises = ConnectionError("unreachable")
+        fake.heartbeat_raises = RommConnectionError("unreachable")
         svc, _ = make_service(tmp_path, fake_api=fake)
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
@@ -399,7 +401,7 @@ class TestPostExitSyncConnectivity:
     async def test_offline_skips_before_device_registration(self, tmp_path):
         """post_exit_sync returns offline without attempting device registration."""
         fake = FakeSaveApi()
-        fake.heartbeat_raises = OSError("connection refused")
+        fake.heartbeat_raises = RommConnectionError("connection refused")
         svc, _ = make_service(tmp_path, fake_api=fake)
         svc._config.settings["save_sync_enabled"] = True
         # No device_id — would trigger registration if heartbeat passed

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -568,6 +568,28 @@ class TestEdgeCases:
         assert entry.note_id is None  # push failed before any note was created
 
     @pytest.mark.asyncio
+    async def test_record_session_end_swallows_romm_sync_failure_with_debug_log(self):
+        """If the best-effort RomM playtime push raises outright, record_session_end
+        still returns success (the local fold committed) and the swallow is logged
+        at debug rather than vanishing silently (#971)."""
+        clk = FakeClock(now=datetime(2026, 1, 1, 0, 1, tzinfo=UTC))
+        logs: list[str] = []
+        svc, _fake, uow = make_service(clock=clk, log_debug=logs.append)
+        start = (clk.now() - timedelta(seconds=60)).isoformat()
+        _seed_playtime(uow, 42, Playtime(last_session_start=start))
+
+        def _boom(rom_id: int, session_duration_sec: int) -> None:
+            raise RommApiError("kaboom")
+
+        svc._sync_playtime_to_romm_io = _boom  # bypass the inner catch to hit the outer swallow
+
+        result = await svc.record_session_end(42)
+
+        assert result["success"] is True
+        assert result["total_seconds"] == 60
+        assert any("playtime-to-RomM sync failed" in m and "rom 42" in m and "kaboom" in m for m in logs)
+
+    @pytest.mark.asyncio
     async def test_sync_playtime_error_logged_not_raised(self):
         svc, fake, uow = make_service()
         _seed_playtime(uow, 42, Playtime(total_seconds=100, session_count=1, last_session_duration_sec=60))

--- a/tests/services/test_session_lifecycle.py
+++ b/tests/services/test_session_lifecycle.py
@@ -355,6 +355,126 @@ class TestFinalizeSyncToasts:
         assert result.sync.toast_title == "RomM Save Sync"
         assert result.sync.toast_body == "Failed to sync saves after exit"
 
+    def test_failure_with_auth_message_names_the_cause(self, event_loop, logger):
+        """#971: a classified auth failure surfaces its own message, not the generic body."""
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "reason": "AUTH_FAILED",
+                "message": "Authentication failed — sign in again",
+                "synced": 0,
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Authentication failed — sign in again"
+        # The generic fallback must NOT be used when a classified cause is present.
+        assert result.sync.toast_body != "Failed to sync saves after exit"
+
+    def test_failure_with_ssl_message_names_the_cause(self, event_loop, logger):
+        """#971: an SSL/server-classified failure surfaces its specific message."""
+        post = FakePostExitSync(
+            payload={
+                "success": False,
+                "reason": "UNKNOWN",
+                "message": "SSL certificate verification failed",
+                "synced": 0,
+            }
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "SSL certificate verification failed"
+
+    def test_failure_without_message_falls_back_to_generic_body(self, event_loop, logger):
+        """A failure with no ``message`` key falls back to the generic failure body."""
+        post = FakePostExitSync(payload={"success": False, "synced": 0})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+
+    def test_failure_with_non_str_message_falls_back_to_generic_body(self, event_loop, logger):
+        """A non-str ``message`` (e.g. None) is coerced away → generic failure body."""
+        post = FakePostExitSync(payload={"success": False, "synced": 0, "message": None})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_title == "RomM Save Sync"
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+
+    def test_offline_message_does_not_override_offline_body(self, event_loop, logger):
+        """Regression guard: the offline branch keeps its body even when a message is present."""
+        post = FakePostExitSync(payload={"success": False, "offline": True, "message": "Server offline", "synced": 0})
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.offline is True
+        assert result.sync.toast_body == "Server offline — saves will sync next time"
+
+    def test_success_message_does_not_override_synced_body(self, event_loop, logger):
+        """Regression guard: a successful sync keeps the synced body, ignoring ``message``."""
+        post = FakePostExitSync(
+            payload={"success": True, "synced": 2, "conflicts": [], "message": "Uploaded 2 save(s)"}
+        )
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.success is True
+        assert result.sync.toast_body == "Saves synced with RomM"
+
     def test_post_exit_exception_renders_failure_toast(self, event_loop, logger):
         """Post-exit sync raises → failure toast, downstream still runs."""
         post = FakePostExitSync(side_effect=RuntimeError("network down"))
@@ -377,6 +497,31 @@ class TestFinalizeSyncToasts:
         assert result.sync.conflicts == []
         # Post-exit failure must NOT short-circuit migration refresh.
         assert migration.refresh_calls == 1
+
+    def test_post_exit_exception_path_has_no_classified_message(self, event_loop, logger):
+        """The raise path produces no structured result, so the generic body is correct.
+
+        Decision: the earlier failure-return (the ``except`` branch) has no
+        ``result["message"]`` to surface — the sync raised rather than
+        returning a classified dict — so it stays on the generic fallback body.
+        Even when the underlying exception carries a descriptive ``str``, the
+        toast body is the generic constant, never the exception text.
+        """
+        post = FakePostExitSync(side_effect=RuntimeError("Authentication failed — sign in again"))
+        service = _make_service(
+            playtime_recorder=FakePlaytimeRecorder(),
+            post_exit_sync=post,
+            achievement_sync=FakeAchievementSync(),
+            migration_reader=FakeMigrationReader(),
+            logger=logger,
+        )
+
+        result = event_loop.run_until_complete(service.finalize(99))
+        event_loop.run_until_complete(_drain_background_tasks(service))
+
+        assert result.sync.toast_body == "Failed to sync saves after exit"
+        # The exception text must never leak into the toast body.
+        assert "Authentication failed" not in result.sync.toast_body
 
     def test_synced_field_non_int_treated_as_falsy(self, event_loop, logger):
         """``synced`` not an int (None, str) → no synced toast even when success=True."""


### PR DESCRIPTION
Closes #971.

The save-sync heartbeat and device registration collapsed every exception onto "Server offline", so a revoked token, SSL misconfig, or any adapter bug all read as a reachability failure — a user whose token expired would see "Server offline" forever against a perfectly reachable server. The typed `RommApiError` hierarchy that exists precisely to distinguish these wasn't consulted.

**Fix:** only `RommConnectionError`/`RommTimeoutError` are treated as offline; everything else is classified via `classify_error` and surfaces its own `reason` + `message`, so the UI names the real cause instead of lying about reachability. Two best-effort calls that previously swallowed exceptions with zero logging now log at debug.

- `engine.py` — `_heartbeat_failure_result` partitions connection/timeout (→ "Server offline", `offline: true`) from auth/SSL/server (→ classified `reason`/`message`, no `offline` flag); both `pre_launch_sync` and `post_exit_sync` delegate to it, with a debug log in the offline branch.
- `devices.py` — `ensure_device_registered` failure classifies via `classify_error` instead of a hardcoded `SERVER_UNREACHABLE`; the best-effort `update_device` touch logs at debug.
- `playtime.py` — the playtime-to-RomM push failure logs at debug.
- `session_lifecycle.py` — the post-exit toast names the classified cause (e.g. "Authentication failed — sign in again") instead of the generic "Failed to sync saves after exit". The pre-launch fallback modal already surfaced the message; this makes both surfaces consistent.

Docs: `save-file-sync-architecture.md` (new heartbeat-classification subsection) and `save-sync.md` (clarified that "Server offline" is only for true reachability failures; auth/token errors report their own message on both the before-launch warning and the after-exit toast).

On-device: the live Steam toast string can only be eyeballed on the Deck (an auth failure after a game exit), but the title/body is built backend-side and is fully covered by unit tests — no frontend change.
