### PR TITLE
chore(deps): bump prettier to 3.9.1 and reformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "globals": "^17.6.0",
     "happy-dom": "^20.10.6",
     "markdownlint-cli2": "^0.22.1",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-icons": "^5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
       prettier:
-        specifier: ^3.8.4
-        version: 3.8.4
+        specifier: ^3.9.1
+        version: 3.9.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -2042,8 +2042,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.1:
+    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4702,7 +4702,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.1: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -53,15 +53,7 @@ import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { reconfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 
 type PlayButtonState =
-  | "loading"
-  | "not_romm"
-  | "download"
-  | "conflict"
-  | "syncing"
-  | "play"
-  | "launching"
-  | "dl_complete"
-  | "uninstalling";
+  "loading" | "not_romm" | "download" | "conflict" | "syncing" | "play" | "launching" | "dl_complete" | "uninstalling";
 
 interface DownloadProgress {
   bytesDownloaded: number;

--- a/src/utils/saveSetup.ts
+++ b/src/utils/saveSetup.ts
@@ -14,9 +14,7 @@
 import type { SaveSetupInfo } from "../types";
 
 export type SaveSetupOutcome =
-  | { kind: "server_unreachable" }
-  | { kind: "auto_confirm"; slot: string }
-  | { kind: "needs_user_choice" };
+  { kind: "server_unreachable" } | { kind: "auto_confirm"; slot: string } | { kind: "needs_user_choice" };
 
 /** Resolve a SaveSetupInfo into the action its callers should take. */
 export function resolveSaveSetupOutcome(info: SaveSetupInfo): SaveSetupOutcome {


### PR DESCRIPTION
prettier 3.9 changes one formatting default (short union types collapse to a single line), so a bump fails `format:check` until the source is reformatted. This does both in one commit.

Supersedes Renovate's prettier PRs — once this is on main, **#1240** (prettier 3.9.1) and **#1250** (lock file maintenance, which was red for the same prettier reason) resolve / auto-close. Done from main rather than pushing to the Renovate branch, since Renovate rebases its branch and drops manual commits.

Churn is tiny: 2 source files (the union-type reformat).

docs: N/A — formatting + dev-dependency bump, no user-visible or architectural change.