### PR TITLE
fix(downloads): name multi-file extract dir from the ROM identity, not files[0]

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -290,15 +290,20 @@ a ZIP. Keying on `has_multiple_files` alone would take the single-file path and 
 unreadable `.nsp`. The boolean is kept as a defensive fallback for payloads that omit `files`; a genuine nested-single
 ROM has `len(files) == 1` and correctly stays on the flat single-file path.
 
-**ES-DE directory-collapse rename**: a multi-file ROM is extracted into a staging folder named after the ZIP
-(`fs_name_no_ext`), but the per-game folder is then renamed after the **detected launch file including its extension**
-(e.g. `Final Fantasy VII (USA).m3u/` containing `Final Fantasy VII (USA).m3u`). ES-DE only collapses a directory into a
-single game entry when the folder name matches the launch file's full name with extension; without the rename a
-multi-disc game shows in ES-DE as a folder plus loose disc files. The launch file is only known after extraction (an
-`.m3u` may be auto-generated — see below), so the rename happens last, after launch-file detection, via
-`es_de_collapse_rename` (`domain/rom_files.py`) + the `DownloadFileStore.move_dir` whole-directory move. On a name
-collision (target already exists) the rename is skipped and the staging folder is kept — never clobbered or merged.
-Existing installs from before this feature keep their old folder layout until re-downloaded.
+**ES-DE directory-collapse rename**: a multi-file ROM is extracted into a staging folder named after the **ROM's
+identity** — `fs_name_no_ext`, falling back to `splitext(fs_name)` (`resolve_extract_dir_name` in `domain/rom_files.py`)
+— **never** after `files[0]`. That distinction matters for a `has_nested_single_file` folder game served as a ZIP (a PS3
+title whose first listed file is an arbitrary inner asset like a music file): `resolve_local_file_name` returns that
+asset's name for the local _filename_, but the extract _directory_ must carry the game's identity or the whole install —
+launch `file_path`, `rom_dir`, and the folder-boot launch bake — inherits the wrong name. The staging folder is then
+renamed after the **detected launch file including its extension** (e.g. `Final Fantasy VII (USA).m3u/` containing
+`Final Fantasy VII (USA).m3u`). ES-DE only collapses a directory into a single game entry when the folder name matches
+the launch file's full name with extension; without the rename a multi-disc game shows in ES-DE as a folder plus loose
+disc files. The launch file is only known after extraction (an `.m3u` may be auto-generated — see below), so the rename
+happens last, after launch-file detection, via `es_de_collapse_rename` (`domain/rom_files.py`) + the
+`DownloadFileStore.move_dir` whole-directory move. On a name collision (target already exists) the rename is skipped and
+the staging folder is kept — never clobbered or merged. Existing installs from before this feature keep their old folder
+layout until re-downloaded.
 
 **M3U generation rule** (`needs_m3u` in `domain/rom_files.py`): a game-named `<fs_name_no_ext>.m3u` is auto-generated
 (when no `.m3u` already exists) for **multi-disc** ROMs — two or more disc files of any kind (`.cue`/`.chd`/`.iso`) — so

--- a/py_modules/domain/rom_files.py
+++ b/py_modules/domain/rom_files.py
@@ -193,6 +193,18 @@ def es_de_collapse_rename(rom_dir: str, launch_file: str) -> tuple[str, str] | N
     return (new_rom_dir, new_launch_file)
 
 
+def synthetic_rom_name(rom_detail: dict[str, Any]) -> str:
+    """Last-resort identity name for a ROM whose ``fs_name`` is missing or unusable.
+
+    ``rom_<id>`` (or ``rom_unknown`` when ``id`` is also absent). Shared by the
+    local-filename and extract-dir resolvers as the fallback so a ROM without a
+    usable server-supplied name still lands under a single, stable identity — and
+    used again by the download service as the substitute when a server-supplied
+    name coerces to a degenerate path component.
+    """
+    return f"rom_{rom_detail.get('id', 'unknown')}"
+
+
 def resolve_local_file_name(rom_detail: dict[str, Any]) -> tuple[str, bool]:
     """Resolve the on-disk filename for a ROM.
 
@@ -211,10 +223,33 @@ def resolve_local_file_name(rom_detail: dict[str, Any]) -> tuple[str, bool]:
         inconsistent state the resolved name still falls back to
         ``fs_name``.
     """
-    fs_name = rom_detail.get("fs_name", f"rom_{rom_detail.get('id', 'unknown')}")
+    fs_name = rom_detail.get("fs_name", synthetic_rom_name(rom_detail))
     if not rom_detail.get("has_nested_single_file"):
         return (fs_name, False)
     files = rom_detail.get("files") or []
     if not files:
         return (fs_name, True)
     return (files[0].get("file_name") or fs_name, False)
+
+
+def resolve_extract_dir_name(rom_detail: dict[str, Any]) -> str:
+    """Resolve the directory name for an extracted multi-file ROM.
+
+    The extract directory must carry the ROM's own identity, because
+    everything downstream inherits it — the launch ``file_path``, the
+    ``rom_dir`` install record, and any folder-boot launch bake. RomM reports
+    the extensionless ROM name as ``fs_name_no_ext``; when that is absent the
+    extension is stripped from ``fs_name``, and when ``fs_name`` is also
+    missing the synthetic ``rom_<id>`` (or ``rom_unknown``) mirrors
+    ``resolve_local_file_name``.
+
+    Deliberately never reads ``files[0]``: for a ``has_nested_single_file``
+    ROM that RomM serves as a ZIP (a folder game such as a PS3 title),
+    ``files[0]`` is an arbitrary inner asset, so naming the directory after it
+    would misname the whole install.
+    """
+    fs_name_no_ext = rom_detail.get("fs_name_no_ext")
+    if fs_name_no_ext:
+        return fs_name_no_ext
+    fs_name = rom_detail.get("fs_name", synthetic_rom_name(rom_detail))
+    return os.path.splitext(fs_name)[0]

--- a/py_modules/lib/path_safety.py
+++ b/py_modules/lib/path_safety.py
@@ -8,19 +8,25 @@ belongs in ``lib/`` rather than ``domain/``. The source of the
 configured root (e.g. the ``RetroDeckPaths`` Protocol) stays in
 ``services/``; this module only consumes the resolved string.
 
-Two guards live here for server-supplied path components:
+Guards for server-supplied path components:
 
 - :func:`safe_path_component` — lexical (no I/O). Validates that an
   untrusted string is a single safe filename component before it is
-  joined onto a base.
+  joined onto a base, **raising** on a violation.
+- :func:`coerce_safe_component` — lexical (no I/O). The *defanging*
+  counterpart: reduces an untrusted string to a single safe component and
+  **substitutes a caller-supplied fallback** for a degenerate result
+  (``..``/``.``/empty/whitespace) instead of raising, for call sites that
+  must proceed with a safe name rather than abort the operation.
 - :func:`safe_join` — realpath containment. Joins untrusted parts onto a
   trusted base and confirms the result resolves strictly below the base
   (the same semantics as :func:`is_safe_rom_path`), so a multi-component
   registry path or a symlink cannot escape.
 
-Both raise :class:`PathTraversalError` on a violation so call sites can
-fail closed (abort the operation, surface a canonical failure) rather
-than silently writing outside the configured root.
+The two validating guards (:func:`safe_path_component`, :func:`safe_join`)
+raise :class:`PathTraversalError` so call sites can fail closed (abort the
+operation, surface a canonical failure) rather than silently writing
+outside the configured root; :func:`coerce_safe_component` never raises.
 """
 
 from __future__ import annotations
@@ -70,6 +76,37 @@ def safe_path_component(name: str) -> str:
     if os.path.normpath(name) != name:
         raise PathTraversalError(f"path component is not normalized: {name!r}")
     return name
+
+
+_DEGENERATE_COMPONENTS = frozenset({"", ".", ".."})
+
+
+def coerce_safe_component(name: str, fallback: str) -> tuple[str, bool]:
+    """Coerce *name* to a single safe path component, or *fallback*. Lexical, no I/O.
+
+    The defanging counterpart to :func:`safe_path_component`: where that
+    *raises* to abort the whole operation, this *coerces* so the caller can
+    proceed with a safe name. It strips any directory portion with
+    ``os.path.basename``, then substitutes *fallback* for a degenerate result
+    that would not name a real child — the empty string, whitespace only,
+    ``"."`` or ``".."``.
+
+    The degenerate check is load-bearing: ``os.path.basename("..") == ".."``
+    and ``os.path.basename("dir/") == ""``, and ``os.path.join(base, "..")``
+    (or ``os.path.join(base, "")``) resolves to *base*'s parent or *base*
+    itself — so a downstream ``rmtree`` or write would hit the wrong directory.
+    Basename alone (traversal-stripping) is not enough.
+
+    *fallback* must itself already be a valid single component (e.g. a
+    synthetic ``rom_<id>`` name); it is returned verbatim for a degenerate
+    input. Returns ``(component, changed)`` where *changed* is True whenever
+    the returned component differs from *name*, so the caller logs exactly one
+    warning and never mistakes a coercion for a passthrough.
+    """
+    component = os.path.basename(name)
+    if component.strip() in _DEGENERATE_COMPONENTS:
+        return (fallback, True)
+    return (component, component != name)
 
 
 def safe_join(base: str, *parts: str) -> str:

--- a/py_modules/services/downloads.py
+++ b/py_modules/services/downloads.py
@@ -22,13 +22,15 @@ from domain.rom_files import (
     es_de_collapse_rename,
     is_multi_file_download,
     needs_m3u,
+    resolve_extract_dir_name,
     resolve_local_file_name,
+    synthetic_rom_name,
 )
 from domain.rom_install import RomInstall
 from domain.shortcut_data import EmulatorInvocation, build_launch_options, resolve_emulator_invocation
 from lib.errors import error_response
 from lib.list_result import ErrorCode
-from lib.path_safety import PathTraversalError, safe_join
+from lib.path_safety import PathTraversalError, coerce_safe_component, safe_join
 
 if TYPE_CHECKING:
     import logging
@@ -283,9 +285,12 @@ class DownloadService:
                 self._logger.warning(
                     f"has_nested_single_file=true but files list is empty; falling back to fs_name='{file_name}'"
                 )
-            # Fix 1: Sanitize fs_name to prevent path traversal
-            safe_name = os.path.basename(file_name)
-            if safe_name != file_name:
+            # Coerce the server-supplied name to a single safe component: strip
+            # any directory portion and reject a degenerate result (``..`` would
+            # escape the platform dir, ``.``/``""`` would resolve to it) — falling
+            # back to the synthetic rom_<id> identity.
+            safe_name, name_changed = coerce_safe_component(file_name, synthetic_rom_name(rom_detail))
+            if name_changed:
                 self._logger.warning(f"Sanitized fs_name from '{file_name}' to '{safe_name}'")
                 file_name = safe_name
             file_size = rom_detail.get("fs_size_bytes", 0)
@@ -405,15 +410,36 @@ class DownloadService:
             uow.rom_installs.save(install)
         return file_path, None
 
-    def _post_download_multi_io(self, rom_id, rom_detail, target_path, file_name, system):
+    def _resolve_safe_extract_dir_name(self, rom_detail: dict[str, Any]) -> str:
+        """Resolve the sanitized base name for a multi-file ROM's extract dir.
+
+        Names the directory after the ROM's identity via
+        ``resolve_extract_dir_name`` (never ``files[0]``), then coerces the
+        server-supplied value to a single safe path component
+        (``coerce_safe_component``): a directory portion (``../evil``, an
+        absolute path) is stripped to its basename, AND a degenerate result
+        (``..``/``.``/empty/whitespace — which would resolve to the roms root
+        or the platform dir and turn a later ``remove_tree`` into a
+        library-wide delete) falls back to the synthetic ``rom_<id>`` identity.
+        Mirrors the ``file_name`` guard in ``_begin_download``.
+        """
+        raw = resolve_extract_dir_name(rom_detail)
+        safe, changed = coerce_safe_component(raw, synthetic_rom_name(rom_detail))
+        if changed:
+            self._logger.warning(f"Sanitized extract dir name from '{raw}' to '{safe}'")
+        return safe
+
+    def _post_download_multi_io(self, rom_id, rom_detail, target_path, file_name, system, extract_dir_name):
         """Sync helper for _do_download multi-file — extraction + renames in executor.
 
-        Returns ``(launch_file, error)``. ``error`` is a string when the RomM
-        data fails the ``RomInstall`` invariant — the extracted directory is
-        removed and nothing is persisted — otherwise ``None``.
+        *extract_dir_name* is the ROM-identity-derived, sanitized base name for
+        the extract directory (``_resolve_safe_extract_dir_name``) — never a
+        name derived from ``files[0]``. Returns ``(launch_file, error)``.
+        ``error`` is a string when the RomM data fails the ``RomInstall``
+        invariant — the extracted directory is removed and nothing is
+        persisted — otherwise ``None``.
         """
-        rom_dir_name = os.path.splitext(file_name)[0]
-        extract_dir = os.path.join(os.path.dirname(target_path), rom_dir_name)
+        extract_dir = os.path.join(os.path.dirname(target_path), extract_dir_name)
         self._download_file_store.make_dirs(extract_dir)
         roms_base = self._retrodeck_paths.roms_path()
         tmp_zip = target_path + _ZIP_TMP_EXT
@@ -792,6 +818,12 @@ class DownloadService:
         rom_name = rom_detail.get("name", file_name)
         platform_name = rom_detail.get("platform_name", rom_detail.get("platform_slug", ""))
         has_multiple = is_multi_file_download(rom_detail)
+        # Name the extract dir from the ROM's identity, not files[0] (which may be
+        # an arbitrary inner asset for a nested-single folder game). Computed once
+        # here and threaded to both the extraction and the cleanup so the dir a
+        # failure tears down matches the dir extraction created. Only multi-file
+        # ROMs own a dedicated dir, so single-file skips the derivation.
+        extract_dir_name = self._resolve_safe_extract_dir_name(rom_detail) if has_multiple else ""
         progress_callback = self._make_progress_callback(rom_id, rom_name, platform_name, file_name, control)
         on_meta = self._make_on_meta(rom_id, rom_name, platform_name, file_name)
         # Tracks the resolved launch path once extraction returns it, so a
@@ -846,7 +878,14 @@ class DownloadService:
                         ),
                     )
                     post_io_future = self._loop.run_in_executor(
-                        None, self._post_download_multi_io, rom_id, rom_detail, target_path, file_name, system
+                        None,
+                        self._post_download_multi_io,
+                        rom_id,
+                        rom_detail,
+                        target_path,
+                        file_name,
+                        system,
+                        extract_dir_name,
                     )
                     # Shield the commit await: a cancel here must propagate to this
                     # coroutine WITHOUT cancelling the underlying future, so
@@ -921,7 +960,7 @@ class DownloadService:
             else:
                 entry = self._download_queue[rom_id]
                 entry["status"] = "cancelled"
-                self._cleanup_partial_download(target_path, has_multiple, file_name, final_path)
+                self._cleanup_partial_download(target_path, has_multiple, extract_dir_name, final_path)
                 # #1017: emit a terminal frame so the frontend resets the button
                 # out of its downloading state (the global cancel path was silent).
                 await self._emit(
@@ -944,7 +983,7 @@ class DownloadService:
         except Exception as e:
             self._download_queue[rom_id]["status"] = "failed"
             self._download_queue[rom_id]["error"] = str(e)
-            self._cleanup_partial_download(target_path, has_multiple, file_name, final_path)
+            self._cleanup_partial_download(target_path, has_multiple, extract_dir_name, final_path)
             self._logger.error(f"Download failed for {rom_name}: {e}")
             await self._emit(
                 "download_failed",
@@ -1013,7 +1052,7 @@ class DownloadService:
         result = detect_launch_file(all_files, m3u_supported)
         return result if result is not None else extract_dir
 
-    def _cleanup_partial_download(self, target_path, has_multiple, file_name, final_path=None):
+    def _cleanup_partial_download(self, target_path, has_multiple, extract_dir_name, final_path=None):
         """Clean up partial download files. Each step is independent so one failure doesn't block others.
 
         Only ever called for a download that did NOT commit an install (the
@@ -1034,6 +1073,11 @@ class DownloadService:
         ``None`` until extraction returns it) lets cleanup tear down whichever
         of the two dir names exists — the staging name *and* the renamed dir
         (``os.path.dirname(final_path)``) — so no failure path orphans a dir.
+
+        *extract_dir_name* is the same ROM-identity-derived base name extraction
+        created the staging dir under (``_resolve_safe_extract_dir_name``), so
+        cleanup targets exactly that dir rather than re-deriving it from a stale
+        source (unused for single-file ROMs, which own no dir).
         """
         paths_to_remove = [
             target_path + _ZIP_TMP_EXT,
@@ -1045,7 +1089,7 @@ class DownloadService:
             except Exception as e:
                 self._logger.warning(f"Cleanup failed for {path}: {e}")
         if has_multiple:
-            staging_dir = os.path.join(os.path.dirname(target_path), os.path.splitext(file_name)[0])
+            staging_dir = os.path.join(os.path.dirname(target_path), extract_dir_name)
             dirs_to_remove = {staging_dir}
             if final_path:
                 dirs_to_remove.add(os.path.dirname(final_path))

--- a/tests/domain/test_rom_files.py
+++ b/tests/domain/test_rom_files.py
@@ -11,7 +11,9 @@ from domain.rom_files import (
     es_de_collapse_rename,
     is_multi_file_download,
     needs_m3u,
+    resolve_extract_dir_name,
     resolve_local_file_name,
+    synthetic_rom_name,
 )
 
 
@@ -390,3 +392,45 @@ class TestResolveLocalFileName:
         name, inconsistent = resolve_local_file_name(rom_detail)
         assert name == "parent"
         assert inconsistent is True
+
+
+class TestSyntheticRomName:
+    def test_uses_id(self):
+        assert synthetic_rom_name({"id": 4778}) == "rom_4778"
+
+    def test_missing_id_uses_unknown(self):
+        assert synthetic_rom_name({}) == "rom_unknown"
+
+
+class TestResolveExtractDirName:
+    def test_prefers_fs_name_no_ext(self):
+        rom_detail = {"fs_name_no_ext": "Metal Gear Solid 4", "fs_name": "Metal Gear Solid 4.zip"}
+        assert resolve_extract_dir_name(rom_detail) == "Metal Gear Solid 4"
+
+    def test_never_uses_files_zero(self):
+        """The MGS4 regression: a nested-single folder game's files[0] is an
+        arbitrary inner asset — the dir name must come from the ROM identity."""
+        rom_detail = {
+            "fs_name_no_ext": "Metal Gear Solid 4",
+            "fs_name": "Metal Gear Solid 4",
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "AttackoftheDwarfGekko.dbm"},
+                {"file_name": "PS3_GAME/USRDIR/EBOOT.BIN"},
+            ],
+        }
+        result = resolve_extract_dir_name(rom_detail)
+        assert result == "Metal Gear Solid 4"
+        assert result != "AttackoftheDwarfGekko"
+
+    def test_falls_back_to_splitext_fs_name(self):
+        assert resolve_extract_dir_name({"fs_name": "FF7.zip"}) == "FF7"
+
+    def test_empty_fs_name_no_ext_falls_back(self):
+        assert resolve_extract_dir_name({"fs_name_no_ext": "", "fs_name": "FF7.zip"}) == "FF7"
+
+    def test_missing_fs_name_uses_id_fallback(self):
+        assert resolve_extract_dir_name({"id": 4778}) == "rom_4778"
+
+    def test_missing_fs_name_and_id_uses_unknown_fallback(self):
+        assert resolve_extract_dir_name({}) == "rom_unknown"

--- a/tests/lib/test_path_safety.py
+++ b/tests/lib/test_path_safety.py
@@ -6,6 +6,7 @@ import pytest
 
 from lib.path_safety import (
     PathTraversalError,
+    coerce_safe_component,
     is_safe_rom_path,
     safe_join,
     safe_path_component,
@@ -53,6 +54,49 @@ class TestSafePathComponent:
     def test_rejects_embedded_traversal_segment(self):
         with pytest.raises(PathTraversalError):
             safe_path_component("sub/../../evil")
+
+
+class TestCoerceSafeComponent:
+    _FALLBACK = "rom_42"
+
+    def test_legit_name_is_byte_identical_and_unchanged(self):
+        assert coerce_safe_component("Metal Gear Solid 4", self._FALLBACK) == ("Metal Gear Solid 4", False)
+
+    def test_legit_name_with_spaces_preserved_byte_identical(self):
+        # Leading/trailing spaces in a legit name are NOT stripped (only tested
+        # for degeneracy) — the component stays byte-identical.
+        assert coerce_safe_component("  My Game  ", self._FALLBACK) == ("  My Game  ", False)
+
+    def test_directory_portion_stripped_to_basename(self):
+        assert coerce_safe_component("../../etc/pwned", self._FALLBACK) == ("pwned", True)
+
+    def test_absolute_path_stripped_to_basename(self):
+        assert coerce_safe_component("/etc/passwd", self._FALLBACK) == ("passwd", True)
+
+    def test_dotdot_falls_back(self):
+        # os.path.basename("..") == ".." — the load-bearing degenerate case.
+        assert coerce_safe_component("..", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_dot_falls_back(self):
+        assert coerce_safe_component(".", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_empty_falls_back(self):
+        assert coerce_safe_component("", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_trailing_slash_basenames_to_empty_falls_back(self):
+        # os.path.basename("foo/") == "" — a directory-shaped name.
+        assert coerce_safe_component("foo/", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_whitespace_only_falls_back(self):
+        assert coerce_safe_component("   ", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_dotdot_wrapped_in_dirs_falls_back(self):
+        # os.path.basename("foo/..") == ".." → still degenerate.
+        assert coerce_safe_component("foo/..", self._FALLBACK) == (self._FALLBACK, True)
+
+    def test_leading_dots_name_is_not_degenerate(self):
+        # "..foo" is a real (if unusual) child name, not a traversal.
+        assert coerce_safe_component("..foo", self._FALLBACK) == ("..foo", False)
 
 
 class TestSafeJoin:

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -1343,6 +1343,153 @@ class TestDoDownloadMultiFile:
         assert plugin._download_service._download_queue[99]["status"] == "failed"
 
     @pytest.mark.asyncio
+    async def test_nested_multi_file_names_dir_from_identity_not_files_zero(self, plugin, tmp_path):
+        """#1292: a folder game served as a nested-single ZIP (PS3 MGS4) must name
+        its extract dir after the ROM identity, never after ``files[0]``.
+
+        For ``has_nested_single_file`` ROMs ``resolve_local_file_name`` returns
+        ``files[0].file_name`` — an arbitrary inner asset ("AttackoftheDwarfGekko.dbm",
+        a music file). Deriving the extract dir from it named the whole install
+        after that asset and corrupted the folder-boot launch target. The dir must
+        come from ``fs_name_no_ext`` ("Metal Gear Solid 4") instead.
+        """
+        import zipfile as zf
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "ps3"
+        roms_dir.mkdir(parents=True)
+        # target_path is derived from files[0] (the nested-single filename) — for a
+        # multi-file ROM it only ever names the transient .zip.tmp, never the dir.
+        target_path = str(roms_dir / "AttackoftheDwarfGekko.dbm")
+
+        # ZIP mirroring RomM's mod_zip output: PS3_GAME at the root (no wrapper
+        # folder) plus the arbitrary asset RomM lists first.
+        zip_content_path = tmp_path / "source.zip"
+        with zf.ZipFile(str(zip_content_path), "w") as z:
+            z.writestr("AttackoftheDwarfGekko.dbm", b"\x00" * 32)
+            z.writestr("PS3_GAME/USRDIR/EBOOT.BIN", b"\x00" * 64)
+            z.writestr("PS3_GAME/PARAM.SFO", b"\x00" * 16)
+        zip_bytes = zip_content_path.read_bytes()
+
+        rom_detail = {
+            "id": 4778,
+            "name": "Metal Gear Solid 4",
+            "fs_name": "Metal Gear Solid 4",
+            "fs_name_no_ext": "Metal Gear Solid 4",
+            "platform_slug": "ps3",
+            "platform_name": "PlayStation 3",
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "AttackoftheDwarfGekko.dbm"},
+                {"file_name": "PS3_GAME/USRDIR/EBOOT.BIN"},
+                {"file_name": "PS3_GAME/PARAM.SFO"},
+            ],
+        }
+
+        def fake_download(_rom_id, _filename, dest, _progress_callback=None, *, resume=False, on_meta=None):
+            with open(dest, "wb") as f:
+                f.write(zip_bytes)
+
+        _seed_rom(plugin._uow, 4778, platform_slug="ps3")
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[4778] = {"rom_id": 4778, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(
+                4778, rom_detail, target_path, "ps3", "AttackoftheDwarfGekko.dbm"
+            )
+
+        # The extract dir carries the ROM identity, NOT the files[0] asset name.
+        extract_dir = roms_dir / "Metal Gear Solid 4"
+        assert extract_dir.is_dir()
+        assert (extract_dir / "PS3_GAME" / "USRDIR" / "EBOOT.BIN").exists()
+        # The files[0]-derived dir must NEVER exist.
+        assert not (roms_dir / "AttackoftheDwarfGekko").exists()
+        # EBOOT.BIN is nested, so no ES-DE collapse rename — the dir keeps the
+        # identity name and the launch file points inside it.
+        installed = plugin._uow.rom_installs.get(4778)
+        assert installed is not None
+        assert installed.rom_dir == str(extract_dir)
+        assert installed.file_path == str(extract_dir / "PS3_GAME" / "USRDIR" / "EBOOT.BIN")
+        assert plugin._download_service._download_queue[4778]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_nested_multi_file_cleanup_targets_identity_dir_not_files_zero(self, plugin, tmp_path):
+        """#1292: a failed folder-game download tears down the identity-named
+        extract dir, not a ``files[0]``-derived stale name.
+
+        The extract dir is created and cleaned up from the SAME
+        ROM-identity base name, so a failure never orphans the real dir while
+        removing a phantom one.
+        """
+        from unittest.mock import patch
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+        decky.emit.reset_mock()
+
+        roms_dir = tmp_path / "retrodeck" / "roms" / "ps3"
+        roms_dir.mkdir(parents=True)
+        target_path = str(roms_dir / "AttackoftheDwarfGekko.dbm")
+
+        # Pre-seed the identity-named extract dir as if extraction had partially run.
+        extract_dir = roms_dir / "Metal Gear Solid 4"
+        extract_dir.mkdir()
+        (extract_dir / "PS3_GAME").mkdir()
+
+        rom_detail = {
+            "id": 4778,
+            "name": "Metal Gear Solid 4",
+            "fs_name": "Metal Gear Solid 4",
+            "fs_name_no_ext": "Metal Gear Solid 4",
+            "platform_slug": "ps3",
+            "platform_name": "PlayStation 3",
+            "has_multiple_files": False,
+            "has_nested_single_file": True,
+            "files": [
+                {"file_name": "AttackoftheDwarfGekko.dbm"},
+                {"file_name": "PS3_GAME/USRDIR/EBOOT.BIN"},
+            ],
+        }
+
+        def fake_download(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
+            raise OSError("network died mid-download")
+
+        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._download_queue[4778] = {"rom_id": 4778, "status": "downloading", "progress": 0}
+
+        with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
+            await plugin._download_service._do_download(
+                4778, rom_detail, target_path, "ps3", "AttackoftheDwarfGekko.dbm"
+            )
+
+        # The identity-named dir is torn down; the files[0]-derived name was never
+        # the target, so nothing orphans.
+        assert not extract_dir.exists()
+        assert plugin._download_service._download_queue[4778]["status"] == "failed"
+
+    @pytest.mark.asyncio
     async def test_multi_file_emits_extracting_progress(self, plugin, tmp_path):
         """A multi-file download emits ``download_progress`` ``status:"extracting"``
         frames after the byte transfer, then ``download_complete`` after.
@@ -2256,6 +2403,49 @@ class TestPathTraversalFsName:
         # The coroutine was created — just verify the queue entry is safe
         assert ".." not in queue_entry["file_name"]
 
+    @pytest.mark.asyncio
+    async def test_fs_name_degenerate_falls_back_to_synthetic(self, plugin, tmp_path):
+        """A degenerate fs_name ("..") basenames to ".." — the file_name guard
+        must fall back to the synthetic rom_<id>, so target_path can never
+        resolve to the platform dir's parent (the roms root)."""
+        from unittest.mock import AsyncMock
+
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._download_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+            bios=str(tmp_path / "retrodeck" / "bios"),
+        )
+        plugin._rom_removal_service._retrodeck_paths = FakeRetroDeckPaths(
+            roms=str(tmp_path / "retrodeck" / "roms"),
+        )
+
+        rom_detail = {
+            "id": 77,
+            "name": "Evil ROM",
+            "fs_name": "..",
+            "fs_size_bytes": 1024,
+            "platform_slug": "n64",
+            "platform_name": "Nintendo 64",
+        }
+
+        plugin._download_service._loop = MagicMock()
+        plugin._download_service._loop.run_in_executor = AsyncMock(return_value=rom_detail)
+
+        def _close_coro_task(coro):
+            coro.close()
+            return MagicMock()
+
+        plugin._download_service._loop.create_task = _close_coro_task
+        plugin._download_service._download_file_store.disk_free = lambda _path: 500 * 1024 * 1024
+
+        result = await plugin.start_download(77)
+
+        assert result["success"] is True
+        queue_entry = plugin._download_service._download_queue[77]
+        assert queue_entry["file_name"] == "rom_77"
+
 
 class TestPathTraversalPlatformSlug:
     """#967: an unmapped server platform slug must not escape roms_path."""
@@ -2318,7 +2508,8 @@ class TestCleanupPartialDownload:
         tmp_file = tmp_path / "game.z64.tmp"
         tmp_file.write_text("partial")
 
-        plugin._download_service._cleanup_partial_download(target, False, "game.z64")
+        # Single-file: no extract dir, so extract_dir_name is unused ("").
+        plugin._download_service._cleanup_partial_download(target, False, "")
         assert not tmp_file.exists()
 
     def test_cleans_zip_tmp_multi(self, plugin, tmp_path):
@@ -2326,7 +2517,7 @@ class TestCleanupPartialDownload:
         zip_tmp = tmp_path / "game.zip.zip.tmp"
         zip_tmp.write_text("partial zip")
 
-        plugin._download_service._cleanup_partial_download(target, True, "game.zip")
+        plugin._download_service._cleanup_partial_download(target, True, "game")
         assert not zip_tmp.exists()
 
     def test_cleans_extract_dir(self, plugin, tmp_path):
@@ -2335,28 +2526,75 @@ class TestCleanupPartialDownload:
         extract_dir.mkdir()
         (extract_dir / "disc1.bin").write_bytes(b"\x00" * 100)
 
-        plugin._download_service._cleanup_partial_download(target, True, "game.zip")
+        plugin._download_service._cleanup_partial_download(target, True, "game")
         assert not extract_dir.exists()
 
     def test_cleanup_errors_are_caught(self, plugin, tmp_path):
         """Cleanup should not raise even if files don't exist."""
         target = str(tmp_path / "nonexistent.z64")
         # Should not raise
-        plugin._download_service._cleanup_partial_download(target, False, "nonexistent.z64")
-        plugin._download_service._cleanup_partial_download(target, True, "nonexistent.zip")
+        plugin._download_service._cleanup_partial_download(target, False, "")
+        plugin._download_service._cleanup_partial_download(target, True, "nonexistent")
 
     def test_cleans_renamed_extract_dir_via_final_path(self, plugin, tmp_path):
         """A failure after the ES-DE collapse rename must clean the renamed dir, not just the staging name."""
         target = str(tmp_path / "game.zip")
-        # The staging dir (splitext of file_name) no longer exists — it was
-        # renamed. Only the renamed dir, derived from final_path, is on disk.
+        # The staging dir (the ROM-identity extract_dir_name) no longer exists —
+        # it was renamed. Only the renamed dir, derived from final_path, is on disk.
         renamed_dir = tmp_path / "game.m3u"
         renamed_dir.mkdir()
         (renamed_dir / "game.m3u").write_text("disc1.cue\n")
         final_path = str(renamed_dir / "game.m3u")
 
-        plugin._download_service._cleanup_partial_download(target, True, "game.zip", final_path)
+        plugin._download_service._cleanup_partial_download(target, True, "game", final_path)
         assert not renamed_dir.exists()
+
+
+class TestResolveSafeExtractDirName:
+    """#1292: the extract-dir base name is ROM-identity-derived and traversal-safe."""
+
+    def test_returns_fs_name_no_ext(self, plugin):
+        name = plugin._download_service._resolve_safe_extract_dir_name({"fs_name_no_ext": "Metal Gear Solid 4"})
+        assert name == "Metal Gear Solid 4"
+
+    def test_sanitizes_relative_traversal(self, plugin, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
+            name = plugin._download_service._resolve_safe_extract_dir_name({"fs_name_no_ext": "../../etc/pwned"})
+        assert name == "pwned"
+        assert any("Sanitized extract dir name" in rec.message for rec in caplog.records)
+
+    def test_sanitizes_absolute_path(self, plugin, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
+            name = plugin._download_service._resolve_safe_extract_dir_name({"fs_name": "/etc/passwd"})
+        assert name == "passwd"
+        assert any("Sanitized extract dir name" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize("degenerate", ["..", ".", "foo/", "   "])
+    def test_degenerate_component_falls_back_to_synthetic(self, plugin, caplog, degenerate):
+        """A server-supplied name that basenames to ``..``/``.``/empty/whitespace
+        must NOT resolve to the roms root or platform dir — it falls back to the
+        synthetic rom_<id> identity + one warning (the HIGH-severity guard)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
+            name = plugin._download_service._resolve_safe_extract_dir_name({"id": 4778, "fs_name_no_ext": degenerate})
+        assert name == "rom_4778"
+        assert any("Sanitized extract dir name" in rec.message for rec in caplog.records)
+
+    def test_empty_fs_name_no_ext_yields_synthetic_without_warning(self, plugin, caplog):
+        """An empty ``fs_name_no_ext`` is upstream-handled by
+        ``resolve_extract_dir_name`` (it falls through to the synthetic name), so
+        the guard sees an already-clean component — safe result, no coercion warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="test_romm"):
+            name = plugin._download_service._resolve_safe_extract_dir_name({"id": 4778, "fs_name_no_ext": ""})
+        assert name == "rom_4778"
+        assert not any("Sanitized extract dir name" in rec.message for rec in caplog.records)
 
 
 class TestDoDownloadCancelled:
@@ -3516,7 +3754,7 @@ class TestCleanupPartialDownloadFailureInjection:
         plugin._download_service._download_file_store = fake
 
         with caplog.at_level(logging.WARNING, logger="test_romm"):
-            plugin._download_service._cleanup_partial_download(target, False, "game.z64")
+            plugin._download_service._cleanup_partial_download(target, False, "")
 
         # The failing transient is still in the fake (remove raised); the
         # other transient was successfully removed.
@@ -3547,7 +3785,7 @@ class TestCleanupPartialDownloadFailureInjection:
 
         with caplog.at_level(logging.WARNING, logger="test_romm"):
             # Must NOT raise even though remove_tree raises.
-            plugin._download_service._cleanup_partial_download(target, True, "game.zip")
+            plugin._download_service._cleanup_partial_download(target, True, "game")
 
         # The dir is still present (remove_tree raised before clearing).
         assert extract_dir in fake.dirs
@@ -3922,12 +4160,12 @@ class TestDoDownloadCancelReconcile:
         started = threading.Event()
         release = threading.Event()
 
-        def blocking_post_io_multi(rom_id, _detail, tpath, fname, system):
+        def blocking_post_io_multi(rom_id, _detail, tpath, _fname, system, extract_dir_name):
             # Faithful post-condition of a committed multi-file install: an extract
             # dir with a launch file + a saved RomInstall row.
             started.set()
             release.wait(timeout=5)
-            rom_dir = os.path.join(os.path.dirname(tpath), os.path.splitext(fname)[0])
+            rom_dir = os.path.join(os.path.dirname(tpath), extract_dir_name)
             os.makedirs(rom_dir, exist_ok=True)
             launch_file = os.path.join(rom_dir, "game.m3u")
             with open(launch_file, "wb") as f:


### PR DESCRIPTION
Folder games served by RomM as a multi-file zip with `has_nested_single_file: true` got their extract directory named after `files[0]` — an arbitrary inner asset. On-device: "Metal Gear Solid 4" (ps3, 329 files, alphabetically led by a music asset) installed into `.../roms/ps3/AttackoftheDwarfGekko/`, corrupting the ROM identity and — for PS3 folder-boot (#1302) — the baked launch target. The old EBOOT bake was equally broken for this ROM class.

The extract directory is now derived from the ROM identity: a pure `resolve_extract_dir_name` (fs_name_no_ext → splitext(fs_name) → synthetic `rom_<id>`), computed once in `_do_download` and threaded to the extraction and BOTH cleanup branches (the cleanup previously re-derived the dir from `files[0]` and would have orphaned the real extract dir). The intended nested-single case (Switch base .nsp) is verified a no-op; the single-file path is untouched.

Hardening (review finding, register invariants #10/#11): server-supplied path components were guarded by `os.path.basename` alone, which passes `..`/`.`/empty/trailing-slash through — a degenerate name resolved the extract dir to the platform dir or roms ROOT, and the downstream cleanup/uninstall `rmtree` would have deleted a shared tree. New `lib/path_safety.coerce_safe_component` (basename + degenerate rejection → synthetic fallback, never raises) now guards BOTH the extract-dir name and the sibling `file_name` path (same pre-existing hole, swept per the register rule). The raising `safe_path_component` used by the zip-slip guard is untouched.

Tests: red-then-green end-to-end MGS4 naming + cleanup pins (real zip under tmp_path), degenerate-component matrix at lib/service tiers incl. an end-to-end `fs_name: ".."` → `rom_<id>` pin, synthetic-name domain tests. Architecture docs aligned with the actual naming rule.

On-device follow-up (rides the next verification round): fresh MGS4 download → `.../roms/ps3/Metal Gear Solid 4/` → RPCS3 boots the folder (#1302's gate).