### PR TITLE
feat: add support for alpha and beta romm server versions

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -347,10 +347,10 @@ just-committed install.
 
 #### ConnectionService notes
 
-**The minimum-version gate compares only the numeric core of `SYSTEM.VERSION`.** Release strings (`4.9.0`) and RomM
-pre-releases (`4.9.0-beta`, `5.0.0-alpha.1`, `5.0.0-alpha`) are parsed by `domain.version.meets_min_version`; the
-`-alpha` / `-beta` suffix (and optional `.N` build number) is stripped before tuple comparison against
-`_MIN_REQUIRED_VERSION`. `development` and a missing version bypass the gate.
+**The minimum-version gate is SemVer-aware on `SYSTEM.VERSION`.** `domain.version.meets_min_version` compares the
+numeric core against `_MIN_REQUIRED_VERSION`; when the core equals the floor, a `-alpha` / `-beta` suffix
+(case-insensitive, optional `.N` build number) ranks **below** the release and is rejected — so `4.9.0-beta.3` fails at
+floor `4.9.0` while `4.9.1-beta` passes. `development` and a missing version bypass the gate.
 
 **A Client API Token is bound to the server it was minted against.** When the token is minted, the canonical origin of
 `romm_url` (full `scheme://host[:port]`, default ports folded out, path/query dropped — `lib/url_host.normalize_origin`)

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -347,6 +347,11 @@ just-committed install.
 
 #### ConnectionService notes
 
+**The minimum-version gate compares only the numeric core of `SYSTEM.VERSION`.** Release strings (`4.9.0`) and RomM
+pre-releases (`4.9.0-beta`, `5.0.0-alpha.1`, `5.0.0-alpha`) are parsed by `domain.version.meets_min_version`; the
+`-alpha` / `-beta` suffix (and optional `.N` build number) is stripped before tuple comparison against
+`_MIN_REQUIRED_VERSION`. `development` and a missing version bypass the gate.
+
 **A Client API Token is bound to the server it was minted against.** When the token is minted, the canonical origin of
 `romm_url` (full `scheme://host[:port]`, default ports folded out, path/query dropped — `lib/url_host.normalize_origin`)
 is stored alongside it as `romm_api_token_origin`. `RommHttpAdapter.auth_header()` attaches the bearer **only** when

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -15,9 +15,9 @@ Phase 7.
 
 ## RomM Save API
 
-Requires RomM >= 4.9.0. Pre-release version strings (`-alpha` / `-beta`, with an optional `.N` suffix) are accepted when
-their numeric core meets the minimum; pre-release tags are not compared. The plugin rejects servers below 4.9.0 with
-`reason: "version_error"`.
+Requires RomM >= 4.9.0 (release or higher core). Pre-releases at the exact floor (`4.9.0-beta`, `4.9.0-alpha.1`) rank
+below `4.9.0` and are rejected; a higher core with a suffix (`4.9.1-beta`) passes. The plugin rejects servers below the
+floor with `reason: "version_error"`.
 
 | Endpoint                                                 | Method | Notes                                                                                                                                                                                                                                                                          |
 | -------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -15,7 +15,9 @@ Phase 7.
 
 ## RomM Save API
 
-Requires RomM >= 4.9.0. The plugin rejects servers below 4.9.0 with `reason: "version_error"`.
+Requires RomM >= 4.9.0. Pre-release version strings (`-alpha` / `-beta`, with an optional `.N` suffix) are accepted when
+their numeric core meets the minimum; pre-release tags are not compared. The plugin rejects servers below 4.9.0 with
+`reason: "version_error"`.
 
 | Endpoint                                                 | Method | Notes                                                                                                                                                                                                                                                                          |
 | -------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -218,11 +218,12 @@ You have two options:
 
 ## RomM Version Compatibility
 
-The plugin requires **RomM >= 4.9.0**. Servers below 4.9.0 are rejected at connection time with a full error page in
-both the QAM panel and the game detail view. The plugin uses server-side device tracking, content hashing, save slots,
-and `device_syncs` for conflict detection. The 4.9.0 minimum is set because that is the release that ships RomM's Device
-Sync (`negotiate`) save-sync transport — the direction adopted in
-[ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md).
+The plugin requires **RomM >= 4.9.0**. Pre-release builds are supported when the numeric core meets that floor — for
+example `4.9.0-beta` or `5.0.0-alpha.1` pass the version gate; only the `X.Y.Z` portion is compared. Servers below 4.9.0
+are rejected at connection time with a full error page in both the QAM panel and the game detail view. The plugin uses
+server-side device tracking, content hashing, save slots, and `device_syncs` for conflict detection. The 4.9.0 minimum
+is set because that is the release that ships RomM's Device Sync (`negotiate`) save-sync transport — the direction
+adopted in [ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md).
 
 For technical details on how save sync works internally (three-way conflict detection, state schema, session detection),
 see the [Save File Sync Architecture](../architecture/save-file-sync-architecture.md) technical reference.

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -218,12 +218,13 @@ You have two options:
 
 ## RomM Version Compatibility
 
-The plugin requires **RomM >= 4.9.0**. Pre-release builds are supported when the numeric core meets that floor — for
-example `4.9.0-beta` or `5.0.0-alpha.1` pass the version gate; only the `X.Y.Z` portion is compared. Servers below 4.9.0
-are rejected at connection time with a full error page in both the QAM panel and the game detail view. The plugin uses
-server-side device tracking, content hashing, save slots, and `device_syncs` for conflict detection. The 4.9.0 minimum
-is set because that is the release that ships RomM's Device Sync (`negotiate`) save-sync transport — the direction
-adopted in [ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md).
+The plugin requires **RomM >= 4.9.0**. Pre-release builds whose numeric core is **above** that floor pass — for example
+`4.9.1-beta` or `5.0.0-alpha.1`. Tags at the exact floor (`4.9.0-beta`, `4.9.0-alpha`) are rejected because they rank
+below the `4.9.0` release. Servers below 4.9.0 are rejected at connection time with a full error page in both the QAM
+panel and the game detail view. The plugin uses server-side device tracking, content hashing, save slots, and
+`device_syncs` for conflict detection. The 4.9.0 minimum is set because that is the release that ships RomM's Device
+Sync (`negotiate`) save-sync transport — the direction adopted in
+[ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md).
 
 For technical details on how save sync works internally (three-way conflict detection, state schema, session detection),
 see the [Save File Sync Architecture](../architecture/save-file-sync-architecture.md) technical reference.

--- a/py_modules/domain/version.py
+++ b/py_modules/domain/version.py
@@ -9,8 +9,6 @@ _VERSION_RE = re.compile(r"^(\d+(?:\.\d+)*)(?:-(alpha|beta)(?:\.\d+)?)?$")
 
 def _parse_core_version(version_str: str) -> tuple[int, ...] | None:
     """Parse the numeric core from *version_str*, ignoring any pre-release suffix."""
-    if not isinstance(version_str, str):
-        return None
     match = _VERSION_RE.match(version_str)
     if match is None:
         return None

--- a/py_modules/domain/version.py
+++ b/py_modules/domain/version.py
@@ -2,19 +2,39 @@
 
 from __future__ import annotations
 
+import re
+
+_VERSION_RE = re.compile(r"^(\d+(?:\.\d+)*)(?:-(alpha|beta)(?:\.\d+)?)?$")
+
+
+def _parse_core_version(version_str: str) -> tuple[int, ...] | None:
+    """Parse the numeric core from *version_str*, ignoring any pre-release suffix."""
+    if not isinstance(version_str, str):
+        return None
+    match = _VERSION_RE.match(version_str)
+    if match is None:
+        return None
+    try:
+        return tuple(int(p) for p in match.group(1).split("."))
+    except ValueError:
+        return None
+
 
 def meets_min_version(version_str: str, minimum: tuple[int, ...]) -> bool:
     """Return True when *version_str* parses to a version >= *minimum*.
 
-    *version_str* is a dot-separated numeric string such as ``"4.8.1"``.
-    Returns ``False`` for any input that cannot be parsed as all-integer
-    components (empty string, non-numeric parts, ``None``). Non-numeric
-    sentinel strings like ``"development"`` also return ``False`` —
-    callers that want to bypass the check for development builds must
-    test for them before invoking this function.
+    *version_str* is a dot-separated numeric string such as ``"4.8.1"``, optionally
+    followed by a RomM pre-release suffix ``-alpha`` or ``-beta`` with an optional
+    ``.N`` build number (e.g. ``"5.0.0-alpha.1"``, ``"4.9.0-beta"``). Only the
+    numeric core is compared against *minimum*; pre-release tags are accepted for
+    parsing but do not affect the comparison.
+
+    Returns ``False`` for any input that cannot be parsed (empty string, non-numeric
+    parts, unsupported pre-release tags, ``None``). Non-numeric sentinel strings like
+    ``"development"`` also return ``False`` — callers that want to bypass the check
+    for development builds must test for them before invoking this function.
     """
-    try:
-        parts = tuple(int(p) for p in version_str.split("."))
-    except (ValueError, AttributeError):
+    parts = _parse_core_version(version_str)
+    if parts is None:
         return False
     return parts >= minimum

--- a/py_modules/domain/version.py
+++ b/py_modules/domain/version.py
@@ -4,35 +4,53 @@ from __future__ import annotations
 
 import re
 
-_VERSION_RE = re.compile(r"^(\d+(?:\.\d+)*)(?:-(alpha|beta)(?:\.\d+)?)?$")
+_VERSION_RE = re.compile(
+    r"^(\d+(?:\.\d+)*)(?:-(alpha|beta)(?:\.\d+)?)?$",
+    re.IGNORECASE,
+)
 
 
-def _parse_core_version(version_str: str) -> tuple[int, ...] | None:
-    """Parse the numeric core from *version_str*, ignoring any pre-release suffix."""
+def _parse_version(version_str: str | None) -> tuple[tuple[int, ...], bool] | None:
+    """Parse *version_str* into ``(core_tuple, has_prerelease)``.
+
+    Returns ``None`` when *version_str* is not a supported RomM version shape.
+    """
+    if not isinstance(version_str, str):
+        return None
     match = _VERSION_RE.match(version_str)
     if match is None:
         return None
     try:
-        return tuple(int(p) for p in match.group(1).split("."))
+        core = tuple(int(part) for part in match.group(1).split("."))
     except ValueError:
         return None
+    has_prerelease = match.group(2) is not None
+    return core, has_prerelease
 
 
-def meets_min_version(version_str: str, minimum: tuple[int, ...]) -> bool:
-    """Return True when *version_str* parses to a version >= *minimum*.
+def meets_min_version(version_str: str | None, minimum: tuple[int, ...]) -> bool:
+    """Return True when *version_str* is SemVer-compatible with ``>= minimum``.
 
     *version_str* is a dot-separated numeric string such as ``"4.8.1"``, optionally
-    followed by a RomM pre-release suffix ``-alpha`` or ``-beta`` with an optional
-    ``.N`` build number (e.g. ``"5.0.0-alpha.1"``, ``"4.9.0-beta"``). Only the
-    numeric core is compared against *minimum*; pre-release tags are accepted for
-    parsing but do not affect the comparison.
+    followed by a RomM pre-release suffix ``-alpha`` or ``-beta`` (case-insensitive)
+    with an optional ``.N`` build number (e.g. ``"5.0.0-alpha.1"``, ``"4.9.0-beta"``).
+
+    Pre-releases rank **below** their own release: at floor ``(4, 9, 0)``,
+    ``4.9.0-beta.3`` is rejected while ``4.9.1-beta`` passes because its numeric
+    core is genuinely above the floor. When the numeric core is below *minimum*,
+    the result is ``False`` regardless of suffix.
 
     Returns ``False`` for any input that cannot be parsed (empty string, non-numeric
     parts, unsupported pre-release tags, ``None``). Non-numeric sentinel strings like
     ``"development"`` also return ``False`` — callers that want to bypass the check
     for development builds must test for them before invoking this function.
     """
-    parts = _parse_core_version(version_str)
-    if parts is None:
+    parsed = _parse_version(version_str)
+    if parsed is None:
         return False
-    return parts >= minimum
+    core, has_prerelease = parsed
+    if core < minimum:
+        return False
+    if core > minimum:
+        return True
+    return not has_prerelease

--- a/tests/domain/test_version.py
+++ b/tests/domain/test_version.py
@@ -43,11 +43,6 @@ class TestMeetsMinVersion:
     def test_empty_string_returns_false(self):
         assert meets_min_version("", MIN) is False
 
-    def test_none_returns_false(self):
-        # int() on None raises TypeError; .split on None raises AttributeError.
-        # The function must return False for a None input rather than raising.
-        assert meets_min_version(None, MIN) is False  # type: ignore[arg-type]
-
     def test_development_returns_false(self):
         assert meets_min_version("development", MIN) is False
 

--- a/tests/domain/test_version.py
+++ b/tests/domain/test_version.py
@@ -53,3 +53,21 @@ class TestMeetsMinVersion:
 
     def test_partly_numeric_returns_false(self):
         assert meets_min_version("4.8.x", MIN) is False
+
+    def test_alpha_with_number_above_minimum(self):
+        assert meets_min_version("5.0.0-alpha.1", MIN) is True
+
+    def test_alpha_without_number_above_minimum(self):
+        assert meets_min_version("5.0.0-alpha", MIN) is True
+
+    def test_beta_with_number_above_minimum(self):
+        assert meets_min_version("4.9.0-beta.3", MIN) is True
+
+    def test_beta_without_number_at_exact_minimum(self):
+        assert meets_min_version("4.8.1-beta", MIN) is True
+
+    def test_alpha_below_minimum_fails(self):
+        assert meets_min_version("4.8.0-alpha.99", MIN) is False
+
+    def test_prerelease_missing_tag_number_only(self):
+        assert meets_min_version("5.0.0-alpha.", MIN) is False

--- a/tests/domain/test_version.py
+++ b/tests/domain/test_version.py
@@ -43,6 +43,9 @@ class TestMeetsMinVersion:
     def test_empty_string_returns_false(self):
         assert meets_min_version("", MIN) is False
 
+    def test_none_returns_false(self):
+        assert meets_min_version(None, MIN) is False
+
     def test_development_returns_false(self):
         assert meets_min_version("development", MIN) is False
 
@@ -55,11 +58,21 @@ class TestMeetsMinVersion:
     def test_alpha_without_number_above_minimum(self):
         assert meets_min_version("5.0.0-alpha", MIN) is True
 
-    def test_beta_with_number_above_minimum(self):
-        assert meets_min_version("4.9.0-beta.3", MIN) is True
+    def test_beta_at_exact_floor_rejected(self):
+        assert meets_min_version("4.8.1-beta.3", MIN) is False
 
-    def test_beta_without_number_at_exact_minimum(self):
-        assert meets_min_version("4.8.1-beta", MIN) is True
+    def test_alpha_at_exact_floor_rejected(self):
+        assert meets_min_version("4.8.1-alpha.1", MIN) is False
+
+    def test_beta_without_number_at_exact_floor_rejected(self):
+        assert meets_min_version("4.8.1-beta", MIN) is False
+
+    def test_higher_core_prerelease_passes(self):
+        assert meets_min_version("4.8.2-beta", MIN) is True
+
+    def test_prerelease_tag_case_insensitive(self):
+        assert meets_min_version("4.8.2-BETA", MIN) is True
+        assert meets_min_version("5.0.0-ALPHA.1", MIN) is True
 
     def test_alpha_below_minimum_fails(self):
         assert meets_min_version("4.8.0-alpha.99", MIN) is False

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -168,6 +168,25 @@ class TestTestConnectionVersionGate:
         result = event_loop.run_until_complete(service.test_connection())
         assert result["reason"] == "version_error"
 
+    def test_prerelease_at_exact_floor_rejected(self, event_loop, romm_api, logger):
+        """4.9.0-beta ranks below 4.9.0 — pre-release tags at the floor are rejected."""
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0-beta.3"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is False
+        assert result["reason"] == "version_error"
+        assert result["romm_version"] == "4.9.0-beta.3"
+
+    def test_prerelease_above_floor_accepted(self, event_loop, romm_api, logger):
+        """4.9.1-beta has a core above 4.9.0 and passes the gate."""
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.1-beta"}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert result["romm_version"] == "4.9.1-beta"
+
     def test_development_version_bypasses_gate(self, event_loop, romm_api, logger):
         """``development`` version string skips the minimum-version check."""
         settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}


### PR DESCRIPTION
## AI Disclaimer. This PR was authored with Cursor

## Summary

- Modify `py_modules/domain/version.py` to support romm server versions `X.Y.Z-(alpha|beta)`, instead of having an incompatible version error
- Updated documentation explaining the supported versions
- Added corresponding tests

## Test plan

- [x] `pnpm build` clean
- [x] `basedpyright` zero errors
- [x] `python -m pytest tests/ -q`
- [x] Manual QA on Steam Deck if UI changed

## Docs

- [x] `docs/` updated in this PR
- [ ] OR: opting out — `no-docs-change` label set / reason in Notes (pure refactor, tooling, dep bump, etc.)

Closes #1270 
