### PR TITLE
fix(ui): hide Apply when the sync preview has no real collection delta

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -971,6 +971,39 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Apply Sync")).toBeNull();
     });
 
+    it("collection enabled but zero add/remove delta: Dismiss only, no Apply, 'up to date' (#1147)", async () => {
+      // collection_diff.has_changes is True whenever any collection is enabled
+      // (the backend pins it via an `or current` term so first-sync still
+      // applies), yet an empty added/removed delta means there is nothing to
+      // apply. The gate must key off the real add/remove delta so the button
+      // matches the "Everything is up to date." description.
+      vi.mocked(backend.syncPreview).mockResolvedValue({
+        success: true,
+        summary: {
+          new_count: 0,
+          changed_count: 0,
+          unchanged_count: 0,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+          collection_diff: { has_changes: true, added: [], removed: [] },
+        },
+        new_names: [],
+        changed_names: [],
+        preview_id: "preview-1147",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      const descs = Array.from(container.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
+      expect(descs).toContain("Everything is up to date.");
+    });
+
     it("syncPreview success=false surfaces result.message into status field", async () => {
       vi.mocked(backend.syncPreview).mockResolvedValue({
         success: false,

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -458,7 +458,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   if (preview) {
     const hasChanges =
       preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0 ||
-      preview.summary.collection_diff?.has_changes ||
+      !!(preview.summary.collection_diff?.added.length || preview.summary.collection_diff?.removed.length) ||
       preview.summary.platform_collection_diff?.has_changes;
     syncBody = (
       <>


### PR DESCRIPTION
With any collection enabled, the preview could report "Everything is up to date." while still offering an "Apply Sync" button — pressing it re-applied every unit. The gate counted `collection_diff.has_changes`, which is true whenever a collection is enabled (its `current` term is needed for first-sync), while the description only renders collections with a real add/remove delta.

The gate's collection term now checks `added`/`removed` directly, matching the description. First sync is unaffected (everything lands in `added` there). Backend untouched; `platform_collection_diff.has_changes` is already strict and stays.

Regression test verified red on unmodified main (Apply offered despite "up to date"), green with the fix.

Note: a collection membership change without a name delta still reads "up to date" — pre-existing preview semantics; the deeper preview/apply divergence is tracked separately. This branch shares `MainPage.test.tsx` with the #1045 branch — merge that one first, this rebases trivially.

Closes #1147

docs: N/A (restores the behavior the docs already describe — the preview's "up to date" semantics)
