### PR TITLE
fix(playtime): drain server-rejected play sessions instead of retrying forever

### DIFF
--- a/docs/adr/0018-native-play-session-tracking-additive-ingest.md
+++ b/docs/adr/0018-native-play-session-tracking-additive-ingest.md
@@ -49,7 +49,16 @@ per-session stream. The local `Playtime` aggregate stays the cumulative display 
   no `.romm-backup` — none of the save-sync machinery applies.
 - **Offline outbox.** Unsent sessions are held in a small pending-session outbox owned by the `Playtime` aggregate. Exit
   enqueues and attempts the POST; success dequeues. Offline → the session stays queued and is flushed on the next
-  launch/sync/reconnect. This is the "only DB, then catch up local→server" path, minus any conflict logic.
+  launch/sync/reconnect. This is the "only DB, then catch up local→server" path, minus any conflict logic. **The flush
+  routes each acknowledged (2xx) per-session verdict:** `created`/`duplicate` dequeue as success; a `skipped` — the
+  server's _explicit_ rejection of that exact window (e.g. a sub-second launch-death it refuses on validation) — is
+  dropped from the outbox with a single info log (`play session rejected by server … — dropping from outbox`), never
+  retried, since re-POSTing the byte-identical row draws the same verdict forever. An `error` **and any unknown
+  acknowledged status** are bounded-retried, then quarantined once the row exhausts its attempt threshold — an outbox
+  session exists nowhere else, so we hard-drop only on an explicit `skipped`, never on an ambiguous verdict, while still
+  staying loop-free. Only a transport failure or a row _absent_ from the response keeps the row queued untouched for the
+  next flush. This keeps a permanently-rejected session from wedging the outbox into an infinite retry loop against the
+  periodic flush.
 - **Reconcile is `max(local, Σ server)`.** On the detail view we first flush the outbox, then `GET /api/play-sessions`
   for the ROM and set the displayed total to `max(local_total, Σ server duration)`. Playtime is monotonic, so `max()` is
   always safe: with the outbox drained it naturally adopts the server union ("the server holds the whole total"); with a

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -404,9 +404,13 @@ wizard reappears — a pure `UPDATE`, never deleting rows or baselines (#1276).
 it creates the `rom_playtime_sessions` outbox table (STRICT, `PRIMARY KEY (rom_id, start_time)`,
 `REFERENCES roms(rom_id) ON DELETE CASCADE`, plus an `attempts INTEGER NOT NULL DEFAULT 0` bounded-retry counter) and
 drops the now-readerless `rom_playtime.note_id` column (`ALTER TABLE rom_playtime DROP COLUMN note_id;` — SQLite ≥3.35,
-the Deck ships 3.50). Existing server notes are left in place, harmless. Each outbox row's `attempts` counts consecutive
-ingest `error` verdicts; PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so a
-permanently-rejected session cannot wedge the outbox (only that session's playtime is lost).
+the Deck ships 3.50). Existing server notes are left in place, harmless. The outbox has two wedge-prevention paths. A
+2xx per-session `skipped` — the server's _explicit_ rejection of that exact `(device, rom, start_time)` window (e.g. a
+sub-second launch-death it refuses on validation) — is dropped immediately via `Playtime.drop_rejected_sessions` with a
+single info log, **without** touching `attempts`: re-POSTing the byte-identical row would draw the same verdict forever.
+Separately, each outbox row's `attempts` counts consecutive ingest `error` (or unknown acknowledged) verdicts;
+PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so an ambiguous never-succeeding verdict
+also cannot wedge the outbox. Either way only that session's playtime is lost.
 
 `007_add_last_played.sql` (`user_version = 7`) adds a nullable `last_played TEXT` column to `rom_playtime`
 ([ADR-0018](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0018-native-play-session-tracking-additive-ingest.md),

--- a/py_modules/domain/playtime.py
+++ b/py_modules/domain/playtime.py
@@ -143,6 +143,19 @@ class Playtime:
         for start_time in start_times:
             self.pending_sessions.pop(start_time, None)
 
+    def drop_rejected_sessions(self, start_times: Iterable[str]) -> None:
+        """Drop outbox rows the server acknowledged but refused to store (terminal).
+
+        Distinct from :meth:`quarantine_sessions` (bounded-retry exhaustion): a
+        rejection is the server's first-contact verdict on this exact session
+        window (e.g. a ``skipped`` sub-second launch-death). Re-POSTing the
+        byte-identical row draws the same verdict forever, so the row is dropped
+        immediately rather than retried. Only playtime is lost; unknown start
+        times are ignored.
+        """
+        for start_time in start_times:
+            self.pending_sessions.pop(start_time, None)
+
     def reconcile_total(self, seconds: int) -> None:
         """Raise the cumulative total to ``seconds`` if it is higher.
 

--- a/py_modules/models/play_sessions.py
+++ b/py_modules/models/play_sessions.py
@@ -36,14 +36,23 @@ class PlaySessionIngestResult(TypedDict):
     """The server's verdict for one submitted session, correlated by ``index``.
 
     ``index`` is the entry's position in the submitted ``sessions`` batch;
-    ``status`` is ``created`` (newly stored), ``duplicate`` (already present, a
-    no-op — still a successful ingest), or ``error``. ``id`` is the stored
-    session row id when created.
+    ``status`` is the per-session verdict:
+
+    - ``created`` — newly stored.
+    - ``duplicate`` — already present, a no-op; still a successful ingest.
+    - ``skipped`` — acknowledged but deliberately not stored (e.g. a sub-second
+      launch-death the server rejects on validation). A terminal verdict: the
+      server will draw the same one for the byte-identical window forever.
+    - ``error`` — the server hit an error storing this row (possibly transient).
+
+    ``id`` is the stored session row id when ``created``; ``detail`` is the
+    server's optional human-readable explanation for a non-``created`` verdict.
     """
 
     index: int
-    status: Literal["created", "duplicate", "error"]
+    status: Literal["created", "duplicate", "skipped", "error"]
     id: NotRequired[int | None]
+    detail: NotRequired[str | None]
 
 
 class PlaySessionIngestResponse(TypedDict):

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     import asyncio
     import logging
 
-    from models.play_sessions import PlaySessionIngestEntry
+    from models.play_sessions import PlaySessionIngestEntry, PlaySessionIngestResult
 
     from domain.playtime import PendingSessionRow
     from services.protocols import (
@@ -289,9 +289,13 @@ class PlaytimeService:
         POST carries exactly one device_id), and for each group POSTs to
         ``/api/play-sessions`` strictly between the two UoWs (never holding a
         transaction across network I/O, ADR-0006). Accepted rows (``created`` /
-        ``duplicate``) dequeue; ``error`` rows increment their attempt counter
-        and are quarantined once they exhaust ``_MAX_INGEST_ATTEMPTS``; rows
-        absent from the response stay queued untouched.
+        ``duplicate``) dequeue; a ``skipped`` row — the server's explicit
+        rejection of that exact window — is dropped as terminal (the server
+        draws the same verdict forever); an ``error`` or any unknown acknowledged
+        status increments the attempt counter and is quarantined once it exhausts
+        ``_MAX_INGEST_ATTEMPTS`` (never dropping data on an ambiguous verdict);
+        rows absent from the response (or a transport failure) stay queued
+        untouched.
         """
         with self._uow_factory() as uow:
             rows = uow.playtime.iter_pending_sessions(_FLUSH_BATCH_LIMIT)
@@ -305,6 +309,7 @@ class PlaytimeService:
         sent_by_rom: dict[int, list[str]] = {}
         failed_by_rom: dict[int, list[str]] = {}
         quarantine_by_rom: dict[int, list[str]] = {}
+        rejected_by_rom: dict[int, list[str]] = {}
         undrained: list[PendingSessionRow] = []
 
         for device_id, group in groups.items():
@@ -314,6 +319,7 @@ class PlaytimeService:
                 sent_by_rom=sent_by_rom,
                 failed_by_rom=failed_by_rom,
                 quarantine_by_rom=quarantine_by_rom,
+                rejected_by_rom=rejected_by_rom,
                 undrained=undrained,
             )
 
@@ -323,10 +329,10 @@ class PlaytimeService:
                 f"Play-session flush: {len(undrained)} submitted session(s) not accepted; roms {undrained_roms}"
             )
 
-        if not (sent_by_rom or failed_by_rom or quarantine_by_rom):
+        if not (sent_by_rom or failed_by_rom or quarantine_by_rom or rejected_by_rom):
             return
 
-        self._apply_flush_outcome(sent_by_rom, failed_by_rom, quarantine_by_rom)
+        self._apply_flush_outcome(sent_by_rom, failed_by_rom, quarantine_by_rom, rejected_by_rom)
 
     def _flush_device_group(
         self,
@@ -336,9 +342,10 @@ class PlaytimeService:
         sent_by_rom: dict[int, list[str]],
         failed_by_rom: dict[int, list[str]],
         quarantine_by_rom: dict[int, list[str]],
+        rejected_by_rom: dict[int, list[str]],
         undrained: list[PendingSessionRow],
     ) -> None:
-        """POST one device's batch and sort each row into sent / failed / quarantine.
+        """POST one device's batch and sort each row into sent / failed / quarantine / rejected.
 
         A transport failure on the POST is non-fatal (mirrors
         ``_close_negotiate_session``): the group's rows stay queued and retry on
@@ -363,46 +370,72 @@ class PlaytimeService:
             undrained.extend(group)
             return
 
-        status_by_index: dict[int, str] = {}
+        verdict_by_index: dict[int, PlaySessionIngestResult] = {}
         for result in response.get("results", []):
             index = result.get("index", -1)
             if 0 <= index < len(group):
-                # ``status`` is the per-row verdict; a malformed row missing it
-                # falls through to "not accepted" (stays queued) below.
-                status_by_index[index] = result.get("status")
+                verdict_by_index[index] = result
 
         for index, row in enumerate(group):
-            status = status_by_index.get(index)
+            result = verdict_by_index.get(index)
+            status = result.get("status") if result is not None else None
+            detail = result.get("detail") if result is not None else None
             if status in ("created", "duplicate"):
                 # Both are successful ingests — dequeue.
                 sent_by_rom.setdefault(row.rom_id, []).append(row.start_time)
                 continue
+            if status is None:
+                # Absent from a 2xx response (or a malformed row missing
+                # ``status``): a transient omission, not a verdict. Stay queued
+                # untouched — no attempt bump — and retry on the next flush.
+                undrained.append(row)
+                continue
+            if status == "skipped":
+                # An EXPLICIT server rejection for this exact (device, rom,
+                # start_time) window (e.g. a sub-second launch-death rejected on
+                # validation). Re-POSTing the byte-identical row draws the same
+                # verdict forever, so draining it is the honest terminal action
+                # (only playtime is lost). Log once at info — the single line is
+                # the record. Only ``skipped`` hard-drops: an outbox session
+                # exists nowhere else, so we delete it solely on an explicit
+                # rejection, never on an ambiguous verdict.
+                rejected_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+                detail_suffix = f", detail={detail}" if detail else ""
+                self._logger.info(
+                    f"play session rejected by server for rom {row.rom_id} "
+                    f"(start={row.start_time}, status={status}{detail_suffix}) — dropping from outbox"
+                )
+                continue
+            # ``error`` OR any unknown acknowledged status: bounded retry, then
+            # quarantine once the row exhausts ``_MAX_INGEST_ATTEMPTS``. An
+            # unknown verdict is not an explicit rejection, so it gets the same
+            # never-drop-data-on-ambiguity hedge as a possibly-transient error —
+            # still loop-free (it converges to quarantine after the threshold).
             undrained.append(row)
-            if status == "error":
-                if row.attempts + 1 >= _MAX_INGEST_ATTEMPTS:
-                    quarantine_by_rom.setdefault(row.rom_id, []).append(row.start_time)
-                    self._logger.warning(
-                        f"Dropping play session for rom {row.rom_id} (start={row.start_time}) after "
-                        f"{row.attempts + 1} failed ingest attempts — unrecoverable, only playtime is lost"
-                    )
-                else:
-                    failed_by_rom.setdefault(row.rom_id, []).append(row.start_time)
-            # A row absent from the response (no status) stays queued untouched —
-            # a transient omission, not a rejection, so its attempt count is not bumped.
+            if row.attempts + 1 >= _MAX_INGEST_ATTEMPTS:
+                quarantine_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+                self._logger.warning(
+                    f"Dropping play session for rom {row.rom_id} (start={row.start_time}, status={status}) "
+                    f"after {row.attempts + 1} failed ingest attempts — unrecoverable, only playtime is lost"
+                )
+            else:
+                failed_by_rom.setdefault(row.rom_id, []).append(row.start_time)
 
     def _apply_flush_outcome(
         self,
         sent_by_rom: dict[int, list[str]],
         failed_by_rom: dict[int, list[str]],
         quarantine_by_rom: dict[int, list[str]],
+        rejected_by_rom: dict[int, list[str]],
     ) -> None:
         """Persist the flush verdicts in one short write UoW.
 
-        For each affected ROM: dequeue accepted sessions, drop quarantined ones,
-        and bump the attempt counter on the rest. Each start_time falls into
-        exactly one bucket, so the three mutations never contend for a row.
+        For each affected ROM: dequeue accepted sessions, drop quarantined and
+        server-rejected ones, and bump the attempt counter on the rest. Each
+        start_time falls into exactly one bucket, so the four mutations never
+        contend for a row.
         """
-        rom_ids = set(sent_by_rom) | set(failed_by_rom) | set(quarantine_by_rom)
+        rom_ids = set(sent_by_rom) | set(failed_by_rom) | set(quarantine_by_rom) | set(rejected_by_rom)
         with self._uow_factory() as uow:
             for rid in rom_ids:
                 pt = uow.playtime.get(rid)
@@ -412,6 +445,8 @@ class PlaytimeService:
                     pt.mark_sessions_sent(sent_by_rom[rid])
                 if rid in quarantine_by_rom:
                     pt.quarantine_sessions(quarantine_by_rom[rid])
+                if rid in rejected_by_rom:
+                    pt.drop_rejected_sessions(rejected_by_rom[rid])
                 if rid in failed_by_rom:
                     pt.record_ingest_failure(failed_by_rom[rid])
                 uow.playtime.save(rid, pt)

--- a/tests/contract/test_session_finalize.py
+++ b/tests/contract/test_session_finalize.py
@@ -88,6 +88,31 @@ async def test_finalize_registered_device_ingests_play_session(harness):
     assert stored[0]["duration_ms"] == 300_000
 
 
+async def test_finalize_server_rejected_session_drains_outbox(harness):
+    """A session the server acknowledges but refuses (``skipped``) drains, not retried.
+
+    Regression guard for the infinite-retry loop: a sub-second launch-death gets
+    a ``skipped`` verdict; the outbox row must drop (empty outbox = nothing to
+    re-flush) rather than being retained and re-POSTed on every heartbeat.
+    """
+    seed_rom(harness, 1)
+    harness.plugin.settings["save_sync_enabled"] = False
+    with harness.uow_factory() as uow:
+        uow.kv_config.set("device_id", "device-1")
+    harness.romm.reject_below_duration_ms = 1000  # server refuses sub-1s sessions
+
+    await harness.plugin.record_session_start(1)
+    # No clock advance → a 0ms session the server rejects.
+    result = await harness.plugin.finalize_game_session(1, 0)
+
+    assert result["total_seconds"] == 0  # still folded locally
+    assert harness.romm.play_sessions == {}  # server stored nothing
+    with harness.uow_factory() as uow:
+        entry = uow.playtime.get(1)
+    assert entry is not None
+    assert entry.pending_sessions == {}  # drained — no infinite retry
+
+
 async def test_finalize_unregistered_device_folds_locally_no_ingest(harness):
     """No device id → the session is counted locally but never POSTed (decision #8)."""
     seed_rom(harness, 1)

--- a/tests/domain/test_playtime.py
+++ b/tests/domain/test_playtime.py
@@ -228,6 +228,21 @@ class TestQuarantineSessions:
         assert set(playtime.pending_sessions) == {"s1"}
 
 
+class TestDropRejectedSessions:
+    def test_drops_named_rows(self):
+        playtime = Playtime()
+        playtime.enqueue_session(device_id="d", start_time="s1", end_time="e", duration_ms=1)
+        playtime.enqueue_session(device_id="d", start_time="s2", end_time="e", duration_ms=1)
+        playtime.drop_rejected_sessions(["s1"])
+        assert set(playtime.pending_sessions) == {"s2"}
+
+    def test_unknown_start_is_ignored(self):
+        playtime = Playtime()
+        playtime.enqueue_session(device_id="d", start_time="s1", end_time="e", duration_ms=1)
+        playtime.drop_rejected_sessions(["missing"])
+        assert set(playtime.pending_sessions) == {"s1"}
+
+
 class TestPendingPlaySessionAttempts:
     def test_defaults_to_zero(self):
         row = PendingPlaySession(device_id="d", end_time="e", duration_ms=1)

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -69,6 +69,10 @@ class FakeRommApi:
         # appends here and dedupes on ``(device_id, rom_id, start_time)``.
         self.play_sessions: dict[int, list[dict[str, Any]]] = {}
         self._play_session_ledger: set[tuple[str, int, str]] = set()
+        # Ingest rejects any submitted session shorter than this (ms) with a
+        # ``skipped`` verdict — models RomM refusing a sub-second launch-death.
+        # Default 0 never rejects (durations are >= 0), so existing tests stand.
+        self.reject_below_duration_ms: int = 0
         self.saves: dict[int, dict[str, Any]] = {}
         self.devices: list[dict[str, Any]] = []
         self.current_user: dict[str, Any] = {"id": 1, "username": "tester"}
@@ -378,6 +382,11 @@ class FakeRommApi:
             if key in self._play_session_ledger:
                 # Idempotent re-POST: already stored, a successful no-op.
                 results.append({"index": index, "status": "duplicate", "id": None})
+                skipped += 1
+                continue
+            if session["duration_ms"] < self.reject_below_duration_ms:
+                # Acknowledged but refused (validation) — not stored, terminal.
+                results.append({"index": index, "status": "skipped", "detail": "session too short"})
                 skipped += 1
                 continue
             self._play_session_ledger.add(key)

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -991,6 +991,116 @@ class TestFlushBoundedRetry:
 
 
 # ---------------------------------------------------------------------------
+# TestFlushTerminalRejection — server acknowledged-but-not-created verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestFlushTerminalRejection:
+    @pytest.mark.asyncio
+    async def test_skipped_status_drains_row(self):
+        """A ``skipped`` verdict is terminal — the row drains, not retried forever."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending()}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "skipped"})  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # drained, not queued
+
+    @pytest.mark.asyncio
+    async def test_skipped_does_not_reflush_on_next_cycle(self):
+        """After a terminal drain the outbox is empty — the next cycle makes no POST."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending()}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "skipped"})  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+        fake.call_log.clear()
+        await svc.flush_pending_sessions()  # second cycle
+
+        assert not any(c[0] == "ingest_play_sessions" for c in fake.call_log)
+
+    @pytest.mark.asyncio
+    async def test_skipped_logs_once_at_info_with_detail(self, caplog):
+        """The single info line — rom_id, status, and the server's detail — is the record."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending()}))
+        fake.ingest_play_sessions = _canned_ingest(  # type: ignore[method-assign]
+            {
+                "results": [{"index": 0, "status": "skipped", "detail": "session too short"}],
+                "created_count": 0,
+                "skipped_count": 1,
+            }
+        )
+
+        with caplog.at_level("INFO"):
+            await svc.flush_pending_sessions()
+
+        rejected = [r for r in caplog.records if "rejected by server" in r.message]
+        assert len(rejected) == 1
+        assert rejected[0].levelname == "INFO"
+        assert "rom 42" in rejected[0].message
+        assert "status=skipped" in rejected[0].message
+        assert "session too short" in rejected[0].message
+
+    @pytest.mark.asyncio
+    async def test_skipped_omits_undrained_breadcrumb(self):
+        """A drained rejection is not a queued row — the noisy 'not accepted' line stops."""
+        logs: list[str] = []
+        svc, fake, uow = make_service(log_debug=logs.append)
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending()}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "skipped"})  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        assert not any("not accepted" in m for m in logs)
+
+    @pytest.mark.asyncio
+    async def test_mixed_created_and_skipped_both_drain(self):
+        """A batch of one accepted + one rejected session leaves the outbox empty."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s0": _pending(), "s1": _pending()}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "skipped"})  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # s0 sent, s1 rejected — both gone
+
+    @pytest.mark.asyncio
+    async def test_unknown_acknowledged_status_bounded_retries_not_dropped(self):
+        """An unknown verdict is NOT an explicit rejection — it retries (attempts bump), never insta-drops."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=0)}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "rejected"})  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert set(entry.pending_sessions) == {"s1"}  # retained, not dropped
+        assert entry.pending_sessions["s1"].attempts == 1  # bounded-retry hedge
+
+    @pytest.mark.asyncio
+    async def test_unknown_acknowledged_status_quarantined_at_threshold(self, caplog):
+        """An unknown verdict converges to quarantine after the retry threshold (still loop-free)."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=4)}))
+        fake.ingest_play_sessions = _verdict_by_start({"s1": "rejected"})  # type: ignore[method-assign]
+
+        with caplog.at_level("WARNING"):
+            await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # quarantined (dropped) at threshold
+        assert any("rom 42" in r.message and "s1" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # TestFlushUndrainedBreadcrumb — FIX 6
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
On-device: the play-session outbox retried four server-rejected sessions forever (`Play-session flush: 4 submitted session(s) not accepted; roms […]` every few seconds, indefinitely). The flush loop knew only `created`/`duplicate` (dequeue) and `error` (bounded retry → quarantine); a 2xx per-session `skipped` verdict fell into a catch-all that retained the row without even bumping attempts — the model's status Literal never included `skipped` at all.

Acknowledged verdicts are now routed explicitly:

- `created` / `duplicate` → dequeued (unchanged)
- `skipped` → **immediately dropped** via the new aggregate verb `drop_rejected_sessions`, with one info log carrying the server's status and detail — the only insta-drop path, reserved for an explicit server rejection
- `error` **and any unknown acknowledged status** → the existing bounded-retry-then-quarantine hedge (an outbox session exists nowhere else, so ambiguous or future verdicts never insta-drop; still loop-free — converges to quarantine at the attempts threshold)
- transport failures / rows absent from the response → retained, untouched (the safety direction)

Rejected rows are excluded from the noisy "not accepted" breadcrumb, so the log loop stops. No client-side minimum-duration guess at enqueue time — the server stays the authority on what it accepts.

Tests: verdict-taxonomy matrix at service tier (skipped drains + no re-flush + single info log, mixed batches, unknown-status bounded retry then quarantine, transport-error retention pinned), domain verb tests, and a contract-tier pin driving finalize → flush against a rejecting fake. ADR-0018 outbox semantics and the database-design wedge-prevention paragraph updated.

Refs ADR-0018.