### PR TITLE
fix(ci): pin denoland/setup-deno comment to v2.0.4 to clear Renovate digest warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 


### PR DESCRIPTION
Clears the persistent `Could not determine new digest for update (github-tags package denoland/setup-deno)` warning on the Renovate Dependency Dashboard (#1230).

**Cause:** the SHA pin carried the rolling-major comment `# v2`. Renovate's github-tags datasource lists only specific release tags (`v2.0.4`, `v2.0.3`, …), not the bare `v2`, so the *current* version isn't found on the datasource and Renovate can't compute a digest — a documented false warning ([renovatebot/renovate#38291](https://github.com/renovatebot/renovate/discussions/38291)).

**Fix:** comment now reads `# v2.0.4`, which points to the **same commit** (`667a34c`) — SHA unchanged, action still securely pinned. The specific version lets Renovate resolve the digest, so the warning clears and Renovate can properly auto-update this pin going forward.

docs: N/A — comment-only change to a workflow (no behavior change, SHA unchanged).