### PR TITLE
feat(saves): device-level save-sync serialization gate (#1234 phase 2a)

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -238,6 +238,27 @@ handler resets that flag at its own start, but an incrementally-**skipped** unit
 run could otherwise carry a stale cancel from a prior cancelled run; resetting once per run on `sync_plan` is the
 reliable reset.
 
+#### Save-sync serialization (device gate)
+
+Every save-sync run on the device passes through a single **device-level serialization gate** (`SaveSyncGate`, in
+`services/saves/sync_engine/_gate.py`). Only **one** save-sync run is in flight at a time per device: when a second
+trigger fires while one is running, it **queues** — it waits for the in-flight run to finish rather than running
+alongside it. An `asyncio.Lock` is the serializer/queue; the gate owns only the bounded-acquire discipline around it (no
+run-lifecycle state, no run ids, no cancellation — those are out of scope here).
+
+The wait is **bounded** so a stuck run never traps the launch path. Each of the four trigger methods on `SyncEngine`
+wraps its run body in `bounded_run(timeout=…)` with a per-trigger budget — `pre_launch_sync` (30 s), `post_exit_sync`
+(60 s), `sync_rom_saves` (15 s), `sync_all_saves` (60 s). If the gate can't be acquired within the budget the call
+returns its own fallthrough instead of blocking: the launch-path triggers (`pre_launch_sync` / `post_exit_sync`) return
+the `offline` shape (`reason: SERVER_UNREACHABLE`, additive `offline: True`) so the launch flow treats a busy gate like
+an unreachable server; the manual triggers (`sync_rom_saves` / `sync_all_saves`) return `reason: "sync_busy"`. The lock
+is never leaked on timeout — a timed-out acquire releases any photo-finish hold before raising.
+
+The gate sits **outside** the per-ROM lock (`SyncEngine.rom_lock(rom_id)`): the device gate admits one run at a time
+across the whole device, then each ROM still takes its own `rom_lock` for the read-mutate-write of its `RomSaveState`.
+The cheap stateless early-out (`is_save_sync_enabled()`) runs **before** the gate, so a disabled-feature call never
+queues behind an in-flight run just to report it's off.
+
 #### DownloadService notes
 
 RomM exposes three mutually exclusive file-layout flags on every ROM detail. They control how the server stores files

--- a/py_modules/services/saves/sync_engine/__init__.py
+++ b/py_modules/services/saves/sync_engine/__init__.py
@@ -8,6 +8,7 @@ StatusService; persistence is owned by the public callable's narrow
 Unit of Work (ADR-0006).
 """
 
+from services.saves.sync_engine._gate import SaveSyncGate, SaveSyncTimeoutError
 from services.saves.sync_engine.engine import MatrixOutcome, SyncEngine, SyncEngineConfig
 
-__all__ = ["MatrixOutcome", "SyncEngine", "SyncEngineConfig"]
+__all__ = ["MatrixOutcome", "SaveSyncGate", "SaveSyncTimeoutError", "SyncEngine", "SyncEngineConfig"]

--- a/py_modules/services/saves/sync_engine/_gate.py
+++ b/py_modules/services/saves/sync_engine/_gate.py
@@ -1,0 +1,93 @@
+"""Device-level single-owner serialization gate for save-sync.
+
+One in-flight save-sync run per device: a second trigger waits (queue
+semantics) for the in-flight run to finish rather than running alongside
+it, and the wait is bounded so a stuck run never traps the launch path —
+on expiry the caller gets a timeout it can turn into an offline/busy
+fallthrough. The :class:`asyncio.Lock` IS the serializer/queue; this
+module owns only the bounded-acquire discipline around it.
+
+Run-lifecycle state (run ids, sync-state boxes) and cancellation are out
+of scope here — those belong to a later phase. What lives here is the
+narrow gate that admits exactly one run at a time and times out the rest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+__all__ = [
+    "POST_EXIT_GATE_TIMEOUT",
+    "PRE_LAUNCH_GATE_TIMEOUT",
+    "SYNC_ALL_GATE_TIMEOUT",
+    "SYNC_ROM_GATE_TIMEOUT",
+    "SaveSyncGate",
+    "SaveSyncTimeoutError",
+]
+
+# Per-trigger bounded-wait budgets (seconds). The launch-path triggers
+# carry the tightest budgets so a queued run never stalls the Play button
+# longer than the user would tolerate; the manual full-library sweep gets
+# the most slack because it legitimately runs longest.
+PRE_LAUNCH_GATE_TIMEOUT: float = 30.0
+POST_EXIT_GATE_TIMEOUT: float = 60.0
+SYNC_ROM_GATE_TIMEOUT: float = 15.0
+SYNC_ALL_GATE_TIMEOUT: float = 60.0
+
+
+class SaveSyncTimeoutError(Exception):
+    """Raised when a save-sync run cannot acquire the device gate in time.
+
+    Signals that another run is in flight and the bounded wait elapsed — the
+    caller turns this into its trigger-specific offline/busy fallthrough.
+    """
+
+
+class SaveSyncGate:
+    """Admits one save-sync run per device, queuing and bounding the rest.
+
+    A single :class:`asyncio.Lock` serializes every save-sync run on the
+    device: the first caller holds it for the duration of its run, later
+    callers wait their turn (queue semantics) up to a per-call timeout. The
+    gate sits OUTSIDE the per-ROM lock — it is the device-wide single-owner
+    seam, not a per-ROM one. It holds no run-lifecycle state and offers no
+    cancellation; those belong to a later phase.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def bounded_run(self, *, max_wait: float) -> AsyncIterator[None]:
+        """Acquire the device gate within *max_wait* seconds, holding it for the body.
+
+        Waits up to *max_wait* seconds to acquire the gate (queuing behind any
+        in-flight run). On expiry it raises :class:`SaveSyncTimeoutError`
+        WITHOUT holding the lock, so a timed-out caller never traps the next
+        run. On success the lock is released in ``finally`` even if the body
+        raises.
+        """
+        acquired = False
+        try:
+            async with asyncio.timeout(max_wait):
+                await self._lock.acquire()
+                acquired = True
+        except TimeoutError as exc:
+            # The acquire can win a photo-finish with the deadline; if it did,
+            # release here so a timed-out caller never leaks the held lock.
+            if acquired:
+                self._lock.release()
+            raise SaveSyncTimeoutError(f"save-sync gate not acquired within {max_wait}s") from exc
+        try:
+            yield
+        finally:
+            self._lock.release()
+
+    def is_in_flight(self) -> bool:
+        """Whether a save-sync run currently holds the gate."""
+        return self._lock.locked()

--- a/py_modules/services/saves/sync_engine/engine.py
+++ b/py_modules/services/saves/sync_engine/engine.py
@@ -41,6 +41,14 @@ from services.saves._settings import (
     sync_after_exit,
     sync_before_launch,
 )
+from services.saves.sync_engine._gate import (
+    POST_EXIT_GATE_TIMEOUT,
+    PRE_LAUNCH_GATE_TIMEOUT,
+    SYNC_ALL_GATE_TIMEOUT,
+    SYNC_ROM_GATE_TIMEOUT,
+    SaveSyncGate,
+    SaveSyncTimeoutError,
+)
 from services.saves.sync_engine.matrix import MatrixExecutor, MatrixOutcome
 from services.saves.sync_engine.rollback import RollbackOrchestrator
 
@@ -155,6 +163,11 @@ class SyncEngine:
             log_debug=config.log_debug,
             resolve_core=self.resolve_core,
         )
+        # Device-level single-owner serialization gate: only one save-sync run
+        # in flight at a time per device. A second trigger queues behind the
+        # in-flight one, bounded so a stuck run never traps the launch path.
+        # Sits OUTSIDE the per-ROM ``rom_lock`` — wraps the whole run body.
+        self._device_gate = SaveSyncGate()
 
     def rom_lock(self, rom_id: int) -> asyncio.Lock:
         """Return the lock for this rom_id, creating it lazily."""
@@ -495,71 +508,89 @@ class SyncEngine:
     async def pre_launch_sync(self, rom_id: int) -> dict[str, Any]:
         """Download newer saves from server before game launch."""
         rom_id = int(rom_id)
-        async with self.rom_lock(rom_id):
-            if not self.is_save_sync_enabled():
-                return {"success": True, "message": SAVE_SYNC_DISABLED, "synced": 0}
+        # Cheap stateless early-out before the device gate — never queue behind
+        # an in-flight run just to report the feature is disabled.
+        if not self.is_save_sync_enabled():
+            return {"success": True, "message": SAVE_SYNC_DISABLED, "synced": 0}
 
-            # Defense in depth: block pre_launch_sync if a future caller bypasses
-            # the @migration_blocked decorator at the public callable. saves_dir
-            # would otherwise resolve under the new home and silently desync from
-            # files still living at the old home. Internal do_sync_rom_saves callers
-            # (sync_all_saves, rollback_to_version) are protected by the decorator
-            # on their own public callables — this guard is for pre_launch_sync.
-            if self._is_retrodeck_migration_pending():
+        try:
+            async with self._device_gate.bounded_run(max_wait=PRE_LAUNCH_GATE_TIMEOUT), self.rom_lock(rom_id):
+                # Defense in depth: block pre_launch_sync if a future caller bypasses
+                # the @migration_blocked decorator at the public callable. saves_dir
+                # would otherwise resolve under the new home and silently desync from
+                # files still living at the old home. Internal do_sync_rom_saves callers
+                # (sync_all_saves, rollback_to_version) are protected by the decorator
+                # on their own public callables — this guard is for pre_launch_sync.
+                if self._is_retrodeck_migration_pending():
+                    return {
+                        "success": False,
+                        "reason": "blocked_by_migration",
+                        "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+                        "synced": 0,
+                        "blocked_by_migration": True,
+                    }
+
+                # Refresh save-sort state before the migration gate — see #238.
+                await self._refresh_save_sort_state("pre_launch_sync")
+
+                # Hard-gate: saves go to the content dir — sync is impossible (#239).
+                if self._save_sync_blocked():
+                    return self._content_dir_skip()
+
+                if self._rom_info.is_save_sort_changed():
+                    return {
+                        "success": False,
+                        "reason": "save_sort_changed",
+                        "message": "RetroArch save sorting changed — migrate saves in Settings first",
+                        "synced": 0,
+                        "save_sort_changed": True,
+                    }
+
+                if not sync_before_launch(self._settings):
+                    return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
+
+                # Pre-probe reachability before any sync work — mirror post_exit_sync.
+                # A genuine reachability failure surfaces the canonical unreachable
+                # shape (plus the additive ``offline`` flag) so the launch path can
+                # warn on local drift instead of stalling on a doomed round-trip; an
+                # auth/SSL/server error instead carries its OWN classified reason so
+                # the UI stops lying about reachability (#971).
+                try:
+                    await self._loop.run_in_executor(None, self._romm_api.heartbeat)
+                except Exception as e:
+                    return self._heartbeat_failure_result("pre_launch_sync", e)
+
+                if not self.get_device_id():
+                    reg = await self.ensure_device_registered()
+                    if not reg.get("success"):
+                        return {
+                            "success": False,
+                            "reason": DEVICE_NOT_REGISTERED_REASON,
+                            "message": DEVICE_NOT_REGISTERED,
+                        }
+
+                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+
+                msg = f"Downloaded {synced} save(s)"
+                if errors:
+                    msg += f", {len(errors)} error(s)"
                 return {
-                    "success": False,
-                    "reason": "blocked_by_migration",
-                    "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
-                    "synced": 0,
-                    "blocked_by_migration": True,
+                    "success": len(errors) == 0,
+                    "message": msg,
+                    "synced": synced,
+                    "errors": errors,
+                    "conflicts": list(conflicts),
                 }
-
-            # Refresh save-sort state before the migration gate — see #238.
-            await self._refresh_save_sort_state("pre_launch_sync")
-
-            # Hard-gate: saves go to the content dir — sync is impossible (#239).
-            if self._save_sync_blocked():
-                return self._content_dir_skip()
-
-            if self._rom_info.is_save_sort_changed():
-                return {
-                    "success": False,
-                    "reason": "save_sort_changed",
-                    "message": "RetroArch save sorting changed — migrate saves in Settings first",
-                    "synced": 0,
-                    "save_sort_changed": True,
-                }
-
-            if not sync_before_launch(self._settings):
-                return {"success": True, "message": "Pre-launch sync disabled", "synced": 0}
-
-            # Pre-probe reachability before any sync work — mirror post_exit_sync.
-            # A genuine reachability failure surfaces the canonical unreachable
-            # shape (plus the additive ``offline`` flag) so the launch path can
-            # warn on local drift instead of stalling on a doomed round-trip; an
-            # auth/SSL/server error instead carries its OWN classified reason so
-            # the UI stops lying about reachability (#971).
-            try:
-                await self._loop.run_in_executor(None, self._romm_api.heartbeat)
-            except Exception as e:
-                return self._heartbeat_failure_result("pre_launch_sync", e)
-
-            if not self.get_device_id():
-                reg = await self.ensure_device_registered()
-                if not reg.get("success"):
-                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
-
-            synced, errors, conflicts = await self._run_rom_sync(rom_id)
-
-            msg = f"Downloaded {synced} save(s)"
-            if errors:
-                msg += f", {len(errors)} error(s)"
+        except SaveSyncTimeoutError:
+            # Another save-sync run held the device gate past the bounded wait —
+            # treat as offline so the launch path warns on local drift instead
+            # of trapping the Play button. Mirrors _heartbeat_failure_result.
             return {
-                "success": len(errors) == 0,
-                "message": msg,
-                "synced": synced,
-                "errors": errors,
-                "conflicts": list(conflicts),
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Save-sync busy — treating as offline",
+                "synced": 0,
+                "offline": True,
             }
 
     async def post_exit_sync(self, rom_id: int) -> dict[str, Any]:
@@ -567,109 +598,144 @@ class SyncEngine:
         self._logger.info("post_exit_sync called for rom_id=%d", rom_id)
         rom_id = int(rom_id)
 
-        async with self.rom_lock(rom_id):
-            if not self.is_save_sync_enabled():
-                self._logger.info("post_exit_sync skipped: save sync disabled")
-                return {"success": True, "message": SAVE_SYNC_DISABLED, "synced": 0}
+        # Cheap stateless early-out before the device gate — never queue behind
+        # an in-flight run just to report the feature is disabled.
+        if not self.is_save_sync_enabled():
+            self._logger.info("post_exit_sync skipped: save sync disabled")
+            return {"success": True, "message": SAVE_SYNC_DISABLED, "synced": 0}
 
-            # Defense in depth: same rationale as pre_launch_sync — internal
-            # do_sync_rom_saves callers are protected by @migration_blocked on
-            # their public callables; this guard covers post_exit_sync only.
-            if self._is_retrodeck_migration_pending():
-                self._logger.info("post_exit_sync skipped: retrodeck migration pending")
+        try:
+            async with self._device_gate.bounded_run(max_wait=POST_EXIT_GATE_TIMEOUT), self.rom_lock(rom_id):
+                # Defense in depth: same rationale as pre_launch_sync — internal
+                # do_sync_rom_saves callers are protected by @migration_blocked on
+                # their public callables; this guard covers post_exit_sync only.
+                if self._is_retrodeck_migration_pending():
+                    self._logger.info("post_exit_sync skipped: retrodeck migration pending")
+                    return {
+                        "success": False,
+                        "reason": "blocked_by_migration",
+                        "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+                        "synced": 0,
+                        "blocked_by_migration": True,
+                    }
+
+                if not sync_after_exit(self._settings):
+                    self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
+                    return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
+
+                # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
+                await self._refresh_save_sort_state("post_exit_sync")
+
+                # Hard-gate: saves go to the content dir — sync is impossible (#239).
+                if self._save_sync_blocked():
+                    self._logger.info("post_exit_sync skipped: savefiles_in_content_dir")
+                    return self._content_dir_skip()
+
+                try:
+                    await self._loop.run_in_executor(None, self._romm_api.heartbeat)
+                except Exception as e:
+                    return self._heartbeat_failure_result("post_exit_sync", e)
+
+                if not self.get_device_id():
+                    reg = await self.ensure_device_registered()
+                    if not reg.get("success"):
+                        return {
+                            "success": False,
+                            "reason": DEVICE_NOT_REGISTERED_REASON,
+                            "message": DEVICE_NOT_REGISTERED,
+                        }
+
+                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+
+                self._logger.info(
+                    "post_exit_sync complete for rom_id=%d: synced=%d, errors=%d, conflicts=%d",
+                    rom_id,
+                    synced,
+                    len(errors),
+                    len(conflicts),
+                )
+
+                msg = f"Uploaded {synced} save(s)"
+                if errors:
+                    msg += f", {len(errors)} error(s)"
+                if conflicts:
+                    msg += f", {len(conflicts)} conflict(s)"
                 return {
-                    "success": False,
-                    "reason": "blocked_by_migration",
-                    "message": "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
-                    "synced": 0,
-                    "blocked_by_migration": True,
+                    "success": len(errors) == 0,
+                    "message": msg,
+                    "synced": synced,
+                    "errors": errors,
+                    "conflicts": list(conflicts),
                 }
-
-            if not sync_after_exit(self._settings):
-                self._logger.info("post_exit_sync skipped: sync_after_exit disabled")
-                return {"success": True, "message": "Post-exit sync disabled", "synced": 0}
-
-            # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
-            await self._refresh_save_sort_state("post_exit_sync")
-
-            # Hard-gate: saves go to the content dir — sync is impossible (#239).
-            if self._save_sync_blocked():
-                self._logger.info("post_exit_sync skipped: savefiles_in_content_dir")
-                return self._content_dir_skip()
-
-            try:
-                await self._loop.run_in_executor(None, self._romm_api.heartbeat)
-            except Exception as e:
-                return self._heartbeat_failure_result("post_exit_sync", e)
-
-            if not self.get_device_id():
-                reg = await self.ensure_device_registered()
-                if not reg.get("success"):
-                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
-
-            synced, errors, conflicts = await self._run_rom_sync(rom_id)
-
-            self._logger.info(
-                "post_exit_sync complete for rom_id=%d: synced=%d, errors=%d, conflicts=%d",
-                rom_id,
-                synced,
-                len(errors),
-                len(conflicts),
-            )
-
-            msg = f"Uploaded {synced} save(s)"
-            if errors:
-                msg += f", {len(errors)} error(s)"
-            if conflicts:
-                msg += f", {len(conflicts)} conflict(s)"
+        except SaveSyncTimeoutError:
+            # Another save-sync run held the device gate past the bounded wait —
+            # skip the post-exit upload rather than block on a stuck run.
+            self._logger.info("post_exit_sync skipped: save-sync busy")
             return {
-                "success": len(errors) == 0,
-                "message": msg,
-                "synced": synced,
-                "errors": errors,
-                "conflicts": list(conflicts),
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Save-sync busy — skipping post-exit sync",
+                "synced": 0,
+                "offline": True,
             }
 
     async def sync_rom_saves(self, rom_id: int) -> dict[str, Any]:
         """Bidirectional sync for a single ROM (manual trigger from game detail)."""
         rom_id = int(rom_id)
-        async with self.rom_lock(rom_id):
-            if not self.is_save_sync_enabled():
-                return {
-                    "success": False,
-                    "reason": SAVE_SYNC_DISABLED_REASON,
-                    "message": SAVE_SYNC_DISABLED,
-                    "synced": 0,
-                }
-
-            # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
-            # Manual sync paths must observe fresh sort state too: a user could
-            # edit retroarch.cfg outside of a session and then trigger a manual
-            # sync before any detect has fired.
-            await self._refresh_save_sort_state("sync_rom_saves")
-
-            # Hard-gate: saves go to the content dir — sync is impossible (#239).
-            if self._save_sync_blocked():
-                return self._content_dir_skip()
-
-            if not self.get_device_id():
-                reg = await self.ensure_device_registered()
-                if not reg.get("success"):
-                    return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
-
-            synced, errors, conflicts = await self._run_rom_sync(rom_id)
-
-            msg = f"Synced {synced} save(s)"
-            if errors:
-                msg += f", {len(errors)} error(s)"
-            if conflicts:
-                msg += f", {len(conflicts)} conflict(s)"
+        # Cheap stateless early-out before the device gate — never queue behind
+        # an in-flight run just to report the feature is disabled.
+        if not self.is_save_sync_enabled():
             return {
-                "success": len(errors) == 0,
-                "message": msg,
-                "synced": synced,
-                "errors": errors,
-                "conflicts": list(conflicts),
+                "success": False,
+                "reason": SAVE_SYNC_DISABLED_REASON,
+                "message": SAVE_SYNC_DISABLED,
+                "synced": 0,
+            }
+
+        try:
+            async with self._device_gate.bounded_run(max_wait=SYNC_ROM_GATE_TIMEOUT), self.rom_lock(rom_id):
+                # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
+                # Manual sync paths must observe fresh sort state too: a user could
+                # edit retroarch.cfg outside of a session and then trigger a manual
+                # sync before any detect has fired.
+                await self._refresh_save_sort_state("sync_rom_saves")
+
+                # Hard-gate: saves go to the content dir — sync is impossible (#239).
+                if self._save_sync_blocked():
+                    return self._content_dir_skip()
+
+                if not self.get_device_id():
+                    reg = await self.ensure_device_registered()
+                    if not reg.get("success"):
+                        return {
+                            "success": False,
+                            "reason": DEVICE_NOT_REGISTERED_REASON,
+                            "message": DEVICE_NOT_REGISTERED,
+                        }
+
+                synced, errors, conflicts = await self._run_rom_sync(rom_id)
+
+                msg = f"Synced {synced} save(s)"
+                if errors:
+                    msg += f", {len(errors)} error(s)"
+                if conflicts:
+                    msg += f", {len(conflicts)} conflict(s)"
+                return {
+                    "success": len(errors) == 0,
+                    "message": msg,
+                    "synced": synced,
+                    "errors": errors,
+                    "conflicts": list(conflicts),
+                }
+        except SaveSyncTimeoutError:
+            # Another save-sync run held the device gate past the bounded wait.
+            return {
+                "success": False,
+                "reason": "sync_busy",
+                "message": "Another save-sync run is in progress",
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
             }
 
     def _installed_rom_ids(self) -> list[int]:
@@ -679,6 +745,8 @@ class SyncEngine:
 
     async def sync_all_saves(self) -> dict[str, Any]:
         """Manual full sync of all ROMs with shortcuts (both directions)."""
+        # Cheap stateless early-out before the device gate — never queue behind
+        # an in-flight run just to report the feature is disabled.
         if not self.is_save_sync_enabled():
             return {
                 "success": False,
@@ -688,53 +756,73 @@ class SyncEngine:
                 "conflicts": 0,
             }
 
-        # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
-        # Manual sync paths must observe fresh sort state too: a user could
-        # edit retroarch.cfg outside of a session and then trigger a manual
-        # sync before any detect has fired.
-        await self._refresh_save_sort_state("sync_all_saves")
+        try:
+            # Device gate sits OUTSIDE the per-ROM locks — it wraps the whole
+            # sweep; each ROM still takes its own rom_lock inside the loop.
+            async with self._device_gate.bounded_run(max_wait=SYNC_ALL_GATE_TIMEOUT):
+                # Refresh save-sort state before do_sync_rom_saves reads saves_dir — see #238.
+                # Manual sync paths must observe fresh sort state too: a user could
+                # edit retroarch.cfg outside of a session and then trigger a manual
+                # sync before any detect has fired.
+                await self._refresh_save_sort_state("sync_all_saves")
 
-        # Hard-gate: saves go to the content dir — sync is impossible (#239).
-        if self._save_sync_blocked():
-            return self._content_dir_skip(all_saves=True)
+                # Hard-gate: saves go to the content dir — sync is impossible (#239).
+                if self._save_sync_blocked():
+                    return self._content_dir_skip(all_saves=True)
 
-        if not self.get_device_id():
-            reg = await self.ensure_device_registered()
-            if not reg.get("success"):
-                return {"success": False, "reason": DEVICE_NOT_REGISTERED_REASON, "message": DEVICE_NOT_REGISTERED}
+                if not self.get_device_id():
+                    reg = await self.ensure_device_registered()
+                    if not reg.get("success"):
+                        return {
+                            "success": False,
+                            "reason": DEVICE_NOT_REGISTERED_REASON,
+                            "message": DEVICE_NOT_REGISTERED,
+                        }
 
-        total_synced = 0
-        total_errors: list[str] = []
-        all_conflicts: list[dict[str, Any]] = []
-        rom_count = 0
+                total_synced = 0
+                total_errors: list[str] = []
+                all_conflicts: list[dict[str, Any]] = []
+                rom_count = 0
 
-        # Only iterate installed ROMs — non-installed ROMs have no save files
-        rom_ids = await self._loop.run_in_executor(None, self._installed_rom_ids)
-        self._log_debug(f"sync_all_saves: {len(rom_ids)} ROMs to check")
+                # Only iterate installed ROMs — non-installed ROMs have no save files
+                rom_ids = await self._loop.run_in_executor(None, self._installed_rom_ids)
+                self._log_debug(f"sync_all_saves: {len(rom_ids)} ROMs to check")
 
-        for rom_id_int in rom_ids:
-            rom_count += 1
-            async with self.rom_lock(rom_id_int):
-                synced, errors, conflicts = await self._run_rom_sync(rom_id_int, require_confirmed=True)
-            total_synced += synced
-            total_errors.extend(errors)
-            all_conflicts.extend(conflicts)
+                for rom_id_int in rom_ids:
+                    rom_count += 1
+                    async with self.rom_lock(rom_id_int):
+                        synced, errors, conflicts = await self._run_rom_sync(rom_id_int, require_confirmed=True)
+                    total_synced += synced
+                    total_errors.extend(errors)
+                    all_conflicts.extend(conflicts)
 
-        conflicts_count = len(all_conflicts)
-        msg = f"Synced {total_synced} save(s) across {rom_count} ROM(s)"
-        if total_errors:
-            msg += f", {len(total_errors)} error(s)"
-        if conflicts_count:
-            msg += f", {conflicts_count} conflict(s)"
-        return {
-            "success": len(total_errors) == 0,
-            "message": msg,
-            "synced": total_synced,
-            "conflicts": conflicts_count,
-            "conflicts_list": list(all_conflicts),
-            "roms_checked": rom_count,
-            "errors": total_errors,
-        }
+                conflicts_count = len(all_conflicts)
+                msg = f"Synced {total_synced} save(s) across {rom_count} ROM(s)"
+                if total_errors:
+                    msg += f", {len(total_errors)} error(s)"
+                if conflicts_count:
+                    msg += f", {conflicts_count} conflict(s)"
+                return {
+                    "success": len(total_errors) == 0,
+                    "message": msg,
+                    "synced": total_synced,
+                    "conflicts": conflicts_count,
+                    "conflicts_list": list(all_conflicts),
+                    "roms_checked": rom_count,
+                    "errors": total_errors,
+                }
+        except SaveSyncTimeoutError:
+            # Another save-sync run held the device gate past the bounded wait.
+            return {
+                "success": False,
+                "reason": "sync_busy",
+                "message": "Another save-sync run is in progress",
+                "synced": 0,
+                "conflicts": 0,
+                "conflicts_list": [],
+                "roms_checked": 0,
+                "errors": [],
+            }
 
     async def resolve_sync_conflict(
         self,

--- a/tests/services/saves/sync_engine/test_engine.py
+++ b/tests/services/saves/sync_engine/test_engine.py
@@ -6,7 +6,10 @@ device registration in tests/services/saves/sync_engine/test_devices.py;
 conflict rollback in tests/services/saves/sync_engine/test_rollback.py.
 """
 
+import asyncio
 import logging
+import threading
+import time
 
 import pytest
 
@@ -1106,3 +1109,170 @@ class TestPreLaunchSaveSortGate:
         assert result["synced"] == 0
         # No sync ran.
         assert not any(c[0] in ("upload_save", "download_save_content") for c in fake.call_log)
+
+
+class TestSaveSyncDeviceGate:
+    """Device-level single-owner serialization gate (#1234 phase 2a).
+
+    Only one save-sync run is in flight at a time per device. A second
+    trigger queues behind the in-flight one; the wait is bounded, so a stuck
+    run never traps the launch path — on expiry each trigger returns its
+    own offline/busy fallthrough. The gate sits OUTSIDE the per-ROM lock.
+    """
+
+    async def _assert_timeout_fallthrough(self, svc, monkeypatch, const_name, trigger, expected):
+        """Hold the gate + shrink the timeout, then assert the trigger's fallthrough.
+
+        Holds the engine's device-gate lock so the trigger cannot acquire it,
+        and rebinds the per-trigger timeout constant to a tiny value so the
+        bounded wait expires fast. The trigger must return *expected* verbatim.
+        """
+        engine = svc._sync_engine
+        monkeypatch.setattr(f"services.saves.sync_engine.engine.{const_name}", 0.01)
+        await engine._device_gate._lock.acquire()
+        try:
+            result = await trigger()
+        finally:
+            engine._device_gate._lock.release()
+        assert result == expected
+        # The gate is free again once the external holder released it.
+        assert engine._device_gate.is_in_flight() is False
+
+    @pytest.mark.asyncio
+    async def test_pre_launch_sync_times_out_to_offline(self, tmp_path, monkeypatch):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        fake.saves[100] = _server_save()
+
+        await self._assert_timeout_fallthrough(
+            svc,
+            monkeypatch,
+            "PRE_LAUNCH_GATE_TIMEOUT",
+            lambda: svc.pre_launch_sync(42),
+            {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Save-sync busy — treating as offline",
+                "synced": 0,
+                "offline": True,
+            },
+        )
+        # The gate fired before any sync work — no transfer was attempted.
+        assert not any(c[0] in ("download_save", "list_saves", "heartbeat") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_post_exit_sync_times_out_to_offline(self, tmp_path, monkeypatch):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"data")
+
+        await self._assert_timeout_fallthrough(
+            svc,
+            monkeypatch,
+            "POST_EXIT_GATE_TIMEOUT",
+            lambda: svc.post_exit_sync(42),
+            {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "Save-sync busy — skipping post-exit sync",
+                "synced": 0,
+                "offline": True,
+            },
+        )
+        assert not any(c[0] in ("upload_save", "heartbeat") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_rom_saves_times_out_to_busy(self, tmp_path, monkeypatch):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path)
+        _create_save(tmp_path, content=b"data")
+
+        await self._assert_timeout_fallthrough(
+            svc,
+            monkeypatch,
+            "SYNC_ROM_GATE_TIMEOUT",
+            lambda: svc.sync_rom_saves(42),
+            {
+                "success": False,
+                "reason": "sync_busy",
+                "message": "Another save-sync run is in progress",
+                "synced": 0,
+                "errors": [],
+                "conflicts": [],
+            },
+        )
+        assert not any(c[0] in ("upload_save", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_sync_all_saves_times_out_to_busy(self, tmp_path, monkeypatch):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _create_save(tmp_path, system="gba", rom_name="game1", content=b"save1")
+
+        await self._assert_timeout_fallthrough(
+            svc,
+            monkeypatch,
+            "SYNC_ALL_GATE_TIMEOUT",
+            svc.sync_all_saves,
+            {
+                "success": False,
+                "reason": "sync_busy",
+                "message": "Another save-sync run is in progress",
+                "synced": 0,
+                "conflicts": 0,
+                "conflicts_list": [],
+                "roms_checked": 0,
+                "errors": [],
+            },
+        )
+        assert not any(c[0] in ("upload_save", "list_saves") for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_gate_serializes_runs_across_different_roms(self, tmp_path):
+        """Two manual syncs on DIFFERENT roms fired concurrently serialize via the gate.
+
+        The per-ROM lock does not serialize different rom_ids — only the device
+        gate does. A widening sleep in the stubbed worker would let the two
+        overlap if the gate were absent; the gate forces peak concurrency to 1.
+        Both runs complete successfully (the second waited, it did not time out).
+        """
+        svc, _ = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        _set_device_id(svc, "test-device")
+        _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
+        _install_rom(svc, tmp_path, rom_id=2, system="snes", file_name="game2.sfc")
+        _seed_save_state(svc, 1, RomSaveState(system="gba", slot_confirmed=True, active_slot="default"))
+        _seed_save_state(
+            svc, 2, RomSaveState(system="snes", slot_confirmed=True, active_slot="default"), platform_slug="snes"
+        )
+
+        counter_lock = threading.Lock()
+        state = {"active": 0, "peak": 0}
+
+        def slow_sync(rom_id, *args):
+            with counter_lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            time.sleep(0.05)
+            with counter_lock:
+                state["active"] -= 1
+            return (1, [], [])
+
+        svc._sync_engine.do_sync_rom_saves = slow_sync  # type: ignore[method-assign]
+
+        results = await asyncio.gather(svc.sync_rom_saves(1), svc.sync_rom_saves(2))
+
+        assert all(r["success"] is True for r in results)
+        assert all(r["synced"] == 1 for r in results)
+        # Serialized: the device gate never let both worker calls run at once.
+        assert state["peak"] == 1
+        assert svc._sync_engine._device_gate.is_in_flight() is False

--- a/tests/services/saves/sync_engine/test_gate.py
+++ b/tests/services/saves/sync_engine/test_gate.py
@@ -1,0 +1,176 @@
+"""Tests for SaveSyncGate — the device-level single-owner serialization gate.
+
+Covers the bounded-acquire discipline around the gate's lock: in-flight
+reporting, queue serialization across overlapping runs, the bounded-wait
+timeout, release-on-body-exception, and the no-lock-leak invariant that
+guards the acquire/timeout race.
+"""
+
+import asyncio
+
+import pytest
+
+from services.saves.sync_engine import SaveSyncGate, SaveSyncTimeoutError
+
+
+class TestBoundedRunHappyPath:
+    @pytest.mark.asyncio
+    async def test_in_flight_true_inside_false_outside(self):
+        gate = SaveSyncGate()
+        assert gate.is_in_flight() is False
+        async with gate.bounded_run(max_wait=5.0):
+            assert gate.is_in_flight() is True
+        assert gate.is_in_flight() is False
+
+    @pytest.mark.asyncio
+    async def test_body_value_and_clean_release(self):
+        """A run completes, releases, and a second uncontended run acquires."""
+        gate = SaveSyncGate()
+        async with gate.bounded_run(max_wait=5.0):
+            pass
+        # Lock is free again — a second run acquires without waiting.
+        async with gate.bounded_run(max_wait=5.0):
+            assert gate.is_in_flight() is True
+        assert gate.is_in_flight() is False
+
+
+class TestBoundedRunTimeout:
+    @pytest.mark.asyncio
+    async def test_second_caller_times_out(self):
+        """While one coroutine holds the gate, a bounded second caller times out."""
+        gate = SaveSyncGate()
+        holding = asyncio.Event()
+        release = asyncio.Event()
+
+        async def holder():
+            async with gate.bounded_run(max_wait=5.0):
+                holding.set()
+                await release.wait()
+
+        task = asyncio.create_task(holder())
+        await holding.wait()
+        try:
+            with pytest.raises(SaveSyncTimeoutError):
+                async with gate.bounded_run(max_wait=0.05):
+                    pytest.fail("body must not run when the gate cannot be acquired")
+        finally:
+            release.set()
+            await task
+
+
+class TestBoundedRunReleaseOnException:
+    @pytest.mark.asyncio
+    async def test_body_exception_still_releases(self):
+        """An exception inside the body still releases the lock."""
+        gate = SaveSyncGate()
+
+        class Boom(Exception):
+            pass
+
+        with pytest.raises(Boom):
+            async with gate.bounded_run(max_wait=5.0):
+                raise Boom
+
+        # The lock was released despite the body raising — a later run acquires.
+        assert gate.is_in_flight() is False
+        async with gate.bounded_run(max_wait=5.0):
+            assert gate.is_in_flight() is True
+        assert gate.is_in_flight() is False
+
+
+class TestBoundedRunSerialization:
+    @pytest.mark.asyncio
+    async def test_two_overlapping_runs_serialize(self):
+        """Two overlapping bounded runs both complete, one strictly after the other."""
+        gate = SaveSyncGate()
+        events: list[str] = []
+        first_inside = asyncio.Event()
+
+        async def first():
+            async with gate.bounded_run(max_wait=5.0):
+                events.append("first-enter")
+                first_inside.set()
+                # Hold long enough that ``second`` is forced to wait its turn.
+                await asyncio.sleep(0.05)
+                events.append("first-exit")
+
+        async def second():
+            # Make sure ``first`` is already inside before we contend.
+            await first_inside.wait()
+            async with gate.bounded_run(max_wait=5.0):
+                events.append("second-enter")
+                events.append("second-exit")
+
+        await asyncio.gather(first(), second())
+
+        # Serialized: second only entered after first fully exited.
+        assert events == ["first-enter", "first-exit", "second-enter", "second-exit"]
+
+
+class TestBoundedRunNoLockLeak:
+    @pytest.mark.asyncio
+    async def test_no_lock_leak_after_timeout(self):
+        """After a timeout the gate is free once the holder releases — no phantom hold.
+
+        Guards the acquire/timeout race: a timed-out acquire must not leave a
+        leaked hold that survives the legitimate holder releasing.
+        """
+        gate = SaveSyncGate()
+        holding = asyncio.Event()
+        release = asyncio.Event()
+
+        async def holder():
+            async with gate.bounded_run(max_wait=5.0):
+                holding.set()
+                await release.wait()
+
+        task = asyncio.create_task(holder())
+        await holding.wait()
+
+        # A bounded caller times out while the holder is in flight.
+        with pytest.raises(SaveSyncTimeoutError):
+            async with gate.bounded_run(max_wait=0.05):
+                pytest.fail("body must not run on timeout")
+
+        # Release the legitimate holder; the gate must now be fully free.
+        release.set()
+        await task
+        assert gate.is_in_flight() is False
+
+        # And a fresh run acquires immediately — the timed-out acquire left no leak.
+        async with gate.bounded_run(max_wait=1.0):
+            assert gate.is_in_flight() is True
+        assert gate.is_in_flight() is False
+
+    @pytest.mark.asyncio
+    async def test_acquire_winning_photo_finish_is_released(self, monkeypatch):
+        """An acquire that wins a photo-finish with the deadline is still released.
+
+        Simulates the race where ``acquire()`` completes (so the lock IS held)
+        but the bounding context raises ``TimeoutError`` on exit anyway. The gate
+        must release the just-acquired lock before raising, leaving no leak.
+        """
+        gate = SaveSyncGate()
+
+        class _RaiseOnExitTimeout:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                raise TimeoutError
+
+        monkeypatch.setattr(
+            "services.saves.sync_engine._gate.asyncio.timeout",
+            lambda _t: _RaiseOnExitTimeout(),
+        )
+
+        with pytest.raises(SaveSyncTimeoutError):
+            async with gate.bounded_run(max_wait=5.0):
+                pytest.fail("body must not run when the bounding context times out")
+
+        # The just-acquired lock was released despite the photo-finish timeout.
+        monkeypatch.undo()
+        assert gate.is_in_flight() is False
+        async with gate.bounded_run(max_wait=1.0):
+            assert gate.is_in_flight() is True
+        assert gate.is_in_flight() is False

--- a/tests/services/saves/test_service.py
+++ b/tests/services/saves/test_service.py
@@ -1111,8 +1111,15 @@ class TestPerRomLockSerialization:
         assert kinds == ["enter", "exit", "enter", "exit"], events
 
     @pytest.mark.asyncio
-    async def test_per_rom_lock_does_not_block_different_rom_ids(self, tmp_path):
-        """Concurrent syncs on different rom_ids run in parallel."""
+    async def test_device_gate_serializes_different_rom_ids(self, tmp_path):
+        """Concurrent syncs on different rom_ids serialize via the device gate (#1234 2a).
+
+        The per-ROM lock alone would let different rom_ids sync in parallel, but
+        the device-level serialization gate sits OUTSIDE it and admits one
+        save-sync run at a time per device — so two public ``sync_rom_saves``
+        calls never overlap, regardless of rom_id. (Pre-2a this asserted the
+        opposite; the device gate is the new governing serializer.)
+        """
         svc, _ = make_service(tmp_path)
         _enable_sync_with_device(svc)
         _install_rom(svc, tmp_path, rom_id=1, system="gba", file_name="game1.gba")
@@ -1135,11 +1142,10 @@ class TestPerRomLockSerialization:
 
         await asyncio.gather(svc.sync_rom_saves(1), svc.sync_rom_saves(2))
 
-        # Both enters must happen before either exit (proves overlap).
-        order = [(rid, kind) for rid, kind, _ts in events]
-        enters = [i for i, e in enumerate(order) if e[1] == "enter"]
-        exits = [i for i, e in enumerate(order) if e[1] == "exit"]
-        assert min(exits) > max(enters), order
+        # Strictly serialized by the device gate: the two enter/exit windows
+        # never overlap, even though the rom_ids differ.
+        kinds = [kind for _rid, kind, _ts in events]
+        assert kinds == ["enter", "exit", "enter", "exit"], events
 
 
 class TestHasTrackedSave:


### PR DESCRIPTION
Phase 2a of #1234 (RomM Device Sync negotiate adoption) — per-device save-sync serialization, the foundation the negotiate routing (2b) builds on.

## What

`SaveSyncGate` (`services/saves/sync_engine/_gate.py`): a single `asyncio.Lock` that admits one save-sync run in flight per device. A second trigger **queues** (waits) behind the in-flight run rather than running alongside it; the wait is **bounded** so a stuck run never traps the Play button.

`bounded_run(timeout)` bounds only the *acquire* (a long sync run is never killed); the lock is released on every exit path (body success, body exception, acquire-timeout, and the acquire/timeout photo-finish). `is_in_flight()` exposes the state for 2b.

The four sync triggers wrap their body in the gate, which sits **outside** the per-ROM `rom_lock`. The cheap `is_save_sync_enabled()` early-out stays before the gate. On a bounded-wait timeout:

- `pre_launch_sync` / `post_exit_sync` → the existing `offline: True` shape (the launch path already warns on local drift when offline).
- `sync_rom_saves` / `sync_all_saves` → `reason: "sync_busy"`.

## Why now

Negotiate (2b) is device-scoped — one session per device — so all save-sync runs must serialize at the device level. This gate is that single-owner seam. **Queue, not preempt**: a launch waits for an in-flight bulk rather than aborting it (the server's `cancel_active_sessions` remains a backstop).

## Scope

Lean and deliberate: the gate is *just* serialization. Run-lifecycle state (run ids, sync-state box) and **cancellation** are Phase 2c — their absence here is intentional. One known carry-over: `bounded_run` is not cancellation-safe in the post-acquire window; since nothing cancels save-sync runs in 2a, this is deferred to 2c, where cancellation is introduced and tested.

## Tests

- `test_gate.py` — happy, timeout, release-on-exception, two-runs-serialize, no-leak-after-timeout, photo-finish release.
- `test_engine.py` (`TestSaveSyncDeviceGate`) — per-trigger timeout fallthrough (exact dicts) + a real queue-serialization proof (peak concurrency 1).
- A pre-2a test that asserted different-rom parallelism now pins the new device-serialization invariant.

Docs: `backend-architecture.md` (serialization-gate subsection). Part of #1234 (phase 2a), no sub-issue.

## Verification

3968 tests pass; ruff / basedpyright (full scope incl. tests) / import-linter / all gate scripts green.
