### PR TITLE
fix(sync): validate run/unit identity on unit-result acks and stop sending after cancel

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -173,6 +173,18 @@ the cause (#1052):
   shortcuts that the next sync re-creates as duplicates. The committed binding is mapped by the next sync's
   existing-shortcut scan, so no active orphan deletion is needed (a Steam shortcut is the sole record of its tile).
 
+**Run/unit identity on the ack (#1041).** Every `sync_apply_unit` event carries the `run_id` (the run's
+`current_sync_id` UUID) and the `unit_id` (the `WorkUnit.id`); the frontend echoes both back on the
+`report_unit_results` ack. The orchestrator stamps the dispatched unit's id into `active_unit_id` just before it emits,
+and `report_unit_results` validates the ack against it: the `run_id` must match `current_sync_id` **and** the `unit_id`
+must match `active_unit_id` (both compared by string value, since a platform's id is numeric and a collection's is a
+string). An ack that fails the check — a **late ack from a cancelled run** arriving while a fresh run is in flight, or a
+stray ack for a different unit — is ignored (logged at debug, returns `{success: True, count: 0, ignored: True}`): it is
+neither recorded, signalled, nor committed, so it can never be credited to the wrong run/unit. `active_unit_id` survives
+the heartbeat-timeout abandon window (the same unit's late ack must still validate) and is cleared once the unit commits
+or is cancelled. On the frontend side, the unit handler **does not send the ack at all once cancel has been requested**
+— the first line of defence against a cancelled run's bindings landing in whatever run started next.
+
 #### DownloadService notes
 
 RomM exposes three mutually exclusive file-layout flags on every ROM detail. They control how the server stores files

--- a/main.py
+++ b/main.py
@@ -313,8 +313,8 @@ class Plugin:
     async def get_sync_status(self):
         return self._sync_service.get_sync_status()
 
-    async def report_unit_results(self, rom_id_to_app_id):
-        return await self._sync_service.report_unit_results(rom_id_to_app_id)
+    async def report_unit_results(self, rom_id_to_app_id, run_id, unit_id):
+        return await self._sync_service.report_unit_results(rom_id_to_app_id, run_id, unit_id)
 
     async def get_registry_platforms(self):
         return self._sync_service.get_registry_platforms()

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -63,6 +63,17 @@ class LibrarySyncStateBox:
     # late ``report_unit_results`` can still commit the delivered bindings
     # that the frontend already created Steam shortcuts for (#1052).
     unit_complete_event: asyncio.Event | None = None
+    # Identity of the unit currently dispatched to the frontend: the
+    # ``WorkUnit.id`` (a platform's numeric id or a collection's string id).
+    # Set by the orchestrator just before it emits ``sync_apply_unit`` and
+    # cleared once the unit's ack is committed (or the unit is cancelled).
+    # ``SyncReporter.report_unit_results`` validates the ack against this and
+    # ``current_sync_id`` (the run id) so a late ack from a cancelled run —
+    # or a stray ack for a different unit — is ignored rather than credited
+    # to the wrong unit/run (#1041). Kept (not cleared) across the
+    # heartbeat-timeout abandon window so the late ack for the SAME unit still
+    # validates; the cleared cross-run/cross-unit case is what it rejects.
+    active_unit_id: int | str | None = None
     # Holds the frontend-supplied ``rom_id_to_app_id`` mapping reported
     # for the active unit. Surfaces the result so the orchestrator can
     # accumulate the per-unit registry into the cross-run accumulators.

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -372,11 +372,19 @@ class SyncReporter:
             return int(existing_value)
         return None
 
-    async def report_unit_results(self, rom_id_to_app_id):
+    async def report_unit_results(self, rom_id_to_app_id, run_id, unit_id):
         """Frontend-Callable: ack that this unit's shortcuts have been applied.
 
-        Records the rom_id→app_id mapping into the state box, then routes by
-        the unit's coordination state:
+        First validates the ack's identity against the active run/unit: the
+        ``run_id`` must match ``current_sync_id`` and ``unit_id`` must match
+        the dispatched ``active_unit_id`` (#1041). A late ack from a
+        **cancelled** run that arrives while a **new** run is in flight, or a
+        stray ack for a different unit, is ignored — neither recorded, signalled,
+        nor committed — so it can never be credited to the wrong unit/run.
+        Logged at debug, returns ``ignored: True`` with ``count: 0``.
+
+        For a matching ack, records the rom_id→app_id mapping into the state
+        box, then routes by the unit's coordination state:
 
         * The orchestrator is still waiting (``unit_complete_event`` live):
           signal the event and let the orchestrator drive the per-unit
@@ -387,10 +395,17 @@ class SyncReporter:
           discard them (#1052). Rebuilds ``acked_roms`` from the stashed
           unit ROMs (the ``metadatum`` source) so metadata is stamped too,
           then clears the abandoned-unit stash.
-        * Neither (a stray duplicate ack): no-op, so nothing is
-          double-committed.
+        * Neither (a stray duplicate ack for the active unit): no-op, so
+          nothing is double-committed.
         """
         box = self._sync_state
+        if not self._ack_matches_active_unit(run_id, unit_id):
+            self._logger.debug(
+                f"Ignoring unit ack for run={run_id!r} unit={unit_id!r}: "
+                f"active run={box.current_sync_id!r} unit={box.active_unit_id!r}"
+            )
+            return {"success": True, "count": 0, "ignored": True}
+
         box.last_unit_results = dict(rom_id_to_app_id)
         if box.unit_complete_event is not None:
             box.unit_complete_event.set()
@@ -401,9 +416,27 @@ class SyncReporter:
             box.pending_unit_roms = []
             box.pending_sync = {}
             box.last_unit_results = None
+            box.active_unit_id = None
 
         self._logger.info(f"Unit results acknowledged: {len(rom_id_to_app_id)} shortcuts")
         return {"success": True, "count": len(rom_id_to_app_id)}
+
+    def _ack_matches_active_unit(self, run_id, unit_id) -> bool:
+        """True when the ack's run/unit identity matches the dispatched unit.
+
+        The frontend echoes back the ``run_id`` + ``unit_id`` carried in the
+        ``sync_apply_unit`` event. Both are compared by string value: the run
+        id is a UUID string, and the unit id is JSON-shaped (a number for a
+        platform, a string for a collection) so ``str()`` coercion on both
+        sides is robust to int-vs-str drift on the wire. An ack is rejected
+        when there is no active unit (``active_unit_id is None`` — the unit was
+        cancelled or already committed), so a stray late ack from a cancelled
+        run no-ops instead of being credited to a fresh run (#1041).
+        """
+        box = self._sync_state
+        if box.active_unit_id is None:
+            return False
+        return str(run_id) == str(box.current_sync_id) and str(unit_id) == str(box.active_unit_id)
 
     async def commit_unit_results(self, rom_id_to_app_id, acked_roms):
         """Per-unit commit: cover-path finalize then atomic ``roms`` + metadata upsert.

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -304,8 +304,8 @@ class LibraryService:
         return self._orchestrator.get_sync_status()
 
     # Reporting
-    async def report_unit_results(self, rom_id_to_app_id):
-        return await self._reporter.report_unit_results(rom_id_to_app_id)
+    async def report_unit_results(self, rom_id_to_app_id, run_id, unit_id):
+        return await self._reporter.report_unit_results(rom_id_to_app_id, run_id, unit_id)
 
     # Registry queries
     def get_registry_platforms(self):

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -709,6 +709,10 @@ class SyncOrchestrator:
         # Emit per-unit apply event + wait for the frontend callback.
         box.unit_complete_event = asyncio.Event()
         box.last_unit_results = None
+        # Stamp the unit's identity so the reporter can validate the ack's
+        # run_id + unit_id and reject a late ack from a cancelled run or a
+        # stray ack for a different unit (#1041).
+        box.active_unit_id = unit.id
         # Reset the abandoned-unit stash so a prior timed-out unit can't
         # leak its state into this one's late-ack commit (#1052).
         box.unit_abandoned = False
@@ -734,10 +738,11 @@ class SyncOrchestrator:
             # whether the frontend's in-flight work is recoverable.
             if box.is_cancelling():
                 # User cancel: in-flight work is intentionally discarded.
-                # Drop the pending state and null the event so a stray late
-                # ack can't commit a cancelled unit.
+                # Drop the pending state, null the event, and clear the unit
+                # identity so a stray late ack can't commit a cancelled unit.
                 box.pending_sync = {}
                 box.unit_complete_event = None
+                box.active_unit_id = None
             else:
                 # Heartbeat timeout: the frontend has already created this
                 # unit's Steam shortcuts and will still fire its late
@@ -761,6 +766,7 @@ class SyncOrchestrator:
 
         box.pending_sync = {}
         box.unit_complete_event = None
+        box.active_unit_id = None
         return len(applied)
 
     async def _sync_platform_unit(

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -209,9 +209,10 @@ export interface SgdbSearchResult {
 export const getSgdbResolution = callable<[number], SgdbResolution>("get_sgdb_resolution");
 export const searchSgdbGames = callable<[string], SgdbSearchResult>("search_sgdb_games");
 export const applySgdbGameId = callable<[number, number], { success: boolean }>("apply_sgdb_game_id");
-export const reportUnitResults = callable<[Record<string, number>], { success: boolean; count: number }>(
-  "report_unit_results",
-);
+export const reportUnitResults = callable<
+  [Record<string, number>, string, number | string],
+  { success: boolean; count: number; ignored?: boolean }
+>("report_unit_results");
 export const reportRemovalResults = callable<[(string | number)[]], { success: boolean; message: string }>(
   "report_removal_results",
 );

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -24,7 +24,7 @@ vi.mock("./steamShortcuts", () => ({
   getExistingRomMShortcuts: (...args: unknown[]) => getExistingRomMShortcuts(...args),
 }));
 
-import { initUnitSyncManager } from "./syncManager";
+import { initUnitSyncManager, requestSyncCancel } from "./syncManager";
 
 function unit(launchOptions: string, runId = "run-1"): SyncApplyUnitData {
   return {
@@ -74,8 +74,41 @@ describe("syncManager — existing-shortcut update uses confirm-poll", () => {
 
     expect(setLaunchOptionsConfirmed).toHaveBeenCalledWith(5000, cmd);
     expect(addShortcut).not.toHaveBeenCalled();
-    // The rom_id→appId binding is reported back to the backend.
-    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "42": 5000 });
+    // The rom_id→appId binding is reported back to the backend, echoing the
+    // run + unit identity so the backend can reject a stale ack (#1041).
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "42": 5000 }, "run-confirm", 1);
+  });
+});
+
+describe("syncManager — does not ack a cancelled unit (#1041)", () => {
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    vi.mocked(backend.reportUnitResults).mockClear();
+  });
+
+  it("skips reportUnitResults when cancel is requested during the unit loop", async () => {
+    // Cancel is requested during the once-per-run existing-shortcut scan (a
+    // fresh-run cache miss always calls it), which runs before the unit loop —
+    // so the loop's cancel check breaks early and the post-loop guard skips the
+    // ack. A unique run_id guarantees the module-level scan cache misses here.
+    getExistingRomMShortcuts.mockImplementation(async () => {
+      requestSyncCancel();
+      return new Map<number, number>([[42, 5000]]);
+    });
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-cancel-1041"));
+      await flush(120);
+    });
+
+    // Observable effect of the post-cancel guard: the ack callable is NEVER
+    // invoked, so a cancelled run's bindings can't be credited to a fresh run.
+    expect(vi.mocked(backend.reportUnitResults)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -192,10 +192,21 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       // payload comfortably under the decky.emit WebSocket size ceiling.
       await processUnitArtwork(artworkTargets);
 
-      try {
-        await reportUnitResults(romIdToAppId);
-      } catch (e) {
-        logError(`Failed to report unit results for ${data.unit_name}: ${e}`);
+      // Do NOT ack a cancelled unit: the backend has already discarded this
+      // run's in-flight state, so a post-cancel ack only risks being credited
+      // to whatever run started next (the cross-run collision + rapid-restart
+      // self-cancel in #1041). The backend also validates run_id/unit_id, but
+      // not sending is the first line of defence.
+      if (_cancelRequested) {
+        logInfo(`Per-unit cancel observed for ${data.unit_name}; skipping reportUnitResults`);
+      } else {
+        try {
+          // Echo back the run + unit identity so the backend can reject a stale
+          // ack (cancelled run) instead of crediting it to a fresh run (#1041).
+          await reportUnitResults(romIdToAppId, data.run_id, data.unit_id);
+        } catch (e) {
+          logError(`Failed to report unit results for ${data.unit_name}: ${e}`);
+        }
       }
       logInfo(`sync_apply_unit complete: ${data.unit_name} (${Object.keys(romIdToAppId).length}/${total})`);
     } finally {

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -34,6 +34,16 @@ export function requestSyncCancel(): void {
 }
 
 /**
+ * Read the cancel flag. Accessed through a function so a read after the
+ * per-unit ``_cancelRequested = false`` reset isn't narrowed to a constant
+ * ``false`` by control-flow analysis — the flag is flipped externally by
+ * {@link requestSyncCancel} during the awaited work, which TS can't see.
+ */
+function isCancelRequested(): boolean {
+  return _cancelRequested;
+}
+
+/**
  * Resolve a shortcut item to an appId: update fields on the existing
  * shortcut when one is present, otherwise create a new shortcut. Returns
  * ``undefined`` if no appId could be resolved (creation failed).
@@ -90,7 +100,7 @@ async function processUnitShortcuts(
       syncHeartbeat().catch(() => {});
       lastHeartbeat = Date.now();
     }
-    if (_cancelRequested) {
+    if (isCancelRequested()) {
       logInfo(`Per-unit cancel observed during ${data.unit_name}`);
       break;
     }
@@ -120,7 +130,7 @@ async function processUnitArtwork(artworkTargets: ArtworkTarget[]): Promise<void
   if (artworkTargets.length === 0) return;
   let lastHeartbeat = Date.now();
   for (let i = 0; i < artworkTargets.length; i += ART_CONCURRENCY) {
-    if (_cancelRequested) break;
+    if (isCancelRequested()) break;
     const batch = artworkTargets.slice(i, i + ART_CONCURRENCY);
     await Promise.all(batch.map(applyArtworkForTarget));
     if (Date.now() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
@@ -197,7 +207,7 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       // to whatever run started next (the cross-run collision + rapid-restart
       // self-cancel in #1041). The backend also validates run_id/unit_id, but
       // not sending is the first line of defence.
-      if (_cancelRequested) {
+      if (isCancelRequested()) {
         logInfo(`Per-unit cancel observed for ${data.unit_name}; skipping reportUnitResults`);
       } else {
         try {

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -165,13 +165,36 @@ async def test_report_unit_results_signal_shape(harness):
     import asyncio
 
     box = harness.plugin._sync_service._box
+    box.current_sync_id = "run-1"
+    box.active_unit_id = 1
     box.unit_complete_event = asyncio.Event()
 
-    result = await harness.plugin.report_unit_results({"10": 9001})
+    result = await harness.plugin.report_unit_results({"10": 9001}, "run-1", 1)
 
     assert result == {"success": True, "count": 1}
     assert box.unit_complete_event.is_set()
     # The orchestrator drives the commit on the happy path — nothing bound yet.
+    assert await harness.plugin.get_app_id_rom_id_map() == {}
+
+
+async def test_report_unit_results_stale_run_ignored(harness):
+    """A late ack carrying a CANCELLED run's id is ignored — neither signalled
+    nor credited to the active run (#1041). Pins the ``ignored`` shape and that
+    the active run's wait event stays unset."""
+    import asyncio
+
+    box = harness.plugin._sync_service._box
+    # Active run B, waiting on its own unit's event.
+    box.current_sync_id = "run-B"
+    box.active_unit_id = 7
+    box.unit_complete_event = asyncio.Event()
+
+    # Stale ack from the cancelled run A.
+    result = await harness.plugin.report_unit_results({"10": 9001}, "run-A", 1)
+
+    assert result == {"success": True, "count": 0, "ignored": True}
+    # Run B's wait is untouched and nothing was bound.
+    assert not box.unit_complete_event.is_set()
     assert await harness.plugin.get_app_id_rom_id_map() == {}
 
 
@@ -186,6 +209,9 @@ async def test_report_unit_results_late_ack_binds_orphan(harness):
     box = harness.plugin._sync_service._box
     # The state a heartbeat timeout leaves: pending_sync staged, event already
     # None (the wait returned), unit flagged abandoned with its ROMs stashed.
+    # Run + unit identity survives the abandon window so the late ack validates.
+    box.current_sync_id = "run-1"
+    box.active_unit_id = 1
     box.pending_sync = {
         42: {
             "name": "Orphan Game",
@@ -201,7 +227,7 @@ async def test_report_unit_results_late_ack_binds_orphan(harness):
     # Before the ack: the appId is NOT in the map (would be an orphan).
     assert await harness.plugin.get_app_id_rom_id_map() == {}
 
-    result = await harness.plugin.report_unit_results({"42": 100001})
+    result = await harness.plugin.report_unit_results({"42": 100001}, "run-1", 1)
 
     assert result == {"success": True, "count": 1}
     # The orphan is now a bound row — the next sync's getExistingRomMShortcuts

--- a/tests/scripts/test_check_callable_manifest.py
+++ b/tests/scripts/test_check_callable_manifest.py
@@ -64,8 +64,13 @@ class TestParseFrontendCallables:
 
     def test_nested_generic_comma_not_counted(self, tmp_path: Path):
         # Record<string, number> is ONE element — the inner comma must not inflate.
-        src = _write_ts(tmp_path, "a.ts", 'callable<[Record<string, number>], Foo>("report_unit_results");')
-        assert check.parse_frontend_callables(src) == {"report_unit_results": 1}
+        # Mirrors report_unit_results: Record<…> + run_id + unit_id → arity 3.
+        src = _write_ts(
+            tmp_path,
+            "a.ts",
+            'callable<[Record<string, number>, string, number | string], Foo>("report_unit_results");',
+        )
+        assert check.parse_frontend_callables(src) == {"report_unit_results": 3}
 
     def test_union_with_string_literals_is_arity_two(self, tmp_path: Path):
         src = _write_ts(tmp_path, "a.ts", 'callable<[boolean, "my" | "smart" | null], Foo>("g");')

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1773,25 +1773,75 @@ class TestReportUnitResults:
     @pytest.mark.asyncio
     async def test_signals_unit_complete_event(self, plugin):
         plugin._sync_service._pending_sync = {}
+        box = plugin._sync_service._box
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
         event = asyncio.Event()
-        plugin._sync_service._box.unit_complete_event = event
+        box.unit_complete_event = event
         assert not event.is_set()
 
-        await plugin.report_unit_results({})
+        await plugin.report_unit_results({}, "run-1", 1)
 
         assert event.is_set()
-        assert plugin._sync_service._box.last_unit_results == {}
+        assert box.last_unit_results == {}
 
     @pytest.mark.asyncio
     async def test_records_last_unit_results(self, plugin):
         plugin._sync_service._pending_sync = {}
-        plugin._sync_service._box.unit_complete_event = asyncio.Event()
+        box = plugin._sync_service._box
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
+        box.unit_complete_event = asyncio.Event()
 
-        result = await plugin.report_unit_results({"10": 9001, "11": 9002})
+        result = await plugin.report_unit_results({"10": 9001, "11": 9002}, "run-1", 1)
 
         assert result["success"] is True
         assert result["count"] == 2
-        assert plugin._sync_service._box.last_unit_results == {"10": 9001, "11": 9002}
+        assert box.last_unit_results == {"10": 9001, "11": 9002}
+
+    @pytest.mark.asyncio
+    async def test_stale_run_id_ack_is_ignored_not_credited_to_new_run(self, plugin):
+        """A late ack from a cancelled run A, arriving while run B is in flight,
+        is ignored — not signalled, not recorded, not committed (#1041).
+
+        Run B's wait event must stay UNSET and its registry untouched: the late
+        ack carries run A's id, which no longer matches ``current_sync_id``."""
+        plugin._sync_service._pending_sync = {}
+        box = plugin._sync_service._box
+        # Run B is the active run, waiting on its own unit's event.
+        box.current_sync_id = "run-B"
+        box.active_unit_id = 7
+        event = asyncio.Event()
+        box.unit_complete_event = event
+
+        # Late ack from the cancelled run A (stale run id) for the old unit.
+        result = await plugin.report_unit_results({"10": 9001}, "run-A", 1)
+
+        assert result == {"success": True, "count": 0, "ignored": True}
+        # Run B is untouched: its event stays unset and no result was recorded.
+        assert not event.is_set()
+        assert box.last_unit_results is None
+        # Nothing committed to run B's registry.
+        assert plugin._uow.committed is False
+        with plugin._uow as uow:
+            assert uow.roms.get(10) is None
+
+    @pytest.mark.asyncio
+    async def test_mismatched_unit_id_same_run_is_ignored(self, plugin):
+        """An ack for a different unit within the SAME run is ignored — the
+        unit_id guard rejects it even though the run id matches (#1041)."""
+        plugin._sync_service._pending_sync = {}
+        box = plugin._sync_service._box
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 5  # unit 5 is the active one
+        event = asyncio.Event()
+        box.unit_complete_event = event
+
+        result = await plugin.report_unit_results({"10": 9001}, "run-1", 99)
+
+        assert result == {"success": True, "count": 0, "ignored": True}
+        assert not event.is_set()
+        assert box.last_unit_results is None
 
     @pytest.mark.asyncio
     async def test_late_ack_after_abandon_commits_binding(self, plugin):
@@ -1805,7 +1855,10 @@ class TestReportUnitResults:
         box = plugin._sync_service._box
         # Timeout state the orchestrator leaves behind: pending_sync staged,
         # event already None (the wait returned), unit flagged abandoned with
-        # its live RomM fetch stashed.
+        # its live RomM fetch stashed. The run + unit identity stays set across
+        # the abandon window so the late ack for the SAME unit validates.
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
         box.pending_sync = {
             42: {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""},
         }
@@ -1813,7 +1866,7 @@ class TestReportUnitResults:
         box.unit_abandoned = True
         box.pending_unit_roms = [{"id": 42, "metadatum": {"genres": ["RPG"]}}]
 
-        result = await plugin.report_unit_results({"42": 100001})
+        result = await plugin.report_unit_results({"42": 100001}, "run-1", 1)
 
         assert result == {"success": True, "count": 1}
         # The binding was committed (not discarded).
@@ -1830,6 +1883,9 @@ class TestReportUnitResults:
         assert box.pending_unit_roms == []
         assert box.pending_sync == {}
         assert box.last_unit_results is None
+        # The unit identity is cleared once the late ack commits, so a duplicate
+        # ack for the same unit no longer validates.
+        assert box.active_unit_id is None
 
     @pytest.mark.asyncio
     async def test_late_ack_stamps_only_stashed_acked_roms(self, plugin):
@@ -1837,6 +1893,8 @@ class TestReportUnitResults:
         metadata (its ``metadatum`` source is gone) — the binding is the
         load-bearing data, metadata is best-effort (#1052)."""
         box = plugin._sync_service._box
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
         box.pending_sync = {
             42: {"name": "A", "fs_name": "a.z64", "platform_slug": "gb", "cover_path": ""},
         }
@@ -1845,7 +1903,7 @@ class TestReportUnitResults:
         # The stash carries a DIFFERENT rom than the one acked.
         box.pending_unit_roms = [{"id": 99, "metadatum": {"genres": ["RPG"]}}]
 
-        result = await plugin.report_unit_results({"42": 100001})
+        result = await plugin.report_unit_results({"42": 100001}, "run-1", 1)
 
         assert result == {"success": True, "count": 1}
         with plugin._uow as uow:
@@ -1859,14 +1917,18 @@ class TestReportUnitResults:
 
     @pytest.mark.asyncio
     async def test_stray_ack_when_not_abandoned_is_noop(self, plugin):
-        """An ack with no live wait and no abandoned flag (a stray duplicate)
-        records nothing on disk — it must not double-commit (#1052)."""
+        """An ack for the ACTIVE unit with no live wait and no abandoned flag
+        (a stray duplicate) records nothing on disk — it must not double-commit
+        (#1052). The run/unit identity matches, so it passes validation and
+        falls through to the no-op 'neither' branch."""
         box = plugin._sync_service._box
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
         box.unit_complete_event = None
         box.unit_abandoned = False
         box.pending_sync = {}
 
-        result = await plugin.report_unit_results({"42": 100001})
+        result = await plugin.report_unit_results({"42": 100001}, "run-1", 1)
 
         assert result == {"success": True, "count": 1}
         # The mapping is still recorded, but NOTHING is committed.
@@ -1904,6 +1966,8 @@ class TestLateAckReconciliationWithStaleScan:
 
         # The heartbeat-timeout state the orchestrator leaves behind for the NEW
         # rom_id (2), which the frontend acks with the SAME reused appId.
+        box.current_sync_id = "run-1"
+        box.active_unit_id = 1
         box.pending_sync = {
             2: {"name": "A", "fs_name": "a.z64", "platform_slug": "n64", "cover_path": ""},
         }
@@ -1912,7 +1976,7 @@ class TestLateAckReconciliationWithStaleScan:
         box.pending_unit_roms = [{"id": 2}]
 
         # Late ack: commits the binding AND records app 5000 in committed_app_ids.
-        await plugin.report_unit_results({"2": 5000})
+        await plugin.report_unit_results({"2": 5000}, "run-1", 1)
 
         assert 5000 in box.committed_app_ids
         # rom 2 now holds app 5000; rom 1 was unbound by the collision-safe save.

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -369,8 +369,8 @@ class TestLibrarySyncCallableDelegation:
     @pytest.mark.asyncio
     async def test_report_unit_results_delegates(self, plugin):
         plugin._sync_service.report_unit_results = AsyncMock(return_value={"ok": True})
-        result = await plugin.report_unit_results({"1": 100})
-        plugin._sync_service.report_unit_results.assert_awaited_once_with({"1": 100})
+        result = await plugin.report_unit_results({"1": 100}, "run-1", 1)
+        plugin._sync_service.report_unit_results.assert_awaited_once_with({"1": 100}, "run-1", 1)
         assert result == {"ok": True}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1041.

The data-loss half of #1041 (a late ack creating duplicate shortcuts) was fixed by #1052. This closes the remaining identity gap: `report_unit_results` accepted a unit-result ack with no run/unit identity, so after a cancel + rapid restart a late ack from run A could be credited to run B (and the new run could self-cancel on the heartbeat timeout).

`run_id` and `unit_id` already travel on the wire (`sync_apply_unit`), so the frontend now echoes them back and `report_unit_results` validates: an ack is credited only when it matches the currently-active run **and** unit (`active_unit_id` on the state box). A stale-run or wrong-unit ack is ignored (`{success: True, count: 0, ignored: True}`) — nothing signalled, recorded, or committed. The identity survives #1052's heartbeat-timeout abandon window (so the legitimate unit's late ack still commits its binding) and is cleared on commit/cancel.

The frontend (`syncManager.ts`) no longer posts `reportUnitResults` once a cancel has been requested.

Callable arity: `report_unit_results` / `reportUnitResults` gains `run_id` + `unit_id` — `main.py`, `src/api/backend.ts`, and the callable-manifest stay in sync.

Docs: `backend-architecture.md` — a new "Run/unit identity on the ack" note.
