### PR TITLE
fix(ui): apply RomM overview metadata with readiness retry (#1203)

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "525 KB"
+    "limit": "530 KB"
   }
 ]

--- a/docs/architecture/steam-non-steam-shortcuts.md
+++ b/docs/architecture/steam-non-steam-shortcuts.md
@@ -134,6 +134,21 @@ The current approach owns the entire game detail UI via custom React components 
 
 See: `src/patches/gameDetailPatch.tsx`, `src/components/RomMPlaySection.tsx`
 
+## Overview metadata mutations (readiness-gated)
+
+Beyond the custom UI, the plugin writes three fields directly onto each RomM shortcut's `SteamAppOverview` so the
+shortcut presents like a native Steam game: `controller_support = 2` (the "Full Controller Support" badge — important so
+Game Mode doesn't flag the controller-driven RetroDECK launch), `metacritic_score` (from RomM's `average_rating`), and
+`m_setStoreCategories` (RomM's `steam_categories`).
+
+Steam rebuilds `appStore` from scratch on every `SharedJSContext` mount, so these in-memory mutations are lost on each
+reload and must re-apply per mount. `registerMetadataPatches` builds the appId→romId map; `applyAllMetadata` then
+applies the mutations with a **readiness retry** (the same `[0, 1s, 3s, 5s]` ladder as `applyAllPlaytime`). Without the
+retry the pass runs before `appStore` is populated and silently no-ops on a cold boot, so the badge/rating/categories
+never appear until a later mount (#1203). The mutations are idempotent, so retries are safe.
+
+See: `src/patches/metadataPatches.ts`
+
 ## VDF Format Notes
 
 Shortcut creation goes through the frontend `SteamClient.Apps.AddShortcut()` API — `AddShortcut` returns the real

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -30,6 +30,7 @@ vi.mock("./patches/metadataPatches", () => ({
   registerMetadataPatches: vi.fn(),
   unregisterMetadataPatches: vi.fn(),
   applyAllPlaytime: vi.fn().mockResolvedValue(undefined),
+  applyAllMetadata: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("./utils/launchInterceptor", () => ({
   registerLaunchInterceptor: vi.fn(),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,12 @@ import { setSyncProgress } from "./utils/syncProgress";
 import { updateDownload, getDownloadState } from "./utils/downloadStore";
 import { handleGlobalDownloadFailure } from "./utils/downloadFailure";
 import { registerGameDetailPatch, unregisterGameDetailPatch, registerRomMAppId } from "./patches/gameDetailPatch";
-import { registerMetadataPatches, unregisterMetadataPatches, applyAllPlaytime } from "./patches/metadataPatches";
+import {
+  registerMetadataPatches,
+  unregisterMetadataPatches,
+  applyAllPlaytime,
+  applyAllMetadata,
+} from "./patches/metadataPatches";
 import { registerLaunchInterceptor, unregisterLaunchInterceptor } from "./utils/launchInterceptor";
 import { hasAnySaveConflict } from "./utils/saveStatus";
 import {
@@ -150,6 +155,12 @@ export default definePlugin(() => {
         registerRomMAppId(appId);
       }
     }
+
+    // Apply the overview mutations (controller badge / rating / categories) with a
+    // readiness retry — appStore is rebuilt each mount and may not hold our
+    // overviews yet, so a single pass silently no-ops on a cold boot (#1203).
+    // Detached so the retry's backoff doesn't delay init completion.
+    detach(applyAllMetadata());
 
     try {
       const { playtime } = await withTimeout(getAllPlaytime(), CALLABLE_TIMEOUT);

--- a/src/patches/metadataPatches.test.ts
+++ b/src/patches/metadataPatches.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerMetadataPatches, applyAllMetadata } from "./metadataPatches";
+import type { RomMetadata } from "../types";
+
+// RomMetadata has several required fields; build a full object and override the
+// few that applyDirectMutations actually reads (average_rating, steam_categories).
+function makeMeta(overrides: Partial<RomMetadata> = {}): RomMetadata {
+  return {
+    summary: "",
+    genres: [],
+    companies: [],
+    first_release_date: null,
+    average_rating: null,
+    game_modes: [],
+    player_count: "",
+    cached_at: 0,
+    ...overrides,
+  };
+}
+
+interface FakeOverview {
+  appid: number;
+  controller_support: number;
+  metacritic_score: number;
+  m_setStoreCategories: Set<number>;
+}
+
+function makeOverview(appid: number): FakeOverview {
+  return { appid, controller_support: 0, metacritic_score: 0, m_setStoreCategories: new Set<number>() };
+}
+
+// appId 100 → rom_id 10
+const APP_ID_MAP = { "100": 10 };
+
+describe("applyAllMetadata (#1203 readiness retry)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // test-setup's afterEach calls unstubAllGlobals, so re-stub the Steam globals
+    // each test. __mobxGlobals is undefined here → stateTransaction applies the
+    // mutation block directly (its `if (!globals) return block()` path).
+    vi.stubGlobal("__mobxGlobals", undefined);
+    vi.stubGlobal("appStore", { GetAppOverviewByAppID: vi.fn(), allApps: [] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies controller support, metacritic and categories when the overview is present", async () => {
+    const ov = makeOverview(100);
+    vi.mocked(appStore.GetAppOverviewByAppID).mockReturnValue(ov as unknown as SteamAppOverview);
+    registerMetadataPatches({ "10": makeMeta({ average_rating: 88, steam_categories: [1, 2] }) }, APP_ID_MAP);
+
+    await applyAllMetadata();
+
+    expect(ov.controller_support).toBe(2);
+    expect(ov.metacritic_score).toBe(88);
+    expect([...ov.m_setStoreCategories]).toEqual([1, 2]);
+  });
+
+  it("retries an app whose overview isn't loaded yet, then applies once it appears", async () => {
+    const ov = makeOverview(100);
+    vi.mocked(appStore.GetAppOverviewByAppID)
+      .mockReturnValueOnce(null) // first pass: appStore not populated yet → silent skip today
+      .mockReturnValue(ov as unknown as SteamAppOverview); // retry: overview now present
+    registerMetadataPatches({ "10": makeMeta({ average_rating: 70 }) }, APP_ID_MAP);
+
+    const done = applyAllMetadata();
+    // The first synchronous pass (0ms) ran against a null overview → nothing applied yet.
+    expect(ov.controller_support).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1000); // second attempt fires at +1s
+    await done;
+
+    expect(ov.controller_support).toBe(2);
+    expect(ov.metacritic_score).toBe(70);
+  });
+
+  it("is idempotent — repeated applies don't duplicate categories or corrupt state", async () => {
+    const ov = makeOverview(100);
+    vi.mocked(appStore.GetAppOverviewByAppID).mockReturnValue(ov as unknown as SteamAppOverview);
+    registerMetadataPatches({ "10": makeMeta({ steam_categories: [5, 5, 7] }) }, APP_ID_MAP);
+
+    await applyAllMetadata();
+    await applyAllMetadata(); // a second pass must be safe (retries re-apply)
+
+    expect([...ov.m_setStoreCategories].sort((a, b) => a - b)).toEqual([5, 7]);
+    expect(ov.controller_support).toBe(2);
+  });
+});

--- a/src/patches/metadataPatches.ts
+++ b/src/patches/metadataPatches.ts
@@ -33,10 +33,12 @@ function getMetadataForAppId(appId: number): RomMetadata | null {
 
 /**
  * Apply direct property mutations to a SteamAppOverview for a RomM app.
+ * Returns true if the overview was present and mutated, false if it wasn't
+ * available yet (the caller retries those — see {@link applyAllMetadata}).
  */
-function applyDirectMutations(appId: number, metadata: RomMetadata) {
+function applyDirectMutations(appId: number, metadata: RomMetadata): boolean {
   const overview = appStore.GetAppOverviewByAppID(appId);
-  if (!overview) return;
+  if (!overview) return false;
 
   stateTransaction(() => {
     overview.controller_support = 2;
@@ -51,11 +53,14 @@ function applyDirectMutations(appId: number, metadata: RomMetadata) {
       }
     }
   });
+  return true;
 }
 
 /**
- * Initialize metadata state and apply direct property mutations.
- * Call on plugin load after fetching the metadata cache and app ID map.
+ * Initialize metadata state: the app_id→rom_id map and the registered-appId set.
+ * Pure setup — the overview mutations themselves happen in {@link applyAllMetadata},
+ * which retries until Steam's appStore is populated. Call on plugin load (before
+ * applyAllMetadata) after fetching the metadata cache and app ID map.
  */
 export function registerMetadataPatches(cache: Record<string, RomMetadata>, appIdMap: Record<string, number>) {
   metadataCache = cache;
@@ -69,13 +74,61 @@ export function registerMetadataPatches(cache: Record<string, RomMetadata>, appI
   // Build set of registered app IDs
   registeredAppIds = new Set(Object.keys(appIdToRomId).map(Number));
 
-  // Apply direct mutations for all known apps (controller support, categories, metacritic)
-  for (const appId of registeredAppIds) {
+  logInfo(`Registered metadata for ${registeredAppIds.size} apps`);
+}
+
+/**
+ * Attempt one pass of metadata mutations over the given appIds. Returns the
+ * appIds whose appStore overview wasn't available yet, so the caller can retry.
+ */
+function tryApplyMetadata(appIds: number[]): number[] {
+  const notApplied: number[] = [];
+  for (const appId of appIds) {
     const meta = getMetadataForAppId(appId);
-    if (meta) applyDirectMutations(appId, meta);
+    if (!meta) continue; // no metadata for this app — nothing to apply, not a retry case
+    if (!applyDirectMutations(appId, meta)) notApplied.push(appId);
+  }
+  return notApplied;
+}
+
+/**
+ * Apply the direct overview mutations (controller support, metacritic, store
+ * categories) for every registered RomM app, retrying apps whose appStore
+ * overview isn't available yet. Steam rebuilds appStore on every mount and may
+ * still be loading shortcuts when this first runs, so a single pass silently
+ * no-ops on a cold boot and the controller badge / rating / categories never
+ * apply until a later mount (#1203). Mirrors {@link applyAllPlaytime}'s readiness
+ * retry. Idempotent (re-applying the same values is safe), so retries can't
+ * corrupt state. Call after {@link registerMetadataPatches}.
+ */
+export async function applyAllMetadata(): Promise<void> {
+  let pending = [...registeredAppIds].filter((appId) => getMetadataForAppId(appId) != null);
+  if (pending.length === 0) return;
+
+  // Try up to 4 times with increasing delays (0ms, 1s, 3s, 5s) — same ladder as playtime.
+  const delays = [0, 1000, 3000, 5000];
+  for (let attempt = 0; attempt < delays.length && pending.length > 0; attempt++) {
+    if (delays[attempt]! > 0) {
+      // attempt < delays.length (loop guard) ⇒ index in bounds
+      await new Promise((r) => setTimeout(r, delays[attempt]));
+    }
+
+    pending = tryApplyMetadata(pending);
+
+    if (pending.length > 0 && attempt < delays.length - 1) {
+      detach(
+        debugLog(
+          `applyAllMetadata: attempt ${attempt + 1}, ${pending.length} apps not in appStore yet, retrying in ${delays[attempt + 1]}ms...`,
+        ),
+      );
+    }
   }
 
-  logInfo(`Applied metadata mutations for ${registeredAppIds.size} apps`);
+  if (pending.length > 0) {
+    detach(debugLog(`applyAllMetadata: ${pending.length} apps still unavailable in appStore after all retries`));
+  } else {
+    detach(debugLog(`applyAllMetadata: all metadata mutations applied`));
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Apply the RomM overview metadata mutations (Full Controller Support badge, metacritic score, store categories) with a readiness retry, so they reliably land on a cold boot instead of silently no-op'ing.

## Why

`registerMetadataPatches` applied the overview mutations in a single pass at init. Steam rebuilds `appStore` on every `SharedJSContext` mount and may not hold our overviews yet when that pass runs — so on a cold boot every overview was `null` and the mutations were silently skipped with **no retry** (measured on-device: `applied=0/116`). `applyAllPlaytime` already had a readiness-retry ladder; metadata did not, so the controller badge / rating / categories could fail to appear until a later mount.

## How

- Split `registerMetadataPatches` into setup-only (builds the appId→romId map + registered-appId set) and a new `applyAllMetadata()` that applies the mutations with the same `[0, 1s, 3s, 5s]` retry as `applyAllPlaytime`, re-targeting only the apps whose overview isn't available yet. `applyDirectMutations` now returns whether it applied.
- The mutations are idempotent (`Set.add` dedups; the others are plain assignments), so retries are safe.
- `index.tsx` calls `detach(applyAllMetadata())` after registration, so the backoff doesn't delay startup.

## Testing

- New `src/patches/metadataPatches.test.ts`: apply-when-present, retry-then-apply (drives the ladder via fake timers), idempotency.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean; full `pnpm test` (1392) green.
- On-device (log_level=debug): the plugin log now reports `applyAllMetadata: all metadata mutations applied` instead of the silent 0/116 skip.

## Docs

`docs/architecture/steam-non-steam-shortcuts.md` — new "Overview metadata mutations (readiness-gated)" section.

## Notes

- Scoped from the #1203 investigation. The dramatic boot-freeze / boot-animation-replay symptom in #1203 turned out to be an upstream gamescope crash on the Desktop→Game transition (`drm: flip error: Invalid argument` → SIGABRT), reproducible with all Decky plugins removed — tracked separately, not plugin work.
- Follow-up #1205: a game-detail page can occasionally show native UI instead of the custom UI when `rommAppIds` isn't populated yet (a separate backend-readiness race) — needs its own investigation.

Refs #1203
