### PR TITLE
fix(saves): resolve canonical local target in dispatch_negotiate_ops (#1234)

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -110,6 +110,13 @@ legacy path runs them:
 | `conflict`               | `Conflict(server_save)`          | surface the `SyncConflict` modal (user decides) |
 | `no_op`                  | `Skip(reason)`                   | nothing                                         |
 
+**Canonical local target.** RomM returns the server save's datetime-**tagged** `file_name` in each op (e.g.
+`Game (USA) [2026-06-25_05-57-58].srm`), but the local file on disk is the untagged canonical `<rom_name>.<ext>` that
+RetroArch reads. `dispatch_negotiate_ops` therefore resolves the canonical local target via `local_save_target` (the
+same helper the legacy path uses — deriving the extension from the tagged op name, since the op carries no
+`file_extension`) before the local-file lookup and dispatch, so a download writes to / an upload targets the canonical
+local file rather than the server's tagged name.
+
 **Scope filtering.** Only ops matching this run's `(rom_id, active_slot)` are acted on; a scoped single-ROM POST gets
 the server's **device-wide** download ops back (one for every server save the device lacks locally, across all ROMs),
 but a per-ROM run owns just its own ROM and slot, so ops for any other ROM or slot are dropped — otherwise a foreign

--- a/py_modules/services/saves/sync_engine/matrix.py
+++ b/py_modules/services/saves/sync_engine/matrix.py
@@ -497,6 +497,7 @@ class MatrixExecutor:
     ) -> bool:
         """Execute an ``Upload`` action. Returns True iff the upload was issued."""
         if local_path is None:
+            self._logger.warning(f"_dispatch_upload({rom_id}): {filename}: upload requested but no local file on disk")
             errors.append(f"{filename}: upload requested but no local file")
             return False
         if action.target_save_id is None:
@@ -837,6 +838,40 @@ class MatrixExecutor:
             return Conflict(server_save=conflict_save), [conflict_save]
         return Skip(reason=op.get("reason") or "synced"), []
 
+    @staticmethod
+    def _negotiate_op_out_of_scope(op: SyncOperation, rom_id: int, active_slot: str | None) -> str | None:
+        """Return a drop reason when *op* isn't for this run's ``(rom_id, active_slot)``, else None.
+
+        A scoped single-ROM negotiate POST gets the server's device-wide download
+        ops back; a per-ROM run owns only its own ROM and slot, so a foreign ROM
+        or a foreign slot is dropped (else it would be pulled into the wrong ROM's
+        saves dir / slot).
+        """
+        if op.get("rom_id") != rom_id:
+            return (
+                f"dropping op for rom {op.get('rom_id')!r} "
+                f"(foreign ROM in device-wide negotiate response) {op.get('file_name')}"
+            )
+        op_slot = op.get("slot")
+        if op_slot != active_slot:
+            return f"dropping op for slot {op_slot!r} (active={active_slot!r}) {op.get('file_name')}"
+        return None
+
+    @staticmethod
+    def _canonical_op_filename(op_file_name: str, rom_name: str) -> str:
+        """Resolve the untagged canonical local filename for a negotiate op.
+
+        RomM returns the server save's datetime-TAGGED ``file_name`` (e.g.
+        ``"Game (USA) [2026-06-25_05-57-58].srm"``), but the local file on disk is
+        the untagged ``"<rom_name>.<ext>"`` RetroArch reads. Resolve it the same
+        way the legacy path does (``local_save_target``, with its extension
+        sanitization) so the lookup matches and a download writes to / an upload
+        targets the canonical local file. The op carries no ``file_extension``, so
+        derive it from the tagged op name (which still carries the real extension).
+        """
+        op_ext = os.path.splitext(op_file_name)[1].lstrip(".")
+        return local_save_target({"file_extension": op_ext} if op_ext else {}, rom_name)
+
     def dispatch_negotiate_ops(
         self,
         rom_id: int,
@@ -882,26 +917,11 @@ class MatrixExecutor:
         pending_migration = self._rom_info.is_save_sort_changed()
 
         for op in ops:
-            # A scoped single-ROM negotiate POST gets the server's DEVICE-WIDE
-            # download ops back (every server save the device lacks locally), not
-            # just this ROM's. A per-ROM run owns only its own (rom_id, active_slot)
-            # pair, so drop ops for any other ROM before the slot check — otherwise
-            # a foreign ROM's save in the same slot would be pulled into this ROM's
-            # saves dir and tracked under the wrong rom_id.
-            if op.get("rom_id") != rom_id:
-                self._log_debug(
-                    f"dispatch_negotiate_ops({rom_id}): dropping op for rom {op.get('rom_id')!r} "
-                    f"(foreign ROM in device-wide negotiate response) {op.get('file_name')}"
-                )
+            drop_reason = self._negotiate_op_out_of_scope(op, rom_id, active_slot)
+            if drop_reason:
+                self._log_debug(f"dispatch_negotiate_ops({rom_id}): {drop_reason}")
                 continue
-            op_slot = op.get("slot")
-            if op_slot != active_slot:
-                self._log_debug(
-                    f"dispatch_negotiate_ops({rom_id}): dropping op for slot {op_slot!r} "
-                    f"(active={active_slot!r}) {op.get('file_name')}"
-                )
-                continue
-            filename = op["file_name"]
+            filename = self._canonical_op_filename(op["file_name"], info["rom_name"])
             local_file = local_by_name.get(filename)
             local_path = local_file["path"] if local_file else None
             if local_path is None and pending_migration:

--- a/tests/services/saves/sync_engine/test_matrix.py
+++ b/tests/services/saves/sync_engine/test_matrix.py
@@ -2190,3 +2190,68 @@ class TestDispatchNegotiateOps:
         assert len(errors) == 1
         assert "pokemon.srm" in errors[0]
         assert conflicts == []
+
+    def test_upload_op_with_tagged_server_filename(self, tmp_path):
+        """An upload op whose server file_name is datetime-TAGGED still targets the
+        untagged canonical local file.
+
+        RomM returns the server save's tagged ``file_name`` in the op
+        (e.g. ``pokemon [2026-06-25_05-57-58].srm``) while the local file on disk
+        is the untagged canonical ``pokemon.srm``. The executor must resolve the
+        canonical local target, find the real local file, and issue the upload for
+        it — not push a "no local file" error.
+        """
+        svc, fake = make_service(tmp_path)
+        info, save_state = self._setup(svc, tmp_path, content=b"new local")
+        ops: list[SyncOperation] = [
+            {
+                "action": "upload",
+                "rom_id": 42,
+                "file_name": "pokemon [2026-06-25_05-57-58].srm",  # TAGGED server name
+                "slot": "default",
+                "reason": "new save",
+            }
+        ]
+
+        synced, errors, conflicts = self._dispatch(svc, ops, save_state, info)
+
+        assert errors == []
+        assert synced == 1
+        assert conflicts == []
+        up = [c for c in fake.call_log if c[0] == "upload_save"]
+        assert len(up) == 1
+        # The upload targets the untagged canonical local file, not the tagged name.
+        assert os.path.basename(up[0][1][1]) == "pokemon.srm"
+        assert up[0][1][1] == str(tmp_path / "saves" / "gba" / "pokemon.srm")
+        assert up[0][2]["save_id"] is None  # POST
+
+    def test_download_op_with_tagged_server_filename(self, tmp_path):
+        """A download op with a datetime-TAGGED server file_name writes content to
+        the untagged canonical local path, never a tagged-named file.
+
+        Without canonical resolution the executor would write to
+        ``pokemon [2026-06-25_05-57-58].srm`` — a name RetroArch never reads — and
+        the real ``pokemon.srm`` would be left stale.
+        """
+        svc, fake = make_service(tmp_path)
+        info, save_state = self._setup(svc, tmp_path, content=b"old local")
+        fake.set_server_save_content(555, b"server bytes")
+        ops: list[SyncOperation] = [
+            {
+                "action": "download",
+                "rom_id": 42,
+                "file_name": "pokemon [2026-06-25_05-57-58].srm",  # TAGGED server name
+                "slot": "default",
+                "save_id": 555,
+                "server_updated_at": "2026-02-17T06:00:00Z",
+                "reason": "server newer",
+            }
+        ]
+
+        synced, errors, conflicts = self._dispatch(svc, ops, save_state, info)
+
+        assert (synced, errors, conflicts) == (1, [], [])
+        saves_dir = tmp_path / "saves" / "gba"
+        # Content lands at the canonical untagged path, NOT a tagged-named file.
+        assert (saves_dir / "pokemon.srm").read_bytes() == b"server bytes"
+        assert not (saves_dir / "pokemon [2026-06-25_05-57-58].srm").exists()


### PR DESCRIPTION
Fixes a convergence-critical negotiate save-sync bug (#1234 phase 2b/2c), found during on-device testing.

## The bug

`MatrixExecutor.dispatch_negotiate_ops` used the op's `file_name` directly for the local-file lookup and for dispatch. But RomM returns the server save's **datetime-tagged** name in the op for slotted saves (e.g. `Mario Golf - Advance Tour (USA) [2026-06-25_05-57-58].srm`), while the local file on disk is the untagged canonical `<rom_name>.<ext>` (e.g. `Mario Golf - Advance Tour (USA).srm`). The tagged name never matched `local_by_name` (keyed by the untagged names from `find_save_files`), so:

- `local_path` resolved to `None` → an **upload** op failed with "upload requested but no local file" — **silently** (that branch is a bare `errors.append`, not covered by the recent dispatch-error logging).
- A **download** op wrote to a wrong tagged-named local file.

Deterministic for any slotted save with an existing server save (RomM tags every slotted save's filename) — it broke negotiate uploads for confirmed slots, and explains earlier observed pollution (foreign downloads landed under their tagged server names).

The legacy path resolves the canonical local target everywhere via `local_save_target(server_save, rom_name)`; the negotiate path skipped it.

## The fix

Resolve the canonical local filename in `dispatch_negotiate_ops` via `local_save_target` (the same extension-sanitizing helper the legacy path uses), deriving the extension from the tagged op name (the op carries no `file_extension`). The canonical name is then used for the lookup, the download write, the upload target, and the conflict entry — the op's `save_id` / server reference is untouched. Plus: the previously-silent "no local file" upload error now logs at WARNING.

## Why the tests missed it

The fake staged ops with **untagged** file_names (which happen to match the local file), so the real server's tagged-name behaviour was never exercised — same class of gap as the rom_id-filter fix. Added `test_upload_op_with_tagged_server_filename` and `test_download_op_with_tagged_server_filename` (both fail without the fix, pass with it) — they stage the server's tagged name and assert the untagged local file is matched/written.

Docs: `save-file-sync-architecture.md` (canonical-target note). Part of #1234.

## Verification

3999 tests pass; ruff / basedpyright (full scope) / import-linter / all gate scripts green. On-device re-test of the upload to follow.
