### PR TITLE
fix(saves): cap .romm-backup growth and avoid same-second backup collisions (#974)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -89,6 +89,18 @@ reachable):
 An empty target slot is just the case where step 3 is a no-op: every local file is quarantined, tracking is cleared, and
 the slot starts fresh — with every prior save recoverable under `.romm-backup`.
 
+#### Inside `.romm-backup` — naming and retention
+
+Backups live in `<saves_dir>/.romm-backup` and are named `<name>_<ts>[_<n>]<ext>`, where `<ts>` is the `YYYYMMDD_HHMMSS`
+quarantine time. When several files of one slot are backed up within the same second (so the base `<name>_<ts><ext>`
+name would collide), a `_<n>` counter (`_1`, `_2`, …) is appended so an earlier backup is never overwritten by a later
+one. The folder is capped at the **newest 10** backups per save file: each quarantine prunes the older copies of that
+same file beyond the cap, bounding disk use on the Deck while keeping a deep-enough recovery net. The cap is per save
+file — backups of a different save file in the same folder are never pruned by another file's quarantine. One deliberate
+exception: the backup a quarantine just wrote is never pruned in that same call, so under sustained same-second churn
+the folder may briefly hold one extra copy (11) — honouring the cap by deleting the just-saved file would defeat the
+backup.
+
 ### The `none` slot (legacy)
 
 - Saves uploaded before v2 (or without slot parameter) have `slot=null`

--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -48,6 +48,13 @@ class SaveFileAdapter:
         with contextlib.suppress(FileNotFoundError):
             os.remove(path)
 
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entry names in *directory*; empty list if it does not exist."""
+        try:
+            return os.listdir(directory)
+        except FileNotFoundError:
+            return []
+
     def rename(self, src: str, dst: str) -> None:
         """Atomically rename *src* to *dst*, replacing any existing file at *dst*."""
         os.replace(src, dst)

--- a/py_modules/domain/save_backup.py
+++ b/py_modules/domain/save_backup.py
@@ -1,0 +1,62 @@
+"""Pure naming + retention rules for the local ``.romm-backup`` quarantine.
+
+The matrix executor owns the I/O; the collision-free name and the prune
+set are decided here so both rules are unit-testable without touching the
+filesystem.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_TS = r"\d{8}_\d{6}"
+
+
+def backup_name(filename: str, ts: str, existing: set[str]) -> str:
+    """Return a collision-free backup name for *filename* at timestamp *ts*.
+
+    Builds ``<name>_<ts><ext>`` from *filename* and *ts*. When that name is
+    already present in *existing*, a ``_<n>`` counter (``_1``, ``_2``, …) is
+    appended before the extension until the name is unused — so a multi-file
+    slot whose files all back up in the same second never overwrites an earlier
+    backup (#974).
+    """
+    name, ext = os.path.splitext(filename)
+    candidate = f"{name}_{ts}{ext}"
+    n = 1
+    while candidate in existing:
+        candidate = f"{name}_{ts}_{n}{ext}"
+        n += 1
+    return candidate
+
+
+def select_backups_to_prune(filename: str, existing: list[str], keep: int) -> list[str]:
+    """Return the oldest backups of *filename* to delete so only *keep* remain.
+
+    Considers only entries in *existing* that are a backup of *filename* —
+    ``<name>_<ts>[_<n>]<ext>`` — because the ``.romm-backup`` directory is
+    shared across every save file under the saves directory, so a sibling
+    file's backups must be ignored. The oldest ``len(matches) - keep`` entries
+    (by a plain lexicographic sort) are returned and the newest *keep* are
+    retained; a *keep* of ``0`` or less disables pruning and returns ``[]``.
+
+    Sort caveat: the fixed-width zero-padded ``<ts>`` makes the sort
+    chronological *across* seconds. *Within* one second the ``_<n>`` collision
+    counter is **not** zero-padded (``_10`` sorts before ``_2``), so same-second
+    ordering beyond the first collision is only approximate — immaterial, since
+    those copies share a second. One consequence matters to callers: a base
+    name (``<name>_<ts><ext>``) that was freed by an earlier prune and then
+    reused for a *newer* backup sorts *oldest* (``.`` < ``_``), so a caller that
+    prunes in the same call that creates a backup MUST exclude the just-created
+    name — otherwise the cap would delete the live save it just quarantined
+    (see :meth:`MatrixExecutor.quarantine_local_file`).
+    """
+    if keep <= 0:
+        return []
+    name, ext = os.path.splitext(filename)
+    pattern = re.compile(rf"^{re.escape(name)}_{_TS}(_\d+)?{re.escape(ext)}$")
+    matches = sorted(b for b in existing if pattern.match(b))
+    if len(matches) <= keep:
+        return []
+    return matches[: len(matches) - keep]

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -361,6 +361,10 @@ class SaveFileStore(Protocol):
         """Delete *path*. Idempotent: a missing file is not an error."""
         ...
 
+    def listdir(self, directory: str) -> list[str]:
+        """Return the entry names in *directory*; empty list if it does not exist."""
+        ...
+
     def rename(self, src: str, dst: str) -> None:
         """Atomically rename *src* to *dst*, replacing any existing file at *dst*.
 

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from domain.emulator_tag import build_emulator_tag
 from domain.rom_save_state import FileSyncState, RomSaveState
+from domain.save_backup import backup_name, select_backups_to_prune
 from domain.save_slot import save_in_slot
 from domain.sync_action import (
     Conflict,
@@ -44,6 +45,9 @@ if TYPE_CHECKING:
         SaveFileStore,
     )
     from services.saves.rom_info import RomInfoService
+
+
+_BACKUP_RETENTION = 10  # max .romm-backup copies kept per save file (#974)
 
 
 @dataclass(frozen=True)
@@ -245,9 +249,16 @@ class MatrixExecutor:
         download-overwrite path (:meth:`do_download_save`) and the slot-switch
         removal path route through here, so no local save is ever destroyed
         without a recoverable copy (#965). The backup lands at
-        ``<saves_dir>/.romm-backup/<name>_<ts><ext>`` (``<ts>`` from the injected
-        clock). Returns ``True`` when a file was moved, ``False`` when there was
-        nothing at *filename* to back up.
+        ``<saves_dir>/.romm-backup/<name>_<ts>[_<n>]<ext>`` (``<ts>`` from the
+        injected clock). A same-second collision appends a ``_<n>`` counter so a
+        multi-file slot quarantined within one second never overwrites an earlier
+        backup, and the newest ``_BACKUP_RETENTION`` backups per save file are
+        kept — older ones are pruned to bound the recovery net's disk use (#974).
+        The backup written by this call is never pruned in its own call, so under
+        sustained same-second churn the folder may briefly hold one extra copy
+        (``_BACKUP_RETENTION + 1``) — destroying the just-saved file to honour the
+        cap would defeat the backup. Returns ``True`` when a file was moved,
+        ``False`` when there was nothing at *filename* to back up.
         """
         local_path = os.path.join(saves_dir, filename)
         if not self._save_file_store.is_file(local_path):
@@ -255,8 +266,15 @@ class MatrixExecutor:
         backup_dir = os.path.join(saves_dir, ".romm-backup")
         self._save_file_store.make_dirs(backup_dir)
         ts = self._clock.now().strftime("%Y%m%d_%H%M%S")
-        name, ext = os.path.splitext(filename)
-        self._save_file_store.rename(local_path, os.path.join(backup_dir, f"{name}_{ts}{ext}"))
+        existing = set(self._save_file_store.listdir(backup_dir))
+        backup = backup_name(filename, ts, existing)
+        self._save_file_store.rename(local_path, os.path.join(backup_dir, backup))
+        # Bound the recovery net: keep only the newest N backups per save file (#974).
+        existing.add(backup)
+        for stale in select_backups_to_prune(filename, list(existing), _BACKUP_RETENTION):
+            if stale == backup:
+                continue  # never prune the backup just created this call (#974 — would destroy the save)
+            self._save_file_store.remove_file(os.path.join(backup_dir, stale))
         return True
 
     @staticmethod

--- a/tests/domain/test_save_backup.py
+++ b/tests/domain/test_save_backup.py
@@ -1,0 +1,122 @@
+"""Tests for py_modules/domain/save_backup.py"""
+
+from __future__ import annotations
+
+from domain.save_backup import backup_name, select_backups_to_prune
+
+# ---------------------------------------------------------------------------
+# backup_name
+# ---------------------------------------------------------------------------
+
+
+class TestBackupName:
+    TS = "20260101_000000"
+
+    def test_no_collision_returns_plain_name(self) -> None:
+        """An empty existing set yields ``<name>_<ts><ext>`` with no counter."""
+        assert backup_name("game.srm", self.TS, set()) == f"game_{self.TS}.srm"
+
+    def test_one_collision_appends_1(self) -> None:
+        """The plain name already present → the first counter ``_1`` is used."""
+        existing = {f"game_{self.TS}.srm"}
+        assert backup_name("game.srm", self.TS, existing) == f"game_{self.TS}_1.srm"
+
+    def test_multiple_collisions_increment_counter(self) -> None:
+        """Successive same-second backups walk ``_1``, ``_2``, … past every taken name."""
+        existing: set[str] = set()
+        names = []
+        for _ in range(4):
+            name = backup_name("game.srm", self.TS, existing)
+            names.append(name)
+            existing.add(name)
+        assert names == [
+            f"game_{self.TS}.srm",
+            f"game_{self.TS}_1.srm",
+            f"game_{self.TS}_2.srm",
+            f"game_{self.TS}_3.srm",
+        ]
+
+    def test_different_extension_does_not_collide(self) -> None:
+        """A backup of a sibling extension never blocks this file's plain name."""
+        existing = {f"game_{self.TS}.rtc"}
+        assert backup_name("game.srm", self.TS, existing) == f"game_{self.TS}.srm"
+
+    def test_different_stem_does_not_collide(self) -> None:
+        """A backup of a different save file never blocks this file's plain name."""
+        existing = {f"other_{self.TS}.srm"}
+        assert backup_name("game.srm", self.TS, existing) == f"game_{self.TS}.srm"
+
+    def test_filename_with_no_extension(self) -> None:
+        """A filename without an extension yields ``<name>_<ts>`` (no trailing dot)."""
+        assert backup_name("game", self.TS, set()) == f"game_{self.TS}"
+        existing = {f"game_{self.TS}"}
+        assert backup_name("game", self.TS, existing) == f"game_{self.TS}_1"
+
+
+# ---------------------------------------------------------------------------
+# select_backups_to_prune
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBackupsToPrune:
+    def _backups(self, count: int, stem: str = "game", ext: str = ".srm") -> list[str]:
+        """Build *count* chronological backups of *stem* with distinct timestamps."""
+        return [f"{stem}_202601{day:02d}_000000{ext}" for day in range(1, count + 1)]
+
+    def test_under_limit_returns_empty(self) -> None:
+        """Fewer backups than the keep limit → nothing to prune."""
+        assert select_backups_to_prune("game.srm", self._backups(3), keep=10) == []
+
+    def test_exactly_at_limit_returns_empty(self) -> None:
+        """Exactly the keep limit → nothing to prune."""
+        assert select_backups_to_prune("game.srm", self._backups(10), keep=10) == []
+
+    def test_over_limit_returns_oldest(self) -> None:
+        """Over the limit → the oldest ``len - keep`` are returned, newest kept."""
+        backups = self._backups(12)
+        stale = select_backups_to_prune("game.srm", backups, keep=10)
+        # Two oldest dropped; the newest 10 retained.
+        assert stale == ["game_20260101_000000.srm", "game_20260102_000000.srm"]
+        assert all(b not in stale for b in backups[2:])
+
+    def test_same_second_counter_orders_after_base(self) -> None:
+        """A same-second ``_1`` collision sorts AFTER its base, so the base is the
+        one pruned when only the newest must survive."""
+        backups = [
+            "game_20260101_000000.srm",
+            "game_20260101_000000_1.srm",
+        ]
+        # keep=1 → only the newest survives; the base (sorts first) is pruned.
+        assert select_backups_to_prune("game.srm", backups, keep=1) == ["game_20260101_000000.srm"]
+
+    def test_other_save_files_ignored(self) -> None:
+        """Backups of a different stem in the shared dir are never pruned for this file."""
+        backups = self._backups(12) + self._backups(12, stem="other")
+        stale = select_backups_to_prune("game.srm", backups, keep=10)
+        assert stale == ["game_20260101_000000.srm", "game_20260102_000000.srm"]
+        assert all(b.startswith("game_") for b in stale)
+
+    def test_other_extension_ignored(self) -> None:
+        """A sibling extension's backups don't count toward this file's retention."""
+        backups = self._backups(12) + self._backups(12, ext=".rtc")
+        stale = select_backups_to_prune("game.srm", backups, keep=10)
+        assert stale == ["game_20260101_000000.srm", "game_20260102_000000.srm"]
+        assert all(b.endswith(".srm") for b in stale)
+
+    def test_non_backup_junk_ignored(self) -> None:
+        """Entries that don't match the ``<name>_<ts>[_<n>]<ext>`` shape are ignored."""
+        backups = [*self._backups(11), "game.srm", "game_backup.srm", "README.txt"]
+        stale = select_backups_to_prune("game.srm", backups, keep=10)
+        assert stale == ["game_20260101_000000.srm"]
+
+    def test_keep_zero_disables_pruning(self) -> None:
+        """A keep of 0 disables pruning entirely."""
+        assert select_backups_to_prune("game.srm", self._backups(20), keep=0) == []
+
+    def test_keep_negative_disables_pruning(self) -> None:
+        """A negative keep disables pruning entirely."""
+        assert select_backups_to_prune("game.srm", self._backups(20), keep=-5) == []
+
+    def test_empty_list_returns_empty(self) -> None:
+        """No entries → nothing to prune."""
+        assert select_backups_to_prune("game.srm", [], keep=10) == []

--- a/tests/fakes/fake_save_file_store.py
+++ b/tests/fakes/fake_save_file_store.py
@@ -69,6 +69,16 @@ class FakeSaveFileStore:
         self.files.pop(path, None)
         self.mtimes.pop(path, None)
 
+    def listdir(self, directory: str) -> list[str]:
+        prefix = directory.rstrip("/") + "/"
+        names: set[str] = set()
+        for stored in (*self.files, *self.dirs):
+            if stored.startswith(prefix):
+                rest = stored[len(prefix) :]
+                if rest:
+                    names.add(rest.split("/", 1)[0])
+        return sorted(names)
+
     def rename(self, src: str, dst: str) -> None:
         self.rename_calls.append((src, dst))
         if src not in self.files:

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -1736,3 +1736,121 @@ class TestRecordOwnUploadNoneId:
         state = _do_upload(svc, 42, str(save_path), "pokemon.srm", "gba")
 
         assert state.own_upload_ids == [50, 51]
+
+
+class TestQuarantineBackupRetention:
+    """quarantine_local_file's collision-proof naming + retention pruning (#974).
+
+    The default ``FakeClock(now=datetime(2026, 1, 1))`` stamps the same
+    ``20260101_000000`` timestamp until a test calls ``clock.advance(...)``, so
+    same-second collision tests run it fixed while ordering-sensitive retention
+    tests advance it for distinct timestamps.
+    """
+
+    def test_same_second_collision_keeps_both_backups(self, tmp_path):
+        """Two same-second quarantines of one file produce two distinct backups —
+        the earlier copy is never overwritten by the ``_<n>`` counter."""
+        svc, _ = make_service(tmp_path)
+        matrix = svc._sync_engine._matrix
+        saves_dir = tmp_path / "saves" / "gba"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        save_path = saves_dir / "game.srm"
+
+        save_path.write_bytes(b"first version")
+        assert matrix.quarantine_local_file(str(saves_dir), "game.srm") is True
+
+        save_path.write_bytes(b"second version")
+        assert matrix.quarantine_local_file(str(saves_dir), "game.srm") is True
+
+        backup_dir = saves_dir / ".romm-backup"
+        first = backup_dir / "game_20260101_000000.srm"
+        second = backup_dir / "game_20260101_000000_1.srm"
+        assert first.exists()
+        assert second.exists()
+        # The earlier backup survived the same-second second quarantine.
+        assert first.read_bytes() == b"first version"
+        assert second.read_bytes() == b"second version"
+
+    def test_retention_caps_backups_per_file_and_spares_others(self, tmp_path):
+        """More than the retention limit of quarantines for one file leaves exactly
+        ``_BACKUP_RETENTION`` backups for its stem — the NEWEST versions — while a
+        different file's backup is untouched.
+
+        Uses an advancing clock so every backup has a distinct ``<ts>`` and the
+        chronological prune ordering is unambiguous.
+        """
+        from datetime import UTC, datetime
+
+        from fakes.system_time import FakeClock
+
+        from services.saves.sync_engine.matrix import _BACKUP_RETENTION
+
+        clock = FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC))
+        svc, _ = make_service(tmp_path, clock=clock)
+        matrix = svc._sync_engine._matrix
+        saves_dir = tmp_path / "saves" / "gba"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir = saves_dir / ".romm-backup"
+
+        # A backup of a DIFFERENT save file that must survive game.srm pruning.
+        (saves_dir / "mario.srm").write_bytes(b"mario save")
+        assert matrix.quarantine_local_file(str(saves_dir), "mario.srm") is True
+
+        total = _BACKUP_RETENTION + 5
+        contents = [f"game v{i}".encode() for i in range(total)]
+        for content in contents:
+            clock.advance(1)  # distinct <ts> per quarantine → no same-second collisions
+            (saves_dir / "game.srm").write_bytes(content)
+            assert matrix.quarantine_local_file(str(saves_dir), "game.srm") is True
+
+        entries = os.listdir(backup_dir)
+        game_backups = [n for n in entries if n.startswith("game_")]
+        assert len(game_backups) == _BACKUP_RETENTION
+        # The survivors are exactly the newest _BACKUP_RETENTION versions written…
+        survivor_contents = {(backup_dir / n).read_bytes() for n in game_backups}
+        assert survivor_contents == set(contents[-_BACKUP_RETENTION:])
+        # …and the oldest 5 are gone.
+        assert all(c not in survivor_contents for c in contents[:5])
+        # The unrelated file's single backup was never pruned.
+        assert [n for n in entries if n.startswith("mario_")] == ["mario_20260101_000000.srm"]
+
+    def test_same_second_over_cap_never_deletes_just_created(self, tmp_path):
+        """Same-second churn past the cap must NEVER destroy the file it just backed up.
+
+        Regression for the prune-deletes-its-own-backup bug (#974): once the dir is
+        at cap a freed base name is reused for the newest file, and the base sorts
+        oldest — so an unguarded prune would delete the live save it just
+        quarantined. After every quarantine the just-written content must still be
+        recoverable somewhere in ``.romm-backup``; the folder stays bounded.
+        """
+        from services.saves.sync_engine.matrix import _BACKUP_RETENTION
+
+        svc, _ = make_service(tmp_path)
+        matrix = svc._sync_engine._matrix  # fixed clock → every backup is same-second
+        saves_dir = tmp_path / "saves" / "gba"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+        backup_dir = saves_dir / ".romm-backup"
+
+        total = _BACKUP_RETENTION + 5
+        for i in range(total):
+            content = f"game v{i}".encode()
+            (saves_dir / "game.srm").write_bytes(content)
+            assert matrix.quarantine_local_file(str(saves_dir), "game.srm") is True
+            # The file just quarantined survived its own prune pass.
+            present = {(backup_dir / n).read_bytes() for n in os.listdir(backup_dir)}
+            assert content in present
+            # Bounded: the cap plus at most the one just-created copy.
+            assert len(os.listdir(backup_dir)) <= _BACKUP_RETENTION + 1
+
+        # The very last version written is still present at the end.
+        final = {(backup_dir / n).read_bytes() for n in os.listdir(backup_dir)}
+        assert f"game v{total - 1}".encode() in final
+
+    def test_returns_false_when_nothing_to_back_up(self, tmp_path):
+        """No file at *filename* → early return False, no backup dir churn."""
+        svc, _ = make_service(tmp_path)
+        matrix = svc._sync_engine._matrix
+        saves_dir = tmp_path / "saves" / "gba"
+        saves_dir.mkdir(parents=True, exist_ok=True)
+
+        assert matrix.quarantine_local_file(str(saves_dir), "absent.srm") is False


### PR DESCRIPTION
Closes #974.

## Problem

`MatrixExecutor.quarantine_local_file` — the single `.romm-backup` funnel that backs up a local save before a download-overwrite or slot-switch destroys it — had two flaws:

1. **Unbounded growth.** Backups were never pruned, so `.romm-backup` grew without limit (disk pressure on the Deck).
2. **Same-second name collisions.** The backup name was `<name>_<ts><ext>` with a second-resolution `<ts>`. Multiple files of one slot quarantined within the same second produced the *same* name, and `os.replace` silently overwrote the earlier backup — eroding the recovery net exactly when several files change at once.

## Fix

- **`domain/save_backup.py`** (new, pure): `backup_name` appends a `_<n>` counter on a same-second collision so an earlier backup is never overwritten; `select_backups_to_prune` returns the oldest backups of one file beyond the cap.
- **`listdir` seam** added to the `SaveFileStore` Protocol + `SaveFileAdapter` (and the in-memory fake) so the matrix can list the backup dir.
- **`quarantine_local_file`** now names collision-free and prunes to the newest **10 per save file**.

### Data-safety guard

The prune **never deletes the backup it just created in the same call**. Without the guard, under sustained same-second churn a freed base name gets reused for the newest file and sorts oldest lexicographically, so the prune would delete the save it just quarantined — destroying a file that may exist nowhere else. The guard means the folder may briefly hold one extra copy (`11`) under that churn — bounded, never at the cost of the live save.

## Tests

- `tests/domain/test_save_backup.py` — naming (collision counter, sibling/extension isolation, no-extension) and prune (under/at/over cap, sibling-ignored, junk-ignored, `keep<=0`, empty).
- `TestQuarantineBackupRetention` (matrix): same-second collision keeps both copies; advancing-clock retention keeps the *newest* 10 and prunes the oldest while sparing a sibling file; a same-second over-cap regression test asserting the just-quarantined content is always recoverable and the folder stays `<= 11`; early-return when nothing to back up.
- Full suite green: `3902 passed`. ruff + basedpyright (incl. `tests/`) + import-linter clean.

## Docs

`docs/architecture/save-file-sync-architecture.md` — new subsection documenting the `.romm-backup` naming (`<name>_<ts>[_<n>]<ext>`) and the per-file retention cap.
