### PR TITLE
fix(shortcuts): reset launch_options on kept shortcuts after bulk uninstall

### DIFF
--- a/py_modules/services/rom_removal.py
+++ b/py_modules/services/rom_removal.py
@@ -118,13 +118,18 @@ class RomRemovalService:
 
         return {"success": True, "message": "ROM removed"}
 
-    def _uninstall_all_roms_io(self) -> tuple[int, list[dict[str, str]]]:
+    def _uninstall_all_roms_io(self) -> tuple[int, list[dict[str, str]], list[int]]:
         """Sync helper for uninstall_all_roms — bulk file deletion (outside UoW) then row deletes in a write UoW.
 
         Reads every install record in a short read UoW, deletes files outside
         any transaction (collecting per-ROM errors), then drops the install
         rows for the ROMs whose files were deleted in one write UoW. Per
         ADR-0007 the ``roms`` rows, playtime, saves, and metadata survive.
+
+        Also returns the bound ``shortcut_app_id`` of each ROM whose files were
+        deleted (unbound rows contribute none), so the frontend can reset those
+        kept shortcuts' now-stale ``launch_options`` to the uninstalled
+        placeholder (#1146).
         """
         with self._uow_factory() as uow:
             installs = list(uow.rom_installs.iter_all())
@@ -141,25 +146,33 @@ class RomRemovalService:
                 errors.append({"rom_id": str(install.rom_id), "error": str(e)})
                 self._logger.error(f"Failed to delete ROM {install.rom_id}: {e}")
 
+        app_ids: list[int] = []
         with self._uow_factory() as uow:
             for rom_id in successfully_deleted:
                 uow.rom_installs.delete(rom_id)
-        return count, errors
+                rom = uow.roms.get(rom_id)
+                if rom is not None and rom.shortcut_app_id is not None:
+                    app_ids.append(rom.shortcut_app_id)
+        return count, errors, app_ids
 
     async def uninstall_all_roms(self) -> dict[str, Any]:
         """Remove all installed ROMs: delete files and drop their install records.
 
         Returns ``success`` (True only when every per-ROM deletion
         succeeded), ``removed_count`` (number of ROMs whose files were
-        deleted), and ``errors`` (one ``{"rom_id", "error"}`` entry per
-        failed deletion). Install records for partially-failed bulk runs
+        deleted), ``errors`` (one ``{"rom_id", "error"}`` entry per
+        failed deletion), and ``app_ids`` (the bound Steam ``shortcut_app_id``
+        of each ROM whose files were deleted) so the frontend can reset those
+        kept shortcuts' now-stale ``launch_options`` to the uninstalled
+        placeholder (#1146). Install records for partially-failed bulk runs
         are left intact for the failing entries so the user can retry.
         """
-        count, errors = await self._loop.run_in_executor(None, self._uninstall_all_roms_io)
+        count, errors, app_ids = await self._loop.run_in_executor(None, self._uninstall_all_roms_io)
         if self._download_queue_cleanup is not None:
             self._download_queue_cleanup.clear()
         return {
             "success": len(errors) == 0,
             "removed_count": count,
             "errors": errors,
+            "app_ids": app_ids,
         }

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -222,7 +222,7 @@ export const reconcileShortcuts = callable<
 >("reconcile_shortcuts");
 export const uninstallAllRoms = callable<
   [],
-  { success: boolean; removed_count: number; errors: { rom_id: string; error: string }[] }
+  { success: boolean; removed_count: number; errors: { rom_id: string; error: string }[]; app_ids: number[] }
 >("uninstall_all_roms");
 export const saveSgdbApiKey = callable<[string], { success: boolean; message: string }>("save_sgdb_api_key");
 export const verifySgdbApiKey = callable<[string], { success: boolean; message: string }>("verify_sgdb_api_key");

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -6,18 +6,21 @@
 // over keeping one with zero expects.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent, act } from "@testing-library/react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
 import { DangerZone } from "./DangerZone";
 import * as backend from "../api/backend";
 import { showModal } from "@decky/ui";
-import { removeShortcut } from "../utils/steamShortcuts";
+import { removeShortcut, setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
 import { stubCollectionStore, stubAppStore } from "../test-utils/steamStubs";
 
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
-vi.mock("../utils/steamShortcuts", () => ({ removeShortcut: vi.fn() }));
+// setLaunchOptionsConfirmed is exercised through the real batchConfirmLaunchOptions
+// (launchOptionsReconcile stays unmocked) — mock the leaf so the bulk-uninstall
+// launch-options reset (#1146) is asserted without touching SteamClient.
+vi.mock("../utils/steamShortcuts", () => ({ removeShortcut: vi.fn(), setLaunchOptionsConfirmed: vi.fn() }));
 vi.mock("../utils/collections", () => ({
   clearPlatformCollection: vi.fn(),
   clearAllRomMCollections: vi.fn(),
@@ -87,7 +90,9 @@ describe("DangerZone", () => {
       success: true,
       removed_count: 0,
       errors: [],
+      app_ids: [],
     });
+    vi.mocked(setLaunchOptionsConfirmed).mockResolvedValue(true);
     vi.mocked(backend.deletePlatformSaves).mockResolvedValue({
       success: true,
       deleted_count: 0,
@@ -691,6 +696,7 @@ describe("DangerZone", () => {
         success: true,
         removed_count: 7,
         errors: [],
+        app_ids: [],
       });
       const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
       await flushAsync();
@@ -738,6 +744,7 @@ describe("DangerZone", () => {
           { rom_id: "1", error: "x" },
           { rom_id: "2", error: "y" },
         ],
+        app_ids: [],
       });
       const { getByText } = render(<DangerZone onBack={vi.fn()} />);
       await flushAsync();
@@ -748,6 +755,69 @@ describe("DangerZone", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(formatUninstallStatus)).toHaveBeenCalledWith(4, 2);
+    });
+  });
+
+  describe("ShortcutRemovalSection — bulk uninstall resets kept shortcut launch_options (#1146)", () => {
+    // Two clicks: first arms the confirm, second fires uninstallAllRoms + the reset.
+    async function confirmUninstall(getByText: (t: string) => HTMLElement): Promise<void> {
+      fireEvent.click(getByText("Uninstall All Installed ROMs"));
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: delete all ROM files?"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    it("resets each kept shortcut's launch command to the '' placeholder for every returned app_id", async () => {
+      vi.mocked(backend.uninstallAllRoms).mockResolvedValue({
+        success: true,
+        removed_count: 2,
+        errors: [],
+        app_ids: [100, 200],
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      await confirmUninstall(getByText);
+
+      // Every kept shortcut is reset to "" so a raced-past not_installed can't
+      // exec a stale command into the now-deleted ROM path.
+      await waitFor(() => {
+        expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledWith(100, "");
+        expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledWith(200, "");
+      });
+      expect(vi.mocked(setLaunchOptionsConfirmed)).toHaveBeenCalledTimes(2);
+      // The final status is surfaced only after the reset completes (it is awaited).
+      expect(container.textContent).toContain("Removed 2, 0 errors");
+    });
+
+    it("resets no launch_options when no kept shortcut is bound (empty app_ids)", async () => {
+      vi.mocked(backend.uninstallAllRoms).mockResolvedValue({
+        success: true,
+        removed_count: 1,
+        errors: [],
+        app_ids: [],
+      });
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      await confirmUninstall(getByText);
+
+      expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+    });
+
+    it("does not reset launch_options when the bulk uninstall call rejects", async () => {
+      vi.mocked(backend.uninstallAllRoms).mockRejectedValue(new Error("io"));
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      await confirmUninstall(getByText);
+
+      // The reset lives after the awaited uninstall inside the try — a rejection
+      // short-circuits to the catch, leaving every shortcut untouched.
+      expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("Failed to uninstall ROMs");
     });
   });
 

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -27,6 +27,7 @@ import {
   updateWhitelistSettings,
 } from "../api/backend";
 import { removeShortcut } from "../utils/steamShortcuts";
+import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
@@ -237,6 +238,15 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     try {
       setUninstallStatus("Uninstalling...");
       const result = await uninstallAllRoms();
+      // Reset every kept shortcut's now-stale launch command to the uninstalled
+      // "" placeholder so a raced-past not_installed can't exec a stale
+      // `flatpak run … "<deleted path>"` into a deleted path (#1146, mirrors the
+      // single-ROM fix in #1051). Batched to avoid serializing the per-shortcut
+      // confirm-poll timeouts; best-effort — a failed confirm is logged, not fatal.
+      await batchConfirmLaunchOptions(
+        result.app_ids.map((appId) => ({ app_id: appId, launch_options: "" })),
+        "uninstall-all",
+      );
       setUninstallStatus(formatUninstallStatus(result.removed_count, result.errors.length));
     } catch {
       setUninstallStatus("Failed to uninstall ROMs");

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -63,14 +63,18 @@ async def _sync_loop(service):
     service._loop = asyncio.get_event_loop()
 
 
-def _make_rom(rom_id: int, *, platform_slug: str = "n64") -> Rom:
-    """Build the FK-parent ``roms`` row so a child ``rom_installs`` write commits."""
+def _make_rom(rom_id: int, *, platform_slug: str = "n64", bound: bool = True) -> Rom:
+    """Build the FK-parent ``roms`` row so a child ``rom_installs`` write commits.
+
+    Bound rows carry ``shortcut_app_id = 1000 + rom_id`` (a live Steam
+    shortcut); ``bound=False`` leaves it ``None`` (no shortcut to reset).
+    """
     return Rom(
         rom_id=rom_id,
         platform_slug=platform_slug,
         name=f"Game {rom_id}",
         fs_name=f"game_{rom_id}.z64",
-        shortcut_app_id=1000 + rom_id,
+        shortcut_app_id=(1000 + rom_id) if bound else None,
         last_synced_at="2025-01-01T00:00:00",
     )
 
@@ -461,6 +465,74 @@ class TestUninstallAllRoms:
         assert result["success"] is True
         assert result["removed_count"] == 0
         assert result["errors"] == []
+
+
+class TestUninstallAllRomsAppIds:
+    """The ``app_ids`` field the frontend uses to reset kept shortcuts' launch_options (#1146)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_bound_app_ids_for_deleted_roms(self, service, uow, rom_files):
+        """Happy path: each deleted ROM's bound ``shortcut_app_id`` is returned so the frontend can reset it."""
+        file_a = f"{_ROMS_BASE}/n64/game_a.z64"
+        file_b = f"{_ROMS_BASE}/n64/game_b.z64"
+        rom_files.files[file_a] = b"\x00" * 100
+        rom_files.files[file_b] = b"\x00" * 100
+        with uow:
+            uow.roms.save(_make_rom(1))
+            uow.roms.save(_make_rom(2))
+            uow.rom_installs.save(_make_install(1, file_path=file_a))
+            uow.rom_installs.save(_make_install(2, file_path=file_b))
+
+        result = await service.uninstall_all_roms()
+
+        assert result["success"] is True
+        assert sorted(result["app_ids"]) == [1001, 1002]
+
+    @pytest.mark.asyncio
+    async def test_omits_app_id_for_unbound_rom(self, service, uow, rom_files):
+        """Edge: a deleted ROM with no bound shortcut (``shortcut_app_id`` is None) contributes no app_id."""
+        file_a = f"{_ROMS_BASE}/n64/game_a.z64"
+        file_b = f"{_ROMS_BASE}/n64/game_b.z64"
+        rom_files.files[file_a] = b"\x00" * 100
+        rom_files.files[file_b] = b"\x00" * 100
+        with uow:
+            uow.roms.save(_make_rom(1))  # bound → 1001
+            uow.roms.save(_make_rom(2, bound=False))  # unbound → no app_id
+            uow.rom_installs.save(_make_install(1, file_path=file_a))
+            uow.rom_installs.save(_make_install(2, file_path=file_b))
+
+        result = await service.uninstall_all_roms()
+
+        assert result["success"] is True
+        assert result["app_ids"] == [1001]
+
+    @pytest.mark.asyncio
+    async def test_app_ids_only_for_successfully_deleted(self, service, uow, rom_files):
+        """Bad path: a ROM whose file deletion raised contributes no app_id — only deleted ones are reset."""
+        file_a = f"{_ROMS_BASE}/n64/game_a.z64"
+        file_b = f"{_ROMS_BASE}/n64/game_b.z64"
+        file_c = f"{_ROMS_BASE}/n64/game_c.z64"
+        for p in (file_a, file_b, file_c):
+            rom_files.files[p] = b"\x00" * 100
+        rom_files.remove_file_failures.add(file_b)
+        with uow:
+            for rid, fp in ((1, file_a), (2, file_b), (3, file_c)):
+                uow.roms.save(_make_rom(rid))
+                uow.rom_installs.save(_make_install(rid, file_path=fp))
+
+        result = await service.uninstall_all_roms()
+
+        assert result["success"] is False
+        # ROM 2's deletion raised → its app_id (1002) is absent; the deleted 1 and 3 are present.
+        assert sorted(result["app_ids"]) == [1001, 1003]
+
+    @pytest.mark.asyncio
+    async def test_empty_state_returns_empty_app_ids(self, service, uow):
+        """Edge: no installed ROMs → ``app_ids`` is empty."""
+        _ = uow
+        result = await service.uninstall_all_roms()
+
+        assert result["app_ids"] == []
 
 
 class TestDownloadQueueCleanup:


### PR DESCRIPTION
"Uninstall all" dropped install records and files but left each kept shortcut's `launch_options` holding the full launch command for a now-deleted path — a raced-past `not_installed` gate could exec a stale `flatpak run … "<deleted path>"`. The single-ROM path was fixed in #1145; this brings the bulk path in line.

`uninstall_all_roms` now returns the bound shortcut app ids of the ROMs whose files were deleted (additive `app_ids` field), and DangerZone resets each to the `""` uninstalled placeholder via the existing batched confirm helper. On partial failure the ROMs that were deleted still get their reset.

Tests: backend unit tests for the new return field (bound/unbound/partial-failure/empty); DangerZone component tests (reset on success, none on empty or rejection).

Closes #1146

docs: N/A (makes the bulk path conform to the already-documented uninstalled-placeholder model, ADR-0009)
