### PR TITLE
fix(playtime): register renamed suspend hooks + robust session adoption

### DIFF
--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -64,12 +64,14 @@ manager, sync, and playtime) is absent, so desktop-mode launches are entirely un
   runs the full shared gate, and on approval **relaunches** via `RunGame(gameId, "", -1, 100)`.
 - A **one-shot skip-set** (module-level `Set<appId>`, checked-and-deleted at watcher entry) exempts exactly one launch:
   the watcher's own relaunch, and the Play button's launch (which already ran the gate). This kills the double-gate.
-- An **already-running guard** (checked synchronously at watcher entry, **before** the cancel) skips the whole funnel
-  when the launched appId is the live play session (`sessionManager` `activeRomId`) or any Steam running-app source
-  (`utils/runningApps`) reports it running. A Play press on an already-running game still fires `GameActionStart`;
-  intercepting it would cancel the launch and run the pre-launch sync **mid-session** — uploading the save while the
-  emulator holds the file open — and Steam blocks the relaunch as "already running" anyway, so the cancel + re-sync is
-  pure damage. The guard lets Steam surface its own "already running" popup instead (#1148 round 2).
+- An **already-running guard** skips the whole funnel — on **both** launch surfaces — when the target appId is the live
+  play session (`sessionManager` `activeRomId`) or any Steam running-app source (`utils/runningApps`) reports it
+  running. The watcher checks it synchronously at entry (**before** the cancel); the Play button checks it at the top of
+  `handlePlay` (its enabled state derives from cached install/conflict status, not running state, so it can't rely on
+  the button being disabled). Running the pre-launch sync on an already-running game would upload the save
+  **mid-session** — while the emulator holds the file open — and manufacture a conflict at exit (the watcher
+  additionally cancels a launch Steam blocks as "already running" anyway). Both surfaces skip the sync and just bring
+  the game to front instead (#1148 round 2).
 - Because the watcher cancels **first** and only then does async work, **there is no race** — the defect of awaiting
   against a live launch is gone by construction.
 

--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -64,6 +64,12 @@ manager, sync, and playtime) is absent, so desktop-mode launches are entirely un
   runs the full shared gate, and on approval **relaunches** via `RunGame(gameId, "", -1, 100)`.
 - A **one-shot skip-set** (module-level `Set<appId>`, checked-and-deleted at watcher entry) exempts exactly one launch:
   the watcher's own relaunch, and the Play button's launch (which already ran the gate). This kills the double-gate.
+- An **already-running guard** (checked synchronously at watcher entry, **before** the cancel) skips the whole funnel
+  when the launched appId is the live play session (`sessionManager` `activeRomId`) or any Steam running-app source
+  (`utils/runningApps`) reports it running. A Play press on an already-running game still fires `GameActionStart`;
+  intercepting it would cancel the launch and run the pre-launch sync **mid-session** — uploading the save while the
+  emulator holds the file open — and Steam blocks the relaunch as "already running" anyway, so the cancel + re-sync is
+  pure damage. The guard lets Steam surface its own "already running" popup instead (#1148 round 2).
 - Because the watcher cancels **first** and only then does async work, **there is no race** — the defect of awaiting
   against a live launch is gone by construction.
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1250,10 +1250,13 @@ Session tracking:
 1. `recordSessionStart(romId)`: backend opens the session marker (`last_session_start`) on the ROM's `rom_playtime` row
    in a short write Unit of Work, then schedules a background flush of the pending-session outbox (draining any offline
    backlog on launch)
-2. During play, the frontend `sessionManager` accumulates device-suspend wall-clock across suspend/resume cycles (via
-   `RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend`; an in-flight suspend still open at game-stop is
-   folded in even without a resume event), and passes the rounded `suspended_seconds` to `finalizeGameSession` at
-   session end
+2. During play, the frontend `sessionManager` accumulates device-suspend wall-clock across suspend/resume cycles. The
+   hooks are registered on the legacy `System.RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend` pair when
+   a build still exposes it, else on the renamed `User.RegisterForPrepareForSystemSuspendProgress` /
+   `RegisterForResumeSuspendedGamesProgress` successors — the legacy pair was removed on current SteamOS (#1148). The
+   `User.*` events are progress callbacks that can fire several times per cycle, so the handlers are idempotent (the
+   first suspend stamps; a resume folds once and clears). An in-flight suspend still open at game-stop is folded in even
+   without a resume event, and the rounded `suspended_seconds` is passed to `finalizeGameSession` at session end
 3. Session end (`finalizeGameSession(romId, suspendedSeconds)` → backend `record_session_end`): in an executor worker, a
    short write UoW folds the closed session into the aggregate (`record_session` subtracts `suspended_seconds` from the
    raw elapsed span, then clamps the result to 0–24h — subtraction before the cap, never negative — increments
@@ -1458,10 +1461,20 @@ If the launched app ID is not in the map, it is not a RomM shortcut and the sess
 
 ### Suspend/resume handling
 
-To exclude sleep time from playtime tracking:
+To exclude sleep time from playtime tracking the session manager registers a suspend and a resume hook. The surface is
+chosen at init with a fallback (#1148): the legacy `System.*` pair was removed on current SteamOS, so registration falls
+back to the renamed `User.*` progress successors.
 
-- `SteamClient.System.RegisterForOnSuspendRequest` — records the suspend timestamp
-- `SteamClient.System.RegisterForOnResumeFromSuspend` — calculates paused duration and subtracts it from the session
+- **Suspend** — `SteamClient.System.RegisterForOnSuspendRequest` when present, else
+  `SteamClient.User.RegisterForPrepareForSystemSuspendProgress`. Records the suspend timestamp once per cycle (the
+  `User.*` variant is a progress callback that can fire repeatedly, so the stamp is idempotent).
+- **Resume** — `SteamClient.System.RegisterForOnResumeFromSuspend` when present, else
+  `SteamClient.User.RegisterForResumeSuspendedGamesProgress`. Folds the paused duration into the accumulator once and
+  clears the open suspend, so a repeated resume-progress fire is a no-op; the total is subtracted from the session at
+  game-stop.
+
+The chosen surface and the returned handle shapes are logged at init; a build exposing neither pair warns loudly, and a
+runtime surface probe enumerates whatever suspend/resume members do exist.
 
 ## Native play-session ingest (ADR-0018)
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1459,8 +1459,8 @@ throwing-getter surface degrades to "reported nothing", never a throw), merges t
 a per-source `diagnostics` string. No single surface is reliable across builds/timing: after a `plugin_loader` restart
 `Router.MainRunningApp` stays null for several seconds and never repopulates without a fresh lifecycle event (#1054 /
 #1148 round 2), so the adoption path **polls** the reader (every 500ms up to 15s) instead of reading one surface once,
-and a failed round logs what every candidate reported. The same reader backs the launch interceptor's already-running
-skip ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
+and a failed round logs what every candidate reported. The same reader backs the already-running skip on both launch
+surfaces — the interceptor and the Play button ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
 
 ### App ID to ROM ID mapping
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1277,14 +1277,17 @@ signals let the re-initialized `sessionManager` recover it:
 
 - **Steam running-state (liveness).** `Router.MainRunningApp` is the authority for _whether_ the game is still running
   at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely so it survives the
-  reload, but only Steam can attest the session has not already ended.
+  reload, but only Steam can attest the session has not already ended. This read is **polled** (every 500ms for up to
+  15s), not one-shot: after a full `plugin_loader` restart Steam populates `MainRunningApp` only seconds later, so a
+  single early read raced the restart and wrongly orphaned a still-running session (#1054).
 - **A localStorage breadcrumb (attestation).** A single versioned row (`decky-romm-sync:active-session` →
   `{v, appId, romId, startMs, pausedMs}`) is written at start, has its `pausedMs` refreshed on each completed
   suspend→resume cycle (an in-flight suspend is deliberately **not** persisted), and is removed at stop. It is **not**
   cleared by `destroySessionManager`, so it outlives the reload. Every localStorage access is wrapped — a storage
   failure degrades to the no-attestation path, never throws.
 
-At `initSessionManager` the recovery runs on the lifecycle chain (so a racing stop event serializes after it):
+At `initSessionManager` the recovery runs on the lifecycle chain (so a stop event racing the liveness poll serializes
+after adoption — adopt first, then finalize):
 
 - **Game running + breadcrumb matches** → adopt in-memory state from the breadcrumb (`sessionStartTime`,
   `totalPausedMs`) and leave the durable marker untouched. Re-stamping would discard the pre-reload span the backend
@@ -1292,10 +1295,10 @@ At `initSessionManager` the recovery runs on the lifecycle chain (so a racing st
 - **Game running, no / mismatched / corrupt breadcrumb** → adopt and re-stamp the marker to a truthful lower bound
   (`recordSessionStart`), then write a fresh breadcrumb so a subsequent reload adopts via the matching case instead of
   re-stamping again.
-- **Breadcrumb present but nothing (or a non-RomM app) running** → the session ended while the plugin was down; a
-  truthful finalize is impossible without an observed end, so the breadcrumb is dropped and the session is logged as
-  orphaned — never a fabricated end time. A stale breadcrumb left by a reboot resolves the same way at the next init; no
-  expiry timers.
+- **Breadcrumb present but nothing running once the liveness poll times out** (or a non-RomM app is foreground) → the
+  session ended while the plugin was down; a truthful finalize is impossible without an observed end, so the breadcrumb
+  is dropped and the session is logged as orphaned — never a fabricated end time. A stale breadcrumb left by a reboot
+  resolves the same way at the next init; no expiry timers.
 
 **Attestation invariant:** every finalize fold uses a marker stamped by a start we actually observed (either the
 original `recordSessionStart` or an adoption re-stamp) — the client never invents an end time for a session whose stop
@@ -1447,7 +1450,9 @@ The callback receives:
 
 After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms
 and then reads `Router.MainRunningApp` for a reliable `appid` and `display_name`. Falls back to `unAppID` from the
-notification if `MainRunningApp` is null.
+notification if `MainRunningApp` is null. On reload adoption the window is far longer — after a `plugin_loader` restart
+`MainRunningApp` stays null for several seconds — so the adoption path **polls** it (every 500ms up to 15s) instead of
+reading once (#1054).
 
 ### App ID to ROM ID mapping
 

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1275,11 +1275,14 @@ only on `error` (ADR-0018).
 the next game-stop with nothing to finalize — the pre-reload playtime is lost and the post-exit sync never runs. Two
 signals let the re-initialized `sessionManager` recover it:
 
-- **Steam running-state (liveness).** `Router.MainRunningApp` is the authority for _whether_ the game is still running
-  at re-init — the durable marker (`last_session_start`) is written by `recordSessionStart` precisely so it survives the
-  reload, but only Steam can attest the session has not already ended. This read is **polled** (every 500ms for up to
-  15s), not one-shot: after a full `plugin_loader` restart Steam populates `MainRunningApp` only seconds later, so a
-  single early read raced the restart and wrongly orphaned a still-running session (#1054).
+- **Steam running-state (liveness).** A defensive multi-source reader (`utils/runningApps`) is the authority for
+  _whether_ the game is still running at re-init — the durable marker (`last_session_start`) is written by
+  `recordSessionStart` precisely so it survives the reload, but only Steam can attest the session has not already ended.
+  No single Steam surface is trusted: `Router.MainRunningApp` never repopulates after a full `plugin_loader` restart
+  without a fresh lifecycle event the reloaded context missed (#1054 / #1148 round 2), so the reader also consults the
+  running-apps lists (`Router.RunningApps`, `SteamUIStore.RunningApps`), each through a guard, merged + de-duped. This
+  read is **polled** (every 500ms for up to 15s), not one-shot, and a timed-out round logs the per-source `diagnostics`
+  so the on-device log names the surface that actually works on a given build.
 - **A localStorage breadcrumb (attestation).** A single versioned row (`decky-romm-sync:active-session` →
   `{v, appId, romId, startMs, pausedMs}`) is written at start, has its `pausedMs` refreshed on each completed
   suspend→resume cycle (an in-flight suspend is deliberately **not** persisted), and is removed at stop. It is **not**
@@ -1446,13 +1449,18 @@ The callback receives:
 - `bRunning: boolean` — whether the app just started (`true`) or stopped (`false`)
 - `unAppID: number` — the app ID
 
-### Router.MainRunningApp
+### Running-app detection (`utils/runningApps`)
 
 After a game starts, there is a brief window where the app ID may not be fully resolved. The session manager waits 500ms
-and then reads `Router.MainRunningApp` for a reliable `appid` and `display_name`. Falls back to `unAppID` from the
-notification if `MainRunningApp` is null. On reload adoption the window is far longer — after a `plugin_loader` restart
-`MainRunningApp` stays null for several seconds — so the adoption path **polls** it (every 500ms up to 15s) instead of
-reading once (#1054).
+and then reads the defensive running-app reader for a reliable `appid` and `display_name`, falling back to `unAppID`
+from the notification if nothing is reported. The reader consults MULTIPLE Steam surfaces — `Router.MainRunningApp` plus
+the `Router.RunningApps` / `SteamUIStore.RunningApps` lists — each through a guard (an absent, `null`, or
+throwing-getter surface degrades to "reported nothing", never a throw), merges them into one de-duped list, and returns
+a per-source `diagnostics` string. No single surface is reliable across builds/timing: after a `plugin_loader` restart
+`Router.MainRunningApp` stays null for several seconds and never repopulates without a fresh lifecycle event (#1054 /
+#1148 round 2), so the adoption path **polls** the reader (every 500ms up to 15s) instead of reading one surface once,
+and a failed round logs what every candidate reported. The same reader backs the launch interceptor's already-running
+skip ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
 
 ### App ID to ROM ID mapping
 
@@ -1467,19 +1475,23 @@ If the launched app ID is not in the map, it is not a RomM shortcut and the sess
 ### Suspend/resume handling
 
 To exclude sleep time from playtime tracking the session manager registers a suspend and a resume hook. The surface is
-chosen at init with a fallback (#1148): the legacy `System.*` pair was removed on current SteamOS, so registration falls
-back to the renamed `User.*` progress successors.
+chosen at init from an ordered candidate CHAIN (#1148): the legacy `System.*` pair first (it keeps working where a build
+still exposes it), then the renamed `User.*` progress successors. Registration is not a single try — on current SteamOS
+the `User.*` members EXIST (typeof function) but throw "Unknown method" when INVOKED (the Steam bridge does not back
+them in our CEF context, #1148 round 2). So when a candidate's registration THROWS, the surface + exact error are
+logged, any half-registered handle is rolled back, and the NEXT candidate is tried rather than giving up.
 
-- **Suspend** — `SteamClient.System.RegisterForOnSuspendRequest` when present, else
+- **Suspend** — `SteamClient.System.RegisterForOnSuspendRequest`, else
   `SteamClient.User.RegisterForPrepareForSystemSuspendProgress`. Records the suspend timestamp once per cycle (the
   `User.*` variant is a progress callback that can fire repeatedly, so the stamp is idempotent).
-- **Resume** — `SteamClient.System.RegisterForOnResumeFromSuspend` when present, else
+- **Resume** — `SteamClient.System.RegisterForOnResumeFromSuspend`, else
   `SteamClient.User.RegisterForResumeSuspendedGamesProgress`. Folds the paused duration into the accumulator once and
   clears the open suspend, so a repeated resume-progress fire is a no-op; the total is subtracted from the session at
   game-stop.
 
-The chosen surface and the returned handle shapes are logged at init; a build exposing neither pair warns loudly, and a
-runtime surface probe enumerates whatever suspend/resume members do exist.
+The chosen surface and the returned handle shapes are logged at init; a build exposing neither pair warns that the hooks
+are missing, a build where every candidate throws warns that all surfaces failed, and a runtime surface probe enumerates
+whatever suspend/resume members do exist.
 
 ## Native play-session ingest (ADR-0018)
 

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -60,6 +60,17 @@ vi.mock("../utils/migrationStore", () => ({
   getMigrationState: vi.fn(() => ({ pending: false })),
 }));
 
+// Already-running guard deps (#1148 round 2). Default: no live session and nothing
+// running, so the guard is inert and the existing Play-funnel tests run unchanged.
+// CustomPlayButton is the only in-graph importer of either module, so a full mock
+// exposing just the guard's two functions is safe.
+vi.mock("../utils/sessionManager", () => ({
+  getActiveSessionRomId: vi.fn(() => null),
+}));
+vi.mock("../utils/runningApps", () => ({
+  isAppRunning: vi.fn(() => false),
+}));
+
 // Shared launch-gate modals — spy so the Play button's verdict switch is
 // observable without rendering each modal (mirrors the watcher's test shape).
 vi.mock("../components/OfflineDriftModal", () => ({
@@ -76,6 +87,8 @@ import { getCachedGameDetail } from "../utils/cachedGameDetailStore";
 import { setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { markLaunchSkipped, consumeLaunchSkip } from "../utils/launchGate";
 import { getMigrationState } from "../utils/migrationStore";
+import { getActiveSessionRomId } from "../utils/sessionManager";
+import { isAppRunning } from "../utils/runningApps";
 import { showOfflineDriftModal } from "../components/OfflineDriftModal";
 import { showFallbackLaunchModal } from "../components/FallbackLaunchModal";
 import { handleConflicts } from "../components/SyncConflictModal";
@@ -616,6 +629,101 @@ describe("CustomPlayButton — pre-launch savefiles_in_content_dir benign skip (
     expect(vi.mocked(toaster.toast)).not.toHaveBeenCalled();
     // No fallback-launch confirm modal was opened (would mean we treated it as failure).
     expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42);
+  });
+});
+
+// #1148 round 2: the Play button is the sibling of the launch interceptor's
+// already-running guard. A Play press on an already-running game must NOT run the
+// pre-launch sync (it would upload the save mid-session and manufacture an exit
+// conflict); it skips the whole gate/sync funnel and just brings the game to
+// front. cached rom_id=42, appId=100 → the "Play" state.
+describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
+  beforeEach(() => {
+    // This file has no global mock-clear, so backend callable call history leaks
+    // across describes (an earlier Play test already invoked isSaveTrackingConfigured
+    // / debugLog). Clear it so the "never touched" guard assertions are meaningful.
+    vi.clearAllMocks();
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(toaster.toast).mockReset();
+    // Guard defaults: no live session, nothing running (overridden per test).
+    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isAppRunning).mockReturnValue(false);
+    // Gate predecessors so the NORMAL path can reach preLaunchSync when the guard
+    // is inert; the guard tests assert these are never touched.
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
+    vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
+    vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+    vi.stubGlobal("SteamClient", { Apps: { RunGame: vi.fn() } });
+    vi.stubGlobal("appStore", {
+      GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
+      allApps: [],
+    });
+    vi.mocked(getCachedGameDetail).mockResolvedValue({
+      found: true,
+      rom_id: 42,
+      rom_name: "Test ROM",
+      installed: true,
+    });
+  });
+
+  it("skips the gate/sync and brings the game to front when this rom is the live session", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+
+    // The gate/sync funnel never ran — neither its first op nor the sync itself.
+    expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    // The info log fired (non-vacuous — proves the guard branch, not just the sink).
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+      expect.stringContaining("already running — skipping pre-launch sync"),
+    );
+  });
+
+  it("skips the gate/sync when a running-app source reports the appId running", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isAppRunning).mockReturnValue(true);
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+
+    expect(vi.mocked(isAppRunning)).toHaveBeenCalledWith(100);
+    expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+      expect.stringContaining("already running — skipping pre-launch sync"),
+    );
+  });
+
+  it("runs the normal pre-launch funnel when nothing is running", async () => {
+    // Defaults: no live session, isAppRunning false → guard inert.
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const playBtn = await findByText("Play");
+    await act(async () => {
+      playBtn.click();
+    });
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+
+    // Guard inert → the gate ran the pre-launch sync before launching, and no
+    // already-running log was emitted.
+    expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(backend.debugLog)).not.toHaveBeenCalledWith(expect.stringContaining("already running"));
   });
 });
 

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -47,6 +47,8 @@ import { showFallbackLaunchModal } from "./FallbackLaunchModal";
 import { getMigrationState } from "../utils/migrationStore";
 import { runLaunchGate, markLaunchSkipped } from "../utils/launchGate";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "../utils/launchGate";
+import { getActiveSessionRomId } from "../utils/sessionManager";
+import { isAppRunning } from "../utils/runningApps";
 import type { DownloadProgressEvent, DownloadCompleteEvent, DownloadFailedEvent } from "../types";
 import { SAVEFILES_IN_CONTENT_DIR_REASON } from "../types";
 import { detach } from "../utils/detach";
@@ -492,6 +494,20 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
 
     // Non-RomM / unresolved ROM — nothing to gate, launch straight through.
     if (!romId) {
+      await dispatchLaunch(gameId);
+      return;
+    }
+
+    // Already-running guard (#1148 round 2) — the sibling of the launch
+    // interceptor's guard, since this button is the other launch path and its
+    // enabled state derives from cached install/conflict status, not running
+    // state. A Play press on an already-running game must NOT run the pre-launch
+    // sync: it would upload the save mid-session while the emulator holds the file
+    // open and manufacture a conflict at exit. Skip the whole gate/sync funnel and
+    // just bring the game to front — `dispatchLaunch` skip-marks the appId so the
+    // resulting RunGame doesn't re-enter the interceptor and re-gate either.
+    if (getActiveSessionRomId() === romId || isAppRunning(appId)) {
+      detach(debugLog(`CustomPlayButton: appId=${appId} already running — skipping pre-launch sync`));
       await dispatchLaunch(gameId);
       return;
     }

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -34,8 +34,19 @@ declare var SteamClient: {
   };
   System: {
     GetSystemInfo(): Promise<{ sHostname: string; [key: string]: any }>;
+    // Legacy suspend/resume registrations — removed on current SteamOS (#1148).
+    // The session manager still tries these first (a build that exposes them keeps
+    // working) before falling back to the User.* successors below.
     RegisterForOnSuspendRequest(callback: () => void): { unregister: () => void };
     RegisterForOnResumeFromSuspend(callback: () => void): { unregister: () => void };
+  };
+  User: {
+    // Renamed suspend/resume hooks on current SteamOS (#1148), the successors to
+    // the removed System.RegisterForOn{Suspend,ResumeFromSuspend} pair. These are
+    // PROGRESS callbacks — they may fire multiple times per suspend/resume cycle,
+    // so the handlers registered against them must be idempotent.
+    RegisterForPrepareForSystemSuspendProgress(callback: () => void): { unregister: () => void };
+    RegisterForResumeSuspendedGamesProgress(callback: () => void): { unregister: () => void };
   };
 };
 

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -123,6 +123,25 @@ declare var appStore: {
   allApps: SteamAppOverview[];
 };
 
+// Running-app surfaces read by the defensive `utils/runningApps` reader. Steam SP
+// globals — genuinely absent (hence `undefined`) or `null` on some builds/timing,
+// so every read guards. `RunningApps` is optional: present only on builds that
+// expose it (Router.MainRunningApp stays authoritative for the foreground app).
+declare var Router:
+  | {
+      MainRunningApp: SteamAppOverview | null;
+      RunningApps?: SteamAppOverview[];
+    }
+  | null
+  | undefined;
+
+declare var SteamUIStore:
+  | {
+      RunningApps?: SteamAppOverview[];
+    }
+  | null
+  | undefined;
+
 declare var appDetailsStore: {
   GetDescriptions(appId: number): any;
   GetAssociations(appId: number): any;

--- a/src/utils/launchInterceptor.test.ts
+++ b/src/utils/launchInterceptor.test.ts
@@ -4,6 +4,7 @@ import * as backend from "../api/backend";
 import * as gameDetailPatch from "../patches/gameDetailPatch";
 import * as launchGate from "./launchGate";
 import * as sessionManager from "./sessionManager";
+import * as runningApps from "./runningApps";
 import * as syncConflictModal from "../components/SyncConflictModal";
 import * as offlineDriftModal from "../components/OfflineDriftModal";
 import * as fallbackLaunchModal from "../components/FallbackLaunchModal";
@@ -55,6 +56,11 @@ vi.mock("./launchGate", async (importActual) => {
 
 vi.mock("./sessionManager", () => ({
   getAppIdRomIdMapSnapshot: vi.fn(() => ({ "1234": 42 })),
+  getActiveSessionRomId: vi.fn(() => null),
+}));
+
+vi.mock("./runningApps", () => ({
+  isAppRunning: vi.fn(() => false),
 }));
 
 vi.mock("./migrationStore", () => ({
@@ -148,6 +154,10 @@ describe("launchInterceptor — full funnel watcher", () => {
     });
     // Skip-set empty by default — a marked appId is set per-test.
     vi.mocked(sessionManager.getAppIdRomIdMapSnapshot).mockReturnValue({ "1234": 42 });
+    // Default: no live session and nothing running, so the already-running guard
+    // is inert and the existing funnel tests run unchanged. Overridden per-test.
+    vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(runningApps.isAppRunning).mockReturnValue(false);
     vi.mocked(launchGate.runLaunchGate).mockResolvedValue({ decision: "allow" });
     // The shared relaunch re-confirm (#1152) runs on every relaunch; default it
     // to a resolved command + a clean confirm-set so the existing verdict tests
@@ -192,6 +202,81 @@ describe("launchInterceptor — full funnel watcher", () => {
 
       expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
       expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1148 round 2: a Play press on an ALREADY-RUNNING game still fires
+  // GameActionStart. Intercepting it cancels the launch and runs the pre-launch
+  // sync MID-SESSION (uploading the save while the emulator holds the file) —
+  // pure damage, since Steam blocks the relaunch as "already running" anyway. The
+  // guard skips the whole funnel when the appId is the live session OR any running
+  // -app source reports it running.
+  describe("already-running guard", () => {
+    it("skips the funnel (no cancel, no gate, no sync) when the appId is the live session", async () => {
+      // Our own session state says rom 42 (appId 1234) is live.
+      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(42);
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+      expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
+      expect(backend.preLaunchSync).not.toHaveBeenCalled();
+      expect(runGameMock()).not.toHaveBeenCalled();
+      expect(backend.logInfo).toHaveBeenCalledWith(
+        expect.stringContaining("appId=1234 already running — skipping pre-launch sync"),
+      );
+    });
+
+    it("skips the funnel when a running-app source reports the appId running", async () => {
+      // No live session in our state, but Steam's running-app surfaces show it.
+      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(null);
+      vi.mocked(runningApps.isAppRunning).mockReturnValue(true);
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(runningApps.isAppRunning).toHaveBeenCalledWith(1234);
+      expect(SteamClient.Apps.CancelGameAction).not.toHaveBeenCalled();
+      expect(launchGate.runLaunchGate).not.toHaveBeenCalled();
+      expect(backend.preLaunchSync).not.toHaveBeenCalled();
+      expect(runGameMock()).not.toHaveBeenCalled();
+      expect(backend.logInfo).toHaveBeenCalledWith(
+        expect.stringContaining("already running — skipping pre-launch sync"),
+      );
+    });
+
+    it("does NOT skip when a DIFFERENT rom is the live session — normal funnel runs", async () => {
+      // A different game (rom 99) is live; the pressed appId 1234 (rom 42) is not
+      // running → the guard is inert and the normal cancel+gate funnel proceeds.
+      vi.mocked(sessionManager.getActiveSessionRomId).mockReturnValue(99);
+      vi.mocked(runningApps.isAppRunning).mockReturnValue(false);
+
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(77);
+      expect(launchGate.runLaunchGate).toHaveBeenCalled();
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
+      expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("already running"));
+    });
+
+    it("does NOT skip when nothing is running — normal funnel runs", async () => {
+      // Defaults: no live session, isAppRunning false → guard inert, funnel runs.
+      registerLaunchInterceptor();
+      const handler = captureHandler();
+      handler(77, "1234", "LaunchApp", 0);
+      await flush();
+
+      expect(SteamClient.Apps.CancelGameAction).toHaveBeenCalledWith(77);
+      expect(launchGate.runLaunchGate).toHaveBeenCalled();
+      expect(runGameMock()).toHaveBeenCalledWith("gid-7", "", -1, 100);
     });
   });
 

--- a/src/utils/launchInterceptor.ts
+++ b/src/utils/launchInterceptor.ts
@@ -33,7 +33,8 @@ import {
 } from "../api/backend";
 import { getMigrationState, setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
-import { getAppIdRomIdMapSnapshot } from "./sessionManager";
+import { getAppIdRomIdMapSnapshot, getActiveSessionRomId } from "./sessionManager";
+import { isAppRunning } from "./runningApps";
 import { runLaunchGate, markLaunchSkipped, consumeLaunchSkip } from "./launchGate";
 import type { GateVerdict, LaunchGateOps, PreLaunchSyncOutcome } from "./launchGate";
 import { reconfirmLaunchOptions } from "./launchOptionsReconcile";
@@ -287,6 +288,20 @@ export function registerLaunchInterceptor(): void {
       // One-shot skip: a gated relaunch (the watcher's own RunGame) or a
       // Play-button launch already ran the funnel — do NOT re-gate it.
       if (consumeLaunchSkip(appId)) return;
+
+      // Already-running guard (#1148 round 2). A Play press on a game that is
+      // ALREADY running still fires GameActionStart. Intercepting it would cancel
+      // the launch, run the pre-launch gate, and upload the save MID-SESSION (while
+      // the emulator holds the file open) — and Steam blocks the relaunch as
+      // "already running" anyway, so the cancel+re-sync is pure damage. Skip the
+      // whole funnel when this appId is our live session OR any Steam running-app
+      // source reports it running; Steam surfaces its own "already running" popup.
+      const activeRomId = getActiveSessionRomId();
+      const activeAppRomId = getAppIdRomIdMapSnapshot()[String(appId)];
+      if ((activeRomId !== null && activeAppRomId === activeRomId) || isAppRunning(appId)) {
+        logInfo(`Launch interceptor: appId=${appId} already running — skipping pre-launch sync`);
+        return;
+      }
 
       // CANCEL FIRST — synchronously, before any await. This wins the race
       // against the un-pausable launch: from here the launch is stopped and we

--- a/src/utils/runningApps.test.ts
+++ b/src/utils/runningApps.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readRunningApps, readPrimaryRunningApp, isAppRunning } from "./runningApps";
+
+// The util reads bare Steam SP globals (`Router`, `SteamUIStore`). Each test
+// stubs only the surfaces it exercises; the global afterEach in test-setup.ts
+// runs vi.unstubAllGlobals(), so an unstubbed global reads as truly absent
+// (`typeof X === "undefined"`) rather than leaking across tests.
+
+describe("runningApps — defensive multi-source detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("readRunningApps", () => {
+    it("reads Router.MainRunningApp as the primary source", () => {
+      vi.stubGlobal("Router", { MainRunningApp: { appid: 100, display_name: "Game" } });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([{ appid: 100, display_name: "Game" }]);
+      expect(diagnostics).toContain("Router.MainRunningApp=appid=100");
+    });
+
+    it("reports null when Router.MainRunningApp is null and finds nothing", () => {
+      vi.stubGlobal("Router", { MainRunningApp: null });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toContain("Router.MainRunningApp=null");
+    });
+
+    it("reports no-Router when the global is absent, without throwing", () => {
+      // Router intentionally not stubbed — a bare `=== undefined` would throw
+      // ReferenceError; the util's typeof guard degrades to a note instead.
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toContain("Router.MainRunningApp=no-Router");
+      expect(diagnostics).toContain("SteamUIStore.RunningApps=no-store");
+    });
+
+    it("reads Router.RunningApps as a list source", () => {
+      vi.stubGlobal("Router", {
+        MainRunningApp: null,
+        RunningApps: [
+          { appid: 5, display_name: "A" },
+          { appid: 6, strDisplayName: "B" },
+        ],
+      });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([
+        { appid: 5, display_name: "A" },
+        { appid: 6, display_name: "B" },
+      ]);
+      expect(diagnostics).toContain("Router.RunningApps=[5,6]");
+    });
+
+    it("reads SteamUIStore.RunningApps as a list source", () => {
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 42, display_name: "Zelda" }] });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([{ appid: 42, display_name: "Zelda" }]);
+      expect(diagnostics).toContain("SteamUIStore.RunningApps=[42]");
+    });
+
+    it("merges + de-dupes across sources, MainRunningApp first", () => {
+      vi.stubGlobal("Router", {
+        MainRunningApp: { appid: 100, display_name: "Main" },
+        RunningApps: [{ appid: 100, display_name: "dup" }],
+      });
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 200, display_name: "Second" }] });
+
+      const { apps } = readRunningApps();
+      // 100 de-duped (MainRunningApp wins first-writer), 200 appended.
+      expect(apps).toEqual([
+        { appid: 100, display_name: "Main" },
+        { appid: 200, display_name: "Second" },
+      ]);
+    });
+
+    it("tolerates a throwing MainRunningApp getter and still reads other sources", () => {
+      vi.stubGlobal("Router", {
+        get MainRunningApp() {
+          throw new Error("bridge fault");
+        },
+        RunningApps: [{ appid: 7, display_name: "Survivor" }],
+      });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([{ appid: 7, display_name: "Survivor" }]);
+      expect(diagnostics).toContain("Router.MainRunningApp=threw:");
+    });
+
+    it("drops entries without a numeric appid and reports an empty list", () => {
+      vi.stubGlobal("Router", {
+        MainRunningApp: null,
+        RunningApps: [{ display_name: "no id" }, 42, null],
+      });
+
+      const { apps, diagnostics } = readRunningApps();
+      expect(apps).toEqual([]);
+      expect(diagnostics).toContain("Router.RunningApps=empty");
+    });
+
+    it("coerces a non-array iterable (MobX-style observable) source", () => {
+      const observable = {
+        *[Symbol.iterator]() {
+          yield { appid: 11, display_name: "Obs" };
+        },
+      };
+      vi.stubGlobal("SteamUIStore", { RunningApps: observable });
+
+      const { apps } = readRunningApps();
+      expect(apps).toEqual([{ appid: 11, display_name: "Obs" }]);
+    });
+
+    it("reports absent for a missing list property", () => {
+      vi.stubGlobal("Router", { MainRunningApp: null });
+
+      const { diagnostics } = readRunningApps();
+      expect(diagnostics).toContain("Router.RunningApps=absent");
+    });
+  });
+
+  describe("readPrimaryRunningApp", () => {
+    it("returns the first running app and the round diagnostics", () => {
+      vi.stubGlobal("Router", { MainRunningApp: { appid: 100, display_name: "Game" } });
+
+      const { app, diagnostics } = readPrimaryRunningApp();
+      expect(app).toEqual({ appid: 100, display_name: "Game" });
+      expect(diagnostics).toContain("Router.MainRunningApp=appid=100");
+    });
+
+    it("returns null when no source reports a running app", () => {
+      vi.stubGlobal("Router", { MainRunningApp: null });
+
+      expect(readPrimaryRunningApp().app).toBeNull();
+    });
+  });
+
+  describe("isAppRunning", () => {
+    it("is true when the appId is reported by any source", () => {
+      vi.stubGlobal("Router", { MainRunningApp: null });
+      vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 100, display_name: "Game" }] });
+
+      expect(isAppRunning(100)).toBe(true);
+    });
+
+    it("is false when no source reports the appId", () => {
+      vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "Other" } });
+
+      expect(isAppRunning(100)).toBe(false);
+    });
+
+    it("is false and does not throw when every source is absent", () => {
+      expect(isAppRunning(100)).toBe(false);
+    });
+  });
+});

--- a/src/utils/runningApps.ts
+++ b/src/utils/runningApps.ts
@@ -1,0 +1,160 @@
+/**
+ * Defensive running-app detection.
+ *
+ * Steam surfaces a game's running state through several page globals, and which
+ * one is populated depends on the SteamOS build and on timing. After a
+ * `plugin_loader` restart `Router.MainRunningApp` stays `null` for the whole
+ * adoption window even though a game is running (#1054 / #1148 round 2 device
+ * evidence) — it only (re)populates on a fresh lifecycle event, and our reloaded
+ * JS context missed the one that started the game. So no single source is
+ * trusted: every known surface is read through a guard, the readings merge into
+ * one de-duped list, and a round that finds nothing still reports what EVERY
+ * candidate returned (`diagnostics`) so the on-device log names the surface that
+ * actually works on a given build.
+ *
+ * Every read is guarded. The globals are undeclared Steam SP values — a bare
+ * reference to a truly-absent one throws `ReferenceError`, so presence is
+ * probed with `typeof`; a present one may be `null`, a throwing getter, a plain
+ * array, or a MobX observable (array-like/iterable). Any of those degrades to
+ * "this source reported nothing", never a throw out of the reader.
+ *
+ * `Router` and `SteamUIStore` are the ambient Steam SP globals declared in
+ * `types/steam.d.ts`.
+ */
+
+export interface RunningApp {
+  appid: number;
+  display_name: string;
+}
+
+export interface RunningAppsReading {
+  /** Running apps merged + de-duped (by `appid`) across every list-shaped source. */
+  apps: RunningApp[];
+  /** Per-source diagnostic — what each candidate reported this round. */
+  diagnostics: string;
+}
+
+interface SourceReading {
+  label: string;
+  note: string;
+  apps: RunningApp[];
+}
+
+/** Coerce one candidate into a {@link RunningApp}, or `null` if it isn't one. */
+function coerceRunningApp(value: unknown): RunningApp | null {
+  if (typeof value !== "object" || value === null) return null;
+  const rec = value as Record<string, unknown>;
+  const appid = rec.appid;
+  if (typeof appid !== "number") return null;
+  const name =
+    typeof rec.display_name === "string"
+      ? rec.display_name
+      : typeof rec.strDisplayName === "string"
+        ? rec.strDisplayName
+        : "";
+  return { appid, display_name: name };
+}
+
+/**
+ * Coerce a list-shaped source (plain array or MobX observable) into running
+ * apps, dropping any entry that isn't a running app. Never throws — a
+ * non-iterable or a throwing iterator yields an empty list.
+ */
+function coerceRunningAppList(value: unknown): RunningApp[] {
+  if (value === null || value === undefined) return [];
+  let items: unknown[];
+  if (Array.isArray(value)) {
+    items = value;
+  } else if (typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function") {
+    items = Array.from(value as Iterable<unknown>);
+  } else {
+    return [];
+  }
+  const apps: RunningApp[] = [];
+  for (const item of items) {
+    const app = coerceRunningApp(item);
+    if (app) apps.push(app);
+  }
+  return apps;
+}
+
+/** `Router.MainRunningApp` — the single foreground app (unreliable post-restart). */
+function readRouterMainRunningApp(): SourceReading {
+  const label = "Router.MainRunningApp";
+  // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; a direct
+  // `=== undefined` would throw ReferenceError when it is genuinely absent.
+  if (typeof Router === "undefined" || Router === null) return { label, note: "no-Router", apps: [] };
+  try {
+    const app = coerceRunningApp(Router.MainRunningApp);
+    return { label, note: app ? `appid=${app.appid}` : "null", apps: app ? [app] : [] };
+  } catch (e) {
+    return { label, note: `threw:${e}`, apps: [] };
+  }
+}
+
+/** `Router.RunningApps` — a running-apps array on some Steam builds. */
+function readRouterRunningApps(): SourceReading {
+  const label = "Router.RunningApps";
+  // NOSONAR(typescript:S7741) — see readRouterMainRunningApp.
+  if (typeof Router === "undefined" || Router === null) return { label, note: "no-Router", apps: [] };
+  try {
+    const apps = coerceRunningAppList(Router.RunningApps);
+    return { label, note: describeList(apps, Router.RunningApps), apps };
+  } catch (e) {
+    return { label, note: `threw:${e}`, apps: [] };
+  }
+}
+
+/** `SteamUIStore.RunningApps` — Steam's own UI store of running games. */
+function readSteamUIStoreRunningApps(): SourceReading {
+  const label = "SteamUIStore.RunningApps";
+  // NOSONAR(typescript:S7741) — SteamUIStore is an undeclared Steam SP global.
+  if (typeof SteamUIStore === "undefined" || SteamUIStore === null) return { label, note: "no-store", apps: [] };
+  try {
+    const apps = coerceRunningAppList(SteamUIStore.RunningApps);
+    return { label, note: describeList(apps, SteamUIStore.RunningApps), apps };
+  } catch (e) {
+    return { label, note: `threw:${e}`, apps: [] };
+  }
+}
+
+/** Diagnostic note for a list source — the appids found, or why nothing was. */
+function describeList(apps: RunningApp[], raw: unknown): string {
+  if (apps.length > 0) return `[${apps.map((a) => a.appid).join(",")}]`;
+  if (raw === null || raw === undefined) return "absent";
+  return "empty";
+}
+
+/**
+ * Read every running-app source once, merging into a de-duped list plus a
+ * per-source diagnostic string. `Router.MainRunningApp` is read first so, when
+ * present, it heads the list (the foreground app), but its absence no longer
+ * blinds detection — the list sources fill in after a loader restart.
+ */
+export function readRunningApps(): RunningAppsReading {
+  const sources = [readRouterMainRunningApp(), readRouterRunningApps(), readSteamUIStoreRunningApps()];
+  const merged = new Map<number, RunningApp>();
+  for (const source of sources) {
+    for (const app of source.apps) {
+      if (!merged.has(app.appid)) merged.set(app.appid, app);
+    }
+  }
+  return {
+    apps: Array.from(merged.values()),
+    diagnostics: sources.map((s) => `${s.label}=${s.note}`).join(" | "),
+  };
+}
+
+/**
+ * The primary running app (first source to report one) plus the round's
+ * diagnostics. `null` app means no source saw a running app this round.
+ */
+export function readPrimaryRunningApp(): { app: RunningApp | null; diagnostics: string } {
+  const reading = readRunningApps();
+  return { app: reading.apps[0] ?? null, diagnostics: reading.diagnostics };
+}
+
+/** Is a specific `appId` currently running per ANY source? Never throws. */
+export function isAppRunning(appId: number): boolean {
+  return readRunningApps().apps.some((app) => app.appid === appId);
+}

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -189,6 +189,49 @@ describe("sessionManager suspend accumulator", () => {
 
     expect(backend.finalizeGameSession).toHaveBeenLastCalledWith(ROM_ID, 0);
   });
+
+  it("stamps suspendedAt once across repeated suspend-progress events", async () => {
+    // The renamed suspend hook is a PROGRESS callback that can fire several times
+    // per cycle. A repeated fire must NOT re-stamp the pause start, or the
+    // subtracted span shrinks (here: 60s→90s = 30s, not 70s→90s = 20s).
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+    const suspend = captureSuspendCb();
+    const resume = captureResumeCb();
+
+    await startGame(lifetime);
+    vi.setSystemTime(60_000);
+    suspend(); // first progress fire — stamps
+    vi.setSystemTime(70_000);
+    suspend(); // repeated progress fire — must be ignored
+    vi.setSystemTime(90_000);
+    resume();
+    vi.setSystemTime(120_000);
+    await stopGame(lifetime);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 30);
+  });
+
+  it("folds a resume once across repeated resume-progress events", async () => {
+    // Repeated resume-progress fires in the same cycle must fold only once — the
+    // second fire finds no open suspend and is a no-op (not another 60→100 fold).
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+    const suspend = captureSuspendCb();
+    const resume = captureResumeCb();
+
+    await startGame(lifetime);
+    vi.setSystemTime(60_000);
+    suspend();
+    vi.setSystemTime(90_000);
+    resume(); // folds 30s, clears the open suspend
+    vi.setSystemTime(100_000);
+    resume(); // repeated progress fire — must be a no-op
+    vi.setSystemTime(120_000);
+    await stopGame(lifetime);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 30);
+  });
 });
 
 describe("sessionManager reload adoption", () => {
@@ -531,7 +574,7 @@ describe("sessionManager suspend-hook diagnostics", () => {
 
     // Actionable headline names both absent members (booleans false).
     expect(backend.logWarn).toHaveBeenCalledWith(
-      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=false RegisterForOnResumeFromSuspend=false",
+      "Suspend/resume hooks missing on this build: legacy=false/false user=false/false",
     );
     // Never attempted registration → no throw path was taken.
     expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("registration threw"));
@@ -545,7 +588,23 @@ describe("sessionManager suspend-hook diagnostics", () => {
     await expect(initSessionManager()).resolves.toBeUndefined();
 
     expect(backend.logWarn).toHaveBeenCalledWith(
-      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=true RegisterForOnResumeFromSuspend=false",
+      "Suspend/resume hooks missing on this build: legacy=true/false user=false/false",
+    );
+  });
+
+  it("names the partially-present User.* pair in the missing-hooks headline", async () => {
+    // Legacy gone and only ONE User.* successor present → no usable surface, but
+    // the headline must show the partial User pair so the gap is visible at the
+    // default log level (#1148 LOW-2).
+    stubSteamClient(
+      {}, // no legacy pair
+      { RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })) }, // resume successor absent
+    );
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      "Suspend/resume hooks missing on this build: legacy=false/false user=true/false",
     );
   });
 
@@ -573,11 +632,11 @@ describe("sessionManager suspend-hook diagnostics", () => {
 
     await initSessionManager();
 
-    // No headline warning on a healthy build; the debug tier reports both
-    // handles carry an `unregister` function.
+    // No headline warning on a healthy build; the debug tier names the surface
+    // used and reports both handles carry an `unregister` function.
     expect(backend.logWarn).not.toHaveBeenCalled();
     expect(backend.debugLog).toHaveBeenCalledWith(
-      "Suspend/resume registration: suspend={unregister:fn} resume={unregister:fn}",
+      "Suspend/resume registration [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]: suspend={unregister:fn} resume={unregister:fn}",
     );
   });
 
@@ -623,7 +682,7 @@ describe("sessionManager suspend-hook diagnostics", () => {
 
     // System absent → both members read as false → headline warns.
     expect(backend.logWarn).toHaveBeenCalledWith(
-      "Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=false RegisterForOnResumeFromSuspend=false",
+      "Suspend/resume hooks missing on this build: legacy=false/false user=false/false",
     );
     // The surface probe still emits (init reached it, never threw).
     expect(backend.debugLog).toHaveBeenCalledWith("SteamClient suspend/resume surface: (none)");
@@ -647,7 +706,160 @@ describe("sessionManager suspend-hook diagnostics", () => {
     // threw" (the pre-fix behavior this test pins).
     expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("registration threw"));
     expect(backend.debugLog).toHaveBeenCalledWith(
-      "Suspend/resume registration: suspend=type=undefined resume={unregister:fn}",
+      "Suspend/resume registration [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]: suspend=type=undefined resume={unregister:fn}",
     );
+  });
+
+  it("falls back to the User.* surface when the legacy System hooks are absent", async () => {
+    // Current SteamOS: System.RegisterForOn* are gone; only the renamed User.*
+    // progress hooks remain. Registration must fall through to them.
+    stubSteamClient(
+      {}, // System exposes neither legacy Register* member
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await initSessionManager();
+
+    // A working surface was found → no "hooks missing" headline; the debug line
+    // names the User surface that was used.
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("hooks missing"));
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration [User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress]: suspend={unregister:fn} resume={unregister:fn}",
+    );
+  });
+
+  it("prefers the legacy System surface when both surfaces are present", async () => {
+    // A build that still exposes the legacy pair keeps using it (it works), even
+    // when the User.* successors are also present.
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await initSessionManager();
+
+    expect(backend.logWarn).not.toHaveBeenCalled();
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]: suspend={unregister:fn} resume={unregister:fn}",
+    );
+  });
+});
+
+// #1148: the renamed User.* progress hooks must drive the same suspend accumulator
+// as the legacy System.* pair. These exercise registration + subtraction
+// end-to-end through the fallback surface, including idempotency under the
+// repeated progress fires the User.* callbacks emit per suspend/resume cycle.
+describe("sessionManager suspend subtraction via the User.* fallback (#1148)", () => {
+  let userSuspend: (() => void) | undefined;
+  let userResume: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    userSuspend = undefined;
+    userResume = undefined;
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      System: {}, // legacy System.RegisterForOn* removed on current SteamOS
+      User: {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn((cb: () => void) => {
+          userSuspend = cb;
+          return { unregister: vi.fn() };
+        }),
+        RegisterForResumeSuspendedGamesProgress: vi.fn((cb: () => void) => {
+          userResume = cb;
+          return { unregister: vi.fn() };
+        }),
+      },
+    });
+    // Router.MainRunningApp stays null; startGame drives the session via unAppID.
+    vi.stubGlobal("Router", { MainRunningApp: null });
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
+    vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({
+      total_seconds: null,
+      sync: {
+        offline: false,
+        success: true,
+        synced: 0,
+        conflicts: [],
+        toast_title: null,
+        toast_body: null,
+        conflicts_toast: null,
+      },
+      migration: null,
+    });
+  });
+
+  afterEach(() => {
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("captures the User.* callbacks and subtracts a suspend cycle delivered through them", async () => {
+    await initSessionManager();
+    expect(userSuspend).toBeTypeOf("function");
+    expect(userResume).toBeTypeOf("function");
+
+    const lifetime = captureLifetimeCb();
+    await startGame(lifetime);
+    vi.setSystemTime(60_000);
+    userSuspend!();
+    vi.setSystemTime(90_000);
+    userResume!();
+    vi.setSystemTime(120_000);
+    await stopGame(lifetime);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 30);
+  });
+
+  it("does not double-count repeated User.* suspend/resume progress fires", async () => {
+    await initSessionManager();
+    const lifetime = captureLifetimeCb();
+    await startGame(lifetime);
+
+    vi.setSystemTime(60_000);
+    userSuspend!(); // first suspend-progress — stamps
+    vi.setSystemTime(70_000);
+    userSuspend!(); // repeated progress — ignored
+    vi.setSystemTime(90_000);
+    userResume!(); // folds 30s, clears the open suspend
+    vi.setSystemTime(100_000);
+    userResume!(); // repeated progress — no-op
+    vi.setSystemTime(120_000);
+    await stopGame(lifetime);
+
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 30);
+  });
+
+  it("unregisters the User.* handles on destroy", async () => {
+    const suspendUnregister = vi.fn();
+    const resumeUnregister = vi.fn();
+    vi.stubGlobal("SteamClient", {
+      GameSessions: { RegisterForAppLifetimeNotifications: vi.fn(() => ({ unregister: vi.fn() })) },
+      System: {},
+      User: {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: suspendUnregister })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: resumeUnregister })),
+      },
+    });
+
+    await initSessionManager();
+    destroySessionManager();
+
+    expect(suspendUnregister).toHaveBeenCalledTimes(1);
+    expect(resumeUnregister).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -537,21 +537,27 @@ describe("sessionManager reload adoption", () => {
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
   });
 
-  it("contains an unexpected throw in the adoption path", async () => {
-    // Steam's running-app accessor faulting must not crash init — the lifecycle
-    // chain's .catch logs and lets initialization complete.
+  it("tolerates a throwing running-app getter without erroring adoption", async () => {
+    // Steam's running-app accessor faulting must not crash init. The defensive
+    // reader catches the throw PER-SOURCE (noting it in diagnostics) so adoption
+    // proceeds against the other sources instead of erroring out (#1148 round 2) —
+    // the pre-fix single-source read let the throw escape to the adoption .catch.
     vi.stubGlobal("Router", {
-      MainRunningApp: {
-        get appid(): number {
-          throw new Error("running-app read failed");
-        },
-        display_name: "Game",
+      get MainRunningApp(): unknown {
+        throw new Error("running-app read failed");
       },
     });
 
-    await expect(initSessionManager()).resolves.toBeUndefined();
+    // Nothing else running → the poll times out and init resolves cleanly.
+    const init = initSessionManager();
+    await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
+    await expect(init).resolves.toBeUndefined();
 
-    expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+    // No adoption error surfaced; the timed-out round logged what every candidate
+    // reported, including the throwing source.
+    expect(backend.logError).not.toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("threw:"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("no running app"));
   });
 
   // #1054 follow-up: after a full plugin_loader restart Router.MainRunningApp is
@@ -574,7 +580,7 @@ describe("sessionManager reload adoption", () => {
     // session was never logged as orphaned.
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
     expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("orphaned"));
-    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("MainRunningApp appeared"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("running app appeared"));
 
     // The adopted session finalizes on stop, carrying the breadcrumb's pausedMs.
     const lifetime = captureLifetimeCb();
@@ -651,7 +657,7 @@ describe("sessionManager reload adoption", () => {
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
     expect(readCrumb()).toBeNull(); // no breadcrumb written by the aborted adoption
     expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("Adopted"));
-    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("MainRunningApp appeared"));
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("running app appeared"));
   });
 });
 
@@ -871,6 +877,133 @@ describe("sessionManager suspend-hook diagnostics", () => {
     expect(backend.debugLog).toHaveBeenCalledWith(
       "Suspend/resume registration [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]: suspend={unregister:fn} resume={unregister:fn}",
     );
+  });
+
+  // #1148 round 2: the renamed User.* members EXIST (typeof function) but throw
+  // "Unknown method" when INVOKED — the Steam bridge doesn't back them in our CEF
+  // context. A single try/catch that gives up on the first throw is wrong: the
+  // registration is a candidate CHAIN that logs the throw, rolls back a
+  // half-registered handle, and tries the next surface.
+  it("falls through to the next surface when the first surface's registration throws", async () => {
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => {
+          throw new Error("Unknown method");
+        }),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await initSessionManager();
+
+    // Legacy threw on invocation → warned with the surface + exact error, then the
+    // User surface registered cleanly.
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "registration threw on [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]",
+      ),
+    );
+    expect(backend.logWarn).toHaveBeenCalledWith(expect.stringContaining("Unknown method"));
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration [User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress]: suspend={unregister:fn} resume={unregister:fn}",
+    );
+    // A working surface was found → neither the members-missing nor the all-failed
+    // headline fires.
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("hooks missing"));
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("failed on all"));
+  });
+
+  it("rolls back a half-registered suspend hook when the surface's resume throws, then uses the next", async () => {
+    const legacySuspendUnreg = vi.fn();
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: legacySuspendUnreg })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => {
+          throw new Error("Unknown method");
+        }),
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await initSessionManager();
+
+    // The legacy suspend registered but its resume threw → the dangling suspend
+    // handle is unregistered (no leaked handler on the abandoned surface), and
+    // registration falls through to the User surface.
+    expect(legacySuspendUnreg).toHaveBeenCalledTimes(1);
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration [User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress]: suspend={unregister:fn} resume={unregister:fn}",
+    );
+  });
+
+  it("swallows a throwing rollback unregister and still uses the next surface", async () => {
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => ({
+          unregister: () => {
+            throw new Error("unregister boom");
+          },
+        })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => {
+          throw new Error("Unknown method");
+        }),
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // The rollback unregister threw but was swallowed → registration still reached
+    // and used the User surface without crashing init.
+    expect(backend.debugLog).toHaveBeenCalledWith(
+      "Suspend/resume registration [User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress]: suspend={unregister:fn} resume={unregister:fn}",
+    );
+  });
+
+  it("warns that every candidate surface failed when all registrations throw", async () => {
+    stubSteamClient(
+      {
+        RegisterForOnSuspendRequest: vi.fn(() => {
+          throw new Error("legacy boom");
+        }),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      {
+        RegisterForPrepareForSystemSuspendProgress: vi.fn(() => {
+          throw new Error("user boom");
+        }),
+        RegisterForResumeSuspendedGamesProgress: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    );
+
+    await expect(initSessionManager()).resolves.toBeUndefined();
+
+    // Both candidates threw → each is warned individually, then a distinct
+    // all-failed headline (NOT the members-missing one — the members were present).
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "registration threw on [System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend]",
+      ),
+    );
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "registration threw on [User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress]",
+      ),
+    );
+    expect(backend.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("registration failed on all 2 candidate surface(s)"),
+    );
+    expect(backend.logWarn).not.toHaveBeenCalledWith(expect.stringContaining("hooks missing"));
   });
 });
 

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -60,6 +60,16 @@ async function stopGame(cb: LifetimeCb): Promise<void> {
   await vi.advanceTimersByTimeAsync(0);
 }
 
+// #1148: adoptOrphanedSession now polls Router.MainRunningApp for up to 15s before
+// deciding. When no running app is present, initSessionManager only settles once
+// that poll times out — drain it so the immediate-read tests still resolve.
+const ADOPTION_POLL_MAX_MS = 15_000;
+async function initDrainingAdoptionPoll(): Promise<void> {
+  const init = initSessionManager();
+  await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
+  await init;
+}
+
 describe("sessionManager suspend accumulator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,7 +109,7 @@ describe("sessionManager suspend accumulator", () => {
   });
 
   it("forwards 0 suspended seconds when the device never suspended", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
     await startGame(lifetime);
@@ -110,7 +120,7 @@ describe("sessionManager suspend accumulator", () => {
   });
 
   it("subtracts a single suspend cycle", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
     const resume = captureResumeCb();
@@ -128,7 +138,7 @@ describe("sessionManager suspend accumulator", () => {
   });
 
   it("accumulates across multiple suspend cycles", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
     const resume = captureResumeCb();
@@ -152,7 +162,7 @@ describe("sessionManager suspend accumulator", () => {
   });
 
   it("folds an in-flight suspend at stop (stopped while suspended)", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
 
@@ -167,7 +177,7 @@ describe("sessionManager suspend accumulator", () => {
   });
 
   it("resets the accumulator on the next session start", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
     const resume = captureResumeCb();
@@ -194,7 +204,7 @@ describe("sessionManager suspend accumulator", () => {
     // The renamed suspend hook is a PROGRESS callback that can fire several times
     // per cycle. A repeated fire must NOT re-stamp the pause start, or the
     // subtracted span shrinks (here: 60s→90s = 30s, not 70s→90s = 20s).
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
     const resume = captureResumeCb();
@@ -215,7 +225,7 @@ describe("sessionManager suspend accumulator", () => {
   it("folds a resume once across repeated resume-progress events", async () => {
     // Repeated resume-progress fires in the same cycle must fold only once — the
     // second fire finds no open suspend and is a no-op (not another 60→100 fold).
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     const suspend = captureSuspendCb();
     const resume = captureResumeCb();
@@ -329,7 +339,8 @@ describe("sessionManager reload adoption", () => {
     seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 });
     vi.stubGlobal("Router", { MainRunningApp: null });
 
-    await initSessionManager();
+    // Nothing ever runs → the poll times out and the breadcrumb is orphan-cleared.
+    await initDrainingAdoptionPoll();
 
     // Case (b): orphaned — breadcrumb dropped, no adoption, no fabricated end.
     expect(readCrumb()).toBeNull();
@@ -382,7 +393,7 @@ describe("sessionManager reload adoption", () => {
 
   it("leaves no breadcrumb after a normal start then stop", async () => {
     vi.stubGlobal("Router", { MainRunningApp: null });
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
 
     await startGame(lifetime);
@@ -420,11 +431,12 @@ describe("sessionManager reload adoption", () => {
 
   it("survives a full reload: start, destroy, re-init, stop finalizes the original rom", async () => {
     vi.stubGlobal("Router", { MainRunningApp: null });
-    await initSessionManager();
+    // No game at first load → the adoption poll times out before init settles.
+    await initDrainingAdoptionPoll();
     const lifetime1 = captureLifetimeCb();
 
-    // Start at a non-zero time so the suspend guard (sessionStartTime) stays truthy.
-    vi.setSystemTime(1_000);
+    // Start after the poll window (times are absolute; the poll drained to 15s).
+    vi.setSystemTime(20_000);
     await startGame(lifetime1);
     expect(backend.recordSessionStart).toHaveBeenCalledTimes(1);
 
@@ -433,7 +445,8 @@ describe("sessionManager reload adoption", () => {
     destroySessionManager();
     expect(readCrumb()).not.toBeNull();
 
-    // Re-init while the game is still running — adopt via the surviving breadcrumb.
+    // Re-init while the game is still running — the poll sees MainRunningApp
+    // immediately and adopts via the surviving breadcrumb.
     vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
     await initSessionManager();
     // Case (a): durable marker preserved — no second record_session_start.
@@ -514,7 +527,11 @@ describe("sessionManager reload adoption", () => {
     });
     vi.stubGlobal("Router", { MainRunningApp: null });
 
-    await expect(initSessionManager()).resolves.toBeUndefined();
+    // Nothing running → the poll times out, then the orphaned-breadcrumb clear
+    // hits the throwing removeItem, which must be swallowed.
+    const init = initSessionManager();
+    await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);
+    await expect(init).resolves.toBeUndefined();
 
     expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("clear session breadcrumb"));
     expect(backend.recordSessionStart).not.toHaveBeenCalled();
@@ -535,6 +552,106 @@ describe("sessionManager reload adoption", () => {
     await expect(initSessionManager()).resolves.toBeUndefined();
 
     expect(backend.logError).toHaveBeenCalledWith(expect.stringContaining("Session adoption error"));
+  });
+
+  // #1054 follow-up: after a full plugin_loader restart Router.MainRunningApp is
+  // null for several seconds while the game is still running, so a one-shot read
+  // wrongly orphaned a live session. Adoption now polls MainRunningApp.
+  it("adopts a matching breadcrumb once MainRunningApp appears mid-poll, no orphan log", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 3_000 });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    const init = initSessionManager();
+    // Four polls into the loader-restart window, MainRunningApp is still null.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    // Steam finally populates the running app; the next poll sees it.
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    await vi.advanceTimersByTimeAsync(500);
+    await init;
+
+    // Case (a): the matching breadcrumb is adopted without a re-stamp, and the
+    // session was never logged as orphaned.
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("orphaned"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("MainRunningApp appeared"));
+
+    // The adopted session finalizes on stop, carrying the breadcrumb's pausedMs.
+    const lifetime = captureLifetimeCb();
+    await stopGame(lifetime);
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 3);
+  });
+
+  it("orphan-clears the breadcrumb after the poll times out with nothing running", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    await initDrainingAdoptionPoll();
+
+    expect(readCrumb()).toBeNull();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("no running app"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("orphaned"));
+  });
+
+  it("stays silent when the poll times out with no breadcrumb", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    await initDrainingAdoptionPoll();
+
+    expect(readCrumb()).toBeNull();
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    // No breadcrumb to orphan — the timeout is a no-op beyond the poll log.
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("orphaned"));
+    expect(backend.logInfo).toHaveBeenCalledWith(expect.stringContaining("no running app"));
+  });
+
+  it("queues a racing stop behind the poll so it finalizes after adoption", async () => {
+    seedBreadcrumb({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 1_000, pausedMs: 2_000 });
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    const init = initSessionManager();
+    // Let init register the lifetime hook and enter the poll.
+    await vi.advanceTimersByTimeAsync(500);
+    const lifetime = captureLifetimeCb();
+
+    // A stop arrives WHILE the poll is still running. It queues on the lifecycle
+    // chain behind the in-flight adoption task rather than interleaving with it.
+    lifetime({ bRunning: false, unAppID: APP_ID });
+
+    // The game becomes visible; the poll resolves and adoption (a) runs first.
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    await vi.advanceTimersByTimeAsync(500);
+    await init;
+    await vi.advanceTimersByTimeAsync(0); // flush the queued stop task
+
+    // Ordering proof: the stop finalized the ADOPTED session (carrying the
+    // breadcrumb's 2000ms paused → 2s). Had the stop run before adoption,
+    // activeRomId would still be null and handleGameStop a no-op (no finalize).
+    expect(backend.finalizeGameSession).toHaveBeenCalledWith(ROM_ID, 2);
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+  });
+
+  it("aborts an in-flight adoption poll when destroy tears the manager down", async () => {
+    // Nothing running yet → the poll is mid-flight when destroy fires. A game that
+    // appears AFTER teardown must not be adopted: the aborted poll writes no
+    // breadcrumb, records no session, and takes no adoption action (#1148 LOW-1).
+    vi.stubGlobal("Router", { MainRunningApp: null });
+
+    const init = initSessionManager();
+    await vi.advanceTimersByTimeAsync(2_000); // poll running, nothing found yet
+    destroySessionManager(); // tears down mid-poll → bumps the epoch
+    // A running game appears after teardown; the still-pending poll would adopt it
+    // (case a′ → recordSessionStart + breadcrumb) if it did not check the epoch.
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+    await vi.advanceTimersByTimeAsync(500);
+    await init;
+
+    expect(backend.debugLog).toHaveBeenCalledWith("adoption: cancelled by destroy");
+    expect(backend.recordSessionStart).not.toHaveBeenCalled();
+    expect(readCrumb()).toBeNull(); // no breadcrumb written by the aborted adoption
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("Adopted"));
+    expect(backend.logInfo).not.toHaveBeenCalledWith(expect.stringContaining("MainRunningApp appeared"));
   });
 });
 
@@ -560,7 +677,10 @@ describe("sessionManager suspend-hook diagnostics", () => {
     vi.clearAllMocks();
     vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
     vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
-    vi.stubGlobal("Router", { MainRunningApp: null });
+    // A running (non-RomM) app so the #1148 adoption poll returns on its first read
+    // and init settles under real timers — these tests exercise hook registration,
+    // not adoption, so the app is inert background (999 is not in the rom map).
+    vi.stubGlobal("Router", { MainRunningApp: { appid: 999, display_name: "background" } });
   });
 
   afterEach(() => {
@@ -784,7 +904,8 @@ describe("sessionManager suspend subtraction via the User.* fallback (#1148)", (
         }),
       },
     });
-    // Router.MainRunningApp stays null; startGame drives the session via unAppID.
+    // No game at load → the adoption poll drains before init settles; startGame
+    // then drives the session via unAppID (Router.MainRunningApp stays null).
     vi.stubGlobal("Router", { MainRunningApp: null });
     vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
     vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
@@ -809,7 +930,7 @@ describe("sessionManager suspend subtraction via the User.* fallback (#1148)", (
   });
 
   it("captures the User.* callbacks and subtracts a suspend cycle delivered through them", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     expect(userSuspend).toBeTypeOf("function");
     expect(userResume).toBeTypeOf("function");
 
@@ -826,7 +947,7 @@ describe("sessionManager suspend subtraction via the User.* fallback (#1148)", (
   });
 
   it("does not double-count repeated User.* suspend/resume progress fires", async () => {
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     const lifetime = captureLifetimeCb();
     await startGame(lifetime);
 
@@ -856,7 +977,7 @@ describe("sessionManager suspend subtraction via the User.* fallback (#1148)", (
       },
     });
 
-    await initSessionManager();
+    await initDrainingAdoptionPoll();
     destroySessionManager();
 
     expect(suspendUnregister).toHaveBeenCalledTimes(1);

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as backend from "../api/backend";
-import { initSessionManager, destroySessionManager } from "./sessionManager";
+import { initSessionManager, destroySessionManager, ADOPTION_POLL_MAX_MS } from "./sessionManager";
 
 // sessionManager talks to the backend callable surface and the migration
 // stores. Mock both so the test observes only what `handleGameStop` forwards
@@ -60,10 +60,11 @@ async function stopGame(cb: LifetimeCb): Promise<void> {
   await vi.advanceTimersByTimeAsync(0);
 }
 
-// #1148: adoptOrphanedSession now polls Router.MainRunningApp for up to 15s before
-// deciding. When no running app is present, initSessionManager only settles once
-// that poll times out — drain it so the immediate-read tests still resolve.
-const ADOPTION_POLL_MAX_MS = 15_000;
+// #1148: adoptOrphanedSession now polls the running-app surfaces for up to 15s
+// before deciding. When no running app is present, initSessionManager only settles
+// once that poll times out — drain it (using the real source-side constant, so a
+// change to the poll window can't silently desync this fast-forward) so the
+// immediate-read tests still resolve.
 async function initDrainingAdoptionPoll(): Promise<void> {
   const init = initSessionManager();
   await vi.advanceTimersByTimeAsync(ADOPTION_POLL_MAX_MS);

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -3,7 +3,8 @@
  * save sync + playtime tracking via backend callables.
  *
  * Uses SteamClient.GameSessions.RegisterForAppLifetimeNotifications to detect
- * game lifecycle events and Router.MainRunningApp for reliable app ID resolution.
+ * game lifecycle events and the defensive `runningApps` reader (multiple Steam
+ * surfaces, not just `Router.MainRunningApp`) for reliable app-ID resolution.
  */
 
 import { toaster } from "@decky/api";
@@ -20,10 +21,7 @@ import { setMigrationStatus } from "./migrationStore";
 import { setSaveSortMigrationStatus } from "./saveSortMigrationStore";
 import { updatePlaytimeDisplay } from "../patches/metadataPatches";
 import { detach } from "./detach";
-
-declare let Router: {
-  MainRunningApp: { appid: number; display_name: string } | null;
-};
+import { readPrimaryRunningApp, readRunningApps, type RunningApp } from "./runningApps";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -66,6 +64,17 @@ function getRomIdForApp(appId: number): number | null {
  */
 export function getAppIdRomIdMapSnapshot(): Record<string, number> {
   return appIdToRomId;
+}
+
+/**
+ * The romId of the session this manager currently tracks as live, or `null` when
+ * none is open. The launch interceptor reads it synchronously to skip its
+ * cancel-then-gate funnel for a Play press on an already-running game (#1148
+ * round 2) — re-syncing mid-session would upload the save while the emulator
+ * holds the file open, and Steam blocks the relaunch as "already running" anyway.
+ */
+export function getActiveSessionRomId(): number | null {
+  return activeRomId;
 }
 
 function getAppIdForRom(romId: number): number | null {
@@ -255,31 +264,29 @@ function handleResume(): void {
   }
 }
 
-/** Read Steam's running-app, guarding the undeclared `Router` SP global. */
-function readMainRunningApp(): { appid: number; display_name: string } | null {
-  return typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
-}
-
 // Adoption polls Steam's running-app before deciding a session's fate: after a
-// full `plugin_loader` restart `Router.MainRunningApp` is not yet populated for
-// several seconds even though the game is still running (#1054 device evidence),
-// so a single early read wrongly orphaned a live session. Poll until it appears
-// or the window elapses.
+// full `plugin_loader` restart the running-app surfaces are not populated for
+// several seconds even though the game is still running (#1054 / #1148 round 2
+// device evidence), so a single early read wrongly orphaned a live session. Poll
+// the defensive multi-source reader until a running app appears or the window
+// elapses.
 const ADOPTION_POLL_INTERVAL_MS = 500;
 const ADOPTION_POLL_MAX_MS = 15_000;
 
 /**
- * Poll `Router.MainRunningApp` until a running app appears or the window elapses.
- * Returns the app (any app, RomM or not — the caller applies the adoption matrix)
- * or `null` on timeout. Does not read `.appid`, so a throwing-getter running-app
- * surfaces in the caller's adoption decision, not here.
+ * Poll every running-app source until one reports a running app or the window
+ * elapses. Returns the primary app (any app, RomM or not — the caller applies
+ * the adoption matrix) or `null` on timeout, alongside the last round's
+ * per-source `diagnostics` so a timed-out adoption logs what EVERY candidate
+ * reported. Each round's diagnostics are also emitted at debug level.
  */
-async function pollForRunningApp(): Promise<{ appid: number; display_name: string } | null> {
+async function pollForRunningApp(): Promise<{ app: RunningApp | null; diagnostics: string }> {
   const started = Date.now();
   for (;;) {
-    const running = readMainRunningApp();
-    if (running) return running;
-    if (Date.now() - started >= ADOPTION_POLL_MAX_MS) return null;
+    const reading = readRunningApps();
+    detach(debugLog(`adoption poll round: ${reading.diagnostics}`));
+    if (reading.apps.length > 0) return { app: reading.apps[0]!, diagnostics: reading.diagnostics };
+    if (Date.now() - started >= ADOPTION_POLL_MAX_MS) return { app: null, diagnostics: reading.diagnostics };
     await delay(ADOPTION_POLL_INTERVAL_MS);
   }
 }
@@ -294,14 +301,16 @@ async function pollForRunningApp(): Promise<{ appid: number; display_name: strin
  * breadcrumb is the attestation of a start we actually observed. Every finalize
  * fold thus stays anchored to a marker stamped by an observed start.
  *
- * The liveness read is POLLED (not a single read): after a loader restart Steam
- * populates `MainRunningApp` only seconds later, so a one-shot read raced the
- * restart and wrongly orphaned a still-running session (#1054).
+ * The liveness read is POLLED (not a single read) and consults MULTIPLE Steam
+ * surfaces: after a loader restart `Router.MainRunningApp` stays null for seconds
+ * and never repopulates without a fresh lifecycle event our reloaded context
+ * missed (#1054 / #1148 round 2), so a one-shot single-source read raced the
+ * restart and wrongly orphaned a still-running session.
  */
 async function adoptOrphanedSession(): Promise<void> {
   const epoch = sessionEpoch;
   const pollStart = Date.now();
-  const running = await pollForRunningApp();
+  const { app: running, diagnostics } = await pollForRunningApp();
   if (epoch !== sessionEpoch) {
     // destroySessionManager ran while the poll was in flight — abort before
     // touching module state, the breadcrumb, or the backend.
@@ -310,7 +319,9 @@ async function adoptOrphanedSession(): Promise<void> {
   }
   const waitedMs = Date.now() - pollStart;
   logInfo(
-    running ? `adoption: MainRunningApp appeared after ${waitedMs}ms` : `adoption: no running app after ${waitedMs}ms`,
+    running
+      ? `adoption: running app appeared after ${waitedMs}ms [${diagnostics}]`
+      : `adoption: no running app after ${waitedMs}ms [${diagnostics}]`,
   );
   const runningRomId = running ? getRomIdForApp(running.appid) : null;
   const crumb = readSessionBreadcrumb();
@@ -442,9 +453,9 @@ export async function initSessionManager(): Promise<void> {
     lifecycleChain = lifecycleChain
       .then(async () => {
         if (update.bRunning) {
-          // Game started — wait for Router.MainRunningApp to populate
+          // Game started — wait for the running-app surfaces to populate
           await delay(500);
-          const running = readMainRunningApp();
+          const running = readPrimaryRunningApp().app;
           const appId = running?.appid ?? update.unAppID;
           if (appId) {
             // Refresh map in case a sync happened since init
@@ -463,15 +474,20 @@ export async function initSessionManager(): Promise<void> {
 
   // Suspend/resume for accurate playtime. #1148: on current SteamOS the legacy
   // `System.RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend` pair
-  // was removed, so decision C's suspend-subtraction shipped dormant. Register on
-  // the legacy pair when a build still exposes it (it keeps working), else fall
-  // back to the renamed `User.*` progress successors. Both namespaces are read
-  // through an `unknown` view — the runtime is the authority here, not the
-  // `.d.ts`, which the on-device probe proved can drift; `readClientNamespace`
-  // tolerates an absent / non-object / throwing namespace so a malformed
-  // SteamClient still emits the diagnostics and reaches the #1054 adoption instead
-  // of throwing. The registration debug line names WHICH surface was used, and the
-  // surface probe enumerates every suspend/resume member the build exposes.
+  // was removed, so decision C's suspend-subtraction shipped dormant. The renamed
+  // `User.*` progress successors EXIST (typeof function) but — device round 2 —
+  // throw "Unknown method" when INVOKED: the Steam bridge doesn't back them in our
+  // CEF context. So a single try/catch that gives up on the first throw is wrong:
+  // we build an ordered candidate CHAIN (legacy first — it keeps working where it
+  // exists — then the User.* successors) and, when a surface's registration THROWS,
+  // log the surface + exact error, roll back any half-registered handle, and try
+  // the NEXT candidate. Both namespaces are read through an `unknown` view — the
+  // runtime is the authority, not the `.d.ts` the on-device probe proved can
+  // drift; `readClientNamespace` tolerates an absent / non-object / throwing
+  // namespace so a malformed SteamClient still emits the diagnostics and reaches
+  // the #1054 adoption instead of throwing. The registration debug line names
+  // WHICH surface was used; the surface probe enumerates every member the build
+  // exposes.
   const systemApi = readClientNamespace("System");
   const userApi = readClientNamespace("User");
   const hasLegacySuspend = typeof systemApi.RegisterForOnSuspendRequest === "function";
@@ -480,40 +496,74 @@ export async function initSessionManager(): Promise<void> {
   const hasUserResume = typeof userApi.RegisterForResumeSuspendedGamesProgress === "function";
 
   type SuspendRegister = (handler: () => void) => unknown;
-  let surface: string | null = null;
-  let registerSuspend: SuspendRegister | null = null;
-  let registerResume: SuspendRegister | null = null;
+  interface SuspendCandidate {
+    surface: string;
+    registerSuspend: SuspendRegister;
+    registerResume: SuspendRegister;
+  }
+  const candidates: SuspendCandidate[] = [];
   if (hasLegacySuspend && hasLegacyResume) {
-    surface = "System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend";
-    registerSuspend = systemApi.RegisterForOnSuspendRequest as SuspendRegister;
-    registerResume = systemApi.RegisterForOnResumeFromSuspend as SuspendRegister;
-  } else if (hasUserSuspend && hasUserResume) {
-    surface = "User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress";
-    registerSuspend = userApi.RegisterForPrepareForSystemSuspendProgress as SuspendRegister;
-    registerResume = userApi.RegisterForResumeSuspendedGamesProgress as SuspendRegister;
+    candidates.push({
+      surface: "System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend",
+      registerSuspend: systemApi.RegisterForOnSuspendRequest as SuspendRegister,
+      registerResume: systemApi.RegisterForOnResumeFromSuspend as SuspendRegister,
+    });
+  }
+  if (hasUserSuspend && hasUserResume) {
+    candidates.push({
+      surface: "User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress",
+      registerSuspend: userApi.RegisterForPrepareForSystemSuspendProgress as SuspendRegister,
+      registerResume: userApi.RegisterForResumeSuspendedGamesProgress as SuspendRegister,
+    });
   }
 
-  if (surface === null || registerSuspend === null || registerResume === null) {
-    // Neither the legacy `System` pair nor the renamed `User` pair is present — the
-    // members decision C depends on are gone on this build. Warn at headline level
-    // (lands even at the default log level); the surface probe below reports
-    // whatever suspend/resume members the runtime actually exposes.
+  if (candidates.length === 0) {
+    // No candidate pair is even present — the members decision C depends on are
+    // gone on this build. Warn at headline level (lands even at the default log
+    // level); the surface probe below reports whatever members the runtime exposes.
     logWarn(
       `Suspend/resume hooks missing on this build: legacy=${hasLegacySuspend}/${hasLegacyResume} user=${hasUserSuspend}/${hasUserResume}`,
     );
   } else {
-    try {
-      const suspendReturn = registerSuspend(handleSuspend);
-      const resumeReturn = registerResume(handleResume);
-      suspendHook = isUnregisterHandle(suspendReturn) ? suspendReturn : null;
-      resumeHook = isUnregisterHandle(resumeReturn) ? resumeReturn : null;
-      detach(
-        debugLog(
-          `Suspend/resume registration [${surface}]: suspend=${describeHandle(suspendReturn)} resume=${describeHandle(resumeReturn)}`,
-        ),
+    let registered = false;
+    for (const candidate of candidates) {
+      try {
+        const suspendReturn = candidate.registerSuspend(handleSuspend);
+        suspendHook = isUnregisterHandle(suspendReturn) ? suspendReturn : null;
+        const resumeReturn = candidate.registerResume(handleResume);
+        resumeHook = isUnregisterHandle(resumeReturn) ? resumeReturn : null;
+        detach(
+          debugLog(
+            `Suspend/resume registration [${candidate.surface}]: suspend=${describeHandle(suspendReturn)} resume=${describeHandle(resumeReturn)}`,
+          ),
+        );
+        registered = true;
+        break;
+      } catch (e) {
+        // A member that exists but the bridge doesn't back throws "Unknown method"
+        // when INVOKED (#1148 round 2) — distinct from a missing member. Warn with
+        // the surface + exact error, roll back a half-registered suspend hook (its
+        // resume threw) so we don't leak a live handler on an abandoned surface,
+        // then fall through to the next candidate.
+        logWarn(`Suspend/resume registration threw on [${candidate.surface}] (trying next surface): ${e}`);
+        if (suspendHook) {
+          try {
+            suspendHook.unregister();
+          } catch {
+            // Rolling back a surface we're abandoning — a failing unregister is inert.
+          }
+        }
+        suspendHook = null;
+        resumeHook = null;
+      }
+    }
+    if (!registered) {
+      // Every present candidate threw on invocation — no usable surface, so decision
+      // C's suspend-subtraction stays dormant. Loud headline (distinct from the
+      // members-missing one) so a Game-Mode run surfaces it.
+      logWarn(
+        `Suspend/resume registration failed on all ${candidates.length} candidate surface(s) — playtime will not exclude suspend time`,
       );
-    } catch (e) {
-      logWarn(`Suspend/resume registration threw: ${e}`);
     }
   }
   // Investigation point 3 — enumerate the suspend/resume members SteamClient

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -271,7 +271,7 @@ function handleResume(): void {
 // the defensive multi-source reader until a running app appears or the window
 // elapses.
 const ADOPTION_POLL_INTERVAL_MS = 500;
-const ADOPTION_POLL_MAX_MS = 15_000;
+export const ADOPTION_POLL_MAX_MS = 15_000;
 
 /**
  * Poll every running-app source until one reports a running app or the window

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -224,13 +224,20 @@ async function handleGameStop(): Promise<void> {
 }
 
 function handleSuspend(): void {
-  if (activeRomId && sessionStartTime) {
+  // Idempotent across repeated fires: the renamed User.* hook is a PROGRESS
+  // callback that can fire several times during one suspend, so stamp only on the
+  // first (`suspendedAt === null`). Re-stamping would move the pause start forward
+  // and undercount the suspended span subtracted from playtime (#1148).
+  if (activeRomId && sessionStartTime && suspendedAt === null) {
     suspendedAt = Date.now();
     logInfo("Device suspended during session, pausing playtime");
   }
 }
 
 function handleResume(): void {
+  // Idempotent across repeated resume-progress fires: fold only while a suspend is
+  // open (`suspendedAt` set), then clear it so a second fire in the same cycle is a
+  // no-op and cannot double-count (#1148).
   if (activeRomId && suspendedAt) {
     const pauseDuration = Date.now() - suspendedAt;
     totalPausedMs += pauseDuration;
@@ -304,19 +311,33 @@ async function adoptOrphanedSession(): Promise<void> {
 }
 
 /**
- * Read `SteamClient.System` as a plain record, tolerating a runtime where it is
- * absent, not an object, or a throwing getter — any of which yields an empty
- * record. Keeps the #1148 presence check from throwing out of
- * `initSessionManager` (before adoption) when SteamClient is malformed.
+ * Read a `SteamClient` namespace (`System`, `User`, …) as a plain record,
+ * tolerating a runtime where it is absent, not an object, or a throwing getter —
+ * any of which yields an empty record. Keeps the #1148 presence check from
+ * throwing out of `initSessionManager` (before adoption) when SteamClient is
+ * malformed, and lets the suspend/resume registration probe both the legacy
+ * `System.*` surface and its renamed `User.*` successor through the same guard.
  */
-function readSystemApi(): Record<string, unknown> {
+function readClientNamespace(namespace: string): Record<string, unknown> {
   try {
-    const system = (SteamClient as unknown as Record<string, unknown>).System;
-    if (system !== null && typeof system === "object") return system as Record<string, unknown>;
+    const ns = (SteamClient as unknown as Record<string, unknown>)[namespace];
+    if (ns !== null && typeof ns === "object") return ns as Record<string, unknown>;
   } catch {
     // Odd SteamClient shape (e.g. a throwing getter) — fall through to {}.
   }
   return {};
+}
+
+/**
+ * Narrow a registration's runtime return to an unregister handle without trusting
+ * its declared type — a build may hand back `undefined` instead of a handle
+ * (#1148). Only a genuine `{ unregister: fn }` is stored as a hook, so teardown
+ * stays null-safe on every other shape.
+ */
+function isUnregisterHandle(value: unknown): value is { unregister: () => void } {
+  return (
+    typeof value === "object" && value !== null && typeof (value as Record<string, unknown>).unregister === "function"
+  );
 }
 
 /**
@@ -389,36 +410,60 @@ export async function initSessionManager(): Promise<void> {
       });
   });
 
-  // Suspend/resume for accurate playtime. #1148 diagnostics: on-device these
-  // hooks never fired, so decision C's suspend-subtraction shipped dormant.
-  // Probe presence, registration outcome, and the returned handle shape once per
-  // init so a single Game-Mode run tells us whether the API is missing, throwing,
-  // or registering but never firing. The typed SteamClient claims the members
-  // always exist, so presence is read through an `unknown` view — the runtime is
-  // the authority here, not the `.d.ts`. `SteamClient.System` itself is read
-  // defensively (absent, non-object, or a throwing getter → empty record) so a
-  // broken SteamClient still emits the "hooks missing" headline + surface probe
-  // and lets init reach the #1054 adoption, rather than throwing before either.
-  const systemApi = readSystemApi();
-  const hasSuspendReg = typeof systemApi.RegisterForOnSuspendRequest === "function";
-  const hasResumeReg = typeof systemApi.RegisterForOnResumeFromSuspend === "function";
-  if (!hasSuspendReg || !hasResumeReg) {
-    // Actionable headline — the members decision C depends on are absent on this
-    // build. Warn so it lands even at the default log level.
-    logWarn(
-      `Suspend/resume hooks missing on this build: RegisterForOnSuspendRequest=${hasSuspendReg} RegisterForOnResumeFromSuspend=${hasResumeReg}`,
-    );
+  // Suspend/resume for accurate playtime. #1148: on current SteamOS the legacy
+  // `System.RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend` pair
+  // was removed, so decision C's suspend-subtraction shipped dormant. Register on
+  // the legacy pair when a build still exposes it (it keeps working), else fall
+  // back to the renamed `User.*` progress successors. Both namespaces are read
+  // through an `unknown` view — the runtime is the authority here, not the
+  // `.d.ts`, which the on-device probe proved can drift; `readClientNamespace`
+  // tolerates an absent / non-object / throwing namespace so a malformed
+  // SteamClient still emits the diagnostics and reaches the #1054 adoption instead
+  // of throwing. The registration debug line names WHICH surface was used, and the
+  // surface probe enumerates every suspend/resume member the build exposes.
+  const systemApi = readClientNamespace("System");
+  const userApi = readClientNamespace("User");
+  const hasLegacySuspend = typeof systemApi.RegisterForOnSuspendRequest === "function";
+  const hasLegacyResume = typeof systemApi.RegisterForOnResumeFromSuspend === "function";
+  const hasUserSuspend = typeof userApi.RegisterForPrepareForSystemSuspendProgress === "function";
+  const hasUserResume = typeof userApi.RegisterForResumeSuspendedGamesProgress === "function";
+
+  type SuspendRegister = (handler: () => void) => unknown;
+  let surface: string | null = null;
+  let registerSuspend: SuspendRegister | null = null;
+  let registerResume: SuspendRegister | null = null;
+  if (hasLegacySuspend && hasLegacyResume) {
+    surface = "System.RegisterForOnSuspendRequest/RegisterForOnResumeFromSuspend";
+    registerSuspend = systemApi.RegisterForOnSuspendRequest as SuspendRegister;
+    registerResume = systemApi.RegisterForOnResumeFromSuspend as SuspendRegister;
+  } else if (hasUserSuspend && hasUserResume) {
+    surface = "User.RegisterForPrepareForSystemSuspendProgress/RegisterForResumeSuspendedGamesProgress";
+    registerSuspend = userApi.RegisterForPrepareForSystemSuspendProgress as SuspendRegister;
+    registerResume = userApi.RegisterForResumeSuspendedGamesProgress as SuspendRegister;
   }
-  try {
-    if (hasSuspendReg) suspendHook = SteamClient.System.RegisterForOnSuspendRequest(handleSuspend);
-    if (hasResumeReg) resumeHook = SteamClient.System.RegisterForOnResumeFromSuspend(handleResume);
-    detach(
-      debugLog(
-        `Suspend/resume registration: suspend=${describeHandle(suspendHook)} resume=${describeHandle(resumeHook)}`,
-      ),
+
+  if (surface === null || registerSuspend === null || registerResume === null) {
+    // Neither the legacy `System` pair nor the renamed `User` pair is present — the
+    // members decision C depends on are gone on this build. Warn at headline level
+    // (lands even at the default log level); the surface probe below reports
+    // whatever suspend/resume members the runtime actually exposes.
+    logWarn(
+      `Suspend/resume hooks missing on this build: legacy=${hasLegacySuspend}/${hasLegacyResume} user=${hasUserSuspend}/${hasUserResume}`,
     );
-  } catch (e) {
-    logWarn(`Suspend/resume registration threw: ${e}`);
+  } else {
+    try {
+      const suspendReturn = registerSuspend(handleSuspend);
+      const resumeReturn = registerResume(handleResume);
+      suspendHook = isUnregisterHandle(suspendReturn) ? suspendReturn : null;
+      resumeHook = isUnregisterHandle(resumeReturn) ? resumeReturn : null;
+      detach(
+        debugLog(
+          `Suspend/resume registration [${surface}]: suspend=${describeHandle(suspendReturn)} resume=${describeHandle(resumeReturn)}`,
+        ),
+      );
+    } catch (e) {
+      logWarn(`Suspend/resume registration threw: ${e}`);
+    }
   }
   // Investigation point 3 — enumerate the suspend/resume members SteamClient
   // actually exposes at runtime. Debug-gated; never throws.

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -38,6 +38,12 @@ let totalPausedMs = 0;
 // Serialization chain — ensures lifecycle events don't interleave
 let lifecycleChain: Promise<void> = Promise.resolve();
 
+// Bumped by destroySessionManager. The adoption poll can run for up to 15s, past
+// a teardown; adoption captures this at entry and re-checks it after the poll so a
+// destroy mid-poll aborts before mutating any module state, the breadcrumb, or the
+// backend.
+let sessionEpoch = 0;
+
 // Hook handles for cleanup
 let lifetimeHook: { unregister: () => void } | null = null;
 let suspendHook: { unregister: () => void } | null = null;
@@ -249,6 +255,35 @@ function handleResume(): void {
   }
 }
 
+/** Read Steam's running-app, guarding the undeclared `Router` SP global. */
+function readMainRunningApp(): { appid: number; display_name: string } | null {
+  return typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
+}
+
+// Adoption polls Steam's running-app before deciding a session's fate: after a
+// full `plugin_loader` restart `Router.MainRunningApp` is not yet populated for
+// several seconds even though the game is still running (#1054 device evidence),
+// so a single early read wrongly orphaned a live session. Poll until it appears
+// or the window elapses.
+const ADOPTION_POLL_INTERVAL_MS = 500;
+const ADOPTION_POLL_MAX_MS = 15_000;
+
+/**
+ * Poll `Router.MainRunningApp` until a running app appears or the window elapses.
+ * Returns the app (any app, RomM or not — the caller applies the adoption matrix)
+ * or `null` on timeout. Does not read `.appid`, so a throwing-getter running-app
+ * surfaces in the caller's adoption decision, not here.
+ */
+async function pollForRunningApp(): Promise<{ appid: number; display_name: string } | null> {
+  const started = Date.now();
+  for (;;) {
+    const running = readMainRunningApp();
+    if (running) return running;
+    if (Date.now() - started >= ADOPTION_POLL_MAX_MS) return null;
+    await delay(ADOPTION_POLL_INTERVAL_MS);
+  }
+}
+
 /**
  * Adopt a play session orphaned by a plugin reload mid-game.
  *
@@ -258,9 +293,25 @@ function handleResume(): void {
  * (`Router.MainRunningApp`) is the liveness authority; the localStorage
  * breadcrumb is the attestation of a start we actually observed. Every finalize
  * fold thus stays anchored to a marker stamped by an observed start.
+ *
+ * The liveness read is POLLED (not a single read): after a loader restart Steam
+ * populates `MainRunningApp` only seconds later, so a one-shot read raced the
+ * restart and wrongly orphaned a still-running session (#1054).
  */
 async function adoptOrphanedSession(): Promise<void> {
-  const running = typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
+  const epoch = sessionEpoch;
+  const pollStart = Date.now();
+  const running = await pollForRunningApp();
+  if (epoch !== sessionEpoch) {
+    // destroySessionManager ran while the poll was in flight — abort before
+    // touching module state, the breadcrumb, or the backend.
+    detach(debugLog("adoption: cancelled by destroy"));
+    return;
+  }
+  const waitedMs = Date.now() - pollStart;
+  logInfo(
+    running ? `adoption: MainRunningApp appeared after ${waitedMs}ms` : `adoption: no running app after ${waitedMs}ms`,
+  );
   const runningRomId = running ? getRomIdForApp(running.appid) : null;
   const crumb = readSessionBreadcrumb();
 
@@ -393,7 +444,7 @@ export async function initSessionManager(): Promise<void> {
         if (update.bRunning) {
           // Game started — wait for Router.MainRunningApp to populate
           await delay(500);
-          const running = typeof Router === "undefined" ? null : Router.MainRunningApp; // NOSONAR(typescript:S7741) — Router is an undeclared Steam SP global; direct === undefined would throw ReferenceError.
+          const running = readMainRunningApp();
           const appId = running?.appid ?? update.unAppID;
           if (appId) {
             // Refresh map in case a sync happened since init
@@ -506,6 +557,8 @@ export function destroySessionManager(): void {
   suspendedAt = null;
   totalPausedMs = 0;
   lifecycleChain = Promise.resolve();
+  // Signal any in-flight adoption poll to abort instead of mutating torn-down state.
+  sessionEpoch++;
 
   logInfo("Session manager destroyed");
 }


### PR DESCRIPTION
Two on-device-diagnosed fixes in the session manager, both from tonight's Game Mode verification run.

**Renamed suspend/resume hooks (#1148).** The #1303 diagnostics proved the legacy `SteamClient.System.RegisterForOnSuspendRequest` / `RegisterForOnResumeFromSuspend` no longer exist on current SteamOS, and the surface probe named the successors. Registration now walks a fallback chain: the legacy pair when present (a full pair is required — never half-registered), else `SteamClient.User.RegisterForPrepareForSystemSuspendProgress` / `RegisterForResumeSuspendedGamesProgress`, else the (now both-surfaces) missing-hooks headline. The successors are progress callbacks that can fire several times per cycle, so the handlers are idempotent — one suspendedAt stamp, one fold per cycle; consecutive suspend cycles accumulate correctly. All namespace reads stay guarded; teardown unregisters whichever surface registered.

**Session adoption polls MainRunningApp (follow-up to #1054).** After a full plugin_loader restart, `Router.MainRunningApp` is empty at re-init — the adoption wrongly orphan-cleared a live session ("Session orphaned (romId=4399)" while the game ran). Adoption now polls (500 ms, ≤15 s) inside the lifecycle chain before deciding; a racing stop still serializes after adoption. The double-`recordSessionStart` window of the unconditional poll was analyzed end-to-end and is benign (the durable marker is last-write-wins, one fold, one outbox row). An epoch guard cancels an in-flight poll on destroy so it can never mutate state post-teardown.

Tests: 15 new/updated (fallback chain incl. partial-surface states, progress-event idempotency through both surfaces, mid-poll adoption, timeout orphan-clear, racing-stop ordering, destroy-mid-poll cancellation). Architecture docs updated for both flows.

**Merge gate: on-device verification** (next Game Mode round) — a real suspend/resume cycle subtracts pause time via the User.* surface (log shows `Suspend/resume registration [User.…]`), and a reload mid-game adopts instead of orphaning (`adoption: MainRunningApp appeared after Nms`). CI cannot prove either — that is how #1148 stayed dormant.

Closes #1148