### PR TITLE
fix(saves): send autocleanup_limit on save upload so the setting caps retained versions (#1060)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -32,7 +32,9 @@ Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `reason: "ve
 **New parameters on POST:**
 
 - `slot` — slot name (e.g. `"default"`). If omitted, save has `slot=null` (legacy behavior).
-- `autocleanup_limit` — max save versions retained per slot (default: 10).
+- `autocleanup` — whether RomM prunes old stacked versions. Defaults to **false**.
+- `autocleanup_limit` — max save versions retained per slot (default: 10). Inert unless `autocleanup=true` is sent
+  alongside it.
 - `device_id` — server-registered device UUID. Used to populate `device_syncs` per save.
 
 **New fields on save metadata:**
@@ -62,6 +64,9 @@ different save states per device).
 
 - Every game gets a `default` slot (configurable in QAM settings as "Default Save Slot")
 - First upload = POST (creates save entry with timestamp filename, server assigns ID)
+- On that POST the plugin sends `autocleanup=true` together with the user-configured `autocleanup_limit` (QAM
+  "Auto-cleanup limit"), so the setting actually caps how many versions RomM retains. It is POST-only: PUT updates in
+  place and never stacks, so the cap is established once at entry creation.
 - All subsequent syncs = PUT to the tracked `save_id` (content update, no stacking)
 - Normal single-device flow: exactly 1 save entry per game per slot
 - Multi-device: all devices share the same save entry via `tracked_save_id`

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -180,6 +180,7 @@ class RommApiAdapter:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
         params = f"rom_id={rom_id}&emulator={urllib.parse.quote(emulator, safe='')}"
         if device_id is not None:
@@ -190,6 +191,12 @@ class RommApiAdapter:
             params += "&overwrite=true"
         if save_id is not None:
             return self._client.upload_multipart(f"/api/saves/{save_id}?{params}", file_path, method="PUT")
+        # POST creates the save entry and is the only path that stacks versions —
+        # PUT updates in place. RomM's autocleanup defaults OFF, so capping the
+        # retained version count requires enabling it explicitly alongside the
+        # limit; hence both params, and only here (POST).
+        if autocleanup_limit is not None:
+            params += f"&autocleanup=true&autocleanup_limit={autocleanup_limit}"
         return self._client.upload_multipart(f"/api/saves?{params}", file_path, method="POST")
 
     def download_save(self, save_id: int, dest_path: str) -> None:

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -254,8 +254,13 @@ class RommSaveApi(Protocol):
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
-        """Upload (or replace) a save; raises ``RommConflictError`` on 409 unless ``overwrite=True``."""
+        """Upload (or replace) a save; raises ``RommConflictError`` on 409 unless ``overwrite=True``.
+
+        ``autocleanup_limit`` caps the server-retained version count and is honored
+        on the POST (create) path only — PUT updates in place and never stacks.
+        """
         ...
 
     def download_save_content(

--- a/py_modules/services/saves/slots/setup.py
+++ b/py_modules/services/saves/slots/setup.py
@@ -18,7 +18,7 @@ from domain.rom_save_state import RomSaveState
 from domain.save_layout import SAVE_SYNC_CONTENT_DIR_REASON
 from domain.save_slot import save_in_slot, slot_query_param
 from services.saves._messages import SAVE_SYNC_IN_CONTENT_DIR
-from services.saves._settings import resolve_default_slot
+from services.saves._settings import autocleanup_limit, resolve_default_slot
 
 if TYPE_CHECKING:
     import asyncio
@@ -317,6 +317,11 @@ class SetupWizard:
         core_so = await self._loop.run_in_executor(None, self._resolve_core, rom_id)
         emulator = build_emulator_tag(core_so)
 
+        # Carry-over uploads POST a new entry into the chosen slot, so the user's
+        # retention cap applies here too (RomM autocleanup defaults off → without
+        # it, repeated migrations stack uncapped).
+        cleanup_limit = autocleanup_limit(self._settings)
+
         ids_to_delete: list[int] = []
         not_carried: list[str] = []
 
@@ -341,6 +346,7 @@ class SetupWizard:
                         em,
                         device_id=device_id,
                         slot=slot_query_param(chosen_slot),
+                        autocleanup_limit=cleanup_limit,
                     ),
                 ),
             )

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -34,7 +34,13 @@ from services.saves._messages import (
     SAVE_SYNC_IN_CONTENT_DIR,
     SAVE_SYNC_IN_CONTENT_DIR_REASON,
 )
-from services.saves._settings import resolve_default_slot, save_sync_enabled, sync_after_exit, sync_before_launch
+from services.saves._settings import (
+    autocleanup_limit,
+    resolve_default_slot,
+    save_sync_enabled,
+    sync_after_exit,
+    sync_before_launch,
+)
 from services.saves.sync_engine.matrix import MatrixExecutor, MatrixOutcome
 from services.saves.sync_engine.rollback import RollbackOrchestrator
 
@@ -203,9 +209,10 @@ class SyncEngine:
         device_id: str | None,
         core_so: str | None,
         default_slot: str | None = None,
+        autocleanup_limit: int | None = None,
     ) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Sync saves for a single ROM (delegate to :class:`MatrixExecutor`)."""
-        return self._matrix.sync_rom_saves(rom_id, save_state, device_id, core_so, default_slot)
+        return self._matrix.sync_rom_saves(rom_id, save_state, device_id, core_so, default_slot, autocleanup_limit)
 
     def do_download_save(
         self,
@@ -235,10 +242,20 @@ class SyncEngine:
         core_so: str | None,
         server_save: dict[str, Any] | None = None,
         default_slot: str | None = None,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
         """Upload a local save file to server (delegate to :class:`MatrixExecutor`)."""
         return self._matrix.do_upload_save(
-            rom_id, file_path, filename, save_state, device_id, system, core_so, server_save, default_slot
+            rom_id,
+            file_path,
+            filename,
+            save_state,
+            device_id,
+            system,
+            core_so,
+            server_save,
+            default_slot,
+            autocleanup_limit=autocleanup_limit,
         )
 
     def iter_matrix_outcomes(
@@ -468,8 +485,9 @@ class SyncEngine:
             return 0, [], []
         core_so = await self._loop.run_in_executor(None, self.resolve_core, rom_id)
         default_slot = resolve_default_slot(self._settings)
+        cleanup_limit = autocleanup_limit(self._settings)
         synced, errors, conflicts = await self._loop.run_in_executor(
-            None, self.do_sync_rom_saves, rom_id, save_state, device_id, core_so, default_slot
+            None, self.do_sync_rom_saves, rom_id, save_state, device_id, core_so, default_slot, cleanup_limit
         )
         await self._loop.run_in_executor(None, self._write_save_state, rom_id, save_state)
         return synced, errors, conflicts

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -308,6 +308,7 @@ class MatrixExecutor:
         core_so: str | None,
         server_save: dict[str, Any] | None = None,
         default_slot: str | None = None,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
         """Upload a local save file to server.
 
@@ -315,7 +316,8 @@ class MatrixExecutor:
         attribution, local→server slot promotion); the operation entry owns
         the surrounding write Unit of Work. *core_so* is the active core
         resolved once by the caller so this worker stays free of installed-rom
-        reads.
+        reads. *autocleanup_limit* caps server-retained versions — the adapter
+        honors it on the POST (create) path only, so PUT callers leave it None.
         """
         save_id = server_save.get("id") if server_save else None
         emulator = build_emulator_tag(core_so)
@@ -325,7 +327,13 @@ class MatrixExecutor:
 
         result = self._retry.with_retry(
             lambda: self._romm_api.upload_save(
-                int(rom_id), file_path, emulator, save_id, device_id=device_id, slot=slot
+                int(rom_id),
+                file_path,
+                emulator,
+                save_id,
+                device_id=device_id,
+                slot=slot,
+                autocleanup_limit=autocleanup_limit,
             )
         )
 
@@ -448,6 +456,7 @@ class MatrixExecutor:
         system: str,
         core_so: str | None,
         default_slot: str | None,
+        autocleanup_limit: int | None = None,
         server_saves: list[dict[str, Any]],
         errors: list[str],
     ) -> bool:
@@ -456,13 +465,24 @@ class MatrixExecutor:
             errors.append(f"{filename}: upload requested but no local file")
             return False
         if action.target_save_id is None:
-            # POST path: brand-new save in slot.
+            # POST path: brand-new save in slot. The retention cap is POST-only —
+            # RomM stacks versions on create, so the limit is sent here alone.
             self.do_upload_save(
-                rom_id, local_path, filename, save_state, device_id, system, core_so, None, default_slot
+                rom_id,
+                local_path,
+                filename,
+                save_state,
+                device_id,
+                system,
+                core_so,
+                None,
+                default_slot,
+                autocleanup_limit=autocleanup_limit,
             )
             return True
         # PUT path: re-upload to update the tracked save (local diverged while
-        # is_current=true).
+        # is_current=true). PUT updates in place and never stacks, so the
+        # autocleanup cap is left at its None default.
         server_save = next((s for s in server_saves if s.get("id") == action.target_save_id), None)
         if server_save is None:
             # Picked save vanished between read and dispatch — best-effort.
@@ -489,6 +509,7 @@ class MatrixExecutor:
         system: str,
         core_so: str | None,
         default_slot: str | None,
+        autocleanup_limit: int | None = None,
         server_saves: list[dict[str, Any]],
         sink: DispatchSink,
     ) -> bool:
@@ -520,6 +541,7 @@ class MatrixExecutor:
                     system=system,
                     core_so=core_so,
                     default_slot=default_slot,
+                    autocleanup_limit=autocleanup_limit,
                     server_saves=server_saves,
                     errors=sink.errors,
                 )
@@ -650,6 +672,7 @@ class MatrixExecutor:
         device_id: str | None,
         core_so: str | None,
         default_slot: str | None = None,
+        autocleanup_limit: int | None = None,
     ) -> tuple[int, list[str], list[dict[str, Any]]]:
         """Sync saves for a single ROM, mutating *save_state* in memory.
 
@@ -658,7 +681,9 @@ class MatrixExecutor:
         ``(synced_count, errors_list, conflicts_list)``. *core_so* is the
         active core resolved once by the caller (for the upload emulator tag);
         *default_slot* seeds the active slot when a brand-new ROM's first sync
-        lands; the operation entry owns the surrounding read/write Unit of Work.
+        lands; *autocleanup_limit* caps server-retained versions on the POST
+        (create) upload; the operation entry owns the surrounding read/write
+        Unit of Work.
         """
         t_total = self._clock.time()
         rom_id = int(rom_id)
@@ -717,6 +742,7 @@ class MatrixExecutor:
                 system=system,
                 core_so=core_so,
                 default_slot=default_slot,
+                autocleanup_limit=autocleanup_limit,
                 server_saves=outcome.server_candidates,
                 sink=sink,
             ):

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -81,6 +81,22 @@ class DispatchSink:
     conflicts: list[dict[str, Any]]
 
 
+@dataclass(frozen=True)
+class SyncRunOptions:
+    """The settings-derived values threaded through one ROM's sync dispatch.
+
+    Resolved once per sync run and constant across every file of the ROM, so
+    they ride through ``_dispatch_sync_action`` / ``_dispatch_upload`` as one
+    argument rather than widening every signature (mirrors ``DispatchSink``).
+    ``default_slot`` seeds the active slot on a brand-new ROM's first sync and
+    selects the upload slot; ``autocleanup_limit`` caps server-retained versions
+    on the POST (create) upload.
+    """
+
+    default_slot: str | None = None
+    autocleanup_limit: int | None = None
+
+
 class MatrixExecutor:
     """Newest-wins matrix executor + per-file sync I/O dispatch.
 
@@ -455,8 +471,7 @@ class MatrixExecutor:
         local_path: str | None,
         system: str,
         core_so: str | None,
-        default_slot: str | None,
-        autocleanup_limit: int | None = None,
+        options: SyncRunOptions,
         server_saves: list[dict[str, Any]],
         errors: list[str],
     ) -> bool:
@@ -476,8 +491,8 @@ class MatrixExecutor:
                 system,
                 core_so,
                 None,
-                default_slot,
-                autocleanup_limit=autocleanup_limit,
+                options.default_slot,
+                autocleanup_limit=options.autocleanup_limit,
             )
             return True
         # PUT path: re-upload to update the tracked save (local diverged while
@@ -491,7 +506,7 @@ class MatrixExecutor:
             )
             return False
         self.do_upload_save(
-            rom_id, local_path, filename, save_state, device_id, system, core_so, server_save, default_slot
+            rom_id, local_path, filename, save_state, device_id, system, core_so, server_save, options.default_slot
         )
         return True
 
@@ -508,8 +523,7 @@ class MatrixExecutor:
         saves_dir: str,
         system: str,
         core_so: str | None,
-        default_slot: str | None,
-        autocleanup_limit: int | None = None,
+        options: SyncRunOptions,
         server_saves: list[dict[str, Any]],
         sink: DispatchSink,
     ) -> bool:
@@ -540,14 +554,13 @@ class MatrixExecutor:
                     local_path=local_path,
                     system=system,
                     core_so=core_so,
-                    default_slot=default_slot,
-                    autocleanup_limit=autocleanup_limit,
+                    options=options,
                     server_saves=server_saves,
                     errors=sink.errors,
                 )
             if isinstance(action, Download):
                 self.do_download_save(
-                    action.server_save, saves_dir, filename, save_state, device_id, system, default_slot
+                    action.server_save, saves_dir, filename, save_state, device_id, system, options.default_slot
                 )
                 return True
             if isinstance(action, Conflict):
@@ -715,6 +728,7 @@ class MatrixExecutor:
         errors: list[str] = []
         conflicts: list[dict[str, Any]] = []
         sink = DispatchSink(errors=errors, conflicts=conflicts)
+        options = SyncRunOptions(default_slot=default_slot, autocleanup_limit=autocleanup_limit)
         synced = 0
 
         pending_migration = self._rom_info.is_save_sort_changed()
@@ -741,8 +755,7 @@ class MatrixExecutor:
                 saves_dir=saves_dir,
                 system=system,
                 core_so=core_so,
-                default_slot=default_slot,
-                autocleanup_limit=autocleanup_limit,
+                options=options,
                 server_saves=outcome.server_candidates,
                 sink=sink,
             ):

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -171,6 +171,33 @@ class TestUploadSave:
         path = client.upload_multipart.call_args[0][0]
         assert "overwrite" not in path
 
+    def test_post_with_autocleanup_limit(self):
+        """POST sends autocleanup=true AND the limit so RomM caps retained versions."""
+        api, client = _make_api()
+        client.upload_multipart.return_value = {"id": 1}
+        api.upload_save(42, "/tmp/save.srm", "retroarch-mgba", autocleanup_limit=25)
+        path = client.upload_multipart.call_args[0][0]
+        # autocleanup defaults OFF on RomM, so both flags are required.
+        assert "autocleanup=true" in path
+        assert "autocleanup_limit=25" in path
+
+    def test_post_without_autocleanup_limit_unchanged(self):
+        """POST with no autocleanup_limit (default) keeps the query free of autocleanup."""
+        api, client = _make_api()
+        client.upload_multipart.return_value = {"id": 1}
+        api.upload_save(42, "/tmp/save.srm", "retroarch-mgba")
+        path = client.upload_multipart.call_args[0][0]
+        assert "autocleanup" not in path
+
+    def test_put_ignores_autocleanup_limit(self):
+        """PUT updates in place and never stacks, so the cap is POST-only — not on PUT."""
+        api, client = _make_api()
+        client.upload_multipart.return_value = {"id": 5}
+        api.upload_save(42, "/tmp/save.srm", "retroarch-mgba", save_id=5, autocleanup_limit=25)
+        path = client.upload_multipart.call_args[0][0]
+        assert path.startswith("/api/saves/5?")
+        assert "autocleanup" not in path
+
     def test_encodes_emulator(self):
         """Slash in emulator name is encoded (safe="" — house style)."""
         api, client = _make_api()

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -443,6 +443,7 @@ class FakeRommApi:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
         self._log(
             "upload_save",
@@ -452,6 +453,7 @@ class FakeRommApi:
                 "device_id": device_id,
                 "slot": slot,
                 "overwrite": overwrite,
+                "autocleanup_limit": autocleanup_limit,
             },
         )
         self._check_fail(self.upload_save_side_effect)

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -306,6 +306,7 @@ class FakeSaveApi:
         device_id: str | None = None,
         slot: str | None = None,
         overwrite: bool = False,
+        autocleanup_limit: int | None = None,
     ) -> dict[str, Any]:
         self.call_log.append(
             (
@@ -316,6 +317,7 @@ class FakeSaveApi:
                     "device_id": device_id,
                     "slot": slot,
                     "overwrite": overwrite,
+                    "autocleanup_limit": autocleanup_limit,
                 },
             )
         )

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -14,7 +14,7 @@ import pytest
 
 from domain.rom_save_state import RomSaveState
 from lib.errors import RommApiError
-from services.saves.sync_engine.matrix import DispatchSink
+from services.saves.sync_engine.matrix import DispatchSink, SyncRunOptions
 from tests.services.saves._helpers import (
     _create_save,
     _do_sync,
@@ -1649,7 +1649,7 @@ class TestHandleUnexpectedError:
             saves_dir=str(saves_dir),
             system="gba",
             core_so=None,
-            default_slot=None,
+            options=SyncRunOptions(),
             server_saves=[],
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -1695,7 +1695,7 @@ class TestDispatchSyncActionErrorBranches:
             saves_dir=str(saves_dir),
             system="gba",
             core_so=None,
-            default_slot=None,
+            options=SyncRunOptions(),
             server_saves=[],
             sink=DispatchSink(errors=errors, conflicts=conflicts),
         )
@@ -1728,7 +1728,7 @@ class TestDispatchUploadDefensiveBranches:
             local_path=None,
             system="gba",
             core_so=None,
-            default_slot=None,
+            options=SyncRunOptions(),
             server_saves=[],
             errors=errors,
         )
@@ -1760,7 +1760,7 @@ class TestDispatchUploadDefensiveBranches:
             local_path=str(save_path),
             system="gba",
             core_so=None,
-            default_slot=None,
+            options=SyncRunOptions(),
             server_saves=[{"id": 100, "file_name": "pokemon.srm"}],
             errors=errors,
         )

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -1132,6 +1132,69 @@ class TestDoUploadSaveFileStatePersistence:
         assert reloaded_file.tracked_save_id == 100
 
 
+class TestAutocleanupLimitThreading:
+    """The user's ``autocleanup_limit`` setting reaches the POST upload, POST-only.
+
+    Drives the real public ``sync_rom_saves`` so the value is resolved from
+    ``settings.json`` in ``_run_rom_sync`` and threaded the whole way down to
+    ``upload_save`` — the path the dead-setting bug (#1060) left disconnected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_post_upload_carries_autocleanup_limit(self, tmp_path):
+        """A POST (new save) upload sends the configured ``autocleanup_limit``."""
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["autocleanup_limit"] = 25
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path)  # local only → POST
+
+        await svc.sync_rom_saves(42)
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["save_id"] is None  # POST path
+        assert upload_calls[0][2]["autocleanup_limit"] == 25
+
+    @pytest.mark.asyncio
+    async def test_put_upload_drops_autocleanup_limit(self, tmp_path):
+        """A PUT (update tracked save) upload leaves ``autocleanup_limit`` None.
+
+        Even with the cap configured, the PUT branch sends nothing — RomM
+        updates in place and never stacks, so the cap is POST-only.
+        """
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc, device_id="device-1")
+        svc._config.settings["autocleanup_limit"] = 25
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"diverged local content")
+
+        # is_current=true on our device + local diverged from the baseline →
+        # Upload(target_save_id=100) → PUT.
+        fake.saves[100] = _server_save_with_syncs(
+            save_id=100,
+            slot="default",
+            device_syncs=[{"device_id": "device-1", "is_current": True}],
+        )
+        _seed_save_state_dict(
+            svc,
+            42,
+            {
+                "files": {"pokemon.srm": {"tracked_save_id": 100, "last_sync_hash": "oldhash"}},
+                "system": "gba",
+                "active_slot": "default",
+                "slot_confirmed": True,
+            },
+        )
+
+        await svc.sync_rom_saves(42)
+
+        upload_calls = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(upload_calls) == 1
+        assert upload_calls[0][2]["save_id"] == 100  # PUT path
+        assert upload_calls[0][2]["autocleanup_limit"] is None
+
+
 class TestSyncRomSavesDispatch:
     def test_sync_rom_saves_skip_when_synced(self, tmp_path):
         """is_current=true + matching hash + tracked → Skip, no I/O."""

--- a/tests/services/saves/test_slots.py
+++ b/tests/services/saves/test_slots.py
@@ -605,6 +605,7 @@ class TestConfirmSlotChoice:
         """
         svc, fake = make_service(tmp_path)
         svc._config.settings["save_sync_enabled"] = True
+        svc._config.settings["autocleanup_limit"] = 7
         _set_device_id(svc, "dev-1")
         _install_rom(svc, tmp_path)
         _create_save(tmp_path)
@@ -618,6 +619,8 @@ class TestConfirmSlotChoice:
         assert len(upload_calls) >= 1
         # Check it was uploaded with the new slot
         assert upload_calls[0][2].get("slot") == "default"
+        # Carry-over POST creates a new entry, so the user's retention cap rides along.
+        assert upload_calls[0][2].get("autocleanup_limit") == 7
         # Old save should have been deleted
         delete_calls = [c for c in fake.call_log if c[0] == "delete_server_saves"]
         assert len(delete_calls) == 1


### PR DESCRIPTION
Closes #1060.

## Problem

`autocleanup_limit` is exposed in the UI, persisted, and documented as a `POST /api/saves` parameter that caps retained save versions — but `upload_save` never sent it, so the user's choice had no effect.

Verified against the live RomM 4.9.2 OpenAPI: `POST /api/saves` accepts `autocleanup` (boolean, **default `false`**) and `autocleanup_limit` (integer). Because `autocleanup` defaults off, the server does **not** prune on POST unless the plugin enables it — so without this fix, save versions stack uncapped on the POST path.

## Fix — send it

`upload_save` now appends `autocleanup=true&autocleanup_limit=<N>` on the **POST** path, and the configured value is threaded from `settings.json` (`autocleanup_limit(settings)`) through the sync engine to the adapter, mirroring how `default_slot` is threaded.

**POST-only by design:** `PUT /api/saves/{id}` updates a tracked save in place and never stacks versions (and the RomM API accepts the params on POST only). The sweep covers **both** POST upload sites:

- the normal sync flow (`MatrixExecutor._dispatch_upload` POST branch), and
- the slot-migration carry-over (`slots/setup.py` `_migrate_slot_saves`).

PUT sites (rollback, conflict-keep-local, version switch) correctly omit the cap. The adapter also returns on the PUT branch before the autocleanup block, so the params can never leak onto a PUT.

## Tests

- `tests/adapters/romm/test_romm_api.py` — POST with a limit carries `autocleanup=true&autocleanup_limit=<N>`; default POST carries neither; PUT never carries it.
- `tests/services/saves/sync_engine/test_matrix.py` — drives the **real** `sync_rom_saves`, asserting the configured limit reaches `upload_save` on the POST path and is absent (`None`) on the PUT path — exercising the actual engine settings-resolution wiring.
- `tests/services/saves/test_slots.py` — the slot-migration carry-over upload carries the configured limit.
- Full suite green (`3887 passed`); ruff + basedpyright (incl. `tests/`) + import-linter clean.

## Docs

`docs/architecture/save-file-sync-architecture.md` — states the plugin sends `autocleanup=true` with the configured `autocleanup_limit` on the POST path (POST-only because PUT updates in place without stacking).
