### PR TITLE
feat: route PS2/PS3/etc... games to standalone emulators

### DIFF
--- a/defaults/core_defaults.json
+++ b/defaults/core_defaults.json
@@ -963,12 +963,20 @@
       "default_label": "LRPS2",
       "cores": {
         "pcsx2_libretro": "PCSX2"
+      },
+      "standalone": {
+        "label": "PCSX2 (Standalone)",
+        "command": "%EMULATOR_PCSX2% -batch %ROM%"
       }
     },
     "ps3": {
       "default_core": null,
       "default_label": null,
-      "cores": {}
+      "cores": {},
+      "standalone": {
+        "label": "RPCS3 Directory (Standalone)",
+        "command": "%EMULATOR_RPCS3% --no-gui %ROM%"
+      }
     },
     "psp": {
       "default_core": "ppsspp_libretro",

--- a/docs/architecture/core-emulator-selection.md
+++ b/docs/architecture/core-emulator-selection.md
@@ -11,8 +11,8 @@ which emulator a game uses, where that decision is stored, and how it is applied
 The central rule: **the read-path core equals the launched core.** Whatever core the plugin reports for a game — in the
 BIOS-requirement filter, the save-directory name, the save-sync core tag, the core-change warning, the game-detail badge
 — is the exact core that game will launch on. A single resolver guarantees that, and the launch command is baked from
-the same resolved emulator. The plugin **owns emulator selection end to end**: it reads RetroDECK/ES-DE configuration for
-the default emulator, but its own launches never depend on ES-DE's `gamelist.xml` — it neither reads nor writes that
+the same resolved emulator. The plugin **owns emulator selection end to end**: it reads RetroDECK/ES-DE configuration
+for the default emulator, but its own launches never depend on ES-DE's `gamelist.xml` — it neither reads nor writes that
 file. See
 [ADR-0011](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0011-per-game-core-override-in-db-applied-via-e-flag.md)
 (the per-game DB override + `-e`) and
@@ -94,9 +94,9 @@ this ROM actually launch with?" It exposes two methods over the **same** four-la
 - **`active_emulator_for_rom(rom_id) -> EmulatorInvocation | None`** — the **launch-bake seam**. Returns the full
   resolved emulator (libretro core OR standalone), or `None` when the platform has no resolvable emulator at all.
 - **`active_core_for_rom(rom_id) -> (core_so, label)`** — the **read-path projection** of the above, kept for the
-  `.so`-space consumers. A libretro emulator yields `(core_so, label)`; a **standalone** emulator yields `(None, label)`;
-  an unresolvable platform yields `(None, None)`. Consumers already degrade on a `None` core, so a standalone launch
-  never breaks them.
+  `.so`-space consumers. A libretro emulator yields `(core_so, label)`; a **standalone** emulator yields
+  `(None, label)`; an unresolvable platform yields `(None, None)`. Consumers already degrade on a `None` core, so a
+  standalone launch never breaks them.
 
 The precedence is the invariant:
 
@@ -128,9 +128,9 @@ active_core_for_rom(rom_id):                               ── the .so-space 
 
 The system-layer fallback is `CoreResolver.get_default_emulator(system)` (`adapters/es_de_config.py`), the
 **standalone-aware** layer: if `core_defaults.json` marks the system with a curated `standalone` block it bakes that
-emulator (see [Standalone-emulator selection](#standalone-emulator-selection-the-curated-default)), otherwise it projects
-the libretro `get_active_core(system)` default (live `es_systems.xml` default with bundled `core_defaults.json` as
-fallback). It **no longer reads any gamelist** — neither a per-game `<altemulator>` nor a system-level
+emulator (see [Standalone-emulator selection](#standalone-emulator-selection-the-curated-default)), otherwise it
+projects the libretro `get_active_core(system)` default (live `es_systems.xml` default with bundled `core_defaults.json`
+as fallback). It **no longer reads any gamelist** — neither a per-game `<altemulator>` nor a system-level
 `<alternativeEmulator>`; the gamelist is off every plugin code path. The per-platform deviation that used to live in the
 gamelist is now the `settings.json` layer above. A pinned per-game or per-platform LABEL that no longer resolves (a core
 a RetroDECK update removed) is **never fatal**: the resolver logs a WARNING and degrades to the next layer, never
@@ -202,13 +202,12 @@ filename (see
 **Always `-e`.** Per
 [ADR-0012](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0012-plugin-owns-core-selection-always-e-no-gamelist.md),
 every installed ROM bakes its **full resolved active emulator** through `-e` — the per-game pin, the per-platform core,
-the es_systems libretro default, or a standalone emulator, whichever the resolver returns. The plain `flatpak run` launch
-is **not** the "no override" case any more; it is reserved for the single fallback where the resolver yields `None` (a
-platform with no resolvable default at all). Baking the default for every ROM is what lets the plugin own launch
-selection completely: a launch that
-is _not_ `-e` would let RetroDECK consult the gamelist, re-coupling the plugin to ES-DE's state. The cost is that a
-RetroDECK update changing a platform's default core needs a **Force Full Sync** to re-bake — see
-[A frozen default needs a Force Full Sync](#a-frozen-default-needs-a-force-full-sync).
+the es_systems libretro default, or a standalone emulator, whichever the resolver returns. The plain `flatpak run`
+launch is **not** the "no override" case any more; it is reserved for the single fallback where the resolver yields
+`None` (a platform with no resolvable default at all). Baking the default for every ROM is what lets the plugin own
+launch selection completely: a launch that is _not_ `-e` would let RetroDECK consult the gamelist, re-coupling the
+plugin to ES-DE's state. The cost is that a RetroDECK update changing a platform's default core needs a **Force Full
+Sync** to re-bake — see [A frozen default needs a Force Full Sync](#a-frozen-default-needs-a-force-full-sync).
 
 ### The three bake sites
 
@@ -216,11 +215,11 @@ RetroDECK update changing a platform's default core needs a **Force Full Sync** 
 emulator** through the same `ActiveCoreResolver.active_emulator_for_rom` seam and pass the `EmulatorInvocation` into
 `resolve_emulator_invocation`, so the read-path core and the launched emulator cannot diverge:
 
-| Bake site                                    | When it runs                             | How it resolves the emulator                                                          |
-| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| Bake site                                    | When it runs                             | How it resolves the emulator                                                             |
+| -------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `SyncOrchestrator` → `_build_core_overrides` | every sync (preview + apply)             | each ROM through `active_emulator_for_rom` → `{rom_id: EmulatorInvocation}` for the bake |
-| `DownloadService` → `_resolve_bound_app_id`  | on download-complete (install/reinstall) | the ROM through `active_emulator_for_rom` in the same flow                             |
-| `MigrationService` → `_build_relaunch_items` | on RetroDECK-home migration              | each relocated ROM through `active_emulator_for_rom`                                   |
+| `DownloadService` → `_resolve_bound_app_id`  | on download-complete (install/reinstall) | the ROM through `active_emulator_for_rom` in the same flow                               |
+| `MigrationService` → `_build_relaunch_items` | on RetroDECK-home migration              | each relocated ROM through `active_emulator_for_rom`                                     |
 
 The download-complete bake is the one that re-applies a pin after reinstall — the exact path `roms` storage was chosen
 to protect. Each site bakes `-e` for every ROM that resolves to a concrete emulator (libretro or standalone), and the
@@ -305,8 +304,8 @@ path-override layering the `-e` core override uses.
 
 The three sites that re-bake the core override re-bake the disc path through this seam, and the two compose: the disc
 resolver yields the **path**, `ActiveCoreResolver` yields the **`EmulatorInvocation`**, and
-`resolve_emulator_invocation(rom, emulator)` + `build_launch_options(invocation, disc_path)` fold them into one command —
-a per-game core (or standalone emulator) and a pinned disc on the same shortcut coexist.
+`resolve_emulator_invocation(rom, emulator)` + `build_launch_options(invocation, disc_path)` fold them into one command
+— a per-game core (or standalone emulator) and a pinned disc on the same shortcut coexist.
 
 | Bake site                                                              | How it resolves the disc path                                                             |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
@@ -424,10 +423,10 @@ The `-e` flag, the `%EMULATOR_RETROARCH%` / `%ROM%` placeholders, and the `/var/
 **RetroDECK-adapter concerns**, isolated at the single seam `resolve_emulator_invocation`. RetroDECK is the supported
 launcher for V1 — this is the correct V1 shape, not a placeholder. The per-ROM **selection** (which emulator does this
 ROM resolve to?) is a service-layer read; the seam only **renders** the chosen `EmulatorInvocation` into a command
-string. Standalone-emulator support ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129)) is the
-first half of the multi-emulator lift: a standalone emulator is still launched **through RetroDECK's `-e`**, so the
-RetroDECK flatpak invocation remains the single seam — only the `-e` payload changed (a verbatim ES-DE command instead
-of the RetroArch `-L` form). The remaining lift ([#918](https://github.com/danielcopper/decky-romm-sync/issues/918)) — a
+string. Standalone-emulator support ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129)) is the first
+half of the multi-emulator lift: a standalone emulator is still launched **through RetroDECK's `-e`**, so the RetroDECK
+flatpak invocation remains the single seam — only the `-e` payload changed (a verbatim ES-DE command instead of the
+RetroArch `-L` form). The remaining lift ([#918](https://github.com/danielcopper/decky-romm-sync/issues/918)) — a
 non-RetroDECK launcher behind a `Frontend`-style port — is net-new work and is not built until a second launcher is
 concrete.
 

--- a/docs/architecture/core-emulator-selection.md
+++ b/docs/architecture/core-emulator-selection.md
@@ -2,20 +2,40 @@
 
 ## Overview
 
-A RomM game launches through RetroDECK on some **RetroArch core**. Most games use their platform's default core, but the
-user can pin a different core for a single game (a **per-game** emulator override) or for a whole platform (a
-**per-platform** emulator override). This page documents how the plugin decides which core a game uses, where that
-decision is stored, and how it is applied at launch.
+A RomM game launches through RetroDECK on some **emulator** — most often a **RetroArch libretro core**, but for a few
+platforms (PS2, PS3, …) a **standalone emulator** (PCSX2, RPCS3) that ES-DE lists as the working default. Most games use
+their platform's default emulator, but the user can pin a different core for a single game (a **per-game** emulator
+override) or for a whole platform (a **per-platform** emulator override). This page documents how the plugin decides
+which emulator a game uses, where that decision is stored, and how it is applied at launch.
 
 The central rule: **the read-path core equals the launched core.** Whatever core the plugin reports for a game — in the
 BIOS-requirement filter, the save-directory name, the save-sync core tag, the core-change warning, the game-detail badge
 — is the exact core that game will launch on. A single resolver guarantees that, and the launch command is baked from
-the same resolved core. The plugin **owns core selection end to end**: it reads RetroDECK/ES-DE configuration for the
-default core, but its own launches never depend on ES-DE's `gamelist.xml` — it neither reads nor writes that file. See
+the same resolved emulator. The plugin **owns emulator selection end to end**: it reads RetroDECK/ES-DE configuration for
+the default emulator, but its own launches never depend on ES-DE's `gamelist.xml` — it neither reads nor writes that
+file. See
 [ADR-0011](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0011-per-game-core-override-in-db-applied-via-e-flag.md)
 (the per-game DB override + `-e`) and
 [ADR-0012](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0012-plugin-owns-core-selection-always-e-no-gamelist.md)
 (per-platform core in `settings.json`, always `-e`, gamelist dropped) for the decision records.
+
+### Two emulator kinds: libretro core and standalone
+
+The resolved emulator is a pure value object — `domain.shortcut_data.EmulatorInvocation` — that carries **exactly one**
+of two payloads:
+
+- **`kind == "libretro"`** — a RetroArch core, identified by its bare `.so` name (`core_so`). Rendered as the
+  `-e "%EMULATOR_RETROARCH% -L <coresdir>/<so>.so %ROM%"` form. This is the overwhelming-majority path; per-game and
+  per-platform overrides only ever produce libretro invocations (the picker offers libretro cores).
+- **`kind == "standalone"`** — a standalone emulator, identified by its full ES-DE `<command>` text (already ending in
+  `%ROM%`, e.g. `%EMULATOR_RPCS3% --no-gui %ROM%`). Baked verbatim into `-e`. RetroDECK resolves `%EMULATOR_*%` and
+  substitutes `%ROM%` at launch, the same as the libretro form. This is the standalone-emulator seam
+  ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129)): a system whose working ES-DE default is a
+  standalone emulator (PS2 → PCSX2, PS3 → RPCS3) launches on that emulator instead of a deprecated/absent libretro core.
+
+A standalone emulator has **no** libretro `.so`, so the read-path projection reports `core_so = None` and every
+`.so`-space consumer degrades exactly as it does for an unconfigured platform (see
+[the single read seam](#the-single-read-seam-activecoreresolver)).
 
 ## The two override scopes
 
@@ -68,37 +88,71 @@ write resolves the freshly-written value rather than a stale snapshot.
 
 ## The single read seam: `ActiveCoreResolver`
 
-`ActiveCoreResolver.active_core_for_rom(rom_id) -> (core_so, label)` (`py_modules/services/active_core_resolver.py`) is
-the one place that answers "which core will this ROM actually launch with?" Its precedence is the invariant:
+`ActiveCoreResolver` (`py_modules/services/active_core_resolver.py`) is the one place that answers "which emulator will
+this ROM actually launch with?" It exposes two methods over the **same** four-layer resolution:
 
-> **per-game DB `emulator_override` (top) → per-platform `settings.json` `platform_cores` → es_systems default (live) →
-> `core_defaults`.**
+- **`active_emulator_for_rom(rom_id) -> EmulatorInvocation | None`** — the **launch-bake seam**. Returns the full
+  resolved emulator (libretro core OR standalone), or `None` when the platform has no resolvable emulator at all.
+- **`active_core_for_rom(rom_id) -> (core_so, label)`** — the **read-path projection** of the above, kept for the
+  `.so`-space consumers. A libretro emulator yields `(core_so, label)`; a **standalone** emulator yields `(None, label)`;
+  an unresolvable platform yields `(None, None)`. Consumers already degrade on a `None` core, so a standalone launch
+  never breaks them.
+
+The precedence is the invariant:
+
+> **per-game DB `emulator_override` (top) → per-platform `settings.json` `platform_cores` → es_systems default (live,
+> standalone-aware) → `core_defaults`.**
 
 ```text
-active_core_for_rom(rom_id):
+active_emulator_for_rom(rom_id):
   rom = read roms row (platform_slug + emulator_override)  ── one UoW read
   system = resolve_system(rom.platform_slug)               ── platform→system (ADR-0010)
   available = get_available_cores(system)
-  if rom.emulator_override is not None:                    ── layer 1: per-game pin
+  if rom.emulator_override is not None:                    ── layer 1: per-game pin (always libretro)
       core_so = label_to_core_so(available, override)
       if core_so is not None:
-          return (core_so, override)
+          return EmulatorInvocation.libretro(core_so, override)
       # stale per-game label: warn, fall through
-  platform_label = get_platform_core(rom.platform_slug)    ── layer 2: per-platform settings.json
+  platform_label = get_platform_core(rom.platform_slug)    ── layer 2: per-platform settings.json (always libretro)
   if platform_label is not None:
       core_so = label_to_core_so(available, platform_label)
       if core_so is not None:
-          return (core_so, platform_label)
+          return EmulatorInvocation.libretro(core_so, platform_label)
       # stale per-platform label: warn, fall through
-  return get_active_core(system)                           ── layer 3/4: es_systems default → core_defaults
+  return get_default_emulator(system)                      ── layer 3/4: standalone-aware es_systems default → core_defaults
+
+active_core_for_rom(rom_id):                               ── the .so-space projection
+  e = active_emulator_for_rom(rom_id)
+  return (None, None) if e is None else (e.core_so, e.label)
 ```
 
-The system-layer fallback is `CoreResolver.get_active_core(system)` (`adapters/es_de_config.py`), which resolves the
-live `es_systems.xml` default with the bundled `core_defaults.json` as a fallback. It **no longer reads any gamelist** —
-neither a per-game `<altemulator>` nor a system-level `<alternativeEmulator>`; the gamelist is off every plugin code
-path. The per-platform deviation that used to live in the gamelist is now the `settings.json` layer above. A pinned
-per-game or per-platform LABEL that no longer resolves (a core a RetroDECK update removed) is **never fatal**: the
-resolver logs a WARNING and degrades to the next layer, never returning a bogus `None.so`.
+The system-layer fallback is `CoreResolver.get_default_emulator(system)` (`adapters/es_de_config.py`), the
+**standalone-aware** layer: if `core_defaults.json` marks the system with a curated `standalone` block it bakes that
+emulator (see [Standalone-emulator selection](#standalone-emulator-selection-the-curated-default)), otherwise it projects
+the libretro `get_active_core(system)` default (live `es_systems.xml` default with bundled `core_defaults.json` as
+fallback). It **no longer reads any gamelist** — neither a per-game `<altemulator>` nor a system-level
+`<alternativeEmulator>`; the gamelist is off every plugin code path. The per-platform deviation that used to live in the
+gamelist is now the `settings.json` layer above. A pinned per-game or per-platform LABEL that no longer resolves (a core
+a RetroDECK update removed) is **never fatal**: the resolver logs a WARNING and degrades to the next layer, never
+returning a bogus `None.so`.
+
+### Standalone-emulator selection: the curated default
+
+Selection of a standalone emulator is **data-driven**. A system gains a `standalone` block in
+`defaults/core_defaults.json` naming the preferred ES-DE command **label**; the live `es_systems.xml` supplies the
+command text for that label (the bundled string is the offline fallback):
+
+```json
+"ps2": { "...": "...", "standalone": { "label": "PCSX2 (Standalone)",        "command": "%EMULATOR_PCSX2% -batch %ROM%" } },
+"ps3": { "...": "...", "standalone": { "label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --no-gui %ROM%" } }
+```
+
+A curated label is needed because ES-DE's **first** `<command>` is not always the one to bake — PS3's first command is a
+fragile shortcut form (`%ENABLESHORTCUTS% %EMULATOR_OS-SHELL% %ROM%`), not the direct `--no-gui` launch. The parser
+captures **every** `<command>` per system as `{label: command_text}` (plus the first label as ES-DE's true default), so
+`get_default_emulator` can resolve the curated label against the live file and pick up a RetroDECK update. Adding a new
+standalone system (Switch/Xbox/Vita/Wii U) once its ES-DE labels are confirmed is a **data-only** change — one
+`standalone` block, no code.
 
 **Every per-game core read consumer draws from this one seam**, so the launch core cannot diverge from any derived
 value:
@@ -120,49 +174,58 @@ default). No consumer ever sees a bogus `.so`.
 Per
 [ADR-0009](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md),
 the launcher is a pure `exec "$@"` wrapper and the full launch command lives in the Steam shortcut's `launch_options`.
-The pure seam `domain.shortcut_data.resolve_emulator_invocation(rom, active_core_so)` renders the invocation:
+The pure seam `domain.shortcut_data.resolve_emulator_invocation(rom, emulator)` takes the resolved `EmulatorInvocation`
+and renders the invocation:
 
-- `active_core_so` set → the `-e` form:
+- **libretro** invocation → the RetroArch `-e` form:
 
   ```text
   flatpak run net.retrodeck.retrodeck -e "%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/<core>.so %ROM%"
   ```
 
-- `active_core_so is None` → the plain `flatpak run net.retrodeck.retrodeck`.
+- **standalone** invocation → the emulator's full ES-DE command baked verbatim:
 
-`%EMULATOR_RETROARCH%` and `%ROM%` stay as ES-DE placeholders — RetroDECK's `run_game.sh` resolves and single-quotes
-them at launch, so a ROM path with spaces or parens is handled. Only the in-sandbox cores directory
+  ```text
+  flatpak run net.retrodeck.retrodeck -e "%EMULATOR_RPCS3% --no-gui %ROM%"
+  ```
+
+- `emulator is None` → the plain `flatpak run net.retrodeck.retrodeck`.
+
+`%EMULATOR_*%` and `%ROM%` stay as ES-DE placeholders — RetroDECK's `run_game.sh` resolves and single-quotes them at
+launch, so a ROM path with spaces or parens is handled. For the libretro form, only the in-sandbox cores directory
 (`/var/config/retroarch/cores`) is baked literally; ES-DE's `%CORE_RETROARCH%` variable is **not** expanded through
-`-e`, so the plugin bakes the resolved path itself. The `-e` flag makes RetroDECK skip its gamelist lookup entirely,
-which is why a baked core applies for any filename (see
+`-e`, so the plugin bakes the resolved path itself (a standalone command carries no `%CORE_RETROARCH%`, so it bakes
+as-is). The `-e` flag makes RetroDECK skip its gamelist lookup entirely, which is why a baked emulator applies for any
+filename (see
 [Why the plugin always bakes the core, never the gamelist](#why-the-plugin-always-bakes-the-core-never-the-gamelist)).
 
 **Always `-e`.** Per
 [ADR-0012](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0012-plugin-owns-core-selection-always-e-no-gamelist.md),
-every installed ROM bakes its **full resolved active core** through `-e` — the per-game pin, the per-platform core, or
-the es_systems default, whichever the resolver returns. The plain `flatpak run` launch is **not** the "no override" case
-any more; it is reserved for the single fallback where the resolver yields `(None, None)` (a platform with no resolvable
-default at all). Baking the default for every ROM is what lets the plugin own launch selection completely: a launch that
+every installed ROM bakes its **full resolved active emulator** through `-e` — the per-game pin, the per-platform core,
+the es_systems libretro default, or a standalone emulator, whichever the resolver returns. The plain `flatpak run` launch
+is **not** the "no override" case any more; it is reserved for the single fallback where the resolver yields `None` (a
+platform with no resolvable default at all). Baking the default for every ROM is what lets the plugin own launch
+selection completely: a launch that
 is _not_ `-e` would let RetroDECK consult the gamelist, re-coupling the plugin to ES-DE's state. The cost is that a
 RetroDECK update changing a platform's default core needs a **Force Full Sync** to re-bake — see
 [A frozen default needs a Force Full Sync](#a-frozen-default-needs-a-force-full-sync).
 
 ### The three bake sites
 
-`launch_options` is written wherever a shortcut's command is (re)built. All three resolve the ROM's **full active core**
-through the same `ActiveCoreResolver` seam and pass the `.so` into `resolve_emulator_invocation`, so the read-path core
-and the launched core cannot diverge:
+`launch_options` is written wherever a shortcut's command is (re)built. All three resolve the ROM's **full active
+emulator** through the same `ActiveCoreResolver.active_emulator_for_rom` seam and pass the `EmulatorInvocation` into
+`resolve_emulator_invocation`, so the read-path core and the launched emulator cannot diverge:
 
-| Bake site                                    | When it runs                             | How it resolves the core                                                  |
-| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| `SyncOrchestrator` → `_build_core_overrides` | every sync (preview + apply)             | each ROM through `active_core_for_rom` → `{rom_id: core_so}` for the bake |
-| `DownloadService` → `_resolve_bound_app_id`  | on download-complete (install/reinstall) | the ROM through `active_core_for_rom` in the same flow → `.so`            |
-| `MigrationService` → `_build_relaunch_items` | on RetroDECK-home migration              | each relocated ROM through `active_core_for_rom` → `.so`                  |
+| Bake site                                    | When it runs                             | How it resolves the emulator                                                          |
+| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| `SyncOrchestrator` → `_build_core_overrides` | every sync (preview + apply)             | each ROM through `active_emulator_for_rom` → `{rom_id: EmulatorInvocation}` for the bake |
+| `DownloadService` → `_resolve_bound_app_id`  | on download-complete (install/reinstall) | the ROM through `active_emulator_for_rom` in the same flow                             |
+| `MigrationService` → `_build_relaunch_items` | on RetroDECK-home migration              | each relocated ROM through `active_emulator_for_rom`                                   |
 
 The download-complete bake is the one that re-applies a pin after reinstall — the exact path `roms` storage was chosen
-to protect. Each site bakes `-e` for every ROM that resolves to a concrete core, and the plain launch only when the
-resolver returns `(None, None)`. A stale LABEL is handled inside the resolver (warn + degrade), so no bake site ever
-emits `None.so`.
+to protect. Each site bakes `-e` for every ROM that resolves to a concrete emulator (libretro or standalone), and the
+plain launch only when the resolver returns `None`. A stale LABEL is handled inside the resolver (warn + degrade), so no
+bake site ever emits `None.so`.
 
 ## Multi-disc selection
 
@@ -241,10 +304,9 @@ path-override layering the `-e` core override uses.
 ### The same three bake sites — disc path composes with the core
 
 The three sites that re-bake the core override re-bake the disc path through this seam, and the two compose: the disc
-resolver yields the **path**, `ActiveCoreResolver` yields the **core `.so`**, and
-`resolve_emulator_invocation(rom,
-core_so)` + `build_launch_options(invocation, disc_path)` fold them into one command —
-a per-game core and a pinned disc on the same shortcut coexist.
+resolver yields the **path**, `ActiveCoreResolver` yields the **`EmulatorInvocation`**, and
+`resolve_emulator_invocation(rom, emulator)` + `build_launch_options(invocation, disc_path)` fold them into one command —
+a per-game core (or standalone emulator) and a pinned disc on the same shortcut coexist.
 
 | Bake site                                                              | How it resolves the disc path                                                             |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
@@ -360,12 +422,19 @@ an externally-changed RetroDECK default carries this caveat.
 
 The `-e` flag, the `%EMULATOR_RETROARCH%` / `%ROM%` placeholders, and the `/var/config/retroarch/cores` path are
 **RetroDECK-adapter concerns**, isolated at the single seam `resolve_emulator_invocation`. RetroDECK is the supported
-launcher for V1 — this is the correct V1 shape, not a placeholder. The per-ROM **selection** (does this ROM have an
-override?) is a service-layer DB read; the seam only **renders** the chosen invocation into a command string. The
-multi-emulator lift ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129) /
-[#918](https://github.com/danielcopper/decky-romm-sync/issues/918)) is a near-mechanical extraction of that one seam
-into a RetroDECK adapter behind a `Frontend`-style port; a sibling emulator's launch argv is net-new work, so the port
-is not built until a second emulator is concrete.
+launcher for V1 — this is the correct V1 shape, not a placeholder. The per-ROM **selection** (which emulator does this
+ROM resolve to?) is a service-layer read; the seam only **renders** the chosen `EmulatorInvocation` into a command
+string. Standalone-emulator support ([#129](https://github.com/danielcopper/decky-romm-sync/issues/129)) is the
+first half of the multi-emulator lift: a standalone emulator is still launched **through RetroDECK's `-e`**, so the
+RetroDECK flatpak invocation remains the single seam — only the `-e` payload changed (a verbatim ES-DE command instead
+of the RetroArch `-L` form). The remaining lift ([#918](https://github.com/danielcopper/decky-romm-sync/issues/918)) — a
+non-RetroDECK launcher behind a `Frontend`-style port — is net-new work and is not built until a second launcher is
+concrete.
+
+Two follow-ups stay out of scope for the standalone seam as it stands: the per-game / per-platform **core picker** still
+lists only libretro cores (you cannot choose standalone PCSX2 vs the LRPS2 libretro core in the UI), and **BIOS badge /
+save-sync** for a standalone system read `active_core = None` and degrade — the launch works (BIOS already present
+on-device), but badge accuracy and standalone save-sync are separate efforts.
 
 ---
 

--- a/py_modules/adapters/es_de_config.py
+++ b/py_modules/adapters/es_de_config.py
@@ -17,6 +17,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from adapters.flatpak_install import flatpak_app_files_dirs
+from domain.shortcut_data import EmulatorInvocation
 
 if TYPE_CHECKING:
     import logging
@@ -111,6 +112,39 @@ class CoreResolver:
             return (default_info["default_core"], default_info.get("default_label"))
 
         return (None, None)
+
+    def get_default_emulator(self, system_name: str) -> EmulatorInvocation | None:
+        """Resolve the system-layer default **emulator** (libretro OR standalone).
+
+        Some systems (PS2, PS3, …) launch on a **standalone** emulator, not a
+        RetroArch core, so the libretro-only :meth:`get_active_core` cannot
+        describe them. This is the standalone-aware system layer:
+
+        1. If ``core_defaults.json`` marks this system with a curated
+           ``standalone`` preference (``{"label", "command"}``), bake that
+           emulator — preferring the **live** ``es_systems.xml`` command text for
+           that label (so a RetroDECK update is picked up) and falling back to the
+           bundled command. A curated label is needed because ES-DE's *first*
+           command isn't always the right one to bake (e.g. PS3's first command is
+           the shortcut form, not the direct ``--no-gui`` launch).
+        2. Otherwise fall back to the libretro default (:meth:`get_active_core`).
+        3. ``None`` when neither resolves — the caller bakes the plain launch.
+
+        Keeps the read-path/launch-path invariant: the resolved emulator is both
+        what the ROM launches with and what derived values key on.
+        """
+        defaults = self._load_core_defaults()
+        pref = defaults.get(system_name, {}).get("standalone")
+        if pref and pref.get("label"):
+            live = self._load_es_systems().get(system_name)
+            command = (live or {}).get("commands", {}).get(pref["label"]) or pref.get("command")
+            if command:
+                return EmulatorInvocation.standalone(command, pref["label"])
+
+        core_so, label = self.get_active_core(system_name)
+        if core_so:
+            return EmulatorInvocation.libretro(core_so, label)
+        return None
 
     def get_available_cores(self, system_name):
         """Return available RetroArch cores for a system.
@@ -214,6 +248,8 @@ class CoreResolver:
                 "default_label": None,
                 "cores": {},
                 "label_to_core": {},
+                "commands": {},
+                "first_command_label": None,
                 "extensions": set(),
             }
         elif name == "command":
@@ -236,12 +272,25 @@ class CoreResolver:
 
     @staticmethod
     def _handle_es_command_end(state, sys, text):
-        """Handle </command> inside a <system> — extract core info."""
+        """Handle </command> inside a <system> — capture the command + any core info.
+
+        Records EVERY ``<command>`` (libretro AND standalone) as ``label →
+        command text`` in ``commands``, and remembers the FIRST command's label
+        (ES-DE's true default emulator) in ``first_command_label``. Standalone
+        commands (PCSX2, RPCS3, …) carry no ``%CORE_RETROARCH%/<core>.so`` token,
+        so they don't populate the libretro ``cores`` / ``default_core`` maps —
+        those stay libretro-only for the BIOS/save/menu read-paths — but their
+        command text is now available for the standalone launch bake.
+        """
+        label = state["current_label"]
+        sys["commands"][label] = text
+        if sys["first_command_label"] is None:
+            sys["first_command_label"] = label
+
         match = _CORE_SO_RE.search(text)
         if not match:
             return
         core_so = match.group(1)
-        label = state["current_label"]
         sys["cores"][core_so] = label
         sys["label_to_core"][label] = core_so
         if sys["default_core"] is None:
@@ -258,6 +307,8 @@ class CoreResolver:
                 "default_label": sys["default_label"],
                 "cores": sys["cores"],
                 "label_to_core": sys["label_to_core"],
+                "commands": sys["commands"],
+                "first_command_label": sys["first_command_label"],
                 "extensions": sys["extensions"],
             }
         state["current_system"] = None
@@ -289,8 +340,12 @@ class CoreResolver:
 
         Returns: ``{system_name: {"default_core": str | None, "default_label":
         str | None, "cores": {core_so: label}, "label_to_core": {label:
-        core_so}, "extensions": set[str]}}``. ``extensions`` holds the
-        lowercased ``<extension>`` tokens ES-DE uses to decide directory-collapse.
+        core_so}, "commands": {label: command_text}, "first_command_label": str |
+        None, "extensions": set[str]}}``. ``cores``/``default_core`` are
+        libretro-only; ``commands`` holds every ``<command>`` (libretro AND
+        standalone) and ``first_command_label`` is ES-DE's true default emulator.
+        ``extensions`` holds the lowercased ``<extension>`` tokens ES-DE uses to
+        decide directory-collapse.
 
         Returns empty dict if file can't be parsed or fails structural validation.
         """

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -6,6 +6,7 @@ No I/O, no imports from services, adapters, or lib.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any
 
 # The emulator invocation prefix the launch command wraps the resolved ROM
@@ -18,27 +19,71 @@ RETRODECK_INVOCATION = "flatpak run net.retrodeck.retrodeck"
 _RETROARCH_CORES_DIR = "/var/config/retroarch/cores"
 
 
-def resolve_emulator_invocation(rom: dict[str, Any], active_core_so: str | None = None) -> str:
+@dataclass(frozen=True)
+class EmulatorInvocation:
+    """What a ROM launches with — a RetroArch libretro core OR a standalone emulator.
+
+    The plugin resolves one of these per ROM and bakes it into the shortcut's
+    ``launch_options`` via :func:`resolve_emulator_invocation`. Exactly one of
+    ``core_so`` / ``command`` carries the payload:
+
+    - ``kind == "libretro"`` → ``core_so`` is the BARE core name (no ``.so``); the
+      renderer emits the RetroArch ``-L <coresdir>/<so>.so %ROM%`` form (the cores
+      dir is baked literally because RetroDECK does not expand ``%CORE_RETROARCH%``
+      through ``-e``).
+    - ``kind == "standalone"`` → ``command`` is the full ES-DE ``<command>`` text
+      (already ending in ``%ROM%``, e.g. ``%EMULATOR_RPCS3% --no-gui %ROM%``),
+      baked verbatim into ``-e``. RetroDECK resolves ``%EMULATOR_*%`` and
+      substitutes ``%ROM%`` with the trailing rom path at launch — the same path
+      the libretro form relies on.
+
+    ``label`` is the ES-DE display label (diagnostics only). This is the
+    standalone-emulator seam (#129); read-path consumers that only understand
+    libretro keep reading ``core_so`` (``None`` for a standalone emulator) and
+    degrade exactly as they do for a ``(None, None)`` resolution.
+    """
+
+    kind: str  # "libretro" | "standalone"
+    label: str | None = None
+    core_so: str | None = None
+    command: str | None = None
+
+    @classmethod
+    def libretro(cls, core_so: str, label: str | None = None) -> EmulatorInvocation:
+        """A RetroArch libretro core, identified by its bare ``.so`` name."""
+        return cls(kind="libretro", label=label, core_so=core_so)
+
+    @classmethod
+    def standalone(cls, command: str, label: str | None = None) -> EmulatorInvocation:
+        """A standalone emulator, identified by its full ES-DE ``<command>`` text."""
+        return cls(kind="standalone", label=label, command=command)
+
+
+def resolve_emulator_invocation(rom: dict[str, Any], emulator: EmulatorInvocation | None = None) -> str:
     """Return the emulator invocation prefix for *rom*.
 
-    With ``active_core_so`` unset (``None``) the ROM follows the RetroDECK/ES-DE
-    default and resolves to the plain RetroDECK flatpak command. With a bare core
-    name it returns the RetroDECK ``-e`` override that forces that RetroArch core:
-    ``flatpak run … -e "%EMULATOR_RETROARCH% -L <cores>/<so>.so %ROM%"``. The
-    cores dir is baked literally; ``%EMULATOR_RETROARCH%`` and ``%ROM%`` remain
-    ES-DE placeholders. *rom* is the per-emulator-branch seam (#129) and is
-    ignored today.
+    With *emulator* unset (``None``) the ROM follows the plain RetroDECK flatpak
+    command (the single genuine fallback for a platform with no resolvable
+    emulator). A **libretro** invocation renders the RetroDECK ``-e`` override that
+    forces that RetroArch core:
+    ``flatpak run … -e "%EMULATOR_RETROARCH% -L <cores>/<so>.so %ROM%"`` (cores dir
+    literal; ``%EMULATOR_RETROARCH%`` / ``%ROM%`` stay ES-DE placeholders). A
+    **standalone** invocation bakes the emulator's full ES-DE command verbatim:
+    ``flatpak run … -e "<command … %ROM%>"`` (e.g. ``%EMULATOR_RPCS3% --no-gui
+    %ROM%``) — RetroDECK resolves ``%EMULATOR_*%`` and substitutes ``%ROM%`` at
+    launch. *rom* is the per-emulator-branch seam and is ignored today.
     """
     del rom  # reserved for the future per-emulator branch
-    # B4: branch on None explicitly so None never reaches the f-string (no
-    # "None.so"); an unresolvable override degrades to the plain launch upstream.
-    if active_core_so is None:
+    # Branch explicitly so a half-resolved invocation never reaches the f-string
+    # (no "None.so" / empty -e); anything unrenderable degrades to the plain launch.
+    if emulator is None:
         return RETRODECK_INVOCATION
-    # active_core_so is the BARE core name (no extension) — the es_systems parser
-    # captures the name without ".so" (regex group excludes the suffix), and both
-    # core_defaults.json and the bios registry key on bare names too. Append the
-    # ".so" here for the on-disk RetroArch core path that retroarch's -L expects.
-    return f'{RETRODECK_INVOCATION} -e "%EMULATOR_RETROARCH% -L {_RETROARCH_CORES_DIR}/{active_core_so}.so %ROM%"'
+    if emulator.kind == "standalone" and emulator.command:
+        return f'{RETRODECK_INVOCATION} -e "{emulator.command}"'
+    if emulator.kind == "libretro" and emulator.core_so:
+        # The bare core name + ".so" forms the on-disk RetroArch core path -L expects.
+        return f'{RETRODECK_INVOCATION} -e "%EMULATOR_RETROARCH% -L {_RETROARCH_CORES_DIR}/{emulator.core_so}.so %ROM%"'
+    return RETRODECK_INVOCATION
 
 
 def label_to_core_so(available_cores: list[dict[str, Any]], label: str) -> str | None:
@@ -73,7 +118,7 @@ def build_shortcuts_data(
     roms: list[dict[str, Any]],
     plugin_dir: str,
     installed_paths: dict[int, str],
-    core_overrides: dict[int, str],
+    core_overrides: dict[int, EmulatorInvocation],
 ) -> list[dict[str, Any]]:
     """Transform ROM list into shortcut data dicts for frontend AddShortcut calls.
 
@@ -81,12 +126,14 @@ def build_shortcuts_data(
     installed ROM gets a full launch command in ``launch_options``; a ROM absent
     from the map gets ``""`` (empty placeholder) until it is downloaded.
 
-    *core_overrides* maps ``rom_id`` to the **already-resolved** ``.so`` filename
-    of a per-game emulator override — only ROMs whose ``emulator_override`` LABEL
-    resolved to a real core appear (the caller omits stale ones with a WARNING).
-    A ROM absent from the map follows the RetroDECK/ES-DE default (plain launch,
-    no ``-e``); a present ROM bakes the ``-e`` override into ``launch_options``.
-    Required so a new bake site can never silently skip the override.
+    *core_overrides* maps ``rom_id`` to the **already-resolved**
+    :class:`EmulatorInvocation` the ROM launches with (its full active emulator —
+    libretro core or standalone — folding the per-game/per-platform override over
+    the es_systems default). Only ROMs that resolved to an emulator appear (the
+    caller omits the ``(None, None)`` fallback); a ROM absent from the map follows
+    the plain RetroDECK launch, a present ROM bakes its ``-e`` form into
+    ``launch_options``. Required so a new bake site can never silently skip the
+    override.
     """
     exe = os.path.join(plugin_dir, "bin", "rom-launcher")
     start_dir = os.path.join(plugin_dir, "bin")

--- a/py_modules/services/active_core_resolver.py
+++ b/py_modules/services/active_core_resolver.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from domain.shortcut_data import label_to_core_so
+from domain.shortcut_data import EmulatorInvocation, label_to_core_so
 
 if TYPE_CHECKING:
     import logging
@@ -61,29 +61,29 @@ class ActiveCoreResolver:
         self._resolve_system = config.resolve_system
         self._logger = config.logger
 
-    def active_core_for_rom(self, rom_id: int) -> tuple[str | None, str | None]:
-        """Return the ``(core_so, label)`` the ROM ``rom_id`` will launch with.
+    def active_emulator_for_rom(self, rom_id: int) -> EmulatorInvocation | None:
+        """Return the :class:`EmulatorInvocation` the ROM ``rom_id`` will launch with.
 
-        Reads the ROM's ``platform_slug`` + ``emulator_override`` once, then
-        applies the four-layer precedence:
+        The launch-bake seam. Reads the ROM's ``platform_slug`` +
+        ``emulator_override`` once, then applies the four-layer precedence:
 
-        1. Per-game DB ``emulator_override``: resolves the stored LABEL through
-           the es_systems ``available_cores`` map and returns ``(core_so,
-           label)`` when it resolves.
-        2. Per-platform ``settings.json`` core: resolves the platform's stored
-           LABEL the same way and returns it when it resolves.
-        3. es_systems default (system-layer ``get_active_core``).
-        4. ``core_defaults`` fallback (also via ``get_active_core``).
+        1. Per-game DB ``emulator_override`` (a libretro core LABEL from the
+           picker) → a libretro invocation when it resolves.
+        2. Per-platform ``settings.json`` core (also a libretro LABEL) → a
+           libretro invocation when it resolves.
+        3. / 4. System-layer default via ``get_default_emulator`` — which is
+           **standalone-aware**: it returns a standalone invocation (PCSX2, RPCS3,
+           …) for systems whose working emulator isn't a libretro core, else the
+           libretro es_systems / ``core_defaults`` default.
 
-        The system layer may yield ``(None, None)`` when nothing is configured;
-        that passes through unchanged. A stale per-game or per-platform label is
-        never fatal and never produces a bogus ``.so`` — it degrades to the next
-        layer with a WARNING.
+        Returns ``None`` when the platform has no resolvable emulator at all (the
+        caller bakes the plain launch). A stale per-game/per-platform label is
+        never fatal — it degrades to the next layer with a WARNING.
         """
         rom = self._read_rom(rom_id)
         if rom is None:
-            self._logger.warning("active_core_resolver: no ROM for rom_id=%s; resolving to (None, None)", rom_id)
-            return (None, None)
+            self._logger.warning("active_core_resolver: no ROM for rom_id=%s; resolving to plain launch", rom_id)
+            return None
 
         system = self._resolve_system(rom.platform_slug)
         available = self._core_info.get_available_cores(system)
@@ -92,7 +92,7 @@ class ActiveCoreResolver:
         if override is not None:
             core_so = label_to_core_so(available, override)
             if core_so is not None:
-                return (core_so, override)
+                return EmulatorInvocation.libretro(core_so, override)
             self._logger.warning(
                 "active_core_resolver: per-game override '%s' for rom_id=%s no longer resolves on %s; "
                 "degrading to the per-platform/system default",
@@ -105,7 +105,7 @@ class ActiveCoreResolver:
         if platform_label is not None:
             core_so = label_to_core_so(available, platform_label)
             if core_so is not None:
-                return (core_so, platform_label)
+                return EmulatorInvocation.libretro(core_so, platform_label)
             self._logger.warning(
                 "active_core_resolver: per-platform core '%s' for %s (rom_id=%s) no longer resolves; "
                 "degrading to the system default",
@@ -114,7 +114,23 @@ class ActiveCoreResolver:
                 rom_id,
             )
 
-        return self._core_info.get_active_core(system)
+        return self._core_info.get_default_emulator(system)
+
+    def active_core_for_rom(self, rom_id: int) -> tuple[str | None, str | None]:
+        """Return the ``(core_so, label)`` the ROM ``rom_id`` will launch with.
+
+        The read-path projection of :meth:`active_emulator_for_rom`, kept for the
+        ``.so``-space consumers (BIOS status, per-core save dir, save-emulator
+        tag, core-change detection, the cores menu's active marker). A **libretro**
+        emulator yields its ``(core_so, label)``; a **standalone** emulator yields
+        ``(None, label)`` — those consumers already degrade on a ``None`` core
+        exactly as they did for the old ``(None, None)`` resolution, so the
+        read-path core never disagrees with the (now possibly standalone) launch.
+        """
+        emulator = self.active_emulator_for_rom(rom_id)
+        if emulator is None:
+            return (None, None)
+        return (emulator.core_so, emulator.label)
 
     def _read_rom(self, rom_id: int) -> Rom | None:
         with self._uow_factory() as uow:

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -248,9 +248,7 @@ class CoreService:
             uow.roms.set_emulator_override(rom_id, rom.emulator_override)
             # The picker only offers libretro cores, so a pinned override is a
             # libretro invocation built from the just-resolved .so.
-            launch_options, app_id = self._launch_options_for(
-                uow, rom, EmulatorInvocation.libretro(core_so, label)
-            )
+            launch_options, app_id = self._launch_options_for(uow, rom, EmulatorInvocation.libretro(core_so, label))
         return {"success": True, "launch_options": launch_options, "app_id": app_id}
 
     async def clear_game_core(self, rom_id: int) -> dict[str, Any]:

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.shortcut_data import (
+    EmulatorInvocation,
     build_launch_options,
     label_to_core_so,
     resolve_emulator_invocation,
@@ -163,8 +164,8 @@ class CoreService:
                 install = uow.rom_installs.get(rom.rom_id)
                 if install is None:
                     continue
-                core_so, _label = self._active_core.active_core_for_rom(rom.rom_id)
-                invocation = resolve_emulator_invocation({}, core_so)
+                emulator = self._active_core.active_emulator_for_rom(rom.rom_id)
+                invocation = resolve_emulator_invocation({}, emulator)
                 # Fold the ROM's persisted disc pick over the install so a
                 # per-platform core change re-bakes the pinned disc, not disc 1 /
                 # the m3u. A single-disc ROM resolves to its own file_path. The
@@ -245,7 +246,11 @@ class CoreService:
             # write path (never the sync UPSERT).
             rom.pin_emulator_override(label)
             uow.roms.set_emulator_override(rom_id, rom.emulator_override)
-            launch_options, app_id = self._launch_options_for(uow, rom, core_so)
+            # The picker only offers libretro cores, so a pinned override is a
+            # libretro invocation built from the just-resolved .so.
+            launch_options, app_id = self._launch_options_for(
+                uow, rom, EmulatorInvocation.libretro(core_so, label)
+            )
         return {"success": True, "launch_options": launch_options, "app_id": app_id}
 
     async def clear_game_core(self, rom_id: int) -> dict[str, Any]:
@@ -276,24 +281,24 @@ class CoreService:
             rom.clear_emulator_override()
             uow.roms.set_emulator_override(rom_id, rom.emulator_override)
             # Cleared pin → follow the per-platform/system default. Resolve the
-            # ROM's full active core AFTER the NULL lands so a per-platform core
-            # still bakes its -e override (not a plain launch).
-            core_so, _label = self._active_core.active_core_for_rom(rom_id)
-            launch_options, app_id = self._launch_options_for(uow, rom, core_so)
+            # ROM's full active emulator AFTER the NULL lands so a per-platform
+            # core (or a standalone system default) still bakes its -e form.
+            emulator = self._active_core.active_emulator_for_rom(rom_id)
+            launch_options, app_id = self._launch_options_for(uow, rom, emulator)
         return {"success": True, "launch_options": launch_options, "app_id": app_id}
 
     def _launch_options_for(
         self,
         uow: UnitOfWork,
         rom: Rom,
-        active_core_so: str | None,
+        emulator: EmulatorInvocation | None,
     ) -> tuple[str | None, int | None]:
-        """Bake the launch command for *rom* with *active_core_so*, or ``(None, None)``.
+        """Bake the launch command for *rom* with *emulator*, or ``(None, None)``.
 
         An installed (``RomInstall`` with a ``file_path``) **and** bound
         (``shortcut_app_id`` set) ROM gets the full launch command — the ``-e``
-        override form when ``active_core_so`` is set, the plain form when it is
-        ``None`` — over the disc-resolved bake path (the ROM's persisted
+        form when *emulator* is set (libretro core or standalone), the plain form
+        when it is ``None`` — over the disc-resolved bake path (the ROM's persisted
         ``selected_disc`` for a multi-disc ROM, its ``file_path`` unchanged for a
         single-disc ROM), paired with its Steam ``app_id``. An uninstalled or
         unbound ROM has no live shortcut to update, so both are ``None`` and the
@@ -305,7 +310,7 @@ class CoreService:
         install = uow.rom_installs.get(rom.rom_id)
         if install is None:
             return (None, None)
-        invocation = resolve_emulator_invocation({}, active_core_so)
+        invocation = resolve_emulator_invocation({}, emulator)
         # Fold the ROM's persisted disc pick over the install so a per-game core
         # pin/clear re-bakes the pinned disc, not disc 1 / the m3u. A single-disc
         # ROM resolves to its own file_path. *rom* is already loaded in the open

--- a/py_modules/services/disc.py
+++ b/py_modules/services/disc.py
@@ -175,5 +175,5 @@ class DiscService:
         keeps it from nesting on the same SQLite connection.
         """
         bake_path = self._disc_resolver.resolve_bake_path(install, discs, selected_disc)
-        core_so, _label = self._active_core.active_core_for_rom(rom_id)
-        return build_launch_options(resolve_emulator_invocation({"id": rom_id}, core_so), bake_path)
+        emulator = self._active_core.active_emulator_for_rom(rom_id)
+        return build_launch_options(resolve_emulator_invocation({"id": rom_id}, emulator), bake_path)

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -491,9 +491,7 @@ class DownloadService:
             cleanup=lambda: self._download_file_store.remove_file(target_path),
         )
 
-    def _resolve_bound_app_id(
-        self, rom_id: int, file_path: str
-    ) -> tuple[int | None, EmulatorInvocation | None, str]:
+    def _resolve_bound_app_id(self, rom_id: int, file_path: str) -> tuple[int | None, EmulatorInvocation | None, str]:
         """Return the ROM's ``(shortcut_app_id, emulator, bake_path)`` for the re-bake.
 
         Reads the ROM + its fresh install record in a short read UoW, then
@@ -719,9 +717,7 @@ class DownloadService:
                 "platform_name": platform_name,
                 "file_path": final_path,
                 "app_id": app_id,
-                "launch_options": build_launch_options(
-                    resolve_emulator_invocation(rom_detail, emulator), bake_path
-                ),
+                "launch_options": build_launch_options(resolve_emulator_invocation(rom_detail, emulator), bake_path),
                 "resumable": entry.get("resumable", False),
             },
         )

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -25,7 +25,7 @@ from domain.rom_files import (
     resolve_local_file_name,
 )
 from domain.rom_install import RomInstall
-from domain.shortcut_data import build_launch_options, resolve_emulator_invocation
+from domain.shortcut_data import EmulatorInvocation, build_launch_options, resolve_emulator_invocation
 from lib.errors import error_response
 from lib.list_result import ErrorCode
 from lib.path_safety import PathTraversalError, safe_join
@@ -491,23 +491,25 @@ class DownloadService:
             cleanup=lambda: self._download_file_store.remove_file(target_path),
         )
 
-    def _resolve_bound_app_id(self, rom_id: int, file_path: str) -> tuple[int | None, str | None, str]:
-        """Return the ROM's ``(shortcut_app_id, active_core_so, bake_path)`` for the re-bake.
+    def _resolve_bound_app_id(
+        self, rom_id: int, file_path: str
+    ) -> tuple[int | None, EmulatorInvocation | None, str]:
+        """Return the ROM's ``(shortcut_app_id, emulator, bake_path)`` for the re-bake.
 
         Reads the ROM + its fresh install record in a short read UoW, then
-        resolves the ROM's FULL active core through the shared ``active_core``
+        resolves the ROM's FULL active emulator through the shared ``active_core``
         resolver and the multi-disc launch path through the shared
         ``disc_resolver`` so ``download_complete`` re-bakes the right launch
         command. ``app_id`` is ``None`` when the ROM has no Steam shortcut yet
         (not synced) — the frontend no-ops and the next sync writes the launch
-        command. ``active_core_so`` is the resolved ``.so`` when the ROM's
-        per-game/per-platform/system resolution yields a core (bake the ``-e``
-        form), ``None`` when it resolves to ``(None, None)`` — a genuinely
-        unresolvable platform (bake the plain launch). ``bake_path`` is the
-        selected disc's path for a multi-disc ROM (the persisted pick survives
+        command. ``emulator`` is the resolved :class:`EmulatorInvocation` (libretro
+        core or standalone) when the ROM's per-game/per-platform/system resolution
+        yields one (bake the ``-e`` form), ``None`` when it resolves to nothing — a
+        genuinely unresolvable platform (bake the plain launch). ``bake_path`` is
+        the selected disc's path for a multi-disc ROM (the persisted pick survives
         uninstall → reinstall, just like the core override), or *file_path*
         unchanged for a single-disc ROM. The resolver already warns + degrades on
-        a stale label/pin, so no bogus ``None.so`` or missing-disc path ever
+        a stale label/pin, so no bogus invocation or missing-disc path ever
         reaches the bake. This is the load-bearing site: the per-game override and
         the disc pin both live on ``roms`` so they survive uninstall → reinstall,
         and reinstall goes through here.
@@ -518,14 +520,14 @@ class DownloadService:
             selected_disc = rom.selected_disc if rom is not None else None
         if rom is None:
             return (None, None, file_path)
-        core_so, _label = self._active_core.active_core_for_rom(int(rom_id))
+        emulator = self._active_core.active_emulator_for_rom(int(rom_id))
         # The install record was committed just before this read, so it is
         # present in the normal flow; guard for the rare race where it is not and
         # fall back to the raw download path (no multi-disc resolution possible).
         bake_path = (
             self._disc_resolver.resolve_for_install(install, selected_disc) if install is not None else file_path
         )
-        return (rom.shortcut_app_id, core_so, bake_path)
+        return (rom.shortcut_app_id, emulator, bake_path)
 
     def _make_progress_callback(self, rom_id, rom_name, platform_name, file_name, control=None):
         """Build a throttled progress callback for a download."""
@@ -706,7 +708,7 @@ class DownloadService:
         entry = self._download_queue[rom_id]
         entry["status"] = "completed"
         entry["progress"] = 1.0
-        app_id, active_core_so, bake_path = await self._loop.run_in_executor(
+        app_id, emulator, bake_path = await self._loop.run_in_executor(
             None, self._resolve_bound_app_id, rom_id, final_path
         )
         await self._emit(
@@ -718,7 +720,7 @@ class DownloadService:
                 "file_path": final_path,
                 "app_id": app_id,
                 "launch_options": build_launch_options(
-                    resolve_emulator_invocation(rom_detail, active_core_so), bake_path
+                    resolve_emulator_invocation(rom_detail, emulator), bake_path
                 ),
                 "resumable": entry.get("resumable", False),
             },

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.preview_delta import PreviewDelta
-from domain.shortcut_data import build_shortcuts_data
+from domain.shortcut_data import EmulatorInvocation, build_shortcuts_data
 from domain.sync_diff import (
     classify_roms,
     compute_collection_diff,
@@ -901,24 +901,24 @@ class SyncOrchestrator:
             stale_rom_ids=[rom_id for rom_id, _app_id in stale],
         )
 
-    def _build_core_overrides(self, roms: list[dict[str, Any]]) -> dict[int, str]:
-        """Resolve each ROM's FULL active core to its ``.so`` for the bake.
+    def _build_core_overrides(self, roms: list[dict[str, Any]]) -> dict[int, EmulatorInvocation]:
+        """Resolve each ROM's FULL active emulator for the bake.
 
         Runs every ROM in *roms* through the shared per-ROM ``active_core``
-        resolver (the single read-path seam that folds the per-game
-        ``emulator_override`` and per-platform ``settings.json`` core over the
-        es_systems default). Only ROMs that resolve to a non-``None`` core appear
-        in the returned ``{rom_id: core_so}`` map, so :func:`build_shortcuts_data`
-        bakes the ``-e`` override for them; a ROM that resolves to ``(None,
-        None)`` (a genuinely unresolvable platform) is absent and falls back to
-        the plain launch. The resolver already warns + degrades on a stale label,
-        so no bogus ``None.so`` ever reaches the bake.
+        resolver (the single seam that folds the per-game ``emulator_override``
+        and per-platform ``settings.json`` core over the standalone-aware
+        es_systems default). Only ROMs that resolve to an emulator (libretro core
+        or standalone) appear in the returned ``{rom_id: EmulatorInvocation}``
+        map, so :func:`build_shortcuts_data` bakes their ``-e`` form; a ROM that
+        resolves to nothing (a genuinely unresolvable platform) is absent and
+        falls back to the plain launch. The resolver already warns + degrades on
+        a stale label, so no bogus invocation ever reaches the bake.
         """
-        resolved: dict[int, str] = {}
+        resolved: dict[int, EmulatorInvocation] = {}
         for rom in roms:
-            core_so, _label = self._active_core.active_core_for_rom(rom["id"])
-            if core_so is not None:
-                resolved[rom["id"]] = core_so
+            emulator = self._active_core.active_emulator_for_rom(rom["id"])
+            if emulator is not None:
+                resolved[rom["id"]] = emulator
         return resolved
 
     def _scan_installed_paths(self) -> dict[int, str]:

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from domain.disc_selection import Disc
     from domain.rom_install import RomInstall
     from domain.save_layout import SaveLayout
+    from domain.shortcut_data import EmulatorInvocation
 
 
 class RetryStrategy(Protocol):
@@ -50,16 +51,19 @@ class BiosChecker(Protocol):
 class ActiveCoreReader(Protocol):
     """Per-ROM active-core resolution consumed by the read-path core consumers.
 
-    The composition root satisfies this with ``ActiveCoreResolver``. Consumers
-    (BIOS status, per-core save dir, save-emulator tag, core-change detection,
-    and the launch-bake sites) ask "which ``.so`` will this ROM launch with?"
-    and operate entirely in ``.so`` space — the resolver runs the stored
-    ``emulator_override`` LABEL through ``label_to_core_so`` so no consumer ever
-    sees the raw DB label. ``(None, None)`` means the system has no configured
-    core; a stale override degrades to the system default rather than raising.
+    The composition root satisfies this with ``ActiveCoreResolver``. The
+    ``.so``-space read consumers (BIOS status, per-core save dir, save-emulator
+    tag, core-change detection, the cores menu) call ``active_core_for_rom`` and
+    operate entirely in ``.so`` space — ``(None, None)`` / ``(None, label)`` means
+    no libretro core (unconfigured, or a standalone emulator) and they degrade.
+    The launch-bake sites call ``active_emulator_for_rom``, which also describes
+    **standalone** emulators (PCSX2, RPCS3, …) via a full ES-DE command. Both draw
+    from the same resolution, so the read-path core never diverges from the launch.
     """
 
     def active_core_for_rom(self, rom_id: int) -> tuple[str | None, str | None]: ...
+
+    def active_emulator_for_rom(self, rom_id: int) -> EmulatorInvocation | None: ...
 
 
 class DiscResolver(Protocol):

--- a/py_modules/services/protocols/paths.py
+++ b/py_modules/services/protocols/paths.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from domain.save_layout import SaveLayout
+    from domain.shortcut_data import EmulatorInvocation
     from lib.retrodeck_health import RetroDeckConfigHealth
 
 
@@ -77,6 +78,8 @@ class CoreInfoProvider(Protocol):
     """
 
     def get_active_core(self, system_name: str) -> tuple[str | None, str | None]: ...
+
+    def get_default_emulator(self, system_name: str) -> EmulatorInvocation | None: ...
 
     def get_available_cores(self, system_name: str) -> list[dict[str, Any]]: ...
 

--- a/py_modules/services/relaunch_options_resolver.py
+++ b/py_modules/services/relaunch_options_resolver.py
@@ -75,8 +75,8 @@ class RelaunchOptionsResolver:
         multi-disc ROM bakes its selected disc's path, a single-disc ROM its own
         ``file_path``.
         """
-        core_so, _label = self._active_core.active_core_for_rom(rom.rom_id)
-        invocation = resolve_emulator_invocation({"id": rom.rom_id}, core_so)
+        emulator = self._active_core.active_emulator_for_rom(rom.rom_id)
+        invocation = resolve_emulator_invocation({"id": rom.rom_id}, emulator)
         bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
         return {
             "app_id": rom.shortcut_app_id,

--- a/tests/adapters/test_es_de_config.py
+++ b/tests/adapters/test_es_de_config.py
@@ -434,7 +434,9 @@ class TestGetDefaultEmulator:
     def test_standalone_pref_prefers_live_es_systems_command(self):
         resolver = _make_resolver()
         defaults = {
-            "ps3": {"standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --bundled %ROM%"}}
+            "ps3": {
+                "standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --bundled %ROM%"}
+            }
         }
         live = {"ps3": {"commands": {"RPCS3 Directory (Standalone)": "%EMULATOR_RPCS3% --no-gui %ROM%"}}}
         with (
@@ -450,7 +452,9 @@ class TestGetDefaultEmulator:
     def test_standalone_pref_falls_back_to_bundled_command(self):
         resolver = _make_resolver()
         defaults = {
-            "ps3": {"standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --no-gui %ROM%"}}
+            "ps3": {
+                "standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --no-gui %ROM%"}
+            }
         }
         # es_systems.xml absent (or lacks the curated label) → bundled command.
         with (

--- a/tests/adapters/test_es_de_config.py
+++ b/tests/adapters/test_es_de_config.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 
 from adapters.es_de_config import CoreResolver
+from domain.shortcut_data import EmulatorInvocation
 
 # conftest.py patches decky before this import.
 # main.py adds py_modules to sys.path (provides vdf, etc.).
@@ -216,6 +217,44 @@ class TestParseEsSystems:
         finally:
             os.unlink(path)
 
+    def test_every_command_captured_including_standalone(self, resolver):
+        # The standalone seam (#129): ``commands`` records EVERY <command> by
+        # label, libretro AND standalone — even the ones excluded from ``cores``.
+        path = _write_temp_xml(SAMPLE_ES_SYSTEMS_XML)
+        try:
+            result = resolver.parse_es_systems(path)
+            gba = result["gba"]
+            assert set(gba["commands"]) == {"mGBA", "gpSP", "VBA-M", "mGBA Standalone"}
+            # The standalone command text is preserved verbatim for the bake.
+            assert gba["commands"]["mGBA Standalone"] == "%EMULATOR_MGBA% %ROM%"
+        finally:
+            os.unlink(path)
+
+    def test_first_command_label_records_es_de_default_emulator(self, resolver):
+        # ``first_command_label`` is ES-DE's true default emulator — the FIRST
+        # <command>, even when that command is a standalone (no %CORE_RETROARCH%).
+        xml = """\
+<?xml version="1.0"?>
+<systemList>
+  <system>
+    <name>ps2</name>
+    <command label="PCSX2 (Standalone)">%EMULATOR_PCSX2% -batch %ROM%</command>
+    <command label="LRPS2">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/pcsx2_libretro.so %ROM%</command>
+  </system>
+</systemList>
+"""
+        path = _write_temp_xml(xml)
+        try:
+            result = resolver.parse_es_systems(path)
+            ps2 = result["ps2"]
+            # ES-DE's default emulator is the standalone, but the libretro
+            # ``default_core`` capture stays the first LIBRETRO command.
+            assert ps2["first_command_label"] == "PCSX2 (Standalone)"
+            assert ps2["default_core"] == "pcsx2_libretro"
+            assert ps2["commands"]["PCSX2 (Standalone)"] == "%EMULATOR_PCSX2% -batch %ROM%"
+        finally:
+            os.unlink(path)
+
 
 # A realistic multi-platform excerpt mirroring RetroDECK's shipped es_systems.xml
 # (linux/). The first RetroArch %CORE_RETROARCH% command per system is the
@@ -381,6 +420,72 @@ class TestGetActiveCore:
         ):
             result = resolver.get_active_core("totally_unknown_system")
         assert result == (None, None)
+
+
+class TestGetDefaultEmulator:
+    """The standalone-aware system layer (#129).
+
+    A system with a curated ``standalone`` block in ``core_defaults.json`` bakes
+    that emulator (preferring the live ``es_systems.xml`` command for the curated
+    label, falling back to the bundled command); a system without one projects
+    the libretro ``get_active_core`` default; an unresolvable system → ``None``.
+    """
+
+    def test_standalone_pref_prefers_live_es_systems_command(self):
+        resolver = _make_resolver()
+        defaults = {
+            "ps3": {"standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --bundled %ROM%"}}
+        }
+        live = {"ps3": {"commands": {"RPCS3 Directory (Standalone)": "%EMULATOR_RPCS3% --no-gui %ROM%"}}}
+        with (
+            mock.patch.object(CoreResolver, "_load_core_defaults", return_value=defaults),
+            mock.patch.object(CoreResolver, "_load_es_systems", return_value=live),
+        ):
+            result = resolver.get_default_emulator("ps3")
+        # Live command for the curated label wins over the bundled fallback.
+        assert result == EmulatorInvocation.standalone(
+            "%EMULATOR_RPCS3% --no-gui %ROM%", "RPCS3 Directory (Standalone)"
+        )
+
+    def test_standalone_pref_falls_back_to_bundled_command(self):
+        resolver = _make_resolver()
+        defaults = {
+            "ps3": {"standalone": {"label": "RPCS3 Directory (Standalone)", "command": "%EMULATOR_RPCS3% --no-gui %ROM%"}}
+        }
+        # es_systems.xml absent (or lacks the curated label) → bundled command.
+        with (
+            mock.patch.object(CoreResolver, "_load_core_defaults", return_value=defaults),
+            mock.patch.object(CoreResolver, "_load_es_systems", return_value={}),
+        ):
+            result = resolver.get_default_emulator("ps3")
+        assert result == EmulatorInvocation.standalone(
+            "%EMULATOR_RPCS3% --no-gui %ROM%", "RPCS3 Directory (Standalone)"
+        )
+
+    def test_no_standalone_pref_projects_libretro_default(self):
+        resolver = _make_resolver()
+        live = {
+            "gba": {
+                "default_core": "mgba_libretro",
+                "default_label": "mGBA",
+                "cores": {"mgba_libretro": "mGBA"},
+            }
+        }
+        with (
+            mock.patch.object(CoreResolver, "_load_core_defaults", return_value={}),
+            mock.patch.object(CoreResolver, "_load_es_systems", return_value=live),
+        ):
+            result = resolver.get_default_emulator("gba")
+        assert result == EmulatorInvocation.libretro("mgba_libretro", "mGBA")
+
+    def test_unresolvable_system_returns_none(self):
+        resolver = _make_resolver()
+        with (
+            mock.patch.object(CoreResolver, "_load_core_defaults", return_value={}),
+            mock.patch.object(CoreResolver, "_load_es_systems", return_value={}),
+        ):
+            result = resolver.get_default_emulator("totally_unknown_system")
+        assert result is None
 
 
 class TestGetAvailableCores:

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -32,6 +32,19 @@ class TestResolveEmulatorInvocation:
         assert result == RETRODECK_INVOCATION
         assert "-e" not in result
 
+    def test_unrenderable_invocation_degrades_to_plain(self):
+        # A non-None but half-resolved invocation (standalone without a command,
+        # libretro without a core_so, or an unknown kind) must never reach the
+        # f-string and bake a broken -e — it degrades to the plain launch.
+        for emulator in (
+            EmulatorInvocation(kind="standalone", command=None),
+            EmulatorInvocation(kind="libretro", core_so=None),
+            EmulatorInvocation(kind="unknown"),
+        ):
+            result = resolve_emulator_invocation({"id": 1}, emulator)
+            assert result == RETRODECK_INVOCATION
+            assert "-e" not in result
+
     def test_one_arg_default_has_no_override(self):
         assert "-e" not in resolve_emulator_invocation({"id": 1})
 
@@ -278,7 +291,9 @@ class TestBuildShortcutsData:
     def test_installed_rom_absent_from_overrides_is_plain(self):
         # A rom_id NOT in core_overrides follows the default — plain launch, no -e.
         roms = [{"id": 1, "name": "Plain"}]
-        result = build_shortcuts_data(roms, "/plugin", {1: "/roms/n64/g.z64"}, {2: EmulatorInvocation.libretro("other_libretro")})
+        result = build_shortcuts_data(
+            roms, "/plugin", {1: "/roms/n64/g.z64"}, {2: EmulatorInvocation.libretro("other_libretro")}
+        )
         assert result[0]["launch_options"] == 'flatpak run net.retrodeck.retrodeck "/roms/n64/g.z64"'
         assert "-e" not in result[0]["launch_options"]
 

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -5,6 +5,7 @@ import shlex
 
 from domain.shortcut_data import (
     RETRODECK_INVOCATION,
+    EmulatorInvocation,
     build_launch_options,
     build_shortcuts_data,
     label_to_core_so,
@@ -38,7 +39,7 @@ class TestResolveEmulatorInvocation:
         # Byte-exact golden -e string: literal cores dir, preserved %…% placeholders.
         # The core name is BARE (no extension) as the es_systems parser yields it;
         # the bake appends exactly one ".so" for the on-disk RetroArch core path.
-        result = resolve_emulator_invocation({"id": 1}, "pcsx_rearmed_libretro")
+        result = resolve_emulator_invocation({"id": 1}, EmulatorInvocation.libretro("pcsx_rearmed_libretro"))
         assert result == (
             "flatpak run net.retrodeck.retrodeck "
             '-e "%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/pcsx_rearmed_libretro.so %ROM%"'
@@ -48,18 +49,33 @@ class TestResolveEmulatorInvocation:
         # Regression for the on-device crash: the bake appended no ".so" and the
         # fakes hid it by passing ".so"-suffixed names. With the real bare name
         # the baked -L path must carry exactly one ".so" — not zero, not two.
-        result = resolve_emulator_invocation({"id": 1}, "pcsx_rearmed")
+        result = resolve_emulator_invocation({"id": 1}, EmulatorInvocation.libretro("pcsx_rearmed"))
         assert "/var/config/retroarch/cores/pcsx_rearmed.so" in result
         assert "pcsx_rearmed.so.so" not in result
         assert "/cores/pcsx_rearmed %ROM%" not in result
 
     def test_core_so_uses_literal_cores_dir_and_keeps_placeholders(self):
-        result = resolve_emulator_invocation({"id": 1}, "pcsx_rearmed_libretro")
+        result = resolve_emulator_invocation({"id": 1}, EmulatorInvocation.libretro("pcsx_rearmed_libretro"))
         assert "/var/config/retroarch/cores" in result
         assert "%EMULATOR_RETROARCH%" in result
         assert "%ROM%" in result
         # The cores dir is baked literally; %CORE_RETROARCH% is NOT used.
         assert "%CORE_RETROARCH%" not in result
+
+    def test_standalone_bakes_command_verbatim(self):
+        # A standalone emulator's full ES-DE <command> (already ending in %ROM%) is
+        # baked verbatim into -e; RetroDECK expands %EMULATOR_*% and %ROM% at launch.
+        result = resolve_emulator_invocation(
+            {"id": 1}, EmulatorInvocation.standalone("%EMULATOR_RPCS3% --no-gui %ROM%")
+        )
+        assert result == 'flatpak run net.retrodeck.retrodeck -e "%EMULATOR_RPCS3% --no-gui %ROM%"'
+        # No libretro -L form leaks in for a standalone emulator.
+        assert "-L " not in result
+        assert "%CORE_RETROARCH%" not in result
+
+    def test_standalone_ps2_batch_form(self):
+        result = resolve_emulator_invocation({"id": 1}, EmulatorInvocation.standalone("%EMULATOR_PCSX2% -batch %ROM%"))
+        assert result == 'flatpak run net.retrodeck.retrodeck -e "%EMULATOR_PCSX2% -batch %ROM%"'
 
     def test_none_never_yields_none_so(self):
         # B4 guard: a None core must never reach the f-string as the literal "None.so".
@@ -166,7 +182,7 @@ class TestBuildLaunchOptions:
         ]
 
     def test_override_invocation_is_preserved_unescaped(self):
-        invocation = resolve_emulator_invocation({"id": 1}, "mgba")
+        invocation = resolve_emulator_invocation({"id": 1}, EmulatorInvocation.libretro("mgba"))
         path = '/roms/gba/Game".gba'
         result = build_launch_options(invocation, path)
         # The invocation's own -e "..." quoting is part of the trusted prefix and
@@ -236,24 +252,40 @@ class TestBuildShortcutsData:
     def test_installed_rom_with_core_override_bakes_e_form(self):
         # A rom_id present in core_overrides bakes the -e override into its launch.
         roms = [{"id": 1, "name": "PSX Game"}]
-        result = build_shortcuts_data(roms, "/plugin", {1: "/roms/psx/game.chd"}, {1: "pcsx_rearmed_libretro"})
+        result = build_shortcuts_data(
+            roms, "/plugin", {1: "/roms/psx/game.chd"}, {1: EmulatorInvocation.libretro("pcsx_rearmed_libretro")}
+        )
         assert result[0]["launch_options"] == (
             "flatpak run net.retrodeck.retrodeck "
             '-e "%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/pcsx_rearmed_libretro.so %ROM%" '
             '"/roms/psx/game.chd"'
         )
 
+    def test_installed_rom_with_standalone_override_bakes_e_form(self):
+        # A standalone emulator override bakes its verbatim ES-DE command into -e.
+        roms = [{"id": 1, "name": "PS3 Game"}]
+        result = build_shortcuts_data(
+            roms,
+            "/plugin",
+            {1: "/roms/ps3/game/PS3_GAME/USRDIR/EBOOT.BIN"},
+            {1: EmulatorInvocation.standalone("%EMULATOR_RPCS3% --no-gui %ROM%")},
+        )
+        assert result[0]["launch_options"] == (
+            'flatpak run net.retrodeck.retrodeck -e "%EMULATOR_RPCS3% --no-gui %ROM%" '
+            '"/roms/ps3/game/PS3_GAME/USRDIR/EBOOT.BIN"'
+        )
+
     def test_installed_rom_absent_from_overrides_is_plain(self):
         # A rom_id NOT in core_overrides follows the default — plain launch, no -e.
         roms = [{"id": 1, "name": "Plain"}]
-        result = build_shortcuts_data(roms, "/plugin", {1: "/roms/n64/g.z64"}, {2: "other_libretro"})
+        result = build_shortcuts_data(roms, "/plugin", {1: "/roms/n64/g.z64"}, {2: EmulatorInvocation.libretro("other_libretro")})
         assert result[0]["launch_options"] == 'flatpak run net.retrodeck.retrodeck "/roms/n64/g.z64"'
         assert "-e" not in result[0]["launch_options"]
 
     def test_uninstalled_rom_with_override_still_empty(self):
         # An override on an UNINSTALLED rom can't bake — no path, empty placeholder.
         roms = [{"id": 1, "name": "NotDownloaded"}]
-        result = build_shortcuts_data(roms, "/plugin", {}, {1: "pcsx_rearmed_libretro"})
+        result = build_shortcuts_data(roms, "/plugin", {}, {1: EmulatorInvocation.libretro("pcsx_rearmed_libretro")})
         assert result[0]["launch_options"] == ""
 
     def test_empty_roms(self):

--- a/tests/fakes/fake_active_core_resolver.py
+++ b/tests/fakes/fake_active_core_resolver.py
@@ -8,6 +8,8 @@ recorded so a consumer test can assert the seam was queried by ``rom_id``.
 
 from __future__ import annotations
 
+from domain.shortcut_data import EmulatorInvocation
+
 
 class FakeActiveCoreResolver:
     """Maps ``rom_id`` to a configured ``(core_so, label)`` for tests.
@@ -15,6 +17,14 @@ class FakeActiveCoreResolver:
     ``per_rom`` takes precedence; any ``rom_id`` absent from it resolves to
     ``default``. ``calls`` records each queried ``rom_id`` so consumer tests can
     assert the seam was reached with the right ROM.
+
+    :meth:`active_emulator_for_rom` is the launch-bake seam. By default it
+    projects the same ``(core_so, label)`` tuple config into a libretro
+    :class:`EmulatorInvocation` (or ``None`` when the core is ``None``), so the
+    existing tuple-configured tests keep working unchanged. To exercise a
+    **standalone** emulator (PCSX2, RPCS3, …), pass an explicit
+    ``default_emulator`` and/or ``per_rom_emulator`` map — those take precedence
+    over the tuple projection.
     """
 
     def __init__(
@@ -22,11 +32,29 @@ class FakeActiveCoreResolver:
         *,
         default: tuple[str | None, str | None] = (None, None),
         per_rom: dict[int, tuple[str | None, str | None]] | None = None,
+        default_emulator: EmulatorInvocation | None = None,
+        per_rom_emulator: dict[int, EmulatorInvocation | None] | None = None,
     ) -> None:
         self.default = default
         self.per_rom: dict[int, tuple[str | None, str | None]] = per_rom if per_rom is not None else {}
+        self.default_emulator = default_emulator
+        self.per_rom_emulator: dict[int, EmulatorInvocation | None] = (
+            per_rom_emulator if per_rom_emulator is not None else {}
+        )
         self.calls: list[int] = []
+        self.emulator_calls: list[int] = []
 
     def active_core_for_rom(self, rom_id: int) -> tuple[str | None, str | None]:
         self.calls.append(rom_id)
         return self.per_rom.get(rom_id, self.default)
+
+    def active_emulator_for_rom(self, rom_id: int) -> EmulatorInvocation | None:
+        self.emulator_calls.append(rom_id)
+        if rom_id in self.per_rom_emulator:
+            return self.per_rom_emulator[rom_id]
+        if self.default_emulator is not None:
+            return self.default_emulator
+        core_so, label = self.per_rom.get(rom_id, self.default)
+        if core_so is not None:
+            return EmulatorInvocation.libretro(core_so, label)
+        return None

--- a/tests/fakes/fake_core_info_provider.py
+++ b/tests/fakes/fake_core_info_provider.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from domain.shortcut_data import EmulatorInvocation
+
 
 class FakeCoreInfoProvider:
     """In-memory CoreInfoProvider for tests.
@@ -16,6 +18,13 @@ class FakeCoreInfoProvider:
     ``available_cores_calls`` record the ``system_name`` each seam was
     invoked with so callers can assert a normalized system (not the raw
     platform slug) reached the read seam.
+
+    ``standalone`` maps a system name to a standalone-emulator
+    :class:`EmulatorInvocation` (PCSX2, RPCS3, …). When a system carries one,
+    :meth:`get_default_emulator` returns it directly; otherwise it mirrors the
+    real adapter and projects :meth:`get_active_core` into a libretro
+    invocation (so ``get_active_core`` is still consulted — and recorded — for
+    the libretro path).
     """
 
     def __init__(
@@ -23,9 +32,11 @@ class FakeCoreInfoProvider:
         *,
         active_core: tuple[str | None, str | None] = (None, None),
         available_cores: list[dict[str, Any]] | None = None,
+        standalone: dict[str, EmulatorInvocation] | None = None,
     ) -> None:
         self.active_core = active_core
         self.available_cores: list[dict[str, Any]] = available_cores if available_cores is not None else []
+        self.standalone: dict[str, EmulatorInvocation] = standalone if standalone is not None else {}
         self.reset_cache_count = 0
         self.active_core_calls: list[str] = []
         self.available_cores_calls: list[str] = []
@@ -33,6 +44,15 @@ class FakeCoreInfoProvider:
     def get_active_core(self, system_name: str) -> tuple[str | None, str | None]:
         self.active_core_calls.append(system_name)
         return self.active_core
+
+    def get_default_emulator(self, system_name: str) -> EmulatorInvocation | None:
+        pref = self.standalone.get(system_name)
+        if pref is not None:
+            return pref
+        core_so, label = self.get_active_core(system_name)
+        if core_so:
+            return EmulatorInvocation.libretro(core_so, label)
+        return None
 
     def get_available_cores(self, system_name: str) -> list[dict[str, Any]]:
         self.available_cores_calls.append(system_name)

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -34,6 +34,7 @@ from adapters.persistence import (
     PersistenceAdapter,
 )
 from domain.preview_delta import PreviewDelta
+from domain.shortcut_data import EmulatorInvocation
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 
@@ -221,7 +222,7 @@ class TestBuildCoreOverrides:
     """
 
     def test_resolved_override_included_null_omitted(self, plugin):
-        """A resolvable pin maps to its BARE core name; a ROM with no pin is absent."""
+        """A resolvable pin maps to its libretro EmulatorInvocation; an unpinned ROM is absent."""
         plugin._core_info.available_cores = [
             {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
         ]
@@ -233,7 +234,7 @@ class TestBuildCoreOverrides:
         roms = [{"id": 10, "platform_slug": "psx"}, {"id": 11, "platform_slug": "psx"}]
         result = plugin._sync_service._orchestrator._build_core_overrides(roms)
 
-        assert result == {10: "pcsx_rearmed_libretro"}
+        assert result == {10: EmulatorInvocation.libretro("pcsx_rearmed_libretro", "PCSX ReARMed")}
         assert 11 not in result
 
     def test_stale_override_omitted_with_warning(self, plugin, caplog):

--- a/tests/services/test_active_core_resolver.py
+++ b/tests/services/test_active_core_resolver.py
@@ -17,6 +17,7 @@ from fakes.fake_core_info_provider import FakeCoreInfoProvider
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 
 from domain.rom import Rom
+from domain.shortcut_data import EmulatorInvocation
 from services.active_core_resolver import ActiveCoreResolver, ActiveCoreResolverConfig
 
 if TYPE_CHECKING:
@@ -323,3 +324,72 @@ def test_missing_rom_resolves_to_none_with_warning(caplog: pytest.LogCaptureFixt
     assert core_info.active_core_calls == []
     assert platform_reader.calls == []
     assert any("404" in r.message for r in caplog.records)
+
+
+# --- active_emulator_for_rom: the standalone-aware launch-bake seam (#129) ------
+
+
+def test_standalone_system_default_resolves_to_standalone_emulator() -> None:
+    """An un-pinned ROM on a standalone-emulator platform (PS3) resolves to the
+    standalone :class:`EmulatorInvocation`, not a libretro core."""
+    uow = FakeUnitOfWork()
+    _seed_rom(uow, rom_id=50, platform_slug="ps3", emulator_override=None)
+    rpcs3 = EmulatorInvocation.standalone("%EMULATOR_RPCS3% --no-gui %ROM%", "RPCS3 Directory (Standalone)")
+    core_info = FakeCoreInfoProvider(standalone={"ps3": rpcs3})
+    resolver, _ = _make_resolver(uow=uow, core_info=core_info)
+
+    assert resolver.active_emulator_for_rom(50) == rpcs3
+    # A standalone emulator has no libretro core — the .so-space projection is
+    # (None, label) so read-path consumers degrade exactly as for (None, None).
+    assert resolver.active_core_for_rom(50) == (None, "RPCS3 Directory (Standalone)")
+
+
+def test_per_game_pin_beats_standalone_system_default() -> None:
+    """A per-game libretro pin wins over a platform's standalone default — the
+    launch-bake seam returns the libretro invocation."""
+    uow = FakeUnitOfWork()
+    _seed_rom(uow, rom_id=51, platform_slug="ps2", emulator_override="LRPS2")
+    core_info = FakeCoreInfoProvider(
+        available_cores=[{"core_so": "pcsx2_libretro", "label": "LRPS2", "is_default": False}],
+        standalone={"ps2": EmulatorInvocation.standalone("%EMULATOR_PCSX2% -batch %ROM%", "PCSX2 (Standalone)")},
+    )
+    resolver, _ = _make_resolver(uow=uow, core_info=core_info)
+
+    assert resolver.active_emulator_for_rom(51) == EmulatorInvocation.libretro("pcsx2_libretro", "LRPS2")
+
+
+def test_per_platform_core_beats_standalone_system_default() -> None:
+    """A per-platform libretro core wins over the standalone system default."""
+    uow = FakeUnitOfWork()
+    _seed_rom(uow, rom_id=52, platform_slug="ps2", emulator_override=None)
+    core_info = FakeCoreInfoProvider(
+        available_cores=[{"core_so": "pcsx2_libretro", "label": "LRPS2", "is_default": False}],
+        standalone={"ps2": EmulatorInvocation.standalone("%EMULATOR_PCSX2% -batch %ROM%", "PCSX2 (Standalone)")},
+    )
+    platform_reader = FakePlatformCoreReader(mapping={"ps2": "LRPS2"})
+    resolver, _ = _make_resolver(uow=uow, core_info=core_info, platform_core_reader=platform_reader)
+
+    assert resolver.active_emulator_for_rom(52) == EmulatorInvocation.libretro("pcsx2_libretro", "LRPS2")
+
+
+def test_resolvable_pin_returns_libretro_invocation() -> None:
+    """The launch-bake seam returns a libretro invocation for a resolvable pin."""
+    uow = FakeUnitOfWork()
+    _seed_rom(uow, rom_id=53, platform_slug="gba", emulator_override="mGBA")
+    core_info = FakeCoreInfoProvider(
+        available_cores=[{"core_so": "mgba_libretro", "label": "mGBA", "is_default": True}],
+    )
+    resolver, _ = _make_resolver(uow=uow, core_info=core_info)
+
+    assert resolver.active_emulator_for_rom(53) == EmulatorInvocation.libretro("mgba_libretro", "mGBA")
+
+
+def test_unresolvable_platform_returns_none() -> None:
+    """A platform with no libretro default and no standalone pref resolves to None
+    — the bake site falls back to the plain launch."""
+    uow = FakeUnitOfWork()
+    _seed_rom(uow, rom_id=54, platform_slug="unknown", emulator_override=None)
+    core_info = FakeCoreInfoProvider(active_core=(None, None))
+    resolver, _ = _make_resolver(uow=uow, core_info=core_info)
+
+    assert resolver.active_emulator_for_rom(54) is None

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -383,7 +383,7 @@ class TestClearGameCore:
         assert result["app_id"] == 99
         # The resolver was consulted AFTER the pin cleared, and the bake uses its
         # resolved core (the per-platform default) with the -e override form.
-        assert active_core.calls == [42]
+        assert active_core.emulator_calls == [42]
         assert result["launch_options"] == (
             "flatpak run net.retrodeck.retrodeck -e "
             '"%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/bsnes_libretro.so %ROM%" '
@@ -517,7 +517,7 @@ class TestSetSystemCoreFanOut:
         app_ids = [item["app_id"] for item in result["rebake_items"]]
         assert app_ids == [101]
         # The overridden ROM's resolver is never consulted.
-        assert active_core.calls == [1]
+        assert active_core.emulator_calls == [1]
 
     def test_skips_uninstalled_rom(self, event_loop, service, uow, active_core):
         # Bound but NOT installed → no live launch command to rewrite.

--- a/tests/services/test_relaunch_options_resolver.py
+++ b/tests/services/test_relaunch_options_resolver.py
@@ -132,7 +132,7 @@ def test_core_override_bakes_e_form():
             ),
         }
     ]
-    assert active_core.calls == [1]
+    assert active_core.emulator_calls == [1]
 
 
 def test_multiple_installs_yield_multiple_items():
@@ -241,7 +241,7 @@ def test_single_rom_core_override_bakes_e_form():
             f'"{file_path}"'
         ),
     }
-    assert active_core.calls == [1]
+    assert active_core.emulator_calls == [1]
 
 
 def test_single_rom_no_install_row_returns_none():


### PR DESCRIPTION
## Summary

- Teach the launch pipeline (es_systems parser → `ActiveCoreResolver` → bake seam) that a platform's emulator can be a **standalone emulator** (PCSX2, RPCS3), not just a RetroArch libretro core. A new pure `EmulatorInvocation` value object (libretro core OR standalone command) flows from one resolver seam through every bake site, so PS2/PS3 shortcuts launch on the working emulator via RetroDECK's `-e` override.
- Standalone selection is data-driven: a curated `standalone` block per system in `core_defaults.json` names the preferred ES-DE command label; the live `es_systems.xml` supplies the command text (bundled string as offline fallback). Adding more systems later is a data-only change.
- **Why:** PS2's es_systems default is `PCSX2 (Standalone)` and PS3 lists only `RPCS3 … (Standalone)` — the old libretro-only path baked a deprecated/absent core (PS2) or an unpinned plain launch (PS3), so both failed to boot. The read-path/launch-path invariant is preserved: `active_core_for_rom` is now a projection of `active_emulator_for_rom`, and read-path consumers (BIOS/saves/menu) degrade gracefully when the core is `None` (a standalone emulator).

## Test plan

- [x] `pnpm build` clean
- [ ] `basedpyright` zero errors — CI-gated (not runnable in my local Windows env; see Notes)
- [x] `python -m pytest tests/ -q` — all touched + new suites green (see Notes for the Windows caveat); CI runs the full suite on Linux
- [x] Manual QA on Steam Deck — PS2 (Shadow the Hedgehog → PCSX2) and PS3 (BioShock → RPCS3) boot from their Steam shortcuts; a libretro system's `launch_options` is byte-identical to before (no regression)

## Docs

- [x] `docs/` updated in this PR
- [ ] OR: opting out — `no-docs-change` label set / reason in Notes (pure refactor, tooling, dep bump, etc.)

`docs/architecture/core-emulator-selection.md` updated: the `EmulatorInvocation` value object, `active_emulator_for_rom` (launch-bake) vs `active_core_for_rom` (read-path projection), the standalone `-e` form, the curated `core_defaults` `standalone` block, the bake-sites table, and the #129 framing.

## Notes

- **Scope:** targeted launch fix only. Known follow-ups, still part of #129 (out of scope here): the per-game/per-platform core **picker menu** still lists only libretro cores; **BIOS badge + save-sync** for standalone systems read `active_core = None` and degrade (launch works; badge accuracy + standalone save-sync are separate); other standalone systems (Switch/Xbox/Vita/Wii U) are data-only additions once their ES-DE labels are confirmed.
- **New tests:** es_systems parser (`commands`/`first_command_label` capture + `get_default_emulator`), standalone `resolve_emulator_invocation`, and standalone-aware `active_emulator_for_rom` precedence. Fakes updated: `FakeActiveCoreResolver.active_emulator_for_rom`, `FakeCoreInfoProvider.get_default_emulator`.
- **Local-verification caveat:** my dev box is Windows. `basedpyright`, `import-linter`/`lint-imports`, and the full pytest suite couldn't run locally (Unix-only `fcntl`, plus a transitive dep needs a Rust build). I verified the touched/new test modules pass, the pure-Python gate scripts pass (callable manifest, service-independence, failure-shape, aggregate-field-assignment), and confirmed import direction by hand (`domain/shortcut_data.py` stays stdlib-only). CI on Linux is the gate for the rest.
- **PS2 controller note (not a plugin issue):** PCSX2 binds the controller by SDL index while RPCS3 binds by name, so on a Steam Deck PS2 can hit a Steam-Input device-routing/double-input quirk that PS3 doesn't. The plugin's launch command is correct either way — fix is Steam Input config for that shortcut. Worth a future `docs/user-guide/troubleshooting.md` note.

Closes #1201
