### PR TITLE
fix(dev): drop stale root-level defaults snapshots on deploy

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -71,6 +71,12 @@ mkdir -p "$DEST/dist" "$DEST/bin" "$DEST/defaults" "$DEST/py_modules"
 rsync -a --delete dist/ "$DEST/dist/"
 rsync -a --delete bin/ "$DEST/bin/"
 rsync -a --delete defaults/ "$DEST/defaults/"
+# A prior release install places the defaults/ snapshots (core_defaults.json,
+# config.json, bios_registry.json) at the plugin ROOT, where the loaders look
+# FIRST (root, then defaults/). A dev deploy only refreshes defaults/, so a stale
+# root copy from an earlier release would shadow the freshly-deployed snapshot.
+# Drop any root-level namesake so a dev deploy always reads the just-deployed defaults/.
+for f in defaults/*; do rm -f "$DEST/$(basename "$f")"; done
 rsync -a --delete py_modules/ "$DEST/py_modules/"
 cp -f main.py plugin.json package.json "$DEST/"
 """


### PR DESCRIPTION
## Summary

`mise run dev` rsyncs `defaults/` into the plugin dir but never updated the plugin-**root** copies of those snapshots. The loaders (`adapters/es_de_config.py`, `adapters/romm/http.py`, `services/firmware.py`) read `core_defaults.json` / `config.json` / `bios_registry.json` from the plugin **root first**, falling back to `defaults/` only when the root file is absent. So a stale root snapshot left by an earlier **release** install shadows the freshly-deployed `defaults/` one.

Concretely: deploying a build with an updated `core_defaults.json` (e.g. new standalone-emulator entries) over a release install kept resolving against the old root snapshot — the new data never took effect until the root file was removed by hand.

Fix: after the `defaults/` rsync, drop any root-level namesake of a `defaults/` file, so a dev deploy always reads what it just wrote. Release installs are unaffected — they write the root snapshots fresh.

## Test plan

- [x] `mise run dev` over a release install no longer leaves a stale root `core_defaults.json` shadowing the deployed `defaults/` copy — resolver reads the fresh `defaults/`.

docs: N/A — dev-deploy tooling fix, no user-facing or architecture change.
