### PR TITLE
fix(ui): surface backend bootstrap failure instead of eternal "Checking…"

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -7,12 +7,13 @@ Common issues and how to fix them.
 ### Connection shows "Backend error"
 
 **Symptom**: The RomM Sync QAM panel's **Connection** row shows a "Backend error" badge with the note "Plugin backend
-failed to start — check Decky logs", and the Sync buttons are disabled.
+failed to start — check Decky logs", and the Sync buttons are disabled. This state means the plugin's own Python backend
+process never started — it is **not** the same as an unreachable RomM server, which shows **Not connected** instead.
 
-**Fix**: The plugin's Python backend aborted during startup — most often a failed data migration after an update — so
-the UI can't reach it. Open the Decky plugin log to find the underlying error, then reload RomM Sync from the Decky
-plugin list. If it still fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log
-output when you report it.
+**Fix**: The backend aborted during startup — most often a failed data migration after an update — so the UI can't reach
+it. Open the Decky plugin log to find the underlying error, then reload RomM Sync from the Decky plugin list. If it
+still fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log output when you
+report it.
 
 ## Games Won't Launch
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -2,6 +2,18 @@
 
 Common issues and how to fix them.
 
+## Plugin Backend Won't Start
+
+### Connection shows "Backend error"
+
+**Symptom**: The RomM Sync QAM panel's **Connection** row shows a "Backend error" badge with the note "Plugin backend
+failed to start — check Decky logs", and the Sync buttons are disabled.
+
+**Fix**: The plugin's Python backend aborted during startup — most often a failed data migration after an update — so
+the UI can't reach it. Open the Decky plugin log to find the underlying error, then reload RomM Sync from the Decky
+plugin list. If it still fails after a reload, restart Steam (or the Steam Deck); if the error persists, include the log
+output when you report it.
+
 ## Games Won't Launch
 
 ### BIOS files missing

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -648,31 +648,63 @@ describe("MainPage", () => {
   // D2. Backend bootstrap failure — the retry-exhausted failure state (#1045)
   // ===========================================================================
   describe("backend bootstrap failure (#1045)", () => {
-    it("falls to an explicit backend-failure state when every connection attempt fails (retries exhausted)", async () => {
+    it("shows 'Backend error' only when the backend itself is dead (testConnection AND getSettings both fail)", async () => {
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       try {
-        // The backend never answers (bootstrap aborted) — every test_connection
-        // attempt rejects, across the whole backoff window.
+        // Bootstrap aborted: the whole RPC bridge is dead, so BOTH the
+        // test_connection probes AND the get_settings liveness ping fail.
         vi.mocked(backend.testConnection).mockRejectedValue(new Error("backend down"));
+        vi.mocked(backend.getSettings).mockRejectedValue(new Error("backend down"));
         const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         const { container } = render(<MainPage onNavigate={vi.fn()} />);
-        // Drive the full retry schedule (2+5+10+15+20s of backoff) to exhaustion.
+        // Drive the full retry schedule (2+5+10+15+20s of backoff) + the ping.
         await act(async () => {
           await vi.advanceTimersByTimeAsync(60_000);
         });
-        // The connection row lands on the explicit failure — not an eternal
-        // "Checking…" spinner (the #1045 bug).
+        // The row lands on the explicit failure — not an eternal "Checking…"
+        // spinner (the #1045 bug), and not the false "Not connected".
         expect(container.textContent).toContain("Backend error");
         expect(container.textContent).toContain("Plugin backend failed to start — check Decky logs.");
         expect(container.textContent).not.toContain("Checking...");
+        expect(container.textContent).not.toContain("Not connected");
         // Sync is gated off while the backend is down.
         const sync = buttonByExactText(container, "Sync Library");
         expect(sync).not.toBeNull();
         expect(sync!.disabled).toBe(true);
-        // Non-vacuous catch coverage: the exhaustion branch logs to console.error
-        // (logError is itself a callable and would hang against a dead backend).
-        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("test_connection unreachable"), expect.anything());
+        // Non-vacuous catch coverage: the dead-backend branch logs the liveness
+        // ping failure to console.error (logError itself would hang here).
+        expect(errSpy).toHaveBeenCalledWith(
+          expect.stringContaining("backend RPC bridge unreachable"),
+          expect.anything(),
+        );
         errSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("shows 'Not connected' (NOT 'Backend error') when the backend is alive but the server is unreachable-by-timeout", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        // Healthy backend, hanging RomM server: test_connection never answers
+        // within any per-attempt deadline (the backend heartbeat outlives it),
+        // but the get_settings liveness ping resolves — the backend IS alive.
+        vi.mocked(backend.testConnection).mockImplementation(
+          () =>
+            new Promise(() => {
+              /* never resolves — server round-trip hangs past every deadline */
+            }),
+        );
+        vi.mocked(backend.getSettings).mockResolvedValue(defaultSettings());
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        // Drive every 5s per-attempt timeout + backoff to exhaustion, then the ping.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(90_000);
+        });
+        // Truthful state for an unreachable server — the backend didn't fail.
+        expect(container.textContent).toContain("Not connected");
+        expect(container.textContent).not.toContain("Backend error");
+        expect(container.textContent).not.toContain("Checking...");
       } finally {
         vi.useRealTimers();
       }

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -540,13 +540,15 @@ describe("MainPage", () => {
       logSpy.mockRestore();
     });
 
-    it("logs the failure when testConnection rejects on mount", async () => {
+    it("keeps the connection row in 'Checking…' after a single testConnection rejection (retrying, not failed) (#1045)", async () => {
+      // A lone rejection is treated as transient — the probe retries rather than
+      // declaring the backend dead. Before any backoff elapses (only microtasks
+      // flushed) the row must still read "Checking…", never the failure state.
       vi.mocked(backend.testConnection).mockRejectedValue(new Error("net"));
-      const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<MainPage onNavigate={vi.fn()} />);
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to test connection"));
-      logSpy.mockRestore();
+      expect(container.textContent).toContain("Checking...");
+      expect(container.textContent).not.toContain("Backend error");
     });
 
     it("logs the failure when getSettings rejects on mount", async () => {
@@ -610,7 +612,7 @@ describe("MainPage", () => {
   });
 
   // ===========================================================================
-  // D. ConnectionIndicator — 3 states (covered via top-level rendering)
+  // D. ConnectionIndicator — 4 states (covered via top-level rendering)
   // ===========================================================================
   describe("ConnectionIndicator", () => {
     it("connected=null (testConnection never resolves) renders 'Checking...' + Spinner", async () => {
@@ -639,6 +641,61 @@ describe("MainPage", () => {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       expect(container.textContent).toContain("Not connected");
+    });
+  });
+
+  // ===========================================================================
+  // D2. Backend bootstrap failure — the retry-exhausted failure state (#1045)
+  // ===========================================================================
+  describe("backend bootstrap failure (#1045)", () => {
+    it("falls to an explicit backend-failure state when every connection attempt fails (retries exhausted)", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        // The backend never answers (bootstrap aborted) — every test_connection
+        // attempt rejects, across the whole backoff window.
+        vi.mocked(backend.testConnection).mockRejectedValue(new Error("backend down"));
+        const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        // Drive the full retry schedule (2+5+10+15+20s of backoff) to exhaustion.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(60_000);
+        });
+        // The connection row lands on the explicit failure — not an eternal
+        // "Checking…" spinner (the #1045 bug).
+        expect(container.textContent).toContain("Backend error");
+        expect(container.textContent).toContain("Plugin backend failed to start — check Decky logs.");
+        expect(container.textContent).not.toContain("Checking...");
+        // Sync is gated off while the backend is down.
+        const sync = buttonByExactText(container, "Sync Library");
+        expect(sync).not.toBeNull();
+        expect(sync!.disabled).toBe(true);
+        // Non-vacuous catch coverage: the exhaustion branch logs to console.error
+        // (logError is itself a callable and would hang against a dead backend).
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("test_connection unreachable"), expect.anything());
+        errSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("recovers to 'Connected' when a retry succeeds after a slow start (no false backend-failure)", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        // The backend is merely slow: the first two probes reject, the third
+        // resolves. The row must recover, never showing the failure state.
+        vi.mocked(backend.testConnection)
+          .mockRejectedValueOnce(new Error("starting"))
+          .mockRejectedValueOnce(new Error("starting"))
+          .mockResolvedValue({ success: true, message: "" });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+        expect(container.textContent).toContain("Connected");
+        expect(container.textContent).not.toContain("Backend error");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -12,7 +12,7 @@ import {
   ConfirmModal,
   showModal,
 } from "@decky/ui";
-import { FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import { FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import {
   testConnection,
   cancelSync,
@@ -66,6 +66,28 @@ interface MainPageProps {
   onNavigate: (page: Page) => void;
 }
 
+// The connection probe races each `test_connection()` attempt against a deadline
+// (the callable never times out on its own and hangs forever when the backend
+// isn't up yet) and retries across the slow-cold-boot window. A call that
+// resolves — success OR "not connected" — is authoritative and ends the probe;
+// only an exhausted retry budget means the plugin backend never came up
+// (bootstrap aborted), which the connection row surfaces explicitly instead of
+// an eternal "Checking…" spinner (#1045). The schedule mirrors the metadata init
+// loop's tuned window in index.tsx (#1203).
+const CONNECTION_RETRY_DELAYS = [2000, 5000, 10000, 15000, 20000];
+const CONNECTION_CALLABLE_TIMEOUT = 5000;
+
+/** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
+type BackendFailed = "backend_failed";
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer!: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 function formatChanges(pairs: [number, string][]): string {
   return pairs
     .filter(([n]) => n > 0)
@@ -73,7 +95,15 @@ function formatChanges(pairs: [number, string][]): string {
     .join(", ");
 }
 
-const ConnectionIndicator: FC<{ connected: boolean | null }> = ({ connected }) => {
+const ConnectionIndicator: FC<{ connected: boolean | null | BackendFailed }> = ({ connected }) => {
+  if (connected === "backend_failed") {
+    return (
+      <>
+        <FaExclamationTriangle style={{ color: "#d4a72c", fontSize: "14px" }} />
+        <span style={{ fontSize: "12px" }}>Backend error</span>
+      </>
+    );
+  }
   if (connected === null) {
     return (
       <>
@@ -175,7 +205,7 @@ function formatPreviewDescription(s: SyncPreviewSummary): string {
 
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [stats, setStats] = useState<SyncStats | null>(null);
-  const [connected, setConnected] = useState<boolean | null>(null);
+  const [connected, setConnected] = useState<boolean | null | BackendFailed>(null);
   const versionError = useVersionError();
   const [syncing, setSyncing] = useState(false);
   // Disarmed "Cancelling…" state during the backend's RUNNING→CANCELLING→IDLE
@@ -205,6 +235,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   };
 
   useEffect(() => {
+    // Guards for the async connection probe below: `cancelled` stops the retry
+    // loop from touching state after unmount; the timer ref lets cleanup clear a
+    // pending backoff delay.
+    let cancelled = false;
+    let connectionRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
     refreshMigrationState()
       .then(({ retrodeck, save_sort }) => {
         setMigrationStatus(retrodeck);
@@ -214,12 +250,38 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     getSyncStats()
       .then(setStats)
       .catch((e) => logError(`Failed to load sync stats: ${e}`));
-    testConnection()
-      .then((r) => {
-        setConnected(r.success);
-        setVersionError(r.reason === "version_error" ? r.message : null);
-      })
-      .catch((e) => logError(`Failed to test connection: ${e}`));
+
+    // Probe the backend for the connection row. Each attempt has a deadline
+    // because the callable hangs (rather than rejects) while the backend is
+    // still starting, and the retries ride out a slow cold boot. A resolved call
+    // ends the probe — "not connected" (success:false) is an authoritative
+    // answer, not a failure. Only an exhausted retry budget means the backend
+    // never came up (bootstrap aborted); surface that explicitly (#1045).
+    const probeConnection = async (isCancelled: () => boolean) => {
+      for (let attempt = 0; !isCancelled(); attempt++) {
+        try {
+          const r = await withTimeout(testConnection(), CONNECTION_CALLABLE_TIMEOUT);
+          if (isCancelled()) return;
+          setConnected(r.success);
+          setVersionError(r.reason === "version_error" ? r.message : null);
+          return;
+        } catch (e) {
+          if (isCancelled()) return;
+          if (attempt >= CONNECTION_RETRY_DELAYS.length) {
+            setConnected("backend_failed");
+            // logError is itself a callable and would hang against a dead
+            // backend — log to the console instead.
+            console.error(`[RomM] test_connection unreachable after ${attempt + 1} attempts:`, e);
+            return;
+          }
+          await new Promise<void>((resolve) => {
+            connectionRetryTimer = setTimeout(resolve, CONNECTION_RETRY_DELAYS[attempt]);
+          });
+        }
+      }
+    };
+    detach(probeConnection(() => cancelled));
+
     getSettings()
       .then((s) => {
         if (s.retroarch_input_check) {
@@ -284,6 +346,8 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     const unsubPlaytimeScope = onPlaytimeScopeChange(() => setPlaytimeScope(getPlaytimeScopeState()));
     const unsubSaveSort = onSaveSortMigrationChange(() => setSaveSortMigration(getSaveSortMigrationState()));
     return () => {
+      cancelled = true;
+      if (connectionRetryTimer) clearTimeout(connectionRetryTimer);
       unsubProgress();
       unsubMigration();
       unsubSettingsReset();
@@ -446,6 +510,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   );
   const hasDownloads = activeDownloads.length > 0 || completedDownloads.length > 0;
 
+  // Sync is unavailable when the server test failed OR the plugin backend never
+  // started — both gate the Sync buttons off.
+  const connectionUnavailable = connected === false || connected === "backend_failed";
+
   if (versionError) {
     return <VersionErrorCard message={versionError} compact />;
   }
@@ -570,7 +638,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             onClick={() => {
               detach(handleSync());
             }}
-            disabled={loading || connected === false}
+            disabled={loading || connectionUnavailable}
             // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
             onFocus={scrollToTop}
           >
@@ -607,7 +675,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                   })(),
                 );
               }}
-              disabled={loading || connected === false}
+              disabled={loading || connectionUnavailable}
             >
               Force Full Sync
             </ButtonItem>
@@ -628,7 +696,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           </PanelSectionRow>
         )}
         <PanelSectionRow>
-          <Field label="Connection">
+          <Field
+            label="Connection"
+            description={
+              connected === "backend_failed" ? "Plugin backend failed to start — check Decky logs." : undefined
+            }
+          >
             <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
               <ConnectionIndicator connected={connected} />
             </div>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -59,6 +59,7 @@ import type {
   MigrationStatus,
 } from "../types";
 import { detach } from "../utils/detach";
+import { withTimeout } from "../utils/withTimeout";
 
 type Page = "settings" | "library" | "data" | "downloads" | "system";
 
@@ -79,14 +80,6 @@ const CONNECTION_CALLABLE_TIMEOUT = 5000;
 
 /** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
 type BackendFailed = "backend_failed";
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timer!: ReturnType<typeof setTimeout>;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
-}
 
 function formatChanges(pairs: [number, string][]): string {
   return pairs
@@ -265,13 +258,28 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           setConnected(r.success);
           setVersionError(r.reason === "version_error" ? r.message : null);
           return;
-        } catch (e) {
+        } catch {
           if (isCancelled()) return;
           if (attempt >= CONNECTION_RETRY_DELAYS.length) {
-            setConnected("backend_failed");
-            // logError is itself a callable and would hang against a dead
-            // backend — log to the console instead.
-            console.error(`[RomM] test_connection unreachable after ${attempt + 1} attempts:`, e);
+            // Retry budget exhausted. test_connection() also waits out the
+            // server round-trip — a hanging RomM server keeps the backend's
+            // retrying heartbeat busy for up to ~90s, far past our per-attempt
+            // deadline — so an exhausted budget alone can't tell a dead backend
+            // from an unreachable server. Ping get_settings (a pure in-memory
+            // read that resolves iff the backend RPC bridge is alive) to decide:
+            // alive ⇒ the server is merely unreachable ("Not connected");
+            // dead ⇒ the backend never came up ("Backend error").
+            try {
+              await withTimeout(getSettings(), CONNECTION_CALLABLE_TIMEOUT);
+              if (isCancelled()) return;
+              setConnected(false);
+            } catch (pingErr) {
+              if (isCancelled()) return;
+              setConnected("backend_failed");
+              // logError is itself a callable and would hang against a dead
+              // backend — log to the console instead.
+              console.error("[RomM] backend RPC bridge unreachable (get_settings ping failed):", pingErr);
+            }
             return;
           }
           await new Promise<void>((resolve) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,18 +59,12 @@ import type {
 } from "./types";
 import { removeShortcut, setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
 import { batchConfirmLaunchOptions } from "./utils/launchOptionsReconcile";
+import { withTimeout } from "./utils/withTimeout";
 
 type Page = "main" | "settings" | "library" | "data" | "downloads" | "system";
 
 // Module-level page state survives QAM remounts (e.g. after modal close)
 let currentPage: Page = "main";
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms)),
-  ]);
-}
 
 const QAMPanel: FC = () => {
   const [page, setPageState] = useState<Page>(currentPage); // NOSONAR(typescript:S6754) — setter intentionally renamed; setPage wraps it below to provide custom navigation behavior.

--- a/src/utils/withTimeout.test.ts
+++ b/src/utils/withTimeout.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { withTimeout } from "./withTimeout";
+
+describe("withTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the promise's value when it settles before the deadline", async () => {
+    await expect(withTimeout(Promise.resolve("ok"), 1000)).resolves.toBe("ok");
+  });
+
+  it("propagates the promise's rejection when it rejects before the deadline", async () => {
+    await expect(withTimeout(Promise.reject(new Error("boom")), 1000)).rejects.toThrow("boom");
+  });
+
+  it("rejects with a timeout error once the deadline elapses first", async () => {
+    vi.useFakeTimers();
+    const pending = new Promise<string>(() => {
+      /* never settles */
+    });
+    const assertion = expect(withTimeout(pending, 5000)).rejects.toThrow("callable timed out after 5000ms");
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+  });
+
+  it("clears the deadline timer once the promise settles — no leaked timer", async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    await withTimeout(Promise.resolve("done"), 5000);
+    // The finally-cleanup cleared the deadline, leaving nothing pending.
+    expect(clearSpy).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    clearSpy.mockRestore();
+  });
+});

--- a/src/utils/withTimeout.ts
+++ b/src/utils/withTimeout.ts
@@ -1,0 +1,17 @@
+/**
+ * Race a promise against a deadline. Resolves/rejects with `promise` when it
+ * settles first; rejects with a timeout error once `ms` elapses. The deadline
+ * timer is cleared as soon as the race settles, so a settled call never leaves a
+ * pending timer behind.
+ *
+ * Decky's `callable()` has no timeout of its own and hangs forever when the
+ * backend isn't ready — every callable probe that must stay responsive races
+ * through this.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer!: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`callable timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
When the backend aborts at bootstrap (intended inert posture, e.g. a failed SQLite migration), the QAM connection row spun on "Checking…" forever: the one-shot `testConnection()` rejected, `connected` stayed null, and the init retry loop gave up silently.

The mount effect now probes with a per-attempt 5s deadline across a bounded retry window (mirroring the #1203 init schedule — the callable can hang rather than reject during a slow cold boot). A resolved call ends the probe ("not connected" is an authoritative answer). Only an exhausted budget escalates, and a final liveness ping (`getSettings`, a pure in-memory read) decides: ping resolves → backend alive → "Not connected" (unreachable server); ping fails → "Backend error — check Decky logs", with Sync actions disabled. The discriminator matters because `testConnection` rides the retrying heartbeat (up to ~90s against a hanging server) — without it, a healthy backend with an offline server would be misreported as a dead backend.

Also extracts the duplicated `withTimeout` into a shared util — the copy in `index.tsx` leaked a 5s timer per call; the shared version clears it on settle.

Tests: exhaustion (both callables dead → "Backend error"), alive-but-server-hung (→ "Not connected", not "Backend error"), recovery after transient rejects, plus unit tests for `withTimeout`. Troubleshooting docs updated ("Backend error" = backend process never started; an unreachable server shows "Not connected").

Closes #1045
