### PR TITLE
build: raise bundle size budget to 550 KB

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "540 KB"
+    "limit": "550 KB"
   }
 ]


### PR DESCRIPTION
The 540 KB budget was 657 B short of admitting the session-adoption feature (#1289), and the current wave of frontend fixes sits close enough to the line that cumulative merges could cross it on main. 550 KB keeps the runaway-bloat guardrail while giving the wave honest headroom.

docs: N/A (CI/tooling budget change; no user-facing or architectural change)