### PR TITLE
fix(library): stop classifying the derived platform_name (permanent preview delta)

### DIFF
--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -31,10 +31,22 @@ def classify_roms(
     """Bucket fetched ROMs against the saved shortcut registry.
 
     Returns the ROMs split into new (not in registry), changed (registry
-    entry exists but name/platform_name/platform_slug/fs_name differs),
-    unchanged_ids (registry matches exactly), stale (in registry but not in
-    the current fetch), and the count of stale ROMs whose stored platform
-    no longer appears in fetched_platform_names.
+    entry exists but a *persisted* identity field — name, platform_slug, or
+    fs_name — differs), unchanged_ids (registry matches exactly), stale (in
+    registry but not in the current fetch), and the count of stale ROMs whose
+    stored platform no longer appears in fetched_platform_names.
+
+    ``platform_name`` is deliberately excluded from the changed comparison:
+    it is a derived display field, never persisted on the ``roms`` row. The
+    registry side resolves it from the enabled-platforms-only slug→name map
+    (falling back to the bare slug for a disabled platform), while the fetch
+    side gets RomM's full display name, so a divergence between the two can
+    never be healed by an apply (the upsert writes only
+    platform_slug/name/fs_name) — comparing it produced a permanent phantom
+    "changed" delta (#1292). Platform display renames are diffed separately by
+    ``compute_platform_collection_diff``. ``platform_name`` is still read here
+    for the disabled-platform stale count, which intentionally keys on the
+    live-resolved display name.
 
     Changed ROMs are returned as fresh dicts with an added ``existing_app_id``
     key — the caller's shortcuts_data is not mutated.
@@ -47,9 +59,11 @@ def classify_roms(
         reg = registry.get(str(sd["rom_id"]))
         if not reg or not reg.get("app_id"):
             new.append(sd)
+        # Compare only persisted identity fields. platform_name is a derived
+        # display field (never on the roms row) — comparing it produced a
+        # permanent phantom "changed" delta (#1292); see the docstring.
         elif (
             reg.get("name") != sd["name"]
-            or reg.get("platform_name") != sd.get("platform_name")
             or reg.get("platform_slug") != sd.get("platform_slug")
             or reg.get("fs_name") != sd.get("fs_name", "")
         ):

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -34,7 +34,7 @@ def _make_sd(
 
 
 def _reg(name="Game", platform_name="N64", platform_slug="n64", fs_name="game.z64", app_id=1001):
-    """Build a registry entry dict matching build_registry_entry output."""
+    """Build a registry entry dict matching _read_preview_baseline output."""
     return {
         "app_id": app_id,
         "name": name,
@@ -119,14 +119,39 @@ class TestClassifyRoms:
         assert new == []
         assert unchanged_ids == []
 
-    def test_platform_name_change_detected(self):
+    def test_platform_name_divergence_not_classified_as_changed(self):
+        """A derived-display-only divergence never counts as changed (#1292).
+
+        ``platform_name`` is a derived, non-persisted display field. A ROM
+        riding an enabled collection whose platform is *disabled* resolves to
+        the bare slug ("gba") on the registry side (the enabled-only
+        slug→name map has no entry, so it falls back to the slug) but to
+        RomM's full display name ("Game Boy Advance") on the fetch side. With
+        every persisted field (name/platform_slug/fs_name) equal, that
+        divergence must NOT classify as changed — the apply upsert persists
+        only platform_slug/name/fs_name, so it could never be healed and
+        produced a permanent phantom "1 updated" preview delta.
+        """
         registry = {
-            "1": _reg(name="Game A", platform_name="Nintendo 64", app_id=1001),
+            "1": _reg(name="Game A", platform_name="gba", platform_slug="gba", fs_name="game.gba", app_id=1001),
         }
-        sd = [_make_sd(1, "Game A", platform_name="N64")]
-        _, changed, _, _, _ = classify_roms(sd, registry, {"N64"})
+        sd = [_make_sd(1, "Game A", platform_name="Game Boy Advance", platform_slug="gba", fs_name="game.gba")]
+        new, changed, unchanged_ids, _, _ = classify_roms(sd, registry, {"N64"})
+        assert changed == []
+        assert new == []
+        assert unchanged_ids == [1]
+
+    def test_platform_slug_change_detected(self):
+        """A genuine platform change (persisted platform_slug differs) is changed."""
+        registry = {
+            "1": _reg(name="Game A", platform_name="Game Boy Advance", platform_slug="gba", app_id=1001),
+        }
+        sd = [_make_sd(1, "Game A", platform_name="Game Boy Color", platform_slug="gbc")]
+        _, changed, unchanged_ids, _, _ = classify_roms(sd, registry, {"N64"})
         assert len(changed) == 1
         assert changed[0]["rom_id"] == 1
+        assert changed[0]["existing_app_id"] == 1001
+        assert unchanged_ids == []
 
     def test_fs_name_change_detected(self):
         registry = {


### PR DESCRIPTION
On-device, every sync preview permanently reported "ROMs: 1 updated": a ROM riding an enabled collection while its platform is disabled diverges on `platform_name` — the registry side falls back to the bare slug (the enabled-platforms map lacks the disabled platform) while the collection fetch carries RomM's display name. `platform_name` is a derived, never-persisted display field, and the apply upsert writes only name/platform_slug/fs_name — so the divergence is structurally un-healable (verified live: Force Full Sync re-committed the ROM and the delta persisted).

`classify_roms` no longer compares `platform_name`. The clause provably never fired legitimately: for enabled platforms both sides derive the value from the same live work-queue, and platform display renames are detected separately by `compute_platform_collection_diff`. The classifier now compares only fields the apply actually persists, so every "changed" verdict is healable. The registry still carries `platform_name` for the disabled-platform remove count, which is untouched.

Regression test pins the exact trigger (red on the pre-fix code, green with the fix); a sibling test pins that a genuine `platform_slug` change still classifies as changed.

Refs #1292 (fixes this self-contained sub-case; the broader preview/apply unification stays open)

docs: N/A (restores the documented "up to date" preview semantics; the data model docs already state platform_name is not persisted)