### PR TITLE
fix(saves): gate sync_all_saves on slot confirmation to avoid auto-uploading unconfigured ROMs

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -971,10 +971,15 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 User-initiated from the "Sync All Saves Now" button in Save Sync settings.
 
 1. Iterates all installed ROMs from the backend registry.
-2. For each ROM with sync state: runs `do_sync_rom_saves`.
+2. For each ROM **whose slot the user has confirmed** (`slot_confirmed`): runs `do_sync_rom_saves`. A never-configured
+   ROM — one the user has not yet set up save sync for — is **skipped**, so its possibly-stale local save can't be
+   auto-uploaded into the default slot and overwrite another device's newer progress (#1055). The single-ROM paths
+   (pre-launch / post-exit / per-game manual sync) stay ungated — those are the user's explicit per-ROM actions and the
+   first-sync auto-seed path, where the user decides.
 3. Per-rom asyncio.Lock prevents collision with concurrent pre-launch / post-exit syncs.
 4. Reports total synced count and number of pending conflicts. Conflicts surface via the modal individually at each
-   game's next pre-launch sync.
+   game's next pre-launch sync. Skipped (unconfirmed) ROMs contribute zero synced / zero conflicts; `roms_checked` stays
+   the count of installed ROMs iterated.
 
 ### Get save status (read-only)
 

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -75,6 +75,10 @@ Tap **Sync All Saves Now** to sync saves for all installed ROMs at once. This is
 - Catching up after a period of offline play
 - Verifying that all saves are in sync
 
+This only covers games you've already set up save sync for (games whose save slot you've confirmed). Games you haven't
+configured yet are left untouched, so a stale local save can't accidentally overwrite newer progress from another
+device.
+
 ## Resolving Conflicts
 
 When both your local save and the server save have changed since the last sync, a modal appears with both versions.

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -439,7 +439,9 @@ class SyncEngine:
             "synced": 0,
         }
 
-    async def _run_rom_sync(self, rom_id: int) -> tuple[int, list[str], list[dict[str, Any]]]:
+    async def _run_rom_sync(
+        self, rom_id: int, *, require_confirmed: bool = False
+    ) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Read inputs → sync in executor → persist, for one ROM under its lock.
 
         The narrow-UoW shape (ADR-0006): a short read UoW loads the aggregate +
@@ -449,12 +451,21 @@ class SyncEngine:
         A ROM with no install record has nothing to sync — and no ``roms`` row
         to anchor a ``rom_save_states`` write against (ADR-0007 FK) — so we
         short-circuit before touching the aggregate.
+
+        When *require_confirmed* is set (the bulk ``sync_all_saves`` sweep), a ROM
+        whose slot the user has not confirmed is skipped entirely — no transfer,
+        no write — so a never-configured ROM's possibly-stale local save can't be
+        auto-uploaded into the default slot and overwrite another device's newer
+        progress (#1055). The single-ROM entry points leave it unset.
         """
         info = await self._loop.run_in_executor(None, self._rom_info.get_rom_save_info, rom_id)
         if not info:
             self._log_debug(f"_run_rom_sync({rom_id}): ROM not installed, skipping")
             return 0, [], []
         save_state, device_id = await self._loop.run_in_executor(None, self._read_sync_inputs, rom_id)
+        if require_confirmed and not save_state.slot_confirmed:
+            self._log_debug(f"_run_rom_sync({rom_id}): slot not confirmed, skipping bulk sync")
+            return 0, [], []
         core_so = await self._loop.run_in_executor(None, self.resolve_core, rom_id)
         default_slot = resolve_default_slot(self._settings)
         synced, errors, conflicts = await self._loop.run_in_executor(
@@ -686,7 +697,7 @@ class SyncEngine:
         for rom_id_int in rom_ids:
             rom_count += 1
             async with self.rom_lock(rom_id_int):
-                synced, errors, conflicts = await self._run_rom_sync(rom_id_int)
+                synced, errors, conflicts = await self._run_rom_sync(rom_id_int, require_confirmed=True)
             total_synced += synced
             total_errors.extend(errors)
             all_conflicts.extend(conflicts)

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -10,6 +10,7 @@ import logging
 
 import pytest
 
+from domain.rom_save_state import RomSaveState
 from domain.save_layout import ContentDir, InSaveDir
 from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError, RommTimeoutError
 from lib.list_result import ErrorCode
@@ -18,6 +19,7 @@ from tests.services.saves._helpers import (
     _do_sync,
     _get_device_id,
     _install_rom,
+    _seed_save_state,
     _server_save,
     _set_device_id,
     _set_sort_settings,
@@ -190,6 +192,10 @@ class TestSyncAllSaves:
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _seed_save_state(
+            svc, 2, RomSaveState(system="snes", slot_confirmed=True, active_slot="default"), platform_slug="snes"
+        )
         _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
         _create_save(tmp_path, system="snes", rom_name="game2", content=b"save2")
 
@@ -213,6 +219,10 @@ class TestSyncAllSaves:
 
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
         _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _seed_save_state(
+            svc, 2, RomSaveState(system="snes", slot_confirmed=True, active_slot="default"), platform_slug="snes"
+        )
         _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
         _create_save(tmp_path, system="snes", rom_name="game2", content=b"save2")
 
@@ -250,6 +260,7 @@ class TestSyncAllSaves:
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
         _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
 
         orig_sync = svc._sync_engine.do_sync_rom_saves
@@ -279,6 +290,7 @@ class TestSyncAllSaves:
         svc._config.settings["save_sync_enabled"] = True
         _set_device_id(svc, "test-device")
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
 
         # Stub internal sync to produce conflicts but no errors
         def stub_sync(rom_id, *args):
@@ -291,6 +303,103 @@ class TestSyncAllSaves:
         assert result["success"] is True
         assert result["conflicts"] >= 1
         assert "conflict(s)" in result["message"]
+
+    # ------------------------------------------------------------------
+    # #1055: the bulk sweep gates each ROM on slot confirmation so a
+    # never-configured ROM's stale local save can't be auto-uploaded into
+    # the default slot and overwrite another device's newer progress.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_confirmed_rom_is_swept_and_uploads(self, tmp_path):
+        """A ROM whose slot the user has confirmed IS swept and uploads (#1055)."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        result = await svc.sync_all_saves()
+
+        assert result["success"] is True
+        assert result["synced"] == 1
+        assert result["roms_checked"] == 1
+        assert any(c[0] == "upload_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_rom_is_skipped_no_upload(self, tmp_path):
+        """A never-configured ROM is SKIPPED — no upload, no download (#1055).
+
+        Non-vacuous: the assertion that NO ``upload_save`` reached the server is
+        what proves the slot-confirmation gate fired before any transfer.
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        # No save state seeded → slot_confirmed defaults to False → never configured.
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        result = await svc.sync_all_saves()
+
+        assert result["synced"] == 0
+        assert result["roms_checked"] == 1
+        assert not any(c[0] == "upload_save" for c in fake.call_log)
+        assert not any(c[0] == "download_save" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_mixed_only_confirmed_rom_syncs(self, tmp_path):
+        """With one confirmed and one unconfirmed ROM, only the confirmed one syncs (#1055)."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        # rom 2 left unconfirmed (no save state seeded).
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+        _create_save(tmp_path, system="snes", rom_name="game2", content=b"save2")
+
+        result = await svc.sync_all_saves()
+
+        assert result["synced"] == 1
+        assert result["roms_checked"] == 2
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        # The single upload was for the confirmed ROM (rom_id is the first positional arg).
+        assert upload_calls[0][1][0] == 1
+
+    @pytest.mark.asyncio
+    async def test_confirmed_legacy_rom_is_swept_and_uploads_as_null(self, tmp_path):
+        """A confirmed LEGACY-slot ROM is swept and uploads slot=None — gate doesn't skip it (#1055).
+
+        Belt-and-suspenders for Arm A: confirming the legacy slot goes through
+        ``confirm_slot(None)`` → ``slot_confirmed=True``, so the bulk sweep must
+        include it and upload with ``slot:null`` (not 'default').
+        """
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _seed_save_state(
+            svc,
+            1,
+            RomSaveState(
+                system="gba",
+                slot_confirmed=True,
+                active_slot=None,
+                slots={"": {"source": "local", "count": 0, "latest_updated_at": None}},
+            ),
+        )
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        result = await svc.sync_all_saves()
+
+        assert result["synced"] == 1
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["slot"] is None  # legacy-confirmed → slot:null, NOT "default"
 
 
 class TestPreLaunchSync:


### PR DESCRIPTION
Closes #1055.

Arm A (legacy-mode duplicate POSTs into "default") was already fixed by #1061. This closes **Arm B**: `sync_all_saves` (the manual "Sync All Saves Now" sweep) iterated every installed ROM with no confirmation gate, so a never-configured ROM's possibly-stale local save was auto-uploaded into the default slot with `updated_at=now` — silently beating another device's newer progress, which the other device then downloaded as authoritative.

**Fix:** the bulk sweep now skips ROMs whose slot the user hasn't confirmed (`RomSaveState.slot_confirmed`, set only by the explicit confirm-slot action; confirming the legacy slot counts, so legacy-confirmed ROMs are still swept). The three single-ROM paths (`pre_launch_sync`, `post_exit_sync`, `sync_rom_saves`) stay **ungated** — a game you just played has the newest local save and syncs on launch/exit as before. Only the bulk sweep, which can touch never-played ROMs holding stale copies, is gated. The skip runs under `rom_lock` before any transfer or state write, so a skipped ROM mutates nothing.

This matches the save-sync principle that unconfigured ROMs are never auto-adopted — the user confirms first.

Docs: `save-file-sync-architecture.md` ("Manual sync all") and `save-sync.md` ("Sync All Saves Now") note that the sweep only syncs confirmed ROMs.
