### PR TITLE
fix(sync): scope cancel_sync to the active run so a stale cancel can't abort a fresh sync

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -185,6 +185,27 @@ the heartbeat-timeout abandon window (the same unit's late ack must still valida
 or is cancelled. On the frontend side, the unit handler **does not send the ack at all once cancel has been requested**
 — the first line of defence against a cancelled run's bindings landing in whatever run started next.
 
+**Run identity on the cancel (#1198).** `cancel_sync(run_id)` is run-scoped, mirroring the ack-path
+`_ack_matches_active_unit` check above. A Cancel click meant for run N can land after run N finalized to IDLE
+(`current_sync_id` nulled) and run N+1 started fresh — an unscoped cancel would flip run N+1 to CANCELLING (a sync the
+user never cancelled), which would abort it and report cancelled. So when the requested `run_id` is **truthy and does
+not match** `current_sync_id`, the cancel is **ignored** (logged at INFO, returns
+`{success: True, message: "Cancel
+ignored (stale run)"}`) — `sync_state` is left RUNNING. A matching id (or no active
+run) flips RUNNING → CANCELLING as before. A **falsy/`None`** `run_id` cancels **unconditionally** — legacy callers and
+the "no active run id captured yet" safety case — so cancel is never made less reliable. Every cancel logs one INFO line
+recording the requested `run_id`, the active `current_sync_id`, and the `sync_state` at call time. The frontend captures
+the run id from the `sync_plan` event (now carrying `run_id`) and the `sync_apply_unit` event into a module variable
+(`getActiveRunId`) and passes it on the Cancel click; an empty string when no run is in flight maps to the unconditional
+path. `sync_cancel_preview` is **not** run-scoped: it only clears the pending preview delta (`pending_delta`), never
+touches `sync_state`, and `sync_apply_delta` independently validates the `preview_id`, so a stale preview-cancel cannot
+abort a fresh sync.
+
+The same `sync_plan` capture point also clears the frontend's per-run cancel flag (`_cancelRequested`). The per-unit
+handler resets that flag at its own start, but an incrementally-**skipped** unit never runs that handler, so a skip-only
+run could otherwise carry a stale cancel from a prior cancelled run; resetting once per run on `sync_plan` is the
+reliable reset.
+
 #### DownloadService notes
 
 RomM exposes three mutually exclusive file-layout flags on every ROM detail. They control how the server stores files

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -196,10 +196,13 @@ run) flips RUNNING → CANCELLING as before. A **falsy/`None`** `run_id` cancels
 the "no active run id captured yet" safety case — so cancel is never made less reliable. Every cancel logs one INFO line
 recording the requested `run_id`, the active `current_sync_id`, and the `sync_state` at call time. The frontend captures
 the run id from the `sync_plan` event (now carrying `run_id`) and the `sync_apply_unit` event into a module variable
-(`getActiveRunId`) and passes it on the Cancel click; an empty string when no run is in flight maps to the unconditional
-path. `sync_cancel_preview` is **not** run-scoped: it only clears the pending preview delta (`pending_delta`), never
-touches `sync_state`, and `sync_apply_delta` independently validates the `preview_id`, so a stale preview-cancel cannot
-abort a fresh sync.
+(`getActiveRunId`) and passes it on the Cancel click. The sync trigger (`handleSync` / `handleApply`) calls
+`beginSyncRun("")` at the **top**, before the backend mints the new run's id and emits `sync_plan` — clearing the
+_previous_ run's captured id to `null`, so a Cancel in the "Fetching library…" window (reconcile + `build_work_queue`
+paginate for seconds) sends `""`, which maps to the unconditional path, rather than the previous run's id, which the
+backend would reject as a cross-run mismatch and silently drop the genuine cancel. `sync_cancel_preview` is **not**
+run-scoped: it only clears the pending preview delta (`pending_delta`), never touches `sync_state`, and
+`sync_apply_delta` independently validates the `preview_id`, so a stale preview-cancel cannot abort a fresh sync.
 
 The same `sync_plan` capture point also clears the frontend's per-run cancel flag (`_cancelRequested`). The per-unit
 handler resets that flag at its own start, but an incrementally-**skipped** unit never runs that handler, so a skip-only

--- a/main.py
+++ b/main.py
@@ -293,8 +293,8 @@ class Plugin:
     async def start_sync(self):
         return self._sync_service.start_sync()
 
-    async def cancel_sync(self):
-        return self._sync_service.cancel_sync()
+    async def cancel_sync(self, run_id):
+        return self._sync_service.cancel_sync(run_id)
 
     async def sync_heartbeat(self):
         return self._sync_service.sync_heartbeat()

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -284,8 +284,8 @@ class LibraryService:
     def start_sync(self):
         return self._orchestrator.start_sync()
 
-    def cancel_sync(self):
-        return self._orchestrator.cancel_sync()
+    def cancel_sync(self, run_id=None):
+        return self._orchestrator.cancel_sync(run_id)
 
     def sync_heartbeat(self):
         return self._orchestrator.sync_heartbeat()

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -142,10 +142,27 @@ class SyncOrchestrator:
         self._loop.create_task(self._do_sync_per_unit())
         return {"success": True, "message": "Sync started"}
 
-    def cancel_sync(self):
+    def cancel_sync(self, run_id=None):
+        """Request cancellation of the active sync, scoped to *run_id*.
+
+        A truthy *run_id* must match the active run's ``current_sync_id`` for
+        the cancel to take effect — a cancel click meant for run N can land
+        after run N finalized to IDLE and run N+1 started fresh, and an
+        unscoped cancel would wrongly abort run N+1 (the bug #1198 fixes,
+        mirroring the ack-path identity check ``_ack_matches_active_unit``).
+        A falsy/``None`` *run_id* cancels **unconditionally** — legacy callers
+        that pass no id, and the "no active run id yet" safety case — so cancel
+        is never made less reliable.
+        """
         box = self._sync_state
+        self._logger.info(
+            f"cancel_sync: run_id={run_id!r} active run={box.current_sync_id!r} state={box.sync_state.value}"
+        )
         if box.sync_state != SyncState.RUNNING:
             return {"success": True, "message": "No sync in progress"}
+        if run_id and str(run_id) != str(box.current_sync_id):
+            self._logger.info(f"Ignoring stale cancel for run={run_id!r}; active run={box.current_sync_id!r}")
+            return {"success": True, "message": "Cancel ignored (stale run)"}
         box.sync_state = SyncState.CANCELLING
         return {"success": True, "message": "Sync cancelling..."}
 
@@ -438,6 +455,7 @@ class SyncOrchestrator:
             await self._emit(
                 "sync_plan",
                 {
+                    "run_id": str(run_id or ""),
                     "units": [u.to_event_payload() for u in work_queue],
                     "total_units": total_units,
                     "total_roms": total_roms_planned,

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -106,7 +106,7 @@ export const updateWhitelistSettings = callable<[string[], string[]], { success:
 
 export const testConnection = callable<[], BackendResult>("test_connection");
 export const startSync = callable<[], BackendResult>("start_sync");
-export const cancelSync = callable<[], BackendResult>("cancel_sync");
+export const cancelSync = callable<[string], BackendResult>("cancel_sync");
 export const syncHeartbeat = callable<[], { success: boolean }>("sync_heartbeat");
 export const syncPreview = callable<[], SyncPreview>("sync_preview");
 export const syncApplyDelta = callable<[string], BackendResult>("sync_apply_delta");

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -112,6 +112,7 @@ import * as saveSortMigrationStore from "../utils/saveSortMigrationStore";
 vi.mock("../utils/syncManager", () => ({
   requestSyncCancel: vi.fn(),
   reconcileStaleShortcuts: vi.fn().mockResolvedValue(undefined),
+  getActiveRunId: vi.fn().mockReturnValue("run-active"),
 }));
 
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
@@ -270,6 +271,10 @@ describe("MainPage", () => {
 
     // Re-stub useVersionError (resetAllMocks wiped it).
     vi.mocked(useVersionError).mockReturnValue(null);
+
+    // Re-stub getActiveRunId (resetAllMocks wiped the module-mock return value).
+    // handleCancel reads it to scope the cancel to the active run (#1198).
+    vi.mocked(syncManager.getActiveRunId).mockReturnValue("run-active");
 
     // Re-stub migrationStore impls.
     vi.mocked(migrationStore.getMigrationState).mockImplementation(() => currentMigrationState);
@@ -1254,7 +1259,9 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(syncManager.requestSyncCancel)).toHaveBeenCalled();
-      expect(vi.mocked(backend.cancelSync)).toHaveBeenCalled();
+      // Cancel is scoped to the active run id captured frontend-side (#1198) —
+      // getActiveRunId() returns "run-active" in this suite's syncManager mock.
+      expect(vi.mocked(backend.cancelSync)).toHaveBeenCalledWith("run-active");
     });
 
     it("cancelSync success: surfaces result.message in the status field (un-gated)", async () => {

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -113,6 +113,7 @@ vi.mock("../utils/syncManager", () => ({
   requestSyncCancel: vi.fn(),
   reconcileStaleShortcuts: vi.fn().mockResolvedValue(undefined),
   getActiveRunId: vi.fn().mockReturnValue("run-active"),
+  beginSyncRun: vi.fn(),
 }));
 
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
@@ -1076,6 +1077,34 @@ describe("MainPage", () => {
       expect(order).toEqual(["reconcile", "startSync"]);
     });
 
+    it("clears the captured run id BEFORE reconcile/startSync (#1198 C1)", async () => {
+      const order: string[] = [];
+      vi.mocked(syncManager.beginSyncRun).mockImplementation((runId: string) => {
+        order.push(`beginSyncRun(${JSON.stringify(runId)})`);
+      });
+      vi.mocked(syncManager.reconcileStaleShortcuts).mockImplementation(async () => {
+        order.push("reconcile");
+      });
+      vi.mocked(backend.startSync).mockImplementation(async () => {
+        order.push("startSync");
+        return { success: true, message: "" };
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const toggle = container.querySelector('[data-testid="toggle-input"]') as HTMLInputElement | null;
+      fireEvent.click(toggle!);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The stale run id must be cleared (beginSyncRun("") → null) before the
+      // backend mints the new run's id, so a Cancel in the fetch window sends
+      // "" → unconditional cancel.
+      expect(order).toEqual(['beginSyncRun("")', "reconcile", "startSync"]);
+    });
+
     it("reconciles stale shortcuts BEFORE syncPreview (preview path) (#1046)", async () => {
       const order: string[] = [];
       vi.mocked(syncManager.reconcileStaleShortcuts).mockImplementation(async () => {
@@ -1262,6 +1291,37 @@ describe("MainPage", () => {
       // Cancel is scoped to the active run id captured frontend-side (#1198) —
       // getActiveRunId() returns "run-active" in this suite's syncManager mock.
       expect(vi.mocked(backend.cancelSync)).toHaveBeenCalledWith("run-active");
+    });
+
+    it("cancel in the pre-sync_plan window (no run id captured) cancels unconditionally (#1198 C1)", async () => {
+      // The "Fetching library…" window: the sync trigger cleared the captured
+      // run id (clearActiveRunId) and the backend hasn't emitted sync_plan yet,
+      // so getActiveRunId() is null. handleCancel must send "" → the backend's
+      // unconditional cancel path, NOT a stale id that would be ignored as a
+      // cross-run mismatch and silently drop the user's genuine cancel.
+      vi.mocked(syncManager.getActiveRunId).mockReturnValue(null);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        message: "Fetching library...",
+      });
+      vi.mocked(backend.cancelSync).mockResolvedValue({
+        success: true,
+        message: "cancelled-msg",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const cancel = buttonByExactText(container, "Cancel Sync");
+      expect(cancel).not.toBeNull();
+      await act(async () => {
+        fireEvent.click(cancel!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Non-vacuous: "" (not "run-active") proves the null run id maps to the
+      // unconditional cancel. A regression that kept the stale id would send a
+      // non-empty string and the backend would ignore it.
+      expect(vi.mocked(backend.cancelSync)).toHaveBeenCalledWith("");
     });
 
     it("cancelSync success: surfaces result.message in the status field (un-gated)", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -40,7 +40,7 @@ import {
   onSaveSortMigrationChange,
   setSaveSortMigrationStatus,
 } from "../utils/saveSortMigrationStore";
-import { reconcileStaleShortcuts, requestSyncCancel } from "../utils/syncManager";
+import { reconcileStaleShortcuts, requestSyncCancel, getActiveRunId } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
@@ -370,7 +370,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     }
     try {
       requestSyncCancel();
-      const result = await cancelSync();
+      // Scope the cancel to the active run so a click meant for this run can't
+      // abort a fresh run that started in the meantime (#1198). An empty string
+      // when no run id is captured yet → backend cancels unconditionally.
+      const result = await cancelSync(getActiveRunId() ?? "");
       finishCancelWithStatus(result.message);
     } catch {
       finishCancelWithStatus("Failed to cancel sync");

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -40,7 +40,7 @@ import {
   onSaveSortMigrationChange,
   setSaveSortMigrationStatus,
 } from "../utils/saveSortMigrationStore";
-import { reconcileStaleShortcuts, requestSyncCancel, getActiveRunId } from "../utils/syncManager";
+import { reconcileStaleShortcuts, requestSyncCancel, getActiveRunId, beginSyncRun } from "../utils/syncManager";
 import { setVersionError } from "../utils/connectionState";
 import { retroDeckBanner, type RetroDeckBanner } from "../utils/retrodeckHealth";
 import { VersionErrorCard, useVersionError } from "./VersionErrorCard";
@@ -287,6 +287,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   const handleSync = async () => {
+    // Clear any captured run id from a prior run BEFORE the backend mints this
+    // run's id (beginSyncRun("") → null). The Cancel button goes live with
+    // setSyncing(true) below, but sync_plan (which re-captures the new id) only
+    // fires after reconcile + build_work_queue paginate the library (seconds).
+    // A Cancel in that window must send "" → the backend's unconditional cancel,
+    // not a stale id that would be ignored as a cross-run mismatch (#1198).
+    beginSyncRun("");
     // Optimistically disable the button and show the in-progress UI before
     // the backend's first sync_progress event lands — writing running:true
     // into the MODULE store (the single source of truth the subscription
@@ -330,6 +337,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const handleApply = async () => {
     if (!preview) return;
     const previewId = preview.preview_id;
+    // Same window as handleSync: syncApplyDelta mints a fresh run id and emits
+    // sync_plan only later, so clear the stale captured id first (beginSyncRun("")
+    // → null) so a Cancel in the apply window cancels unconditionally rather than
+    // being ignored (#1198).
+    beginSyncRun("");
     setPreview(null);
     setLoading(true);
     setSyncing(true);

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -18,6 +18,7 @@ import { emitDeckyEvent, deckyEventListenerCount } from "./test-utils/decky-api-
 import { getSettingsResetNotice, getAllPlaytime, getAppIdRomIdMap, getInstalledRelaunchOptions } from "./api/backend";
 import { getSettingsResetState, setSettingsResetState } from "./utils/settingsResetStore";
 import { recordSyncCreated, resetSyncDelta } from "./utils/syncDeltaStore";
+import { beginSyncRun } from "./utils/syncManager";
 import type { DownloadCompleteEvent, SyncPlanData, SyncStaleData } from "./types";
 
 vi.mock("./patches/gameDetailPatch", () => ({
@@ -40,6 +41,7 @@ vi.mock("./utils/sessionManager", () => ({
 }));
 vi.mock("./utils/syncManager", () => ({
   initUnitSyncManager: vi.fn(() => () => {}),
+  beginSyncRun: vi.fn(),
 }));
 
 // Observe the collection create/update + stale-cleanup calls fired by
@@ -613,11 +615,26 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     resetSyncDelta();
   });
 
+  it("sync_plan begins the run frontend-side — captures run id + resets cancel (#1198)", async () => {
+    const plugin = pluginFactory();
+    vi.mocked(beginSyncRun).mockClear();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-xyz", units: [], total_units: 1, total_roms: 1 });
+    });
+
+    // The listener routes the run id into beginSyncRun, which both captures it
+    // (for a run-scoped cancel) and clears the per-run cancel flag — reliable
+    // even on a skip-only run where no per-unit handler fires.
+    expect(vi.mocked(beginSyncRun)).toHaveBeenCalledWith("run-xyz");
+    plugin.onDismount();
+  });
+
   it("reports 'X added, Y removed' when both are non-zero (ignores total_games)", async () => {
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 2, total_roms: 2 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 2, total_roms: 2 });
     });
     // Two distinct shortcuts created this run (what the syncManager create path records).
     recordSyncCreated(100);
@@ -641,7 +658,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 1, total_roms: 0 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 1, total_roms: 0 });
     });
     act(() => {
       emitDeckyEvent<[SyncStaleData]>("sync_stale", {
@@ -664,7 +681,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 1, total_roms: 53 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 1, total_roms: 53 });
     });
     // No creates, no removes — but total_games=53 (the old toast wrongly said
     // "53 games added"). The fixed toast must say the library is up to date.
@@ -681,7 +698,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 2, total_roms: 1 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 2, total_roms: 1 });
     });
     // Same appId surfaces in its platform unit and a collection unit; the Set
     // in the store collapses it to one "added".
@@ -700,7 +717,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 3, total_roms: 10 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 3, total_roms: 10 });
     });
     recordSyncCreated(100);
     recordSyncCreated(200);
@@ -722,7 +739,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     const plugin = pluginFactory();
 
     act(() => {
-      emitDeckyEvent<[SyncPlanData]>("sync_plan", { units: [], total_units: 3, total_roms: 10 });
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 3, total_roms: 10 });
     });
     act(() => {
       emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { LibraryPage } from "./components/LibraryPage";
 import { SystemPage } from "./components/SystemPage";
 import { DangerZone } from "./components/DangerZone";
 import { DownloadQueue } from "./components/DownloadQueue";
-import { initUnitSyncManager } from "./utils/syncManager";
+import { initUnitSyncManager, beginSyncRun } from "./utils/syncManager";
 import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
 import { handleGlobalDownloadFailure } from "./utils/downloadFailure";
@@ -423,6 +423,10 @@ export default definePlugin(() => {
     // sync_plan fires once per run, before any unit — reset the per-run delta
     // so the terminal toast counts only this run's created/removed shortcuts.
     resetSyncDelta();
+    // Capture the run id and clear the per-run cancel flag. Doing it here (not
+    // only in the per-unit handler) keeps cancel run-scoped and the flag fresh
+    // even on a skip-only run, where no unit handler ever runs (#1198).
+    beginSyncRun(data.run_id);
     logInfo(`sync_plan received: ${data.total_units} units, ${data.total_roms} ROMs total`);
   });
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -104,6 +104,8 @@ interface SyncPlanUnit {
 }
 
 export interface SyncPlanData {
+  /** Identifies the sync run; captured frontend-side so a Cancel click is scoped to the active run (#1198). */
+  run_id: string;
   units: SyncPlanUnit[];
   total_units: number;
   total_roms: number;

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -25,7 +25,7 @@ vi.mock("./steamShortcuts", () => ({
   getLiveRomMShortcutAppIds: vi.fn(),
 }));
 
-import { initUnitSyncManager, requestSyncCancel, beginSyncRun, getActiveRunId } from "./syncManager";
+import { initUnitSyncManager, requestSyncCancel, beginSyncRun, getActiveRunId, isCancelRequested } from "./syncManager";
 
 function unit(launchOptions: string, runId = "run-1"): SyncApplyUnitData {
   return {
@@ -187,27 +187,21 @@ describe("syncManager — run-id capture + per-run cancel reset (#1198)", () => 
     expect(getActiveRunId()).toBe("run-from-unit");
   });
 
-  it("beginSyncRun clears a stale cancel so the next run's first unit DOES ack", async () => {
-    // Stale cancel from a prior (cancelled) run. beginSyncRun is driven by
-    // sync_plan, which fires before the run's first unit — so even a run whose
-    // first work is a SKIP (no per-unit handler reset) starts with a clean flag
-    // (#1198). Non-vacuous: the post-loop guard SKIPS reportUnitResults entirely
-    // while _cancelRequested is true (the #1041 path above). The scan here does
-    // NOT re-request cancel, so if the prior requestSyncCancel() were still in
-    // effect the ack would never fire — its presence proves beginSyncRun reset
-    // the flag before the unit ran.
+  it("beginSyncRun clears a stale cancel on the skip-only path (no sync_apply_unit)", async () => {
+    // Stale cancel from a prior (cancelled) run. beginSyncRun is what the
+    // sync_plan listener calls, and sync_plan fires once per run BEFORE any
+    // unit — so even a run whose only work is an incremental SKIP (no
+    // sync_apply_unit, hence no per-unit handler reset) must start with a clean
+    // flag (#1198). This exercises that exact path: NO sync_apply_unit is
+    // dispatched, so the only thing that can clear the flag is beginSyncRun.
+    // Non-vacuous: if beginSyncRun's `_cancelRequested = false` line were
+    // removed, isCancelRequested() would still be true here and this fails.
     requestSyncCancel();
-    beginSyncRun("run-after-reset");
+    expect(isCancelRequested()).toBe(true);
 
-    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
-    initUnitSyncManager();
-    await act(async () => {
-      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-after-reset"));
-      await flush(120);
-    });
+    beginSyncRun("run-skip-only");
 
-    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith(expect.anything(), "run-after-reset", 1);
+    expect(isCancelRequested()).toBe(false);
   });
 });
 

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -25,7 +25,7 @@ vi.mock("./steamShortcuts", () => ({
   getLiveRomMShortcutAppIds: vi.fn(),
 }));
 
-import { initUnitSyncManager, requestSyncCancel } from "./syncManager";
+import { initUnitSyncManager, requestSyncCancel, beginSyncRun, getActiveRunId } from "./syncManager";
 
 function unit(launchOptions: string, runId = "run-1"): SyncApplyUnitData {
   return {
@@ -154,6 +154,60 @@ describe("syncManager — once-per-run existing-shortcut scan cache", () => {
 
     // A new run_id is a cache miss → fresh scan.
     expect(getExistingRomMShortcuts).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("syncManager — run-id capture + per-run cancel reset (#1198)", () => {
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[42, 5000]]));
+    vi.mocked(backend.reportUnitResults).mockClear();
+  });
+
+  it("beginSyncRun captures the run id for getActiveRunId", () => {
+    beginSyncRun("run-captured");
+    expect(getActiveRunId()).toBe("run-captured");
+  });
+
+  it("beginSyncRun(empty) maps to null so the backend cancels unconditionally", () => {
+    beginSyncRun("");
+    expect(getActiveRunId()).toBeNull();
+  });
+
+  it("a sync_apply_unit event also captures its run id", async () => {
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-from-unit"));
+      await flush(120);
+    });
+    expect(getActiveRunId()).toBe("run-from-unit");
+  });
+
+  it("beginSyncRun clears a stale cancel so the next run's first unit DOES ack", async () => {
+    // Stale cancel from a prior (cancelled) run. beginSyncRun is driven by
+    // sync_plan, which fires before the run's first unit — so even a run whose
+    // first work is a SKIP (no per-unit handler reset) starts with a clean flag
+    // (#1198). Non-vacuous: the post-loop guard SKIPS reportUnitResults entirely
+    // while _cancelRequested is true (the #1041 path above). The scan here does
+    // NOT re-request cancel, so if the prior requestSyncCancel() were still in
+    // effect the ack would never fire — its presence proves beginSyncRun reset
+    // the flag before the unit ran.
+    requestSyncCancel();
+    beginSyncRun("run-after-reset");
+
+    const cmd = 'flatpak run net.retrodeck.retrodeck "/games/test.bin"';
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", unit(cmd, "run-after-reset"));
+      await flush(120);
+    });
+
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith(expect.anything(), "run-after-reset", 1);
   });
 });
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -56,13 +56,23 @@ export function requestSyncCancel(): void {
 }
 
 /**
- * Mark a fresh sync run started: capture its ``run_id`` and clear the cancel
- * flag. Called from the ``sync_plan`` listener, which fires exactly once per
- * run before any unit. The per-unit handler also clears ``_cancelRequested``,
- * but that handler never runs for an incrementally-SKIPPED unit — so a
- * skip-only run would otherwise carry a stale ``_cancelRequested`` from a prior
- * cancelled run (the #1198 adjacent H4 defect). Resetting here, once per run,
- * is the reliable reset.
+ * Set the captured run id and clear the cancel flag, marking a fresh run.
+ *
+ * Two callers, two roles:
+ *
+ * - The ``sync_plan`` listener passes the real ``run_id`` — sync_plan fires
+ *   once per run before any unit, so this is the per-run cancel-flag reset that
+ *   the per-unit handler can't be relied on for (a skip-only run never runs
+ *   that handler and would otherwise carry a stale ``_cancelRequested`` from a
+ *   prior cancelled run — the #1198 adjacent H4 defect).
+ * - The sync trigger (``handleSync`` / ``handleApply``) passes ``""`` at the
+ *   TOP, before the backend mints the new run's id. That clears the *previous*
+ *   run's captured id (``"" → null``) so a Cancel in the "Fetching library…"
+ *   window (reconcile + build_work_queue paginate for seconds, before
+ *   sync_plan) sends ``""`` → the backend's unconditional-cancel path, not a
+ *   stale id the backend would reject as a cross-run mismatch and drop (#1198).
+ *   It can't reintroduce the cross-run race: an *already-fired* stale cancel
+ *   carried its own run id as a bound argument, unaffected by this reset.
  */
 export function beginSyncRun(runId: string): void {
   _activeRunId = runId || null;
@@ -83,8 +93,10 @@ export function getActiveRunId(): string | null {
  * per-unit ``_cancelRequested = false`` reset isn't narrowed to a constant
  * ``false`` by control-flow analysis — the flag is flipped externally by
  * {@link requestSyncCancel} during the awaited work, which TS can't see.
+ * Exported so tests can observe the per-run reset on the skip-only path
+ * (``sync_plan`` with no following ``sync_apply_unit``).
  */
-function isCancelRequested(): boolean {
+export function isCancelRequested(): boolean {
   return _cancelRequested;
 }
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -31,6 +31,16 @@ let _cancelRequested = false;
 let _isUnitRunning = false;
 
 /**
+ * Run id of the sync currently in flight, captured from the backend
+ * ``sync_plan`` / ``sync_apply_unit`` events. Passed back on cancel so a
+ * Cancel click is scoped to the active run — a click meant for run N can land
+ * after run N finalized and run N+1 started, and an unscoped cancel would
+ * wrongly abort run N+1 (#1198). ``null`` before any run has started; the
+ * backend then cancels unconditionally (the safety case).
+ */
+let _activeRunId: string | null = null;
+
+/**
  * Once-per-run cache of the existing-shortcut scan. The backend emits one
  * ``sync_apply_unit`` event per unit but the scan only needs to run once per
  * run: every pre-existing RomM shortcut is captured at the first unit, and the
@@ -43,6 +53,29 @@ let _scanCache: { runId: string; map: Map<number, number> } | null = null;
 /** Request cancellation of the frontend shortcut processing loop. */
 export function requestSyncCancel(): void {
   _cancelRequested = true;
+}
+
+/**
+ * Mark a fresh sync run started: capture its ``run_id`` and clear the cancel
+ * flag. Called from the ``sync_plan`` listener, which fires exactly once per
+ * run before any unit. The per-unit handler also clears ``_cancelRequested``,
+ * but that handler never runs for an incrementally-SKIPPED unit — so a
+ * skip-only run would otherwise carry a stale ``_cancelRequested`` from a prior
+ * cancelled run (the #1198 adjacent H4 defect). Resetting here, once per run,
+ * is the reliable reset.
+ */
+export function beginSyncRun(runId: string): void {
+  _activeRunId = runId || null;
+  _cancelRequested = false;
+}
+
+/**
+ * Run id of the sync currently in flight, or ``null`` before any run has
+ * started. Passed to ``cancelSync`` so the backend scopes the cancel to the
+ * active run (#1198).
+ */
+export function getActiveRunId(): string | null {
+  return _activeRunId;
 }
 
 /**
@@ -225,6 +258,10 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
       }
 
       _cancelRequested = false;
+      // Capture the run id here too — ``sync_apply_unit`` always carries it, so
+      // a Cancel click resolves the right run even if the ``sync_plan`` capture
+      // was missed (#1198).
+      _activeRunId = data.run_id || _activeRunId;
       const romIdToAppId: Record<string, number> = {};
       const artworkTargets: ArtworkTarget[] = [];
 

--- a/tests/contract/test_sync_cancel_scope.py
+++ b/tests/contract/test_sync_cancel_scope.py
@@ -1,0 +1,115 @@
+"""Contract tests for run-scoped ``cancel_sync`` (#1198).
+
+A Cancel click meant for run A can land after run A finalized to IDLE and run
+B started fresh. The argument-less cancel would flip run B to CANCELLING — a
+sync the user never cancelled — so it would abort and report cancelled. The
+run-scoped cancel ignores a stale run id; an unscoped (falsy) cancel still
+cancels unconditionally.
+
+Driven through the real ``cancel_sync`` callable over the real wired plugin,
+asserting the response shape and the downstream effect on run B's terminal
+``sync_complete`` event.
+"""
+
+from __future__ import annotations
+
+from domain.sync_state import SyncState
+
+
+def _orchestrator(harness):
+    return harness.plugin._sync_service._orchestrator
+
+
+async def _ack_immediately(_unit, event):
+    """Stand-in for ``_wait_for_unit_complete``: ack with an empty map.
+
+    The frontend's ``report_unit_results`` callback never runs in the contract
+    tier; this lets run B's per-unit pipeline complete deterministically so its
+    terminal ``sync_complete`` can be asserted.
+    """
+    event.set()
+    return {}
+
+
+def _sync_complete_payloads(harness):
+    return [c.args[1] for c in harness.emit.call_args_list if c.args and c.args[0] == "sync_complete"]
+
+
+async def test_cancel_sync_shape_when_idle(harness):
+    """Idle: the callable returns the success-shaped no-op (not a failure shape)."""
+    result = await harness.plugin.cancel_sync("any-run")
+    assert result == {"success": True, "message": "No sync in progress"}
+
+
+async def test_cancel_sync_stale_run_does_not_abort_fresh_run(harness):
+    """The #1198 repro: run-A's cancel must not abort the fresh run-B.
+
+    Start run A and capture its run id; finalize A to IDLE (id nulled); start
+    run B with a fresh id; then deliver run A's Cancel click. Run B must run to
+    completion with ``cancelled`` absent from its ``sync_complete`` payload.
+    """
+    # Seed one platform so run B has a real unit to process.
+    harness.romm.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+    harness.romm.roms[10] = {
+        "id": 10,
+        "name": "Game",
+        "platform_id": 1,
+        "platform_name": "N64",
+        "platform_slug": "n64",
+    }
+    harness.plugin.settings["enabled_platforms"] = {"1": True}
+
+    orch = _orchestrator(harness)
+    orch._wait_for_unit_complete = _ack_immediately
+
+    # Run A: start through the real callable. The deterministic FakeUuidGen mints
+    # a fixed id, so pin run A's id explicitly to model the cross-run race
+    # (run A's id must differ from run B's).
+    run_a_id = "run-A"
+    start_a = await harness.plugin.start_sync()
+    assert start_a["success"] is True
+    harness.plugin._sync_service._current_sync_id = run_a_id
+
+    # Finalize run A to IDLE exactly as the lifecycle does (id nulled).
+    await orch._finish_sync("Sync cancelled")
+    assert harness.plugin._sync_service._sync_state == SyncState.IDLE
+    assert harness.plugin._sync_service._current_sync_id is None
+
+    # Run B: a fresh run with a distinct id.
+    run_b_id = "run-B"
+    start_b = await harness.plugin.start_sync()
+    assert start_b["success"] is True
+    harness.plugin._sync_service._current_sync_id = run_b_id
+
+    # Run A's Cancel click lands now — it must be ignored as stale.
+    cancel = await harness.plugin.cancel_sync(run_a_id)
+    assert cancel == {"success": True, "message": "Cancel ignored (stale run)"}
+    assert harness.plugin._sync_service._sync_state == SyncState.RUNNING
+
+    # Drive run B to completion. It was never cancelled.
+    await orch._do_sync_per_unit()
+
+    completes = _sync_complete_payloads(harness)
+    assert completes, "run B must emit a terminal sync_complete"
+    assert "cancelled" not in completes[-1]
+    assert harness.plugin._sync_service._sync_state == SyncState.IDLE
+
+
+async def test_cancel_sync_matching_run_aborts_it(harness):
+    """A cancel that matches the active run id flips it to CANCELLING."""
+    harness.plugin._sync_service._sync_state = SyncState.RUNNING
+    harness.plugin._sync_service._current_sync_id = "run-B"
+
+    cancel = await harness.plugin.cancel_sync("run-B")
+    assert cancel == {"success": True, "message": "Sync cancelling..."}
+    assert harness.plugin._sync_service._sync_state == SyncState.CANCELLING
+
+
+async def test_cancel_sync_empty_run_id_cancels_unconditionally(harness):
+    """The frontend's no-id-yet fallback (empty string) always cancels."""
+    harness.plugin._sync_service._sync_state = SyncState.RUNNING
+    harness.plugin._sync_service._current_sync_id = "run-B"
+
+    cancel = await harness.plugin.cancel_sync("")
+    assert cancel == {"success": True, "message": "Sync cancelling..."}
+    assert harness.plugin._sync_service._sync_state == SyncState.CANCELLING

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -609,6 +609,50 @@ class TestSyncControl:
         assert result["success"] is True
         assert "No sync" in result["message"]
 
+    def test_cancel_sync_with_matching_run_id_sets_cancelling(self, plugin):
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-B"
+        result = plugin._sync_service.cancel_sync("run-B")
+        assert result["success"] is True
+        assert plugin._sync_service._sync_state == SyncState.CANCELLING
+
+    def test_cancel_sync_with_stale_run_id_is_noop(self, plugin):
+        """A cancel meant for run-A must NOT abort the fresh run-B (#1198).
+
+        The regression case: run-A finalized to IDLE and run-B started fresh,
+        then run-A's Cancel click lands. The argument-less cancel would flip
+        run-B to CANCELLING; the run-scoped cancel ignores the stale id.
+        """
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-B"
+        result = plugin._sync_service.cancel_sync("run-A")
+        assert result["success"] is True
+        assert "stale" in result["message"].lower()
+        assert plugin._sync_service._sync_state == SyncState.RUNNING
+
+    def test_cancel_sync_with_none_run_id_cancels_unconditionally(self, plugin):
+        """A falsy run_id (legacy caller / no id captured yet) always cancels."""
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-B"
+        result = plugin._sync_service.cancel_sync(None)
+        assert result["success"] is True
+        assert plugin._sync_service._sync_state == SyncState.CANCELLING
+
+    def test_cancel_sync_with_empty_run_id_cancels_unconditionally(self, plugin):
+        """An empty-string run_id (the frontend's no-id-yet fallback) cancels."""
+        plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-B"
+        result = plugin._sync_service.cancel_sync("")
+        assert result["success"] is True
+        assert plugin._sync_service._sync_state == SyncState.CANCELLING
+
+    def test_cancel_sync_stale_run_id_when_idle_is_no_op(self, plugin):
+        """Idle short-circuits before the run-id check — no sync, plain no-op."""
+        plugin._sync_service._current_sync_id = "run-B"
+        result = plugin._sync_service.cancel_sync("run-A")
+        assert result["success"] is True
+        assert "No sync" in result["message"]
+
     def test_sync_heartbeat(self, plugin):
         old = plugin._sync_service._sync_last_heartbeat
         # Advance the injected FakeClock so monotonic moves forward.
@@ -922,6 +966,7 @@ class TestDoSyncPerUnit:
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
         plugin._sync_service._sync_state = SyncState.RUNNING
+        plugin._sync_service._current_sync_id = "run-plan"
 
         await plugin._sync_service._orchestrator._do_sync_per_unit()
 
@@ -930,6 +975,8 @@ class TestDoSyncPerUnit:
         payload = plan_events[0][0][1]
         assert payload["total_units"] == 1
         assert payload["units"][0]["name"] == "N64"
+        # The frontend captures this run_id to scope a later Cancel click (#1198).
+        assert payload["run_id"] == "run-plan"
 
     @pytest.mark.asyncio
     async def test_processes_each_unit_in_order(self, plugin, fake_romm_api):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1023,9 +1023,9 @@ class TestCancelCallablesNotBlockedByMigration:
     async def test_cancel_sync_callable_when_migration_pending(self, plugin):
         plugin._migration_service.is_retrodeck_migration_pending.return_value = True
         plugin._sync_service.cancel_sync = MagicMock(return_value={"success": True, "stopped": True})
-        result = await plugin.cancel_sync()
+        result = await plugin.cancel_sync("run-1")
         assert result.get("blocked_by_migration") is not True
-        plugin._sync_service.cancel_sync.assert_called_once()
+        plugin._sync_service.cancel_sync.assert_called_once_with("run-1")
 
     @pytest.mark.asyncio
     async def test_sync_cancel_preview_callable_when_migration_pending(self, plugin):


### PR DESCRIPTION
Closes #1198.

`cancel_sync()` wasn't run-scoped — #1041 added run-identity validation to the *ack* path (`report_unit_results` vs `current_sync_id`) but the *cancel* path never got it. A "Cancel" click meant for run N could reach the loop after N finalized to `IDLE` and N+1 started fresh, so the argument-less `cancel_sync()` flipped **N+1** (a sync the user never cancelled) to `CANCELLING` → `cancelled=true`. Observed on device during rapid Sync→Cancel cycles; compounded by #1046's pre-sync reconcile leaving a game missing across the spuriously-cancelled syncs.

**Fix:**
- **Run-scoped cancel** — `cancel_sync(run_id)` ignores a cancel whose `run_id` ≠ `current_sync_id` (logs + returns `"Cancel ignored (stale run)"`, leaves the run `RUNNING`); a falsy/`None` id cancels unconditionally (legacy + safety). Mirrors the #1041 ack-path `_ack_matches_active_unit` check. Plus a cancel-path instrumentation log (there was none) recording the `run_id` arg + active `current_sync_id` + `sync_state`.
- **Frontend run-id capture** — `sync_plan` now carries `run_id`; the frontend captures it (`beginSyncRun`/`getActiveRunId`) and `handleCancel` passes it to `cancelSync`. `handleSync`/`handleApply` clear the captured id at the top (`beginSyncRun("")` → `null` → unconditional on the wire) so a Cancel in the pre-`sync_plan` "Fetching library…" window stays unconditional rather than sending a stale id that the backend would reject as a cross-run mismatch and drop.
- **Reset `_cancelRequested` per run** on `sync_plan` (not only per-unit), fixing the stale-flag carryover on skip-only runs.

`sync_cancel_preview` is structurally immune (only clears `pending_delta`, never touches `sync_state`; `sync_apply_delta` validates `preview_id` independently).

Tests: backend unit (stale / matching / None / empty / idle); contract (`test_cancel_sync_stale_run_does_not_abort_fresh_run`); frontend (run-id capture, window-cancel goes unconditional, skip-only `_cancelRequested` reset) — the frontend resets are **mutation-verified non-vacuous** (removing either reset fails its test).

Docs: `backend-architecture.md` — cancel run-identity + per-run reset notes.

The reconcile-strand that compounded the on-device symptom is tracked separately in #1199 (Option A — defer the unbind so it commits only on a non-cancelled run).
