### PR TITLE
fix(launch): bake the game folder as the PS3 launch target

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,11 +113,16 @@ on-disk artifact.
 
 The two path fields on `RomInstall` (`domain/rom_install.py`) answer different questions and must not be conflated:
 
-- **`file_path`** — the **launch target**: the single file RetroDECK is handed. It is baked into the Steam shortcut's
-  `launch_options` (`flatpak run … "<file_path>"`) and the `rom-launcher` exec wrapper runs that command (per
-  [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md), which superseded the dynamic SQLite read
-  of [ADR-0005](docs/adr/0005-launcher-resolves-path-from-sqlite.md)). Present for every ROM. Save-path resolution,
-  ES-DE core resolution, and the displayed filename all derive from it.
+- **`file_path`** — the **launch file**: the single file that is the ROM's launch identity. Present for every ROM;
+  save-path resolution, ES-DE core resolution, and the displayed filename all derive from it. It is the **default**
+  launch target baked into the Steam shortcut's `launch_options` (`flatpak run … "<file_path>"`, run by the
+  `rom-launcher` exec wrapper per [ADR-0009](docs/adr/0009-launcher-pure-exec-wrapper-baked-launch-options.md), which
+  superseded the dynamic SQLite read of [ADR-0005](docs/adr/0005-launcher-resolves-path-from-sqlite.md)) — but the baked
+  launch **target** may be **overridden at bake time** without rewriting `file_path`: a multi-disc pin bakes the
+  selected disc's path
+  ([ADR-0014](docs/adr/0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md)), and a
+  folder-boot system (PS3/RPCS3) bakes the game **directory** rather than the nested launch file
+  ([ADR-0019](docs/adr/0019-folder-as-launch-target.md)). `file_path` stays the launch **file** anchor in every case.
 - **`rom_dir`** — the **dedicated per-ROM directory**, present only for folder-backed (multi-file) ROMs. **NULL for
   single-file ROMs**, which live as a bare file directly in the shared `<roms>/<system>/` directory and own no dedicated
   folder.

--- a/docs/adr/0008-rom-install-launch-file-and-rom-dir.md
+++ b/docs/adr/0008-rom-install-launch-file-and-rom-dir.md
@@ -7,6 +7,11 @@ Accepted. Refines the `RomInstall` aggregate (introduced for the per-ROM split i
 the JSON→SQLite remodel (#784) introduced, and records the **per-file `RomFile[]` model as the committed but deferred
 target**.
 
+> **Refined by [ADR-0019](0019-folder-as-launch-target.md)
+> ([#1212](https://github.com/danielcopper/decky-romm-sync/issues/1212)).** For a folder-boot system (PS3/RPCS3) the
+> baked launch **target** is the game directory, not `file_path` — applied as a bake-time override that leaves
+> `file_path` (the launch **file** anchor decided below) unchanged.
+
 ## Context
 
 The legacy JSON install record (`InstalledRomEntry`) carried `file_path` always, plus `rom_dir: NotRequired[str]` —

--- a/docs/adr/0019-folder-as-launch-target.md
+++ b/docs/adr/0019-folder-as-launch-target.md
@@ -1,0 +1,154 @@
+# Folder-boot systems bake the game directory as the launch target; `file_path` stays the launch FILE anchor
+
+## Status
+
+Accepted. Extends [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md) (the baked-`launch_options` model)
+and [ADR-0014](0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md) (the bake-time
+launch-path override layer) with a folder-as-target branch, and **refines**
+[ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) (`file_path` = launch file, `rom_dir` = dedicated folder) by
+recording that for a folder-boot system the baked launch **target** deliberately differs from `file_path`. Tracked under
+[#1212](https://github.com/danielcopper/decky-romm-sync/issues/1212) (part of the #914 standalone-emulator epic,
+surfaced by the #1208 PS3-standalone routing).
+
+## Context
+
+With standalone routing ([#1208](https://github.com/danielcopper/decky-romm-sync/issues/1208)) a PS3 ROM launches via
+`%EMULATOR_RPCS3% --no-gui %ROM%`. A PS3 game installs as a folder whose launchable payload is the nested
+`…/PS3_GAME/USRDIR/EBOOT.BIN`, and `detect_launch_file` ([ADR-0008](0008-rom-install-launch-file-and-rom-dir.md)) picks
+exactly that EBOOT as the install's `file_path` — correct as the launch **file** identity (the payload that "is" the
+game), and load-bearing for save-path resolution, core resolution, and the displayed filename.
+
+But RPCS3's directory-boot rejects the nested EBOOT and wants the game **root folder** — the directory that _contains_
+`PS3_GAME` (hardware-confirmed, RPCS3 0.0.40):
+
+```text
+Booting '…/PS3_GAME/USRDIR/EBOOT.BIN' failed
+Reason: Invalid file or folder
+Emulation is stopped
+```
+
+So the launch **target** (what gets baked into the argv the emulator receives) and the launch **file** (`file_path`, the
+payload identity) are two different axes for a folder-boot system. #1208 got the _invocation_ right (`--no-gui`); the
+remaining gap is the _target_: the baked `%ROM%` must be the game directory, not the EBOOT.
+
+This is the exact shape [ADR-0014](0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md)
+already established for the disc picker — a per-game deviation the plugin owns, applied as a **bake-time launch-path
+override** that changes only the argument baked into `launch_options` and never rewrites `file_path`. A folder-boot
+system is another value of the same axis: "which path does this ROM actually launch with?" The answer is the game
+folder, not the file `detect_launch_file` chose.
+
+## Decision
+
+### 1. Folder-boot identity is a small hardcoded marker table in `domain/`
+
+`domain/rom_files.py` (next to `detect_launch_file`, which owns the `EBOOT.BIN` literal) hardcodes the format-semantic
+fact es_systems cannot express — that a PS3 layout's trailing `PS3_GAME/USRDIR/EBOOT.BIN` run identifies a
+launch-the-folder game:
+
+```python
+FOLDER_BOOT_MARKERS = (("PS3_GAME", "USRDIR", "EBOOT.BIN"),)
+```
+
+Matched **case-sensitively** — the on-disk layout is standardised uppercase, so a lowercase `ps3_game` is not a
+folder-boot marker. A future folder-boot system is a **data-only** addition to this tuple, never new control flow.
+
+### 2. `folder_boot_root(launch_path, rom_dir)` — pure path algebra, `domain/`
+
+A pure function derives the game root from a launch path: when the path's trailing components match a marker, it strips
+those components and returns the remaining game root. This also collapses a one-level-deeper extract
+(`rom_dir/<Game>/PS3_GAME/USRDIR/EBOOT.BIN` → `rom_dir/<Game>`). It returns the root **only** when both guards hold:
+
+- **`rom_dir` is set.** A single-file ROM (`rom_dir is None`, [ADR-0008](0008-rom-install-launch-file-and-rom-dir.md))
+  owns no folder and is never a folder-boot game.
+- **The derived root is inside-or-equal `rom_dir`.** A pathological bare `<roms>/<system>/PS3_GAME/USRDIR/EBOOT.BIN`
+  sitting directly in the shared system directory would strip to that shared directory; the containment guard rejects it
+  (the stripped root is `rom_dir`'s parent, not inside it), so the shared directory is never baked as a launch target.
+
+Otherwise it returns `None` and the caller keeps the launch file unchanged. Stdlib-only, no I/O — it belongs in
+`domain/` beside the other pure launch-file logic.
+
+### 3. Application: one seam in `DiscLaunchResolver`, `file_path` never rewritten
+
+The override is applied at exactly one place: `DiscLaunchResolver.resolve_bake_path`
+([ADR-0014](0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md)'s single read seam), after
+the existing disc resolution:
+
+```python
+path, stale = resolve_launch_path(install.file_path, discs, selected_disc)
+# …warn on a stale pin…
+root = folder_boot_root(path, install.rom_dir)
+return root or path
+```
+
+Because it fires only when the resolved path still carries a folder-boot marker, it composes cleanly with disc
+resolution: a resolved disc path (`…/Game (Disc 2).cue`) carries no marker, so a multi-disc ROM is never
+folder-stripped; the folder rule applies only when disc resolution returned `file_path` unchanged.
+**`RomInstall.file_path` is never rewritten** — it stays the EBOOT
+([ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) anchor), so save-path resolution, core resolution, and the
+displayed filename are untouched, exactly as the disc override and the `-e` core override leave them.
+
+All **seven** launch-bake sites draw their path from this one seam (`resolve_bake_path`, reached directly or through
+`resolve_for_install`): sync scan/apply, download-complete, per-game core set/clear, migration relaunch, the startup
+relaunch reconcile, and the disc picker. They inherit the folder-boot target with **zero call-site edits**. A ROM
+installed before this change self-heals on its next sync (or any re-bake), because every bake now resolves through the
+override.
+
+## Consequences
+
+- **PS3 folder games launch.** RPCS3's directory-boot receives the game folder it expects instead of the nested EBOOT it
+  rejects.
+- **No new launch mechanism, no `file_path` rewrite.** The folder path rides the existing baked-`launch_options` layer;
+  the launcher stays a pure `exec "$@"` wrapper ([ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md));
+  every `file_path`-derived value (save path, core, filename) is unchanged.
+- **The hardcoded surface is minimal.** Exactly one marker, matched case-sensitively; a new folder-boot system is a
+  data-only tuple entry. The two guards (`rom_dir` set, root inside `rom_dir`) keep a stray EBOOT from ever baking the
+  shared system directory.
+- **Existing installs self-heal.** The override lives entirely in the bake resolution, so no migration or re-download is
+  needed — the next sync/re-bake emits the folder target.
+- **One documented degrade path.** The `downloads.py` raw-`file_path` fallback edge (used only in the rare race where
+  the install row is not yet readable at download-complete) does not run through the resolver, so it bakes the raw path.
+  This is an acceptable, transient degrade — the next sync heals it — and is not worth threading the override through a
+  second, edge-only site.
+
+## Alternatives considered
+
+- **Re-point `RomInstall.file_path` to the game folder.** Rejected, same reason
+  [ADR-0014](0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md) rejected it for the disc
+  pick: `file_path` is the launch **file** identity that save-path resolution, core resolution, and the displayed
+  filename all derive from ([ADR-0008](0008-rom-install-launch-file-and-rom-dir.md)). None of those should change
+  because the emulator wants a directory argument. A bake-time path override changes only the launch command and leaves
+  every `file_path`-derived value stable — the layering the disc and core overrides already use.
+- **ES-DE's `.ps3` / `.ps3dir` folder-rename convention.** ES-DE collapses a PS3 game folder into a single entry when it
+  is renamed `<Game>.ps3dir` (or paired with a `.ps3` file), which also signals "launch the directory." Rejected: the
+  plugin does not launch through ES-DE's gamelist for owned shortcuts — it bakes the full command into a Steam
+  shortcut's `launch_options` ([ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md)), so an ES-DE naming
+  convention buys nothing here and would add a folder-rename step (and the ES-DE-collapse hazard ADR-0013/#1111 already
+  navigated) for a mechanism the plugin does not use.
+- **A RetroDECK `.desktop` shortcut mechanism.** Rejected for the same structural reason: it is a different launch
+  channel than the plugin's baked-`launch_options` model, adding a second launch path to maintain when the existing
+  bake-time override answers the question directly.
+
+## Deferred (deliberately)
+
+- **The PSN `<serial>/USRDIR` layout.** Digital PSN PS3 titles can install under a `<title-id>/USRDIR/…` shape without a
+  `PS3_GAME` directory. No real library case has surfaced, and the marker table is a data-only extension point, so a
+  second marker is added when (if) such a ROM appears — not speculatively.
+- **Renaming `DiscLaunchResolver`.** The seam is now a general "which path does this ROM launch with?" resolver (disc +
+  folder-boot), so its disc-specific name is slightly narrow. A rename is cosmetic and touches every wiring site; it is
+  left for a follow-up rather than bundled here.
+
+## On-device verification (gates the merge)
+
+- RPCS3 (via RetroDECK) boots a PS3 game when handed the **game root folder** as `%ROM%` (the `--no-gui <dir>` form).
+- RetroDECK's `run_game.sh` accepts a **directory** argument for the RPCS3 path (the standalone invocation from #1208
+  passes the baked folder through unchanged).
+- A previously-synced PS3 ROM re-bakes to the folder target on the next sync (the self-heal path), and its saves / core
+  badge / displayed filename are unchanged (proving `file_path` was not perturbed).
+
+See also: [ADR-0008](0008-rom-install-launch-file-and-rom-dir.md) (`file_path` = launch file, `rom_dir` = dedicated
+folder — refined here), [ADR-0009](0009-launcher-pure-exec-wrapper-baked-launch-options.md) (the baked-`launch_options`
+model the folder path rides),
+[ADR-0014](0014-per-game-disc-selection-in-db-applied-as-bake-time-launch-path-override.md) (the bake-time launch-path
+override this extends — same seam, same "never rewrite `file_path`" discipline),
+[Core and Emulator Selection](../architecture/core-emulator-selection.md#folder-boot-launch-target) (the resolver, the
+bake sites, and how the folder target composes with the disc path and the core).

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -300,6 +300,15 @@ multi-disc game shows in ES-DE as a folder plus loose disc files. The launch fil
 collision (target already exists) the rename is skipped and the staging folder is kept — never clobbered or merged.
 Existing installs from before this feature keep their old folder layout until re-downloaded.
 
+**Folder-boot launch target (PS3)**: for a PS3 folder game `detect_launch_file` picks the nested
+`…/PS3_GAME/USRDIR/EBOOT.BIN` as the install's `file_path` — the correct launch _file_ identity (save path, core, and
+displayed filename all derive from it). But RPCS3's directory-boot wants the game **folder**, not the EBOOT, so the
+baked `launch_options` carries the game directory instead. This is a bake-time path override (`folder_boot_root`,
+`domain/rom_files.py`) applied in the `DiscLaunchResolver` seam, never a `file_path` rewrite: `file_path` stays the
+EBOOT anchor while only the argument baked into the shortcut becomes the folder
+([ADR-0019](../adr/0019-folder-as-launch-target.md), see
+[Core and Emulator Selection](core-emulator-selection.md#folder-boot-launch-target)).
+
 **M3U generation rule** (`needs_m3u` in `domain/rom_files.py`): a game-named `<fs_name_no_ext>.m3u` is auto-generated
 (when no `.m3u` already exists) for **multi-disc** ROMs — two or more disc files of any kind (`.cue`/`.chd`/`.iso`) — so
 the emulator can switch discs, **and** for **single-disc bin/cue** ROMs — exactly one `.cue` — so the extract dir is

--- a/docs/architecture/core-emulator-selection.md
+++ b/docs/architecture/core-emulator-selection.md
@@ -286,12 +286,14 @@ and resolves the persisted `selected_disc` over them (`domain/disc_selection.res
 ```text
 resolve_for_install(install, selected_disc):
   discs = enumerate_discs(scan(install.rom_dir), supported_extensions(install.system))
-  if len(discs) < 2:                    ── not multi-disc → file_path unchanged
-      return install.file_path
-  if selected_disc names a disc:        ── valid pin
-      return that disc's path
-  # NULL, or a stale pin (warn + degrade):
-  return install.file_path if it ends .m3u else discs[0].path   ── the default
+  path =
+    if len(discs) < 2:                    ── not multi-disc → file_path unchanged
+        install.file_path
+    elif selected_disc names a disc:      ── valid pin
+        that disc's path
+    else:                                 ── NULL, or a stale pin (warn + degrade)
+        install.file_path if it ends .m3u else discs[0].path   ── the default
+  return folder_boot_root(path, install.rom_dir) or path   ── folder-boot override (ADR-0019)
 ```
 
 A **non-multi-disc ROM resolves to its own `file_path`** — zero behavior change for the overwhelming majority of games.
@@ -299,6 +301,24 @@ A **stale pin** (the selected disc no longer present) degrades to the default wi
 `ActiveCoreResolver`'s stale-label handling. Crucially, the resolver **never rewrites `file_path`**: it returns the path
 to bake, and `file_path`-derived values (save path, core, displayed filename) stay stable — the same bake-time
 path-override layering the `-e` core override uses.
+
+### Folder-boot launch target
+
+Some systems boot a game **directory**, not the nested launch file. A PS3 game installs as a folder whose payload is
+`…/PS3_GAME/USRDIR/EBOOT.BIN`, and `detect_launch_file` picks that EBOOT as `file_path` — correct as the launch _file_
+identity, but RPCS3's directory-boot rejects it and wants the folder that contains `PS3_GAME`
+([#1212](https://github.com/danielcopper/decky-romm-sync/issues/1212)). This is a second bake-time path override,
+layered **after** disc resolution in the same `resolve_bake_path` seam: `folder_boot_root(path, install.rom_dir)`
+(`domain/rom_files.py`) strips a hardcoded `FOLDER_BOOT_MARKERS` run (`PS3_GAME/USRDIR/EBOOT.BIN`, matched
+case-sensitively) from the resolved path and returns the game root, guarded so it fires only when `rom_dir` is set and
+the derived root stays inside `rom_dir` (a bare EBOOT in the shared system dir never bakes that shared dir). Because it
+triggers only when the resolved path still carries the marker, it composes with disc resolution — a resolved disc path
+(`…(Disc 2).cue`) has no marker, so a multi-disc ROM is never folder-stripped, and the folder rule applies only when
+disc resolution returned `file_path`. `RomInstall.file_path` stays the EBOOT (the
+[ADR-0008](../adr/0008-rom-install-launch-file-and-rom-dir.md) anchor), so save-path, core, and displayed-filename
+derivations are untouched; only the baked argument becomes the folder. The override lives in the one seam, so **every**
+bake site (the three below plus the download-complete, core set/clear, and startup-reconcile bakes) inherits it, and a
+PS3 ROM synced before this change self-heals on its next bake. See [ADR-0019](../adr/0019-folder-as-launch-target.md).
 
 ### The same three bake sites — disc path composes with the core
 

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -151,6 +151,62 @@ def detect_launch_file(files: list[tuple[str, int]], m3u_supported: bool) -> str
     return max(files, key=lambda t: t[1])[0]
 
 
+# Folder-boot systems launch the game *directory*, not the nested launch file
+# ``detect_launch_file`` picks. Each marker is the trailing component run that
+# identifies such a layout; it is matched case-sensitively (the on-disk layout
+# is standardised uppercase) and stripped to yield the game root. A future
+# folder-boot system is a data-only addition here.
+FOLDER_BOOT_MARKERS: tuple[tuple[str, ...], ...] = (("PS3_GAME", "USRDIR", "EBOOT.BIN"),)
+
+
+def folder_boot_root(launch_path: str, rom_dir: str | None) -> str | None:
+    """Return the game-root directory to bake for a folder-boot ROM, or ``None``.
+
+    Some emulators boot a game **directory** rather than the nested launch file
+    ``detect_launch_file`` selects: RPCS3 rejects ``…/PS3_GAME/USRDIR/EBOOT.BIN``
+    and wants the folder that contains ``PS3_GAME``. When *launch_path*'s trailing
+    components match a folder-boot marker (:data:`FOLDER_BOOT_MARKERS`), those
+    components are stripped and the remaining game root is returned. This also
+    collapses a one-level-deeper extract
+    (``rom_dir/<Game>/PS3_GAME/USRDIR/EBOOT.BIN`` → ``rom_dir/<Game>``).
+
+    The root is returned only when *rom_dir* is set — a single-file ROM owns no
+    folder and is never a folder-boot game — **and** the derived root is
+    inside-or-equal *rom_dir*, so a bare ``<roms>/<system>/PS3_GAME/USRDIR/EBOOT.BIN``
+    sitting directly in the shared system directory never bakes that shared
+    directory as the launch target. Returns ``None`` when no marker matches or the
+    containment guard fails; the caller then keeps the launch file unchanged.
+
+    Pure path algebra, stdlib only.
+    """
+    if rom_dir is None:
+        return None
+    rom_dir_norm = os.path.normpath(rom_dir)
+    for marker in FOLDER_BOOT_MARKERS:
+        root = _strip_marker_components(launch_path, marker)
+        if root is None:
+            continue
+        root_norm = os.path.normpath(root)
+        if root_norm == rom_dir_norm or root_norm.startswith(rom_dir_norm + os.sep):
+            return root
+    return None
+
+
+def _strip_marker_components(path: str, marker: tuple[str, ...]) -> str | None:
+    """Strip a trailing *marker* component run from *path*, or ``None`` if it does not match.
+
+    The marker components are compared against *path*'s trailing basenames in
+    order, case-sensitively. Returns the surviving prefix (the game root) when
+    every component matches, ``None`` on the first mismatch.
+    """
+    root = path
+    for expected in reversed(marker):
+        if os.path.basename(root) != expected:
+            return None
+        root = os.path.dirname(root)
+    return root
+
+
 def es_de_collapse_rename(rom_dir: str, launch_file: str) -> tuple[str, str] | None:
     """Return ``(new_rom_dir, new_launch_file)`` renaming *rom_dir* after the launch file.
 

--- a/py_modules/services/disc_launch_resolver.py
+++ b/py_modules/services/disc_launch_resolver.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from domain.disc_selection import Disc, enumerate_discs, resolve_launch_path
+from domain.rom_files import folder_boot_root
 
 if TYPE_CHECKING:
     import logging
@@ -86,6 +87,13 @@ class DiscLaunchResolver:
         unpinned ROM both resolve to the default (the ``.m3u`` when ``file_path``
         is one, else disc 1), a valid pin resolves to that disc, and a stale pin
         degrades to the default with a WARNING — never fatal, never a bogus path.
+
+        A final folder-boot override layer (``folder_boot_root``) then bakes the
+        game **directory** for a system whose emulator boots a folder rather than
+        the nested launch file (PS3/RPCS3 — ``…/PS3_GAME/USRDIR/EBOOT.BIN`` →
+        ``…``, ADR-0019). It only fires when the resolved path still carries a
+        folder-boot marker, so a resolved disc path is never rewritten;
+        ``file_path`` itself is left untouched.
         """
         path, stale = resolve_launch_path(install.file_path, discs, selected_disc)
         if stale:
@@ -95,7 +103,8 @@ class DiscLaunchResolver:
                 selected_disc,
                 install.rom_id,
             )
-        return path
+        root = folder_boot_root(path, install.rom_dir)
+        return root or path
 
     def resolve_for_install(self, install: RomInstall, selected_disc: str | None) -> str:
         """Enumerate *install* and resolve the launch-bake path in one call.

--- a/tests/contract/test_rom_relaunch_options.py
+++ b/tests/contract/test_rom_relaunch_options.py
@@ -15,6 +15,8 @@ the TS union says ``null``.
 
 from __future__ import annotations
 
+from domain.rom_install import RomInstall
+
 from ._seed import seed_install, seed_rom
 
 
@@ -44,3 +46,38 @@ async def test_unknown_rom_returns_none(harness):
     """A rom_id with no rows at all → None — nothing to re-confirm."""
     item = await harness.plugin.get_rom_relaunch_options(999)
     assert item is None
+
+
+async def test_ps3_folder_install_bakes_game_root_not_eboot(harness):
+    """A PS3 folder game bakes the game ROOT directory, not the nested EBOOT (#1212).
+
+    The install's ``file_path`` stays the ``…/PS3_GAME/USRDIR/EBOOT.BIN`` launch
+    file (the ADR-0008 anchor), but the folder-boot override (ADR-0019) makes the
+    baked ``launch_options`` quote the game folder so RPCS3's directory-boot can
+    launch it. Drives the real bake seam over real on-disk files under tmp_path.
+    """
+    rom_id = 55
+    seed_rom(harness, rom_id, platform_slug="ps3", shortcut_app_id=rom_id)
+    rom_dir = harness.tmp_path / "retrodeck" / "roms" / "ps3" / "MyGame"
+    eboot = rom_dir / "PS3_GAME" / "USRDIR" / "EBOOT.BIN"
+    eboot.parent.mkdir(parents=True, exist_ok=True)
+    eboot.write_bytes(b"\x00" * 16)
+    with harness.uow_factory() as uow:
+        uow.rom_installs.save(
+            RomInstall.mark_installed(
+                rom_id=rom_id,
+                file_path=str(eboot),
+                rom_dir=str(rom_dir),
+                platform_slug="ps3",
+                system="ps3",
+                installed_at="2026-01-01T00:00:00",
+            )
+        )
+
+    item = await harness.plugin.get_rom_relaunch_options(rom_id)
+
+    assert item is not None
+    launch_options = item["launch_options"]
+    # The baked path is the game folder (quoted), never the nested EBOOT.
+    assert f'"{rom_dir}"' in launch_options
+    assert "EBOOT.BIN" not in launch_options

--- a/tests/domain/test_rom_files.py
+++ b/tests/domain/test_rom_files.py
@@ -9,6 +9,7 @@ from domain.rom_files import (
     build_m3u_content,
     detect_launch_file,
     es_de_collapse_rename,
+    folder_boot_root,
     is_multi_file_download,
     needs_m3u,
     resolve_local_file_name,
@@ -343,6 +344,46 @@ class TestEsDeCollapseRename:
         rom_dir = "/roms/wiiu/Game"
         launch_file = "/roms/wiiu/Game/code/Game.rpx"
         assert es_de_collapse_rename(rom_dir, launch_file) is None
+
+
+class TestFolderBootRoot:
+    """Tests for folder_boot_root — the PS3-style folder-as-launch-target override."""
+
+    def test_ps3_marker_strips_to_game_root(self):
+        # …/PS3_GAME/USRDIR/EBOOT.BIN → the game folder (the dir holding PS3_GAME).
+        rom_dir = "/roms/ps3/MyGame"
+        launch = "/roms/ps3/MyGame/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert folder_boot_root(launch, rom_dir) == rom_dir
+
+    def test_nested_one_level_deeper_extract_strips_to_inner_game_root(self):
+        # An extract that nests the PS3_GAME tree one level below rom_dir still
+        # resolves to the folder that holds PS3_GAME, which stays inside rom_dir.
+        rom_dir = "/roms/ps3/MyGame"
+        launch = "/roms/ps3/MyGame/InnerGame/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert folder_boot_root(launch, rom_dir) == "/roms/ps3/MyGame/InnerGame"
+
+    def test_none_rom_dir_returns_none(self):
+        # A single-file ROM owns no folder → never a folder-boot game.
+        launch = "/roms/ps3/MyGame/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert folder_boot_root(launch, None) is None
+
+    def test_non_marker_eboot_elsewhere_returns_none(self):
+        # An EBOOT.BIN not under the full PS3_GAME/USRDIR run does not match.
+        rom_dir = "/roms/ps3/MyGame"
+        assert folder_boot_root("/roms/ps3/MyGame/EBOOT.BIN", rom_dir) is None
+
+    def test_derived_root_escaping_rom_dir_returns_none(self):
+        # The stripped root is the shared system dir (rom_dir's parent), so the
+        # containment guard rejects it — never bake the shared directory.
+        rom_dir = "/roms/ps3/MyGame"
+        launch = "/roms/ps3/PS3_GAME/USRDIR/EBOOT.BIN"
+        assert folder_boot_root(launch, rom_dir) is None
+
+    def test_lowercase_marker_directory_does_not_match(self):
+        # The layout is standardised uppercase; lowercase ps3_game must not match.
+        rom_dir = "/roms/ps3/MyGame"
+        launch = "/roms/ps3/MyGame/ps3_game/USRDIR/EBOOT.BIN"
+        assert folder_boot_root(launch, rom_dir) is None
 
 
 class TestResolveLocalFileName:

--- a/tests/services/test_disc_launch_resolver.py
+++ b/tests/services/test_disc_launch_resolver.py
@@ -189,3 +189,45 @@ class TestResolveForInstall:
         resolver = _build(FakeFileLister(), FakeSystemExtensions(), logger)
         install = _install(file_path="/roms/snes/game.sfc", rom_dir=None)
         assert resolver.resolve_for_install(install, None) == "/roms/snes/game.sfc"
+
+
+class TestFolderBootTarget:
+    """The PS3-style folder-as-launch-target override layered over disc resolution.
+
+    A folder-boot ROM (PS3/RPCS3) bakes the game **directory**, not the nested
+    ``…/PS3_GAME/USRDIR/EBOOT.BIN`` launch file. The override rides on top of disc
+    resolution: it fires only when the resolved path still carries the folder-boot
+    marker, so a resolved disc path (multi-disc) or a single-file ROM is never
+    touched. See ADR-0019.
+    """
+
+    def test_ps3_folder_install_bakes_the_game_root(self, logger):
+        # PS3 folder game: no disc images, so disc resolution returns file_path
+        # (the EBOOT), then the folder-boot override strips to the game folder.
+        rom_dir = "/roms/ps3/MyGame"
+        eboot = f"{rom_dir}/PS3_GAME/USRDIR/EBOOT.BIN"
+        files = {rom_dir: [eboot]}
+        resolver = _build(FakeFileLister(files), FakeSystemExtensions(), logger)
+        install = _install(file_path=eboot, rom_dir=rom_dir, system="ps3")
+        assert resolver.resolve_for_install(install, None) == rom_dir
+
+    def test_resolved_disc_path_is_never_folder_stripped(self, logger):
+        # Precedence: the folder rule applies only when disc resolution returned
+        # file_path. A pinned multi-disc ROM resolves to its disc path, which
+        # carries no folder-boot marker, so the override is a no-op.
+        files = {
+            "/roms/psx/game": [
+                "/roms/psx/game/Game (Disc 1).cue",
+                "/roms/psx/game/Game (Disc 2).cue",
+            ]
+        }
+        resolver = _build(FakeFileLister(files), FakeSystemExtensions(), logger)
+        install = _install(file_path="/roms/psx/game/Game (Disc 1).cue", rom_dir="/roms/psx/game")
+        assert resolver.resolve_for_install(install, "Game (Disc 2).cue") == "/roms/psx/game/Game (Disc 2).cue"
+
+    def test_single_file_install_unaffected_by_folder_rule(self, logger):
+        # rom_dir is None → the override is skipped by construction; regression
+        # guard that the folder rule cannot perturb a bare single-file ROM.
+        resolver = _build(FakeFileLister(), FakeSystemExtensions(), logger)
+        install = _install(file_path="/roms/snes/game.sfc", rom_dir=None)
+        assert resolver.resolve_for_install(install, None) == "/roms/snes/game.sfc"


### PR DESCRIPTION
With standalone routing (#1208), PS3 games launched via `%EMULATOR_RPCS3% --no-gui %ROM%` — but `%ROM%` was baked as the nested `…/PS3_GAME/USRDIR/EBOOT.BIN` from `detect_launch_file`, which RPCS3's directory-boot rejects ("Invalid file or folder"). It wants the game root folder.

The launch TARGET is now overridable at bake time, extending ADR-0014's override layer: a pure `folder_boot_root` kernel (marker table `PS3_GAME/USRDIR/EBOOT.BIN`, case-sensitive, guarded by rom_dir containment) plus a two-line hook in `DiscLaunchResolver.resolve_bake_path` — all seven bake sites inherit through the existing seam with zero call-site edits. `RomInstall.file_path` stays the launch FILE and ADR-0008 derivation anchor (saves, display, migration unaffected); already-installed PS3 games self-heal on the next sync, no migration needed. A resolved disc path can never match the marker (disc extensions exclude `.bin`), so disc selection composes untouched.

Decision + rejected alternatives (re-pointing file_path; ES-DE `.ps3`/`.ps3dir` folder renames; RetroDECK `.desktop` shortcuts) and the deliberate deferrals (PSN `<serial>/USRDIR` layout; resolver rename) are recorded in the new ADR-0019. CONTEXT.md and both architecture pages updated.

Tests: domain path-algebra cases (containment guard, case pin, nested-deeper), resolver precedence (disc pin wins, single-file untouched), and a real-bootstrap contract test asserting the emitted launch_options quotes the game root and carries no EBOOT.BIN.

**Merge gate: on-device verification** (recorded in ADR-0019) — RPCS3 0.0.40 boots the folder handed through RetroDECK's run_game.sh, and a pre-existing PS3 install re-bakes on sync with saves/core/display unchanged. This PR stays open until that Game Mode check passes.

Closes #1212

---

**Update after on-device verification:** the "run_game.sh passes directories through" assumption was falsified on-device (run_game.sh:63-67 reinterprets any directory as ES-DE "directory as a file": `<dir>/<dirname>`). The folder TARGET from this PR stands (RPCS3 verifiably rejects the nested EBOOT and boots the folder); the missing half — a direct sandbox invocation that bypasses run_game for folder-boot games, plus m3u suppression and a PS3_DISC.SFB dump heal — lives in #1305 (it depends on the es_find_rules resolver introduced there). ADR-0019 was revised accordingly in #1305. Merge order: this PR first, then #1305 retargeted onto main.