### PR TITLE
fix(saves): drop foreign-rom negotiate ops in dispatch_negotiate_ops (#1234)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -110,8 +110,10 @@ legacy path runs them:
 | `conflict`               | `Conflict(server_save)`          | surface the `SyncConflict` modal (user decides) |
 | `no_op`                  | `Skip(reason)`                   | nothing                                         |
 
-**Slot scoping.** Only ops whose `slot` equals the ROM's `active_slot` are acted on; the server may return device-wide
-download ops for a scoped POST, but a per-ROM run owns just its own slot, so ops for any other slot are dropped. The
+**Scope filtering.** Only ops matching this run's `(rom_id, active_slot)` are acted on; a scoped single-ROM POST gets
+the server's **device-wide** download ops back (one for every server save the device lacks locally, across all ROMs),
+but a per-ROM run owns just its own ROM and slot, so ops for any other ROM or slot are dropped — otherwise a foreign
+ROM's save in the same slot would be pulled into this ROM's saves dir and tracked under the wrong `rom_id`. The
 save-sort migration guard from the legacy path is mirrored: a server-only download (no local file) is suppressed while a
 save-sort migration is pending (#238).
 

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -854,12 +854,13 @@ class MatrixExecutor:
         dispatched through the unchanged :meth:`_dispatch_sync_action`. Returns
         ``(synced_count, errors_list, conflicts_list)``.
 
-        Only ops whose ``slot`` equals the ROM's ``active_slot`` are acted on —
-        the server may return device-wide download ops for a scoped POST, but a
-        per-ROM run owns just its own slot, so ops for any other slot are
-        dropped. A ``download`` op for a file with no local copy is the
-        cross-device case (a save made on another device) and is pulled to
-        recover the content; the server-only migration guard still suppresses it
+        Only ops matching this run's ``(rom_id, active_slot)`` are acted on — a
+        scoped POST gets the server's device-wide download ops back, but a per-ROM
+        run owns just its own ROM and slot, so ops for any other ROM or slot are
+        dropped (else a foreign save would be pulled into this ROM's saves dir).
+        A ``download`` op for a file with no local copy is the cross-device case
+        (a save made on another device) and is pulled to recover the content;
+        the server-only migration guard still suppresses it
         while a save-sort migration is pending (#238). ``info``
         (``get_rom_save_info``) and ``options`` are resolved by the caller;
         *core_so* stamps the upload emulator tag. The operation entry owns the
@@ -879,6 +880,18 @@ class MatrixExecutor:
         pending_migration = self._rom_info.is_save_sort_changed()
 
         for op in ops:
+            # A scoped single-ROM negotiate POST gets the server's DEVICE-WIDE
+            # download ops back (every server save the device lacks locally), not
+            # just this ROM's. A per-ROM run owns only its own (rom_id, active_slot)
+            # pair, so drop ops for any other ROM before the slot check — otherwise
+            # a foreign ROM's save in the same slot would be pulled into this ROM's
+            # saves dir and tracked under the wrong rom_id.
+            if op.get("rom_id") != rom_id:
+                self._log_debug(
+                    f"dispatch_negotiate_ops({rom_id}): dropping op for rom {op.get('rom_id')!r} "
+                    f"(foreign ROM in device-wide negotiate response) {op.get('file_name')}"
+                )
+                continue
             op_slot = op.get("slot")
             if op_slot != active_slot:
                 self._log_debug(

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -2119,6 +2119,32 @@ class TestDispatchNegotiateOps:
         assert (synced, errors, conflicts) == (0, [], [])
         assert not any(c[0] == "download_save_content" for c in fake.call_log)
 
+    def test_op_for_foreign_rom_id_is_dropped(self, tmp_path):
+        """A download op for a DIFFERENT rom_id in the SAME slot is dropped, not
+        pulled into this ROM's saves dir (#1266 device-wide-POST leak).
+
+        A scoped single-ROM negotiate POST returns the server's device-wide
+        download ops; one for a foreign ROM that happens to share the active slot
+        passes the slot check, so the rom_id check is what stops it.
+        """
+        svc, fake = make_service(tmp_path)
+        info, save_state = self._setup(svc, tmp_path, active_slot="default", content=b"local")
+        ops: list[SyncOperation] = [
+            {
+                "action": "download",
+                "rom_id": 9999,
+                "file_name": "Other Game (USA).srm",
+                "slot": "default",
+                "save_id": 777,
+                "reason": "device-wide cross-device download",
+            }
+        ]
+
+        synced, errors, conflicts = self._dispatch(svc, ops, save_state, info)
+
+        assert (synced, errors, conflicts) == (0, [], [])
+        assert not any(c[0] == "download_save_content" for c in fake.call_log)
+
     def test_server_only_download_skipped_during_pending_migration(self, tmp_path):
         """A download op with no local file is suppressed while a save-sort
         migration is pending (mirrors the legacy server-only guard, #238)."""


### PR DESCRIPTION
Fixes a data-pollution bug in the negotiate sync path (#1234 phase 2b/2c, #1266), **found during on-device testing**.

## The bug

A scoped single-ROM `negotiate` POST gets the server's **device-wide** download ops back — one for every server save the device lacks locally, across all ROMs. `dispatch_negotiate_ops` filtered these only by **slot**, so a foreign ROM's save that happened to share the run's active slot passed the filter and was downloaded into the synced ROM's saves directory and tracked under the wrong `rom_id`.

Observed: a manual sync of one GBA ROM pulled two unrelated saves (including an N64 save) into that ROM's `saves/gba/` directory and added two foreign rows to its `rom_save_files` baseline. The ROM's own save was untouched (the foreign downloads had different filenames), so no data loss — but real state pollution.

## The fix

`dispatch_negotiate_ops` now drops any op whose `rom_id` differs from the run's `rom_id`, before the slot check — a per-ROM run owns only its own `(rom_id, active_slot)` pair. One filter line; the bulk path was already safe (it groups ops by `rom_id` before dispatch), but the filter makes the dispatch robust regardless of caller.

## Why the tests missed it

The dispatch tests only ever staged ops for the target `rom_id`, so the server's real "device-wide download ops" behaviour was never simulated. Added `test_op_for_foreign_rom_id_is_dropped`: a `download` op for a different `rom_id` in the **same** slot (so it passes the slot check) is dropped and never downloaded.

## Verification

3997 tests pass; ruff / basedpyright / import-linter / all gate scripts green. On-device re-test (the same single-ROM sync should now return a clean `no_op` with no foreign downloads) pending before merge.
