### PR TITLE
fix(playtime): adopt orphaned session after plugin reload

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1157,7 +1157,10 @@ Triggered automatically when a game stops (if `sync_after_exit` is enabled).
 1. `RegisterForAppLifetimeNotifications` fires with `bRunning: false`.
 2. `sessionManager.handleGameStop` makes a single `finalizeGameSession(romId)` call; the backend
    `SessionLifecycleService.finalize` orchestrates playtime record → post-exit save sync → migration refresh and returns
-   one typed payload (the old `recordSessionEnd` / `postExitSync` frontend callables were collapsed into it).
+   one typed payload (the old `recordSessionEnd` / `postExitSync` frontend callables were collapsed into it). If the
+   plugin was reloaded mid-session, `handleGameStop` still fires for the adopted session — see
+   [Surviving a plugin reload mid-session](#surviving-a-plugin-reload-mid-session) — so the post-exit sync is not
+   skipped.
 3. Backend runs `do_sync_rom_saves`. For most rows the local file's hash will differ from `last_sync_hash` (the user
    just played), so the typical action is `Upload` — matrix row 9 — POSTed as a new version (`overwrite=false`,
    409-backstopped).
@@ -1262,6 +1265,38 @@ Playtime is **additive, not a conflict** — the union of per-device session str
 newest-wins / conflict / `.romm-backup` machinery. The server dedupes on `(user_id, device_id, rom_id, start_time)`, so
 a re-POST of a queued session is idempotent; the outbox dequeues on a `created` or `duplicate` result and stays queued
 only on `error` (ADR-0018).
+
+### Surviving a plugin reload mid-session
+
+`destroySessionManager` wipes the in-memory session on unload, so a plugin reload while a game is running would leave
+the next game-stop with nothing to finalize — the pre-reload playtime is lost and the post-exit sync never runs. Two
+signals let the re-initialized `sessionManager` recover it:
+
+- **Steam running-state (liveness).** `Router.MainRunningApp` is the authority for _whether_ the game is still running
+  at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely so it survives the
+  reload, but only Steam can attest the session has not already ended.
+- **A localStorage breadcrumb (attestation).** A single versioned row (`decky-romm-sync:active-session` →
+  `{v, appId, romId, startMs, pausedMs}`) is written at start, has its `pausedMs` refreshed on each completed
+  suspend→resume cycle (an in-flight suspend is deliberately **not** persisted), and is removed at stop. It is **not**
+  cleared by `destroySessionManager`, so it outlives the reload. Every localStorage access is wrapped — a storage
+  failure degrades to the no-attestation path, never throws.
+
+At `initSessionManager` the recovery runs on the lifecycle chain (so a racing stop event serializes after it):
+
+- **Game running + breadcrumb matches** → adopt in-memory state from the breadcrumb (`sessionStartTime`,
+  `totalPausedMs`) and leave the durable marker untouched. Re-stamping would discard the pre-reload span the backend
+  already holds.
+- **Game running, no / mismatched / corrupt breadcrumb** → adopt and re-stamp the marker to a truthful lower bound
+  (`recordSessionStart`), then write a fresh breadcrumb so a subsequent reload adopts via the matching case instead of
+  re-stamping again.
+- **Breadcrumb present but nothing (or a non-RomM app) running** → the session ended while the plugin was down; a
+  truthful finalize is impossible without an observed end, so the breadcrumb is dropped and the session is logged as
+  orphaned — never a fabricated end time. A stale breadcrumb left by a reboot resolves the same way at the next init; no
+  expiry timers.
+
+**Attestation invariant:** every finalize fold uses a marker stamped by a start we actually observed (either the
+original `recordSessionStart` or an adoption re-stamp) — the client never invents an end time for a session whose stop
+it did not see.
 
 ### Steam display
 

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -188,3 +188,216 @@ describe("sessionManager suspend accumulator", () => {
     expect(backend.finalizeGameSession).toHaveBeenLastCalledWith(ROM_ID, 0);
   });
 });
+
+describe("sessionManager reload adoption", () => {
+  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
+
+  const seedBreadcrumb = (crumb: { v: number; appId: number; romId: number; startMs: number; pausedMs: number }) =>
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify(crumb));
+
+  const readCrumb = (): unknown => {
+    const raw = localStorage.getItem(BREADCRUMB_KEY);
+    return raw === null ? null : JSON.parse(raw);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    localStorage.clear();
+    // See the suspend-accumulator beforeEach — the global afterEach wipes the
+    // SteamClient stub, so re-stub the surface this module registers against.
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      System: {
+        RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    });
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
+    vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({
+      total_seconds: null,
+      sync: {
+        offline: false,
+        success: true,
+        synced: 0,
+        conflicts: [],
+        toast_title: null,
+        toast_body: null,
+        conflicts_toast: null,
+      },
+      migration: null,
+    });
+  });
+
+  afterEach(() => {
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("adopts a matching breadcrumb without re-stamping the marker, then finalizes on stop", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 3_000 });
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    // Case (a): the durable marker is preserved — no re-stamp.
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+
+    // Carried pausedMs (3000ms → 3s) folds in; the original rom is finalized.
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 3);
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+  });
+
+  it("adopts a running game with no breadcrumb and re-stamps the marker", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    // Case (a′): re-stamp exactly once, then attest with a fresh breadcrumb so
+    // a later reload adopts via case (a) instead of re-stamping again.
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID, pausedMs: 0 });
+  });
+
+  it("adopts and re-stamps when the breadcrumb names a different app than the running game", async () => {
+    // Stale breadcrumb for a different app; the running game is authoritative.
+    seedBreadcrumb({ v: 1, appId: 555, romId: 99, startMs: 5_000, pausedMs: 4_000 });
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+    // The stale breadcrumb is overwritten with a fresh one for the live game.
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID, pausedMs: 0 });
+  });
+
+  it("clears the breadcrumb and does not adopt when nothing is running", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    await initSessionManager();
+
+    // Case (b): orphaned — breadcrumb dropped, no adoption, no fabricated end.
+    expect(readCrumb()).toBeNull();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+
+    const lifetime = captureLifetimeCb();
+    // A stop with no adopted session is a no-op — nothing to finalize.
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+
+    // The next real start → stop still works normally.
+    await startGame(lifetime);
+    vi.setSystemTime(30_000);
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 0);
+  });
+
+  it("does not adopt when a non-RomM app is running", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+  });
+
+  it("carries the breadcrumb pausedMs forward and keeps accumulating after adoption", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 1_000, pausedMs: 5_000 });
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+    const suspend = captureSuspendCb();
+    const resume = captureResumeCb();
+
+    // 5s of pre-reload suspend carried in; add a 10s suspend cycle after adopt.
+    vi.setSystemTime(20_000);
+    suspend();
+    vi.setSystemTime(30_000);
+    resume();
+    vi.setSystemTime(40_000);
+    await stopGame(lifetime);
+
+    // 5000ms carried + 10000ms new = 15s.
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 15);
+  });
+
+  it("leaves no breadcrumb after a normal start then stop", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: null });
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    // Breadcrumb written during start.
+    expect(readCrumb()).not.toBeNull();
+
+    vi.setSystemTime(60_000);
+    await stopGame(lifetime);
+    // Cleared on stop — no residue.
+    expect(readCrumb()).toBeNull();
+  });
+
+  it("degrades to re-stamping when localStorage throws", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    // happy-dom's localStorage is a Proxy — swap the whole global (restored by
+    // the global afterEach's vi.unstubAllGlobals) rather than spying a method.
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("storage blocked");
+      },
+      setItem: () => {
+        throw new Error("storage blocked");
+      },
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // Both read and write throw → no usable breadcrumb, best-effort write
+    // swallowed → case (a′): marker re-stamped once, no crash.
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+  });
+
+  it("survives a full reload: start, destroy, re-init, stop finalizes the original rom", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: null });
+    await initSessionManager();
+    const lifetime1 = captureLifetimeCb();
+
+    // Start at a non-zero time so the suspend guard (sessionStartTime) stays truthy.
+    vi.setSystemTime(1_000);
+    await startGame(lifetime1);
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+
+    // Plugin reload: destroy wipes in-memory state but leaves the breadcrumb.
+    vi.setSystemTime(120_000);
+    destroySessionManager();
+    expect(readCrumb()).not.toBeNull();
+
+    // Re-init while the game is still running — adopt via the surviving breadcrumb.
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    await initSessionManager();
+    // Case (a): durable marker preserved — no second record_session_start.
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+
+    const lifetime2 = captureLifetimeCb();
+    vi.setSystemTime(180_000);
+    await stopGame(lifetime2);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 0);
+  });
+});

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -400,4 +400,95 @@ describe("sessionManager reload adoption", () => {
 
     expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 0);
   });
+
+  it("treats a wrong-version breadcrumb as unusable and re-stamps (a′)", async () => {
+    // A breadcrumb from a future schema (v2) fails isSessionBreadcrumb.
+    seedBreadcrumb({ v: 2, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 9_000 });
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+    // Overwritten with a fresh v1 breadcrumb; the stale pausedMs=9000 is discarded.
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID, pausedMs: 0 });
+  });
+
+  it("treats a non-object breadcrumb JSON as unusable and re-stamps (a′)", async () => {
+    // Valid JSON but not an object — isSessionBreadcrumb rejects it.
+    localStorage.setItem(BREADCRUMB_KEY, JSON.stringify(42));
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID, pausedMs: 0 });
+  });
+
+  it("survives a rejected recordSessionStart during adoption", async () => {
+    vi.mocked(backend.recordSessionStart).mockRejectedValueOnce(new Error("network down"));
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    // (a′) awaits recordSessionStart; its rejection is caught, not surfaced.
+    await expect(initSessionManager()).resolves.toBeUndefined();
+    expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("record session start on adoption"));
+
+    // The breadcrumb is written before the failing call, and the session is
+    // still adopted — a subsequent stop finalizes the original rom.
+    expect(readCrumb()).toMatchObject({ v: 1, appId: APP_ID, romId: ROM_ID, pausedMs: 0 });
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 0);
+  });
+
+  it("clears a live breadcrumb when a non-RomM app is in the foreground", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 });
+    vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+
+    await initSessionManager();
+
+    // The RomM game is not the foreground app → its session is orphaned, its
+    // breadcrumb dropped, and nothing is adopted or finalized.
+    expect(readCrumb()).toBeNull();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).not.toHaveBeenCalled();
+  });
+
+  it("swallows a localStorage failure while clearing an orphaned breadcrumb", async () => {
+    // Live breadcrumb present, nothing running (case b) → clear is attempted,
+    // but removeItem throws. The failure must be contained, not surfaced.
+    vi.stubGlobal("localStorage", {
+      getItem: () => JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 }),
+      setItem: vi.fn(),
+      removeItem: () => {
+        throw new Error("storage blocked");
+      },
+      clear: vi.fn(),
+    });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("clear session breadcrumb"));
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+  });
+
+  it("contains an unexpected throw in the adoption path", async () => {
+    // Steam's running-app accessor faulting must not crash init — the lifecycle
+    // chain's .catch logs and lets initialization complete.
+    vi.stubGlobal("Router", {
+      MainRunningApp: {
+        get appid(): number {
+          throw new Error("running-app read failed");
+        },
+        display_name: "Game",
+      },
+    });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+  });
 });

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -68,6 +68,67 @@ async function refreshAppIdMap(): Promise<void> {
   }
 }
 
+// Durable attestation of the open session — survives a plugin reload so the
+// re-initialized manager can adopt the still-running game and finalize its
+// stop. A single versioned localStorage row; every access is wrapped so a
+// storage failure degrades to the no-attestation path instead of throwing.
+const SESSION_BREADCRUMB_KEY = "decky-romm-sync:active-session";
+const SESSION_BREADCRUMB_VERSION = 1;
+
+interface SessionBreadcrumb {
+  v: number;
+  appId: number;
+  romId: number;
+  startMs: number;
+  pausedMs: number;
+}
+
+function isSessionBreadcrumb(value: unknown): value is SessionBreadcrumb {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return (
+    c.v === SESSION_BREADCRUMB_VERSION &&
+    typeof c.appId === "number" &&
+    typeof c.romId === "number" &&
+    typeof c.startMs === "number" &&
+    typeof c.pausedMs === "number"
+  );
+}
+
+function readSessionBreadcrumb(): SessionBreadcrumb | null {
+  try {
+    const raw = localStorage.getItem(SESSION_BREADCRUMB_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isSessionBreadcrumb(parsed) ? parsed : null;
+  } catch (e) {
+    logError(`Failed to read session breadcrumb: ${e}`);
+    return null;
+  }
+}
+
+function writeSessionBreadcrumb(crumb: SessionBreadcrumb): void {
+  try {
+    localStorage.setItem(SESSION_BREADCRUMB_KEY, JSON.stringify(crumb));
+  } catch (e) {
+    logError(`Failed to write session breadcrumb: ${e}`);
+  }
+}
+
+function clearSessionBreadcrumb(): void {
+  try {
+    localStorage.removeItem(SESSION_BREADCRUMB_KEY);
+  } catch (e) {
+    logError(`Failed to clear session breadcrumb: ${e}`);
+  }
+}
+
+/** Persist the running suspend accumulator onto the open breadcrumb (no-op if none). */
+function updateSessionBreadcrumbPaused(pausedMs: number): void {
+  const crumb = readSessionBreadcrumb();
+  if (crumb) writeSessionBreadcrumb({ ...crumb, pausedMs });
+}
+
 async function handleGameStart(appId: number): Promise<void> {
   const romId = getRomIdForApp(appId);
   if (!romId) return; // Not a RomM shortcut
@@ -77,6 +138,9 @@ async function handleGameStart(appId: number): Promise<void> {
   sessionStartTime = Date.now();
   suspendedAt = null;
   totalPausedMs = 0;
+
+  // Attest the open session so a reload mid-game can adopt and finalize it.
+  writeSessionBreadcrumb({ v: SESSION_BREADCRUMB_VERSION, appId, romId, startMs: sessionStartTime, pausedMs: 0 });
 
   // Record session start for playtime tracking
   try {
@@ -100,11 +164,13 @@ async function handleGameStop(): Promise<void> {
   }
   const suspendedSeconds = Math.round(totalPausedMs / 1000);
 
-  // Clear active session immediately to avoid double-processing
+  // Clear active session immediately to avoid double-processing. The breadcrumb
+  // goes with it — the stop is observed, so there is nothing left to adopt.
   activeRomId = null;
   sessionStartTime = null;
   suspendedAt = null;
   totalPausedMs = 0;
+  clearSessionBreadcrumb();
 
   try {
     const result = await finalizeGameSession(romId, suspendedSeconds);
@@ -161,6 +227,70 @@ function handleResume(): void {
     totalPausedMs += pauseDuration;
     logInfo(`Device resumed, paused for ${Math.round(pauseDuration / 1000)}s`);
     suspendedAt = null;
+    // Persist the completed suspend cycle so an adopted session keeps it. An
+    // in-flight suspend (still open at reload) is intentionally not persisted.
+    updateSessionBreadcrumbPaused(totalPausedMs);
+  }
+}
+
+/**
+ * Adopt a play session orphaned by a plugin reload mid-game.
+ *
+ * `destroySessionManager` wipes the in-memory session on unload, so the
+ * game-stop after a reload would otherwise never finalize — the pre-reload
+ * playtime is lost and the post-exit sync never runs. Steam's running-state
+ * (`Router.MainRunningApp`) is the liveness authority; the localStorage
+ * breadcrumb is the attestation of a start we actually observed. Every finalize
+ * fold thus stays anchored to a marker stamped by an observed start.
+ */
+async function adoptOrphanedSession(): Promise<void> {
+  const running = typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
+  const runningRomId = running ? getRomIdForApp(running.appid) : null;
+  const crumb = readSessionBreadcrumb();
+
+  if (running && runningRomId !== null) {
+    const appId = running.appid;
+    if (crumb && crumb.appId === appId && crumb.romId === runningRomId) {
+      // (a) The breadcrumb attests this exact running session. Restore the
+      // in-memory state and leave the durable marker untouched — re-stamping it
+      // would discard the pre-reload playtime the backend already holds.
+      activeRomId = runningRomId;
+      sessionStartTime = crumb.startMs;
+      suspendedAt = null;
+      totalPausedMs = crumb.pausedMs;
+      logInfo(`Adopted running session from breadcrumb: romId=${runningRomId}, appId=${appId}`);
+    } else {
+      // (a′) A game is running but no usable breadcrumb (missing / mismatched /
+      // corrupt). Adopt it and re-stamp the marker to a truthful lower bound
+      // from now, then attest with a fresh breadcrumb so a later reload adopts
+      // via (a) rather than re-stamping again.
+      activeRomId = runningRomId;
+      sessionStartTime = Date.now();
+      suspendedAt = null;
+      totalPausedMs = 0;
+      writeSessionBreadcrumb({
+        v: SESSION_BREADCRUMB_VERSION,
+        appId,
+        romId: runningRomId,
+        startMs: sessionStartTime,
+        pausedMs: 0,
+      });
+      try {
+        await recordSessionStart(runningRomId);
+      } catch (e) {
+        logError(`Failed to record session start on adoption: ${e}`);
+      }
+      logInfo(`Adopted running session without breadcrumb, re-stamped marker: romId=${runningRomId}, appId=${appId}`);
+    }
+    return;
+  }
+
+  // No RomM game is running (nothing running, or a non-RomM app). A breadcrumb
+  // here names a session whose stop we never saw — a truthful finalize is
+  // impossible without an observed end, so drop it rather than fabricate one.
+  if (crumb) {
+    clearSessionBreadcrumb();
+    logInfo(`Session orphaned — playtime not recorded (romId=${crumb.romId})`);
   }
 }
 
@@ -203,6 +333,17 @@ export async function initSessionManager(): Promise<void> {
   } catch (e) {
     console.warn("[romm-sync] Suspend/resume hooks unavailable:", e);
   }
+
+  // Adopt a session orphaned by a plugin reload mid-game. Serialized on the
+  // lifecycle chain so a stop notification arriving during adoption finalizes
+  // after it rather than interleaving with the in-memory state it restores.
+  const adoption = lifecycleChain
+    .then(() => adoptOrphanedSession())
+    .catch((e) => {
+      logError(`Session adoption error: ${e}`);
+    });
+  lifecycleChain = adoption;
+  await adoption;
 
   logInfo("Session manager initialized");
 }


### PR DESCRIPTION
A plugin reload mid-game orphaned the running session: `destroySessionManager` reset the in-memory state, so the eventual game-stop never finalized — no playtime fold, no post-exit save sync.

The backend start marker (`last_session_start`) is already durable; what was missing was frontend state. The session manager now writes a localStorage breadcrumb (appId, romId, start, paused ms) on game start and adopts on re-init with `Router.MainRunningApp` as the liveness authority:

- game running + matching breadcrumb → adopt without re-stamping (full playtime from the durable marker)
- game running, no/corrupt breadcrumb → adopt and re-stamp (truthful lower bound, self-heals stale markers)
- nothing running (or a different app foregrounded) → clear the breadcrumb and log; a finalize is never fabricated — an end time that was never observed is not invented

Adoption runs on the lifecycle chain, so a racing stop event serializes after it. RomM dedups sessions on start_time, so an adopted finalize is idempotent.

Tests: 15 cases covering the adoption matrix, breadcrumb bad paths (corrupt/wrong-version JSON, storage failures), paused-time carry-over, and a full reload simulation. Architecture docs document the flow and the attestation invariant.

Needs on-device confirmation that `Router.MainRunningApp` is populated at re-init (part of the upcoming Game Mode verification batch).

Closes #1054
