### PR TITLE
refactor(saves): route device-id reads through DeviceRegistry and harden registration

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -141,7 +141,12 @@ uploaded each save.
 
 1. On first use with save sync enabled, the plugin calls `POST /api/devices` with the friendly device label (`name`),
    platform, client info, and the contents of `/etc/machine-id` as the `hostname` fingerprint
-2. Server returns a `device_id` (UUID) stored as `server_device_id` in state
+2. Server returns a `device_id` (UUID). Registration writes it to `kv_config["device_id"]` **first** — the `device_id`
+   is the authoritative "registered" signal — then writes the device label to `settings.json` as a **best-effort** step
+   (the two live in separate stores per [ADR-0003](../adr/0003-json-sqlite-persistence-boundary.md), so the two writes
+   can't be one atomic op). A failed label write leaves a fully registered, usable device (valid `device_id`,
+   prior/default label) instead of a broken half-state, and logs at debug; the in-memory settings dict is rolled back so
+   an unsaved label never lingers
 3. This ID is passed to `list_saves` (populates `device_syncs` per save) and `upload_save` / `download_save_content`
    (tracks sync status)
 4. `device_syncs` array on each save shows per-device sync status: `device_id`, `device_name`, `is_current`,
@@ -1010,6 +1015,19 @@ The raw exception is logged at debug in every branch, so the probe is no longer 
 classification applies to the device-registration failure path in `services/saves/sync_engine/devices.py`
 (`ensure_device_registered`): an auth/SSL failure during `register_device` produces its own classified `reason` +
 `message` rather than a generic "Could not register device" unreachable slug.
+
+### `DeviceRegistry` owns device identity
+
+`DeviceRegistry` (`services/saves/sync_engine/devices.py`) is the **single owner** of the server device id. It reads
+`kv_config["device_id"]` **once** through a narrow Unit of Work and serves the cached value thereafter via
+`get_device_id()` — no per-flow transaction. The cache is refreshed when registration writes a new id and can be dropped
+via `invalidate_device_id_cache()` for the rare case where `kv_config["device_id"]` is mutated outside the registry
+(registration is the only in-process writer, so this is currently reached only from test backdoors). Every save-sync
+sub-service that needs the id — `SyncEngine`, `StatusService`, `VersionsService`, the slot sub-services (`SlotListing` /
+`SlotSwitcher` / `SetupWizard` / `SlotDeleter`), and `RollbackOrchestrator` — receives the shared `DeviceRegistry`
+through its `*ServiceConfig` (the [same-bounded-context peer-ref carve-out](backend-architecture.md)) and reads the id
+through it, instead of each opening its own `kv_config` read. The registry is built once in the `SaveService` facade and
+threaded into every sub-service config.
 
 ## Playtime Tracking
 

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -27,6 +27,7 @@ from services.saves.rom_info import RomInfoService, RomInfoServiceConfig
 from services.saves.slots import SlotsService, SlotsServiceConfig
 from services.saves.status import StatusService, StatusServiceConfig
 from services.saves.sync_engine import SyncEngine, SyncEngineConfig
+from services.saves.sync_engine.devices import DeviceRegistry
 from services.saves.versions import VersionsService, VersionsServiceConfig
 
 if TYPE_CHECKING:
@@ -58,9 +59,26 @@ class SaveService:
         self._save_file_store = config.save_file_store
         self._uow_factory: UnitOfWorkFactory = config.uow_factory
         self._settings_persister = config.settings_persister
-        # Resolve plugin version once at construction; SyncEngine and any
-        # other consumer receive the resolved string, not the Protocol.
+        # Resolve plugin version once at construction; the DeviceRegistry and
+        # any other consumer receive the resolved string, not the Protocol.
         plugin_version = config.plugin_metadata.read_version(config.plugin_dir)
+
+        # The single owner of the server device id (kv_config["device_id"]).
+        # Built once here and shared into every sub-service that needs the id
+        # (sync_engine, status, versions, slots) — the same-bounded-context
+        # peer-ref carve-out — so the id is read once and cached, never
+        # re-queried per flow through a fresh UoW. The device label stays in
+        # settings.json (ADR-0003).
+        self._device_registry = DeviceRegistry(
+            uow_factory=config.uow_factory,
+            settings=config.settings,
+            romm_api=config.romm_api,
+            retry=config.retry,
+            logger=config.logger,
+            log_debug=config.log_debug,
+            settings_persister=config.settings_persister,
+            plugin_version=plugin_version,
+        )
 
         self._rom_info = RomInfoService(
             config=RomInfoServiceConfig(
@@ -78,6 +96,7 @@ class SaveService:
                 settings=config.settings,
                 uow_factory=config.uow_factory,
                 rom_info=self._rom_info,
+                device_registry=self._device_registry,
                 romm_api=config.romm_api,
                 retry=config.retry,
                 loop=config.loop,
@@ -88,8 +107,6 @@ class SaveService:
                 active_core=config.active_core,
                 hostname_provider=config.hostname_provider,
                 machine_id_provider=config.machine_id_provider,
-                settings_persister=config.settings_persister,
-                plugin_version=plugin_version,
                 detect_sort_change=config.detect_sort_change,
                 is_retrodeck_migration_pending=config.is_retrodeck_migration_pending,
             ),
@@ -100,6 +117,7 @@ class SaveService:
                 settings=config.settings,
                 uow_factory=config.uow_factory,
                 sync_engine=self._sync_engine,
+                device_registry=self._device_registry,
                 rom_info=self._rom_info,
                 romm_api=config.romm_api,
                 retry=config.retry,
@@ -117,6 +135,7 @@ class SaveService:
                 settings=config.settings,
                 uow_factory=config.uow_factory,
                 sync_engine=self._sync_engine,
+                device_registry=self._device_registry,
                 rom_info=self._rom_info,
                 resolve_core=self._sync_engine.resolve_core,
                 romm_api=config.romm_api,
@@ -132,6 +151,7 @@ class SaveService:
                 settings=config.settings,
                 uow_factory=config.uow_factory,
                 sync_engine=self._sync_engine,
+                device_registry=self._device_registry,
                 status_service=self._status,
                 rom_info=self._rom_info,
                 resolve_core=self._sync_engine.resolve_core,

--- a/py_modules/services/saves/slots/deletion.py
+++ b/py_modules/services/saves/slots/deletion.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     )
     from services.saves.rom_info import RomInfoService
     from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 class SlotDeleter:
@@ -39,6 +40,7 @@ class SlotDeleter:
         *,
         settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
+        device_registry: DeviceRegistry,
         rom_info: RomInfoService,
         romm_api: RommSaveApi,
         retry: RetryStrategy,
@@ -49,6 +51,7 @@ class SlotDeleter:
     ) -> None:
         self._settings = settings
         self._uow_factory = uow_factory
+        self._device_registry = device_registry
         self._rom_info = rom_info
         self._romm_api = romm_api
         self._retry = retry
@@ -60,10 +63,6 @@ class SlotDeleter:
     def _read_save_state(self, rom_id: int) -> RomSaveState | None:
         with self._uow_factory() as uow:
             return uow.rom_save_states.get(rom_id)
-
-    def _read_device_id(self) -> str | None:
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         with self._uow_factory() as uow:
@@ -108,7 +107,7 @@ class SlotDeleter:
         # Server save count
         server_save_ids: list[int] = []
         if source == "server":
-            device_id = await self._loop.run_in_executor(None, self._read_device_id)
+            device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
             try:
                 # Legacy slot ("" → null on the server) is addressed by omitting
                 # ``slot=`` and filtering client-side (#1061), so a legacy delete
@@ -157,7 +156,7 @@ class SlotDeleter:
 
     async def _delete_server_slot_saves(self, rom_id: int, slot: str) -> dict[str, Any]:
         """Delete all server saves in a slot. Returns result dict with count and IDs."""
-        device_id = await self._loop.run_in_executor(None, self._read_device_id)
+        device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
         try:
             # Legacy slot ("" → null on the server) deletes ONLY the null saves:
             # omit ``slot=`` and filter client-side (#1061). Named slots filter

--- a/py_modules/services/saves/slots/listing.py
+++ b/py_modules/services/saves/slots/listing.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         RommSaveApi,
         UnitOfWorkFactory,
     )
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 class SlotListing:
@@ -35,6 +36,7 @@ class SlotListing:
         *,
         settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
+        device_registry: DeviceRegistry,
         romm_api: RommSaveApi,
         retry: RetryStrategy,
         loop: asyncio.AbstractEventLoop,
@@ -42,6 +44,7 @@ class SlotListing:
     ) -> None:
         self._settings = settings
         self._uow_factory = uow_factory
+        self._device_registry = device_registry
         self._romm_api = romm_api
         self._retry = retry
         self._loop = loop
@@ -50,8 +53,7 @@ class SlotListing:
     def _read_inputs(self, rom_id: int) -> tuple[RomSaveState | None, str | None]:
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id)
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._device_registry.get_device_id()
 
     async def get_save_slots(self, rom_id: int) -> dict[str, Any]:
         """List available save slots for a ROM.
@@ -184,7 +186,7 @@ class SlotListing:
                 "saves": [],
             }
 
-        device_id = await self._loop.run_in_executor(None, self._read_device_id)
+        device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
 
         try:
             # Legacy slot ("" → null on the server) can't be addressed by any
@@ -217,7 +219,3 @@ class SlotListing:
                 "slot": slot,
                 "saves": [],
             }
-
-    def _read_device_id(self) -> str | None:
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")

--- a/py_modules/services/saves/slots/service.py
+++ b/py_modules/services/saves/slots/service.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from services.saves.rom_info import RomInfoService
     from services.saves.status import StatusService
     from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 __all__ = ["SlotsService", "SlotsServiceConfig"]
@@ -50,7 +51,8 @@ class SlotsServiceConfig:
     Holds the live ``settings.json`` dict (save-sync toggles + default
     slot), the Unit-of-Work factory (the transactional seam over the
     SQLite repositories), the peer save sub-services (sync_engine,
-    status, rom_info), the core resolver used to stamp the upload
+    status, rom_info, and the shared :class:`DeviceRegistry` that owns the
+    server device id), the core resolver used to stamp the upload
     emulator tag, the Protocol-typed RomM adapter and retry strategy,
     runtime infrastructure (loop, logger, clock), the Protocol-typed
     filesystem adapter, and the ``DebugLogger`` seam.
@@ -59,6 +61,7 @@ class SlotsServiceConfig:
     settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
+    device_registry: DeviceRegistry
     status_service: StatusService
     rom_info: RomInfoService
     resolve_core: Callable[[int], str | None]
@@ -80,6 +83,7 @@ class SlotsService:
         self._listing = SlotListing(
             settings=config.settings,
             uow_factory=config.uow_factory,
+            device_registry=config.device_registry,
             romm_api=config.romm_api,
             retry=config.retry,
             loop=config.loop,
@@ -89,6 +93,7 @@ class SlotsService:
             settings=config.settings,
             uow_factory=config.uow_factory,
             sync_engine=config.sync_engine,
+            device_registry=config.device_registry,
             status_service=config.status_service,
             rom_info=config.rom_info,
             romm_api=config.romm_api,
@@ -101,6 +106,7 @@ class SlotsService:
         self._setup = SetupWizard(
             settings=config.settings,
             uow_factory=config.uow_factory,
+            device_registry=config.device_registry,
             rom_info=config.rom_info,
             resolve_core=config.resolve_core,
             romm_api=config.romm_api,
@@ -114,6 +120,7 @@ class SlotsService:
         self._deleter = SlotDeleter(
             settings=config.settings,
             uow_factory=config.uow_factory,
+            device_registry=config.device_registry,
             rom_info=config.rom_info,
             romm_api=config.romm_api,
             retry=config.retry,

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     )
     from services.saves.rom_info import RomInfoService
     from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 class SetupWizard:
@@ -44,6 +45,7 @@ class SetupWizard:
         *,
         settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
+        device_registry: DeviceRegistry,
         rom_info: RomInfoService,
         resolve_core: Callable[[int], str | None],
         romm_api: RommSaveApi,
@@ -56,6 +58,7 @@ class SetupWizard:
     ) -> None:
         self._settings = settings
         self._uow_factory = uow_factory
+        self._device_registry = device_registry
         self._rom_info = rom_info
         self._resolve_core = resolve_core
         self._romm_api = romm_api
@@ -69,10 +72,6 @@ class SetupWizard:
     def _read_save_state(self, rom_id: int) -> RomSaveState | None:
         with self._uow_factory() as uow:
             return uow.rom_save_states.get(rom_id)
-
-    def _read_device_id(self) -> str | None:
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         with self._uow_factory() as uow:
@@ -195,8 +194,7 @@ class SetupWizard:
     def _read_setup_inputs(self, rom_id: int) -> tuple[RomSaveState | None, str | None]:
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id)
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._device_registry.get_device_id()
 
     async def confirm_slot_choice(
         self,
@@ -296,7 +294,7 @@ class SetupWizard:
         could not be carried over are collected and reported. Safe order for the
         carried-over saves: POST first, DELETE after.
         """
-        device_id = await self._loop.run_in_executor(None, self._read_device_id)
+        device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
 
         # Find server saves in the old slot. The legacy source (None/"") can't be
         # addressed by ``slot=`` (RomM stores it as null), so list ALL saves and

--- a/py_modules/services/saves/slots/switching.py
+++ b/py_modules/services/saves/slots/switching.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from services.saves.rom_info import RomInfoService
     from services.saves.status import StatusService
     from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 class SlotSwitcher:
@@ -51,6 +52,7 @@ class SlotSwitcher:
         settings: dict[str, Any],
         uow_factory: UnitOfWorkFactory,
         sync_engine: SyncEngine,
+        device_registry: DeviceRegistry,
         status_service: StatusService,
         rom_info: RomInfoService,
         romm_api: RommSaveApi,
@@ -63,6 +65,7 @@ class SlotSwitcher:
         self._settings = settings
         self._uow_factory = uow_factory
         self._sync_engine = sync_engine
+        self._device_registry = device_registry
         self._status_service = status_service
         self._rom_info = rom_info
         self._romm_api = romm_api
@@ -75,8 +78,7 @@ class SlotSwitcher:
     def _read_inputs(self, rom_id: int) -> tuple[RomSaveState, str | None]:
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id) or RomSaveState()
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._device_registry.get_device_id()
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         with self._uow_factory() as uow:

--- a/py_modules/services/saves/status/service.py
+++ b/py_modules/services/saves/status/service.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     )
     from services.saves.rom_info import RomInfoService
     from services.saves.sync_engine import MatrixOutcome, SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 @dataclass(frozen=True)
@@ -40,7 +41,8 @@ class StatusServiceConfig:
 
     Holds the live ``settings.json`` dict (save-sync enabled toggle), the
     Unit-of-Work factory (the transactional seam over the SQLite
-    repositories), the peer save sub-services (sync_engine, rom_info),
+    repositories), the peer save sub-services (sync_engine, rom_info, and
+    the shared :class:`DeviceRegistry` that owns the server device id),
     the Protocol-typed RomM adapter and retry strategy, the plugin event
     loop, the standard-library logger, the ``DebugLogger`` seam, the
     per-ROM active-core resolver, the event emitter used to push background
@@ -52,6 +54,7 @@ class StatusServiceConfig:
     settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
+    device_registry: DeviceRegistry
     rom_info: RomInfoService
     romm_api: RommSaveApi
     retry: RetryStrategy
@@ -71,6 +74,7 @@ class StatusService:
         self._settings = config.settings
         self._uow_factory = config.uow_factory
         self._sync_engine = config.sync_engine
+        self._device_registry = config.device_registry
         self._rom_info = config.rom_info
         self._romm_api = config.romm_api
         self._retry = config.retry
@@ -214,7 +218,7 @@ class StatusService:
         with self._uow_factory() as uow:
             save_state = uow.rom_save_states.get(rom_id)
             playtime = uow.playtime.get(rom_id)
-            device_id = uow.kv_config.get("device_id")
+        device_id = self._device_registry.get_device_id()
 
         active_slot = save_state.active_slot if save_state else None
         server_in_slot = self._sync_engine.filter_server_saves_to_slot(server_saves, active_slot)
@@ -350,7 +354,7 @@ class StatusService:
         server_saves: list[dict[str, Any]] = []
         server_query_failed = False
         try:
-            device_id = await self._loop.run_in_executor(None, self._read_device_id)
+            device_id = await self._loop.run_in_executor(None, self._device_registry.get_device_id)
             server_saves = await self._loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(lambda: self._romm_api.list_saves(rom_id, device_id=device_id)),
@@ -368,10 +372,6 @@ class StatusService:
                     server_query_failed=server_query_failed,
                 ),
             )
-
-    def _read_device_id(self) -> str | None:
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")
 
     async def check_save_status_background(self, rom_id: int) -> None:
         """Run full save status check in background and emit result to frontend."""

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -42,21 +42,23 @@ if TYPE_CHECKING:
 
 
 class DeviceRegistry:
-    """Device registration entry points for every save-sync flow.
+    """Sole owner of the server device identity for every save-sync flow.
 
-    Co-locates the device-identity fallback used by every sync callable
-    (pre_launch_sync, post_exit_sync, sync_rom_saves, sync_all_saves)
-    when ``device_id`` is missing. Kept beside SyncEngine because the
-    fallback is reached from inside those callables and pushing it out
-    to a peer service would require an extra constructor callback.
+    The single source of truth for ``kv_config["device_id"]`` — the
+    server-issued device id every sync, slot, status, and version flow
+    needs to attribute uploads and filter per-slot server views. Every
+    consumer reads the id through :meth:`get_device_id` (one cached
+    Unit-of-Work read, reused for the process lifetime) rather than
+    opening its own transaction, and registration is the only writer.
+    The device *label* lives in ``settings.json`` (ADR-0003: server
+    identity in ``kv_config``, user-set label in settings) and flows
+    through the injected ``SettingsPersister``.
 
-    The server device id is read from and written to
-    ``kv_config["device_id"]`` through the injected Unit-of-Work factory;
-    the device label flows through ``settings.json``. The async entry
-    points take ``loop``, ``hostname_provider``, and ``machine_id_provider``
-    per call so :class:`SyncEngine` can pass its live (test-rebindable)
-    attributes without having to thread reassignments through this
-    sub-module.
+    Also co-locates the device-identity fallback every sync callable
+    reaches when no id is registered yet. The async entry points take
+    ``loop``, ``hostname_provider``, and ``machine_id_provider`` per call
+    so :class:`SyncEngine` can pass its live (test-rebindable) attributes
+    without having to thread reassignments through this sub-module.
     """
 
     def __init__(
@@ -79,21 +81,75 @@ class DeviceRegistry:
         self._log_debug = log_debug
         self._settings_persister = settings_persister
         self._plugin_version = plugin_version
+        # Cached server device id. ``_device_id_loaded`` distinguishes
+        # "never read" from "read and found absent" (``None``) so an
+        # unregistered device is not re-queried on every call. The id is a
+        # truly-singleton scalar that only registration mutates, so a one-shot
+        # read reused for the process lifetime is safe; the cache is refreshed
+        # by :meth:`_set_device_id` on (re)registration and can be dropped via
+        # :meth:`invalidate_device_id_cache`.
+        self._cached_device_id: str | None = None
+        self._device_id_loaded: bool = False
 
-    def _get_device_id(self) -> str | None:
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")
+    def get_device_id(self) -> str | None:
+        """Return the server device id (``None`` when unregistered).
+
+        The single device-id accessor for the whole save-sync bounded
+        context: reads ``kv_config["device_id"]`` once through a narrow
+        Unit of Work, caches it, and returns the cached value thereafter —
+        no per-call transaction. Synchronous so sync-worker callers can
+        invoke it directly inside their ``run_in_executor`` blocks.
+        """
+        if not self._device_id_loaded:
+            with self._uow_factory() as uow:
+                self._cached_device_id = uow.kv_config.get("device_id")
+            self._device_id_loaded = True
+        return self._cached_device_id
+
+    def invalidate_device_id_cache(self) -> None:
+        """Drop the cached device id so the next :meth:`get_device_id` re-reads.
+
+        For the rare case where ``kv_config["device_id"]`` is mutated outside
+        this registry (registration is the only in-process writer, so today
+        this is reached only from test backdoors that seed the row directly) —
+        invalidating keeps the cache from serving a stale value.
+        """
+        self._cached_device_id = None
+        self._device_id_loaded = False
 
     def _set_device_id(self, device_id: str) -> None:
         with self._uow_factory() as uow:
             uow.kv_config.set("device_id", device_id)
+        # Keep the cache coherent with the write so callers that read the id
+        # immediately after (re)registration see the new value, not a stale
+        # ``None`` left from a pre-registration probe.
+        self._cached_device_id = device_id
+        self._device_id_loaded = True
 
     def _get_device_name(self) -> str | None:
         return self._settings.get("device_name")
 
     def _set_device_name(self, name: str) -> None:
+        """Persist the device label to settings.json, atomic on failure.
+
+        Mutates the in-memory settings dict and triggers the persist; if the
+        persist raises, the in-memory dict is rolled back to its prior value so
+        an unsaved label never lingers in memory (a later unrelated
+        ``save_settings`` would otherwise commit it). The caller treats the
+        re-raised failure as a best-effort miss — the device id is already the
+        authoritative registered signal.
+        """
+        had_name = "device_name" in self._settings
+        prior = self._settings.get("device_name")
         self._settings["device_name"] = name
-        self._settings_persister.save_settings()
+        try:
+            self._settings_persister.save_settings()
+        except Exception:
+            if had_name:
+                self._settings["device_name"] = prior
+            else:
+                self._settings.pop("device_name", None)
+            raise
 
     async def ensure_device_registered(
         self,
@@ -137,7 +193,7 @@ class DeviceRegistry:
             except Exception as e:
                 self._logger.debug(f"ensure_device_registered: version probe failed (non-fatal): {e}")
 
-        device_id = await loop.run_in_executor(None, self._get_device_id)
+        device_id = await loop.run_in_executor(None, self.get_device_id)
         if device_id:
             server_id_str = str(device_id)
             # Best-effort touch of the server-side client_version. A failure here
@@ -174,13 +230,28 @@ class DeviceRegistry:
             server_device_id = result.get("id") or result.get("device_id")
             if server_device_id:
                 new_id = str(server_device_id)
+                # The kv_config device id is the AUTHORITATIVE "registered"
+                # signal — write it first. The device label is a best-effort
+                # write to settings.json AFTER: ADR-0003 keeps the two in
+                # separate stores, so the writes can't be one atomic op. If the
+                # label write fails (e.g. a settings.json fsync error) the
+                # device is still fully registered and usable — the prior/default
+                # label persists — instead of being left in a broken half-state.
                 await loop.run_in_executor(None, self._set_device_id, new_id)
-                self._set_device_name(hostname)
+                device_name = hostname
+                try:
+                    await loop.run_in_executor(None, self._set_device_name, hostname)
+                except Exception as e:
+                    device_name = self._get_device_name() or ""
+                    self._log_debug(
+                        f"ensure_device_registered: device_name write failed (non-fatal, "
+                        f"device usable with id {new_id}): {e}"
+                    )
                 self._logger.info(f"Device registered with server: {server_device_id} ({hostname})")
                 return {
                     "success": True,
                     "device_id": new_id,
-                    "device_name": hostname,
+                    "device_name": device_name,
                     "server_device_id": new_id,
                 }
         except Exception as e:
@@ -217,7 +288,7 @@ class DeviceRegistry:
                 "disabled": True,
             }
         try:
-            own_id = await loop.run_in_executor(None, self._get_device_id)
+            own_id = await loop.run_in_executor(None, self.get_device_id)
             devices = await loop.run_in_executor(
                 None,
                 lambda: self._retry.with_retry(lambda: self._romm_api.list_devices()),

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -35,7 +35,6 @@ from services.saves._messages import (
     SAVE_SYNC_IN_CONTENT_DIR_REASON,
 )
 from services.saves._settings import resolve_default_slot, save_sync_enabled, sync_after_exit, sync_before_launch
-from services.saves.sync_engine.devices import DeviceRegistry
 from services.saves.sync_engine.matrix import MatrixExecutor, MatrixOutcome
 from services.saves.sync_engine.rollback import RollbackOrchestrator
 
@@ -55,10 +54,10 @@ if TYPE_CHECKING:
         RommSyncApi,
         SaveFileStore,
         SaveSortChangeFn,
-        SettingsPersister,
         UnitOfWorkFactory,
     )
     from services.saves.rom_info import RomInfoService
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 __all__ = ["MatrixOutcome", "SyncEngine", "SyncEngineConfig"]
@@ -70,20 +69,20 @@ class SyncEngineConfig:
 
     Holds the live ``settings.json`` dict (home of the save-sync feature
     toggles), the Unit-of-Work factory (the transactional seam over the
-    SQLite repositories), the peer save sub-service (rom_info), the
+    SQLite repositories), the peer save sub-services (rom_info and the
+    shared :class:`DeviceRegistry` that owns the server device id), the
     Protocol-typed RomM adapter and retry strategy, runtime
     infrastructure (loop, logger, clock), the Protocol-typed filesystem
     adapter, the ``DebugLogger`` seam, the per-ROM active-core resolver,
-    the hostname provider + machine-id provider + settings persister used for
-    device registration,
-    the plugin version string passed to the server on register/update,
-    and the optional sort-change and migration-pending callbacks
-    SyncEngine consults at the entry of every public flow.
+    the hostname provider + machine-id provider passed through to device
+    registration, and the optional sort-change and migration-pending
+    callbacks SyncEngine consults at the entry of every public flow.
     """
 
     settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     rom_info: RomInfoService
+    device_registry: DeviceRegistry
     romm_api: RommSyncApi
     retry: RetryStrategy
     loop: asyncio.AbstractEventLoop
@@ -94,8 +93,6 @@ class SyncEngineConfig:
     active_core: ActiveCoreReader
     hostname_provider: HostnameReader
     machine_id_provider: MachineIdReader
-    settings_persister: SettingsPersister
-    plugin_version: str
     detect_sort_change: SaveSortChangeFn
     is_retrodeck_migration_pending: MigrationPendingFn
 
@@ -108,6 +105,7 @@ class SyncEngine:
         self._settings = config.settings
         self._uow_factory = config.uow_factory
         self._rom_info = config.rom_info
+        self._devices = config.device_registry
         self._romm_api = config.romm_api
         self._retry = config.retry
         self._loop = config.loop
@@ -118,8 +116,6 @@ class SyncEngine:
         self._active_core = config.active_core
         self._hostname_provider = config.hostname_provider
         self._machine_id_provider = config.machine_id_provider
-        self._settings_persister = config.settings_persister
-        self._plugin_version = config.plugin_version
         self._detect_sort_change = config.detect_sort_change
         self._is_retrodeck_migration_pending = config.is_retrodeck_migration_pending
         # Last observed RetroArch save-file layout, refreshed by
@@ -140,19 +136,10 @@ class SyncEngine:
             save_file_store=config.save_file_store,
             log_debug=config.log_debug,
         )
-        self._devices = DeviceRegistry(
-            uow_factory=config.uow_factory,
-            settings=config.settings,
-            romm_api=config.romm_api,
-            retry=config.retry,
-            logger=config.logger,
-            log_debug=config.log_debug,
-            settings_persister=config.settings_persister,
-            plugin_version=config.plugin_version,
-        )
         self._rollback = RollbackOrchestrator(
             uow_factory=config.uow_factory,
             rom_info=config.rom_info,
+            device_registry=self._devices,
             romm_api=config.romm_api,
             matrix=self._matrix,
             retry=config.retry,
@@ -178,9 +165,13 @@ class SyncEngine:
         return save_sync_enabled(self._settings)
 
     def get_device_id(self) -> str | None:
-        """Server-side device id from ``kv_config`` (None when unregistered)."""
-        with self._uow_factory() as uow:
-            return uow.kv_config.get("device_id")
+        """Server-side device id (None when unregistered).
+
+        Delegates to the shared :class:`DeviceRegistry` — the single owner of
+        ``kv_config["device_id"]`` — so the id is read once and cached rather
+        than re-queried per sync flow.
+        """
+        return self._devices.get_device_id()
 
     def resolve_core(self, rom_id: int) -> str | None:
         """Resolve the active RetroArch core for a ROM, or ``None``.
@@ -314,13 +305,14 @@ class SyncEngine:
         """Short read UoW: load the ROM's save state + device id.
 
         Returns the loaded :class:`RomSaveState` (a fresh default when absent)
-        and the server device id. The aggregate is mutated outside the
-        transaction by the matrix worker; :meth:`_write_save_state` persists it.
+        and the server device id (read through the shared
+        :class:`DeviceRegistry`, the single device-id owner). The aggregate is
+        mutated outside the transaction by the matrix worker;
+        :meth:`_write_save_state` persists it.
         """
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id) or RomSaveState()
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._devices.get_device_id()
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         """Short write UoW: persist the mutated save state for *rom_id*."""

--- a/py_modules/services/saves/sync_engine/rollback.py
+++ b/py_modules/services/saves/sync_engine/rollback.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
         UnitOfWorkFactory,
     )
     from services.saves.rom_info import RomInfoService
+    from services.saves.sync_engine.devices import DeviceRegistry
     from services.saves.sync_engine.matrix import MatrixExecutor
 
 
@@ -62,6 +63,7 @@ class RollbackOrchestrator:
         *,
         uow_factory: UnitOfWorkFactory,
         rom_info: RomInfoService,
+        device_registry: DeviceRegistry,
         romm_api: RommSyncApi,
         matrix: MatrixExecutor,
         retry: RetryStrategy,
@@ -73,6 +75,7 @@ class RollbackOrchestrator:
     ) -> None:
         self._uow_factory = uow_factory
         self._rom_info = rom_info
+        self._device_registry = device_registry
         self._romm_api = romm_api
         self._matrix = matrix
         self._retry = retry
@@ -86,8 +89,7 @@ class RollbackOrchestrator:
         """Short read UoW: load the ROM's save state + device id."""
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id) or RomSaveState()
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._device_registry.get_device_id()
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         """Short write UoW: persist the mutated save state for *rom_id*."""

--- a/py_modules/services/saves/versions.py
+++ b/py_modules/services/saves/versions.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from services.protocols import DebugLogger, RetryStrategy, RommSaveApi, UnitOfWorkFactory
     from services.saves.rom_info import RomInfoService
     from services.saves.sync_engine import SyncEngine
+    from services.saves.sync_engine.devices import DeviceRegistry
 
 
 @dataclass(frozen=True)
@@ -40,15 +41,17 @@ class VersionsServiceConfig:
     Holds the live ``settings.json`` dict (default-slot seeding), the
     Unit-of-Work factory (the transactional seam over the SQLite
     repositories), the peer save sub-services consumed during rollback
-    orchestration (sync_engine, rom_info), the core resolver used to
-    stamp the upload emulator tag, the Protocol-typed RomM adapter and
-    retry strategy, the plugin event loop, the standard-library logger,
-    and the ``DebugLogger`` seam.
+    orchestration (sync_engine, rom_info, and the shared
+    :class:`DeviceRegistry` that owns the server device id), the core
+    resolver used to stamp the upload emulator tag, the Protocol-typed
+    RomM adapter and retry strategy, the plugin event loop, the
+    standard-library logger, and the ``DebugLogger`` seam.
     """
 
     settings: dict[str, Any]
     uow_factory: UnitOfWorkFactory
     sync_engine: SyncEngine
+    device_registry: DeviceRegistry
     rom_info: RomInfoService
     resolve_core: Callable[[int], str | None]
     romm_api: RommSaveApi
@@ -71,6 +74,7 @@ class VersionsService:
         self._settings = config.settings
         self._uow_factory = config.uow_factory
         self._sync_engine = config.sync_engine
+        self._device_registry = config.device_registry
         self._rom_info = config.rom_info
         self._resolve_core = config.resolve_core
         self._romm_api = config.romm_api
@@ -86,8 +90,7 @@ class VersionsService:
     def _read_inputs(self, rom_id: int) -> tuple[RomSaveState, str | None]:
         with self._uow_factory() as uow:
             state = uow.rom_save_states.get(rom_id) or RomSaveState()
-            device_id = uow.kv_config.get("device_id")
-        return state, device_id
+        return state, self._device_registry.get_device_id()
 
     def _write_save_state(self, rom_id: int, save_state: RomSaveState) -> None:
         with self._uow_factory() as uow:

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -297,19 +297,30 @@ def _file_md5(path):
 
 
 def _enable_sync_with_device(svc, device_id: str = "device-1") -> None:
-    """Flip on save sync and bind a server device id (matches FakeSaveApi)."""
+    """Flip on save sync and bind a server device id (matches FakeSaveApi).
+
+    Writes ``kv_config["device_id"]`` directly (a test backdoor that bypasses
+    the :class:`DeviceRegistry`), so the registry cache is invalidated to keep
+    the seeded id observable through ``get_device_id``.
+    """
     svc._config.settings["save_sync_enabled"] = True
     with _uow(svc) as uow:
         uow.kv_config.set("device_id", device_id)
+    svc._device_registry.invalidate_device_id_cache()
 
 
 def _set_device_id(svc, device_id: str | None) -> None:
-    """Set or clear the server device id in ``kv_config`` (None deletes it)."""
+    """Set or clear the server device id in ``kv_config`` (None deletes it).
+
+    A test backdoor that bypasses the :class:`DeviceRegistry`; invalidates the
+    registry cache so the change is observable through ``get_device_id``.
+    """
     with _uow(svc) as uow:
         if device_id is None:
             uow.kv_config.delete("device_id")
         else:
             uow.kv_config.set("device_id", device_id)
+    svc._device_registry.invalidate_device_id_cache()
 
 
 def _get_device_id(svc) -> str | None:

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -5,18 +5,62 @@ DeviceRegistry contract guarantees; pure-orchestration assertions live in
 test_engine.py.
 """
 
+import logging
+
 import pytest
+from conftest import _make_retry
 from fakes.fake_hostname_reader import FakeHostnameReader
 from fakes.fake_machine_id_reader import FakeMachineIdReader
+from fakes.fake_save_api import FakeSaveApi
+from fakes.fake_unit_of_work import FakeUnitOfWorkFactory
 
 from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError
 from lib.list_result import ErrorCode
+from services.saves.sync_engine.devices import DeviceRegistry
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
     _install_rom,
     make_service,
 )
+
+
+class _FailingSettingsPersister:
+    """A ``SettingsPersister`` whose ``save_settings`` always raises.
+
+    Used to exercise the best-effort device-name write: a settings.json
+    write failure during registration must leave the device usable, not in a
+    broken half-state.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.save_count = 0
+
+    def save_settings(self) -> None:
+        self.save_count += 1
+        raise self._exc
+
+
+def _make_registry(*, settings=None, settings_persister=None):
+    """Build a stand-alone :class:`DeviceRegistry` over fresh fakes.
+
+    Returns ``(registry, uow_factory, fake_api)`` so a test can drive the
+    registry in isolation and count the underlying Unit-of-Work opens.
+    """
+    uow_factory = FakeUnitOfWorkFactory()
+    fake = FakeSaveApi()
+    registry = DeviceRegistry(
+        uow_factory=uow_factory,
+        settings=settings if settings is not None else {"save_sync_enabled": True},
+        romm_api=fake,
+        retry=_make_retry(),
+        logger=logging.getLogger("test"),
+        log_debug=lambda msg: None,
+        settings_persister=settings_persister or _FailingSettingsPersister(RuntimeError("unused")),
+        plugin_version="0.14.0",
+    )
+    return registry, uow_factory, fake
 
 
 def _register_call(fake):
@@ -225,3 +269,108 @@ class TestEnsureDeviceRegisteredUpdateSwallowLogs:
         assert result["success"] is True
         assert result["device_id"] == "server-uuid"
         assert any("update_device failed" in m and "boom" in m for m in debug_log)
+
+
+class TestRegistrationDeviceNameWriteIsBestEffort:
+    """The kv_config device id is the AUTHORITATIVE registered signal — written
+    first. The settings.json device_name is a best-effort write AFTER, so a
+    label-write failure leaves a fully registered, usable device (valid id,
+    prior/default name) instead of a broken half-state (#984)."""
+
+    @pytest.mark.asyncio
+    async def test_device_id_persisted_when_name_write_fails(self, tmp_path):
+        debug_log: list[str] = []
+        svc, _fake = make_service(
+            tmp_path,
+            log_debug=debug_log.append,
+            settings_persister=_FailingSettingsPersister(OSError("settings.json fsync failed")),
+        )
+        svc._config.settings["save_sync_enabled"] = True
+        # No prior device_name — the failed write leaves it unset.
+        svc._config.settings.pop("device_name", None)
+
+        result = await svc.ensure_device_registered()
+
+        # The device is fully registered and usable despite the name-write failure.
+        assert result["success"] is True
+        assert result["device_id"]  # a real server id was issued and persisted
+        # The id is the authoritative registered signal — written before the name.
+        assert svc._sync_engine.get_device_id() == result["device_id"]
+        # The label write failed, so the device falls back to the prior/default
+        # name (empty here) rather than the half-applied hostname.
+        assert result["device_name"] == ""
+        # The swallow leaves a debug breadcrumb naming the still-usable id.
+        assert any(
+            "device_name write failed" in m and result["device_id"] in m and "fsync failed" in m for m in debug_log
+        )
+
+    @pytest.mark.asyncio
+    async def test_prior_device_name_survives_a_failed_name_write(self, tmp_path):
+        svc, _fake = make_service(
+            tmp_path,
+            settings_persister=_FailingSettingsPersister(OSError("disk full")),
+        )
+        svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["device_name"] = "previous-label"
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        assert result["device_id"]
+        # The previously-persisted label is preserved as the fallback.
+        assert result["device_name"] == "previous-label"
+
+
+class TestDeviceIdCachedRead:
+    """DeviceRegistry is the single device-id owner: it reads kv_config ONCE and
+    serves the cached value thereafter, never re-querying per call (#984)."""
+
+    def test_repeated_reads_open_one_unit_of_work(self):
+        registry, uow_factory, _fake = _make_registry()
+        with uow_factory() as uow:
+            uow.kv_config.set("device_id", "server-uuid")
+        opens_after_seed = uow_factory.call_count
+
+        first = registry.get_device_id()
+        second = registry.get_device_id()
+        third = registry.get_device_id()
+
+        assert first == second == third == "server-uuid"
+        # Exactly one additional UoW open across the three reads — the cache
+        # served the 2nd and 3rd without re-querying SQLite.
+        assert uow_factory.call_count == opens_after_seed + 1
+
+    def test_invalidate_forces_a_re_read(self):
+        registry, uow_factory, _fake = _make_registry()
+        with uow_factory() as uow:
+            uow.kv_config.set("device_id", "first")
+        registry.get_device_id()  # caches "first"
+
+        # Mutate kv_config behind the registry's back, then invalidate.
+        with uow_factory() as uow:
+            uow.kv_config.set("device_id", "second")
+        opens_before = uow_factory.call_count
+        registry.invalidate_device_id_cache()
+
+        assert registry.get_device_id() == "second"
+        # The invalidation forced exactly one fresh read.
+        assert uow_factory.call_count == opens_before + 1
+
+
+class TestDeviceIdAbsent:
+    """Edge: no device registered yet — get_device_id behaves as before (None),
+    and a cached absent result is not re-queried on every call (#984)."""
+
+    def test_unregistered_returns_none(self):
+        registry, _uow_factory, _fake = _make_registry()
+        assert registry.get_device_id() is None
+
+    def test_absent_result_is_cached(self):
+        registry, uow_factory, _fake = _make_registry()
+        assert registry.get_device_id() is None
+        opens_after_first = uow_factory.call_count
+
+        # A second read of the still-unregistered device must not re-query —
+        # "read and found absent" is distinct from "never read".
+        assert registry.get_device_id() is None
+        assert uow_factory.call_count == opens_after_first

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -205,12 +205,17 @@ def _get_save_state(plugin, rom_id):
 
 
 def _set_device_id(plugin, device_id):
-    """Set or clear the server device id in ``kv_config``."""
+    """Set or clear the server device id in ``kv_config``.
+
+    A test backdoor that bypasses the :class:`DeviceRegistry`; invalidates the
+    registry cache so the change is observable through ``get_device_id``.
+    """
     with _uow(plugin) as uow:
         if device_id is None:
             uow.kv_config.delete("device_id")
         else:
             uow.kv_config.set("device_id", device_id)
+    plugin._save_sync_service._device_registry.invalidate_device_id_cache()
 
 
 def _get_device_id(plugin):


### PR DESCRIPTION
Closes #984.

Device identity was dual-written non-atomically (`device_id` in SQLite `kv_config`, `device_name` in `settings.json`), and ~11 modules across the saves sub-services read `kv_config["device_id"]` directly — each opening its own UoW/connection — bypassing `DeviceRegistry`, the documented owner.

**`DeviceRegistry` is now the single cached owner of the device id.** It reads `kv_config["device_id"]` once (lazy, with an explicit loaded-vs-absent flag), reuses the value, and refreshes the cache on registration. Every direct read in `engine.py`, `versions.py`, `rollback.py`, `slots/{listing,setup,switching,deletion}.py`, and `status/service.py` now goes through `DeviceRegistry.get_device_id()` — no per-call connections, four redundant `_read_device_id` helpers removed.

**Wiring:** `DeviceRegistry` was lifted out of `SyncEngine.__init__` up to the `SaveService` facade (the saves bounded-context's local composition root, where `plugin_version` already resolves) and threaded into each sub-service's `*ServiceConfig` as a concrete peer ref (the same-bounded-context carve-out — these sub-services share the `RomSaveState` context). A single shared instance, so one cache.

**Registration hardened:** `device_id` (kv_config) is written first as the authoritative "registered" signal; `device_name` (settings.json) is best-effort after, with a debug breadcrumb and an in-memory rollback on persist failure (this also fixes a pre-existing bug where the in-memory label was mutated before the persist, leaving an unsaved label on failure). A partial failure now leaves a fully usable device.

**Note on approach:** the issue proposed co-locating `device_name` into `kv_config` for a one-transaction registration. That contradicts ADR-0003, which deliberately splits the two stores (`device_name` → settings.json as a user-set label; `device_id` → kv_config as server-issued identity — "the split is honest, not a split aggregate"). This PR keeps `device_name` in `settings.json` and fixes the bug via the read-through + safe-registration route instead. ADR-0003 needs no amendment; no Device aggregate/table is introduced.

Docs: `save-file-sync-architecture.md` — registration flow (id-first / name-best-effort) and a new "DeviceRegistry owns device identity" subsection.
