### PR TITLE
feat(saves): zip-aware content_hash matching RomM's per-entry scheme (#1234 phase 1b)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -42,8 +42,16 @@ Requires RomM >= 4.9.0. The plugin rejects servers below 4.9.0 with `reason: "ve
 - `slot` — the slot this save belongs to (string or null)
 - `file_name_no_tags` — base filename without timestamp tags (e.g. `Game` from `Game [2026-03-24_15-18-50].srm`)
 - `file_extension` — file extension (e.g. `srm`)
-- `content_hash` — MD5 hash of the save file content (eliminates download-and-hash slow path)
+- `content_hash` — RomM's content hash of the save: a plain MD5 for a single file, or a per-entry combined MD5 for a
+  zipped multi-file save (eliminates the download-and-hash slow path)
 - `device_syncs` — array of per-device sync records: `device_id`, `device_name`, `is_current`, `last_synced_at`
+
+The plugin reproduces this `content_hash` byte-for-byte so a save's local and server hashes agree and sync converges:
+single-file MD5 via `SaveFileStore.checksum_md5`, and the zip per-entry scheme via `SaveFileStore.content_hash` →
+`domain.save_hash.combine_zip_entry_hashes` (sorted `name:md5(entry)` lines joined by `\n`, then MD5'd; dispatch is by
+`zipfile.is_zipfile`, a content sniff, not the extension). This hash parity is the foundation the RomM Device Sync
+negotiate transport requires ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md) / #1234); the
+legacy decision matrix below still computes the single-file `checksum_md5` until the negotiate path is wired.
 
 ## Save Slots
 

--- a/py_modules/adapters/save_file.py
+++ b/py_modules/adapters/save_file.py
@@ -15,6 +15,9 @@ import contextlib
 import hashlib
 import os
 import tempfile
+import zipfile
+
+from domain.save_hash import combine_zip_entry_hashes
 
 _MD5_CHUNK_SIZE = 8192
 
@@ -82,6 +85,27 @@ class SaveFileAdapter:
             for chunk in iter(lambda: f.read(_MD5_CHUNK_SIZE), b""):
                 h.update(chunk)
         return h.hexdigest()
+
+    def content_hash(self, path: str) -> str:
+        """Return RomM's content hash for *path* — zip-aware, MD5-based.
+
+        Matches the server's ``compute_content_hash`` so a save's local and
+        server hashes agree and save-sync converges. Dispatch mirrors RomM
+        exactly: a file that *is* a zip archive (``zipfile.is_zipfile`` — a
+        content sniff, not the extension) is hashed per entry and combined via
+        :func:`domain.save_hash.combine_zip_entry_hashes`; any other file is the
+        plain streamed MD5 of :meth:`checksum_md5`. Directory entries inside the
+        archive are skipped. Non-security use, like ``checksum_md5``.
+        """
+        if not zipfile.is_zipfile(path):
+            return self.checksum_md5(path)
+        with zipfile.ZipFile(path, "r") as zf:
+            entries = [
+                (name, hashlib.md5(zf.read(name), usedforsecurity=False).hexdigest())
+                for name in zf.namelist()
+                if not name.endswith("/")
+            ]
+        return combine_zip_entry_hashes(entries)
 
     def make_temp_path(self, suffix: str = "") -> str:
         """Return a fresh, unique path safe to write to.

--- a/py_modules/domain/save_hash.py
+++ b/py_modules/domain/save_hash.py
@@ -1,0 +1,36 @@
+"""Combine per-entry hashes of a multi-file (zip) save into one content hash.
+
+RomM stores a multi-file save as a single zipped asset and identifies it by a
+content hash computed *per zip entry*, not over the raw archive bytes — the zip
+container's own framing (member order, timestamps, compression) is not stable,
+so hashing the archive whole would never converge across clients. The plugin
+must reproduce that exact scheme so a zip save's local and server hashes match
+and save-sync converges instead of round-tripping forever.
+
+This is the pure half of that computation: given the already-hashed zip entries,
+derive the single combined hash. Reading the archive and hashing each entry's
+bytes is I/O and lives in the ``SaveFileStore`` adapter. No I/O, no
+service/adapter/lib imports — stdlib only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def combine_zip_entry_hashes(entries: list[tuple[str, str]]) -> str:
+    """Combine ``(entry_name, entry_md5_hex)`` pairs into RomM's zip content hash.
+
+    Mirrors RomM's ``_compute_zip_hash`` byte-for-byte: the entries are sorted
+    by name, rendered one per line as ``name:hexdigest``, joined with ``\\n``,
+    and the UTF-8 encoding of that block is MD5-hashed. Sorting by name makes the
+    result independent of the order entries were read from the archive; an empty
+    list (an archive with no file entries) hashes the empty string.
+
+    Each ``entry_md5_hex`` is the MD5 of that entry's raw bytes, computed by the
+    caller (the adapter, which owns the archive I/O) — it is the ``name``/hash
+    pairing that RomM hashes, not the entry bytes themselves.
+    """
+    lines = [f"{name}:{digest}" for name, digest in sorted(entries, key=lambda entry: entry[0])]
+    combined = "\n".join(lines)
+    return hashlib.md5(combined.encode(), usedforsecurity=False).hexdigest()

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -390,6 +390,16 @@ class SaveFileStore(Protocol):
         """
         ...
 
+    def content_hash(self, path: str) -> str:
+        """Return RomM's zip-aware content hash for *path*.
+
+        Identical to :meth:`checksum_md5` for a plain file; for a zip archive
+        (a multi-file save) the per-entry combined hash RomM computes, so a
+        zipped save converges on its content rather than mismatching on the
+        archive container's framing. Non-security use, like ``checksum_md5``.
+        """
+        ...
+
     def make_temp_path(self, suffix: str = "") -> str:
         """Return a fresh, unique path safe to write to.
 

--- a/tests/adapters/test_save_file.py
+++ b/tests/adapters/test_save_file.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import zipfile
 
 import pytest
 
 from adapters.save_file import SaveFileAdapter
+
+# Golden value computed independently via RomM's _compute_zip_hash algorithm
+# (sorted entries → "name:md5(bytes)" lines joined by "\n" → md5 of the UTF-8
+# block) over a zip of {"a.srm": b"alpha", "b.srm": b"beta"}. Pins byte-exact
+# parity with the 4.9.2 server; a separator/sort/encoding drift breaks it.
+_GOLDEN_TWO_ENTRY_ZIP_HASH = "6e42de0bba44de86f213ca48f5c388dd"
 
 
 @pytest.fixture
@@ -172,6 +179,66 @@ class TestChecksumMd5:
     def test_missing_file_raises(self, save_files, tmp_path):
         with pytest.raises(FileNotFoundError):
             save_files.checksum_md5(str(tmp_path / "missing.srm"))
+
+
+def _write_zip(path, entries: list[tuple[str, bytes]]) -> None:
+    """Write a zip at *path* with the given ``(name, bytes)`` members."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in entries:
+            zf.writestr(name, data)
+
+
+class TestContentHash:
+    """``content_hash`` mirrors RomM's ``compute_content_hash`` (zip-aware MD5)."""
+
+    def test_plain_file_matches_checksum_md5(self, save_files, tmp_path):
+        """A non-zip file hashes identically to the streamed single-file MD5."""
+        f = tmp_path / "game.srm"
+        payload = b"save payload bytes"
+        f.write_bytes(payload)
+        assert save_files.content_hash(str(f)) == hashlib.md5(payload).hexdigest()
+        assert save_files.content_hash(str(f)) == save_files.checksum_md5(str(f))
+
+    def test_zip_matches_romm_golden(self, save_files, tmp_path):
+        """A multi-file (zip) save converges on RomM's per-entry combined hash."""
+        z = tmp_path / "multi.zip"
+        _write_zip(z, [("a.srm", b"alpha"), ("b.srm", b"beta")])
+        assert save_files.content_hash(str(z)) == _GOLDEN_TWO_ENTRY_ZIP_HASH
+
+    def test_dispatch_is_by_content_not_extension(self, save_files, tmp_path):
+        """A zip archive named ``.srm`` still takes the zip path (content sniff)."""
+        z = tmp_path / "looks_single.srm"
+        _write_zip(z, [("a.srm", b"alpha"), ("b.srm", b"beta")])
+        # Zip path → the combined hash, NOT a raw-bytes MD5 of the archive.
+        assert save_files.content_hash(str(z)) == _GOLDEN_TWO_ENTRY_ZIP_HASH
+        assert save_files.content_hash(str(z)) != save_files.checksum_md5(str(z))
+
+    def test_member_order_independent(self, save_files, tmp_path):
+        """Reversing the archive write order yields the same hash (RomM sorts)."""
+        forward = tmp_path / "forward.zip"
+        reverse = tmp_path / "reverse.zip"
+        _write_zip(forward, [("a.srm", b"alpha"), ("b.srm", b"beta")])
+        _write_zip(reverse, [("b.srm", b"beta"), ("a.srm", b"alpha")])
+        assert save_files.content_hash(str(forward)) == save_files.content_hash(str(reverse))
+
+    def test_directory_entries_are_skipped(self, save_files, tmp_path):
+        """A directory member does not change the hash — only file entries count."""
+        plain = tmp_path / "plain.zip"
+        withdir = tmp_path / "withdir.zip"
+        _write_zip(plain, [("a.srm", b"alpha"), ("b.srm", b"beta")])
+        _write_zip(withdir, [("sub/", b""), ("a.srm", b"alpha"), ("b.srm", b"beta")])
+        assert save_files.content_hash(str(withdir)) == save_files.content_hash(str(plain))
+        assert save_files.content_hash(str(withdir)) == _GOLDEN_TWO_ENTRY_ZIP_HASH
+
+    def test_empty_zip_hashes_empty_string(self, save_files, tmp_path):
+        """A zip with no file entries hashes the empty string (md5 of '')."""
+        z = tmp_path / "empty.zip"
+        _write_zip(z, [])
+        assert save_files.content_hash(str(z)) == hashlib.md5(b"").hexdigest()
+
+    def test_missing_file_raises(self, save_files, tmp_path):
+        with pytest.raises(OSError):
+            save_files.content_hash(str(tmp_path / "missing.srm"))
 
 
 class TestMakeTempPath:

--- a/tests/domain/test_save_hash.py
+++ b/tests/domain/test_save_hash.py
@@ -1,0 +1,41 @@
+"""Tests for domain.save_hash.combine_zip_entry_hashes — RomM zip-hash parity."""
+
+from __future__ import annotations
+
+import hashlib
+
+from domain.save_hash import combine_zip_entry_hashes
+
+
+class TestCombineZipEntryHashes:
+    def test_empty_hashes_the_empty_string(self):
+        """No file entries → md5 of the empty string (matches RomM)."""
+        assert combine_zip_entry_hashes([]) == hashlib.md5(b"").hexdigest()
+
+    def test_single_entry_format(self):
+        """One entry renders as ``name:hexdigest`` then is MD5'd — pins the format."""
+        entry_md5 = hashlib.md5(b"hello").hexdigest()
+        expected = hashlib.md5(f"save.srm:{entry_md5}".encode()).hexdigest()
+        assert combine_zip_entry_hashes([("save.srm", entry_md5)]) == expected
+
+    def test_two_entries_match_romm_golden(self):
+        """Golden value computed independently via RomM's algorithm."""
+        a = hashlib.md5(b"alpha").hexdigest()
+        b = hashlib.md5(b"beta").hexdigest()
+        assert combine_zip_entry_hashes([("a.srm", a), ("b.srm", b)]) == "6e42de0bba44de86f213ca48f5c388dd"
+
+    def test_sorted_by_name_not_input_order(self):
+        """Input order does not matter — entries are sorted by name before joining."""
+        a = hashlib.md5(b"alpha").hexdigest()
+        b = hashlib.md5(b"beta").hexdigest()
+        forward = combine_zip_entry_hashes([("a.srm", a), ("b.srm", b)])
+        reverse = combine_zip_entry_hashes([("b.srm", b), ("a.srm", a)])
+        assert forward == reverse
+
+    def test_distinct_entry_set_changes_hash(self):
+        """A different entry payload (hence per-entry md5) yields a different combined hash."""
+        a = hashlib.md5(b"alpha").hexdigest()
+        b = hashlib.md5(b"beta").hexdigest()
+        c = hashlib.md5(b"gamma").hexdigest()
+        assert combine_zip_entry_hashes([("a.srm", a)]) != combine_zip_entry_hashes([("a.srm", c)])
+        assert combine_zip_entry_hashes([("a.srm", a)]) != combine_zip_entry_hashes([("a.srm", a), ("b.srm", b)])

--- a/tests/domain/test_save_hash_property.py
+++ b/tests/domain/test_save_hash_property.py
@@ -1,0 +1,49 @@
+"""Property-based tests for domain.save_hash.combine_zip_entry_hashes (#1234 1b).
+
+The combined zip content hash is convergence-critical: it must match RomM's
+``_compute_zip_hash`` byte-for-byte or a zipped save round-trips between client
+and server forever. Two invariants the generated input space exercises better
+than the hand-enumerated cases in ``test_save_hash``:
+
+- **Permutation-independence**: the result depends only on the *set* of
+  ``(name, digest)`` entries, never on the order they were read from the
+  archive — because the function sorts by name before joining. A regression
+  that dropped the sort would still pass the happy-path example but break this.
+- **Output shape**: the result is always a 32-char lowercase MD5 hex digest.
+
+The CI-safe Hypothesis profile (``deadline=None``, fixed ``max_examples``) is
+applied in ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.save_hash import combine_zip_entry_hashes
+
+# Realistic zip-entry names (unique via dict keys) and 32-char MD5 hex digests.
+_NAMES = st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789._-/", min_size=1, max_size=16)
+_HEX = st.text(alphabet="0123456789abcdef", min_size=32, max_size=32)
+_ENTRY_SETS = st.dictionaries(keys=_NAMES, values=_HEX, max_size=8)
+
+
+@given(entries=_ENTRY_SETS, data=st.data())
+def test_permutation_independent(entries, data):
+    items = list(entries.items())
+    permuted = list(data.draw(st.permutations(items)))
+    assert combine_zip_entry_hashes(items) == combine_zip_entry_hashes(permuted)
+
+
+@given(entries=_ENTRY_SETS)
+def test_output_is_md5_hex(entries):
+    result = combine_zip_entry_hashes(list(entries.items()))
+    assert re.fullmatch(r"[0-9a-f]{32}", result)
+
+
+@given(entries=_ENTRY_SETS)
+def test_deterministic(entries):
+    items = list(entries.items())
+    assert combine_zip_entry_hashes(items) == combine_zip_entry_hashes(items)

--- a/tests/fakes/fake_save_file_store.py
+++ b/tests/fakes/fake_save_file_store.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import io
+import zipfile
+
+from domain.save_hash import combine_zip_entry_hashes
 
 
 class FakeSaveFileStore:
@@ -106,6 +110,18 @@ class FakeSaveFileStore:
         if path not in self.files:
             raise FileNotFoundError(path)
         return hashlib.md5(self.files[path]).hexdigest()
+
+    def content_hash(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        data = self.files[path]
+        if not zipfile.is_zipfile(io.BytesIO(data)):
+            return hashlib.md5(data).hexdigest()
+        with zipfile.ZipFile(io.BytesIO(data), "r") as zf:
+            entries = [
+                (name, hashlib.md5(zf.read(name)).hexdigest()) for name in zf.namelist() if not name.endswith("/")
+            ]
+        return combine_zip_entry_hashes(entries)
 
     def make_temp_path(self, suffix: str = "") -> str:
         self.temp_counter += 1


### PR DESCRIPTION
Phase 1b of #1234 (RomM Device Sync negotiate adoption) — the convergence-critical hash parity.

## What

Adds `SaveFileStore.content_hash(path)`, which reproduces RomM 4.9's `compute_content_hash` exactly so a save's local and server hashes match (a mismatch makes a zipped save round-trip between client and server forever):

- **Single file** → the existing streamed MD5 (`checksum_md5`), already byte-identical to RomM (verified against the live 4.9.2 server).
- **Zip multi-file save** → RomM's per-entry scheme: `sorted(name)` → `name:md5(entry_bytes)` lines joined by `\n` → MD5 of the UTF-8 block. Dispatch is by `zipfile.is_zipfile` (a content sniff, **not** the extension); directory entries are skipped.

## Where the logic lives

The pure combine (sort + format + join + outer MD5) is a new `domain/save_hash.py::combine_zip_entry_hashes`; the adapter (`save_file.py`) owns the archive I/O (open, read entries, per-entry MD5). This follows the project's pattern of keeping convergence-critical pure kernels in `domain/` with property tests (`sync_action`, `save_path`, `save_size`) while I/O stays in the adapter.

## Tests

- **Golden parity** (`tests/adapters/test_save_file.py`): a known two-entry zip hashes to a value computed independently via RomM's algorithm — pins byte-exact parity; a separator/sort/encoding drift breaks it.
- **Property** (`tests/domain/test_save_hash_property.py`): permutation-independence (a dropped sort would pass the happy path but break this), output shape, determinism.
- **Dispatch/edge**: a zip named `.srm` still takes the zip path; directory entries skipped; empty zip → `md5("")`; member-order independence.
- Grounded against `rommapp/romm` `backend/handler/filesystem/assets_handler.py` and the live 4.9.2 server's stored `content_hash`.

## Scope

Additive, **no behavior change** — the legacy decision matrix still computes the single-file `checksum_md5`; the negotiate path wires `content_hash` in Phase 2.

Docs: `save-file-sync-architecture.md` updated. Part of #1234 (phase 1b), no sub-issue.

## Verification

3933 tests pass; ruff / basedpyright / import-linter (domain stays stdlib-only) / all gate scripts green.
