### PR TITLE
feat(ui): show last played from restored playtime data

### DIFF
--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1313,6 +1313,13 @@ drained it adopts the cross-device server union; offline / partial-flush / not-y
 regressing below local truth. The GET needs the `roms.user.read` scope (added to the minted token in #1280); without it
 the reconcile degrades to local-only — never an error.
 
+The `reconcile_playtime` result also carries the restored `last_played` (ISO-8601). The game-detail Play section
+(`RomMPlaySection`) renders it as the **LAST PLAYED** value in preference to Steam's device-local `rt_last_time_played`:
+Steam synthesizes the latter to "now" after a device cutover / fresh device, so the restored cross-device timestamp is
+the truthful one. When `last_played` is `null` (the server has no session for the ROM yet, or the reconcile ran
+local-only) the display falls back to Steam's value, so there is no regression before any server data exists. This is
+display-only — the plugin does not write the restored value back into Steam's `rt_last_time_played` (#1294).
+
 ## Save-Sync State — the `RomSaveState` aggregate
 
 Per-ROM save-sync state lives in SQLite — there is no JSON file. The per-ROM scalars are the `RomSaveState` aggregate

--- a/docs/user-guide/save-sync.md
+++ b/docs/user-guide/save-sync.md
@@ -171,6 +171,10 @@ read scope and a fresh sign-in; until then the displayed value is your local tot
 enable cross-device playtime** — the plugin shows a banner in the QAM panel prompting this whenever your saved login
 predates the play-session read scope. When RomM is unreachable the displayed value stays on your local total.
 
+The **LAST PLAYED** date on the detail page comes from this same cross-device history, so it stays correct after you
+move to a new device — where Steam would otherwise reset it and show every game as just played. Until the server has a
+recorded session for a game (or while RomM is unreachable), the date falls back to Steam's own last-played value.
+
 Steam also tracks playtime natively for non-Steam shortcuts, so you'll see playtime in the standard Steam UI as well.
 
 > **Upgrading from an older version:** earlier releases stored playtime in a hidden RomM note named

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -1039,6 +1039,66 @@ describe("RomMPlaySection", () => {
   });
 
   // ------------------------------------------------------------------
+  // E3. LAST PLAYED source (#1294) — the restored cross-device last_played
+  //     from reconcile_playtime wins over Steam's device-local
+  //     rt_last_time_played, which Steam synthesizes to "now" after a cutover.
+  // ------------------------------------------------------------------
+
+  describe("LAST PLAYED source (#1294)", () => {
+    // Echo the numeric timestamp so OUR (restored) date and Steam's device-local
+    // date render as distinguishable strings — the default formatLastPlayed mock
+    // collapses every non-zero value to a single "2024-01-15".
+    function applyEchoLastPlayedFormatter(): void {
+      vi.mocked(formatters.formatLastPlayed).mockImplementation((rt: number) => (rt ? `lp:${rt}` : ""));
+    }
+
+    function mountReconciled(lastPlayed: string | null, steamRt: number) {
+      applyEchoLastPlayedFormatter();
+      stubAppStore({ [testAppId]: { rt_last_time_played: steamRt, minutes_playtime_forever: 60 } });
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 1294,
+        save_sync_enabled: false,
+      });
+      vi.mocked(backend.testConnection).mockResolvedValue({ success: true, message: "ok" });
+      vi.mocked(backend.reconcilePlaytime).mockResolvedValue({
+        total_seconds: 3600,
+        session_count: 1,
+        last_played: lastPlayed,
+        server_query_failed: false,
+      });
+      return render(<RomMPlaySection appId={testAppId} />);
+    }
+
+    it("renders OUR restored last_played over Steam's rt_last_time_played", async () => {
+      const iso = "2023-06-15T10:00:00.000Z";
+      const ourSecs = Math.floor(Date.parse(iso) / 1000);
+      const { container } = mountReconciled(iso, 1111111111);
+      await flushAsync();
+      // Restored ISO routed through the SAME formatter (converted to seconds),
+      // and the Steam device-local value is NOT what's shown.
+      expect(vi.mocked(formatters.formatLastPlayed)).toHaveBeenCalledWith(ourSecs);
+      expect(container.textContent).toContain("LAST PLAYED");
+      expect(container.textContent).toContain(`lp:${ourSecs}`);
+      expect(container.textContent).not.toContain("lp:1111111111");
+    });
+
+    it("falls back to Steam's rt_last_time_played when last_played is null (no regression)", async () => {
+      const { container } = mountReconciled(null, 1111111111);
+      await flushAsync();
+      expect(container.textContent).toContain("lp:1111111111");
+    });
+
+    it("falls back safely to Steam's value when last_played is unparseable (no crash)", async () => {
+      const { container } = mountReconciled("not-a-real-date", 1111111111);
+      await flushAsync();
+      // Unparseable restored value → Steam device-local value shown, no throw.
+      expect(container.textContent).toContain("lp:1111111111");
+      expect(container.textContent).not.toContain("lp:NaN");
+    });
+  });
+
+  // ------------------------------------------------------------------
   // F. romm_data_changed DOM event handler
   // ------------------------------------------------------------------
 

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -1096,6 +1096,26 @@ describe("RomMPlaySection", () => {
       expect(container.textContent).toContain("lp:1111111111");
       expect(container.textContent).not.toContain("lp:NaN");
     });
+
+    it("keeps OUR restored last_played across a later romm_playtime_changed signal (onPlaytimeChanged branch)", async () => {
+      const iso = "2023-06-15T10:00:00.000Z";
+      const ourSecs = Math.floor(Date.parse(iso) / 1000);
+      const { container } = mountReconciled(iso, 1111111111);
+      await flushAsync();
+      // Restored value adopted on reconcile.
+      expect(container.textContent).toContain(`lp:${ourSecs}`);
+
+      // A later playtime signal (session end / bulk write) raises Steam's
+      // device-local rt to a DIFFERENT value and fires the chokepoint signal.
+      // The reactive handler must keep the restored value — Steam's synthesized
+      // rt must NOT win.
+      stubAppStore({ [testAppId]: { rt_last_time_played: 2222222222, minutes_playtime_forever: 120 } });
+      act(() => {
+        globalThis.dispatchEvent(new CustomEvent("romm_playtime_changed", { detail: { appId: testAppId } }));
+      });
+      expect(container.textContent).toContain(`lp:${ourSecs}`);
+      expect(container.textContent).not.toContain("lp:2222222222");
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/RomMPlaySection.tsx
+++ b/src/components/RomMPlaySection.tsx
@@ -75,6 +75,21 @@ import {
 /** Track which appIds have had auto-artwork applied this session */
 const artworkApplied = new Set<number>();
 
+/** Resolve the LAST PLAYED display, preferring our restored cross-device
+ *  `last_played` (ISO-8601, from `reconcile_playtime` / native play sessions,
+ *  #1294) over Steam's device-local `rt_last_time_played`. Steam synthesizes the
+ *  latter to "now" after a device cutover, so the restored value wins whenever
+ *  it parses; a null or unparseable restored value falls back to Steam's
+ *  Unix-seconds value. Both route through `formatLastPlayed` so the rendered
+ *  format is identical either way. */
+function resolveLastPlayed(restoredIso: string | null, steamUnixSeconds: number): string {
+  if (restoredIso) {
+    const ms = Date.parse(restoredIso);
+    if (!Number.isNaN(ms)) return formatLastPlayed(Math.floor(ms / 1000));
+  }
+  return formatLastPlayed(steamUnixSeconds);
+}
+
 interface RomMPlaySectionProps {
   appId: number;
 }
@@ -86,6 +101,10 @@ interface InfoState {
   romName: string;
   platformSlug: string;
   lastPlayed: string;
+  /** Restored cross-device `last_played` (ISO-8601) from `reconcile_playtime`,
+   *  or `null` until the server yields one. Preferred over Steam's device-local
+   *  `rt_last_time_played` when rendering LAST PLAYED (#1294). */
+  restoredLastPlayed: string | null;
   playtime: string;
   saveSyncEnabled: boolean;
   saveSyncStatus: "synced" | "conflict" | "none" | null;
@@ -224,6 +243,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
     romName: "",
     platformSlug: "",
     lastPlayed: initialLastPlayed,
+    restoredLastPlayed: null,
     playtime: initialPlaytime,
     saveSyncEnabled: false,
     saveSyncStatus: null,
@@ -376,6 +396,17 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
         const result = await reconcilePlaytime(romId);
         if (isCancelled) return;
         if (result.server_query_failed) return;
+        // Adopt the restored cross-device last_played (#1294) and refresh the
+        // display from it. Set BEFORE updatePlaytimeDisplay so the synchronous
+        // romm_playtime_changed handler below reads the new restoredLastPlayed;
+        // also covers the sub-minute total case where updatePlaytimeDisplay
+        // emits no signal.
+        const steamSecs = appStore.GetAppOverviewByAppID(appId)?.rt_last_time_played ?? 0;
+        setInfo((prev) => ({
+          ...prev,
+          restoredLastPlayed: result.last_played,
+          lastPlayed: resolveLastPlayed(result.last_played, steamSecs),
+        }));
         updatePlaytimeDisplay(appId, result.total_seconds, false);
       } catch (e) {
         detach(debugLog(`RomMPlaySection: playtime reconcile error: ${e}`));
@@ -532,7 +563,7 @@ export const RomMPlaySection: FC<RomMPlaySectionProps> = ({ appId }) => { // NOS
       setInfo((prev) => ({
         ...prev,
         playtime: formatPlaytime(ov.minutes_playtime_forever ?? 0),
-        lastPlayed: formatLastPlayed(ov.rt_last_time_played ?? 0),
+        lastPlayed: resolveLastPlayed(prev.restoredLastPlayed, ov.rt_last_time_played ?? 0),
       }));
     };
     globalThis.addEventListener("romm_playtime_changed", onPlaytimeChanged);


### PR DESCRIPTION
The game-detail Play section rendered LAST PLAYED from Steam's device-local `rt_last_time_played`, which Steam synthesizes to "now" after a cutover/fresh device — so every game showed a wrong date exactly when the restored data (#903 / #1288) knew the truth.

The section now prefers the restored `last_played` already present in the `reconcilePlaytime` response (no new callable, no extra fetch), routed through the existing `formatLastPlayed`; Steam's value stays as the fallback when the server has no data or the value is unparseable. The reactive playtime-changed handler is restored-aware, so a later display signal cannot clobber the truthful date with Steam's synthesized one. Prefer (not max): the restored value is a local monotonic fold — session end stamps the local row before any reconcile reads it — so it is never behind a just-finished local session, while Steam's post-cutover value is precisely the untrustworthy side. Steam write-back is out of scope per the issue.

Tests: restored value rendered (differs from Steam fixture), null → Steam fallback, unparseable → safe fallback, and the reactive-handler branch pinned across a `romm_playtime_changed` signal. Architecture + user-guide docs updated.

One residual edge is deliberately left for on-device verification: if the detail section can stay mounted across an entire game session in Game Mode, a pre-session restored date could briefly shadow the fresh one until the next remount (self-heals via the local fold).

Closes #1294