### PR TITLE
fix(library): reconcile Steam-UI-deleted shortcuts by unbinding dead appIds at sync start

### DIFF
--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -87,6 +87,38 @@ Two guards keep this from wiping a freshly-synced shortcut (`#1036`):
   removal. The `get_by_app_id` reverse lookup orders `rom_id DESC LIMIT 1` so it resolves the live (newest) binding for
   any pre-migration edge state.
 
+## Sync-start reconcile of Steam-UI-deleted shortcuts
+
+A user can delete a RomM shortcut through **Steam's own UI** (remove from library), which the plugin never observes. The
+`roms` row keeps its now-dead `shortcut_app_id`, so `get_app_id_rom_id_map` keeps serving it (playtime writes and
+launch-options bakes aim at a Steam app that no longer exists) and the **incremental skip never recreates it**: the skip
+counts bound `roms` rows, not live Steam shortcuts, so the platform reports "unchanged" forever. The game stays gone
+until a server-side change or a Force Full Sync (`#1046`).
+
+The fix is a **frontend-assisted reconcile at sync start**, because only the frontend can read Steam's shortcut store.
+It runs **before** the sync builds its work queue — so the unbind lands before the incremental-skip decision — on both
+the skip-preview (`start_sync`) and preview (`sync_preview`) paths:
+
+1. `getLiveRomMShortcutAppIds()` (`src/utils/steamShortcuts.ts`) scans Steam's live shortcuts and returns the raw appIds
+   of every RomM-owned shortcut (exe ends with `/bin/rom-launcher`), regardless of any backend binding. It returns
+   `null` when the store was **unreadable** (`collectionStore` absent) versus `[]` when the scan **ran and found none**
+   — a load-bearing distinction.
+2. `reconcileStaleShortcuts()` (`src/utils/syncManager.ts`) skips the reconcile on a `null` scan (reconciling against
+   "couldn't look" would unbind every binding), and otherwise calls the `reconcile_shortcuts` callable with the live
+   set. It is best-effort: a scan or backend failure is logged and swallowed, never blocking the sync.
+3. `ShortcutRemovalService.reconcile_live_shortcuts` unbinds every bound `roms` row whose `shortcut_app_id` is **not**
+   in the live set — clearing only the binding (`Rom.unbind_shortcut`, ADR-0007), never deleting the row or its per-ROM
+   children. An empty live set is the correct "they're all gone" signal and unbinds every binding.
+
+Once a row is unbound, the fetcher's incremental baseline (`_read_incremental_baseline`, which reconstructs only rows
+with a non-NULL `shortcut_app_id`) no longer counts it, so `unit.rom_count == registry_count` fails and the platform
+falls through to a full fetch that recreates the shortcut. The unbind is reversible by design — the next sync re-binds.
+
+This is **eager (sync-start) reconciliation of the Steam-shortcut binding**, distinct from `#951`'s lazy on-access
+reconciliation of the `rom_installs` (on-disk install) view: a different aggregate, a different cost driver, and —
+unlike installs — one the backend physically cannot reconcile lazily, since no per-game backend seam observes Steam's
+shortcut store.
+
 ## BIsModOrShortcut
 
 Non-Steam shortcuts return `BIsModOrShortcut() = true` by default. This is their natural state — Steam uses this flag to
@@ -195,17 +227,18 @@ hero/logo/grid/icon, writing the icon into the grid dir) own the artwork flow. I
 
 ## Key Files
 
-| File                                  | Purpose                                                                                                                                                                                                                                                      |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `src/utils/steamShortcuts.ts`         | `addShortcut()`, `removeShortcut()`, `getExistingRomMShortcuts()` — frontend shortcut CRUD. The existing-shortcut scan emits a sync heartbeat every 10s between batches so a large library can't stall the run past the backend's per-unit heartbeat timeout |
-| `src/utils/syncManager.ts`            | Listens for sync events, orchestrates shortcut creation/removal, artwork application, collection management. Caches the existing-shortcut scan per run (keyed by the `sync_apply_unit` `run_id`) so it scans Steam once per run, not once per unit           |
-| `src/utils/collections.ts`            | Machine-scoped Steam collection management                                                                                                                                                                                                                   |
-| `src/patches/gameDetailPatch.tsx`     | Route patch for `/library/app/:appid` — injects RomMPlaySection for custom game detail UI                                                                                                                                                                    |
-| `src/patches/metadataPatches.ts`      | Store patches for description, associations, categories, release date display                                                                                                                                                                                |
-| `py_modules/adapters/steam_config.py` | `SteamConfigAdapter` — VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                                                                                                                     |
-| `py_modules/services/library/`        | LibraryService — builds shortcut data, drives per-unit sync apply                                                                                                                                                                                            |
-| `py_modules/domain/sgdb_artwork.py`   | `to_signed_app_id`, SGDB asset-type/endpoint maps                                                                                                                                                                                                            |
-| `bin/rom-launcher`                    | Pure `exec "$@"` wrapper invoked by Steam — runs the full launch command baked into the shortcut's launch options; owns no state, no path resolution, no emulator knowledge                                                                                  |
+| File                                      | Purpose                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/steamShortcuts.ts`             | `addShortcut()`, `removeShortcut()`, `getExistingRomMShortcuts()`, `getLiveRomMShortcutAppIds()` (raw live appId scan for the sync-start reconcile) — frontend shortcut CRUD. The existing-shortcut scan emits a sync heartbeat every 10s between batches so a large library can't stall the run past the backend's per-unit heartbeat timeout |
+| `src/utils/syncManager.ts`                | Listens for sync events, orchestrates shortcut creation/removal, artwork application, collection management. `reconcileStaleShortcuts()` runs the sync-start reconcile of Steam-UI-deleted shortcuts. Caches the existing-shortcut scan per run (keyed by the `sync_apply_unit` `run_id`) so it scans Steam once per run, not once per unit    |
+| `py_modules/services/shortcut_removal.py` | `ShortcutRemovalService` — resolves shortcut-removal sets, unbinds removed ROMs, and runs `reconcile_live_shortcuts` (the sync-start reconcile of Steam-UI-deleted bindings)                                                                                                                                                                   |
+| `src/utils/collections.ts`                | Machine-scoped Steam collection management                                                                                                                                                                                                                                                                                                     |
+| `src/patches/gameDetailPatch.tsx`         | Route patch for `/library/app/:appid` — injects RomMPlaySection for custom game detail UI                                                                                                                                                                                                                                                      |
+| `src/patches/metadataPatches.ts`          | Store patches for description, associations, categories, release date display                                                                                                                                                                                                                                                                  |
+| `py_modules/adapters/steam_config.py`     | `SteamConfigAdapter` — VDF read/write, grid dir, shortcut icon write, Steam Input config                                                                                                                                                                                                                                                       |
+| `py_modules/services/library/`            | LibraryService — builds shortcut data, drives per-unit sync apply                                                                                                                                                                                                                                                                              |
+| `py_modules/domain/sgdb_artwork.py`       | `to_signed_app_id`, SGDB asset-type/endpoint maps                                                                                                                                                                                                                                                                                              |
+| `bin/rom-launcher`                        | Pure `exec "$@"` wrapper invoked by Steam — runs the full launch command baked into the shortcut's launch options; owns no state, no path resolution, no emulator knowledge                                                                                                                                                                    |
 
 ## Common Pitfalls
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -102,6 +102,10 @@ shortcuts are updated rather than duplicated.
 To remove synced games, use the **Danger Zone** page. See
 [Troubleshooting — Danger Zone](troubleshooting.md#danger-zone) for details on the available removal options.
 
+If you delete a synced game directly from **Steam's own library** (rather than the Danger Zone), the next sync brings it
+back. The plugin notices the shortcut is gone at sync start and re-creates it, so deleting through Steam is not a
+permanent way to remove a RomM game — use the Danger Zone for that.
+
 ---
 
 **Previous:** [Configuration](configuration.md) | **Next:** [Managing Games](managing-games.md)

--- a/main.py
+++ b/main.py
@@ -330,6 +330,9 @@ class Plugin:
     async def report_removal_results(self, removed_rom_ids):
         return await self._shortcut_removal_service.report_removal_results(removed_rom_ids)
 
+    async def reconcile_shortcuts(self, live_app_ids):
+        return await self._shortcut_removal_service.reconcile_live_shortcuts(live_app_ids)
+
     async def get_artwork_base64(self, rom_id):
         return await self._artwork_service.get_artwork_base64(rom_id)
 

--- a/py_modules/services/shortcut_removal.py
+++ b/py_modules/services/shortcut_removal.py
@@ -1,11 +1,13 @@
 """ShortcutRemovalService — Steam-shortcut removal and ROM unbinding.
 
-Resolves the Steam ``app_id``/``rom_id`` sets the frontend removes via the
-SteamClient API, then reconciles persistence: removing a shortcut **unbinds**
-the ROM (clears ``shortcut_app_id``, keeps the row and its per-ROM children per
-ADR-0007), never deletes it. Reads the synced-shortcut binding from ``uow.roms``;
-the offline ``platform_slug → display_name`` label comes from the ``kv_config``
-cache the library sync refreshes each run.
+The home for clearing a ROM's Steam-shortcut binding: both the user-driven
+removal flows (the frontend removes shortcuts via SteamClient, this service
+unbinds the rows) and the sync-start reconcile against Steam's live shortcut
+set (a shortcut the user deleted through Steam's own UI is unbound so the next
+sync recreates it — #1046). Unbinding clears ``shortcut_app_id`` and keeps the
+row and its per-ROM children (ADR-0007), never deletes. Reads the synced-shortcut
+binding from ``uow.roms``; the offline ``platform_slug → display_name`` label
+comes from the ``kv_config`` cache the library sync refreshes each run.
 """
 
 from __future__ import annotations
@@ -153,3 +155,60 @@ class ShortcutRemovalService:
         """Called by frontend after removing shortcuts via SteamClient."""
         await self._loop.run_in_executor(None, self._report_removal_results_io, removed_rom_ids)
         return {"success": True, "message": f"Removed {len(removed_rom_ids)} shortcuts"}
+
+    # ── Live-shortcut reconcile ────────────────────────────────────────────
+
+    def _reconcile_live_shortcuts_io(self, live_app_ids: list[int | str]) -> int:
+        """Unbind every bound ROM whose ``shortcut_app_id`` is absent from the live set.
+
+        *live_app_ids* is the set of appIds the frontend observed in Steam's live
+        shortcut store (every shortcut whose exe is the plugin launcher). Each
+        bound ROM (``shortcut_app_id`` not NULL) whose appId is **not** in that
+        set lost its Steam shortcut out-of-band — unbind it (ADR-0007: clear the
+        link, keep the row and its per-ROM children), so the next sync's
+        incremental skip no longer counts it and the unit re-fetches to recreate
+        the shortcut. Returns the count unbound. Defensive ``int`` coercion: the
+        frontend may serialize appIds as strings, and a non-numeric entry is
+        dropped (it can never match a numeric ``shortcut_app_id``).
+        """
+        live: set[int] = set()
+        for raw in live_app_ids:
+            try:
+                live.add(int(raw))
+            except (TypeError, ValueError):
+                continue
+
+        unbound = 0
+        with self._uow_factory() as uow:
+            for rom in list(uow.roms.iter_all()):
+                if rom.shortcut_app_id is None or rom.shortcut_app_id in live:
+                    continue
+                rom.unbind_shortcut()
+                uow.roms.save(rom)
+                unbound += 1
+        return unbound
+
+    async def reconcile_live_shortcuts(self, live_app_ids: list[int | str]) -> dict[str, Any]:
+        """Reconcile bound ROMs against the live Steam-shortcut set the frontend supplies.
+
+        Called at sync start with the appIds of every RomM shortcut still present
+        in Steam's live shortcut store. Bindings absent from that set are stale
+        (the user deleted the shortcut via Steam's own UI) and are unbound so the
+        next sync recreates them — fixing the "deleted shortcut never comes back"
+        loop (#1046). An empty *live_app_ids* means the frontend's scan found zero
+        RomM shortcuts in Steam, so every binding is unbound; the frontend MUST
+        only call this when its scan actually ran (Steam's store was readable),
+        never on a scan it could not perform.
+        """
+        try:
+            unbound = await self._loop.run_in_executor(None, self._reconcile_live_shortcuts_io, live_app_ids)
+        except Exception as e:
+            self._logger.error(f"Failed to reconcile live shortcuts: {e}")
+            return {
+                "success": False,
+                "reason": ErrorCode.UNKNOWN.value,
+                "message": f"Reconcile failed: {e}",
+            }
+        if unbound:
+            self._logger.info(f"Reconcile: unbound {unbound} stale Steam shortcut(s)")
+        return {"success": True, "unbound_count": unbound, "message": f"Unbound {unbound} stale shortcut(s)"}

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -216,6 +216,10 @@ export const reportUnitResults = callable<
 export const reportRemovalResults = callable<[(string | number)[]], { success: boolean; message: string }>(
   "report_removal_results",
 );
+export const reconcileShortcuts = callable<
+  [number[]],
+  { success: boolean; reason?: string; message: string; unbound_count?: number }
+>("reconcile_shortcuts");
 export const uninstallAllRoms = callable<
   [],
   { success: boolean; removed_count: number; errors: { rom_id: string; error: string }[] }

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -111,6 +111,7 @@ import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
 
 vi.mock("../utils/syncManager", () => ({
   requestSyncCancel: vi.fn(),
+  reconcileStaleShortcuts: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
@@ -1045,6 +1046,60 @@ describe("MainPage", () => {
       expect(vi.mocked(backend.syncPreview)).not.toHaveBeenCalled();
       // Preview did not appear — Cancel Sync (in-flight) replaces Sync Library.
       expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+    });
+
+    it("reconciles stale shortcuts BEFORE startSync (skipPreview path) (#1046)", async () => {
+      const order: string[] = [];
+      vi.mocked(syncManager.reconcileStaleShortcuts).mockImplementation(async () => {
+        order.push("reconcile");
+      });
+      vi.mocked(backend.startSync).mockImplementation(async () => {
+        order.push("startSync");
+        return { success: true, message: "" };
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const toggle = container.querySelector('[data-testid="toggle-input"]') as HTMLInputElement | null;
+      fireEvent.click(toggle!);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Reconcile must unbind dead bindings before the work queue is built.
+      expect(order).toEqual(["reconcile", "startSync"]);
+    });
+
+    it("reconciles stale shortcuts BEFORE syncPreview (preview path) (#1046)", async () => {
+      const order: string[] = [];
+      vi.mocked(syncManager.reconcileStaleShortcuts).mockImplementation(async () => {
+        order.push("reconcile");
+      });
+      vi.mocked(backend.syncPreview).mockImplementation(async () => {
+        order.push("syncPreview");
+        return {
+          success: true,
+          summary: {
+            new_count: 0,
+            changed_count: 0,
+            unchanged_count: 0,
+            remove_count: 0,
+            disabled_platform_remove_count: 0,
+          },
+          new_names: [],
+          changed_names: [],
+          preview_id: "p-order",
+        };
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(order).toEqual(["reconcile", "syncPreview"]);
     });
 
     it("with skipPreview=true: startSync success=false surfaces result.message", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -40,7 +40,7 @@ import {
   onSaveSortMigrationChange,
   setSaveSortMigrationStatus,
 } from "../utils/saveSortMigrationStore";
-import { requestSyncCancel } from "../utils/syncManager";
+import { reconcileStaleShortcuts, requestSyncCancel } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
@@ -297,6 +297,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setPreview(null);
     setStoredSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
+      // Reconcile shortcuts the user deleted via Steam's own UI BEFORE the work
+      // queue is built (both sync paths fetch through it): unbind any dead
+      // binding so the incremental skip re-fetches the platform and recreates
+      // the missing shortcut (#1046). Best-effort — never blocks the sync.
+      await reconcileStaleShortcuts();
       // Skip Preview takes the per-unit pipeline (start_sync) — incremental
       // shortcut delivery, per-unit crash safety, no upfront full library
       // fetch. The legacy preview/apply path remains for users who want to

--- a/src/utils/reconcileStaleShortcuts.test.ts
+++ b/src/utils/reconcileStaleShortcuts.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Exercises the sync-start stale-shortcut reconcile (#1046): the frontend reads
+ * Steam's live RomM-shortcut appIds and asks the backend to unbind any dead
+ * binding before the work queue is built, so the next sync recreates a shortcut
+ * the user deleted via Steam's own UI.
+ *
+ * Lives in its own file (separate module instance) so the reconcile path never
+ * shares syncManager's module-level per-unit state (_isUnitRunning / _scanCache)
+ * with the event-handler tests in syncManager.test.ts.
+ *
+ * steamShortcuts is mocked so getLiveRomMShortcutAppIds is observable; the
+ * backend reconcileShortcuts callable uses the global test-setup mock.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as backend from "../api/backend";
+
+const getLiveRomMShortcutAppIds = vi.fn();
+vi.mock("./steamShortcuts", () => ({
+  getLiveRomMShortcutAppIds: (...args: unknown[]) => getLiveRomMShortcutAppIds(...args),
+  // The other steamShortcuts exports are unused by reconcileStaleShortcuts but
+  // must exist so syncManager's imports resolve.
+  setLaunchOptionsConfirmed: vi.fn(),
+  addShortcut: vi.fn(),
+  getExistingRomMShortcuts: vi.fn(),
+}));
+
+import { reconcileStaleShortcuts } from "./syncManager";
+
+describe("reconcileStaleShortcuts (#1046)", () => {
+  beforeEach(() => {
+    getLiveRomMShortcutAppIds.mockReset();
+    vi.mocked(backend.reconcileShortcuts).mockReset();
+    vi.mocked(backend.reconcileShortcuts).mockResolvedValue({ success: true, message: "", unbound_count: 0 });
+  });
+
+  it("passes the live appId set to the backend reconcile callable", async () => {
+    getLiveRomMShortcutAppIds.mockResolvedValue([100, 200]);
+
+    await reconcileStaleShortcuts();
+
+    expect(vi.mocked(backend.reconcileShortcuts)).toHaveBeenCalledWith([100, 200]);
+  });
+
+  it("passes an empty live set through (scan ran, found none)", async () => {
+    getLiveRomMShortcutAppIds.mockResolvedValue([]);
+
+    await reconcileStaleShortcuts();
+
+    // [] is a real "no RomM shortcuts in Steam" signal the backend acts on.
+    expect(vi.mocked(backend.reconcileShortcuts)).toHaveBeenCalledWith([]);
+  });
+
+  it("does NOT reconcile when the live scan returns null (store unreadable)", async () => {
+    getLiveRomMShortcutAppIds.mockResolvedValue(null);
+
+    await reconcileStaleShortcuts();
+
+    // null = could-not-scan: reconciling against it would unbind every binding.
+    expect(vi.mocked(backend.reconcileShortcuts)).not.toHaveBeenCalled();
+  });
+
+  it("swallows a scan rejection without calling reconcile", async () => {
+    getLiveRomMShortcutAppIds.mockRejectedValue(new Error("scan boom"));
+    const logErrorSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    try {
+      await expect(reconcileStaleShortcuts()).resolves.toBeUndefined();
+
+      expect(vi.mocked(backend.reconcileShortcuts)).not.toHaveBeenCalled();
+      // Non-vacuous: the catch surfaces the failure rather than throwing.
+      expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("scan boom"));
+    } finally {
+      logErrorSpy.mockRestore();
+    }
+  });
+
+  it("swallows a backend reconcile rejection (best-effort, never blocks sync)", async () => {
+    getLiveRomMShortcutAppIds.mockResolvedValue([100]);
+    vi.mocked(backend.reconcileShortcuts).mockRejectedValue(new Error("reconcile boom"));
+    const logErrorSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
+    try {
+      await expect(reconcileStaleShortcuts()).resolves.toBeUndefined();
+
+      // Non-vacuous: the catch surfaces the failure rather than throwing.
+      expect(logErrorSpy).toHaveBeenCalledWith(expect.stringContaining("reconcile boom"));
+    } finally {
+      logErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs the unbound count when the backend reports stale bindings cleared", async () => {
+    getLiveRomMShortcutAppIds.mockResolvedValue([100]);
+    vi.mocked(backend.reconcileShortcuts).mockResolvedValue({ success: true, message: "", unbound_count: 3 });
+    const logInfoSpy = vi.spyOn(backend, "logInfo").mockImplementation(() => {});
+    try {
+      await reconcileStaleShortcuts();
+
+      // Non-vacuous: the success branch surfaces how many bindings were cleared.
+      expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining("3"));
+    } finally {
+      logInfoSpy.mockRestore();
+    }
+  });
+});

--- a/src/utils/steamShortcuts.test.ts
+++ b/src/utils/steamShortcuts.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as backend from "../api/backend";
-import { getExistingRomMShortcuts, setLaunchOptionsConfirmed } from "./steamShortcuts";
+import { getExistingRomMShortcuts, getLiveRomMShortcutAppIds, setLaunchOptionsConfirmed } from "./steamShortcuts";
+
+const ROM_LAUNCHER = "/home/deck/homebrew/plugins/decky-romm-sync/bin/rom-launcher";
 
 /**
  * Builds a RegisterForAppDetails mock that, on registration, schedules a single
@@ -61,6 +63,59 @@ describe("setLaunchOptionsConfirmed", () => {
     await expect(promise).resolves.toBe(false);
     expect(setLaunchOptions).toHaveBeenCalledWith(99, "new-value");
     expect(unregister).toHaveBeenCalled();
+  });
+});
+
+describe("getLiveRomMShortcutAppIds", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the raw appIds of our-exe shortcuts with no backend-map intersection", async () => {
+    const exeByAppId: Record<number, string> = {
+      10: ROM_LAUNCHER,
+      20: ROM_LAUNCHER,
+      30: "/usr/bin/some-other-game",
+    };
+    const { fn } = makeRegisterForAppDetails((appId) => ({ strShortcutExe: exeByAppId[appId] ?? "" }));
+    vi.stubGlobal("SteamClient", { Apps: { RegisterForAppDetails: fn } });
+    vi.stubGlobal("collectionStore", {
+      deckDesktopApps: {
+        apps: new Map([
+          [10, {}],
+          [20, {}],
+          [30, {}],
+        ]),
+      },
+    });
+    // Reconcile must NOT touch the backend map — the raw live set is exe-only.
+    const mapSpy = vi.mocked(backend.getAppIdRomIdMap);
+
+    const result = await getLiveRomMShortcutAppIds();
+    expect(result).toEqual([10, 20]);
+    expect(mapSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when collectionStore is undefined (scan could not run)", async () => {
+    vi.stubGlobal("SteamClient", { Apps: { RegisterForAppDetails: vi.fn() } });
+    vi.stubGlobal("collectionStore", undefined);
+    const result = await getLiveRomMShortcutAppIds();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when deckDesktopApps.apps is absent (store unreadable)", async () => {
+    vi.stubGlobal("SteamClient", { Apps: { RegisterForAppDetails: vi.fn() } });
+    vi.stubGlobal("collectionStore", { deckDesktopApps: undefined });
+    const result = await getLiveRomMShortcutAppIds();
+    expect(result).toBeNull();
+  });
+
+  it("returns [] when the scan ran but found no RomM shortcuts", async () => {
+    const { fn } = makeRegisterForAppDetails(() => ({ strShortcutExe: "/usr/bin/other" }));
+    vi.stubGlobal("SteamClient", { Apps: { RegisterForAppDetails: fn } });
+    vi.stubGlobal("collectionStore", { deckDesktopApps: { apps: new Map([[10, {}]]) } });
+    const result = await getLiveRomMShortcutAppIds();
+    expect(result).toEqual([]);
   });
 });
 

--- a/src/utils/steamShortcuts.ts
+++ b/src/utils/steamShortcuts.ts
@@ -79,32 +79,30 @@ export function setLaunchOptionsConfirmed(appId: number, value: string, timeoutM
 }
 
 /**
- * Scan all non-Steam shortcuts and return those managed by RomM.
+ * Scan Steam's live shortcut store and return the appIds of every RomM-owned
+ * shortcut — those whose `strShortcutExe` ends with `/bin/rom-launcher` (the
+ * live-in-Steam ownership marker), regardless of any backend binding.
  *
- * A shortcut is RomM-owned when BOTH hold: its `strShortcutExe` ends with
- * `/bin/rom-launcher` (live-in-Steam ownership marker) AND its appId is bound
- * to a rom_id in the backend's `get_app_id_rom_id_map()` (the authoritative
- * rom_id↔appId binding now that launch options no longer carry the id). After
- * a DB reset the backend map is empty, so our shortcuts are detected by exe but
- * remain unmapped — they're treated as orphans and re-sync recreates them.
+ * Returns the raw live appId list, or `null` when the scan could **not** run
+ * because Steam's shortcut store was unreadable (`collectionStore` /
+ * `deckDesktopApps.apps` absent). The `null`-vs-`[]` distinction is
+ * load-bearing for reconcile: `[]` means "scan ran, found zero RomM shortcuts"
+ * (a real signal — unbind everything), whereas `null` means "could not look"
+ * (callers must NOT reconcile against it, or they'd unbind every binding on a
+ * transiently-broken store).
  *
- * Returns Map<romId, steamAppId>.
+ * Detection runs in parallel batches (RegisterForAppDetails is ~2s serial per
+ * shortcut); a heartbeat every 10s keeps the backend's per-unit timeout from
+ * cancelling a long scan over a large library.
  */
-export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
-  const result = new Map<number, number>();
-
-  if (typeof collectionStore === "undefined") return result;
+export async function getLiveRomMShortcutAppIds(): Promise<number[] | null> {
+  if (typeof collectionStore === "undefined") return null;
 
   const deckApps = collectionStore.deckDesktopApps?.apps;
-  if (!deckApps) return result;
+  if (!deckApps) return null;
 
   const appIds = Array.from(deckApps.keys());
 
-  // Detect our shortcuts by exe, in parallel batches to avoid 2s-per-shortcut
-  // serial overhead from RegisterForAppDetails. A large library makes this scan
-  // take tens of seconds, so emit a heartbeat every 10s between batches —
-  // otherwise the backend's per-unit heartbeat timeout cancels the run before
-  // the scan finishes.
   const ourAppIds: number[] = [];
   const CONCURRENCY = 10;
   let lastHeartbeat = Date.now();
@@ -122,7 +120,26 @@ export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
     }
   }
 
-  if (ourAppIds.length === 0) return result;
+  return ourAppIds;
+}
+
+/**
+ * Scan all non-Steam shortcuts and return those managed by RomM.
+ *
+ * A shortcut is RomM-owned when BOTH hold: its `strShortcutExe` ends with
+ * `/bin/rom-launcher` (live-in-Steam ownership marker) AND its appId is bound
+ * to a rom_id in the backend's `get_app_id_rom_id_map()` (the authoritative
+ * rom_id↔appId binding now that launch options no longer carry the id). After
+ * a DB reset the backend map is empty, so our shortcuts are detected by exe but
+ * remain unmapped — they're treated as orphans and re-sync recreates them.
+ *
+ * Returns Map<romId, steamAppId>.
+ */
+export async function getExistingRomMShortcuts(): Promise<Map<number, number>> {
+  const result = new Map<number, number>();
+
+  const ourAppIds = await getLiveRomMShortcutAppIds();
+  if (!ourAppIds || ourAppIds.length === 0) return result;
 
   // Resolve rom_id for each of our appIds via the authoritative backend map.
   // The map is keyed by appId-string → rom_id; keep only the intersection of

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -22,6 +22,7 @@ vi.mock("./steamShortcuts", () => ({
   setLaunchOptionsConfirmed: (...args: unknown[]) => setLaunchOptionsConfirmed(...args),
   addShortcut: (...args: unknown[]) => addShortcut(...args),
   getExistingRomMShortcuts: (...args: unknown[]) => getExistingRomMShortcuts(...args),
+  getLiveRomMShortcutAppIds: vi.fn(),
 }));
 
 import { initUnitSyncManager, requestSyncCancel } from "./syncManager";

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -1,7 +1,19 @@
 import { addEventListener } from "@decky/api";
 import type { SyncAddItem, SyncApplyUnitData } from "../types";
-import { getArtworkBase64, reportUnitResults, syncHeartbeat, logInfo, logError } from "../api/backend";
-import { getExistingRomMShortcuts, addShortcut, setLaunchOptionsConfirmed } from "./steamShortcuts";
+import {
+  getArtworkBase64,
+  reconcileShortcuts,
+  reportUnitResults,
+  syncHeartbeat,
+  logInfo,
+  logError,
+} from "../api/backend";
+import {
+  getExistingRomMShortcuts,
+  getLiveRomMShortcutAppIds,
+  addShortcut,
+  setLaunchOptionsConfirmed,
+} from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 import { recordSyncCreated } from "./syncDeltaStore";
 
@@ -154,6 +166,42 @@ async function resolveExistingShortcuts(runId: string): Promise<Map<number, numb
   _scanCache = { runId, map };
   logInfo(`getExistingRomMShortcuts: scanned ${map.size} RomM shortcuts in ${Date.now() - start}ms (run ${runId})`);
   return map;
+}
+
+/**
+ * Sync-start reconcile of stale shortcut bindings (#1046).
+ *
+ * Reads Steam's live RomM-shortcut appIds and asks the backend to unbind any
+ * binding absent from that set — a shortcut the user deleted via Steam's own UI
+ * leaves a dead ``roms.shortcut_app_id``, which the incremental skip otherwise
+ * counts as "unchanged" forever, so the shortcut never comes back. Unbinding
+ * before the work queue is built lets the next sync's incremental skip re-fetch
+ * the platform and recreate the missing shortcut.
+ *
+ * Best-effort: only reconciles when the live scan actually ran (a `null` scan —
+ * Steam's store unreadable — is skipped, never reconciled, so a transient store
+ * failure can't unbind every binding). Any error is logged and swallowed so a
+ * reconcile failure never blocks the sync itself.
+ */
+export async function reconcileStaleShortcuts(): Promise<void> {
+  let liveAppIds: number[] | null;
+  try {
+    liveAppIds = await getLiveRomMShortcutAppIds();
+  } catch (e) {
+    logError(`reconcileStaleShortcuts: failed to scan live shortcuts: ${e}`);
+    return;
+  }
+  // null = Steam's shortcut store was unreadable; do NOT reconcile (would unbind
+  // every binding). [] = scan ran, found none — a real signal the backend acts on.
+  if (liveAppIds === null) return;
+  try {
+    const result = await reconcileShortcuts(liveAppIds);
+    if (result.unbound_count) {
+      logInfo(`reconcileStaleShortcuts: backend unbound ${result.unbound_count} stale shortcut(s)`);
+    }
+  } catch (e) {
+    logError(`reconcileStaleShortcuts: backend reconcile failed: ${e}`);
+  }
 }
 
 /**

--- a/tests/contract/test_shortcut_reconcile.py
+++ b/tests/contract/test_shortcut_reconcile.py
@@ -1,0 +1,85 @@
+"""Contract tests for the sync-start shortcut reconcile callable.
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``reconcileShortcuts = callable<[number[]], {success, reason?, message, unbound_count?}>``.
+
+The frontend reads Steam's live RomM-shortcut appIds at sync start and passes
+them here; the backend unbinds every bound ``roms.shortcut_app_id`` absent from
+that live set so the next sync's incremental skip recreates the shortcut the
+user deleted via Steam's own UI (#1046). The contract is the response SHAPE and
+the binding side effect: dead bindings cleared, live bindings untouched, rows
+always kept (ADR-0007).
+"""
+
+from __future__ import annotations
+
+from ._seed import seed_rom
+
+
+async def test_unbinds_dead_appid_keeps_live(harness):
+    """A bound appId not in the live set is unbound; a present one is untouched."""
+    seed_rom(harness, 1, shortcut_app_id=100)
+    seed_rom(harness, 2, shortcut_app_id=200)
+    seed_rom(harness, 3, shortcut_app_id=300)
+
+    result = await harness.plugin.reconcile_shortcuts([100, 200])
+
+    assert result["success"] is True
+    assert result["unbound_count"] == 1
+    assert isinstance(result["message"], str)
+    with harness.uow_factory() as uow:
+        assert uow.roms.get(1).shortcut_app_id == 100
+        assert uow.roms.get(2).shortcut_app_id == 200
+        # ROM 3's shortcut was deleted in Steam → unbound, row kept.
+        assert uow.roms.get(3).shortcut_app_id is None
+
+
+async def test_all_present_no_unbind(harness):
+    """When the live set covers every binding nothing is unbound."""
+    seed_rom(harness, 1, shortcut_app_id=100)
+    seed_rom(harness, 2, shortcut_app_id=200)
+
+    result = await harness.plugin.reconcile_shortcuts([100, 200])
+
+    assert result == {
+        "success": True,
+        "unbound_count": 0,
+        "message": "Unbound 0 stale shortcut(s)",
+    }
+    with harness.uow_factory() as uow:
+        assert uow.roms.get(1).shortcut_app_id == 100
+        assert uow.roms.get(2).shortcut_app_id == 200
+
+
+async def test_empty_live_set_unbinds_all(harness):
+    """An empty live set (scan ran, found none) unbinds every binding, keeps rows."""
+    seed_rom(harness, 1, shortcut_app_id=100)
+    seed_rom(harness, 2, shortcut_app_id=200)
+
+    result = await harness.plugin.reconcile_shortcuts([])
+
+    assert result["success"] is True
+    assert result["unbound_count"] == 2
+    with harness.uow_factory() as uow:
+        assert uow.roms.get(1).shortcut_app_id is None
+        assert uow.roms.get(2).shortcut_app_id is None
+
+
+async def test_unbind_drops_row_from_app_id_rom_id_map(harness):
+    """After reconcile the dead appId is gone from the map playtime/launch bakes read.
+
+    ``get_app_id_rom_id_map`` only serves bound rows; unbinding the stale
+    appId stops it being served to a nonexistent Steam app, and the same NULL
+    binding is what makes the incremental skip re-fetch the platform next sync.
+    """
+    seed_rom(harness, 1, shortcut_app_id=100)
+    seed_rom(harness, 2, shortcut_app_id=200)
+
+    before = await harness.plugin.get_app_id_rom_id_map()
+    assert before == {"100": 1, "200": 2}
+
+    await harness.plugin.reconcile_shortcuts([100])
+
+    after = await harness.plugin.get_app_id_rom_id_map()
+    assert after == {"100": 1}
+    assert "200" not in after

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -253,6 +253,116 @@ class TestReportRemovalResults:
         assert call.args[2]["app_id"] == 1001
 
 
+# ── TestReconcileLiveShortcuts ────────────────────────────────────────────────
+
+
+class TestReconcileLiveShortcuts:
+    @pytest.mark.asyncio
+    async def test_unbinds_appid_absent_from_live_set(self, svc, uow):
+        """A bound appId not in the live Steam set is unbound; present ones survive."""
+        _seed_rom(uow, 10, app_id=100, name="Game A")
+        _seed_rom(uow, 20, app_id=200, name="Game B")
+        _seed_rom(uow, 30, app_id=300, name="Game C")
+
+        result = await svc.reconcile_live_shortcuts([100, 200])
+        assert result["success"] is True
+        assert result["unbound_count"] == 1
+        assert isinstance(result["message"], str)
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id == 100
+            assert uow.roms.get(20).shortcut_app_id == 200
+            # 300 was deleted from Steam → unbound (row kept, link cleared).
+            assert uow.roms.get(30).shortcut_app_id is None
+
+    @pytest.mark.asyncio
+    async def test_all_present_leaves_everything_bound(self, svc, uow):
+        """When the live set covers every binding nothing is unbound."""
+        _seed_rom(uow, 10, app_id=100, name="Game A")
+        _seed_rom(uow, 20, app_id=200, name="Game B")
+
+        result = await svc.reconcile_live_shortcuts([100, 200, 999])
+        assert result["success"] is True
+        assert result["unbound_count"] == 0
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id == 100
+            assert uow.roms.get(20).shortcut_app_id == 200
+
+    @pytest.mark.asyncio
+    async def test_empty_live_set_unbinds_all_bound(self, svc, uow):
+        """An empty live set means the scan found zero RomM shortcuts → unbind every binding.
+
+        This is the correct semantic: the frontend only calls this when its scan
+        actually ran (Steam's store was readable), so [] is a real "they're all
+        gone" signal. The rows survive (ADR-0007); the next sync recreates them.
+        """
+        _seed_rom(uow, 10, app_id=100, name="Game A")
+        _seed_rom(uow, 20, app_id=200, name="Game B")
+
+        result = await svc.reconcile_live_shortcuts([])
+        assert result["success"] is True
+        assert result["unbound_count"] == 2
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id is None
+            assert uow.roms.get(20).shortcut_app_id is None
+
+    @pytest.mark.asyncio
+    async def test_already_unbound_rows_ignored(self, svc, uow):
+        """NULL-app_id rows are not counted and never re-saved (no churn)."""
+        _seed_rom(uow, 10, app_id=None, name="Already Unbound")
+        _seed_rom(uow, 20, app_id=200, name="Bound But Live")
+
+        result = await svc.reconcile_live_shortcuts([200])
+        assert result["success"] is True
+        assert result["unbound_count"] == 0
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id is None
+            assert uow.roms.get(20).shortcut_app_id == 200
+
+    @pytest.mark.asyncio
+    async def test_string_app_ids_coerced_and_matched(self, svc, uow):
+        """Frontend-serialized string appIds match numeric bindings (no spurious unbind)."""
+        _seed_rom(uow, 10, app_id=100, name="Game A")
+
+        result = await svc.reconcile_live_shortcuts(["100"])
+        assert result["unbound_count"] == 0
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id == 100
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_live_entry_dropped(self, svc, uow):
+        """A non-numeric live entry can never match, so it never blocks an unbind and never crashes."""
+        _seed_rom(uow, 10, app_id=100, name="Game A")
+        _seed_rom(uow, 20, app_id=200, name="Game B")
+
+        result = await svc.reconcile_live_shortcuts(["junk", 200])
+        assert result["success"] is True
+        # 100 absent from the (sanitized) live set {200} → unbound; 200 survives.
+        assert result["unbound_count"] == 1
+        with uow:
+            assert uow.roms.get(10).shortcut_app_id is None
+            assert uow.roms.get(20).shortcut_app_id == 200
+
+    @pytest.mark.asyncio
+    async def test_empty_registry(self, svc):
+        """No ROMs at all → nothing to unbind, canonical success shape."""
+        result = await svc.reconcile_live_shortcuts([100, 200])
+        assert result["success"] is True
+        assert result["unbound_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_exception(self, svc):
+        """An executor failure returns the canonical failure shape."""
+        mock_loop = MagicMock()
+        mock_loop.run_in_executor = MagicMock(side_effect=Exception("boom"))
+        svc._loop = mock_loop
+
+        result = await svc.reconcile_live_shortcuts([100])
+        assert result["success"] is False
+        assert result["reason"]
+        assert "boom" in result["message"]
+        assert "unbound_count" not in result
+
+
 # ── TestRemovalCleansUpArtwork ────────────────────────────────────────────────
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -747,6 +747,10 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "report_unit_results",
     "get_registry_platforms",
     "report_removal_results",
+    # Sync-start reconcile of Steam-UI-deleted shortcut bindings (#1046) — clears
+    # only the SQLite ``shortcut_app_id`` link (never a RetroDECK path), so it is
+    # not gated by a pending migration, matching report_removal_results above.
+    "reconcile_shortcuts",
     "get_artwork_base64",
     "get_sync_status",
     "get_sync_stats",


### PR DESCRIPTION
Closes #1046.

When a user deletes a RomM shortcut via Steam's own UI, `roms.shortcut_app_id` kept the dead appId forever: `get_app_id_rom_id_map` kept serving it (playtime writes + launch_options bakes aimed at a nonexistent app), and the incremental sync skip — which counts bound DB rows, not live Steam shortcuts — reported "unchanged" and never recreated the shortcut. The game stayed gone until a server-side change or a Force Full Sync.

**Fix:** a frontend-assisted reconcile at sync start. `getLiveRomMShortcutAppIds()` scans Steam's live shortcuts (reusing the `getExistingRomMShortcuts` mechanism) and `reconcileStaleShortcuts()` calls the new `reconcile_shortcuts(live_app_ids)` callable before `startSync`/`syncPreview`. The backend unbinds — via the existing `Rom.unbind_shortcut()`, which clears `shortcut_app_id` and **keeps the row** per ADR-0007 — any bound appId no longer present in Steam. Unbinding drops the registry count so the incremental skip no longer matches, and the next sync recreates the shortcut with its binding/artwork.

**Safety:** `getLiveRomMShortcutAppIds()` returns `null` when Steam's store is unreadable (reconcile skipped — nothing unbound) and only `[]` when the scan genuinely found no RomM shortcuts. The reconcile is non-destructive (rows survive; a spurious unbind self-heals on the next sync) and best-effort (a failure never blocks the sync).

The new `reconcile_shortcuts` callable is Steam-side only (whitelisted in the migration-coverage gate — it never touches RetroDECK paths).

Docs: `steam-non-steam-shortcuts.md` (reconcile flow) + `syncing-your-library.md` (user-facing note).
