### PR TITLE
feat(auth): sign in with a pasted RomM client API token (OIDC)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,11 @@ You should receive a response within 7 days.
 This plugin handles:
 
 - **A scoped RomM Client API Token** stored in the plugin's settings file (`settings.json`) in Decky's settings
-  directory. Your RomM username and password are used **once, in memory only**, to mint that token at sign-in and are
-  then discarded — they are never written to disk. The plugin stores only the server URL, the minted token (plus its
-  server-side id and the origin it was minted against), and the SSL-verification flag.
+  directory. The token is either **minted by the plugin** at credential sign-in — your RomM username and password are
+  used **once, in memory only**, then discarded, never written to disk — or **supplied by you**: a Client API Token you
+  created in RomM's web UI and pasted in (e.g. for OIDC / SSO accounts, which have no password to mint from). In both
+  cases the plugin stores only the server URL, the token (plus its server-side id when minted; none for a user-supplied
+  token), the origin it was minted or accepted against, a provenance marker, and the SSL-verification flag.
 - **An optional SteamGridDB API key** stored in the same `settings.json`
 - **HTTP requests** to self-hosted RomM servers (optionally with SSL verification disabled for self-signed certificates)
 
@@ -40,9 +42,12 @@ This plugin handles:
 - The settings file is stored with `0600` permissions (owner-only read/write); the plugin actively migrates an older
   world-readable `0644` file to `0600` on load.
 - Credentials and tokens are never logged — masked in all log output.
-- The RomM Client API Token is **bound to the origin it was minted against** (`scheme://host[:port]`) and is only ever
-  sent to that exact origin. If the configured server URL no longer matches, the bearer is withheld rather than sent — a
-  changed or hostile host never receives the credential.
+- The RomM Client API Token is **bound to the origin it was minted or accepted against** (`scheme://host[:port]`) and is
+  only ever sent to that exact origin — a user-supplied token is stamped with the origin it was validated against at
+  sign-in. If the configured server URL no longer matches, the bearer is withheld rather than sent — a changed or
+  hostile host never receives the credential.
+- The plugin **never deletes or modifies a user-supplied token** on the RomM server — that token's lifecycle is managed
+  by you in RomM; only tokens the plugin itself minted are revoked on re-sign-in.
 - Path components supplied by the RomM server (filenames, ROM and save paths) are validated against path traversal
   before they are used to build local filesystem paths, so a compromised or malicious server cannot write outside the
   plugin's directories.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -123,7 +123,7 @@ the rest are single modules. A service over ~700 LOC is the decomposition signal
 | `metadata.py`             | MetadataService — ROM metadata reads from `rom_metadata` (7-day TTL), app_id mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `launch_gate.py`          | LaunchGateService — pre-launch gate (rom lookup, install check, save status)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `startup_healing.py`      | StartupHealingService — prunes stale `rom_installs` rows against disk on load (via the UoW) + reconciles orphaned `running` SyncRuns (a hard crash leaves a `running` row → marked errored) + `get_installed_relaunch_options()` builds the startup launch-options reconcile items (see [StartupHealingService notes](#startuphealingservice-notes))                                                                                                                                                                                                                       |
-| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials, host-bound to the minting origin; see [ConnectionService notes](#connectionservice-notes))                                                                                                                                                                                                                                                                                                                                                   |
+| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials, or validate/store a user-pasted token for OIDC accounts; host-bound to the minting origin; see [ConnectionService notes](#connectionservice-notes))                                                                                                                                                                                                                                                                                          |
 | `protocols/`              | Protocol interfaces grouped by concern (see [Protocol Interfaces](#protocol-interfaces))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 #### LibraryService decomposition (`services/library/`)
@@ -401,11 +401,36 @@ usable token, or a disk error) the in-memory auth state is rolled back to the pr
 disk was never touched the prior working credentials survive a failed sign-in. Only a successful mint commits
 `romm_url` + SSL flag + token + id + origin to disk in a single `save_settings()` call.
 
-**The old-token DELETE is origin-guarded.** RomM scopes a Client API Token to the account, and re-auth deletes the
-device's previous token. That DELETE is only fired when the old token's stored origin matches the new URL's origin
-(same-server re-auth) — replaying it against a different server would delete an unrelated token there, so the DELETE is
-skipped (and logged) when the origins differ or the old origin is unknown. The DELETE uses Basic auth from the one-time
+**The old-token DELETE is origin-guarded and provenance-guarded.** RomM scopes a Client API Token to the account, and
+re-auth deletes the device's previous token. That DELETE is only fired when the old token's stored origin matches the
+new URL's origin (same-server re-auth) — replaying it against a different server would delete an unrelated token there,
+so the DELETE is skipped (and logged) when the origins differ or the old origin is unknown. It is **also** skipped
+whenever the previous token's `romm_api_token_source` is `"user"`: a token the user pasted belongs to the user, not to
+this device, and must never be revoked by the plugin (a user token also carries no `romm_api_token_id`, so there is
+nothing to DELETE by anyway — the source check states the intent). The DELETE uses Basic auth from the one-time
 credentials, unaffected by the cleared bearer.
+
+**A token's provenance is recorded in `romm_api_token_source`.** The value is `"minted"` for a token the plugin minted
+from a username/password (`establish_token` and the startup `migrate_legacy_credentials`) and `"user"` for a token the
+user pasted (`establish_user_token`). It is part of the snapshot/restore auth-state set, so a failed sign-in rolls it
+back with the rest of the auth state. Settings migration `v9 → v10` seeds it — `"minted"` when a token already exists (a
+pre-v10 install could only hold minted tokens), else `None`.
+
+**Pasted-token sign-in (`establish_user_token`) — the OIDC path.** OIDC / SSO accounts have no password to mint from, so
+the user creates a Client API Token in RomM's web UI and pastes it. `establish_user_token` mirrors `establish_token`'s
+validate → probe → gate → validate → persist-on-success-only shape, but the credential is the pasted token rather than a
+fresh mint, so there is **no** mint and **no** server-side DELETE of any prior token. The entered URL is trimmed and
+rejected if non-http(s); a blank/whitespace token is rejected as `config_error` before any network call. The candidate
+URL and the pasted token are held in memory only, with `romm_api_token_origin` stamped to the candidate origin and
+`romm_api_token_source = "user"`, so the auth-header guard attaches **this** token (not the old server's bearer) to the
+validation probe. Validation is an authenticated `GET /api/users/me`: a 401 means the token is invalid or revoked, a 403
+means it authenticates but lacks a required scope (the plugin cannot introspect a token's granted scopes, since
+`/api/users/me`'s `oauth_scopes` reflects the user's role, not the token's grants, so this connect-time authenticated
+probe is the only validation). Both map to the canonical `auth_failed` failure with a token-specific message. On any
+failure the in-memory auth state is rolled back and disk is never touched; only a successful validation commits URL +
+SSL flag + token + `id = None` + origin + source in a single `save_settings()`. The token value is never logged. The
+device-forget-on-origin-change and playtime-scope-notice clear run on the success path exactly as they do for
+`establish_token`.
 
 **The registered device id is forgotten on an origin change.** A device registered with RomM (`POST /api/devices`, its
 id stored in `kv_config["device_id"]`) is bound to the server it was registered against — RomM's `negotiate` save-sync

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -12,14 +12,65 @@ The Connection Settings page manages your RomM server connection.
 - **RomM URL** — the full URL of your RomM server, including port if needed (e.g. `http://192.168.1.100:8080`). Tap
   **Edit** to change it; the URL saves automatically.
 - **RomM Account** — shows **Signed in** once a token is stored, or **Not signed in** otherwise. Tap **Sign in** to open
-  a one-time prompt for your RomM username and password. The plugin exchanges them for a RomM Client API Token and
-  stores only the token; your password is discarded after the token is minted and never saved. The username and password
-  are write-only — they are never pre-filled or shown back to you. If your account cannot create API tokens, the status
-  reports that.
+  a one-time prompt. The prompt offers two sign-in methods, chosen from the **Sign-in method** dropdown:
+  - **Username & password** (default) — enter your RomM username and password once. The plugin exchanges them for a RomM
+    Client API Token and stores only the token; your password is discarded after the token is minted and never saved. If
+    your account cannot create API tokens, the status reports that.
+  - **API token** — paste a token you created in RomM's web UI. This is the path for accounts that have no password to
+    mint from, such as **OIDC / SSO logins**. See [Sign in with an API token (OIDC)](#sign-in-with-an-api-token-oidc)
+    below.
+
+  Both the credentials and the pasted token are write-only — they are never pre-filled or shown back to you.
 - **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
   only).
 - **Test Connection** — available once you are signed in; verifies the plugin can reach and authenticate with your RomM
   server using the stored token.
+
+### Sign in with an API token (OIDC)
+
+If you log in to RomM through an identity provider (OIDC / SSO), your RomM account has no password, so the plugin cannot
+mint a token for you. Instead, create a token yourself in RomM's web UI and paste it into the plugin.
+
+1. In RomM's web UI, open **Settings → API Tokens** (also called Client API Tokens) and create a new token.
+2. Grant the scopes listed below — make sure the **write** scopes are included. Without them, downloads work but save
+   upload, device sync, and playtime tracking fail with a permissions error.
+3. Copy the token value (RomM shows it only once).
+4. In the plugin's Connection Settings, tap **Sign in**, switch the **Sign-in method** dropdown to **API token**, paste
+   the token, and confirm.
+
+The plugin validates the token at sign-in with an authenticated probe against your RomM profile: a wrong or revoked
+token is rejected there with an "invalid or revoked" message. Sign-in only confirms that the token **authenticates**,
+though — the plugin cannot verify the token's granted scopes, so double-check that you granted the write scopes
+(`assets.write`, `devices.write`, `roms.user.write`) when creating it. A missing write scope is not caught at sign-in;
+it surfaces later as a permissions error on the affected action (save upload, device sync, or playtime).
+
+#### Required scopes
+
+| Scope              | Access    | What it is used for                                                                          |
+| ------------------ | --------- | -------------------------------------------------------------------------------------------- |
+| `me.read`          | read      | Your RomM profile — validates the token at sign-in and reads your RetroAchievements username |
+| `platforms.read`   | read      | Listing your platforms                                                                       |
+| `roms.read`        | read      | Listing and reading ROM metadata (the library)                                               |
+| `roms.user.read`   | read      | Your per-user ROM data — native play-session history                                         |
+| `collections.read` | read      | Reading your collections (user, smart, franchise)                                            |
+| `firmware.read`    | read      | Listing and downloading BIOS / firmware                                                      |
+| `assets.read`      | read      | Downloading save files                                                                       |
+| `devices.read`     | read      | Reading your registered devices (device sync)                                                |
+| `assets.write`     | **write** | Uploading save files                                                                         |
+| `devices.write`    | **write** | Registering this device and opening device-sync sessions                                     |
+| `roms.user.write`  | **write** | Writing your per-user ROM data — playtime ingest                                             |
+
+All eleven scopes are within RomM's **Viewer** role, so a token created by any account (including OIDC accounts) can
+carry them. `me.write` is deliberately **not** requested — a pasted token cannot mint or delete tokens.
+
+> **The plugin never deletes a pasted token.** Signing out of or back into the plugin, or switching servers, leaves your
+> token untouched on the RomM server — you manage its lifecycle in RomM's web UI. (This differs from the
+> username/password method, where the plugin revokes the token it minted when you re-sign-in on the same server.)
+>
+> Note the reverse case too: if you previously signed in with your username and password and then switch to a pasted
+> token on the **same** server, the token the plugin minted earlier is left behind on RomM — it can only revoke that
+> during a same-server password re-sign-in (it has no password once you switch to a token). Revoke the old token
+> manually in RomM's web UI if you no longer want it.
 
 ## SteamGridDB API Key
 

--- a/main.py
+++ b/main.py
@@ -189,6 +189,9 @@ class Plugin:
     async def connect_with_credentials(self, romm_url, username, password, allow_insecure_ssl=None):
         return await self._connection_service.establish_token(romm_url, username, password, allow_insecure_ssl)
 
+    async def connect_with_token(self, romm_url, token, allow_insecure_ssl=None):
+        return await self._connection_service.establish_user_token(romm_url, token, allow_insecure_ssl)
+
     async def save_server_url(self, romm_url, allow_insecure_ssl=None):
         return self._settings_service.save_server_url(romm_url, allow_insecure_ssl)
 

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -16,7 +16,7 @@ from typing import Any, Protocol
 
 from adapters.system_clock import SystemClock
 
-_SETTINGS_VERSION = 9
+_SETTINGS_VERSION = 10
 _LOCK_EXT = ".lock"
 
 
@@ -40,6 +40,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "romm_api_token": None,
     "romm_api_token_id": None,
     "romm_api_token_origin": None,
+    "romm_api_token_source": None,
     "enabled_platforms": {},
     "enabled_collections": {"user": {}, "smart": {}, "franchise": {}},
     "collection_create_platform_groups": False,

--- a/py_modules/domain/state_migrations.py
+++ b/py_modules/domain/state_migrations.py
@@ -33,6 +33,8 @@ def migrate_settings(data: dict[str, Any]) -> dict[str, Any]:
         new_data = _migrate_v7_to_v8(new_data)
     if version < 9:
         new_data = _migrate_v8_to_v9(new_data)
+    if version < 10:
+        new_data = _migrate_v9_to_v10(new_data)
     return new_data
 
 
@@ -231,4 +233,20 @@ def _migrate_v8_to_v9(data: dict[str, Any]) -> dict[str, Any]:
         data.pop("romm_user", None)
         data.pop("romm_pass", None)
     data["version"] = 9
+    return data
+
+
+def _migrate_v9_to_v10(data: dict[str, Any]) -> dict[str, Any]:
+    """v<10 → v10: stamp the token-provenance slot.
+
+    Introduces ``romm_api_token_source`` — ``"minted"`` for a token the plugin
+    minted from credentials, ``"user"`` for a token the user pasted in. Before
+    this version every stored token came from the credential-mint path, so a
+    truthy ``romm_api_token`` is stamped ``"minted"`` and a token-less install
+    is stamped ``None``. The provenance decides whether re-auth may DELETE the
+    old token server-side (a pasted ``"user"`` token belongs to the user and is
+    never deleted); no existing token's provenance is inferred beyond this.
+    """
+    data["romm_api_token_source"] = "minted" if data.get("romm_api_token") else None
+    data["version"] = 10
     return data

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -2,9 +2,10 @@
 
 Owns the ``test_connection`` reachability flow and the Client API Token
 lifecycle: ``establish_token`` mints a scoped token from a one-time
-username/password and discards the credentials, while
-``migrate_legacy_credentials`` upgrades a stored-password install to a
-token on startup. Pure I/O happens through the ``RommConnectionApi``
+username/password and discards the credentials, ``establish_user_token``
+validates and stores a token the user pasted (the OIDC path, which has no
+password to mint from), and ``migrate_legacy_credentials`` upgrades a
+stored-password install to a token on startup. Pure I/O happens through the ``RommConnectionApi``
 Protocol and disk writes through the ``SettingsPersister`` Protocol; this
 service composes that I/O with the response-shape contract the frontend
 depends on. The minimum version is injected so the policy stays anchored
@@ -19,7 +20,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.version import meets_min_version
-from lib.errors import RommForbiddenError, error_response
+from lib.errors import RommAuthError, RommForbiddenError, error_response
 from lib.list_result import ErrorCode
 from lib.url_host import is_valid_server_url, normalize_origin, same_origin
 
@@ -35,9 +36,20 @@ if TYPE_CHECKING:
     )
 
 
+_NO_SERVER_URL_MESSAGE = "No server URL configured"
+
 _FORBIDDEN_TOKEN_MESSAGE = (
     "Your RomM account cannot create API tokens — ask your admin to grant "
     "token permissions or use an account with a higher role."
+)
+
+# Pasted-token validation (``establish_user_token``): a 401 means the token
+# string itself is wrong or was revoked; a 403 means the token authenticates
+# but lacks a scope the validation probe needs (``me.read`` — see the docs for
+# the full scope list the plugin requires).
+_USER_TOKEN_INVALID_MESSAGE = "The API token is invalid or has been revoked. Create a new token in RomM and try again."
+_USER_TOKEN_SCOPE_MESSAGE = (
+    "The API token is missing required permissions (scopes). Grant the scopes listed in the plugin docs and try again."
 )
 
 
@@ -89,7 +101,7 @@ class ConnectionService:
         the heartbeat exposed one.
         """
         if not self._settings.get("romm_url"):
-            return {"success": False, "reason": "config_error", "message": "No server URL configured"}
+            return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
 
         if not self._settings.get("romm_api_token"):
             return {
@@ -164,7 +176,7 @@ class ConnectionService:
         ``reason`` / ``message`` shape as :meth:`test_connection`.
         """
         if not romm_url:
-            return {"success": False, "reason": "config_error", "message": "No server URL configured"}
+            return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
         trimmed = romm_url.strip()
         if not is_valid_server_url(trimmed):
             return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
@@ -172,6 +184,7 @@ class ConnectionService:
         snapshot = self._snapshot_auth_state()
         old_token_id = snapshot["romm_api_token_id"]
         old_token_origin = snapshot["romm_api_token_origin"]
+        old_token_source = snapshot["romm_api_token_source"]
 
         # Hold the candidate URL in memory only; clear the stored token so the
         # version probe never carries the old server's bearer to this host (and
@@ -195,16 +208,19 @@ class ConnectionService:
             self._restore_auth_state(snapshot)
             return version_error
 
+        # #1309: never DELETE a user-supplied token — it belongs to the user, not
+        # this device (and it has no stored id to delete by anyway).
         # #1038: only replay the DELETE against the same server the old token
         # was minted on. A different (or unknown) origin would delete an
         # unrelated token on the new host, so skip it.
-        if old_token_id is not None and same_origin(old_token_origin, trimmed):
-            await self._delete_existing_token(username, password, old_token_id)
-        elif old_token_id is not None:
-            self._logger.info(
-                "Previous token was minted for a different/unknown server; "
-                "skipping DELETE to avoid replaying it against the current server"
-            )
+        if old_token_source != "user" and old_token_id is not None:
+            if same_origin(old_token_origin, trimmed):
+                await self._delete_existing_token(username, password, old_token_id)
+            else:
+                self._logger.info(
+                    "Previous token was minted for a different/unknown server; "
+                    "skipping DELETE to avoid replaying it against the current server"
+                )
 
         try:
             minted = await self._loop.run_in_executor(None, self._mint, username, password)
@@ -229,7 +245,87 @@ class ConnectionService:
             }
 
         try:
-            self._persist_token(raw_token, token_id, origin=normalize_origin(trimmed))
+            self._persist_token(raw_token, token_id, origin=normalize_origin(trimmed), source="minted")
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            return error_response(e)
+
+        await self._forget_device_on_origin_change(old_token_origin, trimmed)
+        await self._clear_playtime_scope_notice_best_effort()
+
+        return self._success_result(version)
+
+    async def establish_user_token(
+        self,
+        romm_url: str,
+        token: str,
+        allow_insecure_ssl: bool | None = None,
+    ) -> dict[str, Any]:
+        """Store a user-supplied Client API Token after validating it.
+
+        The sign-in path for OIDC accounts, which have no password to mint a
+        token from: the user creates a token in RomM's web UI and pastes it
+        here. Structurally mirrors :meth:`establish_token` (validate URL → probe
+        version → gate → validate credential → persist on success only, rolling
+        the in-memory auth state back on any failure), but the credential is the
+        pasted token rather than a fresh mint, so there is no mint and no
+        server-side DELETE of any prior token. The token is host-bound to the
+        entered URL's origin during probing so the auth-header guard attaches it
+        and the old server's bearer never leaks to the candidate host. The token
+        is validated with an authenticated ``/api/users/me`` probe — a 401 means
+        the token is invalid/revoked, a 403 means it authenticates but lacks a
+        required scope. The token value is never logged. Returns the same
+        ``success`` / ``reason`` / ``message`` shape as :meth:`test_connection`.
+        """
+        if not romm_url:
+            return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
+        trimmed = romm_url.strip()
+        if not is_valid_server_url(trimmed):
+            return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+        trimmed_token = token.strip()
+        if not trimmed_token:
+            return {"success": False, "reason": "config_error", "message": "Enter your RomM API token"}
+
+        snapshot = self._snapshot_auth_state()
+        old_token_origin = snapshot["romm_api_token_origin"]
+
+        # Hold the candidate URL + pasted token in memory only; stamp the origin
+        # so the auth-header guard attaches this token (and not the old server's)
+        # to the validation probe. Nothing is persisted until validation passes.
+        self._settings["romm_url"] = trimmed
+        if allow_insecure_ssl is not None:
+            self._settings["romm_allow_insecure_ssl"] = bool(allow_insecure_ssl)
+        self._settings["romm_api_token"] = trimmed_token
+        self._settings["romm_api_token_id"] = None
+        self._settings["romm_api_token_origin"] = normalize_origin(trimmed)
+        self._settings["romm_api_token_source"] = "user"
+
+        try:
+            version = await self._loop.run_in_executor(None, self._probe_version)
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            self._romm_api.set_version(None)
+            return error_response(e)
+
+        version_error = self._version_gate_error(version)
+        if version_error is not None:
+            self._restore_auth_state(snapshot)
+            return version_error
+
+        try:
+            await self._loop.run_in_executor(None, self._romm_api.get_current_user)
+        except RommAuthError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _USER_TOKEN_INVALID_MESSAGE}
+        except RommForbiddenError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _USER_TOKEN_SCOPE_MESSAGE}
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            return error_response(e)
+
+        try:
+            self._persist_token(trimmed_token, None, origin=normalize_origin(trimmed), source="user")
         except Exception as e:
             self._restore_auth_state(snapshot)
             return error_response(e)
@@ -298,7 +394,12 @@ class ConnectionService:
             return
 
         try:
-            self._persist_token(raw_token, token_id, origin=normalize_origin(self._settings.get("romm_url") or ""))
+            self._persist_token(
+                raw_token,
+                token_id,
+                origin=normalize_origin(self._settings.get("romm_url") or ""),
+                source="minted",
+            )
         except Exception as e:
             self._logger.warning(f"Legacy credential migration failed: {e}")
             return
@@ -312,6 +413,7 @@ class ConnectionService:
         "romm_api_token",
         "romm_api_token_id",
         "romm_api_token_origin",
+        "romm_api_token_source",
     )
 
     def _snapshot_auth_state(self) -> dict[str, Any]:
@@ -328,16 +430,19 @@ class ConnectionService:
         for key, value in snapshot.items():
             self._settings[key] = value
 
-    def _persist_token(self, raw_token: str, token_id: int, *, origin: str | None) -> None:
-        """Persist a freshly minted token and retire the legacy credentials.
+    def _persist_token(self, raw_token: str, token_id: int | None, *, origin: str | None, source: str) -> None:
+        """Persist a token and retire the legacy credentials.
 
-        Stores the token + its id + its minting *origin*, drops any stored
-        ``romm_user`` / ``romm_pass`` (a token fully supersedes them — nothing
-        reads the stored credentials at runtime once a token exists), and saves.
+        Stores the token + its id (``None`` for a user-supplied token, which
+        carries no server id) + its *origin* + its *source* provenance
+        (``"minted"`` or ``"user"``), drops any stored ``romm_user`` /
+        ``romm_pass`` (a token fully supersedes them — nothing reads the stored
+        credentials at runtime once a token exists), and saves.
         """
         self._settings["romm_api_token"] = raw_token
         self._settings["romm_api_token_id"] = token_id
         self._settings["romm_api_token_origin"] = origin
+        self._settings["romm_api_token_source"] = source
         self._settings.pop("romm_user", None)
         self._settings.pop("romm_pass", None)
         self._settings_persister.save_settings()

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -101,6 +101,7 @@ export const saveServerUrl = callable<[string, boolean], BackendResult>("save_se
 export const connectWithCredentials = callable<[string, string, string, boolean], BackendResult>(
   "connect_with_credentials",
 );
+export const connectWithToken = callable<[string, string, boolean], BackendResult>("connect_with_token");
 
 export interface WhitelistSettings {
   disabled_defaults: string[];

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -668,6 +668,89 @@ describe("SettingsPage", () => {
     });
   });
 
+  describe("handleConnectToken (pasted API token flow)", () => {
+    it("calls connectWithToken with url + token + ssl, surfaces the message, and sets hasToken on success", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: false,
+      });
+      vi.mocked(backend.connectWithToken).mockResolvedValue({
+        success: true,
+        message: "Connected!",
+        romm_version: "4.9.0",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.connectWithToken)).toHaveBeenCalledWith("https://romm.local", "rmm_pasted", false);
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Connected!");
+      expect(conn?.hasToken).toBe(true);
+    });
+
+    it("surfaces the failure message without setting hasToken (e.g. 403 scope error)", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: false,
+      });
+      vi.mocked(backend.connectWithToken).mockResolvedValue({
+        success: false,
+        message: "The API token is missing required permissions (scopes).",
+        reason: "auth_failed",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_readonly");
+        await Promise.resolve();
+      });
+
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("The API token is missing required permissions (scopes).");
+      expect(conn?.hasToken).toBe(false);
+    });
+
+    it("rejects an invalid URL inline without calling connectWithToken", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        romm_url: "romm.local", // scheme-less — invalid
+        has_token: false,
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.connectWithToken)).not.toHaveBeenCalled();
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
+        "Enter a valid http:// or https:// server URL",
+      );
+    });
+
+    it("sets status='Sign-in failed' when connectWithToken throws", async () => {
+      vi.mocked(backend.connectWithToken).mockRejectedValue(new Error("net"));
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectToken("rmm_pasted");
+        await Promise.resolve();
+      });
+
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
+    });
+  });
+
   describe("handleTest", () => {
     it("forwards the result message into ConnectionSection.status on success", async () => {
       vi.mocked(backend.testConnection).mockResolvedValue({

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5,6 +5,7 @@ import {
   getSettings,
   saveServerUrl,
   connectWithCredentials,
+  connectWithToken,
   testConnection,
   saveSgdbApiKey,
   verifySgdbApiKey,
@@ -305,6 +306,23 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setStatus("Sign-in failed");
     }
   };
+  const handleConnectToken = async (token: string) => {
+    setStatus("");
+    const trimmed = trimServerUrl(url);
+    if (!isValidServerUrl(trimmed)) {
+      setStatus("Enter a valid http:// or https:// server URL");
+      return;
+    }
+    try {
+      const result = await connectWithToken(trimmed, token, allowInsecureSsl);
+      setStatus(result.message);
+      if (result.success) {
+        setHasToken(true);
+      }
+    } catch {
+      setStatus("Sign-in failed");
+    }
+  };
 
   // --- SteamGridDB handlers ---
   const handleSgdbKeySubmit = async (value: string) => {
@@ -444,6 +462,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         }}
         onConnect={(username, password) => {
           detach(handleConnect(username, password));
+        }}
+        onConnectToken={(token) => {
+          detach(handleConnectToken(token));
         }}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
         onTestConnection={() => {

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -5,7 +5,9 @@ import { ConnectModal } from "./ConnectModal";
 
 // Local @decky/ui mock: ConfirmModal exposes its OK button (driving onOK) so
 // the submit path is exercised; TextField forwards label + value + onChange so
-// each field can be typed into and identified by its label.
+// each field can be typed into and identified by its label; DropdownItem
+// renders one button per option (data-testid `mode-<data>`) that drives onChange
+// so a test can flip the sign-in mode.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 interface ConfirmModalProps extends AnyProps {
   onOK?: () => void;
@@ -16,6 +18,16 @@ interface TextFieldProps {
   value?: string;
   bIsPassword?: boolean;
   onChange?: (e: { target: { value: string } }) => void;
+}
+interface DropdownOption {
+  data: string;
+  label: string;
+}
+interface DropdownItemProps {
+  label?: string;
+  rgOptions?: DropdownOption[];
+  selectedOption?: string;
+  onChange?: (option: DropdownOption) => void;
 }
 
 const textFields: TextFieldProps[] = [];
@@ -37,6 +49,18 @@ vi.mock("@decky/ui", () => ({
       onChange: (e: unknown) => p.onChange?.(e as { target: { value: string } }),
     });
   },
+  DropdownItem: (p: DropdownItemProps) =>
+    createElement(
+      "div",
+      { "data-testid": "mode-dropdown", "data-selected": p.selectedOption },
+      (p.rgOptions ?? []).map((o) =>
+        createElement(
+          "button",
+          { key: o.data, "data-testid": `mode-${o.data}`, onClick: () => p.onChange?.(o) },
+          o.label,
+        ),
+      ),
+    ),
 }));
 
 describe("ConnectModal", () => {
@@ -45,36 +69,80 @@ describe("ConnectModal", () => {
     vi.clearAllMocks();
   });
 
-  it("renders a username and an obscured password field, both empty (write-only)", () => {
-    const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} />);
-    const user = getByTestId("field-Username") as HTMLInputElement;
-    const pass = getByTestId("field-Password") as HTMLInputElement;
-    expect(user.value).toBe("");
-    expect(pass.value).toBe("");
-    expect(pass.getAttribute("data-is-password")).toBe("true");
+  describe("credentials mode (default)", () => {
+    it("renders a username and an obscured password field, both empty (write-only)", () => {
+      const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      const user = getByTestId("field-Username") as HTMLInputElement;
+      const pass = getByTestId("field-Password") as HTMLInputElement;
+      expect(user.value).toBe("");
+      expect(pass.value).toBe("");
+      expect(pass.getAttribute("data-is-password")).toBe("true");
+    });
+
+    it("calls onConnect with the entered username + password on Sign in", () => {
+      const onConnect = vi.fn();
+      const onConnectToken = vi.fn();
+      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
+      fireEvent.click(getByTestId("ok-button"));
+
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
+      expect(onConnectToken).not.toHaveBeenCalled();
+    });
+
+    it("passes empty strings to onConnect when nothing is entered", () => {
+      const onConnect = vi.fn();
+      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={vi.fn()} />);
+      fireEvent.click(getByTestId("ok-button"));
+      expect(onConnect).toHaveBeenCalledWith("", "");
+    });
+
+    it("does not render the API token field until token mode is selected", () => {
+      const { queryByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      expect(queryByTestId("field-API Token")).toBeNull();
+    });
   });
 
-  it("calls onConnect with the entered username + password on Sign in", () => {
-    const onConnect = vi.fn();
-    const { getByTestId } = render(<ConnectModal onConnect={onConnect} />);
+  describe("token mode", () => {
+    it("shows an obscured API token field and hides the credential fields after switching", () => {
+      const { getByTestId, queryByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      fireEvent.click(getByTestId("mode-token"));
+      const token = getByTestId("field-API Token") as HTMLInputElement;
+      expect(token.getAttribute("data-is-password")).toBe("true");
+      expect(queryByTestId("field-Username")).toBeNull();
+      expect(queryByTestId("field-Password")).toBeNull();
+    });
 
-    fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
-    fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
-    fireEvent.click(getByTestId("ok-button"));
+    it("calls onConnectToken with the entered token on Sign in", () => {
+      const onConnect = vi.fn();
+      const onConnectToken = vi.fn();
+      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      fireEvent.click(getByTestId("ok-button"));
+      expect(onConnectToken).toHaveBeenCalledTimes(1);
+      expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
+      expect(onConnect).not.toHaveBeenCalled();
+    });
 
-    expect(onConnect).toHaveBeenCalledTimes(1);
-    expect(onConnect).toHaveBeenCalledWith("daniel", "hunter2");
-  });
-
-  it("passes empty strings to onConnect when nothing is entered", () => {
-    const onConnect = vi.fn();
-    const { getByTestId } = render(<ConnectModal onConnect={onConnect} />);
-    fireEvent.click(getByTestId("ok-button"));
-    expect(onConnect).toHaveBeenCalledWith("", "");
+    it("switches back to credentials mode and calls onConnect again", () => {
+      const onConnect = vi.fn();
+      const onConnectToken = vi.fn();
+      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.click(getByTestId("mode-credentials"));
+      fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
+      fireEvent.click(getByTestId("ok-button"));
+      expect(onConnect).toHaveBeenCalledWith("daniel", "");
+      expect(onConnectToken).not.toHaveBeenCalled();
+    });
   });
 
   it("uses 'Sign in' as the OK button label", () => {
-    const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} />);
+    const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
     expect(getByTestId("ok-button").textContent).toBe("Sign in");
   });
 });

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -1,52 +1,92 @@
 /**
- * One-time credential prompt for minting a RomM Client API Token.
+ * One-time prompt for signing in to RomM — either by minting a Client API
+ * Token from a username + password, or by pasting a token created in RomM's
+ * web UI (the path for OIDC accounts, which have no password to mint from).
  *
- * The username + password entered here are write-only: never pre-filled,
- * never echoed back by the backend. On submit the parent calls
- * `connect_with_credentials`, which exchanges them for a scoped token and
- * discards the password. This modal owns only the in-flight field values
- * and hands both to `onConnect` — token minting, status, and persistence
- * live in the parent (SettingsPage).
+ * Both the credentials and the pasted token are write-only: never pre-filled,
+ * never echoed back by the backend. On submit the parent's matching handler
+ * runs — `connect_with_credentials` (which exchanges the credentials for a
+ * scoped token and discards the password) or `connect_with_token` (which
+ * validates and stores the pasted token). This modal owns only the in-flight
+ * field values and the selected mode; token minting/validation, status, and
+ * persistence live in the parent (SettingsPage).
  */
 
 import { FC, useState, ChangeEvent } from "react";
-import { ConfirmModal, TextField } from "@decky/ui";
+import { ConfirmModal, TextField, DropdownItem } from "@decky/ui";
+
+type SignInMode = "credentials" | "token";
 
 interface ConnectModalProps {
   closeModal?: () => void;
   onConnect: (username: string, password: string) => void;
+  onConnectToken: (token: string) => void;
 }
 
-export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect }) => {
+export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onConnectToken }) => {
+  const [mode, setMode] = useState<SignInMode>("credentials");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [token, setToken] = useState("");
 
   return (
     <ConfirmModal
       {...(closeModal === undefined ? {} : { closeModal })}
       onOK={() => {
-        onConnect(username, password);
+        if (mode === "token") {
+          onConnectToken(token);
+        } else {
+          onConnect(username, password);
+        }
       }}
       strTitle="Sign in to RomM"
       strOKButtonText="Sign in"
       bDisableBackgroundDismiss={true}
     >
-      <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>
-        Enter your RomM username and password once. The plugin exchanges them for an API token and never stores your
-        password.
-      </div>
-      <TextField
-        focusOnMount={true}
-        label="Username"
-        value={username}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+      <DropdownItem
+        label="Sign-in method"
+        rgOptions={[
+          { data: "credentials", label: "Username & password" },
+          { data: "token", label: "API token" },
+        ]}
+        selectedOption={mode}
+        onChange={(option) => setMode(option.data as SignInMode)}
       />
-      <TextField
-        label="Password"
-        value={password}
-        bIsPassword
-        onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-      />
+      {mode === "token" ? (
+        <>
+          <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>
+            Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the scopes
+            listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a pasted
+            token; you manage it in RomM.
+          </div>
+          <TextField
+            focusOnMount={true}
+            label="API Token"
+            value={token}
+            bIsPassword
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
+          />
+        </>
+      ) : (
+        <>
+          <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>
+            Enter your RomM username and password once. The plugin exchanges them for an API token and never stores your
+            password.
+          </div>
+          <TextField
+            focusOnMount={true}
+            label="Username"
+            value={username}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+          />
+          <TextField
+            label="Password"
+            value={password}
+            bIsPassword
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+          />
+        </>
+      )}
     </ConfirmModal>
   );
 };

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -67,6 +67,7 @@ interface UrlModalProps {
 }
 interface ConnectModalProps {
   onConnect?: (username: string, password: string) => void;
+  onConnectToken?: (token: string) => void;
 }
 
 function lastShownModalProps<T>(): T | null {
@@ -85,6 +86,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof ConnectionS
     loading: false,
     onUrlChange: vi.fn(),
     onConnect: vi.fn(),
+    onConnectToken: vi.fn(),
     onAllowInsecureSslChange: vi.fn(),
     onTestConnection: vi.fn(),
     ...overrides,
@@ -155,12 +157,14 @@ describe("ConnectionSection", () => {
       expect(getByText("Sign in")).toBeTruthy();
     });
 
-    it("opens a ConnectModal wired to onConnect when clicked", () => {
+    it("opens a ConnectModal wired to onConnect and onConnectToken when clicked", () => {
       const onConnect = vi.fn();
-      const { getByText } = render(<ConnectionSection {...defaultProps({ onConnect })} />);
+      const onConnectToken = vi.fn();
+      const { getByText } = render(<ConnectionSection {...defaultProps({ onConnect, onConnectToken })} />);
       fireEvent.click(getByText("Sign in"));
       const props = lastShownModalProps<ConnectModalProps>();
       expect(props?.onConnect).toBe(onConnect);
+      expect(props?.onConnectToken).toBe(onConnectToken);
     });
   });
 

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -19,6 +19,7 @@ interface ConnectionSectionProps {
   loading: boolean;
   onUrlChange: (value: string) => void;
   onConnect: (username: string, password: string) => void;
+  onConnectToken: (token: string) => void;
   onAllowInsecureSslChange: (value: boolean) => void;
   onTestConnection: () => void;
 }
@@ -31,6 +32,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
   loading,
   onUrlChange,
   onConnect,
+  onConnectToken,
   onAllowInsecureSslChange,
   onTestConnection,
 }) => {
@@ -52,7 +54,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
         <Field label="RomM Account" description={hasToken ? "Signed in" : "Not signed in"}>
           <DialogButton
             style={{ minWidth: "auto", width: "auto" }}
-            onClick={() => showModal(<ConnectModal onConnect={onConnect} />)}
+            onClick={() => showModal(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />)}
           >
             Sign in
           </DialogButton>

--- a/tests/adapters/test_persistence.py
+++ b/tests/adapters/test_persistence.py
@@ -84,8 +84,8 @@ class TestLocking:
 class TestSettingsSchema:
     """Schema-level expectations for the settings defaults + version stamp."""
 
-    def test_settings_version_is_9(self):
-        assert _SETTINGS_VERSION == 9
+    def test_settings_version_is_10(self):
+        assert _SETTINGS_VERSION == 10
 
     def test_default_settings_omit_retired_credential_keys(self):
         """The retired legacy-credential keys must not be re-seeded on load."""
@@ -96,6 +96,7 @@ class TestSettingsSchema:
         assert DEFAULT_SETTINGS["romm_api_token"] is None
         assert DEFAULT_SETTINGS["romm_api_token_id"] is None
         assert DEFAULT_SETTINGS["romm_api_token_origin"] is None
+        assert DEFAULT_SETTINGS["romm_api_token_source"] is None
 
     def test_default_settings_carry_empty_platform_cores(self):
         assert DEFAULT_SETTINGS["platform_cores"] == {}
@@ -130,7 +131,7 @@ class TestVersionStampingOnSave:
         with open(settings_path) as f:
             loaded = json.load(f)
         assert loaded["version"] == _SETTINGS_VERSION
-        assert loaded["version"] == 9
+        assert loaded["version"] == 10
 
 
 # ── Loading edge cases ─────────────────────────────────────────────────────────

--- a/tests/contract/test_connect_with_token.py
+++ b/tests/contract/test_connect_with_token.py
@@ -1,0 +1,55 @@
+"""Contract test for the ``connect_with_token`` callable (pasted API token).
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``connectWithToken = callable<[string, string, boolean], BackendResult>("connect_with_token")``
+— positional ``(romm_url, token, allow_insecure_ssl)``.
+
+Pins the response SHAPE over the real ``Plugin`` for both the happy path (a
+valid token authenticates → success + persisted with ``"user"`` provenance and
+no server-side id) and the failure path (a 401 from the ``/api/users/me``
+validation probe → the canonical ``{success: False, reason, message}`` shape,
+with nothing persisted). The empty-token guard is exercised too.
+"""
+
+from __future__ import annotations
+
+from lib.errors import RommAuthError
+
+
+async def test_connect_with_token_happy_path_persists_user_provenance(harness):
+    harness.romm.heartbeat_response = {"SYSTEM": {"VERSION": "4.9.0"}}
+
+    result = await harness.plugin.connect_with_token("http://romm.local", "rmm_pasted", False)
+
+    assert result["success"] is True
+    assert result["romm_version"] == "4.9.0"
+    assert "Connected" in result["message"]
+    # Persisted with user provenance and no server-side id; no mint, no DELETE.
+    assert harness.plugin.settings["romm_api_token"] == "rmm_pasted"
+    assert harness.plugin.settings["romm_api_token_id"] is None
+    assert harness.plugin.settings["romm_api_token_origin"] == "http://romm.local"
+    assert harness.plugin.settings["romm_api_token_source"] == "user"
+    assert ("mint_client_token",) not in [(c[0],) for c in harness.romm.call_log]
+    assert harness.romm.deleted_token_ids == []
+
+
+async def test_connect_with_token_invalid_token_returns_canonical_failure(harness):
+    harness.romm.heartbeat_response = {"SYSTEM": {"VERSION": "4.9.0"}}
+    harness.romm.get_current_user_side_effect = RommAuthError("401")
+
+    result = await harness.plugin.connect_with_token("http://romm.local", "rmm_bad", False)
+
+    assert result["success"] is False
+    assert result["reason"] == "auth_failed"
+    assert "invalid or has been revoked" in result["message"]
+    # Nothing persisted — the previous (empty) token state stands.
+    assert not harness.plugin.settings.get("romm_api_token")
+    assert harness.plugin.settings.get("romm_api_token_source") is None
+
+
+async def test_connect_with_token_blank_token_is_config_error(harness):
+    result = await harness.plugin.connect_with_token("http://romm.local", "   ", False)
+
+    assert result == {"success": False, "reason": "config_error", "message": "Enter your RomM API token"}
+    # The server was never probed for a blatantly empty token.
+    assert harness.romm.call_log == []

--- a/tests/domain/test_state_migrations.py
+++ b/tests/domain/test_state_migrations.py
@@ -7,6 +7,7 @@ from domain.state_migrations import (
     _migrate_v6_to_v7,
     _migrate_v7_to_v8,
     _migrate_v8_to_v9,
+    _migrate_v9_to_v10,
     fold_legacy_save_sync_settings,
     migrate_settings,
 )
@@ -18,28 +19,28 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
         assert "disable_steam_input" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_disable_steam_input_false(self):
         data = {"version": 0, "disable_steam_input": False}
         result = migrate_settings(data)
         assert "disable_steam_input" not in result
         assert "steam_input_mode" not in result  # False → no override set
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_debug_logging_true(self):
         data = {"version": 0, "debug_logging": True}
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_debug_logging_false(self):
         data = {"version": 0, "debug_logging": False}
         result = migrate_settings(data)
         assert "debug_logging" not in result
         assert "log_level" not in result  # False → no log_level override set
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_both_deprecated(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -48,51 +49,54 @@ class TestMigrateSettings:
         assert result["log_level"] == "debug"
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_no_deprecated_keys(self):
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_url"] == "http://example.com"
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v3_advances_through_token_seeding(self):
-        """v3 → v9: version stamp advances and the token slots are seeded.
+        """v3 → v10: version stamp advances and the token slots are seeded.
 
         The cross-file save-sync fold (v3 → v4) is orchestrated in
         bootstrap, not here, so this step only bumps the version; the
         v4 → v5 step seeds the two ``romm_api_token*`` placeholders; the
         v5 → v6 step is a no-op here because no token is set; the v6 → v7
         step seeds the empty ``platform_cores`` map; the v7 → v8 step seeds
-        the ``romm_api_token_origin`` slot.
+        the ``romm_api_token_origin`` slot; the v9 → v10 step stamps the
+        ``romm_api_token_source`` slot (``None`` here — no token).
         """
         data = {"version": 3, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
             "romm_api_token_id": None,
             "platform_cores": {},
             "romm_api_token_origin": None,
+            "romm_api_token_source": None,
         }
 
     def test_migrate_settings_v4_seeds_token_slots(self):
         data = {"version": 4, "romm_url": "http://example.com", "log_level": "warn"}
         result = migrate_settings(data)
         assert result == {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": None,
             "romm_api_token_id": None,
             "platform_cores": {},
             "romm_api_token_origin": None,
+            "romm_api_token_source": None,
         }
 
     def test_migrate_settings_v5_only_bumps_version(self):
-        """v5 → v9 with a token but no legacy creds advances the version + seeds the new slots."""
+        """v5 → v10 with a token but no legacy creds advances the version + seeds the new slots."""
         data = {
             "version": 5,
             "romm_url": "http://example.com",
@@ -102,17 +106,18 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {},
             "romm_api_token_origin": None,
+            "romm_api_token_source": "minted",
         }
 
     def test_migrate_settings_v6_seeds_platform_cores(self):
-        """v6 → v9 seeds the per-platform core map + token origin and bumps the version."""
+        """v6 → v10 seeds the per-platform core map + token origin + token source and bumps the version."""
         data = {
             "version": 6,
             "romm_url": "http://example.com",
@@ -122,17 +127,18 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {},
             "romm_api_token_origin": None,
+            "romm_api_token_source": "minted",
         }
 
     def test_migrate_settings_v7_seeds_token_origin(self):
-        """v7 → v8 seeds the ``romm_api_token_origin`` slot and bumps the version."""
+        """v7 → v8 seeds the ``romm_api_token_origin`` slot; the chain also stamps the token source."""
         data = {
             "version": 7,
             "romm_url": "http://example.com",
@@ -143,24 +149,26 @@ class TestMigrateSettings:
         }
         result = migrate_settings(data)
         assert result == {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {"snes": "bsnes"},
             "romm_api_token_origin": None,
+            "romm_api_token_source": "minted",
         }
 
-    def test_migrate_settings_v9_no_change(self):
+    def test_migrate_settings_v10_no_change(self):
         data = {
-            "version": 9,
+            "version": 10,
             "romm_url": "http://example.com",
             "log_level": "warn",
             "romm_api_token": "rmm_existing",
             "romm_api_token_id": 7,
             "platform_cores": {"snes": "bsnes"},
             "romm_api_token_origin": "http://example.com",
+            "romm_api_token_source": "minted",
         }
         result = migrate_settings(data)
         assert result == data
@@ -171,7 +179,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] == "rmm_keep"
         assert result["romm_api_token_id"] == 3
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_v0_to_v5_seeds_token_slots(self):
         """A pre-versioning file runs the whole chain and ends with token slots."""
@@ -179,12 +187,12 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_fresh_empty(self):
         data = {}
         result = migrate_settings(data)
-        assert result["version"] == 9
+        assert result["version"] == 10
         assert "disable_steam_input" not in result
         assert "debug_logging" not in result
 
@@ -192,7 +200,7 @@ class TestMigrateSettings:
         data = {"romm_url": "http://example.com", "disable_steam_input": True}
         result = migrate_settings(data)
         assert result["steam_input_mode"] == "force_off"
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_debug_logging_true_overrides_log_level(self):
         """When debug_logging=True is being migrated, log_level is set to 'debug' unconditionally.
@@ -204,7 +212,7 @@ class TestMigrateSettings:
         result = migrate_settings(data)
         assert result["log_level"] == "debug"
         assert "debug_logging" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_migrate_settings_idempotent(self):
         data = {"version": 0, "disable_steam_input": True, "debug_logging": True}
@@ -227,7 +235,7 @@ class TestMigrateSettingsV5Token:
         result = migrate_settings(data)
         assert result["romm_api_token"] is None
         assert result["romm_api_token_id"] is None
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_idempotent_across_two_runs(self):
         data = {"version": 4, "romm_url": "x"}
@@ -294,7 +302,7 @@ class TestMigrateSettingsV6LegacyCredentials:
         assert result["version"] == 6
 
     def test_full_migrate_settings_v4_with_creds_no_token_keeps_creds(self):
-        """A v4 install with legacy creds and no token ends at v9 with creds intact.
+        """A v4 install with legacy creds and no token ends at v10 with creds intact.
 
         The schema step seeds the token slots to ``None``, so the v5 → v6
         credential wipe is a no-op — the creds are retired later at runtime
@@ -302,7 +310,7 @@ class TestMigrateSettingsV6LegacyCredentials:
         """
         data = {"version": 4, "romm_url": "http://example.com", "romm_user": "alice", "romm_pass": "secret"}
         result = migrate_settings(data)
-        assert result["version"] == 9
+        assert result["version"] == 10
         assert result["romm_api_token"] is None
         assert result["romm_user"] == "alice"
         assert result["romm_pass"] == "secret"
@@ -380,7 +388,7 @@ class TestMigrateSettingsV8TokenOrigin:
         data = {"version": 0, "romm_url": "http://example.com"}
         result = migrate_settings(data)
         assert result["romm_api_token_origin"] is None
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_idempotent_via_full_chain(self):
         data = {"version": 7, "romm_api_token_origin": "https://romm.local"}
@@ -445,7 +453,7 @@ class TestMigrateSettingsV9PurgeCredentials:
         assert result["version"] == 9
 
     def test_full_chain_v8_token_install_purges_placeholders(self):
-        """A real steady-state file: token set, empty legacy keys → purged, v9."""
+        """A real steady-state file: token set, empty legacy keys → purged, v10."""
         data = {
             "version": 8,
             "romm_url": "http://example.com",
@@ -459,7 +467,7 @@ class TestMigrateSettingsV9PurgeCredentials:
         result = migrate_settings(data)
         assert "romm_user" not in result
         assert "romm_pass" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_full_chain_tokenless_real_password_survives(self):
         """A token-less legacy install keeps its real creds for the startup mint."""
@@ -467,7 +475,71 @@ class TestMigrateSettingsV9PurgeCredentials:
         result = migrate_settings(data)
         assert result["romm_user"] == "alice"
         assert result["romm_pass"] == "secret"
-        assert result["version"] == 9
+        assert result["version"] == 10
+
+
+class TestMigrateSettingsV10TokenSource:
+    """v9 → v10 migration: stamp the ``romm_api_token_source`` provenance slot.
+
+    Before this version every stored token came from the credential-mint path,
+    so a truthy token is stamped ``"minted"`` and a token-less install ``None``.
+    """
+
+    def test_token_present_stamps_minted(self):
+        data = {"version": 9, "romm_api_token": "rmm_existing"}
+        result = _migrate_v9_to_v10(data)
+        assert result["romm_api_token_source"] == "minted"
+        assert result["version"] == 10
+
+    def test_no_token_stamps_none(self):
+        data = {"version": 9, "romm_api_token": None}
+        result = _migrate_v9_to_v10(data)
+        assert result["romm_api_token_source"] is None
+        assert result["version"] == 10
+
+    def test_absent_token_stamps_none(self):
+        data = {"version": 9}
+        result = _migrate_v9_to_v10(data)
+        assert result["romm_api_token_source"] is None
+        assert result["version"] == 10
+
+    def test_empty_string_token_stamps_none(self):
+        """An empty-string token is falsy → source ``None`` (mirrors the credential guards)."""
+        data = {"version": 9, "romm_api_token": ""}
+        result = _migrate_v9_to_v10(data)
+        assert result["romm_api_token_source"] is None
+
+    def test_preserves_unrelated_keys(self):
+        data = {"version": 9, "romm_url": "http://example.com", "log_level": "warn"}
+        result = _migrate_v9_to_v10(data)
+        assert result["romm_url"] == "http://example.com"
+        assert result["log_level"] == "warn"
+
+    def test_full_chain_token_install_stamps_minted(self):
+        data = {
+            "version": 8,
+            "romm_url": "http://example.com",
+            "romm_api_token": "rmm_existing",
+            "romm_api_token_id": 7,
+            "romm_api_token_origin": "http://example.com",
+            "platform_cores": {},
+        }
+        result = migrate_settings(data)
+        assert result["romm_api_token_source"] == "minted"
+        assert result["version"] == 10
+
+    def test_full_chain_tokenless_stamps_none(self):
+        data = {"version": 0, "romm_url": "http://example.com"}
+        result = migrate_settings(data)
+        assert result["romm_api_token_source"] is None
+        assert result["version"] == 10
+
+    def test_idempotent_via_full_chain(self):
+        data = {"version": 9, "romm_api_token": "rmm_x", "romm_api_token_source": "minted"}
+        once = migrate_settings(data.copy())
+        twice = migrate_settings(once.copy())
+        assert once == twice
+        assert once["romm_api_token_source"] == "minted"
 
 
 class TestMigrateSettingsV3Collections:
@@ -481,7 +553,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_base64_keys_move_to_franchise_bucket(self):
         b64 = "eyJuYW1lIjogIkFuIFRoZSBNYXJpbyJ9"
@@ -503,7 +575,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {b64: True},
         }
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_smart_bucket_always_starts_empty(self):
         """Pre-v3 users had no smart collections — bucket must start empty."""
@@ -521,7 +593,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "romm_url": "x"}
         result = migrate_settings(data)
         assert "enabled_collections" not in result
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_already_nested_value_passes_through_unchanged(self):
         """Defensive: a half-stamped v3-shaped value must not be re-split."""
@@ -533,7 +605,7 @@ class TestMigrateSettingsV3Collections:
         data = {"version": 1, "enabled_collections": already_nested}
         result = migrate_settings(data)
         assert result["enabled_collections"] == already_nested
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_partial_nested_value_normalized_with_missing_buckets(self):
         """A partial-nested value (only one bucket present) is normalized to all three buckets."""
@@ -544,7 +616,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_partial_nested_two_buckets_fills_missing_third(self):
         """Partial-nested with two bucket keys — missing bucket is filled empty."""
@@ -558,7 +630,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {"abc": True},
         }
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_v0_to_v3_runs_both_steps(self):
         """A v0 file with both deprecated keys AND old enabled_collections gets both migrations."""
@@ -575,7 +647,7 @@ class TestMigrateSettingsV3Collections:
             "smart": {},
             "franchise": {},
         }
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_negative_numeric_string_keys_go_to_user(self):
         """``key.lstrip('-').isdigit()`` accepts ``-1`` as a numeric id."""
@@ -591,7 +663,7 @@ class TestMigrateSettingsV3Collections:
         }
         result = migrate_settings(data)
         assert result["enabled_collections"] == {"user": {"1": True}, "smart": {}, "franchise": {}}
-        assert result["version"] == 9
+        assert result["version"] == 10
 
     def test_v3_migration_does_not_mutate_caller_dict(self):
         data = {"version": 1, "enabled_collections": {"1": True, "abc": True}}

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -566,6 +566,50 @@ class TestEstablishTokenDeviceForget:
         forget_device.assert_called_once_with()
 
 
+class TestEstablishTokenProvenance:
+    """#1309: a minted token is stamped ``source="minted"``; a pasted user
+    token (``source="user"``) is never DELETE-replayed on re-auth."""
+
+    def test_persists_source_minted(self, event_loop, romm_api, logger, settings_persister):
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_token("http://romm.local", "alice", "secret"))
+        assert result["success"] is True
+        assert settings["romm_api_token_source"] == "minted"
+
+    def test_skips_delete_when_stored_source_is_user(self, event_loop, romm_api, logger):
+        """A previously pasted user token belongs to the user — never DELETE it on re-auth."""
+        settings = {
+            "romm_api_token_id": 99,
+            "romm_api_token_origin": "http://romm.local",
+            "romm_api_token_source": "user",
+        }
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
+        assert result["success"] is True
+        romm_api.delete_client_token.assert_not_called()
+        # The freshly minted token replaces it and is stamped minted provenance.
+        assert settings["romm_api_token"] == "rmm_minted"
+        assert settings["romm_api_token_source"] == "minted"
+
+    def test_still_deletes_minted_token_on_same_origin(self, event_loop, romm_api, logger):
+        """A minted old token on the same origin is still revoked (#1038 path unchanged)."""
+        settings = {
+            "romm_api_token_id": 99,
+            "romm_api_token_origin": "http://romm.local",
+            "romm_api_token_source": "minted",
+        }
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
+        romm_api.delete_client_token.assert_called_once_with("u", "p", token_id=99)
+
+
 class TestEstablishTokenBadPath:
     def test_empty_url_returns_config_error(self, event_loop, romm_api, logger):
         service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
@@ -649,6 +693,227 @@ class TestEstablishTokenBadPath:
         assert result["success"] is False
         assert result["reason"] == "unknown"
         assert "disk full" in result["message"]
+
+
+class TestEstablishUserTokenHappyPath:
+    def test_stores_pasted_token_with_user_provenance(self, event_loop, romm_api, logger, settings_persister):
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        assert result["success"] is True
+        assert result["romm_version"] == "4.9.0"
+        assert settings["romm_api_token"] == "rmm_pasted"
+        # A pasted token carries no server-side id.
+        assert settings["romm_api_token_id"] is None
+        assert settings["romm_api_token_origin"] == "http://romm.local"
+        assert settings["romm_api_token_source"] == "user"
+        # We never mint or DELETE anything for a user-supplied token.
+        romm_api.mint_client_token.assert_not_called()
+        romm_api.delete_client_token.assert_not_called()
+        # url + ssl + token + id + origin + source commit in a SINGLE atomic save.
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_validates_token_with_authenticated_users_me_probe(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        romm_api.get_current_user.assert_called_once_with()
+
+    def test_trims_token_whitespace_before_use(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "  rmm_pasted  "))
+        assert result["success"] is True
+        assert settings["romm_api_token"] == "rmm_pasted"
+
+    def test_persists_url_and_ssl_flag(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(
+            service.establish_user_token("http://romm.local", "rmm_pasted", allow_insecure_ssl=True)
+        )
+        assert settings["romm_url"] == "http://romm.local"
+        assert settings["romm_allow_insecure_ssl"] is True
+
+    def test_never_logs_the_token_value(self, event_loop, romm_api, logger, caplog):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        with caplog.at_level(logging.DEBUG, logger="test_connection"):
+            event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_supersecret"))
+        assert all("rmm_supersecret" not in r.getMessage() for r in caplog.records)
+
+    def test_forgets_device_on_first_sign_in(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        forget_device.assert_called_once_with()
+
+    def test_clears_playtime_scope_notice(self, event_loop, romm_api, logger):
+        clear = MagicMock()
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            clear_playtime_scope_notice=clear,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        assert result["success"] is True
+        clear.assert_called_once()
+
+
+class TestEstablishUserTokenBadPath:
+    def test_empty_url_returns_config_error(self, event_loop, romm_api, logger):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("", "rmm_x"))
+        assert result == {"success": False, "reason": "config_error", "message": "No server URL configured"}
+        romm_api.heartbeat.assert_not_called()
+
+    @pytest.mark.parametrize("bad_url", ["romm.local", "ftp://romm.local", "   ", "https://"])
+    def test_invalid_url_returns_config_error_without_probing(self, event_loop, romm_api, logger, bad_url):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token(bad_url, "rmm_x"))
+        assert result == {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+        romm_api.heartbeat.assert_not_called()
+        romm_api.get_current_user.assert_not_called()
+
+    @pytest.mark.parametrize("blank_token", ["", "   ", "\t\n"])
+    def test_blank_token_returns_config_error_without_probing(self, event_loop, romm_api, logger, blank_token):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", blank_token))
+        assert result == {"success": False, "reason": "config_error", "message": "Enter your RomM API token"}
+        romm_api.heartbeat.assert_not_called()
+        romm_api.get_current_user.assert_not_called()
+
+    def test_unreachable_server_returns_error_no_validation(self, event_loop, romm_api, logger):
+        romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_x"))
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        romm_api.get_current_user.assert_not_called()
+
+    def test_version_gate_failure_returns_version_error_no_validation(self, event_loop, romm_api, logger):
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_x"))
+        assert result["success"] is False
+        assert result["reason"] == "version_error"
+        romm_api.get_current_user.assert_not_called()
+
+    def test_invalid_token_401_returns_auth_failed(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.get_current_user.side_effect = RommAuthError("401")
+        service = _make_service(
+            settings={},
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_bad"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "invalid or has been revoked" in result["message"]
+        settings_persister.save_settings.assert_not_called()
+
+    def test_scope_403_returns_actionable_scope_message(self, event_loop, romm_api, logger):
+        romm_api.get_current_user.side_effect = RommForbiddenError("403")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_readonly"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "scopes" in result["message"]
+
+    def test_generic_validation_error_returns_error_response(self, event_loop, romm_api, logger):
+        romm_api.get_current_user.side_effect = RommServerError("boom", status_code=500)
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_x"))
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+
+    def test_persist_failure_returns_error(self, event_loop, romm_api, logger, settings_persister):
+        settings_persister.save_settings.side_effect = OSError("disk full")
+        service = _make_service(
+            settings={},
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_x"))
+        assert result["success"] is False
+        assert result["reason"] == "unknown"
+        assert "disk full" in result["message"]
+
+
+class TestEstablishUserTokenSnapshotRestore:
+    """A failed pasted-token sign-in must not clobber the previous working state."""
+
+    def _assert_old_state_intact(self, settings: dict[str, Any]) -> None:
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_id"] == 7
+        assert settings["romm_api_token_origin"] == "https://old.server"
+
+    def test_invalid_token_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.get_current_user.side_effect = RommAuthError("401")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_bad"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_probe_failure_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_bad"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_binds_pasted_token_to_candidate_origin_during_probe(self, event_loop, romm_api, logger):
+        """The validation probe runs with the PASTED token bound to the candidate origin.
+
+        The auth-header guard only attaches a token whose stored origin matches the
+        current URL, so ``establish_user_token`` must stamp both before validating.
+        """
+        seen: dict[str, Any] = {}
+
+        def _capture_get_current_user():
+            seen["token"] = settings.get("romm_api_token")
+            seen["origin"] = settings.get("romm_api_token_origin")
+            return {"id": 1, "username": "tester"}
+
+        romm_api.get_current_user.side_effect = _capture_get_current_user
+        settings = _working_settings()
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_pasted"))
+        assert seen["token"] == "rmm_pasted"
+        assert seen["origin"] == "https://new.server"
 
 
 def _working_settings() -> dict[str, Any]:
@@ -787,6 +1052,8 @@ class TestMigrateLegacyCredentials:
         assert settings["romm_api_token_id"] == 42
         # The origin is stamped from the configured URL at migration time.
         assert settings["romm_api_token_origin"] == "https://romm.local"
+        # A credential-minted token carries the "minted" provenance (#1309).
+        assert settings["romm_api_token_source"] == "minted"
         assert "romm_user" not in settings
         assert "romm_pass" not in settings
         settings_persister.save_settings.assert_called_once_with()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -714,6 +714,7 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "test_connection",
     "get_romm_version",
     "connect_with_credentials",
+    "connect_with_token",
     "save_server_url",
     "get_settings",
     "get_whitelist_settings",


### PR DESCRIPTION
## What

New sign-in method: paste an existing RomM Client API Token instead of username+password. For OIDC/SSO accounts this is the only programmatic auth path — they have no local password, so RomM's Basic auth and password grant both fail.

- **Backend**: `ConnectionService.establish_user_token` + `connect_with_token` callable — same validation ladder as the credential path (URL validation, version gate ≥ 4.9.0, authenticated probe against the user profile), origin binding stamped at acceptance, atomic persist on success, snapshot-restore on any failure. The pasted token is never logged; the old bearer is cleared from memory before the candidate host is probed.
- **Token provenance**: new `romm_api_token_source` settings key (`"minted"` / `"user"`, migration v9→v10 stamps existing tokens `"minted"`). A user-supplied token is never deleted or modified server-side — the same-origin cleanup of plugin-minted tokens on re-sign-in (#1038) is skipped for user tokens.
- **Frontend**: sign-in method selector in the connect modal (Username & password / API token), token field masked.
- **Docs**: new user-guide section "Sign in with an API token (OIDC)" with the required-scope table — RomM tokens default to **read-only**, so the write scopes (`assets.write`, `devices.write`, `roms.user.write`) must be granted — plus an honest note that sign-in can only verify the token authenticates, not its granted scopes (a missing write scope surfaces later as a permissions error on the affected action). ConnectionService notes in backend-architecture.md; SECURITY.md updated to cover both token provenances.

## Why

Part of #1309 — RomM instances behind OIDC cannot sign in with username/password. The issue stays open for verification on a real OIDC setup. Follow-ups: pairing-code sign-in #1331, sign-out UX #1332.

## Testing

- Unit: connection-service happy/failure paths, snapshot-restore on every failure branch, provenance persistence, DELETE-skip for user tokens, migration v9→v10 (both branches + full chain).
- Contract: `connect_with_token` driven frontend-shaped (happy, 401, blank token), literal response-shape asserts.
- Frontend: modal mode switch, no cross-mode credential submission, token submit routes to the right callable.
- Full suite green: 4521 backend + 1503 frontend tests; ruff, basedpyright (incl. tests/), lint-imports, callable-manifest, failure-shape and settings-owner gates all clean.