### PR TITLE
feat(connection)!: require RomM 4.9.0 (drop 4.8.x support)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ silent omission. The CI check enforces this.
   rom_id↔appId comes from the backend `get_app_id_rom_id_map()` (`roms.shortcut_app_id`). launch_options is written at
   sync (installed ROMs), at download-complete, and re-resolved on RetroDECK-home migration (`migration_relaunch_options`
   event). See [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md).
-- **RomM minimum version**: Requires RomM >= 4.8.1. Hard-rejected in `test_connection()` — plugin is inert until server
-  is updated. `_MIN_REQUIRED_VERSION` tuple in `main.py`.
+- **RomM minimum version**: Requires RomM >= 4.9.0. Hard-rejected in `test_connection()` — plugin is inert until server
+  is updated. `_MIN_REQUIRED_VERSION` tuple in `main.py`. The 4.9.0 floor is the release that ships RomM's Device Sync
+  (`negotiate`) save-sync transport (#1234 / ADR-0016); bumped from 4.8.1 as a breaking change while still beta.
 - **Token-host binding**: A Client API Token is bound to the server origin it was minted against
   (`romm_api_token_origin` — canonical `scheme://host[:port]` via `lib/url_host`; `https://h` and `http://h` are
   different origins). The bearer is sent only when `romm_url`'s origin matches; a mismatch raises

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ documentation site. This README is just the quick tour.
 ## Requirements
 
 - [Decky Loader](https://decky.xyz/) on your Steam Deck or Linux HTPC
-- A running [RomM](https://github.com/rommapp/romm) server, **version 4.8.1 or newer** (the plugin stays inert against
+- A running [RomM](https://github.com/rommapp/romm) server, **version 4.9.0 or newer** (the plugin stays inert against
   older servers)
 - [RetroDECK](https://retrodeck.net/) for launching games
 

--- a/docs/adr/0016-save-sync-hands-detection-to-romm-negotiate.md
+++ b/docs/adr/0016-save-sync-hands-detection-to-romm-negotiate.md
@@ -59,12 +59,21 @@ agreement, and the conflict branch is untested server-side. The clean "pair once
 
 ## Decision
 
-**Adopt the negotiate transport behind a ≥4.9 capability gate; keep our resolution/slot/path brain layered on top
-(Option B — hybrid). Retain the legacy `list_saves` path for <4.9 servers and legacy `slot:null` saves.**
+**Adopt the negotiate transport; keep our resolution/slot/path brain layered on top (Option B — hybrid). Require RomM
+≥4.9.0 as the hard minimum (`_MIN_REQUIRED_VERSION`) rather than a soft per-server capability gate — a breaking change
+taken while still beta (#1234 phase 0b) — and retain the legacy `list_saves` path only for legacy `slot:null` saves
+(RomM cannot address `slot:null` through the negotiate inventory param).**
 
-- **Detection moves server-side.** When the server is ≥4.9 and a ROM has a non-legacy slot, the sync run is driven by
-  `negotiate`'s operation list instead of `compute_sync_action`. The client builds a `(rom_id, slot)` inventory, POSTs
-  it, and executes the returned `upload` / `download` / `no_op` ops with the existing executors.
+> **0b refinement (supersedes the original "soft ≥4.9 capability gate" framing).** The first cut of this ADR kept
+> `_MIN_REQUIRED_VERSION` at 4.8.1 and gated negotiate as a per-server capability, retaining the legacy path for both
+> `<4.9` servers and `slot:null` saves. That was reversed: `_MIN_REQUIRED_VERSION` gates the **whole** plugin, so a soft
+> gate bought no benefit (≥4.9 users get negotiate either way) while a hard bump only evicts ≤4.8 users — and the legacy
+> path cannot be deleted regardless, because `slot:null` still needs it. So the floor is bumped to 4.9.0 and the
+> `<4.9-server` capability dimension is dropped; the legacy path survives **only** for `slot:null`.
+
+- **Detection moves server-side.** When a ROM has a non-legacy slot, the sync run is driven by `negotiate`'s operation
+  list instead of `compute_sync_action`. The client builds a `(rom_id, slot)` inventory, POSTs it, and executes the
+  returned `upload` / `download` / `no_op` ops with the existing executors.
 - **Resolution stays the client's.** A `conflict` operation routes into our existing resolution UX (`keep_local` /
   `use_server`) and `.romm-backup` quarantine — the server gives no resolution directive.
 - **The wizard gates the inventory.** Only ROMs with `slot_confirmed=True` and a resolved `active_slot` enter the
@@ -78,21 +87,24 @@ agreement, and the conflict branch is untested server-side. The clean "pair once
   ([#1235](https://github.com/danielcopper/decky-romm-sync/issues/1235)).
 - **Slots survive as a client-side UX dimension** over negotiate's `slot` field; `active_slot` / `source:local` /
   `slot_confirmed` / `default_slot` have no server analog and are unaffected.
-- Once min RomM ≥ 4.9 on the negotiate path, the v4.8.1 `confirm_download` / PUT-bump bookkeeping is dead and is removed
-  ([#748](https://github.com/danielcopper/decky-romm-sync/issues/748)); `is_current` is read from the server watermark.
+- On the negotiate path (the min is now a hard RomM ≥ 4.9.0), the v4.8.1 `confirm_download` / PUT-bump bookkeeping is
+  dead and is removed ([#748](https://github.com/danielcopper/decky-romm-sync/issues/748)); `is_current` is read from
+  the server watermark.
 
 ## Consequences
 
 - **(+)** Interop with the first-party protocol (Argosy/Grout, web/EmulatorJS); the server becomes the authoritative
   source of cross-device sync bookkeeping; the `confirm_download` ack and PUT-bump tricks die.
 - **(−)** New surface to build and maintain: device-id threading into negotiate, the session lifecycle, per-device
-  serialization, the capability gate + legacy fallback, and exact zip-hash parity. Net code change is roughly flat —
-  small deletions offset by new wiring.
-- **Reversible:** capability-gated with the legacy path retained; the detection kernel can be restored if the protocol
-  regresses.
-- **A real existing blocker must be fixed first:** `establish_token` never clears `device_id` on origin change
-  (`connection.py:262-268`), so a server switch leaves a stale device id and negotiate hard-404s a foreign `device_id`.
-  Fixing per-origin device identity is a prerequisite (ties into
+  serialization, the `slot:null` legacy fallback, and exact zip-hash parity. Net code change is roughly flat — small
+  deletions offset by new wiring.
+- **(−)** Breaking change: the `_MIN_REQUIRED_VERSION` bump to 4.9.0 evicts ≤4.8 servers from the whole plugin (not only
+  save sync). Acceptable while pre-1.0/beta; surfaced as a `BREAKING CHANGE` in the release notes.
+- **Reversible:** the floor can be lowered again and the detection kernel restored if the protocol regresses; the legacy
+  path stays on disk for `slot:null` regardless.
+- **A real existing blocker, fixed first (phase 0a, #1258):** `establish_token` never cleared `device_id` on origin
+  change, so a server switch left a stale device id and negotiate hard-404s a foreign `device_id`. Per-origin device
+  identity now forgets the id on an origin change (ties into
   [#163](https://github.com/danielcopper/decky-romm-sync/issues/163)).
 - **On-device (Game Mode) verification required** — the negotiate round-trip, serialization under rapid Sync/Cancel, and
   zip-save convergence can't be unit-tested alone.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -549,7 +549,7 @@ package, organised topically (consumers always deep-import `from services.protoc
 Protocol names carry a suffix that signals shape (`…Reader`, `…Provider`/`…Fn`, `…Store`, `…Cache`, `…Persister`; bare
 names for pervasive primitives like `Clock`).
 
-`RommApiAdapter` implements `RommApi` over `RommHttpAdapter`, targeting RomM 4.8.1+ endpoints.
+`RommApiAdapter` implements `RommApi` over `RommHttpAdapter`, targeting RomM 4.9.0+ endpoints.
 
 ## Boundary Enforcement
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -15,7 +15,7 @@ Phase 7.
 
 ## RomM Save API
 
-Requires RomM >= 4.8.1. The plugin rejects servers below 4.8.1 with `reason: "version_error"`.
+Requires RomM >= 4.9.0. The plugin rejects servers below 4.9.0 with `reason: "version_error"`.
 
 | Endpoint                                                 | Method | Notes                                                                                                                                                                                                                              |
 | -------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -173,7 +173,7 @@ uploaded each save.
 
 ### Why `/etc/machine-id` is the fingerprint
 
-RomM ≥4.8.1 dedupes devices by fingerprint — `mac_address`, OR `hostname` + `platform` — and returns the existing device
+RomM dedupes devices by fingerprint — `mac_address`, OR `hostname` + `platform` — and returns the existing device
 instead of minting a duplicate (`allow_existing` defaults true). The `name` field is **not** fingerprinted, so without a
 stable fingerprint every local-state wipe (the SQLite reinstall path) would create a fresh duplicate device on each
 reinstall.
@@ -182,8 +182,7 @@ The plugin sends `/etc/machine-id` as the RomM `hostname`: it is machine-derived
 device (two Steam Decks stay distinct), and stable. The real OS hostname is deliberately **not** sent — two stock Steam
 Decks both report `steamdeck`, so a `hostname` + `platform` fingerprint built from the OS hostname would collide them
 into one server device. The friendly OS hostname remains the display-only `name`. When `/etc/machine-id` is unreadable
-the `hostname` field is omitted entirely, degrading to the pre-4.8.1 no-fingerprint behaviour rather than sending a
-colliding value.
+the `hostname` field is omitted entirely, degrading to no-fingerprint behaviour rather than sending a colliding value.
 
 ### RomM account requirement
 
@@ -676,7 +675,7 @@ navigation between the buttons uses `Focusable` with `flow-children="right"` for
 ## Server Capabilities
 
 The capabilities system (`get_server_capabilities` callable) has been removed. Since the plugin now requires RomM >=
-4.8.1, all features (device sync, version history, slot deletion, device management) are unconditionally available. The
+4.9.0, all features (device sync, version history, slot deletion, device management) are unconditionally available. The
 frontend no longer fetches or checks capability flags.
 
 ## Conflict Resolution

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -218,10 +218,11 @@ You have two options:
 
 ## RomM Version Compatibility
 
-The plugin requires **RomM >= 4.8.1**. Servers below 4.8.1 are rejected at connection time with a full error page in
-both the QAM panel and the game detail view. The plugin uses v4.7+ features including server-side device tracking,
-content hashing, save slots, and `device_syncs` for conflict detection. The 4.8.1 minimum is set because that is the
-version the plugin has been tested against.
+The plugin requires **RomM >= 4.9.0**. Servers below 4.9.0 are rejected at connection time with a full error page in
+both the QAM panel and the game detail view. The plugin uses server-side device tracking, content hashing, save slots,
+and `device_syncs` for conflict detection. The 4.9.0 minimum is set because that is the release that ships RomM's Device
+Sync (`negotiate`) save-sync transport — the direction adopted in
+[ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md).
 
 For technical details on how save sync works internally (three-way conflict detection, state schema, session detection),
 see the [Save File Sync Architecture](../architecture/save-file-sync-architecture.md) technical reference.

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ class Plugin:
     _steam_config: Any
     _retrodeck_paths: Any
 
-    _MIN_REQUIRED_VERSION = (4, 8, 1)
+    _MIN_REQUIRED_VERSION = (4, 9, 0)
 
     # -- logging ---------------------------------------------------------------
     #

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -1,4 +1,4 @@
-"""RomM API adapter — requires RomM >= 4.8.1.
+"""RomM API adapter — requires RomM >= 4.9.0.
 
 Single adapter covering the full RomM REST surface. All methods map
 directly to HTTP endpoints via RommHttpAdapter.
@@ -32,7 +32,7 @@ _TOKEN_SCOPES = [
 
 
 class RommApiAdapter:
-    """Concrete RomM API adapter for RomM >= 4.8.1."""
+    """Concrete RomM API adapter for RomM >= 4.9.0."""
 
     def __init__(self, client: RommHttpAdapter) -> None:
         self._client = client

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -1056,13 +1056,13 @@ class TestTestConnectionErrors:
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}, "status": "ok"}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}, "status": "ok"}
         plugin._romm_api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
         result = await plugin.test_connection()
         assert result["success"] is True
-        assert "Connected to RomM 4.8.1" in result["message"]
-        assert result["romm_version"] == "4.8.1"
-        plugin._romm_api.set_version.assert_called_with("4.8.1")
+        assert "Connected to RomM 4.9.0" in result["message"]
+        assert result["romm_version"] == "4.9.0"
+        plugin._romm_api.set_version.assert_called_with("4.9.0")
 
     @pytest.mark.asyncio
     async def test_server_reachable_but_api_failed(self, plugin):
@@ -1071,7 +1071,7 @@ class TestTestConnectionErrors:
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.side_effect = RommServerError("500", status_code=500)
         result = await plugin.test_connection()
         assert result["success"] is False
@@ -1089,15 +1089,15 @@ class TestVersionDetection:
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
-        assert result["romm_version"] == "4.8.1"
-        plugin._romm_api.set_version.assert_called_with("4.8.1")
+        assert result["romm_version"] == "4.9.0"
+        plugin._romm_api.set_version.assert_called_with("4.9.0")
 
     @pytest.mark.asyncio
     async def test_old_version_rejected(self, plugin):
-        """Versions below 4.8.1 are rejected with version_error."""
+        """Versions below 4.9.0 are rejected with version_error."""
         import asyncio
 
         _setup_plugin(plugin)
@@ -1111,7 +1111,7 @@ class TestVersionDetection:
 
     @pytest.mark.asyncio
     async def test_46_version_rejected(self, plugin):
-        """RomM 4.6.x is below the 4.8.1 minimum and is rejected."""
+        """RomM 4.6.x is below the 4.9.0 minimum and is rejected."""
         import asyncio
 
         _setup_plugin(plugin)
@@ -1124,7 +1124,7 @@ class TestVersionDetection:
 
     @pytest.mark.asyncio
     async def test_47_version_rejected(self, plugin):
-        """RomM 4.7.x is below the 4.8.1 minimum and is rejected."""
+        """RomM 4.7.x is below the 4.9.0 minimum and is rejected."""
         import asyncio
 
         _setup_plugin(plugin)
@@ -1136,25 +1136,25 @@ class TestVersionDetection:
         assert result["reason"] == "version_error"
 
     @pytest.mark.asyncio
-    async def test_48_minimum_version_accepted(self, plugin):
-        """RomM 4.8.1 meets the minimum version requirement."""
+    async def test_minimum_version_accepted(self, plugin):
+        """RomM 4.9.0 meets the minimum version requirement."""
         import asyncio
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is True
 
     @pytest.mark.asyncio
-    async def test_480_patch_below_minimum_rejected(self, plugin):
-        """RomM 4.8.0 is below the 4.8.1 patch minimum and is rejected."""
+    async def test_former_minimum_now_rejected(self, plugin):
+        """RomM 4.8.1 (the former minimum) is below 4.9.0 and is now rejected."""
         import asyncio
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.0"}}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
         assert result["success"] is False
@@ -1193,7 +1193,7 @@ class TestVersionDetection:
 
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_event_loop()
-        plugin._romm_api.get_version.return_value = "4.8.1"  # previously detected
+        plugin._romm_api.get_version.return_value = "4.9.0"  # previously detected
         plugin._romm_api.heartbeat.side_effect = RommConnectionError("refused")
         result = await plugin.test_connection()
         assert result["success"] is False

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -12,7 +12,7 @@ import pytest
 from lib.errors import RommAuthError, RommConnectionError, RommForbiddenError, RommServerError
 from services.connection import ConnectionService, ConnectionServiceConfig
 
-_MIN_VERSION = (4, 8, 1)
+_MIN_VERSION = (4, 9, 0)
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def logger() -> logging.Logger:
 @pytest.fixture
 def romm_api() -> MagicMock:
     api = MagicMock()
-    api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+    api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
     api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
     api.mint_client_token.return_value = {"id": 42, "raw_token": "rmm_minted"}
     return api
@@ -70,18 +70,18 @@ class TestTestConnectionHappyPath:
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is True
-        assert result["message"] == "Connected to RomM 4.8.1"
-        assert result["romm_version"] == "4.8.1"
-        romm_api.set_version.assert_called_once_with("4.8.1")
+        assert result["message"] == "Connected to RomM 4.9.0"
+        assert result["romm_version"] == "4.9.0"
+        romm_api.set_version.assert_called_once_with("4.9.0")
 
     def test_version_exact_minimum_succeeds(self, event_loop, romm_api, logger):
         """Version equal to minimum tuple is accepted (>= comparison)."""
         settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
-        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["success"] is True
-        assert result["romm_version"] == "4.8.1"
+        assert result["romm_version"] == "4.9.0"
 
 
 class TestTestConnectionBadPath:
@@ -157,13 +157,13 @@ class TestTestConnectionVersionGate:
         assert result["success"] is False
         assert result["reason"] == "version_error"
         assert result["romm_version"] == "4.5.0"
-        assert "4.8.1" in result["message"]
+        assert "4.9.0" in result["message"]
         assert "4.5.0" in result["message"]
 
-    def test_version_one_patch_below_minimum_rejected(self, event_loop, romm_api, logger):
-        """4.8.0 is below 4.8.1 — must be rejected."""
+    def test_former_minimum_now_rejected(self, event_loop, romm_api, logger):
+        """4.8.1 (the former minimum) is below 4.9.0 — must now be rejected."""
         settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
-        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.0"}}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
         result = event_loop.run_until_complete(service.test_connection())
         assert result["reason"] == "version_error"
@@ -239,7 +239,7 @@ class TestEstablishTokenHappyPath:
         )
         result = event_loop.run_until_complete(service.establish_token("http://romm.local", "alice", "secret"))
         assert result["success"] is True
-        assert result["romm_version"] == "4.8.1"
+        assert result["romm_version"] == "4.9.0"
         assert settings["romm_api_token"] == "rmm_minted"
         assert settings["romm_api_token_id"] == 42
         # The token's minting origin is stamped from the trimmed URL.
@@ -659,7 +659,7 @@ class TestEstablishTokenSnapshotRestore:
         def _capture_heartbeat():
             seen["token_during_probe"] = settings.get("romm_api_token")
             seen["origin_during_probe"] = settings.get("romm_api_token_origin")
-            return {"SYSTEM": {"VERSION": "4.8.1"}}
+            return {"SYSTEM": {"VERSION": "4.9.0"}}
 
         romm_api.heartbeat.side_effect = _capture_heartbeat
         settings = _working_settings()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -251,7 +251,7 @@ class TestWireServices:
             "sleeper": FakeSleeper(),
             "hostname_provider": FakeHostnameReader(),
             "machine_id_provider": FakeMachineIdReader(),
-            "min_required_version": (4, 8, 1),
+            "min_required_version": (4, 9, 0),
             "retrodeck_paths": FakeRetroDeckPaths(
                 saves=str(tmp_path / "saves"),
                 roms=str(tmp_path / "retrodeck" / "roms"),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -193,7 +193,7 @@ class TestConnection:
         plugin.loop = asyncio.get_event_loop()
         plugin.settings["romm_url"] = "http://romm.local"
         plugin.settings["romm_api_token"] = "rmm_token"
-        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
+        plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
         # Rebuild connection service with the live event loop so executor
         # callbacks dispatch on the same loop the test awaits.
@@ -210,7 +210,7 @@ class TestConnection:
         )
         result = await plugin.test_connection()
         assert result["success"] is True
-        plugin._romm_api.set_version.assert_called_once_with("4.8.1")
+        plugin._romm_api.set_version.assert_called_once_with("4.9.0")
 
 
 class TestLogLevel:


### PR DESCRIPTION
Bumps the RomM server floor from **4.8.1 to 4.9.0** as a breaking change — phase 0b of #1234 (RomM Device Sync negotiate adoption).

## Why

`_MIN_REQUIRED_VERSION` gates the **whole** plugin in `test_connection`, not just save sync. The original ADR-0016 plan kept the floor at 4.8.1 and gated negotiate as a soft per-server capability. That's reversed here:

- A soft gate buys ≥4.9 users nothing they wouldn't get anyway, while only ever evicting ≤4.8 users — so it helps no one.
- The legacy `list_saves` path can't be deleted regardless, because `slot:null` saves still need it. So a hard floor doesn't add maintenance.
- We're still pre-1.0/beta, so a server-version bump is acceptable now and avoids carrying a soft-capability layer.

4.9.0 is the release that ships RomM's `negotiate` transport (and the convergence fix), so it's the true floor for the negotiate direction.

## What changes for users

A server on 4.8.x is now rejected at connection time (full error page in the QAM and game detail), and the plugin stays inert until the server is upgraded — library sync, downloads, and BIOS included, not only save sync. **Update your RomM server to 4.9.0+ before updating the plugin.**

Surfaced as a `BREAKING CHANGE` in the release notes via release-please (`feat!` + `BREAKING CHANGE:` footer); bumps the next release to `0.25.0` (`bump-minor-pre-major`).

## Changes

- `main.py`: `_MIN_REQUIRED_VERSION = (4, 9, 0)`. The version-gate message is already dynamic, so the user-facing text follows automatically.
- `adapters/romm/romm_api.py`: docstrings.
- Tests: gate-coupled version stubs bumped to 4.9.0; the former minimum (4.8.1) now has explicit "rejected" regression tests in both `test_connection.py` and `test_http.py`. Version stubs in version-agnostic plumbing tests (probe/passthrough) are left as-is.
- Docs (same PR): README, save-sync user guide, backend + save-file-sync architecture, CLAUDE.md.
- ADR-0016 updated: the soft ≥4.9 capability gate is superseded by the hard floor; the legacy path is retained only for `slot:null`.

## Verification

3918 tests pass; ruff / basedpyright / import-linter / all manifest + gate scripts green.

Part of #1234 (phase 0b) — working directly against the epic, no sub-issue.
