### PR TITLE
fix(connection): harden version gate against non-string SYSTEM.VERSION

### DIFF
--- a/py_modules/domain/version.py
+++ b/py_modules/domain/version.py
@@ -41,9 +41,12 @@ def meets_min_version(version_str: str | None, minimum: tuple[int, ...]) -> bool
     the result is ``False`` regardless of suffix.
 
     Returns ``False`` for any input that cannot be parsed (empty string, non-numeric
-    parts, unsupported pre-release tags, ``None``). Non-numeric sentinel strings like
-    ``"development"`` also return ``False`` — callers that want to bypass the check
-    for development builds must test for them before invoking this function.
+    parts, unsupported pre-release tags, ``None``, or any non-``str`` type). The input
+    is server-controlled, so a numeric or structured value is rejected by the
+    ``isinstance`` guard in :func:`_parse_version` rather than raising. Non-numeric
+    sentinel strings like ``"development"`` also return ``False`` — callers that want
+    to bypass the check for development builds must test for them before invoking this
+    function.
     """
     parsed = _parse_version(version_str)
     if parsed is None:

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -345,13 +345,17 @@ class ConnectionService:
     def _probe_version(self) -> str | None:
         """Heartbeat the server, cache the detected version, and return it.
 
-        Runs on the executor thread. A missing/malformed ``SYSTEM.VERSION``
-        yields ``None`` (and clears the cached version).
+        Runs on the executor thread. ``SYSTEM.VERSION`` is server-controlled and
+        untrusted: a missing, non-string, or otherwise malformed value yields
+        ``None`` (and clears the cached version), so the version gate downstream
+        only ever sees a real version string or ``None``.
         """
         heartbeat = self._romm_api.heartbeat()
         version: str | None = None
         with contextlib.suppress(AttributeError, TypeError):
-            version = heartbeat.get("SYSTEM", {}).get("VERSION")
+            raw = heartbeat.get("SYSTEM", {}).get("VERSION")
+            if isinstance(raw, str):
+                version = raw
         self._romm_api.set_version(version)
         if version:
             self._logger.info(f"RomM server version: {version}")

--- a/py_modules/services/saves/sync_engine/devices.py
+++ b/py_modules/services/saves/sync_engine/devices.py
@@ -205,7 +205,11 @@ class DeviceRegistry:
                 heartbeat = await loop.run_in_executor(None, self._romm_api.heartbeat)
                 with contextlib.suppress(AttributeError, TypeError):
                     version = heartbeat.get("SYSTEM", {}).get("VERSION")
-                    if version:
+                    # SYSTEM.VERSION is server-controlled and untrusted: only cache
+                    # a real, non-empty version string. A truthy non-str (e.g. numeric
+                    # 4.9) is treated as absent — never cached — so the adapter's
+                    # version stays a real string or None. See _probe_version (#1275).
+                    if isinstance(version, str) and version:
                         self._romm_api.set_version(version)
             except Exception as e:
                 self._logger.debug(f"ensure_device_registered: version probe failed (non-fatal): {e}")

--- a/tests/domain/test_version.py
+++ b/tests/domain/test_version.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
 from domain.version import meets_min_version
 
 MIN = (4, 8, 1)
@@ -45,6 +49,12 @@ class TestMeetsMinVersion:
 
     def test_none_returns_false(self):
         assert meets_min_version(None, MIN) is False
+
+    @pytest.mark.parametrize("bad_value", [4.9, 5, True, [4, 9, 0], {"version": "4.9.0"}])
+    def test_non_string_input_returns_false(self, bad_value: Any):
+        # SYSTEM.VERSION is server-controlled: a truthy non-str (e.g. numeric 4.9)
+        # must be rejected by the isinstance guard, never raise TypeError.
+        assert meets_min_version(bad_value, MIN) is False
 
     def test_development_returns_false(self):
         assert meets_min_version("development", MIN) is False

--- a/tests/fakes/fake_save_api.py
+++ b/tests/fakes/fake_save_api.py
@@ -61,6 +61,9 @@ class FakeSaveApi:
         self._fail_on_next: Exception | None = None
         self._fail_download_on: dict[int, Exception] = {}  # save_id -> exc for download_save_content
         self.heartbeat_raises: Exception | None = None
+        # Overrides the default heartbeat body when set, so a test can inject a
+        # SYSTEM.VERSION (or a malformed one) into the version-probe path.
+        self.heartbeat_payload: dict[str, Any] | None = None
         self._registered_devices: list[dict[str, Any]] = []
         self._next_device_id = 1
         # Negotiate (4.9 Device Sync): the ops the next negotiate_sync returns and
@@ -241,13 +244,13 @@ class FakeSaveApi:
         self.call_log.append(("heartbeat", (), {}))
         if self.heartbeat_raises is not None:
             raise self.heartbeat_raises
-        return {"status": "ok"}
+        return self.heartbeat_payload if self.heartbeat_payload is not None else {"status": "ok"}
 
     def heartbeat_once(self) -> dict[str, Any]:
         self.call_log.append(("heartbeat_once", (), {}))
         if self.heartbeat_raises is not None:
             raise self.heartbeat_raises
-        return {"status": "ok"}
+        return self.heartbeat_payload if self.heartbeat_payload is not None else {"status": "ok"}
 
     def list_platforms(self) -> list[dict[str, Any]]:
         raise NotImplementedError

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -132,6 +132,37 @@ class TestEnsureDeviceRegisteredFingerprint:
         assert _register_call(fake) is None
 
 
+class TestEnsureDeviceRegisteredVersionProbe:
+    """The pre-registration probe caches SYSTEM.VERSION onto the API adapter, but
+    the value is server-controlled: only a real, non-empty version string is
+    cached; a truthy non-str (e.g. numeric 4.9) is treated as absent (#1275)."""
+
+    @pytest.mark.asyncio
+    async def test_non_string_version_not_cached(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        # No device_id + no cached version → the pre-register version probe runs.
+        fake.heartbeat_payload = {"SYSTEM": {"VERSION": 4.9}}
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        # The truthy non-str version was NOT cached — the adapter stays version-less.
+        assert fake.get_version() is None
+
+    @pytest.mark.asyncio
+    async def test_string_version_is_cached(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        fake.heartbeat_payload = {"SYSTEM": {"VERSION": "4.9.0"}}
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is True
+        # A real version string is cached as before — existing behavior unchanged.
+        assert fake.get_version() == "4.9.0"
+
+
 class TestEnsureDeviceRegisteredFailurePaths:
     """When register_device fails, the four sync callables must surface
     DEVICE_NOT_REGISTERED instead of proceeding with a missing device_id

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -233,6 +233,22 @@ class TestTestConnectionEdgeCases:
         assert result["success"] is True
         romm_api.set_version.assert_called_once_with(None)
 
+    def test_heartbeat_with_non_string_version_normalized_to_none(self, event_loop, romm_api, logger):
+        """A numeric (non-string) SYSTEM.VERSION is normalized to None at the boundary.
+
+        The value is server-controlled: a malformed server sending numeric ``4.9``
+        must not reach the version gate as a non-str. It is coerced to None
+        (treated as absent) → gate bypassed → success, mirroring the
+        SYSTEM-not-a-dict case, so downstream never sees a non-str.
+        """
+        settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": 4.9}}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.test_connection())
+        assert result["success"] is True
+        assert "romm_version" not in result
+        romm_api.set_version.assert_called_once_with(None)
+
     def test_min_required_version_injected(self, event_loop, romm_api, logger):
         """Service uses the injected minimum, not a hard-coded tuple."""
         settings = {"romm_url": "http://romm.local", "romm_api_token": "rmm_token"}


### PR DESCRIPTION
`SYSTEM.VERSION` from the RomM heartbeat is server-controlled, untrusted input. `_probe_version` now normalizes it to `str | None` at the boundary — a truthy non-string (numeric, list, …) is treated as absent, so downstream only ever sees a real version string or None. The same normalize-to-absent guard is applied to the sibling read in `ensure_device_registered`, which cached the raw value into the API adapter.

A malformed version now behaves like every other malformed case (absent/empty/`"development"`/non-dict `SYSTEM`): gate bypassed instead of a `TypeError` — the gate is a compatibility check, not a trust boundary.

Tests: parametrized non-string domain cases (float/int/bool/list/dict), boundary normalization in the connection service, device-registration cache guard.

Closes #1275

docs: N/A (internal hardening of an untrusted-input path; no user-facing change)
