### PR TITLE
fix(ci): enforce version ceilings in Renovate + document where versions live

### DIFF
--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -1,0 +1,71 @@
+# Dependency management
+
+One page for the question "**why is _that_ on _this_ version, and who bumps it?**" Every version in the repo lives in
+one of the files below. Most update automatically (Renovate); a few are pinned by hand on purpose.
+
+## Where every version lives
+
+| File                                               | Holds                                                                       | Updated by                                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `mise.toml`                                        | the dev **toolchain**: `node`, `pnpm`, `python`, `uv`, `deno`               | **by hand** (see [Bumping by hand](#bumping-by-hand))            |
+| `package.json`                                     | npm deps (`^` ranges), `packageManager` (pnpm), `pnpm.overrides` (CVE pins) | Renovate (npm)                                                   |
+| `pnpm-lock.yaml`                                   | resolved npm versions                                                       | generated from `package.json` (Renovate keeps it in sync)        |
+| `requirements-dev.txt` / `requirements-docs.txt`   | Python dep **ranges** — the **source of truth**, incl. deliberate ceilings  | by hand for ceilings; Renovate refreshes within them             |
+| `requirements-dev.lock` / `requirements-docs.lock` | resolved Python versions (uv-compiled)                                      | `mise run lock-update` locally; Renovate recompiles on its PRs   |
+| `.github/workflows/*.yml`                          | action SHA pins (`@<sha> # vX`), `setup-*` version inputs                   | Renovate (github-actions) for the SHAs; toolchain inputs by hand |
+| `renovate.json`                                    | **policy only** — who may bump what. Not a version source.                  | by hand                                                          |
+
+## What's genuinely duplicated (and why it's safe)
+
+A handful of **toolchain** versions appear in more than one file, because each tool reads its own config location and
+all copies must agree:
+
+| Tool           | Appears in                                    | Must match because                                                 |
+| -------------- | --------------------------------------------- | ------------------------------------------------------------------ |
+| `pnpm`         | `mise.toml` + `package.json` `packageManager` | the package manager you run must be one version                    |
+| `python`       | `mise.toml` + workflow `setup-python`         | must match Decky Loader's embedded `libpython3.11`                 |
+| `uv`           | `mise.toml` + workflow `setup-uv`             | the local resolver must equal the lock author (reproducible locks) |
+| `node`, `deno` | `mise.toml` + workflows                       | local == CI                                                        |
+
+These are the only real duplicates, and **Renovate is configured to never touch them** (excluded by dependency name in
+`renovate.json`). So a bot can't bump one copy and desync the rest — they only move when **you** move them, together.
+
+## Who bumps what — the auto-merge policy
+
+Update PRs are opened by [Renovate](https://docs.renovatebot.com/) (`renovate.json`, the Renovate GitHub App).
+Auto-merge uses GitHub's native auto-merge, so **the required CI checks are the gate** — a PR only merges itself when
+everything is green.
+
+| Category                                           | Auto-merges?                    |
+| -------------------------------------------------- | ------------------------------- |
+| Python (pip) in-range minor/patch + lock refreshes | ✅                              |
+| npm / GitHub-Actions minor / patch / digest        | ✅                              |
+| **Any major** (any ecosystem)                      | ❌ → human review               |
+| **Toolchain** (`node`/`pnpm`/`python`/`uv`/`deno`) | ❌ not even proposed (excluded) |
+| **Raising a deliberate ceiling** (see below)       | ❌ not even proposed            |
+
+## Ceilings — versions deliberately held back
+
+Two Python dev tools are capped tighter than "next major", because the next release is known-breaking:
+
+| Dep              | Ceiling | Why                                                                                                   |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `pytest-asyncio` | `<1.4`  | 1.4 changed event-loop semantics ([#806](https://github.com/danielcopper/decky-romm-sync/issues/806)) |
+| `ruff`           | `<0.16` | 0.x minors ship new lint rules (breaking)                                                             |
+
+The ceiling lives in `requirements-dev.txt`. Renovate's `rangeStrategy: update-lockfile` refreshes the lock _within_ the
+range, but it does **not** stop a range-widening PR when a newer version is _above_ the ceiling — so `renovate.json`
+also carries an `allowedVersions` cap for each of these two deps to keep Renovate from proposing the raise at all.
+
+**Heads up — these two ceilings are duplicated:** the `<1.4` / `<0.16` caps exist in **both** `requirements-dev.txt` and
+`renovate.json` (`allowedVersions`). If you deliberately raise a ceiling, change it in **both** places (the
+`renovate.json` rules are commented `KEEP IN SYNC`). This is the only version duplication Renovate forces on us.
+
+## Bumping by hand
+
+- **Toolchain** (`mise.toml`): edit the pin, then update every coupled copy in the same commit — `package.json`
+  `packageManager` for pnpm, the workflow `setup-*` inputs for python/uv/node/deno. Run `mise install` to pick it up.
+- **A Python ceiling**: raise the `<X` in `requirements-*.txt`, raise the matching `allowedVersions` in `renovate.json`,
+  run `mise run lock-update`, commit together.
+- **Python locks** after any `requirements-*.txt` edit: `mise run lock-update` (the `check_lock_sync` CI gate enforces
+  this).

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -29,23 +29,12 @@ Python dependencies are installed from `requirements-dev.lock` — fully-pinned 
 `requirements-dev.txt` by uv. After changing a source (`requirements-dev.txt` / `requirements-docs.txt`) or bumping a
 pin, run `mise run lock-update` to regenerate the locks.
 
-### Automated dependency updates (Renovate)
+### Automated dependency updates
 
-Dependency update PRs are managed by [Renovate](https://docs.renovatebot.com/) (`renovate.json`), across all ecosystems
-— Python (pip), npm, and GitHub Actions. It replaces Dependabot, which could not recompile the `uv pip compile` lock
-files (it only bumped the source range, leaving the lock out of sync).
-
-For Python, Renovate's [pip-compile manager](https://docs.renovatebot.com/modules/manager/pip-compile/) reads the
-command in each `requirements-*.lock` header and recompiles the lock **with uv in the same PR** — so the lock-sync gate
-is always satisfied. Crucially, `rangeStrategy: update-lockfile` means Renovate only moves versions **within the range
-already declared** in `requirements-*.txt`; it never widens a `<X` ceiling. So a deliberate cap (e.g. `pytest-asyncio`
-held `<1.4` for #806) is honored automatically, and raising a ceiling stays a manual edit to the source — the source
-range is the single source of truth.
-
-In-range minor/patch updates auto-merge via GitHub's native auto-merge (`platformAutomerge`), so the required CI checks
-are the gate; nothing installed from pip ships in the plugin (runtime deps are vendored). npm and GitHub-Actions updates
-auto-merge on minor/patch/digest; majors are left for human review. Updating Renovate's behavior is a `renovate.json`
-change; the bot itself runs as the Renovate GitHub App installed on the repository.
+Update PRs are managed by [Renovate](https://docs.renovatebot.com/) (`renovate.json`) across pip, npm, and GitHub
+Actions, and in-range minor/patch updates auto-merge once CI is green. For the full picture — **where every version
+lives, what's coupled, what auto-merges, and how to bump things by hand** — see
+[Dependency management](dependency-management.md).
 
 The toolchain versions — `node`, `pnpm`, `python`, `uv`, `deno` — are **excluded** from Renovate: they are pinned and
 cross-file-coupled (each appears in `mise.toml` and in `package.json`'s `packageManager` and/or the workflow `setup-*`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,3 +77,4 @@ nav:
       - Steam Remote Play & Cross-Device: architecture/steam-remote-play.md
   - Contributing:
       - Development: contributing/development.md
+      - Dependency management: contributing/dependency-management.md

--- a/renovate.json
+++ b/renovate.json
@@ -26,12 +26,26 @@
   },
   "packageRules": [
     {
-      "description": "Python dev/docs tooling: refresh the uv-compiled lock only WITHIN the declared range. update-lockfile never widens a `<X` ceiling, so deliberate caps (e.g. pytest-asyncio <1.4 for #806) are honored automatically and a ceiling raise stays a manual edit to requirements-*.txt. Auto-merge — the required CI checks are the gate; nothing from pip ships in the plugin.",
+      "description": "Python dev/docs tooling: refresh the uv-compiled lock within the declared range. Auto-merge — the required CI checks are the gate; nothing from pip ships in the plugin. (update-lockfile keeps in-range bumps lock-only, but does NOT stop a range-widening PR when the newest version is ABOVE the declared ceiling — that case is covered by the allowedVersions caps below and the no-major-auto-merge rule.)",
       "matchManagers": [
         "pip-compile"
       ],
       "rangeStrategy": "update-lockfile",
       "automerge": true
+    },
+    {
+      "description": "Deliberate tight version ceiling: pytest-asyncio is held <1.4 (#806 — 1.4 changed event-loop semantics). allowedVersions stops Renovate from even proposing a version above the cap; without it, update-lockfile still raises a *minor* (1.3 -> 1.4) range-widening PR that would auto-merge. KEEP IN SYNC with the `<1.4` in requirements-dev.txt — if you deliberately raise that ceiling, update this too.",
+      "matchDepNames": [
+        "pytest-asyncio"
+      ],
+      "allowedVersions": "<1.4"
+    },
+    {
+      "description": "Deliberate tight version ceiling: ruff is held <0.16 (0.x minors are breaking — new lint rules). Same rationale as the pytest-asyncio rule above. KEEP IN SYNC with requirements-dev.txt.",
+      "matchDepNames": [
+        "ruff"
+      ],
+      "allowedVersions": "<0.16"
     },
     {
       "description": "npm + GitHub Actions: auto-merge minor/patch/digest; majors are left for human review.",
@@ -58,6 +72,13 @@
         "astral-sh/uv"
       ],
       "enabled": false
+    },
+    {
+      "description": "Never auto-merge a major update, in any ecosystem — a major dep bump (or, for pip, raising a `<next-major` ceiling such as pytest <10.0) always gets human review. Overrides the manager auto-merge rules above for major updates; minor/patch/digest and lock-file maintenance still auto-merge.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
     }
   ],
   "platformAutomerge": true


### PR DESCRIPTION
## Why

The first batch of Renovate PRs surfaced that **`rangeStrategy: update-lockfile` does not protect a deliberate version ceiling**. It keeps in-range bumps lock-only, but when the newest version is *above* the declared `<X`, Renovate still opens a range-widening PR — and #1241 did exactly that: `pytest-asyncio >=1.3.0,<1.4` → `>=1.4,<1.5` (a *minor*), with **auto-merge on**. That's the #806 cap it was meant to honor. CI happened to catch it (1.4.0 breaks the tests → red), but that's luck, not a guard.

## Fix (renovate.json)

- **`allowedVersions`** caps for the two deps with a deliberate tight ceiling — `pytest-asyncio <1.4`, `ruff <0.16` — so Renovate never even proposes crossing them. These are the **only** versions duplicated into `renovate.json`; both rules are commented `KEEP IN SYNC` with `requirements-dev.txt`.
- A global **"majors never auto-merge"** rule, so raising a `<next-major` ceiling (or any major) always gets human review — consistent with the npm/Actions policy.

This makes **#1241 obsolete** (Renovate won't propose it again) — closing it.

## Plus: one place to look (addresses "too many config files")

Adds **`docs/contributing/dependency-management.md`** — a single page mapping **where every version lives**, which ones are coupled/duplicated (and why that's safe — Renovate can't desync them), what auto-merges, and how to bump each thing by hand. The Renovate blurb in `development.md` now points there instead of repeating it (and no longer claims `update-lockfile` honors ceilings, which it doesn't).

docs: `dependency-management.md` (new) + `development.md` pointer.
