### PR TITLE
fix(playtime): sub-second sessions poison the whole ingest batch → 422 retry loop

### DIFF
--- a/docs/adr/0018-native-play-session-tracking-additive-ingest.md
+++ b/docs/adr/0018-native-play-session-tracking-additive-ingest.md
@@ -47,6 +47,15 @@ per-session stream. The local `Playtime` aggregate stays the cumulative display 
   session `(rom_id, device_id, start, end, duration_ms)` and `POST /api/play-sessions`. RomM accumulates the union
   across devices; `start_time` dedup makes any re-POST idempotent. No `content_hash`, no newest-wins, no conflict modal,
   no `.romm-backup` — none of the save-sync machinery applies.
+- **Only real windows are enqueued (`is_ingestable_session`, #1312).** RomM validates
+  `end_time must be after
+  start_time` at **second** resolution and 422s the _whole_ batch on any entry that fails. A
+  mis-fired launch that starts and ends inside one wall-clock second (the "<1s launch-death", #1305) is therefore not
+  enqueued — the pure `is_ingestable_session` kernel gates the outbox at the recording seam, admitting a window only
+  when `end` is strictly later than `start` once both are floored to the second (the exact rule RomM applies, so we
+  never over-drop a window RomM would accept — a long-but-fully-suspended session with `duration_ms≈0` still has a valid
+  multi-second window and is kept). The duration is still folded into the local total; only the native ingest is
+  skipped. This stops _new_ poison at the source; the outbox heal below repairs rows queued before this gate existed.
 - **Offline outbox.** Unsent sessions are held in a small pending-session outbox owned by the `Playtime` aggregate. Exit
   enqueues and attempts the POST; success dequeues. Offline → the session stays queued and is flushed on the next
   launch/sync/reconnect. This is the "only DB, then catch up local→server" path, minus any conflict logic. **The flush
@@ -59,6 +68,19 @@ per-session stream. The local `Playtime` aggregate stays the cumulative display 
   staying loop-free. Only a transport failure or a row _absent_ from the response keeps the row queued untouched for the
   next flush. This keeps a permanently-rejected session from wedging the outbox into an infinite retry loop against the
   periodic flush.
+- **Whole-request 422 is healed surgically, not looped (#1312).** RomM validates the `sessions` array **atomically**:
+  one invalid entry rejects the ENTIRE `POST /api/play-sessions` with HTTP 422 — there is no per-session verdict list,
+  so a single poison row would block every valid session queued behind it (and the pre-#1312 422 path retained the batch
+  _without_ bumping `attempts`, so 12 real sessions looped forever at `attempts=0`). This **narrows the #1310 assumption
+  that every rejection arrives as a 2xx per-session verdict**: a whole-request rejection is a distinct, structured
+  transport failure. The adapter surfaces it as `RommUnprocessableEntityError` carrying the parsed 422 `detail`
+  (FastAPI/Pydantic names each failing entry's position in `detail[].loc[2] = ["body","sessions",<index>]`); the service
+  extracts those indices via the pure `rejected_session_indices` kernel, drops exactly those rows as terminal (the
+  byte-identical entry draws the same verdict forever — same taxonomy as a `skipped` verdict, via
+  `Playtime.drop_rejected_sessions`) and **resubmits the survivors** so one bad entry never blocks the batch. If the 422
+  body names no usable index (unparseable / no `detail`), the whole group falls back to the `attempts` bounded-retry
+  counter above, so a persistent whole-request 422 converges to quarantine instead of looping. Layer boundary: the
+  adapter parses HTTP (status + `detail`), the service decides (drop + resubmit) via the pure kernel.
 - **Reconcile is `max(local, Σ server)`.** On the detail view we first flush the outbox, then `GET /api/play-sessions`
   for the ROM and set the displayed total to `max(local_total, Σ server duration)`. Playtime is monotonic, so `max()` is
   always safe: with the outbox drained it naturally adopts the server union ("the server holds the whole total"); with a

--- a/docs/adr/0018-native-play-session-tracking-additive-ingest.md
+++ b/docs/adr/0018-native-play-session-tracking-additive-ingest.md
@@ -77,10 +77,17 @@ per-session stream. The local `Playtime` aggregate stays the cumulative display 
   (FastAPI/Pydantic names each failing entry's position in `detail[].loc[2] = ["body","sessions",<index>]`); the service
   extracts those indices via the pure `rejected_session_indices` kernel, drops exactly those rows as terminal (the
   byte-identical entry draws the same verdict forever — same taxonomy as a `skipped` verdict, via
-  `Playtime.drop_rejected_sessions`) and **resubmits the survivors** so one bad entry never blocks the batch. If the 422
-  body names no usable index (unparseable / no `detail`), the whole group falls back to the `attempts` bounded-retry
-  counter above, so a persistent whole-request 422 converges to quarantine instead of looping. Layer boundary: the
-  adapter parses HTTP (status + `detail`), the service decides (drop + resubmit) via the pure kernel.
+  `Playtime.drop_rejected_sessions`) and **resubmits the survivors** so one bad entry never blocks the batch. When the
+  422 body names **no usable index** (a Cloudflare-Tunnel / proxy can mangle the multi-entry validation body — a real
+  risk here), a multi-row batch must NOT quarantine the whole group: a session recorded locally but not yet on the
+  server exists nowhere else, so losing a valid sibling to a poison one would violate "never delete data that exists
+  nowhere else". Instead each session is **re-submitted on its own** (`_flush_single_session`) so the server's
+  per-session verdict isolates the genuine poison — a 201 dequeues the valid one, a lone 422 that now DOES name the
+  entry drops it terminally, a lone 422 that still names nothing bumps only THAT one row's `attempts`, and a transport
+  error retains only that one. A lone row (`len == 1`) has no sibling to isolate, so it skips the re-POST and bumps its
+  own counter directly. Either way a persistent unindexed 422 converges to a per-session quarantine instead of looping,
+  and a valid session is never dropped because a sibling was poison. Layer boundary: the adapter parses HTTP (status +
+  `detail`), the service decides (drop + resubmit / per-session fallback) via the pure kernels.
 - **Reconcile is `max(local, Σ server)`.** On the detail view we first flush the outbox, then `GET /api/play-sessions`
   for the ROM and set the displayed total to `max(local_total, Σ server duration)`. Playtime is monotonic, so `max()` is
   always safe: with the outbox drained it naturally adopts the server union ("the server holds the whole total"); with a

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -412,10 +412,12 @@ A whole-request **HTTP 422** — RomM validates the `sessions` array _atomically
 POST (#1312) — is healed surgically: the adapter surfaces it as `RommUnprocessableEntityError` with the parsed `detail`,
 the pure `rejected_session_indices` kernel reads the failing `detail[].loc[2]` positions, PlaytimeService drops exactly
 those rows (again via `drop_rejected_sessions`) and resubmits the survivors, so one poison entry never blocks the batch;
-a 422 that names no usable index falls back to the `attempts` counter. New sub-second poison is kept out of the outbox
-at the recording seam by the pure `is_ingestable_session` gate (window strictly post-start at second resolution — the
-same rule RomM applies). Separately, each outbox row's `attempts` counts consecutive ingest `error` (or unknown
-acknowledged) verdicts; PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so an ambiguous
+a multi-row 422 that names no usable index (a proxy-mangled body) re-submits each session on its own
+(`_flush_single_session`) so the per-session verdict isolates the genuine poison and a valid sibling is never dropped
+for another's fault, and a lone row bumps only its own `attempts`. New sub-second poison is kept out of the outbox at
+the recording seam by the pure `is_ingestable_session` gate (window strictly post-start at second resolution — the same
+rule RomM applies). Separately, each outbox row's `attempts` counts consecutive ingest `error` (or unknown acknowledged)
+verdicts; PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so an ambiguous
 never-succeeding verdict also cannot wedge the outbox. Either way only that session's playtime is lost.
 
 `007_add_last_played.sql` (`user_version = 7`) adds a nullable `last_played TEXT` column to `rom_playtime`

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -404,13 +404,19 @@ wizard reappears — a pure `UPDATE`, never deleting rows or baselines (#1276).
 it creates the `rom_playtime_sessions` outbox table (STRICT, `PRIMARY KEY (rom_id, start_time)`,
 `REFERENCES roms(rom_id) ON DELETE CASCADE`, plus an `attempts INTEGER NOT NULL DEFAULT 0` bounded-retry counter) and
 drops the now-readerless `rom_playtime.note_id` column (`ALTER TABLE rom_playtime DROP COLUMN note_id;` — SQLite ≥3.35,
-the Deck ships 3.50). Existing server notes are left in place, harmless. The outbox has two wedge-prevention paths. A
+the Deck ships 3.50). Existing server notes are left in place, harmless. The outbox has three wedge-prevention paths. A
 2xx per-session `skipped` — the server's _explicit_ rejection of that exact `(device, rom, start_time)` window (e.g. a
 sub-second launch-death it refuses on validation) — is dropped immediately via `Playtime.drop_rejected_sessions` with a
 single info log, **without** touching `attempts`: re-POSTing the byte-identical row would draw the same verdict forever.
-Separately, each outbox row's `attempts` counts consecutive ingest `error` (or unknown acknowledged) verdicts;
-PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so an ambiguous never-succeeding verdict
-also cannot wedge the outbox. Either way only that session's playtime is lost.
+A whole-request **HTTP 422** — RomM validates the `sessions` array _atomically_, so one invalid entry rejects the entire
+POST (#1312) — is healed surgically: the adapter surfaces it as `RommUnprocessableEntityError` with the parsed `detail`,
+the pure `rejected_session_indices` kernel reads the failing `detail[].loc[2]` positions, PlaytimeService drops exactly
+those rows (again via `drop_rejected_sessions`) and resubmits the survivors, so one poison entry never blocks the batch;
+a 422 that names no usable index falls back to the `attempts` counter. New sub-second poison is kept out of the outbox
+at the recording seam by the pure `is_ingestable_session` gate (window strictly post-start at second resolution — the
+same rule RomM applies). Separately, each outbox row's `attempts` counts consecutive ingest `error` (or unknown
+acknowledged) verdicts; PlaytimeService quarantines (drops) a row once it reaches its retry threshold, so an ambiguous
+never-succeeding verdict also cannot wedge the outbox. Either way only that session's playtime is lost.
 
 `007_add_last_played.sql` (`user_version = 7`) adds a nullable `last_played TEXT` column to `rom_playtime`
 ([ADR-0018](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0018-native-play-session-tracking-additive-ingest.md),

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -29,6 +29,7 @@ from lib.errors import (
     RommServerError,
     RommSSLError,
     RommTimeoutError,
+    RommUnprocessableEntityError,
     TokenHostMismatchError,
 )
 from lib.url_host import same_origin
@@ -183,6 +184,27 @@ class RommHttpAdapter:
             return RommServerError(msg, status_code=code, url=url, method=method)
         return RommApiError(msg, url=url, method=method)
 
+    def _translate_unprocessable(
+        self, exc: urllib.error.HTTPError, url: str, method: str
+    ) -> RommUnprocessableEntityError:
+        """Build a :class:`RommUnprocessableEntityError` carrying the parsed 422 ``detail``.
+
+        Reads the ``HTTPError`` response body once and extracts its ``detail``
+        list (RomM/FastAPI's per-field validation errors). Any failure to read or
+        parse the body degrades to ``detail=None`` — the caller then falls back to
+        a whole-request strategy rather than a per-entry one.
+        """
+        detail = None
+        try:
+            raw = exc.read().decode()
+            body = json.loads(raw) if raw else None
+            if isinstance(body, dict):
+                detail = body.get("detail")
+        except Exception:  # unreadable / non-JSON body — degrade to no detail
+            detail = None
+        msg = f"HTTP 422: {exc.reason} ({method} {url})"
+        return RommUnprocessableEntityError(msg, detail=detail, url=url, method=method)
+
     @staticmethod
     def _translate_unwrapped(exc: Exception, url: str, method: str) -> RommApiError:
         """Translate non-HTTP exceptions (ssl, timeout, connection) to typed errors."""
@@ -197,6 +219,12 @@ class RommHttpAdapter:
     def translate_http_error(self, exc: Exception, url: str, method: str = "GET") -> RommApiError:
         """Translate urllib/socket exceptions into RommApiError subclasses."""
         if isinstance(exc, urllib.error.HTTPError):
+            if exc.code == 422:
+                # A 422 carries a structured validation body (FastAPI's
+                # ``{"detail": [...]}``). Reading it lets the caller act on WHICH
+                # entries a batch endpoint rejected (#1312) instead of collapsing
+                # the whole request to a generic error.
+                return self._translate_unprocessable(exc, url, method)
             msg = f"HTTP {exc.code}: {exc.reason} ({method} {url})"
             return self._translate_http_status(exc.code, msg, url, method)
         if isinstance(exc, urllib.error.URLError):

--- a/py_modules/domain/playtime.py
+++ b/py_modules/domain/playtime.py
@@ -9,6 +9,9 @@ Individual completed sessions are not entities once ingested — only their star
 (while open), their folded-in result, and the still-unsent outbox rows persist.
 RomM's native play-session store is the shared additive record (ADR-0018); this
 aggregate is the local durable + cumulative read model that reconciles with it.
+The module also holds the pure kernels that gate the outbox (``is_ingestable_session``
+— what may enter it) and heal it (``rejected_session_indices`` — which entries a
+whole-request 422 flagged).
 """
 
 from __future__ import annotations
@@ -23,6 +26,75 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 _MAX_SESSION_SECONDS = 86_400  # a single session contributes at most 24h
+
+
+def is_ingestable_session(start_time: str, end_time: str) -> bool:
+    """Whether a closed session's window is safe to POST to RomM's native ingest.
+
+    RomM validates ``end_time must be after start_time`` at SECOND resolution and
+    422s the WHOLE ``sessions`` batch if any one entry fails, so a mis-fired
+    launch that started and ended inside a single wall-clock second (#1305)
+    poisons every valid session queued behind it (#1312). Returns ``True`` only
+    when ``end_time`` is strictly later than ``start_time`` once both are floored
+    to the second — the exact rule RomM applies, so a window this kernel accepts
+    is one RomM accepts and a window it rejects is kept out of the outbox at the
+    recording seam. ``duration_ms`` is deliberately NOT consulted: a long but
+    fully suspended session has a ``duration_ms`` near zero yet a valid
+    multi-second window RomM stores. An unparseable timestamp or a naive/aware
+    mismatch is treated as not ingestable — never enqueue a window that cannot be
+    validated locally.
+    """
+    start = parse_iso(start_time)
+    end = parse_iso(end_time)
+    if start is None or end is None:
+        return False
+    try:
+        return end.replace(microsecond=0) > start.replace(microsecond=0)
+    except TypeError:  # naive/aware mismatch — uncomparable, treat as not ingestable
+        return False
+
+
+def rejected_session_indices(detail: object, batch_size: int) -> list[int]:
+    """Parse RomM's 422 validation body into the rejected ``sessions`` indices.
+
+    RomM (FastAPI/Pydantic) answers a bad play-session batch with
+    ``{"detail": [{"loc": ["body", "sessions", <i>], "msg": ...}, ...]}``, naming
+    each failing entry's position ``<i>`` in the submitted ``sessions`` array.
+    Returns the sorted, deduped positions that fall in ``[0, batch_size)``. A body
+    of any other shape — ``detail`` missing or not a list, a ``loc`` with no
+    ``"sessions"`` int, an index out of range — yields an empty list, the caller's
+    signal to fall back to whole-batch attempt counting rather than dropping a
+    guessed entry.
+    """
+    if not isinstance(detail, list):
+        return []
+    found: set[int] = set()
+    for item in detail:
+        if not isinstance(item, dict):
+            continue
+        index = _session_index_from_loc(item.get("loc"))
+        if index is not None and 0 <= index < batch_size:
+            found.add(index)
+    return sorted(found)
+
+
+def _session_index_from_loc(loc: object) -> int | None:
+    """Extract the ``sessions`` array index from a FastAPI 422 ``loc`` path.
+
+    ``loc`` is the field path, e.g. ``["body", "sessions", 2]`` (a whole-item
+    model-validator error) or ``["body", "sessions", 2, "end_time"]`` (a
+    single-field error). Returns the int immediately following the ``"sessions"``
+    segment, or ``None`` when the path has no such segment or the following
+    element is not a plain int (``bool`` is an ``int`` subclass and is excluded).
+    """
+    if not isinstance(loc, (list, tuple)):
+        return None
+    for pos, segment in enumerate(loc):
+        if segment == "sessions" and pos + 1 < len(loc):
+            nxt = loc[pos + 1]
+            if isinstance(nxt, int) and not isinstance(nxt, bool):
+                return nxt
+    return None
 
 
 @dataclass(frozen=True, slots=True)

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -58,6 +58,22 @@ class RommConflictError(RommApiError):
     status_code = 409
 
 
+class RommUnprocessableEntityError(RommApiError):
+    """422 Unprocessable Entity — the request body failed server-side validation.
+
+    Carries the parsed validation ``detail`` body (RomM/FastAPI's
+    ``{"detail": [{"loc": [...], "msg": ...}, ...]}``) so a caller can identify
+    which entries of a batch endpoint the server rejected. Non-retryable: the
+    same body draws the same validation verdict, so replaying it cannot succeed.
+    """
+
+    status_code = 422
+
+    def __init__(self, message, *, detail=None, url=None, method=None):
+        self.detail = detail
+        super().__init__(message, url=url, method=method)
+
+
 class RommServerError(RommApiError):
     """5xx server errors (500, 502, 503, etc.)."""
 

--- a/py_modules/models/play_sessions.py
+++ b/py_modules/models/play_sessions.py
@@ -11,6 +11,12 @@ wire contract without changing their identity.
 The request envelope (``{"device_id", "sessions"}``) is assembled inline at the
 adapter, not modeled here; the ``GET`` history response is a bare
 ``list[dict[str, Any]]`` (unvalidated at the seam, summed by ``duration_ms``).
+
+A whole-batch validation failure (RomM validates the ``sessions`` array
+atomically — any invalid entry rejects the entire POST, #1312) is a
+transport-level HTTP 422, surfaced as ``lib.errors.RommUnprocessableEntityError``
+carrying the failing ``sessions`` indices in its ``detail`` — NOT a per-entry
+verdict in ``results``.
 """
 
 from __future__ import annotations

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -366,15 +366,7 @@ class PlaytimeService:
         (#1312). Per-row 2xx verdicts are correlated back by the response
         ``index`` (position in this group's submitted batch).
         """
-        batch: list[PlaySessionIngestEntry] = [
-            {
-                "rom_id": row.rom_id,
-                "start_time": row.start_time,
-                "end_time": row.end_time,
-                "duration_ms": row.duration_ms,
-            }
-            for row in group
-        ]
+        batch: list[PlaySessionIngestEntry] = [self._entry_for_row(row) for row in group]
         try:
             response = self._romm_api.ingest_play_sessions(device_id, batch)
         except RommUnprocessableEntityError as exc:
@@ -406,44 +398,82 @@ class PlaytimeService:
             result = verdict_by_index.get(index)
             status = result.get("status") if result is not None else None
             detail = result.get("detail") if result is not None else None
-            if status in ("created", "duplicate"):
-                # Both are successful ingests — dequeue.
-                sent_by_rom.setdefault(row.rom_id, []).append(row.start_time)
-                continue
-            if status is None:
-                # Absent from a 2xx response (or a malformed row missing
-                # ``status``): a transient omission, not a verdict. Stay queued
-                # untouched — no attempt bump — and retry on the next flush.
-                undrained.append(row)
-                continue
-            if status == "skipped":
-                # An EXPLICIT server rejection for this exact (device, rom,
-                # start_time) window (e.g. a sub-second launch-death rejected on
-                # validation). Re-POSTing the byte-identical row draws the same
-                # verdict forever, so draining it is the honest terminal action
-                # (only playtime is lost). Log once at info — the single line is
-                # the record. Only ``skipped`` hard-drops: an outbox session
-                # exists nowhere else, so we delete it solely on an explicit
-                # rejection, never on an ambiguous verdict.
-                rejected_by_rom.setdefault(row.rom_id, []).append(row.start_time)
-                detail_suffix = f", detail={detail}" if detail else ""
-                self._logger.info(
-                    f"play session rejected by server for rom {row.rom_id} "
-                    f"(start={row.start_time}, status={status}{detail_suffix}) — dropping from outbox"
-                )
-                continue
-            # ``error`` OR any unknown acknowledged status: bounded retry, then
-            # quarantine once the row exhausts ``_MAX_INGEST_ATTEMPTS``. An
-            # unknown verdict is not an explicit rejection, so it gets the same
-            # never-drop-data-on-ambiguity hedge as a possibly-transient error —
-            # still loop-free (it converges to quarantine after the threshold).
-            self._bump_ingest_attempt(
+            self._route_2xx_verdict(
                 row,
-                status=status,
+                status,
+                detail,
+                sent_by_rom=sent_by_rom,
                 failed_by_rom=failed_by_rom,
                 quarantine_by_rom=quarantine_by_rom,
+                rejected_by_rom=rejected_by_rom,
                 undrained=undrained,
             )
+
+    @staticmethod
+    def _entry_for_row(row: PendingSessionRow) -> PlaySessionIngestEntry:
+        """Project one outbox row to the ``PlaySessionIngestEntry`` wire shape."""
+        return {
+            "rom_id": row.rom_id,
+            "start_time": row.start_time,
+            "end_time": row.end_time,
+            "duration_ms": row.duration_ms,
+        }
+
+    def _route_2xx_verdict(
+        self,
+        row: PendingSessionRow,
+        status: str | None,
+        detail: object,
+        *,
+        sent_by_rom: dict[int, list[str]],
+        failed_by_rom: dict[int, list[str]],
+        quarantine_by_rom: dict[int, list[str]],
+        rejected_by_rom: dict[int, list[str]],
+        undrained: list[PendingSessionRow],
+    ) -> None:
+        """Sort one row into a bucket from its acknowledged (2xx) per-session verdict.
+
+        Shared by the batch loop and the per-session fallback so the two agree on
+        the verdict taxonomy exactly.
+        """
+        if status in ("created", "duplicate"):
+            # Both are successful ingests — dequeue.
+            sent_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+            return
+        if status is None:
+            # Absent from a 2xx response (or a malformed row missing ``status``):
+            # a transient omission, not a verdict. Stay queued untouched — no
+            # attempt bump — and retry on the next flush.
+            undrained.append(row)
+            return
+        if status == "skipped":
+            # An EXPLICIT server rejection for this exact (device, rom,
+            # start_time) window (e.g. a sub-second launch-death rejected on
+            # validation). Re-POSTing the byte-identical row draws the same
+            # verdict forever, so draining it is the honest terminal action (only
+            # playtime is lost). Log once at info — the single line is the record.
+            # Only ``skipped`` hard-drops: an outbox session exists nowhere else,
+            # so we delete it solely on an explicit rejection, never on an
+            # ambiguous verdict.
+            rejected_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+            detail_suffix = f", detail={detail}" if detail else ""
+            self._logger.info(
+                f"play session rejected by server for rom {row.rom_id} "
+                f"(start={row.start_time}, status={status}{detail_suffix}) — dropping from outbox"
+            )
+            return
+        # ``error`` OR any unknown acknowledged status: bounded retry, then
+        # quarantine once the row exhausts ``_MAX_INGEST_ATTEMPTS``. An unknown
+        # verdict is not an explicit rejection, so it gets the same
+        # never-drop-data-on-ambiguity hedge as a possibly-transient error — still
+        # loop-free (it converges to quarantine after the threshold).
+        self._bump_ingest_attempt(
+            row,
+            status=status,
+            failed_by_rom=failed_by_rom,
+            quarantine_by_rom=quarantine_by_rom,
+            undrained=undrained,
+        )
 
     def _handle_batch_rejection(
         self,
@@ -465,25 +495,49 @@ class PlaytimeService:
         the failing positions in ``detail[].loc[2]``; those rows drop as terminal
         (the byte-identical entry draws the same verdict forever, exactly like a
         ``skipped`` per-row verdict) and the survivors resubmit so they still
-        ingest. When the body names no usable index (unparseable / no ``detail``),
-        the whole group falls back to bounded-retry attempt counting so a
-        persistent whole-request 422 converges to quarantine instead of looping
-        forever. Recursion is bounded: each level drops at least the flagged rows,
-        so the survivor group strictly shrinks (and the no-index branch never
-        recurses).
+        ingest.
+
+        When the body names NO usable index (a proxy/Cloudflare-mangled 422 body
+        is a real risk — RomM sits behind a Cloudflare Tunnel here) a multi-row
+        batch must NOT quarantine the whole group: a session recorded locally but
+        not yet on the server exists nowhere else, so losing a valid sibling to a
+        poison one would violate "never delete data that exists nowhere else".
+        Instead each session is re-submitted on its OWN (:meth:`_flush_single_session`)
+        so the server's per-session verdict isolates the genuine poison from its
+        valid siblings. A lone row (``len == 1``) has no sibling to isolate, so it
+        skips the re-POST and bumps its own attempt counter directly.
+
+        Recursion is bounded: the indexed path drops at least the flagged rows, so
+        the survivor group strictly shrinks; the no-index path fans out into
+        single-session POSTs that never re-enter this method.
         """
         indices = set(rejected_session_indices(exc.detail, len(group)))
         if not indices:
-            self._log_debug(
-                f"Play-session batch rejected (HTTP 422) with no usable detail indices "
-                f"(device {device_id}, {len(group)} session(s)) — bumping attempts"
-            )
-            for row in group:
+            if len(group) == 1:
+                # No sibling to isolate — bump this lone row toward its own quarantine.
+                self._log_debug(
+                    f"Play-session single-session 422 with no usable detail (device {device_id}) — bumping attempts"
+                )
                 self._bump_ingest_attempt(
-                    row,
+                    group[0],
                     status="422",
                     failed_by_rom=failed_by_rom,
                     quarantine_by_rom=quarantine_by_rom,
+                    undrained=undrained,
+                )
+                return
+            self._log_debug(
+                f"Play-session batch 422 with no usable detail indices "
+                f"(device {device_id}, {len(group)} session(s)) — falling back to per-session ingest"
+            )
+            for row in group:
+                self._flush_single_session(
+                    device_id,
+                    row,
+                    sent_by_rom=sent_by_rom,
+                    failed_by_rom=failed_by_rom,
+                    quarantine_by_rom=quarantine_by_rom,
+                    rejected_by_rom=rejected_by_rom,
                     undrained=undrained,
                 )
             return
@@ -509,6 +563,68 @@ class PlaytimeService:
                 rejected_by_rom=rejected_by_rom,
                 undrained=undrained,
             )
+
+    def _flush_single_session(
+        self,
+        device_id: str,
+        row: PendingSessionRow,
+        *,
+        sent_by_rom: dict[int, list[str]],
+        failed_by_rom: dict[int, list[str]],
+        quarantine_by_rom: dict[int, list[str]],
+        rejected_by_rom: dict[int, list[str]],
+        undrained: list[PendingSessionRow],
+    ) -> None:
+        """Re-POST one outbox row on its own after an unindexed whole-batch 422.
+
+        The single-session verdict isolates the genuine poison from its valid
+        siblings, so a proxy-mangled batch 422 (no usable ``detail``) can never
+        quarantine a valid session for a sibling's fault (#1312 L2). Verdicts:
+        a 201 (``created`` / ``duplicate``) dequeues; a lone 422 that now DOES name
+        the entry (index 0) drops it terminally (the genuine poison); a lone 422
+        that STILL names no index bumps only THIS row's attempt counter; a
+        transport error retains only this row. Deliberately does NOT re-enter
+        :meth:`_handle_batch_rejection`, so the fan-out is one POST per session and
+        cannot loop.
+        """
+        try:
+            response = self._romm_api.ingest_play_sessions(device_id, [self._entry_for_row(row)])
+        except RommUnprocessableEntityError as exc:
+            if rejected_session_indices(exc.detail, 1):
+                # The server named this lone session as the poison — drop terminally.
+                rejected_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+                self._logger.info(
+                    f"play session rejected by server for rom {row.rom_id} "
+                    f"(start={row.start_time}, HTTP 422 single-session) — dropping from outbox"
+                )
+            else:
+                # Still no usable detail even for one session — bump only this row.
+                self._bump_ingest_attempt(
+                    row,
+                    status="422",
+                    failed_by_rom=failed_by_rom,
+                    quarantine_by_rom=quarantine_by_rom,
+                    undrained=undrained,
+                )
+            return
+        except Exception as e:
+            self._log_debug(f"Play-session ingest failed (non-fatal): {e}")
+            undrained.append(row)
+            return
+
+        result = next((r for r in response.get("results", []) if r.get("index", -1) == 0), None)
+        status = result.get("status") if result is not None else None
+        detail = result.get("detail") if result is not None else None
+        self._route_2xx_verdict(
+            row,
+            status,
+            detail,
+            sent_by_rom=sent_by_rom,
+            failed_by_rom=failed_by_rom,
+            quarantine_by_rom=quarantine_by_rom,
+            rejected_by_rom=rejected_by_rom,
+            undrained=undrained,
+        )
 
     def _bump_ingest_attempt(
         self,

--- a/py_modules/services/playtime.py
+++ b/py_modules/services/playtime.py
@@ -19,8 +19,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.iso_time import parse_iso
-from domain.playtime import Playtime
-from lib.errors import RommForbiddenError
+from domain.playtime import Playtime, is_ingestable_session, rejected_session_indices
+from lib.errors import RommForbiddenError, RommUnprocessableEntityError
 from lib.list_result import ErrorCode
 
 if TYPE_CHECKING:
@@ -219,17 +219,27 @@ class PlaytimeService:
                         "message": "Failed to calculate session duration",
                     }
                 duration = entry.last_session_duration_sec or 0
-                if device_id:
+                if not device_id:
+                    # Unregistered device: fold locally, never enqueue (an empty
+                    # device id must never reach the wire, ADR-0018 decision #8).
+                    self._log_debug(f"record_session_end: rom {rom_id} not enqueued — device unregistered")
+                elif not is_ingestable_session(started_at, ended_at):
+                    # A window that starts and ends inside one wall-clock second is
+                    # a mis-fired launch (#1305), not real play, and RomM 422s the
+                    # WHOLE ingest batch on it (#1312) — so it never enters the
+                    # outbox. The duration is still folded into the local total
+                    # above; only the native ingest is skipped.
+                    self._log_debug(
+                        f"record_session_end: rom {rom_id} sub-second session not enqueued "
+                        f"(start={started_at}, end={ended_at})"
+                    )
+                else:
                     entry.enqueue_session(
                         device_id=device_id,
                         start_time=started_at,
                         end_time=ended_at,
                         duration_ms=duration * 1000,
                     )
-                else:
-                    # Unregistered device: fold locally, never enqueue (an empty
-                    # device id must never reach the wire, ADR-0018 decision #8).
-                    self._log_debug(f"record_session_end: rom {rom_id} not enqueued — device unregistered")
                 uow.playtime.save(rom_id, entry)
                 total_seconds = entry.total_seconds
                 session_count = entry.session_count
@@ -349,7 +359,11 @@ class PlaytimeService:
 
         A transport failure on the POST is non-fatal (mirrors
         ``_close_negotiate_session``): the group's rows stay queued and retry on
-        the next flush. Per-row verdicts are correlated back by the response
+        the next flush. A whole-request 422 — RomM validates the ``sessions``
+        array atomically and rejects the ENTIRE POST if any entry is invalid — is
+        healed by :meth:`_handle_batch_rejection`: the server-flagged entries drop
+        and the survivors resubmit, so one poison row never blocks the batch
+        (#1312). Per-row 2xx verdicts are correlated back by the response
         ``index`` (position in this group's submitted batch).
         """
         batch: list[PlaySessionIngestEntry] = [
@@ -363,6 +377,18 @@ class PlaytimeService:
         ]
         try:
             response = self._romm_api.ingest_play_sessions(device_id, batch)
+        except RommUnprocessableEntityError as exc:
+            self._handle_batch_rejection(
+                device_id,
+                group,
+                exc,
+                sent_by_rom=sent_by_rom,
+                failed_by_rom=failed_by_rom,
+                quarantine_by_rom=quarantine_by_rom,
+                rejected_by_rom=rejected_by_rom,
+                undrained=undrained,
+            )
+            return
         except Exception as e:
             # No service-level retry wrap — a flush failure is non-fatal and
             # catches up next time. The whole group stays queued.
@@ -411,15 +437,105 @@ class PlaytimeService:
             # unknown verdict is not an explicit rejection, so it gets the same
             # never-drop-data-on-ambiguity hedge as a possibly-transient error —
             # still loop-free (it converges to quarantine after the threshold).
-            undrained.append(row)
-            if row.attempts + 1 >= _MAX_INGEST_ATTEMPTS:
-                quarantine_by_rom.setdefault(row.rom_id, []).append(row.start_time)
-                self._logger.warning(
-                    f"Dropping play session for rom {row.rom_id} (start={row.start_time}, status={status}) "
-                    f"after {row.attempts + 1} failed ingest attempts — unrecoverable, only playtime is lost"
+            self._bump_ingest_attempt(
+                row,
+                status=status,
+                failed_by_rom=failed_by_rom,
+                quarantine_by_rom=quarantine_by_rom,
+                undrained=undrained,
+            )
+
+    def _handle_batch_rejection(
+        self,
+        device_id: str,
+        group: list[PendingSessionRow],
+        exc: RommUnprocessableEntityError,
+        *,
+        sent_by_rom: dict[int, list[str]],
+        failed_by_rom: dict[int, list[str]],
+        quarantine_by_rom: dict[int, list[str]],
+        rejected_by_rom: dict[int, list[str]],
+        undrained: list[PendingSessionRow],
+    ) -> None:
+        """Heal a whole-request 422 by dropping the flagged entries and resubmitting the rest.
+
+        RomM validates the ``sessions`` array atomically: one invalid entry (e.g.
+        a sub-second window) 422s the ENTIRE POST, so a single poison row would
+        block every valid session queued behind it (#1312). The 422 body names
+        the failing positions in ``detail[].loc[2]``; those rows drop as terminal
+        (the byte-identical entry draws the same verdict forever, exactly like a
+        ``skipped`` per-row verdict) and the survivors resubmit so they still
+        ingest. When the body names no usable index (unparseable / no ``detail``),
+        the whole group falls back to bounded-retry attempt counting so a
+        persistent whole-request 422 converges to quarantine instead of looping
+        forever. Recursion is bounded: each level drops at least the flagged rows,
+        so the survivor group strictly shrinks (and the no-index branch never
+        recurses).
+        """
+        indices = set(rejected_session_indices(exc.detail, len(group)))
+        if not indices:
+            self._log_debug(
+                f"Play-session batch rejected (HTTP 422) with no usable detail indices "
+                f"(device {device_id}, {len(group)} session(s)) — bumping attempts"
+            )
+            for row in group:
+                self._bump_ingest_attempt(
+                    row,
+                    status="422",
+                    failed_by_rom=failed_by_rom,
+                    quarantine_by_rom=quarantine_by_rom,
+                    undrained=undrained,
+                )
+            return
+
+        survivors: list[PendingSessionRow] = []
+        for index, row in enumerate(group):
+            if index in indices:
+                rejected_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+                self._logger.info(
+                    f"play session rejected by server for rom {row.rom_id} "
+                    f"(start={row.start_time}, batch index {index}, HTTP 422) — dropping from outbox"
                 )
             else:
-                failed_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+                survivors.append(row)
+
+        if survivors:
+            self._flush_device_group(
+                device_id,
+                survivors,
+                sent_by_rom=sent_by_rom,
+                failed_by_rom=failed_by_rom,
+                quarantine_by_rom=quarantine_by_rom,
+                rejected_by_rom=rejected_by_rom,
+                undrained=undrained,
+            )
+
+    def _bump_ingest_attempt(
+        self,
+        row: PendingSessionRow,
+        *,
+        status: str,
+        failed_by_rom: dict[int, list[str]],
+        quarantine_by_rom: dict[int, list[str]],
+        undrained: list[PendingSessionRow],
+    ) -> None:
+        """Bounded-retry one outbox row that drew a non-terminal ingest failure.
+
+        The row stays queued (``undrained``) and its attempt counter advances;
+        once it would reach ``_MAX_INGEST_ATTEMPTS`` it is quarantined (dropped —
+        only playtime is lost) so a persistently-failing row cannot wedge the
+        outbox. Shared by an ``error`` / unknown per-row verdict and the
+        no-usable-index whole-request-422 fallback.
+        """
+        undrained.append(row)
+        if row.attempts + 1 >= _MAX_INGEST_ATTEMPTS:
+            quarantine_by_rom.setdefault(row.rom_id, []).append(row.start_time)
+            self._logger.warning(
+                f"Dropping play session for rom {row.rom_id} (start={row.start_time}, status={status}) "
+                f"after {row.attempts + 1} failed ingest attempts — unrecoverable, only playtime is lost"
+            )
+        else:
+            failed_by_rom.setdefault(row.rom_id, []).append(row.start_time)
 
     def _apply_flush_outcome(
         self,

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -1,5 +1,7 @@
 import asyncio
 import http.client
+import io
+import json
 import ssl
 import urllib.error
 from unittest.mock import MagicMock, patch
@@ -23,6 +25,7 @@ from lib.errors import (
     RommServerError,
     RommSSLError,
     RommTimeoutError,
+    RommUnprocessableEntityError,
     TokenHostMismatchError,
 )
 
@@ -691,6 +694,31 @@ class TestTranslateHttpError:
         result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/x", "PUT")
         assert isinstance(result, RommConflictError)
         assert result.status_code == 409
+
+    def test_422_becomes_unprocessable_with_parsed_detail(self, plugin):
+        detail = [{"loc": ["body", "sessions", 2], "msg": "end_time must be after start_time"}]
+        body = json.dumps({"detail": detail}).encode()
+        exc = urllib.error.HTTPError("url", 422, "Unprocessable Entity", http.client.HTTPMessage(), io.BytesIO(body))
+        result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/play-sessions", "POST")
+        assert isinstance(result, RommUnprocessableEntityError)
+        assert result.status_code == 422
+        assert result.detail == detail
+        assert result.method == "POST"
+
+    def test_422_with_unreadable_body_degrades_to_none_detail(self, plugin):
+        # fp=None → exc.read() fails → detail degrades to None (whole-request fallback).
+        exc = urllib.error.HTTPError("url", 422, "Unprocessable Entity", http.client.HTTPMessage(), None)
+        result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/play-sessions", "POST")
+        assert isinstance(result, RommUnprocessableEntityError)
+        assert result.detail is None
+
+    def test_422_with_non_json_body_degrades_to_none_detail(self, plugin):
+        exc = urllib.error.HTTPError(
+            "url", 422, "Unprocessable Entity", http.client.HTTPMessage(), io.BytesIO(b"<html>nope</html>")
+        )
+        result = plugin._http_adapter.translate_http_error(exc, "http://romm.local/api/play-sessions", "POST")
+        assert isinstance(result, RommUnprocessableEntityError)
+        assert result.detail is None
 
     def test_500_becomes_server_error(self, plugin):
         exc = urllib.error.HTTPError("url", 500, "Internal Server Error", http.client.HTTPMessage(), None)

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from adapters.romm.romm_api import _TOKEN_SCOPES, RommApiAdapter
-from lib.errors import RommNotFoundError, RommServerError
+from lib.errors import RommNotFoundError, RommServerError, RommUnprocessableEntityError
 
 if TYPE_CHECKING:
     from models.play_sessions import PlaySessionIngestEntry
@@ -824,6 +824,15 @@ class TestIngestPlaySessions:
         client.post_json.side_effect = RommServerError("boom", status_code=500)
         with pytest.raises(RommServerError):
             api.ingest_play_sessions("dev-1", [])
+
+    def test_propagates_422_with_parsed_detail_intact(self):
+        """A whole-request 422 surfaces to the caller as ``RommUnprocessableEntityError`` with its detail."""
+        api, client = _make_api()
+        detail = [{"loc": ["body", "sessions", 0], "msg": "end_time must be after start_time"}]
+        client.post_json.side_effect = RommUnprocessableEntityError("HTTP 422", detail=detail)
+        with pytest.raises(RommUnprocessableEntityError) as excinfo:
+            api.ingest_play_sessions("dev-1", [{"rom_id": 1, "start_time": "t", "end_time": "t", "duration_ms": 0}])
+        assert excinfo.value.detail == detail
 
 
 class TestListPlaySessions:

--- a/tests/contract/test_play_session_reconcile.py
+++ b/tests/contract/test_play_session_reconcile.py
@@ -13,6 +13,7 @@ unreachable GET degrades to the local total.
 
 from __future__ import annotations
 
+from domain.playtime import PendingPlaySession, Playtime
 from lib.errors import RommApiError, RommForbiddenError
 
 from ._seed import seed_rom
@@ -104,6 +105,48 @@ async def test_reconcile_server_unreachable_keeps_local_total(harness):
 
     assert result["server_query_failed"] is True
     assert result["total_seconds"] == 120
+
+
+async def test_queued_poison_session_is_healed_on_flush(harness):
+    """An already-queued sub-second poison row (a legacy pre-filter enqueue) no longer wedges the outbox (#1312).
+
+    RomM 422s the whole batch on the zero-duration entry; the flush drops exactly
+    that entry and resubmits the survivor, which ingests and reconciles.
+    """
+    seed_rom(harness, 1)
+    await _register(harness)
+    harness.plugin.settings["save_sync_enabled"] = False
+
+    # Seed the outbox directly with a poison + a healthy row (bypassing the
+    # recording seam, which now filters sub-second windows at enqueue).
+    with harness.uow_factory() as uow:
+        uow.playtime.save(
+            1,
+            Playtime(
+                pending_sessions={
+                    "2026-07-04T10:00:00Z": PendingPlaySession(
+                        device_id="device-1", end_time="2026-07-04T10:00:00Z", duration_ms=0
+                    ),
+                    "2026-07-04T11:00:00Z": PendingPlaySession(
+                        device_id="device-1", end_time="2026-07-04T11:20:00Z", duration_ms=1_200_000
+                    ),
+                }
+            ),
+        )
+    # RomM rejects the whole POST while any entry is below one second.
+    harness.romm.reject_batch_below_duration_ms = 1
+
+    result = await harness.plugin.reconcile_playtime(1)
+
+    # The outbox is fully drained: poison dropped, survivor ingested.
+    with harness.uow_factory() as uow:
+        entry = uow.playtime.get(1)
+    assert entry is not None
+    assert entry.pending_sessions == {}
+    # Only the healthy 1200s session reached the server; reconcile unions it in.
+    assert [s["duration_ms"] for s in harness.romm.play_sessions[1]] == [1_200_000]
+    assert result["total_seconds"] == 1200
+    assert result["server_query_failed"] is False
 
 
 async def test_forbidden_reconcile_raises_scope_notice_then_clears(harness):

--- a/tests/domain/test_playtime.py
+++ b/tests/domain/test_playtime.py
@@ -4,7 +4,103 @@ from __future__ import annotations
 
 import pytest
 
-from domain.playtime import PendingPlaySession, Playtime
+from domain.playtime import (
+    PendingPlaySession,
+    Playtime,
+    is_ingestable_session,
+    rejected_session_indices,
+)
+
+
+class TestIsIngestableSession:
+    def test_multi_hour_window_is_ingestable(self):
+        assert is_ingestable_session("2026-07-04T10:00:00Z", "2026-07-04T11:00:00Z") is True
+
+    def test_one_second_window_is_ingestable(self):
+        assert is_ingestable_session("2026-07-04T10:00:00Z", "2026-07-04T10:00:01Z") is True
+
+    def test_same_second_sub_ms_window_is_rejected(self):
+        # The #1312 poison: start and end in the same wall-clock second.
+        assert is_ingestable_session("2026-07-04T10:00:00.100Z", "2026-07-04T10:00:00.900Z") is False
+
+    def test_identical_timestamps_are_rejected(self):
+        assert is_ingestable_session("2026-07-04T10:00:00Z", "2026-07-04T10:00:00Z") is False
+
+    def test_end_before_start_is_rejected(self):
+        assert is_ingestable_session("2026-07-04T10:00:05Z", "2026-07-04T10:00:00Z") is False
+
+    def test_sub_second_but_cross_second_boundary_is_ingestable(self):
+        # 0.6s of real time, but the flooring lands on two different seconds — RomM
+        # accepts it (00 < 01), so we do too (mirror RomM exactly, never over-drop).
+        assert is_ingestable_session("2026-07-04T10:00:00.900Z", "2026-07-04T10:00:01.500Z") is True
+
+    def test_fully_suspended_long_window_is_ingestable(self):
+        # A multi-second window whose duration_ms would be ~0 (fully suspended) is
+        # still a valid window — the kernel judges the window, not the duration.
+        assert is_ingestable_session("2026-07-04T10:00:00Z", "2026-07-04T10:05:00Z") is True
+
+    def test_unparseable_start_is_not_ingestable(self):
+        assert is_ingestable_session("not-a-date", "2026-07-04T10:00:01Z") is False
+
+    def test_unparseable_end_is_not_ingestable(self):
+        assert is_ingestable_session("2026-07-04T10:00:00Z", "garbage") is False
+
+    def test_naive_aware_mismatch_is_not_ingestable(self):
+        assert is_ingestable_session("2026-07-04T10:00:00", "2026-07-04T11:00:00Z") is False
+
+    def test_empty_strings_are_not_ingestable(self):
+        assert is_ingestable_session("", "") is False
+
+
+class TestRejectedSessionIndices:
+    def _detail(self, *indices: int) -> list[dict[str, object]]:
+        return [{"loc": ["body", "sessions", i], "msg": "end_time must be after start_time"} for i in indices]
+
+    def test_extracts_the_flagged_indices_sorted(self):
+        assert rejected_session_indices(self._detail(5, 2), 10) == [2, 5]
+
+    def test_single_index(self):
+        assert rejected_session_indices(self._detail(2), 10) == [2]
+
+    def test_dedupes_repeated_indices(self):
+        assert rejected_session_indices(self._detail(2, 2, 2), 10) == [2]
+
+    def test_out_of_range_indices_are_dropped(self):
+        assert rejected_session_indices(self._detail(0, 99, -1), 3) == [0]
+
+    def test_field_level_loc_still_extracts_the_item_index(self):
+        detail = [{"loc": ["body", "sessions", 4, "end_time"], "msg": "bad"}]
+        assert rejected_session_indices(detail, 10) == [4]
+
+    def test_none_detail_yields_empty(self):
+        assert rejected_session_indices(None, 10) == []
+
+    def test_non_list_detail_yields_empty(self):
+        assert rejected_session_indices({"detail": "oops"}, 10) == []
+
+    def test_empty_detail_yields_empty(self):
+        assert rejected_session_indices([], 10) == []
+
+    def test_loc_without_sessions_segment_is_ignored(self):
+        detail = [{"loc": ["body", "device_id"], "msg": "bad"}]
+        assert rejected_session_indices(detail, 10) == []
+
+    def test_non_int_index_is_ignored(self):
+        detail = [{"loc": ["body", "sessions", "two"], "msg": "bad"}]
+        assert rejected_session_indices(detail, 10) == []
+
+    def test_bool_index_is_excluded(self):
+        # bool is an int subclass — True must NOT be read as index 1.
+        detail = [{"loc": ["body", "sessions", True], "msg": "bad"}]
+        assert rejected_session_indices(detail, 10) == []
+
+    def test_non_dict_items_are_skipped(self):
+        detail = ["oops", None, {"loc": ["body", "sessions", 1]}]
+        assert rejected_session_indices(detail, 10) == [1]
+
+    def test_missing_loc_is_skipped(self):
+        detail = [{"msg": "no loc here"}, {"loc": ["body", "sessions", 3]}]
+        assert rejected_session_indices(detail, 10) == [3]
 
 
 class TestBeginSession:

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -81,6 +81,12 @@ class FakeRommApi:
         # whole-request poison. Distinct from ``reject_below_duration_ms`` (a
         # per-entry ``skipped`` verdict inside a 2xx response).
         self.reject_batch_below_duration_ms: int = 0
+        # When True, a MULTI-entry 422 carries ``detail=None`` (a proxy/Cloudflare
+        # Tunnel mangled the validation body), while a SINGLE-entry 422 still names
+        # its index — modelling #1312's L2 no-usable-index path where the batch
+        # gives no target but the per-session re-POST does. Requires
+        # ``reject_batch_below_duration_ms > 0`` to fire.
+        self.mangle_batch_422_detail: bool = False
         self.saves: dict[int, dict[str, Any]] = {}
         self.devices: list[dict[str, Any]] = []
         self.current_user: dict[str, Any] = {"id": 1, "username": "tester"}
@@ -383,12 +389,16 @@ class FakeRommApi:
         if self.reject_batch_below_duration_ms > 0:
             bad = [i for i, s in enumerate(sessions) if s["duration_ms"] < self.reject_batch_below_duration_ms]
             if bad:
-                # Atomic whole-request rejection: nothing is stored, and the 422
-                # body names every offending index.
-                raise RommUnprocessableEntityError(
-                    "HTTP 422: Unprocessable Entity",
-                    detail=[{"loc": ["body", "sessions", i], "msg": "end_time must be after start_time"} for i in bad],
+                # Atomic whole-request rejection: nothing is stored. The 422 body
+                # names every offending index, UNLESS the batch is multi-entry and
+                # ``mangle_batch_422_detail`` is set — modelling a proxy that
+                # strips the detail from a multi-entry validation error.
+                detail = (
+                    None
+                    if (self.mangle_batch_422_detail and len(sessions) > 1)
+                    else [{"loc": ["body", "sessions", i], "msg": "end_time must be after start_time"} for i in bad]
                 )
+                raise RommUnprocessableEntityError("HTTP 422: Unprocessable Entity", detail=detail)
         results: list[PlaySessionIngestResult] = []
         created = 0
         skipped = 0

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -34,6 +34,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from fakes._romm_save_semantics import check_add_save_conflict, compute_is_current, tag_filename
+from lib.errors import RommUnprocessableEntityError
 
 if TYPE_CHECKING:
     from models.play_sessions import (
@@ -73,6 +74,13 @@ class FakeRommApi:
         # ``skipped`` verdict — models RomM refusing a sub-second launch-death.
         # Default 0 never rejects (durations are >= 0), so existing tests stand.
         self.reject_below_duration_ms: int = 0
+        # When > 0, ingest models RomM's ATOMIC batch validation: if ANY submitted
+        # entry's duration_ms is below this floor, the WHOLE POST is rejected with
+        # HTTP 422 (``RommUnprocessableEntityError``) naming every sub-floor index
+        # in ``detail[].loc``, and nothing is stored — mirroring #1312's
+        # whole-request poison. Distinct from ``reject_below_duration_ms`` (a
+        # per-entry ``skipped`` verdict inside a 2xx response).
+        self.reject_batch_below_duration_ms: int = 0
         self.saves: dict[int, dict[str, Any]] = {}
         self.devices: list[dict[str, Any]] = []
         self.current_user: dict[str, Any] = {"id": 1, "username": "tester"}
@@ -372,6 +380,15 @@ class FakeRommApi:
     def ingest_play_sessions(self, device_id: str, sessions: list[PlaySessionIngestEntry]) -> PlaySessionIngestResponse:
         self._log("ingest_play_sessions", (device_id, sessions))
         self._check_fail(self.ingest_play_sessions_side_effect)
+        if self.reject_batch_below_duration_ms > 0:
+            bad = [i for i, s in enumerate(sessions) if s["duration_ms"] < self.reject_batch_below_duration_ms]
+            if bad:
+                # Atomic whole-request rejection: nothing is stored, and the 422
+                # body names every offending index.
+                raise RommUnprocessableEntityError(
+                    "HTTP 422: Unprocessable Entity",
+                    detail=[{"loc": ["body", "sessions", i], "msg": "end_time must be after start_time"} for i in bad],
+                )
         results: list[PlaySessionIngestResult] = []
         created = 0
         skipped = 0

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -13,7 +13,7 @@ from fakes.system_time import FakeClock
 
 from domain.playtime import PendingPlaySession, Playtime
 from domain.rom import Rom
-from lib.errors import RommApiError, RommForbiddenError, RommUnprocessableEntityError
+from lib.errors import RommApiError, RommConnectionError, RommForbiddenError, RommUnprocessableEntityError
 from services.playtime import PlaytimeService, PlaytimeServiceConfig, _coerce_duration_ms
 
 
@@ -1201,8 +1201,8 @@ class TestFlushBatch422:
         assert "HTTP 422" in rejected[0].message
 
     @pytest.mark.asyncio
-    async def test_422_without_detail_bumps_attempts_and_stays_queued(self):
-        """An unparseable 422 (no usable indices) falls back to bounded-retry attempt counting."""
+    async def test_lone_row_422_without_detail_bumps_attempts_and_stays_queued(self):
+        """A lone-row 422 with no usable indices bumps that single row (no sibling to isolate)."""
         svc, fake, uow = make_service()
         _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=0)}))
         fake.ingest_play_sessions = _raise_422(None)  # type: ignore[method-assign]
@@ -1215,8 +1215,8 @@ class TestFlushBatch422:
         assert entry.pending_sessions["s1"].attempts == 1
 
     @pytest.mark.asyncio
-    async def test_422_with_only_out_of_range_indices_bumps_attempts(self):
-        """A 422 naming only out-of-range indices carries no usable target → attempts bump."""
+    async def test_lone_row_422_with_only_out_of_range_indices_bumps_attempts(self):
+        """A lone-row 422 naming only out-of-range indices carries no usable target → attempts bump."""
         svc, fake, uow = make_service()
         _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=0)}))
         fake.ingest_play_sessions = _raise_422(_detail_for(99))  # type: ignore[method-assign]
@@ -1229,8 +1229,8 @@ class TestFlushBatch422:
         assert entry.pending_sessions["s1"].attempts == 1
 
     @pytest.mark.asyncio
-    async def test_persistent_422_without_detail_quarantines_at_threshold(self, caplog):
-        """A whole-request 422 with no indices converges to quarantine, never an infinite loop."""
+    async def test_persistent_lone_row_422_without_detail_quarantines_at_threshold(self, caplog):
+        """A persistent lone-row 422 with no indices converges to quarantine, never an infinite loop."""
         svc, fake, uow = make_service()
         _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=4)}))
         fake.ingest_play_sessions = _raise_422(None)  # type: ignore[method-assign]
@@ -1242,6 +1242,102 @@ class TestFlushBatch422:
         assert entry is not None
         assert entry.pending_sessions == {}  # quarantined (dropped) at the threshold
         assert any("rom 42" in r.message and "s1" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_detail_batch_422_falls_back_per_session_isolating_poison(self):
+        """A no-usable-index batch 422 re-POSTs each session alone: valid survives, poison dropped (#1312 L2).
+
+        Under a whole-group bump the valid sibling would be lost; the per-session
+        fallback keeps it because the single-session verdict isolates the poison.
+        """
+        svc, fake, uow = make_service()
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(pending_sessions={"s_bad": _pending(duration_ms=0), "s_good": _pending(duration_ms=1000)}),
+        )
+        fake.reject_batch_below_duration_ms = 1
+        fake.mangle_batch_422_detail = True  # the multi-entry 422 body carries no usable detail
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # both resolved
+        # The valid session actually reached the server; the poison did not.
+        assert [s["duration_ms"] for s in fake.play_sessions[42]] == [1000]
+        # Batch POST + one single-session POST per row = 3 calls.
+        ingests = [c for c in fake.call_log if c[0] == "ingest_play_sessions"]
+        assert len(ingests) == 3
+        assert [len(c[1][1]) for c in ingests] == [2, 1, 1]  # batch of 2, then singles
+
+    @pytest.mark.asyncio
+    async def test_no_detail_batch_422_does_not_quarantine_valid_sibling_at_threshold(self, caplog):
+        """The money invariant: a valid session at the retry threshold is NOT dropped for a poison sibling.
+
+        With the old whole-group bump, ``s_good`` at attempts=4 would hit its 5th
+        failure and quarantine — losing valid playtime that exists nowhere else.
+        The per-session fallback ingests it instead.
+        """
+        svc, fake, uow = make_service()
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(
+                pending_sessions={
+                    "s_bad": _pending(duration_ms=0, attempts=0),
+                    "s_good": _pending(duration_ms=1000, attempts=4),  # one bump from quarantine
+                }
+            ),
+        )
+        fake.reject_batch_below_duration_ms = 1
+        fake.mangle_batch_422_detail = True
+
+        with caplog.at_level("WARNING"):
+            await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}
+        # s_good was INGESTED (sent), not quarantined — its data survived.
+        assert [s["duration_ms"] for s in fake.play_sessions[42]] == [1000]
+        # No quarantine warning fired for the valid session.
+        assert not any("s_good" in r.message for r in caplog.records if r.levelname == "WARNING")
+
+    @pytest.mark.asyncio
+    async def test_per_session_fallback_retains_row_on_transport_error(self):
+        """A transport error during a single-session re-POST retains only that row (transient)."""
+        svc, fake, uow = make_service()
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(
+                pending_sessions={
+                    "s_bad": _pending(duration_ms=0),
+                    "s_net": _pending(duration_ms=1000),
+                    "s_ok": _pending(duration_ms=1000),
+                }
+            ),
+        )
+
+        def _ingest(_device_id, sessions):
+            if len(sessions) > 1:
+                raise RommUnprocessableEntityError("HTTP 422", detail=None)  # mangled batch body
+            start = sessions[0]["start_time"]
+            if start == "s_bad":
+                raise RommUnprocessableEntityError("HTTP 422", detail=_detail_for(0))  # genuine poison
+            if start == "s_net":
+                raise RommConnectionError("offline")  # transient
+            return {"results": [{"index": 0, "status": "created"}], "created_count": 1, "skipped_count": 0}
+
+        fake.ingest_play_sessions = _ingest  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert set(entry.pending_sessions) == {"s_net"}  # poison dropped, ok sent, only the transient retained
+        assert entry.pending_sessions["s_net"].attempts == 0  # a transport error never bumps attempts
 
     @pytest.mark.asyncio
     async def test_422_heal_omits_undrained_breadcrumb(self):
@@ -1258,6 +1354,63 @@ class TestFlushBatch422:
         await svc.flush_pending_sessions()
 
         assert not any("not accepted" in m for m in logs)
+
+
+# ---------------------------------------------------------------------------
+# TestFlushBatch422MultiLevel — #1312 L1: recursion across resubmit levels
+# ---------------------------------------------------------------------------
+
+
+def _reject_first_sub_floor(floor_ms: int, calls: list[list[int]]):
+    """Stub that 422s naming ONLY the first sub-floor index each call.
+
+    Forces the indexed-drop path to recurse level by level: each resubmit
+    surfaces the NEXT poison at a NEW position, so the test exercises index
+    bookkeeping across multiple levels. Records each submitted batch's rom_ids
+    into ``calls`` (a reassigned stub bypasses ``FakeRommApi.call_log``).
+    """
+
+    def _ingest(_device_id, sessions):
+        calls.append([s["rom_id"] for s in sessions])
+        bad = [i for i, s in enumerate(sessions) if s["duration_ms"] < floor_ms]
+        if bad:
+            raise RommUnprocessableEntityError("HTTP 422", detail=_detail_for(bad[0]))
+        return {
+            "results": [{"index": i, "status": "created"} for i, _ in enumerate(sessions)],
+            "created_count": len(sessions),
+            "skipped_count": 0,
+        }
+
+    return _ingest
+
+
+class TestFlushBatch422MultiLevel:
+    @pytest.mark.asyncio
+    async def test_resubmit_that_itself_422s_drops_the_second_poison_too(self, caplog):
+        """An indexed-422 resubmit that 422s AGAIN on a DIFFERENT index drops that poison too."""
+        svc, fake, uow = make_service()
+        # roms 1 & 3 are poison (duration 0); 2 & 4 are valid. One device group,
+        # ordered (rom_id, start_time): [1, 2, 3, 4].
+        _seed_playtime(uow, 1, Playtime(pending_sessions={"s": _pending(device_id="device-1", duration_ms=0)}))
+        _seed_playtime(uow, 2, Playtime(pending_sessions={"s": _pending(device_id="device-1", duration_ms=1000)}))
+        _seed_playtime(uow, 3, Playtime(pending_sessions={"s": _pending(device_id="device-1", duration_ms=0)}))
+        _seed_playtime(uow, 4, Playtime(pending_sessions={"s": _pending(device_id="device-1", duration_ms=1000)}))
+        calls: list[list[int]] = []
+        fake.ingest_play_sessions = _reject_first_sub_floor(1, calls)  # type: ignore[method-assign]
+
+        with caplog.at_level("INFO"):
+            await svc.flush_pending_sessions()
+
+        # All four resolved: poison roms dropped, valid roms sent.
+        for rid in (1, 2, 3, 4):
+            assert uow.playtime.get(rid).pending_sessions == {}  # type: ignore[union-attr]
+        # Three levels: [1,2,3,4] → drop 1 → [2,3,4] → drop 3 → [2,4] → created.
+        assert calls == [[1, 2, 3, 4], [2, 3, 4], [2, 4]]
+        # Exactly the two poison roms were dropped (index bookkeeping held across levels).
+        dropped = {
+            int(r.message.split("rom ")[1].split(" ")[0]) for r in caplog.records if "rejected by server" in r.message
+        }
+        assert dropped == {1, 3}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -13,7 +13,7 @@ from fakes.system_time import FakeClock
 
 from domain.playtime import PendingPlaySession, Playtime
 from domain.rom import Rom
-from lib.errors import RommApiError, RommForbiddenError
+from lib.errors import RommApiError, RommForbiddenError, RommUnprocessableEntityError
 from services.playtime import PlaytimeService, PlaytimeServiceConfig, _coerce_duration_ms
 
 
@@ -273,6 +273,27 @@ class TestRecordSessionEndIngest:
         assert entry.total_seconds == 60
         assert entry.pending_sessions == {}
         assert any("not enqueued" in m and "unregistered" in m for m in logs)
+
+    @pytest.mark.asyncio
+    async def test_sub_second_session_folds_locally_but_is_not_enqueued(self):
+        """A window inside one wall-clock second is mis-fire launch noise (#1312) — folded, never enqueued."""
+        clk = FakeClock(now=datetime(2026, 1, 1, 0, 0, 0, 900_000, tzinfo=UTC))
+        logs: list[str] = []
+        svc, fake, uow = make_service(clock=clk, log_debug=logs.append)
+        start = (clk.now() - timedelta(milliseconds=500)).isoformat()  # same second as now
+        _seed_playtime(uow, 42, Playtime(last_session_start=start))
+
+        result = await svc.record_session_end(42)
+
+        assert result["success"] is True
+        assert result["duration_sec"] == 0  # sub-second folds to 0s locally
+        assert result["session_count"] == 1
+        # Never POSTed and never queued — the poison never reaches the outbox.
+        assert not any(c[0] == "ingest_play_sessions" for c in fake.call_log)
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}
+        assert any("sub-second session not enqueued" in m for m in logs)
 
     @pytest.mark.asyncio
     async def test_ingest_failure_keeps_session_queued(self):
@@ -1098,6 +1119,145 @@ class TestFlushTerminalRejection:
         assert entry is not None
         assert entry.pending_sessions == {}  # quarantined (dropped) at threshold
         assert any("rom 42" in r.message and "s1" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# TestFlushBatch422 — #1312 whole-request 422 heal (drop flagged, resubmit rest)
+# ---------------------------------------------------------------------------
+
+
+def _raise_422(detail):
+    """Build an ``ingest_play_sessions`` stub that always raises a 422 with ``detail``."""
+
+    def _ingest(_device_id, _sessions):
+        raise RommUnprocessableEntityError("HTTP 422", detail=detail)
+
+    return _ingest
+
+
+def _detail_for(*indices: int):
+    """A FastAPI-shaped 422 ``detail`` list naming the given ``sessions`` indices."""
+    return [{"loc": ["body", "sessions", i], "msg": "end_time must be after start_time"} for i in indices]
+
+
+class TestFlushBatch422:
+    @pytest.mark.asyncio
+    async def test_poison_dropped_and_survivors_resubmitted(self):
+        """The atomic 422 drops exactly the flagged entry and re-POSTs the rest."""
+        svc, fake, uow = make_service()
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(pending_sessions={"s_bad": _pending(duration_ms=0), "s_good": _pending(duration_ms=1000)}),
+        )
+        fake.reject_batch_below_duration_ms = 1  # the zero-duration row poisons the batch
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # poison dropped, survivor sent
+        # Two POSTs: the poisoned batch, then the survivors-only resubmit.
+        ingests = [c for c in fake.call_log if c[0] == "ingest_play_sessions"]
+        assert len(ingests) == 2
+        resubmitted = ingests[1][1][1]
+        assert [s["start_time"] for s in resubmitted] == ["s_good"]
+        # Only the survivor reached the server store.
+        assert [s["duration_ms"] for s in fake.play_sessions[42]] == [1000]
+
+    @pytest.mark.asyncio
+    async def test_poison_and_survivor_on_two_roms_same_device(self):
+        """One device group with a poison ROM + a healthy ROM: the healthy one still ingests."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 1, Playtime(pending_sessions={"a1": _pending(device_id="device-A", duration_ms=0)}))
+        _seed_playtime(uow, 2, Playtime(pending_sessions={"a2": _pending(device_id="device-A", duration_ms=500)}))
+        fake.reject_batch_below_duration_ms = 1
+
+        await svc.flush_pending_sessions()
+
+        assert uow.playtime.get(1).pending_sessions == {}  # type: ignore[union-attr]  # poison dropped
+        assert uow.playtime.get(2).pending_sessions == {}  # type: ignore[union-attr]  # survivor sent
+        assert [s["rom_id"] for s in fake.play_sessions[2]] == [2]
+        assert 1 not in fake.play_sessions  # nothing stored for the poison rom
+
+    @pytest.mark.asyncio
+    async def test_422_drop_logs_once_at_info(self, caplog):
+        """The dropped poison entry is recorded with one info line naming the rom + HTTP 422."""
+        svc, fake, uow = make_service()
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(pending_sessions={"s_bad": _pending(duration_ms=0), "s_good": _pending(duration_ms=1000)}),
+        )
+        fake.reject_batch_below_duration_ms = 1
+
+        with caplog.at_level("INFO"):
+            await svc.flush_pending_sessions()
+
+        rejected = [r for r in caplog.records if "rejected by server" in r.message]
+        assert len(rejected) == 1
+        assert rejected[0].levelname == "INFO"
+        assert "rom 42" in rejected[0].message
+        assert "HTTP 422" in rejected[0].message
+
+    @pytest.mark.asyncio
+    async def test_422_without_detail_bumps_attempts_and_stays_queued(self):
+        """An unparseable 422 (no usable indices) falls back to bounded-retry attempt counting."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=0)}))
+        fake.ingest_play_sessions = _raise_422(None)  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert set(entry.pending_sessions) == {"s1"}  # retained, not dropped on an ambiguous 422
+        assert entry.pending_sessions["s1"].attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_422_with_only_out_of_range_indices_bumps_attempts(self):
+        """A 422 naming only out-of-range indices carries no usable target → attempts bump."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=0)}))
+        fake.ingest_play_sessions = _raise_422(_detail_for(99))  # type: ignore[method-assign]
+
+        await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert set(entry.pending_sessions) == {"s1"}
+        assert entry.pending_sessions["s1"].attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_persistent_422_without_detail_quarantines_at_threshold(self, caplog):
+        """A whole-request 422 with no indices converges to quarantine, never an infinite loop."""
+        svc, fake, uow = make_service()
+        _seed_playtime(uow, 42, Playtime(pending_sessions={"s1": _pending(attempts=4)}))
+        fake.ingest_play_sessions = _raise_422(None)  # type: ignore[method-assign]
+
+        with caplog.at_level("WARNING"):
+            await svc.flush_pending_sessions()
+
+        entry = uow.playtime.get(42)
+        assert entry is not None
+        assert entry.pending_sessions == {}  # quarantined (dropped) at the threshold
+        assert any("rom 42" in r.message and "s1" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_422_heal_omits_undrained_breadcrumb(self):
+        """A fully-healed 422 (poison dropped, survivor sent) leaves nothing 'not accepted'."""
+        logs: list[str] = []
+        svc, fake, uow = make_service(log_debug=logs.append)
+        _seed_playtime(
+            uow,
+            42,
+            Playtime(pending_sessions={"s_bad": _pending(duration_ms=0), "s_good": _pending(duration_ms=1000)}),
+        )
+        fake.reject_batch_below_duration_ms = 1
+
+        await svc.flush_pending_sessions()
+
+        assert not any("not accepted" in m for m in logs)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

The play-session outbox POSTs every queued session as one batch to `POST /api/play-sessions`. RomM validates the `sessions` array **atomically** and returns **HTTP 422 for the whole request** if any single entry is invalid. Two zero-duration sessions (a Switch launch that died in under a second — `start_time` and `end_time` in the same wall-clock second) trip RomM's `end_time must be after start_time` (compared at second resolution), so every valid session queued behind them is rejected too. The old 422 path retained the batch **without** bumping `attempts`, so #1310's drain never engaged — 12 real sessions looped forever at `attempts=0`.

On-device (2026-07-04), the server 422 detail names exactly which entries failed:

```
{"loc":["body","sessions",2],"msg":"end_time must be after start_time","input":{"rom_id":4754,...,"duration_ms":0}}
```

A single-session POST of the same payload returns 201 — the shape is fine; the poison entry is the problem.

## The fix (two coordinated mechanisms)

1. **Don't enqueue sub-second sessions.** A new pure kernel `is_ingestable_session(start, end)` gates the recording seam: a window is enqueued only when `end` is strictly later than `start` once both are floored to the second — the exact rule RomM applies, so I never over-drop a window RomM would accept. `duration_ms` is deliberately not consulted (a long but fully-suspended session has `duration_ms ≈ 0` yet a valid multi-second window). The duration still folds into the local total; only the native ingest is skipped. This stops **new** poison at the source.

2. **422-resilient flush.** The HTTP adapter now reads the 422 body and surfaces it as `RommUnprocessableEntityError` carrying the parsed `detail` (status code + parsed detail, respecting the layer boundary). On a whole-request 422 the service extracts the failing indices via the pure `rejected_session_indices` kernel (`detail[].loc[2]`), drops exactly those rows as terminal (same taxonomy as a `skipped` verdict, via `drop_rejected_sessions`) and **resubmits the survivors** so one bad entry never blocks the batch. A 422 that names no usable index falls back to the existing `attempts` bounded-retry counter, so a persistent whole-request 422 converges to quarantine instead of looping. This **heals the already-queued poison** — the user's 12 stuck sessions: the 2 zero-duration entries drop, the other 10 ingest on the next flush.

This narrows #1310's assumption that every ingest rejection arrives as a 2xx per-session verdict — a whole-request 422 is a distinct, structured transport failure.

## Tests

- **domain** — `is_ingestable_session` (same-second reject, strictly-after accept, cross-second sub-second accept, fully-suspended long window accept, unparseable / naive-aware reject); `rejected_session_indices` (extract/sort/dedupe, out-of-range and bool-index and non-`sessions`-loc handling, `None`/non-list detail).
- **services/playtime** — sub-second session folded-but-not-enqueued; 422 drops the poison and resubmits survivors (single ROM and two ROMs on one device); the drop logs once at info; a no-detail 422 bumps `attempts` and converges to quarantine at the threshold.
- **adapter** — `translate_http_error` builds `RommUnprocessableEntityError` with parsed `detail` (and degrades to `None` on an unreadable / non-JSON body); `ingest_play_sessions` propagates it with `detail` intact.
- **contract** — an already-queued poison + healthy row is fully healed through the real bootstrap: poison dropped, survivor ingested, reconcile unions it in.

## Docs

ADR-0018 and `docs/architecture/database-design.md` updated in the same PR: the recording-time filter and the 422-resilient flush (surgical drop by server-reported index + attempts fallback).

## Checks

`ruff format` + `ruff check`, `basedpyright` (full scope incl. `tests/`), full `pytest` suite (4332 passed), and `mise run lint` (callable-manifest, failure-shape, cosmic-bans, uow-seam, import-linter) all green.

## On-device verification

The exit-time filter and the outbox heal warrant a Game Mode check: launch a game that dies in under a second (or seed a legacy sub-second row), confirm the outbox drains on the next flush and the real sessions ingest.

Closes #1312.
