### PR TITLE
feat(saves): negotiate inventory builder from confirmed-slot saves (#1234 phase 1c)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -62,6 +62,22 @@ single-file MD5 via `SaveFileStore.checksum_md5`, and the zip per-entry scheme v
 negotiate transport requires ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md) / #1234); the
 legacy decision matrix below still computes the single-file `checksum_md5` until the negotiate path is wired.
 
+### Negotiate inventory builder (`SaveService.build_save_inventory`)
+
+The negotiate POST sends this device's local save inventory; `SaveService.build_save_inventory()` assembles it as a
+`list[ClientSaveState]`. It walks the `rom_save_states` aggregate and keeps only ROMs **in scope** — `slot_confirmed` is
+true **and** `active_slot` is a real (truthy) slot, which excludes both the unset `None` and the legacy `""` slot. For
+each in-scope ROM it enumerates the local save files via `RomInfoService.find_save_files` and emits **one
+`ClientSaveState` per file** (per-file granularity): a confirmed ROM with no local files contributes nothing, and a ROM
+with several local files yields one entry each. Per entry, `content_hash` is always set via `SaveFileStore.content_hash`
+— the zip-aware RomM-parity hash above, never the single-file `checksum_md5` — and `updated_at` is the local file's
+mtime rendered as a UTC ISO-8601 string (`domain.iso_time.epoch_to_iso`, the round-trip inverse of
+`parse_iso_to_epoch`).
+
+The builder is **additive and unused**: nothing POSTs the inventory yet — Phase 2 wires it into `negotiate`. It is
+single-file-first; the multi-file-per-slot collision case (several local files mapping to one slot) is a Phase 4 concern
+tracked in #1235.
+
 ## Save Slots
 
 RomM v4.7 introduces **save slots** — named containers for save files. This enables multi-save workflows (e.g.,

--- a/py_modules/domain/iso_time.py
+++ b/py_modules/domain/iso_time.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 
 def parse_iso(value: str | None) -> datetime | None:
@@ -25,3 +25,8 @@ def parse_iso_to_epoch(value: str | None) -> float | None:
     """Parse an ISO-8601 timestamp to epoch seconds (UTC), or None on failure."""
     dt = parse_iso(value)
     return dt.timestamp() if dt is not None else None
+
+
+def epoch_to_iso(epoch: float) -> str:
+    """Render epoch seconds as a UTC ISO-8601 string — round-trip inverse of parse_iso_to_epoch."""
+    return datetime.fromtimestamp(epoch, tz=UTC).isoformat()

--- a/py_modules/services/saves/service.py
+++ b/py_modules/services/saves/service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from domain.iso_time import epoch_to_iso
 from domain.rom_save_state import RomSaveState
 from lib.list_result import ErrorCode
 from services.saves._config import SaveServiceConfig
@@ -31,6 +32,8 @@ from services.saves.sync_engine.devices import DeviceRegistry
 from services.saves.versions import VersionsService, VersionsServiceConfig
 
 if TYPE_CHECKING:
+    from models.sync import ClientSaveState
+
     from services.protocols import UnitOfWorkFactory
 
 
@@ -384,6 +387,51 @@ class SaveService:
         against the new server's negotiate.
         """
         self._device_registry.forget_device()
+
+    # ------------------------------------------------------------------
+    # Negotiate inventory (Phase 1c)
+    # ------------------------------------------------------------------
+
+    def build_save_inventory(self) -> list[ClientSaveState]:
+        """Build the negotiate inventory of this device's local save files.
+
+        Gathers one :class:`ClientSaveState` per local save file belonging to a
+        ROM whose slot is **confirmed** and whose ``active_slot`` is a real
+        (non-legacy) slot — ``slot_confirmed`` is true and ``active_slot`` is
+        truthy (excludes both ``None`` and the legacy ``""``). A confirmed ROM
+        with no local files contributes nothing; per-file granularity means
+        each local file yields its own entry.
+
+        ``content_hash`` is always set via :meth:`SaveFileStore.content_hash`
+        (the zip-aware RomM-parity hash — never ``checksum_md5``), and
+        ``updated_at`` is the local file's mtime rendered as a UTC ISO-8601
+        string.
+
+        Single-file-first: the multi-file-per-slot collision case (several local
+        files mapping to one slot) is a Phase 4 concern tracked in #1235.
+        """
+        with self._uow_factory() as uow:
+            confirmed = [
+                (rom_id, state)
+                for rom_id, state in uow.rom_save_states.iter_all()
+                if state.slot_confirmed and state.active_slot
+            ]
+
+        inventory: list[ClientSaveState] = []
+        for rom_id, state in confirmed:
+            for f in self._rom_info.find_save_files(rom_id):
+                path = f["path"]
+                entry: ClientSaveState = {
+                    "rom_id": rom_id,
+                    "file_name": f["filename"],
+                    "slot": state.active_slot,
+                    "emulator": state.emulator,
+                    "content_hash": self._save_file_store.content_hash(path),
+                    "updated_at": epoch_to_iso(self._save_file_store.get_mtime(path)),
+                    "file_size_bytes": self._save_file_store.get_size(path),
+                }
+                inventory.append(entry)
+        return inventory
 
     # ------------------------------------------------------------------
     # Bulk local-save deletion

--- a/tests/domain/test_iso_time.py
+++ b/tests/domain/test_iso_time.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta, timezone
 
-from domain.iso_time import parse_iso, parse_iso_to_epoch
+from domain.iso_time import epoch_to_iso, parse_iso, parse_iso_to_epoch
 
 
 class TestParseIso:
@@ -120,6 +120,26 @@ class TestParseIsoToEpoch:
         for bad in ("", None, "garbage", "2024-13-01T00:00:00Z"):
             assert parse_iso_to_epoch(bad) is None
             assert parse_iso(bad) is None
+
+
+class TestEpochToIso:
+    def test_epoch_zero_is_unix_epoch_utc(self):
+        assert epoch_to_iso(0.0) == "1970-01-01T00:00:00+00:00"
+
+    def test_known_nonzero_epoch(self):
+        # 1705320000.0 == 2024-01-15T12:00:00Z
+        assert epoch_to_iso(1705320000.0) == "2024-01-15T12:00:00+00:00"
+
+    def test_fractional_seconds_render_microseconds(self):
+        assert epoch_to_iso(1705320000.5) == "2024-01-15T12:00:00.500000+00:00"
+
+    def test_always_carries_utc_offset(self):
+        assert epoch_to_iso(1705320000.0).endswith("+00:00")
+
+    def test_round_trips_through_parse_iso_to_epoch(self):
+        """parse_iso_to_epoch(epoch_to_iso(e)) == e for concrete instants."""
+        for e in (0.0, 1705320000.0, 1705320000.5):
+            assert parse_iso_to_epoch(epoch_to_iso(e)) == e
 
 
 class TestEdgeOffsets:

--- a/tests/domain/test_iso_time_property.py
+++ b/tests/domain/test_iso_time_property.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime
 from hypothesis import given
 from hypothesis import strategies as st
 
-from domain.iso_time import parse_iso_to_epoch
+from domain.iso_time import epoch_to_iso, parse_iso_to_epoch
 
 # Aware UTC datetimes across a wide range; whole-second and microsecond
 # resolution both exercised by the formatting helper below.
@@ -80,3 +80,18 @@ def test_epoch_ordering_independent_of_format(earlier: datetime, later: datetime
 
     # Epoch ordering must match true instant ordering.
     assert (epoch_earlier <= epoch_later) == (e0 <= l0)
+
+
+@given(epoch=st.floats(min_value=0, max_value=4_000_000_000, allow_nan=False, allow_infinity=False))
+def test_epoch_to_iso_round_trips(epoch: float) -> None:
+    """``epoch_to_iso`` is the inverse of ``parse_iso_to_epoch`` up to microsecond
+    rounding: the rendered string parses back to the same instant (to within a
+    sub-millisecond tolerance for float/microsecond truncation) and always
+    carries a UTC ``+00:00`` offset — the inventory's ``updated_at`` is therefore
+    always an unambiguous UTC timestamp the server can compare.
+    """
+    rendered = epoch_to_iso(epoch)
+    assert rendered.endswith("+00:00")
+    recovered = parse_iso_to_epoch(rendered)
+    assert recovered is not None
+    assert abs(recovered - epoch) < 1e-3

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -1,6 +1,7 @@
 """Tests for SaveService aggregate root — public callable surface and cross-service coordination."""
 
 import asyncio
+import hashlib
 import logging
 import os
 import time
@@ -13,6 +14,7 @@ from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_save_api import FakeSaveApi
 from fakes.fake_settings_persister import FakeSettingsPersister
 
+from domain.iso_time import epoch_to_iso
 from domain.rom_save_state import FileSyncState, RomSaveState
 from lib.errors import RommConnectionError
 from services.saves._settings import sanitize_setting
@@ -1268,3 +1270,101 @@ class TestPluginVersionResolution:
 
         assert fake_reader.read_count == 1
         assert fake_reader.last_plugin_dir == plugin_dir
+
+
+class TestBuildSaveInventory:
+    """``build_save_inventory`` — the Phase 1c negotiate inventory builder.
+
+    Scope predicate: ``slot_confirmed`` ∧ a non-legacy (truthy) ``active_slot``.
+    Per-file granularity; ``content_hash`` is the zip-aware store hash and
+    ``updated_at`` is the local mtime as a UTC ISO string.
+    """
+
+    def test_one_confirmed_rom_one_file(self, tmp_path):
+        """A confirmed non-null slot with one local save → one fully-populated entry."""
+        svc, _ = make_service(tmp_path)
+        content = b"pokemon-save-bytes"
+        save_path = _create_save(tmp_path, system="gba", rom_name="pokemon", content=content)
+        os.utime(save_path, (1705320000.0, 1705320000.0))
+        _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba")
+
+        state = RomSaveState(emulator="retroarch-mgba", system="gba")
+        state.confirm_slot("A")
+        _seed_save_state(svc, 42, state)
+
+        inventory = svc.build_save_inventory()
+
+        assert inventory == [
+            {
+                "rom_id": 42,
+                "file_name": "pokemon.srm",
+                "slot": "A",
+                "emulator": "retroarch-mgba",
+                "content_hash": hashlib.md5(content).hexdigest(),
+                "updated_at": epoch_to_iso(1705320000.0),
+                "file_size_bytes": len(content),
+            }
+        ]
+
+    def test_multiple_local_files_yield_one_entry_each(self, tmp_path):
+        """Two local save files for one confirmed ROM → two entries (per-file)."""
+        svc, _ = make_service(tmp_path)
+        _create_save(tmp_path, system="gba", rom_name="pokemon", content=b"a", ext=".srm")
+        _create_save(tmp_path, system="gba", rom_name="pokemon", content=b"bb", ext=".rtc")
+        _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba")
+
+        state = RomSaveState(system="gba")
+        state.confirm_slot("A")
+        _seed_save_state(svc, 42, state)
+
+        inventory = svc.build_save_inventory()
+
+        assert len(inventory) == 2
+        assert {e["file_name"] for e in inventory} == {"pokemon.srm", "pokemon.rtc"}
+        assert all(e["rom_id"] == 42 for e in inventory)
+        assert all(e.get("slot") == "A" for e in inventory)
+
+    def test_excludes_legacy_null_slot(self, tmp_path):
+        """A confirmed ROM whose active_slot is the legacy None is excluded."""
+        svc, _ = make_service(tmp_path)
+        _create_save(tmp_path, system="gba", rom_name="pokemon", content=b"data")
+        _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba")
+
+        state = RomSaveState(system="gba")
+        state.confirm_slot(None)  # slot_confirmed=True, active_slot=None (legacy)
+        assert state.slot_confirmed is True
+        assert state.active_slot is None
+        _seed_save_state(svc, 42, state)
+
+        assert svc.build_save_inventory() == []
+
+    def test_excludes_unconfirmed_slot(self, tmp_path):
+        """A ROM with a real active_slot but slot_confirmed=False is excluded."""
+        svc, _ = make_service(tmp_path)
+        _create_save(tmp_path, system="gba", rom_name="pokemon", content=b"data")
+        _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba")
+
+        state = RomSaveState(system="gba")
+        state.switch_active_slot("A")  # active_slot="A", slot_confirmed stays False
+        assert state.active_slot == "A"
+        assert state.slot_confirmed is False
+        _seed_save_state(svc, 42, state)
+
+        assert svc.build_save_inventory() == []
+
+    def test_confirmed_rom_with_no_local_files_contributes_nothing(self, tmp_path):
+        """A confirmed non-null slot whose ROM has no local save files yields no entry."""
+        svc, _ = make_service(tmp_path)
+        _install_rom(svc, tmp_path, rom_id=42, system="gba", file_name="pokemon.gba")
+        # No _create_save — the saves directory has no matching files.
+
+        state = RomSaveState(system="gba")
+        state.confirm_slot("A")
+        _seed_save_state(svc, 42, state)
+
+        assert svc.build_save_inventory() == []
+
+    def test_no_confirmed_roms_returns_empty(self, tmp_path):
+        """No tracked ROMs at all → empty inventory."""
+        svc, _ = make_service(tmp_path)
+        assert svc.build_save_inventory() == []


### PR DESCRIPTION
Phase 1c of #1234 (RomM Device Sync negotiate adoption) — the client inventory builder, additive.

## What

`SaveService.build_save_inventory() -> list[ClientSaveState]` gathers this device's local save files into the inventory shape Phase 2 will POST to `negotiate`. One `ClientSaveState` per local save file of a ROM whose slot is **confirmed** and whose `active_slot` is a real (non-legacy) slot; a confirmed ROM with no local files contributes nothing.

Per field:

- `content_hash` — `SaveFileStore.content_hash` (the zip-aware RomM-parity hash from 1b), never `checksum_md5`. This is the convergence wall: the server's hash-equality short-circuit is what protects against client/server clock skew.
- `updated_at` — the local file's mtime as a UTC ISO-8601 string, via a new pure `domain.iso_time.epoch_to_iso` (the round-trip inverse of `parse_iso_to_epoch`).
- `slot` / `emulator` — from the `RomSaveState` aggregate.
- `file_size_bytes` — the live file size.

## Placement

The pure timestamp kernel (`epoch_to_iso`) lives in `domain/iso_time.py`; the typed wire-shape assembly lives on `SaveService` (the layer allowed to name `models.ClientSaveState`) and mirrors the existing `_delete_saves_for_roms` collect-then-iterate UoW pattern (no nested UoW). No new `SaveFileStore` method — the three measurements (`content_hash` / `get_mtime` / `get_size`) are called inline through the injected store, matching the established matrix idiom. `domain` stays stdlib-only; `ClientSaveState` is referenced only under `TYPE_CHECKING` in the service layer.

## Scope

Additive, **no behavior change** — `build_save_inventory` is not wired to any Decky callable; nothing drives sync from it yet. Single-file-first: multi-file-per-slot is tracked in #1235 (Phase 4). Phase 2 wires the negotiate round-trip.

## Tests

- `domain.iso_time.epoch_to_iso` — value + round-trip cases, plus a Hypothesis property (`parse_iso_to_epoch ∘ epoch_to_iso ≈ id` over a bounded epoch domain).
- `build_save_inventory` — happy (literal 7-field entry), multi-file, and the three exclusion cases (legacy null slot, unconfirmed, no local files), plus the empty case.

Docs: `save-file-sync-architecture.md` (inventory-builder subsection). Part of #1234 (phase 1c), no sub-issue.

## Verification

3956 tests pass; ruff / basedpyright (full scope incl. tests) / import-linter (domain stays stdlib-only) / all gate scripts green.
