### PR TITLE
fix(cores): resolve active core outside the open UoW

### DIFF
--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     import logging
 
     from domain.rom import Rom
+    from domain.rom_install import RomInstall
     from services.protocols import (
         ActiveCoreReader,
         BiosChecker,
@@ -41,7 +42,6 @@ if TYPE_CHECKING:
         DiscResolver,
         SettingsPersister,
         SystemResolver,
-        UnitOfWork,
         UnitOfWorkFactory,
     )
 
@@ -154,7 +154,13 @@ class CoreService:
         self._settings_persister.save_settings()
         self._core_info.reset_cache()
 
-        rebake_items: list[dict[str, Any]] = []
+        # Snapshot the installed+bound, non-overridden (rom, install) pairs in one
+        # short read UoW, then close it before resolving each ROM's active core:
+        # active_emulator_for_rom opens its own UoW, and the per-connection
+        # BEGIN IMMEDIATE write lock is not re-entrant — resolving inside the
+        # iteration UoW would block on the lock until busy_timeout then raise
+        # "database is locked" (#1134). This read UoW performs no writes.
+        pending: list[tuple[Rom, RomInstall]] = []
         with self._uow_factory() as uow:
             for rom in uow.roms.iter_by_platform(platform_slug):
                 if rom.emulator_override is not None:
@@ -164,20 +170,22 @@ class CoreService:
                 install = uow.rom_installs.get(rom.rom_id)
                 if install is None:
                     continue
-                emulator = self._active_core.active_emulator_for_rom(rom.rom_id)
-                invocation = resolve_emulator_invocation({}, emulator)
-                # Fold the ROM's persisted disc pick over the install so a
-                # per-platform core change re-bakes the pinned disc, not disc 1 /
-                # the m3u. A single-disc ROM resolves to its own file_path. The
-                # rom is already loaded in this UoW, so its selected_disc is read
-                # without a nested read.
-                bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
-                rebake_items.append(
-                    {
-                        "app_id": rom.shortcut_app_id,
-                        "launch_options": build_launch_options(invocation, bake_path),
-                    }
-                )
+                pending.append((rom, install))
+
+        rebake_items: list[dict[str, Any]] = []
+        for rom, install in pending:
+            emulator = self._active_core.active_emulator_for_rom(rom.rom_id)
+            invocation = resolve_emulator_invocation({}, emulator)
+            # Fold the ROM's persisted disc pick over the install so a
+            # per-platform core change re-bakes the pinned disc, not disc 1 /
+            # the m3u. A single-disc ROM resolves to its own file_path.
+            bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
+            rebake_items.append(
+                {
+                    "app_id": rom.shortcut_app_id,
+                    "launch_options": build_launch_options(invocation, bake_path),
+                }
+            )
         return rebake_items
 
     async def set_system_core(self, platform_slug: str, core_label: str) -> dict[str, Any]:
@@ -246,9 +254,11 @@ class CoreService:
             # write path (never the sync UPSERT).
             rom.pin_emulator_override(label)
             uow.roms.set_emulator_override(rom_id, rom.emulator_override)
-            # The picker only offers libretro cores, so a pinned override is a
-            # libretro invocation built from the just-resolved .so.
-            launch_options, app_id = self._launch_options_for(uow, rom, EmulatorInvocation.libretro(core_so, label))
+            install = uow.rom_installs.get(rom_id)
+        # Bake outside the committed write UoW, uniform with the clear path (the
+        # pinned override is the just-resolved libretro core, so there is no
+        # resolver read and no commit-ordering subtlety here).
+        launch_options, app_id = self._launch_options_for(rom, install, EmulatorInvocation.libretro(core_so, label))
         return {"success": True, "launch_options": launch_options, "app_id": app_id}
 
     async def clear_game_core(self, rom_id: int) -> dict[str, Any]:
@@ -278,20 +288,33 @@ class CoreService:
                 }
             rom.clear_emulator_override()
             uow.roms.set_emulator_override(rom_id, rom.emulator_override)
-            # Cleared pin → follow the per-platform/system default. Resolve the
-            # ROM's full active emulator AFTER the NULL lands so a per-platform
-            # core (or a standalone system default) still bakes its -e form.
-            emulator = self._active_core.active_emulator_for_rom(rom_id)
-            launch_options, app_id = self._launch_options_for(uow, rom, emulator)
+            install = uow.rom_installs.get(rom_id)
+        # Cleared pin → follow the per-platform/system default. The write UoW has
+        # committed, so the resolver's own UoW now reads the landed NULL and
+        # returns the POST-clear core — a per-platform core (or standalone system
+        # default) still bakes its -e form. Resolving here (outside the closed
+        # UoW) is also what keeps active_emulator_for_rom's BEGIN IMMEDIATE from
+        # blocking on our write lock (#1047 / #1134). Skip the resolve entirely
+        # when there is no live shortcut to update.
+        if rom.shortcut_app_id is None or install is None:
+            return {"success": True, "launch_options": None, "app_id": None}
+        emulator = self._active_core.active_emulator_for_rom(rom_id)
+        launch_options, app_id = self._launch_options_for(rom, install, emulator)
         return {"success": True, "launch_options": launch_options, "app_id": app_id}
 
     def _launch_options_for(
         self,
-        uow: UnitOfWork,
         rom: Rom,
+        install: RomInstall | None,
         emulator: EmulatorInvocation | None,
     ) -> tuple[str | None, int | None]:
         """Bake the launch command for *rom* with *emulator*, or ``(None, None)``.
+
+        Takes the ROM's ``RomInstall`` snapshot directly (``None`` when
+        uninstalled) so the bake runs with no open Unit of Work — the callers
+        snapshot the install inside their write UoW and close it before baking,
+        since the shared active-core resolver opens its own UoW and the
+        per-connection ``BEGIN IMMEDIATE`` write lock is not re-entrant.
 
         An installed (``RomInstall`` with a ``file_path``) **and** bound
         (``shortcut_app_id`` set) ROM gets the full launch command — the ``-e``
@@ -303,16 +326,12 @@ class CoreService:
         stored pin/clear applies on the next download/sync.
         """
         app_id = rom.shortcut_app_id
-        if app_id is None:
-            return (None, None)
-        install = uow.rom_installs.get(rom.rom_id)
-        if install is None:
+        if app_id is None or install is None:
             return (None, None)
         invocation = resolve_emulator_invocation({}, emulator)
         # Fold the ROM's persisted disc pick over the install so a per-game core
         # pin/clear re-bakes the pinned disc, not disc 1 / the m3u. A single-disc
-        # ROM resolves to its own file_path. *rom* is already loaded in the open
-        # UoW, so its selected_disc is read without a nested read.
+        # ROM resolves to its own file_path.
         bake_path = self._disc_resolver.resolve_for_install(install, rom.selected_disc)
         return (build_launch_options(invocation, bake_path), app_id)
 

--- a/tests/contract/_seed.py
+++ b/tests/contract/_seed.py
@@ -13,6 +13,8 @@ is called by the child seeders.
 
 from __future__ import annotations
 
+import json
+import os
 from typing import TYPE_CHECKING, Any
 
 from domain.rom import Rom
@@ -143,3 +145,28 @@ def seed_server_save(harness: ContractHarness, **kwargs: Any) -> dict[str, Any]:
     entry = server_save(**kwargs)
     harness.romm.saves[entry["id"]] = entry
     return entry
+
+
+_DEFAULT_CORE_DEFAULTS: dict[str, Any] = {
+    "gba": {
+        "default_core": "mgba_libretro",
+        "default_label": "mGBA",
+        "cores": {"mgba_libretro": "mGBA", "vba_next_libretro": "VBA Next"},
+    }
+}
+
+
+def seed_core_defaults(harness: ContractHarness, systems: dict[str, Any] | None = None) -> None:
+    """Write ``<plugin_dir>/core_defaults.json`` for the real ``CoreResolver`` to read.
+
+    The harness roots ``plugin_dir`` at ``tmp_path/plugin`` and no
+    ``es_systems.xml`` exists there, so :class:`CoreResolver` resolves every
+    system through this bundled fallback (``resolve_system`` passes an unmapped
+    slug through unchanged, so ``"gba"`` keys directly). The default seeds a
+    single ``gba`` system with an mGBA default and a VBA Next alternative — two
+    resolvable cores a core-selection contract test can pin/clear between.
+    """
+    plugin_dir = os.path.join(str(harness.tmp_path), "plugin")
+    os.makedirs(plugin_dir, exist_ok=True)
+    with open(os.path.join(plugin_dir, "core_defaults.json"), "w") as f:
+        json.dump({"systems": systems if systems is not None else _DEFAULT_CORE_DEFAULTS}, f)

--- a/tests/contract/test_core_selection.py
+++ b/tests/contract/test_core_selection.py
@@ -1,0 +1,85 @@
+"""Contract tests for the core-selection callables over the real nesting.
+
+``CoreService.clear_game_core`` (Reset / Follow default) and
+``set_system_core`` (per-platform core change fan-out) both re-bake a ROM's
+Steam ``launch_options`` from its active core, resolved through the real
+:class:`ActiveCoreResolver` — which opens its **own** Unit of Work.
+
+The unit tests inject a ``FakeActiveCoreResolver`` (no real UoW), so they never
+exercise the nesting. This tier drives the **real** callables over the
+**real** file-based SQLite UoW the harness wires: every UoW opens with
+``BEGIN IMMEDIATE`` (the per-connection write lock), and the lock is not
+re-entrant. Resolving the active core inside the still-open write UoW would
+block the resolver's own UoW until ``busy_timeout`` then raise
+``database is locked`` (#1047 / #1134) — which is why the write UoW is closed
+before the resolve. ``clear_game_core`` additionally must resolve *after* the
+pin-clear commits so the resolver reads the landed NULL and bakes the
+POST-clear core, never the just-cleared pin (#1047).
+"""
+
+from __future__ import annotations
+
+from ._seed import seed_core_defaults, seed_install
+
+
+async def test_clear_game_core_bakes_post_clear_core_not_old_pin(harness):
+    """Clearing a pin bakes the resolved default, not the just-cleared override.
+
+    A ``gba`` ROM pinned to VBA Next is cleared. The resolver runs after the
+    pin-clear commits, so it reads the landed NULL and resolves to the system
+    default (mGBA); the re-baked ``launch_options`` must carry the mGBA core,
+    never the cleared VBA Next pin. On the unfixed build the resolver's
+    ``BEGIN IMMEDIATE`` blocks on the still-open write UoW for ``busy_timeout``
+    then raises ``database is locked`` (#1047).
+    """
+    seed_core_defaults(harness)
+    seed_install(harness, 42, system="gba", platform_slug="gba", file_name="pokemon.gba")
+    with harness.uow_factory() as uow:
+        uow.roms.set_emulator_override(42, "VBA Next")
+
+    result = await harness.plugin.clear_game_core(42)
+
+    assert result["success"] is True
+    assert result["app_id"] == 42
+    # The POST-clear core (system default mGBA) is baked, NOT the cleared pin.
+    assert "mgba_libretro.so" in result["launch_options"]
+    assert "vba_next_libretro.so" not in result["launch_options"]
+    # The pin is gone (SQL NULL) — read back through a fresh UoW.
+    with harness.uow_factory() as uow:
+        assert uow.roms.get(42).emulator_override is None
+
+
+async def test_clear_game_core_unknown_rom_returns_canonical_failure(harness):
+    """An unknown ROM returns the canonical ``{success, reason, message}`` failure."""
+    result = await harness.plugin.clear_game_core(999)
+
+    assert result["success"] is False
+    assert result["reason"] == "not_found"
+    assert isinstance(result["message"], str)
+    assert result["message"]
+
+
+async def test_set_system_core_rebakes_only_unpinned_rom(harness):
+    """The per-platform fan-out re-bakes each unpinned ROM through the real resolver.
+
+    Two installed+bound ``gba`` ROMs: one plain, one with a per-game pin. Setting
+    the platform core to VBA Next must re-bake only the unpinned ROM (the pin
+    wins over the platform default for the other), with the VBA Next core baked.
+    On the unfixed build the resolve inside the fan-out UoW deadlocks on the
+    write lock then raises ``database is locked`` (#1134).
+    """
+    seed_core_defaults(harness)
+    seed_install(harness, 1, system="gba", platform_slug="gba", file_name="a.gba")
+    seed_install(harness, 2, system="gba", platform_slug="gba", file_name="b.gba")
+    with harness.uow_factory() as uow:
+        uow.roms.set_emulator_override(2, "mGBA")
+
+    result = await harness.plugin.set_system_core("gba", "VBA Next")
+
+    assert result["success"] is True
+    items = result["rebake_items"]
+    # Exactly the unpinned ROM (app_id 1) is re-baked; the pinned ROM is absent.
+    assert len(items) == 1
+    assert items[0]["app_id"] == 1
+    assert "vba_next_libretro.so" in items[0]["launch_options"]
+    assert all(item["app_id"] != 2 for item in items)


### PR DESCRIPTION
`_clear_game_core_io` and `_set_system_core_io` resolved each ROM's active core through `ActiveCoreResolver` while their own write UoW was still open. The resolver opens its own connection and `SqliteUnitOfWork` issues `BEGIN IMMEDIATE`, so the nested transaction blocked ~5s (busy_timeout) and raised "database is locked" — `clear_game_core` escaped as a raw callable rejection, `set_system_core` returned a failure after the hang.

Both sites now snapshot the rom/install rows inside a short UoW, close it, then resolve + bake outside — the pattern #1155 established for the migration site (which already fixed the third site #1134 cites). `clear_game_core` resolves only after the pin-clear commits, so it verifiably bakes the post-clear core (the #1047 correctness half).

Behavior change: the pin-clear commits before the bake, so a bake exception no longer rolls back the clear — the clear is the user's action, the bake is derived and degrades observably. Same accepted window for `_set_game_core_io`'s bake.

New real-SQLite contract tests (`tests/contract/test_core_selection.py`) drive the real callables over the real UoW; both fail with "database is locked" on pre-fix code (verified) and pin the post-clear-core invariant.

Closes #1047
Closes #1134

docs: N/A (sequencing fix; the documented resolver-seam flow is unchanged)
