### PR TITLE
build: raise bundle size budget to 600 KB

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "550 KB"
+    "limit": "600 KB"
   }
 ]


### PR DESCRIPTION
The Decky build ships `dist/index.js` unminified, so comments count against the raw-size budget. main sits at ~548 kB — under 2 kB below the 550 KB limit — which forced the #1148 diagnostics change to trim comments to fit. That is the wrong incentive: the budget exists to catch runaway bloat (an accidental dependency import adds tens of kB at once), not to ration comment bytes. 600 KB restores honest headroom while still failing fast on real bloat.

docs: N/A (CI/tooling budget change; no user-facing or architectural change)