### PR TITLE
feat(auth): request roms.user.read scope for native play-session reads

### DIFF
--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -23,11 +23,14 @@ if TYPE_CHECKING:
 
 # Scopes requested for the minted Client API Token. Deliberately excludes
 # ``me.write`` so the token itself cannot mint or delete tokens — that
-# stays a Basic-auth-only operation.
+# stays a Basic-auth-only operation. ``roms.user.read`` is requested so the
+# token can read per-user ROM data (native play-session history — #1219 /
+# #1234 Phase 5); we already hold ``roms.user.write`` for the ingest POST.
 _TOKEN_SCOPES = [
     "me.read",
     "platforms.read",
     "roms.read",
+    "roms.user.read",
     "collections.read",
     "firmware.read",
     "assets.read",

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -844,11 +844,12 @@ class TestUpdateNote:
 
 class TestTokenScopes:
     def test_locked_scope_list(self):
-        """The 10 requested scopes are fixed and exclude ``me.write``."""
+        """The 11 requested scopes are fixed and exclude ``me.write``."""
         assert _TOKEN_SCOPES == [
             "me.read",
             "platforms.read",
             "roms.read",
+            "roms.user.read",
             "collections.read",
             "firmware.read",
             "assets.read",
@@ -858,6 +859,10 @@ class TestTokenScopes:
             "roms.user.write",
         ]
         assert "me.write" not in _TOKEN_SCOPES
+        # Read + write on per-user ROM data: read for native play-session
+        # history (#1219), write for the ingest POST.
+        assert "roms.user.read" in _TOKEN_SCOPES
+        assert "roms.user.write" in _TOKEN_SCOPES
 
 
 class TestMintClientToken:


### PR DESCRIPTION
## What

Add `roms.user.read` to the Client API Token's requested scope set (`_TOKEN_SCOPES`).

## Why

The token already carries `roms.user.write` (used for the play-session ingest `POST /api/play-sessions`) but not `roms.user.read`, so `GET /api/play-sessions` returns **403** — the token cannot read native play-session history. This is the read-side prerequisite for adopting RomM's native play-session tracking: without it we can write sessions but cannot read them back (session history / per-ROM totals).

Verified against a live RomM 4.9.2 server: the account grants `roms.user.read`, the endpoint requires it, and our token's omission is the sole cause of the 403.

## Effect

Takes effect on the **next sign-in**, which re-mints the token with the broadened scope; existing tokens keep their current scopes until re-minted. `me.write` is still deliberately excluded (the token cannot mint/delete tokens).

## Tests

- `test_locked_scope_list` updated to the 11-scope set + explicit `roms.user.read` / `roms.user.write` presence assertions.
- `romm_api` + `connection` suites, ruff, basedpyright, and the import-linter / architecture lint gates all green.

Part of #1234 (Phase 5) / #1219 — does not close them.

docs: N/A — internal token capability; no user-visible UI or flow change, and no doc enumerates the requested scopes.