### PR TITLE
fix(saves): log dispatch-action sync errors (#1234)

### DIFF
--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -590,8 +590,10 @@ class MatrixExecutor:
                 return False
         except RommApiError as e:
             _code, _msg = classify_error(e)
+            self._logger.warning(f"_dispatch_sync_action({rom_id}): {filename} failed: {_msg}")
             sink.errors.append(f"{filename}: {_msg}")
         except Exception as e:
+            self._logger.warning(f"_dispatch_sync_action({rom_id}): {filename} unexpected error: {e}")
             self._handle_unexpected_error(e, filename, saves_dir, sink.errors)
         return False
 

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -1681,9 +1681,10 @@ class TestDispatchSyncActionErrorBranches:
     """_dispatch_sync_action's typed-error branches (matrix.py lines 476-481).
     RommApiError → classify + record; other Exception → _handle_unexpected_error."""
 
-    def test_dispatch_sync_action_records_rommapi_error(self, tmp_path):
+    def test_dispatch_sync_action_records_rommapi_error(self, tmp_path, caplog):
         """A RommApiError from a Download action is recorded with classify_error
-        message; no .tmp cleanup is attempted on this branch."""
+        message AND logged at WARNING (so a sync failure leaves a log trace, not
+        only an errors-list entry); no .tmp cleanup is attempted on this branch."""
         from domain.sync_action import Download
 
         svc, fake = make_service(tmp_path)
@@ -1719,6 +1720,12 @@ class TestDispatchSyncActionErrorBranches:
         assert synced is False
         assert len(errors) == 1
         assert errors[0].startswith("pokemon.srm:")
+        assert any(
+            r.levelname == "WARNING"
+            and "_dispatch_sync_action(42)" in r.getMessage()
+            and "pokemon.srm" in r.getMessage()
+            for r in caplog.records
+        )
 
 
 class TestDispatchUploadDefensiveBranches:


### PR DESCRIPTION
Fixes an observability gap surfaced during on-device testing of the negotiate sync path (#1234).

## The gap

`MatrixExecutor._dispatch_sync_action` is the shared executor for every save-sync action (upload / download / conflict, both the negotiate and legacy paths). Its two catch blocks recorded a per-action failure into the `errors` list (→ a frontend toast) but **never logged it**:

- `except RommApiError` → `classify_error` + `errors.append`, no log.
- `except Exception` → `_handle_unexpected_error` → `errors.append` + tmp cleanup, no log.

So when a real upload failed on-device (a transient server timeout while RomM was scanning its library), the only trace was `... complete: synced=0, errors=1` — zero detail on *what* failed. A save-sync failure is data-relevant and must leave a log line.

## The fix

A `self._logger.warning(...)` at both catch sites, carrying the `rom_id` + filename + the classified message — matching the existing `do_sync_rom_saves` list-saves-failure log pattern. No behavior change beyond the added log.

## Tests

Extended `test_dispatch_sync_action_records_rommapi_error` with a `caplog` assertion that the failure is logged at WARNING with the rom + filename — non-vacuous (it now pins the log trace, not just the errors-list entry).

`docs: N/A` — pure internal logging addition, no user-visible behavior or architecture change.

## Verification

3997 tests pass; ruff / basedpyright / import-linter / all gate scripts green.
