### PR TITLE
feat(launch): state-aware Resume button for an already-running game

### DIFF
--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -71,7 +71,11 @@ manager, sync, and playtime) is absent, so desktop-mode launches are entirely un
   the button being disabled). Running the pre-launch sync on an already-running game would upload the save
   **mid-session** — while the emulator holds the file open — and manufacture a conflict at exit (the watcher
   additionally cancels a launch Steam blocks as "already running" anyway). Both surfaces skip the sync and just bring
-  the game to front instead (#1148 round 2).
+  the game to front instead (#1148 round 2). The Play button later became **state-aware** (#1313): when running is
+  detected it renders **Resume** and brings the window to front via `SteamClient.Apps.RaiseWindowForGame` (a dialog-free
+  window-raise that fires no `GameActionStart`), so on that surface the guard is now the **backstop for the render→click
+  race** rather than the primary path — the button honestly reflects running state instead of relying on the guard to
+  catch a Play press.
 - Because the watcher cancels **first** and only then does async work, **there is no race** — the defect of awaiting
   against a live launch is gone by construction.
 
@@ -148,5 +152,8 @@ local file to `.romm-backup`, so there is no silent data loss. "Unknown because 
 
 [#1051](https://github.com/danielcopper/decky-romm-sync/issues/1051) (umbrella),
 [#1144](https://github.com/danielcopper/decky-romm-sync/issues/1144) (non-plugin bypass, resolved here),
-[#1146](https://github.com/danielcopper/decky-romm-sync/issues/1146). The suspend-time playtime fix and the
-multi-file-slot conflict fix are bundled in the same work but are separate bugfixes, not part of this ADR's decision.
+[#1146](https://github.com/danielcopper/decky-romm-sync/issues/1146),
+[#1313](https://github.com/danielcopper/decky-romm-sync/issues/1313) (the state-aware Resume button — the Play button
+reflects running state and foregrounds via `RaiseWindowForGame`, keeping this guard as its backstop). The suspend-time
+playtime fix and the multi-file-slot conflict fix are bundled in the same work but are separate bugfixes, not part of
+this ADR's decision.

--- a/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
+++ b/docs/adr/0015-single-launch-gate-cancel-then-relaunch.md
@@ -72,10 +72,10 @@ manager, sync, and playtime) is absent, so desktop-mode launches are entirely un
   **mid-session** — while the emulator holds the file open — and manufacture a conflict at exit (the watcher
   additionally cancels a launch Steam blocks as "already running" anyway). Both surfaces skip the sync and just bring
   the game to front instead (#1148 round 2). The Play button later became **state-aware** (#1313): when running is
-  detected it renders **Resume** and brings the window to front via `SteamClient.Apps.RaiseWindowForGame` (a dialog-free
-  window-raise that fires no `GameActionStart`), so on that surface the guard is now the **backstop for the render→click
-  race** rather than the primary path — the button honestly reflects running state instead of relying on the guard to
-  catch a Play press.
+  detected it renders **Resume** and brings the game to front via Steam's own gamescope resume path
+  (`SteamUIStore.SetRunningApp` + `NavigateToRunningApp`, a dialog-free UI navigation that fires no `GameActionStart`),
+  so on that surface the guard is now the **backstop for the render→click race** rather than the primary path — the
+  button honestly reflects running state instead of relying on the guard to catch a Play press.
 - Because the watcher cancels **first** and only then does async work, **there is no race** — the defect of awaiting
   against a live launch is gone by construction.
 
@@ -154,6 +154,6 @@ local file to `.romm-backup`, so there is no silent data loss. "Unknown because 
 [#1144](https://github.com/danielcopper/decky-romm-sync/issues/1144) (non-plugin bypass, resolved here),
 [#1146](https://github.com/danielcopper/decky-romm-sync/issues/1146),
 [#1313](https://github.com/danielcopper/decky-romm-sync/issues/1313) (the state-aware Resume button — the Play button
-reflects running state and foregrounds via `RaiseWindowForGame`, keeping this guard as its backstop). The suspend-time
-playtime fix and the multi-file-slot conflict fix are bundled in the same work but are separate bugfixes, not part of
-this ADR's decision.
+reflects running state and foregrounds via `SteamUIStore` navigation, keeping this guard as its backstop). The
+suspend-time playtime fix and the multi-file-slot conflict fix are bundled in the same work but are separate bugfixes,
+not part of this ADR's decision.

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1465,13 +1465,17 @@ surfaces — the interceptor and the Play button ([ADR-0015](../adr/0015-single-
 ### State-aware Resume button (#1313)
 
 When the game is already running, the RomM Play button (`CustomPlayButton`) renders **Resume** — top precedence over its
-install / conflict / download states — and a press brings the live window to the foreground via
-`SteamClient.Apps.RaiseWindowForGame(appId)` instead of running the pre-launch sync funnel. `RaiseWindowForGame` is a
-window-raise, not a launch: it fires no `GameActionStart` (so the launch interceptor never re-enters) and shows no Steam
-"already running" dialog, which dissolves the mid-session-sync problem at the UX level rather than defending against it.
-Its result is branched: `Success` is done; `NotRunning` means the running state was stale, so the overlay is cleared and
-the press falls through to the normal launch funnel (self-heal); `Failure` falls back to `RunGame` (accepting Steam's
-native dialog) so the user still reaches the game.
+install / conflict / download states — and a press brings the live session to the foreground via **Steam's own gamescope
+"Resume Game" path**: `SteamUIStore.SetRunningApp(appId)` followed by `SteamUIStore.NavigateToRunningApp()`. This is
+pure UI focus navigation, not a launch: it fires no `GameActionStart` (so the launch interceptor never re-enters) and
+shows no Steam "already running" dialog, which dissolves the mid-session-sync problem at the UX level rather than
+defending against it. (`SteamClient.Apps.RaiseWindowForGame` — the earlier approach — is a **desktop-overlay** call:
+native only acts on it when `SteamUIStore.GetOverlayInstances(appId)` is non-empty, which it never is in gamescope Game
+Mode, so it reports `Success` but silently does nothing. Hence the switch to the store-navigation path.) A click first
+runs a **liveness gate**: if nothing is actually running (`isAppRunning(appId)` / `getActiveSessionRomId()` both say no
+— a stale overlay from a session that ended without a stop event reaching the button), it clears the overlay and falls
+through to the normal launch funnel (self-heal). If `NavigateToRunningApp` is absent on an older SteamUI build, the
+foreground falls back to `Navigation.Navigate("/apprunning")` after the `SetRunningApp` selection (same visible effect).
 
 Detection is **reactive, not polled**: the overlay is seeded synchronously at mount from `getActiveSessionRomId()` /
 `isAppRunning(appId)` (so a page opened mid-session — or after a reload-adoption — shows Resume immediately) and flipped

--- a/docs/architecture/save-file-sync-architecture.md
+++ b/docs/architecture/save-file-sync-architecture.md
@@ -1462,6 +1462,24 @@ a per-source `diagnostics` string. No single surface is reliable across builds/t
 and a failed round logs what every candidate reported. The same reader backs the already-running skip on both launch
 surfaces — the interceptor and the Play button ([ADR-0015](../adr/0015-single-launch-gate-cancel-then-relaunch.md)).
 
+### State-aware Resume button (#1313)
+
+When the game is already running, the RomM Play button (`CustomPlayButton`) renders **Resume** — top precedence over its
+install / conflict / download states — and a press brings the live window to the foreground via
+`SteamClient.Apps.RaiseWindowForGame(appId)` instead of running the pre-launch sync funnel. `RaiseWindowForGame` is a
+window-raise, not a launch: it fires no `GameActionStart` (so the launch interceptor never re-enters) and shows no Steam
+"already running" dialog, which dissolves the mid-session-sync problem at the UX level rather than defending against it.
+Its result is branched: `Success` is done; `NotRunning` means the running state was stale, so the overlay is cleared and
+the press falls through to the normal launch funnel (self-heal); `Failure` falls back to `RunGame` (accepting Steam's
+native dialog) so the user still reaches the game.
+
+Detection is **reactive, not polled**: the overlay is seeded synchronously at mount from `getActiveSessionRomId()` /
+`isAppRunning(appId)` (so a page opened mid-session — or after a reload-adoption — shows Resume immediately) and flipped
+live by the `romm_session_changed` DOM event, which `sessionManager` dispatches on game start (`running: true`), game
+stop (`running: false`), and both reload-adoption branches (`running: true`). The already-running guards from #1148 /
+#1308 (the interceptor and the `handlePlay` guard) stay in place as **backstops** for the render→click race, where the
+session begins between the button rendering Play and the user pressing it.
+
 ### App ID to ROM ID mapping
 
 The session manager maintains a cached `appId -> romId` map loaded from the backend's synced-ROM registry (the `roms`

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1924,6 +1924,38 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
   });
 
+  it("falls back to Navigation.Navigate('/apprunning') when SteamUIStore.SetRunningApp throws (present-but-broken store)", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    // Present store, but SetRunningApp is a throwing getter/method — the exact
+    // present-but-broken failure class this whole PR was born from. Without the
+    // guard the async fn rejects, detach() swallows it, and the route fallback is
+    // skipped → user stranded (no foreground, no backstop).
+    const throwingSet = vi.fn(() => {
+      throw new Error("SetRunningApp exploded");
+    });
+    vi.stubGlobal("SteamUIStore", { SetRunningApp: throwingSet, NavigateToRunningApp: navigateToRunningApp });
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const resumeBtn = await findByText("Resume");
+
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // The throw is swallowed and the last-resort route nav still foregrounds…
+    await waitFor(() => expect(vi.mocked(Navigation.Navigate)).toHaveBeenCalledWith("/apprunning"));
+    // …and the catch is non-vacuously observable: the debug fallback line was logged.
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(
+      expect.stringContaining("SteamUIStore threw, falling back to Navigate"),
+    );
+    // SetRunningApp was attempted (we entered the guarded block); the throw stopped
+    // the navigate-to-running before it ran; and it's still not a launch.
+    expect(throwingSet).toHaveBeenCalledWith(100);
+    expect(navigateToRunningApp).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+  });
+
   it("navigates directly when SteamUIStore is absent (extreme API drift)", async () => {
     vi.mocked(getActiveSessionRomId).mockReturnValue(42);
     // No SteamUIStore at all — the last-resort route nav still foregrounds.

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -633,10 +633,13 @@ describe("CustomPlayButton — pre-launch savefiles_in_content_dir benign skip (
 });
 
 // #1148 round 2: the Play button is the sibling of the launch interceptor's
-// already-running guard. A Play press on an already-running game must NOT run the
-// pre-launch sync (it would upload the save mid-session and manufacture an exit
-// conflict); it skips the whole gate/sync funnel and just brings the game to
-// front. cached rom_id=42, appId=100 → the "Play" state.
+// already-running guard in `handlePlay`. Since #1313 the button renders Resume
+// (not Play) whenever running is detected at/after mount, so this guard is now
+// the BACKSTOP for the render→click RACE: the button shows Play (nothing running
+// at mount), the session starts WITHOUT a session event reaching this button, and
+// a Play press then must still skip the pre-launch sync (which would upload the
+// save mid-session and manufacture an exit conflict) and just bring the game to
+// front. cached rom_id=42, appId=100.
 describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
   beforeEach(() => {
     // This file has no global mock-clear, so backend callable call history leaks
@@ -673,11 +676,13 @@ describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
     });
   });
 
-  it("skips the gate/sync and brings the game to front when this rom is the live session", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
-
+  it("backstop: skips the gate/sync when the live session appears between render and click", async () => {
+    // Nothing running at mount → the button renders Play (no Resume overlay).
     const { findByText } = render(<CustomPlayButton appId={100} />);
     const playBtn = await findByText("Play");
+    // The session starts after render, before the click — the render→click race
+    // the handlePlay guard exists to catch.
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
     await act(async () => {
       playBtn.click();
     });
@@ -692,12 +697,11 @@ describe("CustomPlayButton — already-running guard (#1148 round 2)", () => {
     );
   });
 
-  it("skips the gate/sync when a running-app source reports the appId running", async () => {
-    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
-    vi.mocked(isAppRunning).mockReturnValue(true);
-
+  it("backstop: skips the gate/sync when a running-app source reports the appId at click", async () => {
     const { findByText } = render(<CustomPlayButton appId={100} />);
     const playBtn = await findByText("Play");
+    // Running-app source flips true after render (post-mount race).
+    vi.mocked(isAppRunning).mockReturnValue(true);
     await act(async () => {
       playBtn.click();
     });
@@ -1695,5 +1699,223 @@ describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
       vi.useRealTimers();
       logSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1313 — the state-aware Resume button. When the game is already running the
+// button renders "Resume" (top precedence over install/conflict/download) and
+// brings the live window to the foreground via SteamClient.Apps.RaiseWindowForGame
+// — NOT the pre-launch sync funnel. Detection is reactive: seeded at mount from
+// getActiveSessionRomId()/isAppRunning and flipped live by the romm_session_changed
+// DOM event. The #1148/#1308 already-running guards stay intact as backstops.
+// ---------------------------------------------------------------------------
+describe("CustomPlayButton — state-aware Resume (#1313)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCachedGameDetail).mockReset();
+    vi.mocked(toaster.toast).mockReset();
+    // Detection defaults: not running (overridden per test).
+    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isAppRunning).mockReturnValue(false);
+    // Gate predecessors so the NotRunning self-heal can reach the full funnel.
+    vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
+    vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
+    vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
+    vi.mocked(backend.preLaunchSync).mockResolvedValue({
+      success: true,
+      message: "",
+      synced: 0,
+      errors: [],
+      conflicts: [],
+    });
+    // dispatchLaunch re-confirms launch_options first; keep that fetch fast (a
+    // later describe leaves it hanging and clearAllMocks doesn't reset the impl).
+    vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue(null);
+    // SteamClient: RaiseWindowForGame defaults to Success (2); RunGame is the
+    // launch/backstop sink. appStore resolves a stable gameId.
+    vi.stubGlobal("SteamClient", {
+      Apps: { RunGame: vi.fn(), RaiseWindowForGame: vi.fn().mockResolvedValue(2) },
+    });
+    vi.stubGlobal("appStore", {
+      GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
+      allApps: [],
+    });
+    vi.mocked(getCachedGameDetail).mockResolvedValue({
+      found: true,
+      rom_id: 42,
+      rom_name: "Test ROM",
+      installed: true,
+    });
+  });
+
+  it("renders Resume (not Play) and raises the window when this rom is the live session — no gate/sync", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+
+    // Overlay wins: Resume shows, Play does not.
+    await findByText("Resume");
+    expect(queryByText("Play")).toBeNull();
+
+    const resumeBtn = await findByText("Resume");
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // Foreground the live window via the dialog-free path…
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RaiseWindowForGame)).toHaveBeenCalledWith(100));
+    // …and NEVER the launch funnel: no gate op, no sync, no RunGame.
+    expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+  });
+
+  it("renders Resume and raises the window when a running-app source reports the appId — no gate/sync", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(null);
+    vi.mocked(isAppRunning).mockReturnValue(true);
+
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Resume");
+    expect(queryByText("Play")).toBeNull();
+
+    const resumeBtn = await findByText("Resume");
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // Seeded via isAppRunning(appId) — proves the running-app detection branch.
+    expect(vi.mocked(isAppRunning)).toHaveBeenCalledWith(100);
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RaiseWindowForGame)).toHaveBeenCalledWith(100));
+    expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+  });
+
+  it("renders Play (overlay inert) when nothing is running at mount", async () => {
+    // Defaults: no live session, isAppRunning false.
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+    expect(queryByText("Resume")).toBeNull();
+  });
+
+  it("flips to Resume when a session-start event for this rom arrives", async () => {
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_session_changed", { detail: { running: true, appId: 100, romId: 42 } }),
+      );
+    });
+
+    await findByText("Resume");
+    expect(queryByText("Play")).toBeNull();
+  });
+
+  it("flips back to Play when the session-stop event for this rom arrives", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Resume");
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_session_changed", { detail: { running: false, appId: 100, romId: 42 } }),
+      );
+    });
+
+    await findByText("Play");
+    expect(queryByText("Resume")).toBeNull();
+  });
+
+  it("ignores a session event for a different rom", async () => {
+    const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_session_changed", { detail: { running: true, appId: 999, romId: 999 } }),
+      );
+    });
+
+    // Mismatched romId — the overlay never flips.
+    expect(await findByText("Play")).toBeInTheDocument();
+    expect(queryByText("Resume")).toBeNull();
+  });
+
+  it("removes the romm_session_changed listener on unmount", async () => {
+    const before = deckyEventListenerCount("romm_session_changed");
+    const { unmount } = render(<CustomPlayButton appId={100} />);
+    await waitFor(() => expect(vi.mocked(getCachedGameDetail)).toHaveBeenCalled());
+    unmount();
+    // A stop event after unmount must not throw / touch a torn-down component.
+    act(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_session_changed", { detail: { running: false, appId: 100, romId: 42 } }),
+      );
+    });
+    // globalThis listeners aren't tracked by the decky harness, so the count is a
+    // no-op here (0 before/after); the real assertion is that dispatching post-
+    // unmount is inert (no throw above).
+    expect(deckyEventListenerCount("romm_session_changed")).toBe(before);
+  });
+
+  it("self-heals a stale overlay: RaiseWindowForGame NotRunning falls through to the launch funnel", async () => {
+    // Seed Resume via the session-start EVENT (leaving the live sources false), so
+    // when handleResumeGame falls through to handlePlay the already-running guard
+    // is inert and the FULL funnel runs — the self-heal path.
+    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockResolvedValue(1); // NotRunning
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    await findByText("Play");
+    act(() => {
+      globalThis.dispatchEvent(
+        new CustomEvent("romm_session_changed", { detail: { running: true, appId: 100, romId: 42 } }),
+      );
+    });
+    const resumeBtn = await findByText("Resume");
+
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // NotRunning → cleared overlay → normal funnel ran (pre-launch sync) → launched.
+    await waitFor(() => expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42));
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+  });
+
+  it("falls back to RunGame (native dialog) when RaiseWindowForGame reports Failure", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockResolvedValue(3); // Failure
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const resumeBtn = await findByText("Resume");
+
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // Failure → RunGame backstop so the user still reaches the game, and NOT the
+    // full funnel (this is a direct dispatch, not handlePlay).
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+    expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+  });
+
+  it("swallows a RaiseWindowForGame rejection and falls back to RunGame (non-vacuous catch)", async () => {
+    vi.mocked(getActiveSessionRomId).mockReturnValue(42);
+    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockRejectedValue(new Error("raise boom"));
+
+    const { findByText } = render(<CustomPlayButton appId={100} />);
+    const resumeBtn = await findByText("Resume");
+
+    await act(async () => {
+      resumeBtn.click();
+    });
+
+    // Post-catch state: the catch returned Failure, which drove the Failure branch
+    // (its debug log) AND the RunGame backstop — so the user isn't stranded.
+    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("RaiseWindowForGame failed"));
   });
 });

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -17,7 +17,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, waitFor, act } from "@testing-library/react";
 import { toaster } from "@decky/api";
-import { showContextMenu } from "@decky/ui";
+import { showContextMenu, Navigation } from "@decky/ui";
 import type { ReactElement } from "react";
 import { CustomPlayButton } from "./CustomPlayButton";
 import { emitDeckyEvent, deckyEventListenerCount } from "../test-utils/decky-api-mock";
@@ -1705,12 +1705,17 @@ describe("CustomPlayButton — pre-launch relaunch re-confirm (#1150)", () => {
 // ---------------------------------------------------------------------------
 // #1313 — the state-aware Resume button. When the game is already running the
 // button renders "Resume" (top precedence over install/conflict/download) and
-// brings the live window to the foreground via SteamClient.Apps.RaiseWindowForGame
-// — NOT the pre-launch sync funnel. Detection is reactive: seeded at mount from
+// brings the live session to the foreground via SteamUIStore navigation
+// (SetRunningApp + NavigateToRunningApp) — Steam's own gamescope "Resume Game"
+// path, NOT the pre-launch sync funnel and NOT the desktop-only RaiseWindowForGame
+// (which silently no-ops in Game Mode). Detection is reactive: seeded at mount from
 // getActiveSessionRomId()/isAppRunning and flipped live by the romm_session_changed
 // DOM event. The #1148/#1308 already-running guards stay intact as backstops.
 // ---------------------------------------------------------------------------
 describe("CustomPlayButton — state-aware Resume (#1313)", () => {
+  let setRunningApp: ReturnType<typeof vi.fn>;
+  let navigateToRunningApp: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getCachedGameDetail).mockReset();
@@ -1718,7 +1723,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     // Detection defaults: not running (overridden per test).
     vi.mocked(getActiveSessionRomId).mockReturnValue(null);
     vi.mocked(isAppRunning).mockReturnValue(false);
-    // Gate predecessors so the NotRunning self-heal can reach the full funnel.
+    // Gate predecessors so the self-heal fall-through can reach the full funnel.
     vi.mocked(backend.isSaveTrackingConfigured).mockResolvedValue({ configured: true, active_slot: "default" });
     vi.mocked(backend.checkCoreChange).mockResolvedValue({ changed: false });
     vi.mocked(backend.probeReachability).mockResolvedValue({ online: true });
@@ -1732,11 +1737,13 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     // dispatchLaunch re-confirms launch_options first; keep that fetch fast (a
     // later describe leaves it hanging and clearAllMocks doesn't reset the impl).
     vi.mocked(backend.getRomRelaunchOptions).mockResolvedValue(null);
-    // SteamClient: RaiseWindowForGame defaults to Success (2); RunGame is the
-    // launch/backstop sink. appStore resolves a stable gameId.
-    vi.stubGlobal("SteamClient", {
-      Apps: { RunGame: vi.fn(), RaiseWindowForGame: vi.fn().mockResolvedValue(2) },
-    });
+    // SteamUIStore is the foreground path: SetRunningApp + NavigateToRunningApp.
+    // Fresh spies each test so call assertions are clean; RunGame is the
+    // launch/self-heal sink, appStore resolves a stable gameId.
+    setRunningApp = vi.fn();
+    navigateToRunningApp = vi.fn();
+    vi.stubGlobal("SteamClient", { Apps: { RunGame: vi.fn() } });
+    vi.stubGlobal("SteamUIStore", { SetRunningApp: setRunningApp, NavigateToRunningApp: navigateToRunningApp });
     vi.stubGlobal("appStore", {
       GetAppOverviewByAppID: vi.fn(() => ({ GetGameID: () => "gid-1" })),
       allApps: [],
@@ -1749,7 +1756,7 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     });
   });
 
-  it("renders Resume (not Play) and raises the window when this rom is the live session — no gate/sync", async () => {
+  it("renders Resume (not Play) and foregrounds via SteamUIStore when this rom is the live session — no gate/sync/RunGame", async () => {
     vi.mocked(getActiveSessionRomId).mockReturnValue(42);
 
     const { findByText, queryByText } = render(<CustomPlayButton appId={100} />);
@@ -1763,15 +1770,17 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
       resumeBtn.click();
     });
 
-    // Foreground the live window via the dialog-free path…
-    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RaiseWindowForGame)).toHaveBeenCalledWith(100));
-    // …and NEVER the launch funnel: no gate op, no sync, no RunGame.
+    // Foreground the live session via Steam's own resume path (select + navigate)…
+    await waitFor(() => expect(setRunningApp).toHaveBeenCalledWith(100));
+    expect(navigateToRunningApp).toHaveBeenCalled();
+    // …and NEVER the launch funnel: no gate op, no sync, no RunGame, no route fallback.
     expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
     expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
     expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
+    expect(vi.mocked(Navigation.Navigate)).not.toHaveBeenCalled();
   });
 
-  it("renders Resume and raises the window when a running-app source reports the appId — no gate/sync", async () => {
+  it("renders Resume and foregrounds when a running-app source reports the appId — no gate/sync/RunGame", async () => {
     vi.mocked(getActiveSessionRomId).mockReturnValue(null);
     vi.mocked(isAppRunning).mockReturnValue(true);
 
@@ -1786,7 +1795,8 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
 
     // Seeded via isAppRunning(appId) — proves the running-app detection branch.
     expect(vi.mocked(isAppRunning)).toHaveBeenCalledWith(100);
-    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RaiseWindowForGame)).toHaveBeenCalledWith(100));
+    await waitFor(() => expect(setRunningApp).toHaveBeenCalledWith(100));
+    expect(navigateToRunningApp).toHaveBeenCalled();
     expect(vi.mocked(backend.isSaveTrackingConfigured)).not.toHaveBeenCalled();
     expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
     expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
@@ -1867,12 +1877,11 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     removeSpy.mockRestore();
   });
 
-  it("self-heals a stale overlay: RaiseWindowForGame NotRunning falls through to the launch funnel", async () => {
-    // Seed Resume via the session-start EVENT (leaving the live sources false), so
-    // when handleResumeGame falls through to handlePlay the already-running guard
-    // is inert and the FULL funnel runs — the self-heal path.
-    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockResolvedValue(1); // NotRunning
-
+  it("self-heals a stale overlay: falls through to the launch funnel when nothing is actually running", async () => {
+    // Seed Resume via the session-start EVENT while the live sources stay false
+    // (getActiveSessionRomId null, isAppRunning false), so the liveness gate in
+    // handleResumeGame sees nothing running and falls through to handlePlay — the
+    // already-running guard there is inert, so the FULL funnel runs (self-heal).
     const { findByText } = render(<CustomPlayButton appId={100} />);
     await findByText("Play");
     act(() => {
@@ -1886,14 +1895,19 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
       resumeBtn.click();
     });
 
-    // NotRunning → cleared overlay → normal funnel ran (pre-launch sync) → launched.
+    // Nothing running → cleared overlay → normal funnel ran (pre-launch sync) → launched.
     await waitFor(() => expect(vi.mocked(backend.preLaunchSync)).toHaveBeenCalledWith(42));
     await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+    // The foreground path was NOT taken — no SteamUIStore selection, no route nav.
+    expect(setRunningApp).not.toHaveBeenCalled();
+    expect(navigateToRunningApp).not.toHaveBeenCalled();
+    expect(vi.mocked(Navigation.Navigate)).not.toHaveBeenCalled();
   });
 
-  it("falls back to RunGame (native dialog) when RaiseWindowForGame reports Failure", async () => {
+  it("falls back to Navigation.Navigate('/apprunning') when NavigateToRunningApp is missing (API drift)", async () => {
     vi.mocked(getActiveSessionRomId).mockReturnValue(42);
-    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockResolvedValue(3); // Failure
+    // Older SteamUI: SetRunningApp present, NavigateToRunningApp absent.
+    vi.stubGlobal("SteamUIStore", { SetRunningApp: setRunningApp });
 
     const { findByText } = render(<CustomPlayButton appId={100} />);
     const resumeBtn = await findByText("Resume");
@@ -1902,15 +1916,18 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
       resumeBtn.click();
     });
 
-    // Failure → RunGame backstop so the user still reaches the game, and NOT the
-    // full funnel (this is a direct dispatch, not handlePlay).
-    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
+    // Selection still runs; foregrounding falls back to the direct route nav.
+    await waitFor(() => expect(vi.mocked(Navigation.Navigate)).toHaveBeenCalledWith("/apprunning"));
+    expect(setRunningApp).toHaveBeenCalledWith(100);
+    // Still not a launch: no gate, no sync, no RunGame.
     expect(vi.mocked(backend.preLaunchSync)).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
   });
 
-  it("swallows a RaiseWindowForGame rejection and falls back to RunGame (non-vacuous catch)", async () => {
+  it("navigates directly when SteamUIStore is absent (extreme API drift)", async () => {
     vi.mocked(getActiveSessionRomId).mockReturnValue(42);
-    vi.mocked(SteamClient.Apps.RaiseWindowForGame).mockRejectedValue(new Error("raise boom"));
+    // No SteamUIStore at all — the last-resort route nav still foregrounds.
+    vi.stubGlobal("SteamUIStore", undefined);
 
     const { findByText } = render(<CustomPlayButton appId={100} />);
     const resumeBtn = await findByText("Resume");
@@ -1919,9 +1936,9 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
       resumeBtn.click();
     });
 
-    // Post-catch state: the catch returned Failure, which drove the Failure branch
-    // (its debug log) AND the RunGame backstop — so the user isn't stranded.
-    await waitFor(() => expect(vi.mocked(SteamClient.Apps.RunGame)).toHaveBeenCalledWith("gid-1", "", -1, 100));
-    expect(vi.mocked(backend.debugLog)).toHaveBeenCalledWith(expect.stringContaining("RaiseWindowForGame failed"));
+    await waitFor(() => expect(vi.mocked(Navigation.Navigate)).toHaveBeenCalledWith("/apprunning"));
+    // SetRunningApp is unreachable (no store), and it's still not a launch.
+    expect(setRunningApp).not.toHaveBeenCalled();
+    expect(vi.mocked(SteamClient.Apps.RunGame)).not.toHaveBeenCalled();
   });
 });

--- a/src/components/CustomPlayButton.test.tsx
+++ b/src/components/CustomPlayButton.test.tsx
@@ -1844,21 +1844,27 @@ describe("CustomPlayButton — state-aware Resume (#1313)", () => {
     expect(queryByText("Resume")).toBeNull();
   });
 
-  it("removes the romm_session_changed listener on unmount", async () => {
-    const before = deckyEventListenerCount("romm_session_changed");
+  it("removes the exact romm_session_changed handler on unmount", async () => {
+    // globalThis listeners aren't tracked by the decky harness, so spy the real
+    // add/remove to prove the []-effect cleanup removed the SAME handler ref.
+    const addSpy = vi.spyOn(globalThis, "addEventListener");
+    const removeSpy = vi.spyOn(globalThis, "removeEventListener");
+
     const { unmount } = render(<CustomPlayButton appId={100} />);
     await waitFor(() => expect(vi.mocked(getCachedGameDetail)).toHaveBeenCalled());
+
+    // Capture the exact handler the effect registered for romm_session_changed.
+    const addCall = addSpy.mock.calls.find(([type]) => type === "romm_session_changed");
+    expect(addCall).toBeDefined();
+    const handler = addCall![1];
+
     unmount();
-    // A stop event after unmount must not throw / touch a torn-down component.
-    act(() => {
-      globalThis.dispatchEvent(
-        new CustomEvent("romm_session_changed", { detail: { running: false, appId: 100, romId: 42 } }),
-      );
-    });
-    // globalThis listeners aren't tracked by the decky harness, so the count is a
-    // no-op here (0 before/after); the real assertion is that dispatching post-
-    // unmount is inert (no throw above).
-    expect(deckyEventListenerCount("romm_session_changed")).toBe(before);
+
+    // Non-vacuous: the cleanup removed romm_session_changed with that same ref.
+    expect(removeSpy).toHaveBeenCalledWith("romm_session_changed", handler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 
   it("self-heals a stale overlay: RaiseWindowForGame NotRunning falls through to the launch funnel", async () => {

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -634,17 +634,28 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     // NOSONAR(typescript:S7741) — SteamUIStore is an ambient Steam SP global; the
     // typeof guard keeps a genuinely-absent one from throwing ReferenceError.
     if (typeof SteamUIStore !== "undefined" && SteamUIStore) {
-      SteamUIStore.SetRunningApp(appId);
-      if (typeof SteamUIStore.NavigateToRunningApp === "function") {
-        SteamUIStore.NavigateToRunningApp();
-        detach(debugLog(`CustomPlayButton: resumed appId=${appId} via SteamUIStore.NavigateToRunningApp`));
-        return;
+      // A present-but-broken store is the exact failure class this button was born
+      // from (RaiseWindowForGame reporting Success while doing nothing) — a
+      // throwing `SetRunningApp` / `NavigateToRunningApp` getter must NOT strand the
+      // user with no foreground and no backstop. Any throw is swallowed and falls
+      // through to the route nav below, mirroring how runningApps.ts wraps every
+      // Steam-global access in try/catch.
+      try {
+        SteamUIStore.SetRunningApp(appId);
+        if (typeof SteamUIStore.NavigateToRunningApp === "function") {
+          SteamUIStore.NavigateToRunningApp();
+          detach(debugLog(`CustomPlayButton: resumed appId=${appId} via SteamUIStore.NavigateToRunningApp`));
+          return;
+        }
+      } catch (e) {
+        detach(debugLog(`CustomPlayButton: resume — SteamUIStore threw, falling back to Navigate: ${e}`));
       }
     }
-    // Older SteamUI without `NavigateToRunningApp` (API drift) — navigate to the
-    // running-app route directly. When the store was present `SetRunningApp` above
-    // already selected this app, so the foreground lands on it (the decky-rocketjump
-    // fallback path).
+    // Older SteamUI without `NavigateToRunningApp` (API drift), an absent store, or a
+    // store whose `SetRunningApp` / `NavigateToRunningApp` threw — navigate to the
+    // running-app route directly. When the store was present and `SetRunningApp`
+    // succeeded it already selected this app, so the foreground lands on it (the
+    // decky-rocketjump fallback path).
     Navigation.Navigate("/apprunning");
     detach(debugLog(`CustomPlayButton: resumed appId=${appId} via Navigation.Navigate`));
   };

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -97,6 +97,16 @@ function formatProgress(downloaded: number, total: number): string {
   return `${(downloaded / (1024 * 1024 * 1024)).toFixed(2)} / ${(total / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
+// Runtime mirror of the ambient `ERaiseGameWindowResult` (src/types/steam.d.ts).
+// An ambient enum is a compile-time type only — it has no runtime object — so the
+// result codes we branch on live here, typed back to the enum for clean, overlap-
+// safe comparisons against the RaiseWindowForGame result.
+const RaiseWindowResult = {
+  NotRunning: 1 as ERaiseGameWindowResult,
+  Success: 2 as ERaiseGameWindowResult,
+  Failure: 3 as ERaiseGameWindowResult,
+} as const;
+
 interface CustomPlayButtonProps {
   appId: number;
 }
@@ -111,6 +121,11 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
   const [actionPending, setActionPending] = useState(false);
   const [dlProgress, setDlProgress] = useState<DownloadProgress | null>(null);
   const [isOffline, setIsOffline] = useState(getRommConnectionState() === "offline");
+  // Running overlay (#1313): when the game is already running, the button shows
+  // Resume (top precedence over install/conflict/download) and brings the game to
+  // front instead of running the launch funnel. Seeded synchronously at init and
+  // flipped live by the `romm_session_changed` listener.
+  const [isRunning, setIsRunning] = useState(false);
   const romIdRef = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const transitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -183,6 +198,11 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
         setRomId(rid);
         romIdRef.current = rid;
         if (cached.rom_name) setRomName(cached.rom_name);
+
+        // Seed the running overlay from the live session/running-app state so a
+        // button mounted mid-session (or after a reload-adoption) shows Resume
+        // immediately, without waiting for a session event (#1313).
+        setIsRunning(getActiveSessionRomId() === rid || isAppRunning(appId));
 
         if (cached.installed) {
           // Check for conflicts from cached save status
@@ -305,6 +325,16 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     };
     globalThis.addEventListener("romm_connection_changed", onConnectionChanged);
 
+    // Session start/stop (#1313) — flip the running overlay so the button shows
+    // Resume for the live session and returns to Play when it ends. Matches on
+    // romId (present in every dispatch); a stop for our rom clears the overlay
+    // and the underlying play/conflict state shows through.
+    const onSessionChanged = (e: WindowEventMap["romm_session_changed"]) => {
+      if (e.detail.romId !== romIdRef.current) return;
+      setIsRunning(e.detail.running);
+    };
+    globalThis.addEventListener("romm_session_changed", onSessionChanged);
+
     return () => {
       removeEventListener("download_progress", progressListener);
       removeEventListener("download_complete", completeListener);
@@ -312,6 +342,7 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
       globalThis.removeEventListener("romm_rom_uninstalled", onUninstall);
       globalThis.removeEventListener("romm_data_changed", onDataChanged);
       globalThis.removeEventListener("romm_connection_changed", onConnectionChanged);
+      globalThis.removeEventListener("romm_session_changed", onSessionChanged);
     };
   }, []);
 
@@ -589,6 +620,41 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     }
   };
 
+  // Resume an already-running game: bring its window to the foreground instead of
+  // launching (#1313). `RaiseWindowForGame` focuses the live window WITHOUT firing
+  // GameActionStart (so the launch interceptor never re-enters) and WITHOUT Steam's
+  // native "already running" dialog — so the pre-launch sync funnel never runs
+  // mid-session (which would upload the save while the emulator holds it open).
+  //
+  //  - Success    → done.
+  //  - NotRunning → the running overlay was stale; clear it and fall through to the
+  //                 normal launch funnel (self-heal — the game isn't actually up).
+  //  - Failure    → RunGame backstop (accepts the native dialog) so the user still
+  //                 reaches the game rather than being stranded.
+  const handleResumeGame = async () => {
+    const overview = appStore.GetAppOverviewByAppID(appId);
+    const gameId = overview?.GetGameID?.() ?? String(appId);
+    const raiseResult = await SteamClient.Apps.RaiseWindowForGame(appId).catch((e) => {
+      logError(`CustomPlayButton: RaiseWindowForGame threw: ${e}`);
+      return RaiseWindowResult.Failure;
+    });
+
+    if (raiseResult === RaiseWindowResult.Success) {
+      detach(debugLog(`CustomPlayButton: resumed appId=${appId} via RaiseWindowForGame`));
+      return;
+    }
+    if (raiseResult === RaiseWindowResult.NotRunning) {
+      detach(debugLog(`CustomPlayButton: RaiseWindowForGame reported NotRunning — falling through to launch`));
+      setIsRunning(false);
+      await handlePlay();
+      return;
+    }
+    // Failure (or any unexpected code) — fall back to RunGame so the user still
+    // reaches the game (Steam surfaces its own "already running" dialog here).
+    detach(debugLog(`CustomPlayButton: RaiseWindowForGame failed (${raiseResult}) — RunGame backstop`));
+    await dispatchLaunch(gameId);
+  };
+
   // Resolve the conflict the button is already showing. This is a READ, not a
   // re-sync: it pulls the already-known conflict via `getSaveStatus` and hands
   // it to the shared resolution modal. Re-running the act-capable
@@ -778,6 +844,38 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     fontSize: "16px",
     fontWeight: "bold",
   };
+
+  // Running overlay (#1313) — top precedence over install/conflict/download. A
+  // single green Resume button (no Uninstall chevron: uninstalling a running game
+  // is a footgun) that brings the live session to front via `handleResumeGame`.
+  if (isRunning) {
+    return (
+      <Focusable
+        ref={containerRef}
+        className={[appActionButtonClasses?.PlayButtonContainer, appActionButtonClasses?.Green]
+          .filter(Boolean)
+          .join(" ")}
+        style={btnContainerStyle}
+      >
+        <DialogButton
+          className={[appActionButtonClasses?.PlayButton, "romm-btn-play"].filter(Boolean).join(" ")}
+          style={{
+            ...mainBtnStyle,
+            borderRadius: "2px",
+            background: "linear-gradient(to right, #70d61d 0%, #01a75b 60%)",
+            backgroundPosition: "25%",
+            backgroundSize: "330% 100%",
+          }}
+          onClick={() => {
+            detach(handleResumeGame());
+          }}
+          onFocus={scrollToTop}
+        >
+          Resume
+        </DialogButton>
+      </Focusable>
+    );
+  }
 
   if (state === "dl_complete") {
     // "Ready!" state — must match the Play button exactly (same classes + Green tint)

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useRef, FC, ReactElement } from "react";
 import { addEventListener, removeEventListener, toaster } from "@decky/api";
-import { Focusable, DialogButton, Menu, MenuItem, showContextMenu } from "@decky/ui";
+import { Focusable, DialogButton, Menu, MenuItem, Navigation, showContextMenu } from "@decky/ui";
 import { appActionButtonClasses, basicAppDetailsSectionStylerClasses } from "../utils/deckyUiInternals";
 import { hideNativePlaySection, showNativePlaySection } from "../utils/styleInjector";
 import { hasAnySaveConflict } from "../utils/saveStatus";
@@ -96,18 +96,6 @@ function formatProgress(downloaded: number, total: number): string {
     return `${(downloaded / (1024 * 1024)).toFixed(1)} / ${(total / (1024 * 1024)).toFixed(1)} MB`;
   return `${(downloaded / (1024 * 1024 * 1024)).toFixed(2)} / ${(total / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
-
-// Runtime mirror of `ERaiseGameWindowResult` (typed in src/types/steam.d.ts).
-// @decky/ui defines that enum but does NOT re-export it from its public root
-// (its globals re-export only SteamClient + stores; the enum lives in the
-// internal steam-client/App module), and the ambient enum carries no runtime
-// object — so the result codes we branch on live here, typed back to the enum
-// for clean, overlap-safe comparisons against the RaiseWindowForGame result.
-const RaiseWindowResult = {
-  NotRunning: 1 as ERaiseGameWindowResult,
-  Success: 2 as ERaiseGameWindowResult,
-  Failure: 3 as ERaiseGameWindowResult,
-} as const;
 
 interface CustomPlayButtonProps {
   appId: number;
@@ -622,39 +610,43 @@ export const CustomPlayButton: FC<CustomPlayButtonProps> = ({ appId }) => { // N
     }
   };
 
-  // Resume an already-running game: bring its window to the foreground instead of
-  // launching (#1313). `RaiseWindowForGame` focuses the live window WITHOUT firing
-  // GameActionStart (so the launch interceptor never re-enters) and WITHOUT Steam's
-  // native "already running" dialog — so the pre-launch sync funnel never runs
-  // mid-session (which would upload the save while the emulator holds it open).
-  //
-  //  - Success    → done.
-  //  - NotRunning → the running overlay was stale; clear it and fall through to the
-  //                 normal launch funnel (self-heal — the game isn't actually up).
-  //  - Failure    → RunGame backstop (accepts the native dialog) so the user still
-  //                 reaches the game rather than being stranded.
+  // Resume an already-running game: bring it to the foreground instead of
+  // launching (#1313). Foregrounding is pure UI focus navigation the way Steam's
+  // own gamescope "Resume Game" does it — `SteamUIStore.SetRunningApp(appId)` +
+  // `NavigateToRunningApp()` — NOT a launch: it fires no `GameActionStart` (so the
+  // launch interceptor never re-enters) and shows no "already running" dialog, so
+  // the pre-launch sync funnel never runs mid-session (which would upload the save
+  // while the emulator holds the file open). `RaiseWindowForGame` (the prior
+  // approach) is a DESKTOP-overlay call that silently no-ops in gamescope Game Mode
+  // — it reports Success but does nothing — so it is not used here.
   const handleResumeGame = async () => {
-    const overview = appStore.GetAppOverviewByAppID(appId);
-    const gameId = overview?.GetGameID?.() ?? String(appId);
-    const raiseResult = await SteamClient.Apps.RaiseWindowForGame(appId).catch((e) => {
-      logError(`CustomPlayButton: RaiseWindowForGame threw: ${e}`);
-      return RaiseWindowResult.Failure;
-    });
-
-    if (raiseResult === RaiseWindowResult.Success) {
-      detach(debugLog(`CustomPlayButton: resumed appId=${appId} via RaiseWindowForGame`));
-      return;
-    }
-    if (raiseResult === RaiseWindowResult.NotRunning) {
-      detach(debugLog(`CustomPlayButton: RaiseWindowForGame reported NotRunning — falling through to launch`));
+    // Liveness gate: the overlay can go stale (a session that ended without a stop
+    // event reaching this button). If nothing is actually running, clear the
+    // overlay and fall through to the normal launch funnel — self-heal, so a click
+    // never strands the user on a dead Resume.
+    if (!(isAppRunning(appId) || getActiveSessionRomId() === romId)) {
+      detach(debugLog(`CustomPlayButton: Resume on appId=${appId} but nothing is running — self-healing to launch`));
       setIsRunning(false);
       await handlePlay();
       return;
     }
-    // Failure (or any unexpected code) — fall back to RunGame so the user still
-    // reaches the game (Steam surfaces its own "already running" dialog here).
-    detach(debugLog(`CustomPlayButton: RaiseWindowForGame failed (${raiseResult}) — RunGame backstop`));
-    await dispatchLaunch(gameId);
+
+    // NOSONAR(typescript:S7741) — SteamUIStore is an ambient Steam SP global; the
+    // typeof guard keeps a genuinely-absent one from throwing ReferenceError.
+    if (typeof SteamUIStore !== "undefined" && SteamUIStore) {
+      SteamUIStore.SetRunningApp(appId);
+      if (typeof SteamUIStore.NavigateToRunningApp === "function") {
+        SteamUIStore.NavigateToRunningApp();
+        detach(debugLog(`CustomPlayButton: resumed appId=${appId} via SteamUIStore.NavigateToRunningApp`));
+        return;
+      }
+    }
+    // Older SteamUI without `NavigateToRunningApp` (API drift) — navigate to the
+    // running-app route directly. When the store was present `SetRunningApp` above
+    // already selected this app, so the foreground lands on it (the decky-rocketjump
+    // fallback path).
+    Navigation.Navigate("/apprunning");
+    detach(debugLog(`CustomPlayButton: resumed appId=${appId} via Navigation.Navigate`));
   };
 
   // Resolve the conflict the button is already showing. This is a READ, not a

--- a/src/components/CustomPlayButton.tsx
+++ b/src/components/CustomPlayButton.tsx
@@ -97,10 +97,12 @@ function formatProgress(downloaded: number, total: number): string {
   return `${(downloaded / (1024 * 1024 * 1024)).toFixed(2)} / ${(total / (1024 * 1024 * 1024)).toFixed(2)} GB`;
 }
 
-// Runtime mirror of the ambient `ERaiseGameWindowResult` (src/types/steam.d.ts).
-// An ambient enum is a compile-time type only — it has no runtime object — so the
-// result codes we branch on live here, typed back to the enum for clean, overlap-
-// safe comparisons against the RaiseWindowForGame result.
+// Runtime mirror of `ERaiseGameWindowResult` (typed in src/types/steam.d.ts).
+// @decky/ui defines that enum but does NOT re-export it from its public root
+// (its globals re-export only SteamClient + stores; the enum lives in the
+// internal steam-client/App module), and the ambient enum carries no runtime
+// object — so the result codes we branch on live here, typed back to the enum
+// for clean, overlap-safe comparisons against the RaiseWindowForGame result.
 const RaiseWindowResult = {
   NotRunning: 1 as ERaiseGameWindowResult,
   Success: 2 as ERaiseGameWindowResult,

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -31,11 +31,23 @@ export interface RommConnectionChangedDetail {
   state: "checking" | "connected" | "offline";
 }
 
+/**
+ * A RomM play session started or ended (#1313). Dispatched by `sessionManager`
+ * on game start/stop and on reload-adoption so surfaces like `CustomPlayButton`
+ * can flip to (or away from) the state-aware Resume button without polling.
+ */
+export interface RommSessionChangedDetail {
+  running: boolean;
+  appId: number;
+  romId: number;
+}
+
 declare global {
   interface WindowEventMap {
     romm_data_changed: CustomEvent<RommDataChangedDetail>;
     romm_rom_uninstalled: CustomEvent<RommRomUninstalledDetail>;
     romm_tab_switch: CustomEvent<RommTabSwitchDetail>;
     romm_connection_changed: CustomEvent<RommConnectionChangedDetail>;
+    romm_session_changed: CustomEvent<RommSessionChangedDetail>;
   }
 }

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -21,6 +21,12 @@ declare var SteamClient: {
       callback: (details: SteamAppDetails | undefined) => void,
     ): { unregister: () => void };
     RunGame(gameId: string | number, launchId: string, param2: number, param3: number): void;
+    // Bring an already-running game's window to the foreground. Unlike RunGame
+    // this is NOT a launch — it fires no GameActionStart (so the launch
+    // interceptor never re-enters) and shows no "already running" dialog. Used
+    // by the state-aware Resume button (#1313) to focus a live session instead
+    // of running the pre-launch sync funnel.
+    RaiseWindowForGame(appId: number): Promise<ERaiseGameWindowResult>;
     TerminateApp(appId: number, force: boolean): void;
     RegisterForGameActionStart(
       callback: (gameActionId: number, appIdStr: string, action: string, launchSource: number) => void,
@@ -49,6 +55,15 @@ declare var SteamClient: {
     RegisterForResumeSuspendedGamesProgress(callback: () => void): { unregister: () => void };
   };
 };
+
+// Result of SteamClient.Apps.RaiseWindowForGame (Steam's ERaiseGameWindowResult).
+// Ambient — a compile-time type only, so consumers branch on the numeric code
+// rather than reading enum members off a runtime object that doesn't exist.
+declare enum ERaiseGameWindowResult {
+  NotRunning = 1,
+  Success = 2,
+  Failure = 3,
+}
 
 interface SteamAppDetails {
   // The two launch-options fields the runtime exposes — keys vary by Steam

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -56,9 +56,10 @@ declare var SteamClient: {
   };
 };
 
-// Result of SteamClient.Apps.RaiseWindowForGame (Steam's ERaiseGameWindowResult).
-// Ambient — a compile-time type only, so consumers branch on the numeric code
-// rather than reading enum members off a runtime object that doesn't exist.
+// Result of SteamClient.Apps.RaiseWindowForGame — mirrors @decky/ui's own
+// ERaiseGameWindowResult, which is defined in that package but NOT re-exported
+// from its public root (see the runtime-mirror note in CustomPlayButton), so we
+// declare the type here on our own SteamClient surface.
 declare enum ERaiseGameWindowResult {
   NotRunning = 1,
   Success = 2,

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -21,12 +21,6 @@ declare var SteamClient: {
       callback: (details: SteamAppDetails | undefined) => void,
     ): { unregister: () => void };
     RunGame(gameId: string | number, launchId: string, param2: number, param3: number): void;
-    // Bring an already-running game's window to the foreground. Unlike RunGame
-    // this is NOT a launch — it fires no GameActionStart (so the launch
-    // interceptor never re-enters) and shows no "already running" dialog. Used
-    // by the state-aware Resume button (#1313) to focus a live session instead
-    // of running the pre-launch sync funnel.
-    RaiseWindowForGame(appId: number): Promise<ERaiseGameWindowResult>;
     TerminateApp(appId: number, force: boolean): void;
     RegisterForGameActionStart(
       callback: (gameActionId: number, appIdStr: string, action: string, launchSource: number) => void,
@@ -55,16 +49,6 @@ declare var SteamClient: {
     RegisterForResumeSuspendedGamesProgress(callback: () => void): { unregister: () => void };
   };
 };
-
-// Result of SteamClient.Apps.RaiseWindowForGame — mirrors @decky/ui's own
-// ERaiseGameWindowResult, which is defined in that package but NOT re-exported
-// from its public root (see the runtime-mirror note in CustomPlayButton), so we
-// declare the type here on our own SteamClient surface.
-declare enum ERaiseGameWindowResult {
-  NotRunning = 1,
-  Success = 2,
-  Failure = 3,
-}
 
 interface SteamAppDetails {
   // The two launch-options fields the runtime exposes — keys vary by Steam
@@ -154,6 +138,13 @@ declare var Router:
 declare var SteamUIStore:
   | {
       RunningApps?: SteamAppOverview[];
+      // Focus a running app in gamescope — pure UI selection, not a launch. The
+      // state-aware Resume button (#1313) calls this + NavigateToRunningApp to
+      // foreground a live session (Steam's own "Resume Game" path).
+      SetRunningApp(appId: number): void;
+      // Navigate to the running-app screen. Optional — absent on older SteamUI
+      // builds, where the Resume path falls back to Navigation.Navigate("/apprunning").
+      NavigateToRunningApp?(force?: boolean): void;
     }
   | null
   | undefined;

--- a/src/utils/sessionManager.test.ts
+++ b/src/utils/sessionManager.test.ts
@@ -1118,3 +1118,93 @@ describe("sessionManager suspend subtraction via the User.* fallback (#1148)", (
     expect(resumeUnregister).toHaveBeenCalledTimes(1);
   });
 });
+
+// #1313: the state-aware Resume button reacts to session start/stop without
+// polling by listening for the romm_session_changed DOM event. These pin that
+// sessionManager dispatches it (running:true on start + reload-adoption,
+// running:false on stop) with the appId+romId the button matches on.
+describe("sessionManager session-changed dispatch (#1313)", () => {
+  const BREADCRUMB_KEY = "decky-romm-sync:active-session";
+  let sessionEvents: { running: boolean; appId: number; romId: number }[];
+  let sessionListener: (e: WindowEventMap["romm_session_changed"]) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    localStorage.clear();
+    vi.stubGlobal("SteamClient", {
+      GameSessions: {
+        RegisterForAppLifetimeNotifications: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+      System: {
+        RegisterForOnSuspendRequest: vi.fn(() => ({ unregister: vi.fn() })),
+        RegisterForOnResumeFromSuspend: vi.fn(() => ({ unregister: vi.fn() })),
+      },
+    });
+    vi.mocked(backend.getAppIdRomIdMap).mockResolvedValue({ [String(APP_ID)]: ROM_ID });
+    vi.mocked(backend.recordSessionStart).mockResolvedValue({ success: true });
+    vi.mocked(backend.finalizeGameSession).mockResolvedValue({
+      total_seconds: null,
+      sync: {
+        offline: false,
+        success: true,
+        synced: 0,
+        conflicts: [],
+        toast_title: null,
+        toast_body: null,
+        conflicts_toast: null,
+      },
+      migration: null,
+    });
+    sessionEvents = [];
+    sessionListener = (e) => sessionEvents.push(e.detail);
+    globalThis.addEventListener("romm_session_changed", sessionListener);
+  });
+
+  afterEach(() => {
+    globalThis.removeEventListener("romm_session_changed", sessionListener);
+    destroySessionManager();
+    vi.useRealTimers();
+  });
+
+  it("dispatches running:true on game start and running:false on stop", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: null });
+    await initDrainingAdoptionPoll();
+    const lifetime = captureLifetimeCb();
+
+    await startGame(lifetime);
+    expect(sessionEvents).toContainEqual({ running: true, appId: APP_ID, romId: ROM_ID });
+
+    sessionEvents.length = 0;
+    vi.setSystemTime(60_000);
+    await stopGame(lifetime);
+    expect(sessionEvents).toContainEqual({ running: false, appId: APP_ID, romId: ROM_ID });
+  });
+
+  it("dispatches running:true when adopting a running session via a matching breadcrumb", async () => {
+    localStorage.setItem(
+      BREADCRUMB_KEY,
+      JSON.stringify({ v: 1, appId: APP_ID, romId: ROM_ID, startMs: 5_000, pausedMs: 0 }),
+    );
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    expect(sessionEvents).toContainEqual({ running: true, appId: APP_ID, romId: ROM_ID });
+  });
+
+  it("dispatches running:true when adopting a running session with no breadcrumb", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: { appid: APP_ID, display_name: "Game" } });
+
+    await initSessionManager();
+
+    expect(sessionEvents).toContainEqual({ running: true, appId: APP_ID, romId: ROM_ID });
+  });
+
+  it("does not dispatch a session event when nothing is running at init", async () => {
+    vi.stubGlobal("Router", { MainRunningApp: null });
+    await initDrainingAdoptionPoll();
+    expect(sessionEvents).toEqual([]);
+  });
+});

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -153,6 +153,15 @@ function updateSessionBreadcrumbPaused(pausedMs: number): void {
   if (crumb) writeSessionBreadcrumb({ ...crumb, pausedMs });
 }
 
+/**
+ * Notify open surfaces that a RomM play session started or ended, so they can
+ * flip to/from the state-aware Resume button without polling (#1313). A frontend
+ * DOM CustomEvent — `CustomPlayButton` matches it on `romId`.
+ */
+function dispatchSessionChanged(running: boolean, appId: number, romId: number): void {
+  globalThis.dispatchEvent(new CustomEvent("romm_session_changed", { detail: { running, appId, romId } }));
+}
+
 async function handleGameStart(appId: number): Promise<void> {
   const romId = getRomIdForApp(appId);
   if (!romId) return; // Not a RomM shortcut
@@ -162,6 +171,7 @@ async function handleGameStart(appId: number): Promise<void> {
   sessionStartTime = Date.now();
   suspendedAt = null;
   totalPausedMs = 0;
+  dispatchSessionChanged(true, appId, romId);
 
   // Attest the open session so a reload mid-game can adopt and finalize it.
   writeSessionBreadcrumb({ v: SESSION_BREADCRUMB_VERSION, appId, romId, startMs: sessionStartTime, pausedMs: 0 });
@@ -187,6 +197,12 @@ async function handleGameStop(): Promise<void> {
     totalPausedMs += Date.now() - suspendedAt;
   }
   const suspendedSeconds = Math.round(totalPausedMs / 1000);
+
+  // Flip any open Resume button back to Play before we lose the appId mapping
+  // (#1313). Best-effort — a missing reverse-map entry leaves the button to
+  // self-heal on remount; the button keys on romId regardless.
+  const stoppedAppId = getAppIdForRom(romId);
+  if (stoppedAppId !== null) dispatchSessionChanged(false, stoppedAppId, romId);
 
   // Clear active session immediately to avoid double-processing. The breadcrumb
   // goes with it — the stop is observed, so there is nothing left to adopt.
@@ -336,6 +352,7 @@ async function adoptOrphanedSession(): Promise<void> {
       sessionStartTime = crumb.startMs;
       suspendedAt = null;
       totalPausedMs = crumb.pausedMs;
+      dispatchSessionChanged(true, appId, runningRomId);
       logInfo(`Adopted running session from breadcrumb: romId=${runningRomId}, appId=${appId}`);
     } else {
       // (a′) A game is running but no usable breadcrumb (missing / mismatched /
@@ -353,6 +370,7 @@ async function adoptOrphanedSession(): Promise<void> {
         startMs: sessionStartTime,
         pausedMs: 0,
       });
+      dispatchSessionChanged(true, appId, runningRomId);
       try {
         await recordSessionStart(runningRomId);
       } catch (e) {


### PR DESCRIPTION
## What

When a RomM game is already running, the Play button (`CustomPlayButton`) renders **Resume** — top precedence over its install / conflict / download states — and a press brings the live session to the foreground instead of running the pre-launch sync funnel.

The first cut foregrounded via `SteamClient.Apps.RaiseWindowForGame(appId)`, but on-device (Game Mode) that returned `Success` while doing nothing on a RetroDECK non-Steam shortcut: `RaiseWindowForGame` is a **desktop-overlay** call — native only acts on it when `SteamUIStore.GetOverlayInstances(appId)` is non-empty, and in gamescope there are none. Resume now uses Steam's own gamescope "Resume Game" path — `SteamUIStore.SetRunningApp(appId)` + `SteamUIStore.NavigateToRunningApp()` — pure UI focus navigation: it fires no `GameActionStart` (so the launch interceptor never re-enters) and shows no "already running" dialog. This dissolves the mid-session-sync problem at the UX level — the button honestly reflects running state rather than relying on the already-running guard to catch a Play press.

## How

- **Foreground path.** `handleResumeGame` runs a **liveness gate** first: if nothing is actually running (`isAppRunning(appId)` / `getActiveSessionRomId()` both say no — a stale overlay from a session that ended without a stop event reaching the button), it clears the overlay and falls through to the normal launch funnel (self-heal). Otherwise it foregrounds via `SteamUIStore.SetRunningApp(appId)` + `NavigateToRunningApp()`; if `NavigateToRunningApp` is absent on an older SteamUI build (API drift), it falls back to `Navigation.Navigate("/apprunning")` after the same `SetRunningApp` selection. `SetRunningApp` / optional `NavigateToRunningApp` are added to the `SteamUIStore` typing; `RaiseWindowForGame` and its `ERaiseGameWindowResult` enum are dropped from `src/types/steam.d.ts`.
- **Reactive detection, no polling.** The running overlay is seeded synchronously at mount from `getActiveSessionRomId()` / `isAppRunning(appId)` (so a page opened mid-session — or after a reload-adoption — shows Resume immediately) and flipped live by a `romm_session_changed` DOM event. `sessionManager` dispatches it on game start (`running: true`), game stop (`running: false`), and both reload-adoption branches (`running: true`). The button matches on `romId`.
- **Guards stay as backstops.** The #1148 / #1308 already-running guards (the interceptor and the `handlePlay` guard) are unchanged — they now backstop the render→click race (the session begins between the button rendering Play and the user pressing it).
- **No wire-surface change.** `romm_session_changed` is a frontend `globalThis` `CustomEvent` (like `romm_data_changed`), so it's outside the backend↔frontend event-parity gate, and no callables were added — the callable-manifest gate is untouched.

## Tests

- `src/components/CustomPlayButton.test.tsx` — `state-aware Resume (#1313)` suite (non-vacuous): live-session and `isAppRunning` seedings render Resume + a press calls `SteamUIStore.SetRunningApp(appId)` **and** `NavigateToRunningApp()`, and invokes **no** gate/sync callables, no `RunGame`, and no route fallback; not-running renders Play; the `romm_session_changed` event flips Resume↔Play (and ignores a mismatched rom); a click with nothing actually running self-heals into the funnel (asserts `preLaunchSync` + `RunGame`, and that the foreground path was **not** taken); a missing `NavigateToRunningApp` falls back to `Navigation.Navigate("/apprunning")` after `SetRunningApp`; an absent `SteamUIStore` navigates directly. The two existing #1148 guard tests remain reframed to the render→click race (the button now shows Resume, not Play, when running is live).
- `src/utils/sessionManager.test.ts` — suite pinning the `romm_session_changed` dispatch on start/stop and both adopt branches, and that nothing dispatches when idle.

## Checks

`pnpm typecheck`, `pnpm lint` (0 errors; 2 pre-existing warnings unrelated to this change), `pnpm test` (1502 pass), `pnpm build`, `pnpm size` (574.03 kB / 600 kB budget), callable-manifest (112) + event-parity (13) gates — all green.

## On-device verification (cannot be unit-tested)

- Confirm a **Resume** press foregrounds a **RetroDECK non-Steam-shortcut** in Game Mode via `SteamUIStore.SetRunningApp(appId)` + `NavigateToRunningApp()` — **without a dialog and without relaunching** — both in-session and after a `plugin_loader` restart; and that clicking Resume when the game is not actually running self-heals into the normal launch funnel.

## Docs

- `docs/architecture/save-file-sync-architecture.md` — "State-aware Resume button (#1313)" section updated to the SteamUIStore-navigation mechanism (with the RaiseWindowForGame no-op explained).
- `docs/adr/0015-single-launch-gate-cancel-then-relaunch.md` — already-running guard note + See-also updated to the new mechanism.

Closes #1313. Follow-up to #1148 / #1308.
