### PR TITLE
chore(playtime): add suspend-hook registration diagnostics

### DIFF
--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -10,7 +10,9 @@ vi.mock("../api/backend", () => ({
   getAppIdRomIdMap: vi.fn(),
   finalizeGameSession: vi.fn(),
   logInfo: vi.fn(),
+  logWarn: vi.fn(),
   logError: vi.fn(),
+  debugLog: vi.fn(),
 }));
 
 vi.mock("./migrationStore", () => ({ setMigrationStatus: vi.fn() }));
@@ -490,5 +492,162 @@ describe("sessionManager reload adoption", () => {
     await expect(initSessionManager()).resolves.toBeUndefined();
 
     expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+  });
+});
+
+// #1148: on-device the suspend/resume hooks never fired, so decision C's
+// suspend-subtraction shipped dormant. These cover the registration diagnostics
+// that a Game-Mode run will surface — the API-missing headline, a throwing
+// registration, and the availability probe — plus the happy-path handle report.
+describe("sessionManager suspend-hook diagnostics", () => {
+  // `system` is intentionally allowed to be undefined so a test can model a
+  // SteamClient with no `System` namespace at all (the #1148 crash-proofness case).
+  const stubSteamClient = (system: Record<string, unknown> | undefined, user?: Record<string, unknown>) => {
+    const client: Record<string, unknown> = {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      System: system,
+    };
+    if (user) client.User = user;
+    vi.stubGlobal("SteamClient", client);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
+    vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+  });
+
+  afterEach(() => {
+    destroySessionManager();
+  });
+
+  it("warns at headline level when both suspend/resume members are missing, and init still completes", async () => {
+    stubSteamClient({}); // System exposes neither Register* member
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // Actionable headline names both absent members (booleans false).
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=false RegisterForOnResumeFromSuspend=false",
+    );
+    // Never attempted registration → no throw path was taken.
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("registration threw"));
+    // No hooks were registered, so teardown must not throw on null handles.
+    expect(() => destroySessionManager()).not.toThrow();
+  });
+
+  it("warns only about the missing member when suspend exists but resume does not", async () => {
+    stubSteamClient({ RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })) });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=true RegisterForOnResumeFromSuspend=false",
+    );
+  });
+
+  it("catches and warns when registration throws, and init still completes", async () => {
+    stubSteamClient({
+      RegisterForOnSuspendRequest: vi.fn(() => {
+        throw new Error("boom");
+      }),
+      RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+    });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // Members present → no "missing" headline; the throw is caught and warned.
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("hooks missing"));
+    expect(backend.logWarn).toHaveBeenCalledWith(expect.stringContaining("Suspend/resume registration threw"));
+    expect(backend.logWarn).toHaveBeenCalledWith(expect.stringContaining("boom"));
+  });
+
+  it("debug-logs the handle shape on a clean registration", async () => {
+    stubSteamClient({
+      RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })),
+      RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+    });
+
+    await initSessionManager();
+
+    // No headline warning on a healthy build; the debug tier reports both
+    // handles carry an `unregister` function.
+    expect(backend.logWarn).not.toHaveBeenCalled();
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration: suspend={unregister:fn} resume={unregister:fn}",
+    );
+  });
+
+  it("probes SteamClient for suspend/resume/sleep/wake members and excludes unrelated ones", async () => {
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForOnResumeFromSleep: vi.fn(), // matches /sleep/ — a candidate alternative
+        GetSystemInfo: vi.fn(), // unrelated — must be excluded
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(), // matches /suspend/ under User
+        RegisterForShutdownStart: vi.fn(), // unrelated — must be excluded
+      },
+    );
+
+    await initSessionManager();
+
+    const probeCall = vi
+      .mocked(backend.debugLog)
+      .mock.calls.find((c) => String(c[0]).startsWith("SteamClient suspend/resume surface:"));
+    expect(probeCall).toBeDefined();
+    const surface = String(probeCall?.[0]);
+    expect(surface).toContain("System.RegisterForOnSuspendRequest");
+    expect(surface).toContain("System.RegisterForOnResumeFromSuspend");
+    expect(surface).toContain("System.RegisterForOnResumeFromSleep");
+    expect(surface).toContain("User.RegisterForPrepareForSystemSuspendProgress");
+    expect(surface).not.toContain("GetSystemInfo");
+    expect(surface).not.toContain("RegisterForShutdownStart");
+  });
+
+  it("survives an absent SteamClient.System: warns, still runs adoption, no crash", async () => {
+    stubSteamClient(undefined); // SteamClient has no `System` namespace at all
+    // A running RomM game with no breadcrumb → adoption case (a′) records a
+    // session. That only fires if init got PAST the presence read without
+    // throwing — the guard this test pins. (On the pre-fix commit the presence
+    // read `typeof SteamClient.System.RegisterForOnSuspendRequest` throws a
+    // TypeError that escapes init, so none of the asserts below hold.)
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // System absent → both members read as false → headline warns.
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=false RegisterForOnResumeFromSuspend=false",
+    );
+    // The surface probe still emits (init reached it, never threw).
+    expect(backend.debugLog).toHaveBeenCalledWith("SteamClient suspend/resume surface: (none)");
+    // Adoption still ran — init did not abort before it.
+    expect(backend.recordSessionStart).toHaveBeenCalledWith(ROM_ID);
+    // Nothing registered → teardown must not throw on null handles.
+    expect(() => destroySessionManager()).not.toThrow();
+  });
+
+  it("describes an undefined registration handle by type, not as a thrown registration", async () => {
+    // A build where the member exists but returns undefined instead of a handle.
+    stubSteamClient({
+      RegisterForOnSuspendRequest: vi.fn(() => undefined),
+      RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+    });
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // describeHandle must classify the undefined handle by type rather than
+    // dereferencing it — otherwise the throw is misattributed as "registration
+    // threw" (the pre-fix behavior this test pins).
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("registration threw"));
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration: suspend=type=undefined resume={unregister:fn}",
+    );
   });
 });

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -7,10 +7,19 @@
  */
 
 import { toaster } from "@decky/api";
-import { recordSessionStart, getAppIdRomIdMap, finalizeGameSession, logInfo, logError } from "../api/backend";
+import {
+  recordSessionStart,
+  getAppIdRomIdMap,
+  finalizeGameSession,
+  logInfo,
+  logWarn,
+  logError,
+  debugLog,
+} from "../api/backend";
 import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
+import { detach } from "./detach";
 
 declare let Router: {
   MainRunningApp: { appid: number; display_name: string } | null;
@@ -295,6 +304,60 @@ async function adoptOrphanedSession(): Promise<void> {
 }
 
 /**
+ * Read `SteamClient.System` as a plain record, tolerating a runtime where it is
+ * absent, not an object, or a throwing getter — any of which yields an empty
+ * record. Keeps the #1148 presence check from throwing out of
+ * `initSessionManager` (before adoption) when SteamClient is malformed.
+ */
+function readSystemApi(): Record<string, unknown> {
+  try {
+    const system = (SteamClient as unknown as Record<string, unknown>).System;
+    if (system !== null && typeof system === "object") return system as Record<string, unknown>;
+  } catch {
+    // Odd SteamClient shape (e.g. a throwing getter) — fall through to {}.
+  }
+  return {};
+}
+
+/**
+ * Report an unregister handle's runtime shape without trusting its declared
+ * type — the whole point of the #1148 probe is that the runtime may not match
+ * the `.d.ts`, so the handle is typed `unknown` and every shape is handled:
+ * `null`, a non-object (e.g. a build that returns `undefined`), or an object
+ * that may or may not carry an `unregister` function.
+ */
+function describeHandle(handle: unknown): string {
+  if (handle === null) return "null";
+  if (typeof handle !== "object") return `type=${typeof handle}`;
+  const rec = handle as Record<string, unknown>;
+  return `{unregister:${typeof rec.unregister === "function" ? "fn" : "missing"}}`;
+}
+
+/**
+ * Enumerate the suspend/resume/sleep/wake members `SteamClient` actually exposes
+ * at runtime (#1148 investigation point 3 — is there a newer/alternative API on
+ * this SteamOS build?). Never throws: an odd or absent SteamClient shape degrades
+ * to a marker string that still gets logged.
+ */
+function probeSuspendSurface(): string {
+  try {
+    const client = SteamClient as unknown as Record<string, unknown>;
+    const pattern = /suspend|resume|sleep|wake/i;
+    const matches: string[] = [];
+    for (const namespace of ["System", "User"]) {
+      const ns = client[namespace];
+      if (ns === null || typeof ns !== "object") continue;
+      for (const key of Object.keys(ns)) {
+        if (pattern.test(key)) matches.push(`${namespace}.${key}`);
+      }
+    }
+    return matches.length > 0 ? matches.join(", ") : "(none)";
+  } catch (e) {
+    return `probe failed: ${e}`;
+  }
+}
+
+/**
  * Initialize session manager — registers all lifecycle hooks.
  * Call once during plugin load.
  */
@@ -326,13 +389,40 @@ export async function initSessionManager(): Promise<void> {
       });
   });
 
-  // Suspend/resume for accurate playtime
-  try {
-    suspendHook = SteamClient.System.RegisterForOnSuspendRequest(handleSuspend);
-    resumeHook = SteamClient.System.RegisterForOnResumeFromSuspend(handleResume);
-  } catch (e) {
-    console.warn("[romm-sync] Suspend/resume hooks unavailable:", e);
+  // Suspend/resume for accurate playtime. #1148 diagnostics: on-device these
+  // hooks never fired, so decision C's suspend-subtraction shipped dormant.
+  // Probe presence, registration outcome, and the returned handle shape once per
+  // init so a single Game-Mode run tells us whether the API is missing, throwing,
+  // or registering but never firing. The typed SteamClient claims the members
+  // always exist, so presence is read through an `unknown` view — the runtime is
+  // the authority here, not the `.d.ts`. `SteamClient.System` itself is read
+  // defensively (absent, non-object, or a throwing getter → empty record) so a
+  // broken SteamClient still emits the "hooks missing" headline + surface probe
+  // and lets init reach the #1054 adoption, rather than throwing before either.
+  const systemApi = readSystemApi();
+  const hasSuspendReg = typeof systemApi.RegisterForOnSuspendRequest === "function";
+  const hasResumeReg = typeof systemApi.RegisterForOnResumeFromSuspend === "function";
+  if (!hasSuspendReg || !hasResumeReg) {
+    // Actionable headline — the members decision C depends on are absent on this
+    // build. Warn so it lands even at the default log level.
+    logWarn(
+      `Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=${hasSuspendReg} RegisterForOnResumeFromSuspend=${hasResumeReg}`,
+    );
   }
+  try {
+    if (hasSuspendReg) suspendHook = SteamClient.System.RegisterForOnSuspendRequest(handleSuspend);
+    if (hasResumeReg) resumeHook = SteamClient.System.RegisterForOnResumeFromSuspend(handleResume);
+    detach(
+      debugLog(
+        `Suspend/resume registration: suspend=${describeHandle(suspendHook)} resume=${describeHandle(resumeHook)}`,
+      ),
+    );
+  } catch (e) {
+    logWarn(`Suspend/resume registration threw: ${e}`);
+  }
+  // Investigation point 3 — enumerate the suspend/resume members SteamClient
+  // actually exposes at runtime. Debug-gated; never throws.
+  detach(debugLog(`SteamClient suspend/resume surface: ${probeSuspendSurface()}`));
 
   // Adopt a session orphaned by a plugin reload mid-game. Serialized on the
   // lifecycle chain so a stop notification arriving during adoption finalizes


### PR DESCRIPTION
On-device, the suspend/resume hooks (`RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend`) never fire, leaving the #1051 decision-C suspend subtraction dormant (#1148). The existing handler logs can only show that the handlers did not run — not WHY.

This adds level-gated registration diagnostics to `initSessionManager`, routed through the plugin's frontend log so they land in the same [FE] device log:

- warn (default-visible): a "Suspend/resume hooks missing" headline when the API members are absent — the actionable case.
- debug: the registration result (shape of each returned unregister handle) and a defensive SteamClient surface probe listing every suspend/resume/sleep/wake-ish member — so one debug-level Game Mode run distinguishes renamed-API vs registered-but-silent and surfaces candidate replacement APIs.

All reads go through guarded views (`readSystemApi`, `probeSuspendSurface`, `describeHandle`) — an absent, non-object, or throwing `SteamClient.System` still emits the headline and probe, skips registration, and lets init proceed to the #1054 session adoption (proven by tests that fail on the unguarded variant). Handler logs and the suspend-subtraction flow are untouched.

Refs #1148 (stays open — the fix follows the diagnosis).

docs: N/A (diagnostic logging only; no behavior, flow, or UI change)