### PR TITLE
chore(ci): auto-merge Renovate lock-file maintenance PRs

### DIFF
--- a/docs/contributing/dependency-management.md
+++ b/docs/contributing/dependency-management.md
@@ -40,6 +40,7 @@ everything is green.
 | -------------------------------------------------- | ------------------------------- |
 | Python (pip) in-range minor/patch + lock refreshes | ✅                              |
 | npm / GitHub-Actions minor / patch / digest        | ✅                              |
+| Monthly lock-file maintenance (transitive refresh) | ✅                              |
 | **Any major** (any ecosystem)                      | ❌ → human review               |
 | **Toolchain** (`node`/`pnpm`/`python`/`uv`/`deno`) | ❌ not even proposed (excluded) |
 | **Raising a deliberate ceiling** (see below)       | ❌ not even proposed            |

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
+    "automerge": true,
     "schedule": [
       "before 6am on the first day of the month"
     ]


### PR DESCRIPTION
The monthly `lockFileMaintenance` PR (transitive refresh within existing ranges) has update-type `lockFileMaintenance`, which the per-manager auto-merge rules don't match — so it sat open awaiting a manual merge (#1250).

Adds `automerge: true` to the `lockFileMaintenance` config. It's in-range and CI-gated, so the required checks are the gate, consistent with the rest of the auto-merge policy. Documented in the dependency-management auto-merge table.