### PR TITLE
feat(saves): negotiate-sync adapter surface + wire schemas (#1234 phase 1a)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -17,17 +17,19 @@ Phase 7.
 
 Requires RomM >= 4.9.0. The plugin rejects servers below 4.9.0 with `reason: "version_error"`.
 
-| Endpoint                                                 | Method | Notes                                                                                                                                                                                                                              |
-| -------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/api/saves?rom_id={id}`                                 | GET    | Returns array. Each item now includes `slot`, `file_name_no_tags`, `file_extension`, `content_hash`, and `device_syncs` array.                                                                                                     |
-| `/api/saves/{id}`                                        | GET    | Single save metadata with v4.7 fields                                                                                                                                                                                              |
-| `/api/saves?rom_id={id}&emulator={emulator}&slot={slot}` | POST   | Creates a new save entry. Slot-aware: `slot=default` causes RomM to append a timestamp to the filename (e.g. `Game.srm` becomes `Game [2026-03-24_15-18-50].srm`). Same filename + same slot = upsert. Different slot = new entry. |
-| `/api/saves/{id}`                                        | PUT    | Updates file content only. No metadata changes, no new entry created.                                                                                                                                                              |
-| `/api/saves/{id}/content`                                | GET    | Binary download by save ID (new in v4.7)                                                                                                                                                                                           |
-| `/api/devices`                                           | GET    | List all registered devices for the authenticated user. Returns array of `{id, name, platform, client, client_version, last_seen, created_at, ...}`.                                                                               |
-| `/api/devices`                                           | POST   | Register a device. Accepts hostname, platform, client info. Returns `device_id` (UUID).                                                                                                                                            |
-| `/api/devices/{id}`                                      | DELETE | Remove a device registration. Returns 204 No Content. PATCH (rename) is not supported (405).                                                                                                                                       |
-| `/api/saves/delete`                                      | POST   | Bulk delete saves by ID. Body: `{"saves": [id1, id2, ...]}`. Returns result dict.                                                                                                                                                  |
+| Endpoint                                                 | Method | Notes                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/api/saves?rom_id={id}`                                 | GET    | Returns array. Each item now includes `slot`, `file_name_no_tags`, `file_extension`, `content_hash`, and `device_syncs` array.                                                                                                                                                 |
+| `/api/saves/{id}`                                        | GET    | Single save metadata with v4.7 fields                                                                                                                                                                                                                                          |
+| `/api/saves?rom_id={id}&emulator={emulator}&slot={slot}` | POST   | Creates a new save entry. Slot-aware: `slot=default` causes RomM to append a timestamp to the filename (e.g. `Game.srm` becomes `Game [2026-03-24_15-18-50].srm`). Same filename + same slot = upsert. Different slot = new entry.                                             |
+| `/api/saves/{id}`                                        | PUT    | Updates file content only. No metadata changes, no new entry created.                                                                                                                                                                                                          |
+| `/api/saves/{id}/content`                                | GET    | Binary download by save ID (new in v4.7)                                                                                                                                                                                                                                       |
+| `/api/devices`                                           | GET    | List all registered devices for the authenticated user. Returns array of `{id, name, platform, client, client_version, last_seen, created_at, ...}`.                                                                                                                           |
+| `/api/devices`                                           | POST   | Register a device. Accepts hostname, platform, client info. Returns `device_id` (UUID).                                                                                                                                                                                        |
+| `/api/devices/{id}`                                      | DELETE | Remove a device registration. Returns 204 No Content. PATCH (rename) is not supported (405).                                                                                                                                                                                   |
+| `/api/saves/delete`                                      | POST   | Bulk delete saves by ID. Body: `{"saves": [id1, id2, ...]}`. Returns result dict.                                                                                                                                                                                              |
+| `/api/sync/negotiate`                                    | POST   | Open a 4.9 sync session. Body: `{device_id, saves: ClientSaveState[]}`. Returns `{session_id, operations[], total_*}` — the server's `upload`/`download`/`conflict`/`no_op` verdicts (+ a `reason`). Detects but never resolves; opening cancels this device's prior sessions. |
+| `/api/sync/sessions/{id}/complete`                       | POST   | Close a negotiated session. Body: `{operations_completed, operations_failed, play_sessions?}`. Returns `{session, play_session_ingest?}`.                                                                                                                                      |
 
 **New parameters on POST:**
 
@@ -35,6 +37,13 @@ Requires RomM >= 4.9.0. The plugin rejects servers below 4.9.0 with `reason: "ve
 - `autocleanup` — whether RomM prunes old stacked versions. Defaults to **false**.
 - `autocleanup_limit` — max save versions retained per slot (default: 10). Inert unless `autocleanup=true` is sent
   alongside it.
+
+The `negotiate` / `complete` endpoints are wired into the adapter (`RommApiAdapter.negotiate_sync` /
+`complete_sync_session`) and typed by the `models/sync.py` schemas (`ClientSaveState`, `SyncOperation`,
+`SyncNegotiateResponse`, …), but are **additive and do not yet drive sync** — the legacy decision matrix below still
+owns save-sync until the negotiate path is wired ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md)
+/ #1234 phase 2).
+
 - `device_id` — server-registered device UUID. Used to populate `device_syncs` per save.
 
 **New fields on save metadata:**

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -12,6 +12,13 @@ from typing import TYPE_CHECKING, Any
 from lib.errors import RommNotFoundError
 
 if TYPE_CHECKING:
+    from models.sync import (
+        ClientSaveState,
+        SyncCompleteResponse,
+        SyncNegotiateResponse,
+        SyncPlaySessionEntry,
+    )
+
     from adapters.romm.http import RommHttpAdapter
 
 # Scopes requested for the minted Client API Token. Deliberately excludes
@@ -230,6 +237,40 @@ class RommApiAdapter:
 
     def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         return self._client.post_json("/api/saves/delete", {"saves": save_ids})
+
+    # ── Sync sessions (4.9 negotiate) ─────────────────────────────────
+
+    def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
+        """Open a sync session: POST this device's inventory, get the planned ops.
+
+        The server compares *saves* (per ``(rom_id, slot)``) against its own
+        state and returns a ``session_id`` plus the ``upload`` / ``download`` /
+        ``conflict`` / ``no_op`` operations to execute. It detects but never
+        resolves — a ``conflict`` carries no resolution directive. Opening a
+        session cancels this device's prior in-flight sessions server-side.
+        """
+        return self._client.post_json("/api/sync/negotiate", {"device_id": device_id, "saves": saves})
+
+    def complete_sync_session(
+        self,
+        session_id: int,
+        *,
+        operations_completed: int = 0,
+        operations_failed: int = 0,
+        play_sessions: list[SyncPlaySessionEntry] | None = None,
+    ) -> SyncCompleteResponse:
+        """Close the negotiated session, reporting how many ops ran.
+
+        ``play_sessions`` is the optional play-session report (#1219); omitted
+        when ``None`` so the negotiate path stays independent of play sessions.
+        """
+        payload: dict[str, Any] = {
+            "operations_completed": operations_completed,
+            "operations_failed": operations_failed,
+        }
+        if play_sessions is not None:
+            payload["play_sessions"] = play_sessions
+        return self._client.post_json(f"/api/sync/sessions/{session_id}/complete", payload)
 
     # ── Devices ───────────────────────────────────────────────────────
 

--- a/py_modules/models/sync.py
+++ b/py_modules/models/sync.py
@@ -1,0 +1,98 @@
+"""TypedDicts for RomM's 4.9 Device Sync (negotiate) wire protocol.
+
+The dict shapes exchanged with ``POST /api/sync/negotiate`` and
+``POST /api/sync/sessions/{id}/complete``: the client's per-save inventory
+(``ClientSaveState``), the server's planned operations (``SyncOperation`` /
+``SyncNegotiateResponse``), and the session-completion records. Mirrors the
+shipped RomM 4.9.2 OpenAPI schema field-for-field — required keys are plain,
+server-optional / nullable keys are ``NotRequired[... | None]``. Runtime dicts;
+these describe the wire contract without changing their identity.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NotRequired, TypedDict
+
+
+class ClientSaveState(TypedDict):
+    """One save in the inventory the client POSTs to ``negotiate``.
+
+    ``content_hash`` is RomM's zip-aware content hash (see ``domain.save_hash``);
+    ``slot`` / ``emulator`` are omitted or null for legacy ``slot:null`` saves.
+    """
+
+    rom_id: int
+    file_name: str
+    updated_at: str
+    file_size_bytes: int
+    slot: NotRequired[str | None]
+    emulator: NotRequired[str | None]
+    content_hash: NotRequired[str | None]
+
+
+class SyncOperation(TypedDict):
+    """One operation the server plans for a save in the negotiated session.
+
+    ``action`` is the server's verdict and ``reason`` its human-readable
+    justification. The server detects but never resolves — a ``conflict``
+    carries no resolution directive; the client owns resolution.
+    """
+
+    action: Literal["upload", "download", "conflict", "no_op"]
+    rom_id: int
+    file_name: str
+    reason: str
+    save_id: NotRequired[int | None]
+    slot: NotRequired[str | None]
+    emulator: NotRequired[str | None]
+    server_updated_at: NotRequired[str | None]
+    server_content_hash: NotRequired[str | None]
+
+
+class SyncNegotiateResponse(TypedDict):
+    """The server's response to ``POST /api/sync/negotiate``."""
+
+    session_id: int
+    operations: list[SyncOperation]
+    total_upload: int
+    total_download: int
+    total_conflict: int
+    total_no_op: int
+
+
+class SyncPlaySessionEntry(TypedDict):
+    """One play-session window reported alongside session completion (#1219)."""
+
+    start_time: str
+    end_time: str
+    duration_ms: int
+    rom_id: NotRequired[int | None]
+    save_slot: NotRequired[str | None]
+
+
+class SyncSession(TypedDict):
+    """A sync session's server record (RomM ``SyncSessionSchema``)."""
+
+    id: int
+    device_id: str
+    user_id: int
+    status: str
+    initiated_at: str
+    operations_planned: int
+    operations_completed: int
+    operations_failed: int
+    created_at: str
+    updated_at: str
+    completed_at: NotRequired[str | None]
+    error_message: NotRequired[str | None]
+
+
+class SyncCompleteResponse(TypedDict):
+    """The server's response to ``POST /api/sync/sessions/{id}/complete``.
+
+    ``play_session_ingest`` is the optional play-session ingest summary (#1219),
+    typed loosely until play sessions are wired.
+    """
+
+    session: SyncSession
+    play_session_ingest: NotRequired[dict[str, Any] | None]

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -9,7 +9,15 @@ raw transport (HTTP requests, file writes, Steam IPC calls).
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from models.sync import (
+        ClientSaveState,
+        SyncCompleteResponse,
+        SyncNegotiateResponse,
+        SyncPlaySessionEntry,
+    )
 
 
 class SteamConfigStore(Protocol):
@@ -288,6 +296,25 @@ class RommSaveApi(Protocol):
 
     def delete_server_saves(self, save_ids: list[int]) -> dict[str, Any]:
         """Delete the given save ids via ``POST /api/saves/delete``."""
+        ...
+
+    def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
+        """Open a 4.9 sync session: POST the device inventory, get the planned operations.
+
+        The server detects (``upload`` / ``download`` / ``conflict`` / ``no_op``)
+        but never resolves; opening a session cancels this device's prior ones.
+        """
+        ...
+
+    def complete_sync_session(
+        self,
+        session_id: int,
+        *,
+        operations_completed: int = 0,
+        operations_failed: int = 0,
+        play_sessions: list[SyncPlaySessionEntry] | None = None,
+    ) -> SyncCompleteResponse:
+        """Close the negotiated session, reporting executed-op counts (and optional play sessions)."""
         ...
 
 

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
 from adapters.romm.romm_api import _TOKEN_SCOPES, RommApiAdapter
 from lib.errors import RommNotFoundError, RommServerError
+
+if TYPE_CHECKING:
+    from models.sync import ClientSaveState, SyncPlaySessionEntry
 
 
 def _make_api():
@@ -735,6 +739,78 @@ class TestDeleteServerSaves:
         result = api.delete_server_saves([10, 20])
         client.post_json.assert_called_once_with("/api/saves/delete", {"saves": [10, 20]})
         assert result["deleted"] == 2
+
+
+_EMPTY_NEGOTIATE = {
+    "session_id": 1,
+    "operations": [],
+    "total_upload": 0,
+    "total_download": 0,
+    "total_conflict": 0,
+    "total_no_op": 0,
+}
+
+
+class TestNegotiateSync:
+    def test_posts_device_id_and_inventory(self):
+        api, client = _make_api()
+        client.post_json.return_value = {**_EMPTY_NEGOTIATE, "session_id": 7}
+        saves: list[ClientSaveState] = [
+            {
+                "rom_id": 1,
+                "file_name": "a.srm",
+                "updated_at": "2026-06-01T00:00:00Z",
+                "file_size_bytes": 12,
+                "slot": "default",
+                "content_hash": "abc",
+            }
+        ]
+        result = api.negotiate_sync("dev-1", saves)
+        client.post_json.assert_called_once_with("/api/sync/negotiate", {"device_id": "dev-1", "saves": saves})
+        assert result["session_id"] == 7
+
+    def test_returns_operations(self):
+        api, client = _make_api()
+        client.post_json.return_value = {
+            **_EMPTY_NEGOTIATE,
+            "operations": [{"action": "upload", "rom_id": 1, "file_name": "a.srm", "reason": "newer locally"}],
+            "total_upload": 1,
+        }
+        result = api.negotiate_sync("dev-1", [])
+        assert result["operations"][0]["action"] == "upload"
+
+    def test_propagates_http_error(self):
+        api, client = _make_api()
+        client.post_json.side_effect = RommServerError("boom", status_code=500)
+        with pytest.raises(RommServerError):
+            api.negotiate_sync("dev-1", [])
+
+
+class TestCompleteSyncSession:
+    def test_posts_operation_counts(self):
+        api, client = _make_api()
+        client.post_json.return_value = {"session": {}}
+        api.complete_sync_session(7, operations_completed=3, operations_failed=1)
+        client.post_json.assert_called_once_with(
+            "/api/sync/sessions/7/complete",
+            {"operations_completed": 3, "operations_failed": 1},
+        )
+
+    def test_omits_play_sessions_when_none(self):
+        api, client = _make_api()
+        client.post_json.return_value = {"session": {}}
+        api.complete_sync_session(7)
+        payload = client.post_json.call_args[0][1]
+        assert "play_sessions" not in payload
+        assert payload == {"operations_completed": 0, "operations_failed": 0}
+
+    def test_includes_play_sessions_when_provided(self):
+        api, client = _make_api()
+        client.post_json.return_value = {"session": {}}
+        play_sessions: list[SyncPlaySessionEntry] = [{"start_time": "t0", "end_time": "t1", "duration_ms": 100}]
+        api.complete_sync_session(7, play_sessions=play_sessions)
+        payload = client.post_json.call_args[0][1]
+        assert payload["play_sessions"] == play_sessions
 
 
 class TestGetRomWithNotes:

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -31,7 +31,15 @@ from __future__ import annotations
 
 import pathlib
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from models.sync import (
+        ClientSaveState,
+        SyncCompleteResponse,
+        SyncNegotiateResponse,
+        SyncPlaySessionEntry,
+    )
 
 
 class FakeRommApi:
@@ -536,6 +544,51 @@ class FakeRommApi:
             self.saves.pop(sid, None)
             self._save_content.pop(sid, None)
         return {"deleted": len(save_ids)}
+
+    def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
+        self._log("negotiate_sync", (device_id, saves))
+        self._check_fail()
+        return {
+            "session_id": 1,
+            "operations": [],
+            "total_upload": 0,
+            "total_download": 0,
+            "total_conflict": 0,
+            "total_no_op": 0,
+        }
+
+    def complete_sync_session(
+        self,
+        session_id: int,
+        *,
+        operations_completed: int = 0,
+        operations_failed: int = 0,
+        play_sessions: list[SyncPlaySessionEntry] | None = None,
+    ) -> SyncCompleteResponse:
+        self._log(
+            "complete_sync_session",
+            (session_id,),
+            {
+                "operations_completed": operations_completed,
+                "operations_failed": operations_failed,
+                "play_sessions": play_sessions,
+            },
+        )
+        self._check_fail()
+        return {
+            "session": {
+                "id": session_id,
+                "device_id": "",
+                "user_id": 0,
+                "status": "completed",
+                "initiated_at": "",
+                "operations_planned": 0,
+                "operations_completed": operations_completed,
+                "operations_failed": operations_failed,
+                "created_at": "",
+                "updated_at": "",
+            }
+        }
 
     # ------------------------------------------------------------------
     # RommTokenApi

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -7,6 +7,13 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from models.sync import (
+        ClientSaveState,
+        SyncCompleteResponse,
+        SyncNegotiateResponse,
+        SyncPlaySessionEntry,
+    )
+
     from services.protocols import SaveFileStore
 
 
@@ -199,6 +206,53 @@ class FakeSaveApi:
             self.saves.pop(sid, None)
             self._save_content.pop(sid, None)
         return {"deleted": len(save_ids)}
+
+    def negotiate_sync(self, device_id: str, saves: list[ClientSaveState]) -> SyncNegotiateResponse:
+        self.call_log.append(("negotiate_sync", (device_id, saves), {}))
+        self._check_fail()
+        return {
+            "session_id": 1,
+            "operations": [],
+            "total_upload": 0,
+            "total_download": 0,
+            "total_conflict": 0,
+            "total_no_op": 0,
+        }
+
+    def complete_sync_session(
+        self,
+        session_id: int,
+        *,
+        operations_completed: int = 0,
+        operations_failed: int = 0,
+        play_sessions: list[SyncPlaySessionEntry] | None = None,
+    ) -> SyncCompleteResponse:
+        self.call_log.append(
+            (
+                "complete_sync_session",
+                (session_id,),
+                {
+                    "operations_completed": operations_completed,
+                    "operations_failed": operations_failed,
+                    "play_sessions": play_sessions,
+                },
+            )
+        )
+        self._check_fail()
+        return {
+            "session": {
+                "id": session_id,
+                "device_id": "",
+                "user_id": 0,
+                "status": "completed",
+                "initiated_at": "",
+                "operations_planned": 0,
+                "operations_completed": operations_completed,
+                "operations_failed": operations_failed,
+                "created_at": "",
+                "updated_at": "",
+            }
+        }
 
     def register_device(
         self,

--- a/tests/models/test_sync.py
+++ b/tests/models/test_sync.py
@@ -1,0 +1,110 @@
+"""Tests for the RomM Device Sync wire schemas (models/sync.py).
+
+These TypedDicts mirror the live 4.9.2 OpenAPI; the checks pin the field set
+of each wire shape (a typo'd or dropped key would break negotiate parity) and
+confirm they stay plain dicts at runtime.
+"""
+
+from __future__ import annotations
+
+from models.sync import (
+    ClientSaveState,
+    SyncCompleteResponse,
+    SyncNegotiateResponse,
+    SyncOperation,
+    SyncPlaySessionEntry,
+    SyncSession,
+)
+
+_SCHEMAS = [
+    ClientSaveState,
+    SyncOperation,
+    SyncNegotiateResponse,
+    SyncSession,
+    SyncCompleteResponse,
+    SyncPlaySessionEntry,
+]
+
+
+def test_all_schemas_are_dict_subclasses():
+    """The wire shapes are TypedDicts — plain dicts at runtime, typed at the boundary."""
+    for schema in _SCHEMAS:
+        assert issubclass(schema, dict)
+
+
+def test_client_save_state_field_set():
+    state: ClientSaveState = {
+        "rom_id": 1,
+        "file_name": "a.srm",
+        "updated_at": "2026-06-01T00:00:00Z",
+        "file_size_bytes": 12,
+        "slot": "default",
+        "emulator": "retroarch",
+        "content_hash": "abc",
+    }
+    assert set(state) == {
+        "rom_id",
+        "file_name",
+        "updated_at",
+        "file_size_bytes",
+        "slot",
+        "emulator",
+        "content_hash",
+    }
+
+
+def test_sync_operation_field_set():
+    op: SyncOperation = {
+        "action": "conflict",
+        "rom_id": 1,
+        "file_name": "a.srm",
+        "reason": "both sides changed",
+        "save_id": 9,
+        "slot": "default",
+        "emulator": "retroarch",
+        "server_updated_at": "2026-06-01T00:00:00Z",
+        "server_content_hash": "def",
+    }
+    assert op["action"] == "conflict"
+    assert set(op) == {
+        "action",
+        "rom_id",
+        "file_name",
+        "reason",
+        "save_id",
+        "slot",
+        "emulator",
+        "server_updated_at",
+        "server_content_hash",
+    }
+
+
+def test_negotiate_response_carries_operations():
+    op: SyncOperation = {"action": "upload", "rom_id": 1, "file_name": "a.srm", "reason": "newer locally"}
+    response: SyncNegotiateResponse = {
+        "session_id": 7,
+        "operations": [op],
+        "total_upload": 1,
+        "total_download": 0,
+        "total_conflict": 0,
+        "total_no_op": 0,
+    }
+    assert response["operations"][0]["action"] == "upload"
+    assert response["session_id"] == 7
+
+
+def test_complete_response_nests_session():
+    session: SyncSession = {
+        "id": 7,
+        "device_id": "dev-1",
+        "user_id": 1,
+        "status": "completed",
+        "initiated_at": "t0",
+        "operations_planned": 1,
+        "operations_completed": 1,
+        "operations_failed": 0,
+        "created_at": "t0",
+        "updated_at": "t1",
+    }
+    response: SyncCompleteResponse = {"session": session}
+    assert response["session"]["status"] == "completed"


### PR DESCRIPTION
Phase 1a of #1234 (RomM Device Sync negotiate adoption) — the wire surface + schemas, additive.

## What

Adds the 4.9 negotiate transport to the RomM API adapter:

- `RommApiAdapter.negotiate_sync(device_id, saves)` → `POST /api/sync/negotiate` — POST the device inventory, get back `{session_id, operations[], total_*}`.
- `RommApiAdapter.complete_sync_session(session_id, *, operations_completed, operations_failed, play_sessions=None)` → `POST /api/sync/sessions/{id}/complete`.

Both declared on the `RommSaveApi` Protocol and stubbed in the test fakes (`FakeSaveApi`, `FakeRommApi`).

## Schemas

The wire shapes are TypedDicts in a new `models/sync.py` — `ClientSaveState`, `SyncOperation`, `SyncNegotiateResponse`, `SyncSession`, `SyncCompleteResponse`, `SyncPlaySessionEntry` — mirroring the **live 4.9.2 OpenAPI** field-for-field (required vs `NotRequired[... | None]`). `SyncOperation.action` is `Literal["upload","download","conflict","no_op"]` with a `reason` and **no resolution directive** — confirming ADR-0016's premise (the server detects, the client resolves).

The adapter/protocol signatures reference these TypedDicts (typed in, typed out) so the schemas are live-used rather than dead; the runtime stays plain dicts via `post_json`, consistent with the rest of the adapter.

## Grounding

Schemas + endpoints captured from the running 4.9.2 server's `/openapi.json` and cross-checked against `rommapp/romm`.

## Tests

`tests/adapters/romm/test_romm_api.py` — path + payload shape for both methods (inventory POST, operation parsing, error propagation, play-session include/omit).

## Scope

Additive, **no behavior change** — nothing drives sync from negotiate yet; the legacy decision matrix still owns save-sync. Phase 2 wires it.

Docs: `save-file-sync-architecture.md` (API table + a note that the surface is additive/not-yet-wired). Part of #1234 (phase 1a), no sub-issue.

## Verification

3924 tests pass; ruff / basedpyright / import-linter (models + adapter boundaries clean) / all gate scripts green.
