### PR TITLE
feat(auth): sign in with a RomM pairing code

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,10 @@ This plugin handles:
   hostile host never receives the credential.
 - The plugin **never deletes or modifies a user-supplied token** on the RomM server — that token's lifecycle is managed
   by you in RomM; only tokens the plugin itself minted are revoked on re-sign-in.
+- The **pairing code** used to sign in without pasting a token is a short-lived (60-second), single-use, 8-character
+  code exchanged over an unauthenticated endpoint (the code is the only credential). It is never logged and is discarded
+  after the exchange; the RomM server delivers the freshly rotated raw token only to this device in the exchange
+  response.
 - Path components supplied by the RomM server (filenames, ROM and save paths) are validated against path traversal
   before they are used to build local filesystem paths, so a compromised or malicious server cannot write outside the
   plugin's directories.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -123,7 +123,7 @@ the rest are single modules. A service over ~700 LOC is the decomposition signal
 | `metadata.py`             | MetadataService — ROM metadata reads from `rom_metadata` (7-day TTL), app_id mapping                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `launch_gate.py`          | LaunchGateService — pre-launch gate (rom lookup, install check, save status)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `startup_healing.py`      | StartupHealingService — prunes stale `rom_installs` rows against disk on load (via the UoW) + reconciles orphaned `running` SyncRuns (a hard crash leaves a `running` row → marked errored) + `get_installed_relaunch_options()` builds the startup launch-options reconcile items (see [StartupHealingService notes](#startuphealingservice-notes))                                                                                                                                                                                                                       |
-| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials, or validate/store a user-pasted token for OIDC accounts; host-bound to the minting origin; see [ConnectionService notes](#connectionservice-notes))                                                                                                                                                                                                                                                                                          |
+| `connection.py`           | ConnectionService — connection test + RomM minimum-version gate + Client API Token lifecycle (mint/establish via credentials, validate/store a user-pasted token, or exchange a short-lived pairing code for a token — the latter two for OIDC accounts; host-bound to the minting origin; see [ConnectionService notes](#connectionservice-notes))                                                                                                                                                                                                                        |
 | `protocols/`              | Protocol interfaces grouped by concern (see [Protocol Interfaces](#protocol-interfaces))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 #### LibraryService decomposition (`services/library/`)
@@ -430,7 +430,26 @@ probe is the only validation). Both map to the canonical `auth_failed` failure w
 failure the in-memory auth state is rolled back and disk is never touched; only a successful validation commits URL +
 SSL flag + token + `id = None` + origin + source in a single `save_settings()`. The token value is never logged. The
 device-forget-on-origin-change and playtime-scope-notice clear run on the success path exactly as they do for
-`establish_token`.
+`establish_token`. The `/api/users/me` validation + persist tail is shared with the paired-token path below via the
+private `_validate_and_persist_user_token` helper (both hand the plugin a token to validate and store with `"user"`
+provenance), so their observable behaviour stays identical.
+
+**Pairing-code sign-in (`establish_paired_token`) — the OIDC path without pasting.** The same OIDC accounts can sign in
+by entering a short-lived RomM pairing code instead of pasting the token: the plugin exchanges the code for the token
+over the **public, unauthenticated** `POST /api/client-tokens/exchange` endpoint (the one-time code is itself the
+credential). It mirrors `establish_user_token`'s validate URL → probe version → gate → obtain-credential → validate via
+`/api/users/me` → persist-on-success-only shape, but the credential is fetched by the exchange rather than pasted, and
+the exchange runs with the token trio **cleared** in memory (like `establish_token`) so no old bearer leaks to the
+candidate host during the unauthenticated call. The code is normalized the way RomM normalizes it — all whitespace and
+`-` stripped, then uppercased (`"ab-cd ef23"` → `"ABCDEF23"`) — and a code that is blank after normalization is a
+`config_error` before any network call. The exchange is **never auto-retried**: a pairing code is single-use, and a
+replay would burn both the code and RomM's per-client rate limit, so the transport's `unauthenticated_post_json` skips
+`with_retry`. Each RomM rejection maps to a distinct, actionable message: an invalid/expired/used code, a
+token-no-longer-exists 404, and a disabled-owner 403 all carry `auth_failed`; a 429 carries the bespoke `rate_limited`
+reason. On success the freshly rotated `raw_token` (the exchange regenerates the token server-side, so any previously
+copied raw value stops working) is host-bound in memory and run through the shared `_validate_and_persist_user_token`
+tail, so it is persisted with `"user"` provenance and `id = None` exactly like a pasted token — no mint, no server-side
+DELETE. The pairing code and the returned token are never logged.
 
 **The registered device id is forgotten on an origin change.** A device registered with RomM (`POST /api/devices`, its
 id stored in `kv_config["device_id"]`) is bound to the server it was registered against — RomM's `negotiate` save-sync

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -12,13 +12,16 @@ The Connection Settings page manages your RomM server connection.
 - **RomM URL** — the full URL of your RomM server, including port if needed (e.g. `http://192.168.1.100:8080`). Tap
   **Edit** to change it; the URL saves automatically.
 - **RomM Account** — shows **Signed in** once a token is stored, or **Not signed in** otherwise. Tap **Sign in** to open
-  a one-time prompt. The prompt offers two sign-in methods, chosen from the **Sign-in method** dropdown:
+  a one-time prompt. The prompt offers three sign-in methods, chosen from the **Sign-in method** dropdown:
   - **Username & password** (default) — enter your RomM username and password once. The plugin exchanges them for a RomM
     Client API Token and stores only the token; your password is discarded after the token is minted and never saved. If
     your account cannot create API tokens, the status reports that.
-  - **API token** — paste a token you created in RomM's web UI. This is the path for accounts that have no password to
-    mint from, such as **OIDC / SSO logins**. See [Sign in with an API token (OIDC)](#sign-in-with-an-api-token-oidc)
-    below.
+  - **API token** — paste a Client API Token you created in RomM's web UI. This is one of the two paths for accounts
+    that have no password to mint from, such as **OIDC / SSO logins**. See
+    [Sign in with an API token (OIDC)](#sign-in-with-an-api-token-oidc) below.
+  - **Pairing code** — the other, recommended OIDC path: instead of copying the token, enter the short-lived 8-character
+    code RomM shows when you **Pair** a token. The plugin fetches the token itself, so nothing is copied or pasted. See
+    [Sign in with an API token (OIDC)](#sign-in-with-an-api-token-oidc) below.
 
   Both the credentials and the pasted token are write-only — they are never pre-filled or shown back to you.
 - **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
@@ -29,17 +32,38 @@ The Connection Settings page manages your RomM server connection.
 ### Sign in with an API token (OIDC)
 
 If you log in to RomM through an identity provider (OIDC / SSO), your RomM account has no password, so the plugin cannot
-mint a token for you. Instead, create a token yourself in RomM's web UI and paste it into the plugin.
+mint a token for you. Instead you create a Client API Token yourself in RomM's web UI and hand it to the plugin. There
+are two ways to do that — **pairing code** (recommended) and **pasting the token** — and both grant the same scopes and
+carry the same warnings (see [Required scopes](#required-scopes) below).
+
+Start the same way for either method:
 
 1. In RomM's web UI, open **Settings → API Tokens** (also called Client API Tokens) and create a new token.
 2. Grant the scopes listed below — make sure the **write** scopes are included. Without them, downloads work but save
    upload, device sync, and playtime tracking fail with a permissions error.
-3. Copy the token value (RomM shows it only once).
-4. In the plugin's Connection Settings, tap **Sign in**, switch the **Sign-in method** dropdown to **API token**, paste
+
+#### Pairing code (recommended)
+
+Pairing hands the device the token over a short-lived one-time code, so you never copy or type the token itself.
+
+1. Create the token with the scopes above (steps 1–2).
+2. On that token in RomM's web UI, click **Pair**. RomM shows an 8-character pairing code, valid for **60 seconds**.
+3. In the plugin's Connection Settings, tap **Sign in**, switch the **Sign-in method** dropdown to **Pairing code**,
+   enter the code, and confirm — within the 60-second window. The plugin exchanges the code for the token itself.
+
+> **Pairing rotates the token's secret.** Exchanging a pairing code hands the device a **freshly rotated** secret for
+> that token — any raw token value you copied earlier stops working. Use **one token per device** so pairing a new
+> device never invalidates another.
+
+#### Paste the token
+
+1. Create the token with the scopes above (steps 1–2).
+2. Copy the token value (RomM shows it only once).
+3. In the plugin's Connection Settings, tap **Sign in**, switch the **Sign-in method** dropdown to **API token**, paste
    the token, and confirm.
 
-The plugin validates the token at sign-in with an authenticated probe against your RomM profile: a wrong or revoked
-token is rejected there with an "invalid or revoked" message. Sign-in only confirms that the token **authenticates**,
+Both methods validate the token at sign-in with an authenticated probe against your RomM profile: a wrong, revoked, or
+expired credential is rejected there with an actionable message. Sign-in only confirms that the token **authenticates**,
 though — the plugin cannot verify the token's granted scopes, so double-check that you granted the write scopes
 (`assets.write`, `devices.write`, `roms.user.write`) when creating it. A missing write scope is not caught at sign-in;
 it surfaces later as a permissions error on the affected action (save upload, device sync, or playtime).

--- a/main.py
+++ b/main.py
@@ -192,6 +192,9 @@ class Plugin:
     async def connect_with_token(self, romm_url, token, allow_insecure_ssl=None):
         return await self._connection_service.establish_user_token(romm_url, token, allow_insecure_ssl)
 
+    async def connect_with_pairing_code(self, romm_url, code, allow_insecure_ssl=None):
+        return await self._connection_service.establish_paired_token(romm_url, code, allow_insecure_ssl)
+
     async def save_server_url(self, romm_url, allow_insecure_ssl=None):
         return self._settings_service.save_server_url(romm_url, allow_insecure_ssl)
 

--- a/py_modules/adapters/romm/http.py
+++ b/py_modules/adapters/romm/http.py
@@ -34,6 +34,8 @@ from lib.errors import (
 )
 from lib.url_host import same_origin
 
+_CONTENT_TYPE_JSON = "application/json"
+
 
 class RommHttpAdapter:
     """Low-level HTTP client for RomM API requests.
@@ -184,26 +186,51 @@ class RommHttpAdapter:
             return RommServerError(msg, status_code=code, url=url, method=method)
         return RommApiError(msg, url=url, method=method)
 
+    @staticmethod
+    def _read_error_detail(exc: urllib.error.HTTPError) -> Any:
+        """Read the FastAPI ``detail`` field from an error response body, or ``None``.
+
+        Reads the ``HTTPError`` body once (it is otherwise discarded) and returns
+        its ``detail`` value, so a caller can distinguish two responses that share
+        a status code but carry different ``detail`` text. Any unreadable /
+        non-JSON body degrades to ``None``.
+        """
+        try:
+            raw = exc.read().decode()
+            body = json.loads(raw) if raw else None
+        except Exception:  # unreadable / non-JSON body — degrade to no detail
+            return None
+        return body.get("detail") if isinstance(body, dict) else None
+
     def _translate_unprocessable(
         self, exc: urllib.error.HTTPError, url: str, method: str
     ) -> RommUnprocessableEntityError:
         """Build a :class:`RommUnprocessableEntityError` carrying the parsed 422 ``detail``.
 
         Reads the ``HTTPError`` response body once and extracts its ``detail``
-        list (RomM/FastAPI's per-field validation errors). Any failure to read or
-        parse the body degrades to ``detail=None`` — the caller then falls back to
-        a whole-request strategy rather than a per-entry one.
+        list (RomM/FastAPI's per-field validation errors). A missing/unreadable
+        body degrades to ``detail=None`` — the caller then falls back to a
+        whole-request strategy rather than a per-entry one.
         """
-        detail = None
-        try:
-            raw = exc.read().decode()
-            body = json.loads(raw) if raw else None
-            if isinstance(body, dict):
-                detail = body.get("detail")
-        except Exception:  # unreadable / non-JSON body — degrade to no detail
-            detail = None
+        detail = self._read_error_detail(exc)
         msg = f"HTTP 422: {exc.reason} ({method} {url})"
         return RommUnprocessableEntityError(msg, detail=detail, url=url, method=method)
+
+    def _translate_with_detail(self, exc: urllib.error.HTTPError, url: str, method: str) -> RommApiError:
+        """Translate an ``HTTPError`` like :meth:`translate_http_error`, with ``detail`` attached.
+
+        Same status → type mapping as :meth:`translate_http_error` (422 keeps its
+        own structured path), but the FastAPI ``detail`` string is read once and
+        attached to the typed error, so a caller can branch on reasons that share
+        a status code (two 404s that differ only by ``detail``).
+        """
+        if exc.code == 422:
+            return self._translate_unprocessable(exc, url, method)
+        detail = self._read_error_detail(exc)
+        msg = f"HTTP {exc.code}: {exc.reason} ({method} {url})"
+        error = self._translate_http_status(exc.code, msg, url, method)
+        error.detail = detail
+        return error
 
     @staticmethod
     def _translate_unwrapped(exc: Exception, url: str, method: str) -> RommApiError:
@@ -493,7 +520,7 @@ class RommHttpAdapter:
         def _do_json_request():
             body = json.dumps(data).encode("utf-8")
             req = urllib.request.Request(url, data=body, method=method)
-            req.add_header("Content-Type", "application/json")
+            req.add_header("Content-Type", _CONTENT_TYPE_JSON)
             self._apply_default_headers(req)
             try:
                 with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
@@ -543,6 +570,35 @@ class RommHttpAdapter:
         except Exception as exc:
             raise self.translate_http_error(exc, url, method) from exc
 
+    # Intentionally skips with_retry: a public single-use credential (the pairing
+    # code) must not be replayed — a retry burns the one-time code and the
+    # server-side rate limit.
+    def unauthenticated_post_json(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
+        """POST JSON to a PUBLIC RomM endpoint — no ``Authorization`` header, no retry.
+
+        For endpoints whose credential is the request body itself (the
+        pairing-code exchange, whose one-time code IS the credential): a stored
+        bearer must never be attached (only the ``User-Agent`` goes out). On an
+        HTTP error the response ``detail`` is attached to the raised typed error
+        so the caller can branch on the server's specific reason. Returns ``{}``
+        on a 204 No Content, parsed JSON otherwise.
+        """
+        url = self._settings["romm_url"].rstrip("/") + path
+        body = json.dumps(data).encode("utf-8")
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", _CONTENT_TYPE_JSON)
+        req.add_header("User-Agent", self._user_agent)
+        try:
+            with urllib.request.urlopen(req, context=self.ssl_context(), timeout=30) as resp:
+                if resp.status == 204:
+                    return {}
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as exc:
+            raise self._translate_with_detail(exc, url, "POST") from exc
+        except Exception as exc:
+            raise self.translate_http_error(exc, url, "POST") from exc
+
     # Intentionally skips with_retry: token mint/delete are not idempotent
     # and must not be retried (a duplicate mint would orphan a token).
     def basic_auth_request(
@@ -567,7 +623,7 @@ class RommHttpAdapter:
         body = json.dumps(data).encode("utf-8") if data is not None else None
         req = urllib.request.Request(url, data=body, method=method)
         if body is not None:
-            req.add_header("Content-Type", "application/json")
+            req.add_header("Content-Type", _CONTENT_TYPE_JSON)
         req.add_header("Authorization", self._basic_auth_header(username, password))
         req.add_header("User-Agent", self._user_agent)
         try:

--- a/py_modules/adapters/romm/romm_api.py
+++ b/py_modules/adapters/romm/romm_api.py
@@ -10,7 +10,15 @@ import logging
 import urllib.parse
 from typing import TYPE_CHECKING, Any
 
-from lib.errors import RommNotFoundError
+from lib.errors import (
+    PairingCodeInvalidError,
+    PairingCodeOwnerDisabledError,
+    PairingCodeRateLimitedError,
+    PairingCodeTokenGoneError,
+    RommForbiddenError,
+    RommNotFoundError,
+    RommServerError,
+)
 
 if TYPE_CHECKING:
     from models.play_sessions import PlaySessionIngestEntry, PlaySessionIngestResponse
@@ -27,6 +35,17 @@ _logger = logging.getLogger(__name__)
 # ``/api/play-sessions`` pagination guard: stop after this many pages so a server
 # that never returns a short page (e.g. ignores ``offset``) can't loop forever.
 _MAX_PLAY_SESSION_PAGES = 50
+
+# Public pairing-code exchange endpoint (unauthenticated — the code is the credential).
+_PAIRING_CODE_ENDPOINT = "/api/client-tokens/exchange"
+# Case-folded needle identifying the exchange 404 raised when the token a pairing
+# code was minted for was deleted between pairing and exchange — distinct from the
+# invalid/expired/used-code 404, which the two share only by their FastAPI
+# ``detail`` string. Source string "Token no longer exists": RomM backend
+# ``client_tokens.py`` (verified against RomM 4.9.0 and 4.9.2). Matched by
+# case-insensitive substring containment so a wording/casing/punctuation tweak on
+# the server doesn't silently reroute it to the invalid-code branch.
+_PAIRING_TOKEN_GONE_NEEDLE = "token no longer exists"
 
 # Scopes requested for the minted Client API Token. Deliberately excludes
 # ``me.write`` so the token itself cannot mint or delete tokens — that
@@ -386,3 +405,36 @@ class RommApiAdapter:
             )
         except RommNotFoundError:
             return
+
+    def exchange_pairing_code(self, code: str) -> dict[str, Any]:
+        """Exchange a short-lived RomM pairing code for a Client API Token.
+
+        POSTs ``{"code": code}`` to the PUBLIC ``/api/client-tokens/exchange``
+        endpoint with no Authorization header and no retry — the one-time code is
+        itself the credential, and a replay would burn both the single-use code
+        and the server-side rate limit. Returns RomM's token schema, whose
+        ``raw_token`` is the freshly rotated bearer (the exchange regenerates the
+        token server-side). Neither the code nor the returned token is logged.
+
+        Failure mapping the caller branches on: a 404 for an invalid/expired/used
+        code raises :class:`PairingCodeInvalidError`; a 404 whose ``detail`` says
+        the token is gone raises :class:`PairingCodeTokenGoneError`; a 403 raises
+        :class:`PairingCodeOwnerDisabledError`; a 429 raises
+        :class:`PairingCodeRateLimitedError`. Transport failures propagate as
+        their transport ``RommApiError`` subclass.
+        """
+        try:
+            return self._client.unauthenticated_post_json(_PAIRING_CODE_ENDPOINT, {"code": code})
+        except RommNotFoundError as exc:
+            # Only a real string detail is inspected — a non-string / absent detail
+            # falls through to the invalid/expired branch (never coerced in).
+            detail = exc.detail
+            if isinstance(detail, str) and _PAIRING_TOKEN_GONE_NEEDLE in detail.casefold():
+                raise PairingCodeTokenGoneError("Pairing token no longer exists") from exc
+            raise PairingCodeInvalidError("Pairing code is invalid or expired") from exc
+        except RommForbiddenError as exc:
+            raise PairingCodeOwnerDisabledError("Pairing token owner is disabled") from exc
+        except RommServerError as exc:
+            if exc.status_code == 429:
+                raise PairingCodeRateLimitedError("Too many pairing-code exchange attempts") from exc
+            raise

--- a/py_modules/lib/errors.py
+++ b/py_modules/lib/errors.py
@@ -1,5 +1,7 @@
 """RomM API error types for structured error handling."""
 
+from typing import Any
+
 from lib.list_result import ErrorCode
 
 
@@ -27,6 +29,11 @@ class RommApiError(Exception):
     """Base exception for all RomM HTTP API errors."""
 
     status_code = None
+    # Parsed FastAPI ``detail`` body, populated only by the request paths that
+    # read it (422 validation, the pairing-code exchange). ``None`` otherwise, so
+    # a caller can branch on two responses that share a status code but differ in
+    # ``detail`` without every error path paying to read the body.
+    detail: Any = None
 
     def __init__(self, message, url=None, method=None):
         self.url = url
@@ -114,6 +121,22 @@ class TokenHostMismatchError(RommApiError):
     not minted for, so the credential never leaks to a wrong/hostile server.
     Non-retryable: replaying it cannot succeed, only re-signing-in can.
     """
+
+
+class PairingCodeInvalidError(RommApiError):
+    """Pairing-code exchange rejected: the code is invalid, expired, or already used (404)."""
+
+
+class PairingCodeTokenGoneError(RommApiError):
+    """Pairing-code exchange rejected: the token the code was minted for no longer exists (404)."""
+
+
+class PairingCodeOwnerDisabledError(RommApiError):
+    """Pairing-code exchange rejected: the token owner account is disabled (403)."""
+
+
+class PairingCodeRateLimitedError(RommApiError):
+    """Pairing-code exchange rejected: too many exchange attempts from this client (429)."""
 
 
 def classify_error(exc):

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -4,7 +4,9 @@ Owns the ``test_connection`` reachability flow and the Client API Token
 lifecycle: ``establish_token`` mints a scoped token from a one-time
 username/password and discards the credentials, ``establish_user_token``
 validates and stores a token the user pasted (the OIDC path, which has no
-password to mint from), and ``migrate_legacy_credentials`` upgrades a
+password to mint from), ``establish_paired_token`` exchanges a short-lived RomM
+pairing code for a token (the same OIDC path without pasting), and
+``migrate_legacy_credentials`` upgrades a
 stored-password install to a token on startup. Pure I/O happens through the ``RommConnectionApi``
 Protocol and disk writes through the ``SettingsPersister`` Protocol; this
 service composes that I/O with the response-shape contract the frontend
@@ -20,7 +22,15 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from domain.version import meets_min_version
-from lib.errors import RommAuthError, RommForbiddenError, error_response
+from lib.errors import (
+    PairingCodeInvalidError,
+    PairingCodeOwnerDisabledError,
+    PairingCodeRateLimitedError,
+    PairingCodeTokenGoneError,
+    RommAuthError,
+    RommForbiddenError,
+    error_response,
+)
 from lib.list_result import ErrorCode
 from lib.url_host import is_valid_server_url, normalize_origin, same_origin
 
@@ -37,6 +47,7 @@ if TYPE_CHECKING:
 
 
 _NO_SERVER_URL_MESSAGE = "No server URL configured"
+_INVALID_URL_MESSAGE = "Enter a valid http(s):// server URL"
 
 _FORBIDDEN_TOKEN_MESSAGE = (
     "Your RomM account cannot create API tokens — ask your admin to grant "
@@ -51,6 +62,34 @@ _USER_TOKEN_INVALID_MESSAGE = "The API token is invalid or has been revoked. Cre
 _USER_TOKEN_SCOPE_MESSAGE = (
     "The API token is missing required permissions (scopes). Grant the scopes listed in the plugin docs and try again."
 )
+
+# Pairing-code sign-in (``establish_paired_token``). The 60s single-use pairing
+# code is exchanged for a token over a public endpoint; each rejection carries a
+# distinct, actionable message. The rate-limit reason is a bespoke plain-string
+# slug (the server IS reachable — it is neither an auth nor a reachability fault).
+_ENTER_PAIRING_CODE_MESSAGE = "Enter the pairing code from RomM"
+_PAIRING_CODE_INVALID_MESSAGE = (
+    "Pairing code is invalid or has expired — generate a new one in RomM and try again "
+    "(codes are valid for 60 seconds)."
+)
+_PAIRING_TOKEN_GONE_MESSAGE = (
+    "The token this pairing code was created for no longer exists in RomM. Create a new API token, then pair again."
+)
+_PAIRING_OWNER_DISABLED_MESSAGE = (
+    "This RomM account is disabled — ask your administrator to re-enable it, then try again."
+)
+_PAIRING_RATE_LIMITED_MESSAGE = "Too many attempts — wait a minute and generate a new code."
+_RATE_LIMITED_REASON = "rate_limited"
+
+
+def _normalize_pairing_code(code: str) -> str:
+    """Normalize a pairing code the way RomM does: drop all whitespace and ``-``, then uppercase.
+
+    RomM's exchange endpoint strips ``-`` and uppercases; the plugin additionally
+    removes any whitespace the user pasted (leading, trailing, or embedded). So
+    ``"ab-cd ef23"`` normalizes to ``"ABCDEF23"``.
+    """
+    return "".join(code.split()).replace("-", "").upper()
 
 
 @dataclass(frozen=True)
@@ -179,7 +218,7 @@ class ConnectionService:
             return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
         trimmed = romm_url.strip()
         if not is_valid_server_url(trimmed):
-            return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+            return {"success": False, "reason": "config_error", "message": _INVALID_URL_MESSAGE}
 
         snapshot = self._snapshot_auth_state()
         old_token_id = snapshot["romm_api_token_id"]
@@ -281,7 +320,7 @@ class ConnectionService:
             return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
         trimmed = romm_url.strip()
         if not is_valid_server_url(trimmed):
-            return {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+            return {"success": False, "reason": "config_error", "message": _INVALID_URL_MESSAGE}
         trimmed_token = token.strip()
         if not trimmed_token:
             return {"success": False, "reason": "config_error", "message": "Enter your RomM API token"}
@@ -312,6 +351,123 @@ class ConnectionService:
             self._restore_auth_state(snapshot)
             return version_error
 
+        return await self._validate_and_persist_user_token(trimmed_token, trimmed, old_token_origin, version, snapshot)
+
+    async def establish_paired_token(
+        self,
+        romm_url: str,
+        code: str,
+        allow_insecure_ssl: bool | None = None,
+    ) -> dict[str, Any]:
+        """Exchange a short-lived RomM pairing code for a Client API Token and store it.
+
+        The zero-typing sign-in for OIDC accounts: instead of pasting a token, the
+        user generates a 60-second pairing code in RomM's web UI and enters it
+        here; the plugin exchanges it for the token over a public endpoint.
+        Structurally mirrors :meth:`establish_user_token` (validate URL → probe
+        version → gate → obtain the credential → validate via ``/api/users/me`` →
+        persist on success only, rolling the in-memory auth state back on any
+        failure), but the credential is fetched by the exchange rather than
+        pasted. The candidate URL is held in memory with the token trio CLEARED,
+        so no old bearer can leak to the candidate host during the unauthenticated
+        exchange (or the version probe before it). Each exchange rejection maps to
+        a distinct, actionable message; the exchange is never auto-retried (a
+        single-use code). The pairing code and the returned token are never
+        logged. Returns the same ``success`` / ``reason`` / ``message`` shape as
+        :meth:`test_connection`.
+        """
+        if not romm_url:
+            return {"success": False, "reason": "config_error", "message": _NO_SERVER_URL_MESSAGE}
+        trimmed = romm_url.strip()
+        if not is_valid_server_url(trimmed):
+            return {"success": False, "reason": "config_error", "message": _INVALID_URL_MESSAGE}
+        normalized_code = _normalize_pairing_code(code)
+        if not normalized_code:
+            return {"success": False, "reason": "config_error", "message": _ENTER_PAIRING_CODE_MESSAGE}
+
+        snapshot = self._snapshot_auth_state()
+        old_token_origin = snapshot["romm_api_token_origin"]
+
+        # Hold the candidate URL in memory; clear the token trio so the
+        # unauthenticated exchange (and the version probe before it) never carries
+        # an old server's bearer to the candidate host.
+        self._settings["romm_url"] = trimmed
+        if allow_insecure_ssl is not None:
+            self._settings["romm_allow_insecure_ssl"] = bool(allow_insecure_ssl)
+        self._settings["romm_api_token"] = None
+        self._settings["romm_api_token_id"] = None
+        self._settings["romm_api_token_origin"] = None
+
+        try:
+            version = await self._loop.run_in_executor(None, self._probe_version)
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            self._romm_api.set_version(None)
+            return error_response(e)
+
+        version_error = self._version_gate_error(version)
+        if version_error is not None:
+            self._restore_auth_state(snapshot)
+            return version_error
+
+        try:
+            exchanged = await self._loop.run_in_executor(None, self._exchange, normalized_code)
+        except PairingCodeInvalidError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _PAIRING_CODE_INVALID_MESSAGE}
+        except PairingCodeTokenGoneError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _PAIRING_TOKEN_GONE_MESSAGE}
+        except PairingCodeOwnerDisabledError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": ErrorCode.AUTH_FAILED.value, "message": _PAIRING_OWNER_DISABLED_MESSAGE}
+        except PairingCodeRateLimitedError:
+            self._restore_auth_state(snapshot)
+            return {"success": False, "reason": _RATE_LIMITED_REASON, "message": _PAIRING_RATE_LIMITED_MESSAGE}
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            return error_response(e)
+
+        raw_token = exchanged.get("raw_token")
+        if not raw_token:
+            self._restore_auth_state(snapshot)
+            return {
+                "success": False,
+                "reason": ErrorCode.SERVER_UNREACHABLE.value,
+                "message": "RomM did not return a usable token",
+            }
+
+        # Host-bind the freshly rotated token in memory, then run the exact same
+        # ``/api/users/me`` validation + persist tail as the pasted-token path.
+        self._settings["romm_api_token"] = raw_token
+        self._settings["romm_api_token_id"] = None
+        self._settings["romm_api_token_origin"] = normalize_origin(trimmed)
+        self._settings["romm_api_token_source"] = "user"
+
+        return await self._validate_and_persist_user_token(raw_token, trimmed, old_token_origin, version, snapshot)
+
+    async def _validate_and_persist_user_token(
+        self,
+        raw_token: str,
+        trimmed: str,
+        old_token_origin: str | None,
+        version: str | None,
+        snapshot: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Validate the in-memory host-bound bearer via ``/api/users/me`` and persist on success.
+
+        The shared tail of the two token-handoff sign-ins — the pasted token
+        (:meth:`establish_user_token`) and the paired token
+        (:meth:`establish_paired_token`). Assumes the caller has already placed
+        *raw_token* in memory, host-bound to *trimmed*'s origin, with
+        ``romm_api_token_source = "user"``. Runs the authenticated
+        ``/api/users/me`` probe (a 401 means the token is invalid/revoked, a 403
+        means it lacks a required scope), persists the token with ``id = None``
+        and ``"user"`` provenance, then fires the device-forget-on-origin-change
+        and playtime-scope-notice clear. Rolls the in-memory auth state back to
+        *snapshot* on any failure; disk is untouched until validation passes. The
+        token value is never logged.
+        """
         try:
             await self._loop.run_in_executor(None, self._romm_api.get_current_user)
         except RommAuthError:
@@ -325,7 +481,7 @@ class ConnectionService:
             return error_response(e)
 
         try:
-            self._persist_token(trimmed_token, None, origin=normalize_origin(trimmed), source="user")
+            self._persist_token(raw_token, None, origin=normalize_origin(trimmed), source="user")
         except Exception as e:
             self._restore_auth_state(snapshot)
             return error_response(e)
@@ -512,6 +668,10 @@ class ConnectionService:
     def _mint(self, username: str, password: str) -> dict[str, Any]:
         """Synchronous mint worker invoked on the executor thread."""
         return self._romm_api.mint_client_token(username, password, token_name=self._token_name())
+
+    def _exchange(self, code: str) -> dict[str, Any]:
+        """Synchronous pairing-code exchange worker invoked on the executor thread."""
+        return self._romm_api.exchange_pairing_code(code)
 
     def _delete(self, username: str, password: str, token_id: int) -> None:
         """Synchronous delete worker invoked on the executor thread."""

--- a/py_modules/services/protocols/transport.py
+++ b/py_modules/services/protocols/transport.py
@@ -355,11 +355,12 @@ class RommVersion(Protocol):
 
 
 class RommTokenApi(Protocol):
-    """RomM Client API Token mint/delete surface.
+    """RomM Client API Token surface — mint, delete, and pairing-code exchange.
 
-    The runtime Bearer token deliberately lacks ``me.write``, so both
-    operations need a transient Basic-auth identity built from the
-    username/password passed at call time — never from stored state.
+    Mint and delete need a transient Basic-auth identity built from the
+    username/password passed at call time (never from stored state), because the
+    runtime Bearer token deliberately lacks ``me.write``. The pairing-code
+    exchange is unauthenticated — the one-time code is itself the credential.
     """
 
     def mint_client_token(self, username: str, password: str, *, token_name: str) -> dict[str, Any]:
@@ -372,6 +373,18 @@ class RommTokenApi(Protocol):
 
     def delete_client_token(self, username: str, password: str, *, token_id: int) -> None:
         """Delete a Client API Token by id; a missing token is treated as success."""
+        ...
+
+    def exchange_pairing_code(self, code: str) -> dict[str, Any]:
+        """Exchange a short-lived pairing code for a Client API Token (public, no auth).
+
+        POSTs the one-time code to the unauthenticated exchange endpoint — the
+        code IS the credential, so no bearer is attached and the call is never
+        retried. Returns the server token schema whose ``raw_token`` is the
+        freshly rotated bearer. Raises a pairing-specific ``RommApiError``
+        subclass on a rejected code (invalid/expired, token-gone, owner-disabled,
+        or rate-limited).
+        """
         ...
 
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -102,6 +102,7 @@ export const connectWithCredentials = callable<[string, string, string, boolean]
   "connect_with_credentials",
 );
 export const connectWithToken = callable<[string, string, boolean], BackendResult>("connect_with_token");
+export const connectWithPairingCode = callable<[string, string, boolean], BackendResult>("connect_with_pairing_code");
 
 export interface WhitelistSettings {
   disabled_defaults: string[];

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -751,6 +751,91 @@ describe("SettingsPage", () => {
     });
   });
 
+  describe("handleConnectPairing (pairing-code flow)", () => {
+    it("calls connectWithPairingCode with url + code + ssl, surfaces the message, and sets hasToken on success", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: false,
+      });
+      vi.mocked(backend.connectWithPairingCode).mockResolvedValue({
+        success: true,
+        message: "Connected!",
+        romm_version: "4.9.0",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.connectWithPairingCode)).toHaveBeenCalledWith("https://romm.local", "ABCD2345", false);
+      // The paired flow must not fall through to the pasted-token callable.
+      expect(vi.mocked(backend.connectWithToken)).not.toHaveBeenCalled();
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Connected!");
+      expect(conn?.hasToken).toBe(true);
+    });
+
+    it("surfaces the failure message without setting hasToken (e.g. expired code)", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: false,
+      });
+      vi.mocked(backend.connectWithPairingCode).mockResolvedValue({
+        success: false,
+        message: "Pairing code is invalid or has expired.",
+        reason: "auth_failed",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("BADCODE1");
+        await Promise.resolve();
+      });
+
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Pairing code is invalid or has expired.");
+      expect(conn?.hasToken).toBe(false);
+    });
+
+    it("rejects an invalid URL inline without calling connectWithPairingCode", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        romm_url: "romm.local", // scheme-less — invalid
+        has_token: false,
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.connectWithPairingCode)).not.toHaveBeenCalled();
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe(
+        "Enter a valid http:// or https:// server URL",
+      );
+    });
+
+    it("sets status='Sign-in failed' when connectWithPairingCode throws", async () => {
+      vi.mocked(backend.connectWithPairingCode).mockRejectedValue(new Error("net"));
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onConnectPairing("ABCD2345");
+        await Promise.resolve();
+      });
+
+      expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Sign-in failed");
+    });
+  });
+
   describe("handleTest", () => {
     it("forwards the result message into ConnectionSection.status on success", async () => {
       vi.mocked(backend.testConnection).mockResolvedValue({

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   saveServerUrl,
   connectWithCredentials,
   connectWithToken,
+  connectWithPairingCode,
   testConnection,
   saveSgdbApiKey,
   verifySgdbApiKey,
@@ -323,6 +324,23 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setStatus("Sign-in failed");
     }
   };
+  const handleConnectPairing = async (code: string) => {
+    setStatus("");
+    const trimmed = trimServerUrl(url);
+    if (!isValidServerUrl(trimmed)) {
+      setStatus("Enter a valid http:// or https:// server URL");
+      return;
+    }
+    try {
+      const result = await connectWithPairingCode(trimmed, code, allowInsecureSsl);
+      setStatus(result.message);
+      if (result.success) {
+        setHasToken(true);
+      }
+    } catch {
+      setStatus("Sign-in failed");
+    }
+  };
 
   // --- SteamGridDB handlers ---
   const handleSgdbKeySubmit = async (value: string) => {
@@ -465,6 +483,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         }}
         onConnectToken={(token) => {
           detach(handleConnectToken(token));
+        }}
+        onConnectPairing={(code) => {
+          detach(handleConnectPairing(code));
         }}
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
         onTestConnection={() => {

--- a/src/components/settings/ConnectModal.test.tsx
+++ b/src/components/settings/ConnectModal.test.tsx
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
-import { createElement } from "react";
+import { createElement, forwardRef } from "react";
 import { ConnectModal } from "./ConnectModal";
 
 // Local @decky/ui mock: ConfirmModal exposes its OK button (driving onOK) so
-// the submit path is exercised; TextField forwards label + value + onChange so
-// each field can be typed into and identified by its label; DropdownItem
-// renders one button per option (data-testid `mode-<data>`) that drives onChange
-// so a test can flip the sign-in mode.
+// the submit path is exercised; TextField forwards label + value + onChange +
+// onKeyDown to a real <input> (mirroring the real component's typed contract —
+// TextFieldProps extends HTMLAttributes<HTMLInputElement>) so each field can be
+// typed into, receive key events, and be focused; DropdownItem renders one
+// button per option (data-testid `mode-<data>`) that drives onChange so a test
+// can flip the sign-in mode.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 interface ConfirmModalProps extends AnyProps {
   onOK?: () => void;
@@ -18,6 +20,7 @@ interface TextFieldProps {
   value?: string;
   bIsPassword?: boolean;
   onChange?: (e: { target: { value: string } }) => void;
+  onKeyDown?: (e: unknown) => void;
 }
 interface DropdownOption {
   data: string;
@@ -33,6 +36,15 @@ interface DropdownItemProps {
 const textFields: TextFieldProps[] = [];
 
 vi.mock("@decky/ui", () => ({
+  // Focusable forwards its ref to the wrapping div so the component's
+  // querySelectorAll('input') focus-advance resolves against the boxes.
+  Focusable: forwardRef<HTMLDivElement, AnyProps>((p, ref) =>
+    createElement(
+      "div",
+      { ref, style: p.style, "data-testid": p["data-testid"] as string | undefined },
+      p.children as never,
+    ),
+  ),
   ConfirmModal: (p: ConfirmModalProps) =>
     createElement(
       "div",
@@ -47,6 +59,7 @@ vi.mock("@decky/ui", () => ({
       "data-is-password": p.bIsPassword ? "true" : "false",
       value: p.value ?? "",
       onChange: (e: unknown) => p.onChange?.(e as { target: { value: string } }),
+      onKeyDown: (e: unknown) => p.onKeyDown?.(e),
     });
   },
   DropdownItem: (p: DropdownItemProps) =>
@@ -69,9 +82,31 @@ describe("ConnectModal", () => {
     vi.clearAllMocks();
   });
 
-  describe("credentials mode (default)", () => {
+  it("lists the sign-in methods in order: pairing, token, credentials", () => {
+    const { getByTestId } = render(
+      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+    );
+    const options = Array.from(getByTestId("mode-dropdown").querySelectorAll("button")).map((b) => b.textContent);
+    expect(options).toEqual(["Pairing code", "API token", "Username & password"]);
+  });
+
+  it("opens in pairing mode by default", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+    );
+    // No dropdown interaction — the pairing-code boxes are the ones shown on first render.
+    expect(getByTestId("mode-dropdown").getAttribute("data-selected")).toBe("pairing");
+    expect(getByTestId("pairing-code-row").querySelectorAll("input")).toHaveLength(8);
+    expect(queryByTestId("field-Username")).toBeNull();
+    expect(queryByTestId("field-API Token")).toBeNull();
+  });
+
+  describe("credentials mode", () => {
     it("renders a username and an obscured password field, both empty (write-only)", () => {
-      const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
       const user = getByTestId("field-Username") as HTMLInputElement;
       const pass = getByTestId("field-Password") as HTMLInputElement;
       expect(user.value).toBe("");
@@ -82,8 +117,12 @@ describe("ConnectModal", () => {
     it("calls onConnect with the entered username + password on Sign in", () => {
       const onConnect = vi.fn();
       const onConnectToken = vi.fn();
-      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+      const onConnectPairing = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+      );
 
+      fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
       fireEvent.change(getByTestId("field-Password"), { target: { value: "hunter2" } });
       fireEvent.click(getByTestId("ok-button"));
@@ -95,20 +134,28 @@ describe("ConnectModal", () => {
 
     it("passes empty strings to onConnect when nothing is entered", () => {
       const onConnect = vi.fn();
-      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={vi.fn()} />);
+      const { getByTestId } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.click(getByTestId("ok-button"));
       expect(onConnect).toHaveBeenCalledWith("", "");
     });
 
     it("does not render the API token field until token mode is selected", () => {
-      const { queryByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      const { getByTestId, queryByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-credentials"));
       expect(queryByTestId("field-API Token")).toBeNull();
     });
   });
 
   describe("token mode", () => {
     it("shows an obscured API token field and hides the credential fields after switching", () => {
-      const { getByTestId, queryByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+      const { getByTestId, queryByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
       fireEvent.click(getByTestId("mode-token"));
       const token = getByTestId("field-API Token") as HTMLInputElement;
       expect(token.getAttribute("data-is-password")).toBe("true");
@@ -119,7 +166,10 @@ describe("ConnectModal", () => {
     it("calls onConnectToken with the entered token on Sign in", () => {
       const onConnect = vi.fn();
       const onConnectToken = vi.fn();
-      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+      const onConnectPairing = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+      );
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
       fireEvent.click(getByTestId("ok-button"));
@@ -131,7 +181,10 @@ describe("ConnectModal", () => {
     it("switches back to credentials mode and calls onConnect again", () => {
       const onConnect = vi.fn();
       const onConnectToken = vi.fn();
-      const { getByTestId } = render(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />);
+      const onConnectPairing = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+      );
       fireEvent.click(getByTestId("mode-token"));
       fireEvent.click(getByTestId("mode-credentials"));
       fireEvent.change(getByTestId("field-Username"), { target: { value: "daniel" } });
@@ -141,8 +194,130 @@ describe("ConnectModal", () => {
     });
   });
 
+  describe("pairing mode", () => {
+    // The eight single-character boxes have no per-box label, so the test grabs
+    // each underlying input the same way the component moves focus between them:
+    // querySelectorAll('input') on the row wrapper, in DOM order. The @decky/ui
+    // TextField exposes no ref to its input.
+    const codeBoxes = (getByTestId: (id: string) => HTMLElement): HTMLInputElement[] =>
+      Array.from(getByTestId("pairing-code-row").querySelectorAll("input"));
+    const box = (getByTestId: (id: string) => HTMLElement, index: number): HTMLInputElement => {
+      const input = codeBoxes(getByTestId)[index];
+      if (!input) throw new Error(`no pairing box at index ${index}`);
+      return input;
+    };
+
+    it("renders exactly eight single-character (non-obscured) code boxes and hides the other modes' fields", () => {
+      const { getByTestId, queryByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      const boxes = codeBoxes(getByTestId);
+      expect(boxes).toHaveLength(8);
+      // The code is short-lived and single-use — typability beats obscuring it.
+      for (const box of boxes) {
+        expect(box.getAttribute("data-is-password")).toBe("false");
+      }
+      expect(queryByTestId("field-Username")).toBeNull();
+      expect(queryByTestId("field-Password")).toBeNull();
+      expect(queryByTestId("field-API Token")).toBeNull();
+    });
+
+    it("uppercases a typed character and advances focus to the next box", () => {
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.change(box(getByTestId, 0), { target: { value: "a" } });
+      expect(box(getByTestId, 0).value).toBe("A");
+      // Auto-advance: the character hands the caret to the next box.
+      expect(document.activeElement).toBe(box(getByTestId, 1));
+    });
+
+    it("ignores a non-alphanumeric character, leaving the box empty and focus put", () => {
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.change(box(getByTestId, 0), { target: { value: "!" } });
+      expect(box(getByTestId, 0).value).toBe("");
+      // Nothing entered, so focus does not advance.
+      expect(document.activeElement).not.toBe(box(getByTestId, 1));
+    });
+
+    it("distributes a two-character entry across two boxes (never crams two into one)", () => {
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.change(box(getByTestId, 0), { target: { value: "zq" } });
+      expect(box(getByTestId, 0).value).toBe("Z");
+      expect(box(getByTestId, 1).value).toBe("Q");
+      expect(box(getByTestId, 2).value).toBe("");
+    });
+
+    it("returns focus to the previous box when Backspace is pressed on an empty box", () => {
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      // Fill the first box (auto-advances to the second, which stays empty).
+      fireEvent.change(box(getByTestId, 0), { target: { value: "a" } });
+      expect(document.activeElement).toBe(box(getByTestId, 1));
+      // Backspace on the empty second box steps back to the first.
+      fireEvent.keyDown(box(getByTestId, 1), { key: "Backspace" });
+      expect(document.activeElement).toBe(box(getByTestId, 0));
+    });
+
+    it.each([
+      ["a plain eight-character paste", "abcdefgh", ["A", "B", "C", "D", "E", "F", "G", "H"]],
+      ["a hyphenated eight-character paste", "abcd-efgh", ["A", "B", "C", "D", "E", "F", "G", "H"]],
+      ["a mixed-case paste (uppercased as it fills)", "aB2d-Ef4h", ["A", "B", "2", "D", "E", "F", "4", "H"]],
+    ] as const)("splits %s across all eight boxes", (_name, pasted, expected) => {
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.change(box(getByTestId, 0), { target: { value: pasted } });
+      expect(codeBoxes(getByTestId).map((b) => b.value)).toEqual([...expected]);
+    });
+
+    it("calls onConnectPairing with the concatenated eight characters on Sign in and leaks to no other handler", () => {
+      const onConnect = vi.fn();
+      const onConnectToken = vi.fn();
+      const onConnectPairing = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.change(box(getByTestId, 0), { target: { value: "abcdefgh" } });
+      fireEvent.click(getByTestId("ok-button"));
+      expect(onConnectPairing).toHaveBeenCalledTimes(1);
+      // Bare eight characters in order — the backend normalizes, so no hyphen is sent.
+      expect(onConnectPairing).toHaveBeenCalledWith("ABCDEFGH");
+      expect(onConnect).not.toHaveBeenCalled();
+      expect(onConnectToken).not.toHaveBeenCalled();
+    });
+
+    it("switches from pairing back to token mode and routes to onConnectToken only", () => {
+      const onConnectToken = vi.fn();
+      const onConnectPairing = vi.fn();
+      const { getByTestId } = render(
+        <ConnectModal onConnect={vi.fn()} onConnectToken={onConnectToken} onConnectPairing={onConnectPairing} />,
+      );
+      fireEvent.click(getByTestId("mode-pairing"));
+      fireEvent.click(getByTestId("mode-token"));
+      fireEvent.change(getByTestId("field-API Token"), { target: { value: "rmm_pasted" } });
+      fireEvent.click(getByTestId("ok-button"));
+      expect(onConnectToken).toHaveBeenCalledWith("rmm_pasted");
+      expect(onConnectPairing).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses 'Sign in' as the OK button label", () => {
-    const { getByTestId } = render(<ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} />);
+    const { getByTestId } = render(
+      <ConnectModal onConnect={vi.fn()} onConnectToken={vi.fn()} onConnectPairing={vi.fn()} />,
+    );
     expect(getByTestId("ok-button").textContent).toBe("Sign in");
   });
 });

--- a/src/components/settings/ConnectModal.tsx
+++ b/src/components/settings/ConnectModal.tsx
@@ -1,44 +1,192 @@
 /**
- * One-time prompt for signing in to RomM — either by minting a Client API
- * Token from a username + password, or by pasting a token created in RomM's
- * web UI (the path for OIDC accounts, which have no password to mint from).
+ * One-time prompt for signing in to RomM — by minting a Client API Token from a
+ * username + password, by pasting a token created in RomM's web UI, or by
+ * entering a short-lived pairing code the plugin exchanges for a token (the two
+ * token paths are for OIDC accounts, which have no password to mint from).
  *
- * Both the credentials and the pasted token are write-only: never pre-filled,
- * never echoed back by the backend. On submit the parent's matching handler
- * runs — `connect_with_credentials` (which exchanges the credentials for a
- * scoped token and discards the password) or `connect_with_token` (which
- * validates and stores the pasted token). This modal owns only the in-flight
- * field values and the selected mode; token minting/validation, status, and
- * persistence live in the parent (SettingsPage).
+ * The credentials and the pasted token are write-only: never pre-filled, never
+ * echoed back by the backend. The pairing code is short-lived (60 seconds) and
+ * single-use, so it is entered in the clear across eight single-character boxes
+ * (an OTP-style input grouped 4 – 4 around a hyphen, auto-advancing as you type)
+ * — typability matters more than obscuring a value that expires almost
+ * immediately. On submit the parent's matching handler runs —
+ * `connect_with_credentials` (exchanges the credentials for a scoped token and
+ * discards the password), `connect_with_token` (validates and stores the pasted
+ * token), or `connect_with_pairing_code` (exchanges the code for a token). This
+ * modal owns only the in-flight field values and the selected mode; token
+ * minting/validation, status, and persistence live in the parent (SettingsPage).
  */
 
-import { FC, useState, ChangeEvent } from "react";
-import { ConfirmModal, TextField, DropdownItem } from "@decky/ui";
+import { FC, Fragment, useState, useRef, ChangeEvent, KeyboardEvent } from "react";
+import { ConfirmModal, TextField, DropdownItem, Focusable } from "@decky/ui";
 
-type SignInMode = "credentials" | "token";
+type SignInMode = "credentials" | "token" | "pairing";
 
 interface ConnectModalProps {
   closeModal?: () => void;
   onConnect: (username: string, password: string) => void;
   onConnectToken: (token: string) => void;
+  onConnectPairing: (code: string) => void;
 }
 
-export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onConnectToken }) => {
-  const [mode, setMode] = useState<SignInMode>("credentials");
+// The pairing code is eight characters, shown as eight single-character boxes
+// split into two groups of four around a hyphen.
+const CODE_LENGTH = 8;
+const CODE_GROUP = 4;
+const CODE_INDICES = Array.from({ length: CODE_LENGTH }, (_unused, i) => i);
+
+const helperTextStyle = { fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" } as const;
+const codeLabelStyle = {
+  fontSize: "12px",
+  fontWeight: 600,
+  marginBottom: "8px",
+  color: "rgba(255,255,255,0.6)",
+} as const;
+// A single non-wrapping row: eight fixed-size boxes plus the hyphen must always
+// stay on one line (8·36 (boxes) + 8·6 (gaps between the 9 flex children) + ~8
+// (hyphen) ≈ 344px, comfortably inside the ConfirmModal's content width), so each
+// box is a fixed size and never shrinks or grows as characters are typed.
+const codeRowStyle = {
+  display: "flex",
+  flexWrap: "nowrap",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "6px",
+  width: "100%",
+} as const;
+// @decky/ui's TextField spreads the `style` prop straight onto its underlying
+// <input>, so these metrics apply to the glyph directly. The input's default
+// line-height/padding clips a single character when the cell is squeezed this
+// narrow, so we take over its box model: an explicit box height (44px wrapper),
+// zeroed padding, and a large centered font render the character fully and
+// centered both ways.
+// display:flex with the default align-items:stretch lets Steam's input fill the
+// full box height (a portrait rectangle); centering it here would leave the input
+// at its shorter intrinsic height and read as a square.
+const codeBoxWrapperStyle = { flexShrink: 0, width: "36px", height: "48px", display: "flex" } as const;
+const codeBoxFieldStyle = {
+  minWidth: 0,
+  width: "100%",
+  height: "100%",
+  boxSizing: "border-box",
+  padding: "0",
+  textAlign: "center",
+  fontSize: "20px",
+  lineHeight: "1.2",
+} as const;
+// Match the boxes' 44px flex-centered block so the hyphen shares their exact
+// vertical centerline (a bare inline span aligns by text baseline, which reads
+// as a minor offset next to the input boxes).
+const codeSeparatorStyle = {
+  flexShrink: 0,
+  height: "48px",
+  display: "flex",
+  alignItems: "center",
+  fontSize: "18px",
+  lineHeight: 1,
+  color: "rgba(255,255,255,0.6)",
+} as const;
+
+/**
+ * Reduce a pairing-code fragment to uppercased alphanumerics — strips any
+ * whitespace, hyphen, or stray punctuation a paste or keystroke introduced. The
+ * backend normalizes identically, so this is the canonical form each keystroke
+ * or paste reduces to before it is placed into or distributed across the
+ * single-character boxes.
+ */
+const normalizePairingCode = (value: string): string => value.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
+
+export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onConnectToken, onConnectPairing }) => {
+  const [mode, setMode] = useState<SignInMode>("pairing");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [token, setToken] = useState("");
+  const [code, setCode] = useState<string[]>(() => new Array<string>(CODE_LENGTH).fill(""));
+
+  // The @decky/ui TextField is a plain FC with no ref to its underlying input,
+  // so focus is moved via the wrapping row (querySelectorAll('input')[i] — the
+  // same DOM pattern the QAM uses for buttons) rather than a forwarded ref. The
+  // eight inputs sit in DOM order inside the row, so index maps to box.
+  const codeRowRef = useRef<HTMLDivElement>(null);
+
+  const boxInputAt = (index: number): HTMLInputElement | null =>
+    codeRowRef.current?.querySelectorAll("input")[index] ?? null;
+
+  const focusBox = (index: number) => {
+    boxInputAt(index)?.focus();
+  };
+
+  const focusBoxAtEnd = (index: number) => {
+    const input = boxInputAt(index);
+    if (!input) return;
+    input.focus();
+    const end = input.value.length;
+    input.setSelectionRange(end, end);
+  };
+
+  const setBoxChar = (index: number, char: string) => {
+    setCode((prev) => prev.map((current, idx) => (idx === index ? char : current)));
+  };
+
+  // Write `chars` into consecutive boxes starting at `start`, then land the caret
+  // on the first still-empty box — or blur (dismissing the keyboard) once the
+  // whole code is filled. Used for pastes and any multi-character keystroke.
+  const distributeChars = (start: number, chars: string) => {
+    setCode((prev) => {
+      const next = [...prev];
+      for (let offset = 0; offset < chars.length && start + offset < CODE_LENGTH; offset += 1) {
+        next[start + offset] = chars.charAt(offset);
+      }
+      return next;
+    });
+    const filledThrough = start + chars.length;
+    if (filledThrough >= CODE_LENGTH) {
+      (document.activeElement as HTMLElement | null)?.blur();
+    } else {
+      focusBox(filledThrough);
+    }
+  };
+
+  const handleBoxChange = (index: number) => (e: ChangeEvent<HTMLInputElement>) => {
+    const incoming = normalizePairingCode(e.target.value);
+    if (incoming.length <= 1) {
+      // A single character (or a deletion, which leaves the box empty). Advancing
+      // only on a real character, so a delete never jumps focus forward.
+      setBoxChar(index, incoming);
+      if (incoming.length === 1) focusBox(index + 1);
+      return;
+    }
+    // Multiple characters at once — a paste, or typing past a box that already
+    // holds a character. Drop a leading copy of the box's existing character (a
+    // type-over prepends it) so only the fresh characters are distributed.
+    const existing = code[index] ?? "";
+    const fresh = existing.length > 0 && incoming.startsWith(existing) ? incoming.slice(existing.length) : incoming;
+    distributeChars(index, fresh);
+  };
+
+  const handleBoxKeyDown = (index: number) => (e: KeyboardEvent<HTMLInputElement>) => {
+    // Standard OTP behavior: Backspace on an already-empty box steps focus back
+    // to the previous box with the caret at the end.
+    if (e.key === "Backspace" && (code[index] ?? "") === "" && index > 0) {
+      focusBoxAtEnd(index - 1);
+    }
+  };
+
+  const submit = () => {
+    if (mode === "token") {
+      onConnectToken(token);
+    } else if (mode === "pairing") {
+      // Backend normalizes, so the bare eight characters in order are enough.
+      onConnectPairing(code.join(""));
+    } else {
+      onConnect(username, password);
+    }
+  };
 
   return (
     <ConfirmModal
       {...(closeModal === undefined ? {} : { closeModal })}
-      onOK={() => {
-        if (mode === "token") {
-          onConnectToken(token);
-        } else {
-          onConnect(username, password);
-        }
-      }}
+      onOK={submit}
       strTitle="Sign in to RomM"
       strOKButtonText="Sign in"
       bDisableBackgroundDismiss={true}
@@ -46,15 +194,16 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
       <DropdownItem
         label="Sign-in method"
         rgOptions={[
-          { data: "credentials", label: "Username & password" },
+          { data: "pairing", label: "Pairing code" },
           { data: "token", label: "API token" },
+          { data: "credentials", label: "Username & password" },
         ]}
         selectedOption={mode}
         onChange={(option) => setMode(option.data as SignInMode)}
       />
-      {mode === "token" ? (
+      {mode === "token" && (
         <>
-          <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>
+          <div style={helperTextStyle}>
             Create a token in RomM&apos;s web UI (Settings → API Tokens) and paste it here. Make sure it has the scopes
             listed in the plugin docs so downloads, saves, and device sync work. The plugin never deletes a pasted
             token; you manage it in RomM.
@@ -67,9 +216,38 @@ export const ConnectModal: FC<ConnectModalProps> = ({ closeModal, onConnect, onC
             onChange={(e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
           />
         </>
-      ) : (
+      )}
+      {mode === "pairing" && (
         <>
-          <div style={{ fontSize: "12px", marginBottom: "12px", color: "rgba(255,255,255,0.6)" }}>
+          <div style={helperTextStyle}>
+            In RomM&apos;s web UI open your API token and click <strong>Pair</strong>, then enter the 8-character code
+            here within 60 seconds. The plugin fetches the token itself — nothing to copy or paste.
+          </div>
+          <div style={codeLabelStyle}>Pairing code</div>
+          {/* Focusable + flow-children="horizontal" tells Steam's gamepad nav to
+              step between the boxes left/right (the analog stick/d-pad), not
+              up/down — a plain div defaults to vertical traversal. */}
+          <Focusable flow-children="horizontal" ref={codeRowRef} style={codeRowStyle} data-testid="pairing-code-row">
+            {CODE_INDICES.map((i) => (
+              <Fragment key={i}>
+                {i === CODE_GROUP && <span style={codeSeparatorStyle}>-</span>}
+                <div style={codeBoxWrapperStyle}>
+                  <TextField
+                    focusOnMount={i === 0}
+                    style={codeBoxFieldStyle}
+                    value={code[i] ?? ""}
+                    onChange={handleBoxChange(i)}
+                    onKeyDown={handleBoxKeyDown(i)}
+                  />
+                </div>
+              </Fragment>
+            ))}
+          </Focusable>
+        </>
+      )}
+      {mode === "credentials" && (
+        <>
+          <div style={helperTextStyle}>
             Enter your RomM username and password once. The plugin exchanges them for an API token and never stores your
             password.
           </div>

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -68,6 +68,7 @@ interface UrlModalProps {
 interface ConnectModalProps {
   onConnect?: (username: string, password: string) => void;
   onConnectToken?: (token: string) => void;
+  onConnectPairing?: (code: string) => void;
 }
 
 function lastShownModalProps<T>(): T | null {
@@ -87,6 +88,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof ConnectionS
     onUrlChange: vi.fn(),
     onConnect: vi.fn(),
     onConnectToken: vi.fn(),
+    onConnectPairing: vi.fn(),
     onAllowInsecureSslChange: vi.fn(),
     onTestConnection: vi.fn(),
     ...overrides,
@@ -157,14 +159,18 @@ describe("ConnectionSection", () => {
       expect(getByText("Sign in")).toBeTruthy();
     });
 
-    it("opens a ConnectModal wired to onConnect and onConnectToken when clicked", () => {
+    it("opens a ConnectModal wired to onConnect, onConnectToken, and onConnectPairing when clicked", () => {
       const onConnect = vi.fn();
       const onConnectToken = vi.fn();
-      const { getByText } = render(<ConnectionSection {...defaultProps({ onConnect, onConnectToken })} />);
+      const onConnectPairing = vi.fn();
+      const { getByText } = render(
+        <ConnectionSection {...defaultProps({ onConnect, onConnectToken, onConnectPairing })} />,
+      );
       fireEvent.click(getByText("Sign in"));
       const props = lastShownModalProps<ConnectModalProps>();
       expect(props?.onConnect).toBe(onConnect);
       expect(props?.onConnectToken).toBe(onConnectToken);
+      expect(props?.onConnectPairing).toBe(onConnectPairing);
     });
   });
 

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -20,6 +20,7 @@ interface ConnectionSectionProps {
   onUrlChange: (value: string) => void;
   onConnect: (username: string, password: string) => void;
   onConnectToken: (token: string) => void;
+  onConnectPairing: (code: string) => void;
   onAllowInsecureSslChange: (value: boolean) => void;
   onTestConnection: () => void;
 }
@@ -33,6 +34,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
   onUrlChange,
   onConnect,
   onConnectToken,
+  onConnectPairing,
   onAllowInsecureSslChange,
   onTestConnection,
 }) => {
@@ -54,7 +56,15 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
         <Field label="RomM Account" description={hasToken ? "Signed in" : "Not signed in"}>
           <DialogButton
             style={{ minWidth: "auto", width: "auto" }}
-            onClick={() => showModal(<ConnectModal onConnect={onConnect} onConnectToken={onConnectToken} />)}
+            onClick={() =>
+              showModal(
+                <ConnectModal
+                  onConnect={onConnect}
+                  onConnectToken={onConnectToken}
+                  onConnectPairing={onConnectPairing}
+                />,
+              )
+            }
           >
             Sign in
           </DialogButton>

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -340,6 +340,88 @@ class TestRommBasicAuthRequest:
             plugin._http_adapter.basic_auth_request("/api/client-tokens", "u", "p", method="POST", data={"name": "x"})
 
 
+class TestUnauthenticatedPostJson:
+    """``unauthenticated_post_json`` POSTs to a public endpoint with no bearer, no retry."""
+
+    _ENDPOINT = "/api/client-tokens/exchange"
+
+    def _staged_resp(self, payload: bytes, status: int = 200):
+        resp = MagicMock()
+        resp.status = status
+        resp.read.return_value = payload
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_omits_authorization_even_with_stored_token(self, plugin):
+        # A stored bearer must NEVER go to the public exchange endpoint.
+        plugin.settings["romm_url"] = "http://romm.local"
+        plugin.settings["romm_api_token"] = "rmm_stored"
+        plugin.settings["romm_api_token_origin"] = "http://romm.local"
+        resp = self._staged_resp(json.dumps({"raw_token": "rmm_paired"}).encode())
+
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            result = plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "ABCD2345"})
+
+        assert result == {"raw_token": "rmm_paired"}
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
+        assert req.get_header("User-agent") == "decky-romm-sync/9.9.9"
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_method() == "POST"
+        assert json.loads(req.data.decode()) == {"code": "ABCD2345"}
+
+    def test_returns_empty_dict_on_204(self, plugin):
+        plugin.settings["romm_url"] = "http://romm.local"
+        resp = self._staged_resp(b"", status=204)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "X"})
+        assert result == {}
+
+    def test_attaches_detail_on_error(self, plugin):
+        # The 404 body's ``detail`` must ride along on the typed error so the
+        # adapter can distinguish the two 404s the exchange returns.
+        plugin.settings["romm_url"] = "http://romm.local"
+        body = json.dumps({"detail": "Token no longer exists"}).encode()
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/client-tokens/exchange",
+            404,
+            "Not Found",
+            http.client.HTTPMessage(),
+            io.BytesIO(body),
+        )
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommNotFoundError) as exc_info:
+            plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "X"})
+        assert exc_info.value.detail == "Token no longer exists"
+
+    def test_maps_429_to_server_error(self, plugin):
+        plugin.settings["romm_url"] = "http://romm.local"
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/client-tokens/exchange", 429, "Too Many Requests", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=exc), pytest.raises(RommServerError) as exc_info:
+            plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "X"})
+        assert exc_info.value.status_code == 429
+
+    def test_does_not_retry(self, plugin):
+        # No with_retry — a single-use credential must not be replayed.
+        plugin.settings["romm_url"] = "http://romm.local"
+        exc = urllib.error.HTTPError(
+            "http://romm.local/api/client-tokens/exchange", 500, "Server Error", http.client.HTTPMessage(), None
+        )
+        with patch("urllib.request.urlopen", side_effect=exc) as mock_open, pytest.raises(RommServerError):
+            plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "X"})
+        assert mock_open.call_count == 1
+
+    def test_transport_failure_maps_to_connection_error(self, plugin):
+        plugin.settings["romm_url"] = "http://romm.local"
+        with (
+            patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")),
+            pytest.raises(RommConnectionError),
+        ):
+            plugin._http_adapter.unauthenticated_post_json(self._ENDPOINT, {"code": "X"})
+
+
 class TestRommRequest:
     def test_uses_auth_header(self, plugin):
         import json as _json

--- a/tests/adapters/romm/test_romm_api.py
+++ b/tests/adapters/romm/test_romm_api.py
@@ -8,7 +8,16 @@ from unittest.mock import MagicMock
 import pytest
 
 from adapters.romm.romm_api import _TOKEN_SCOPES, RommApiAdapter
-from lib.errors import RommNotFoundError, RommServerError, RommUnprocessableEntityError
+from lib.errors import (
+    PairingCodeInvalidError,
+    PairingCodeOwnerDisabledError,
+    PairingCodeRateLimitedError,
+    PairingCodeTokenGoneError,
+    RommForbiddenError,
+    RommNotFoundError,
+    RommServerError,
+    RommUnprocessableEntityError,
+)
 
 if TYPE_CHECKING:
     from models.play_sessions import PlaySessionIngestEntry
@@ -24,6 +33,7 @@ def _make_api():
     client.put_json = MagicMock()
     client.upload_multipart = MagicMock()
     client.basic_auth_request = MagicMock()
+    client.unauthenticated_post_json = MagicMock()
     return RommApiAdapter(client), client
 
 
@@ -970,3 +980,82 @@ class TestDeleteClientToken:
         client.basic_auth_request.side_effect = RommServerError("boom", status_code=500)
         with pytest.raises(RommServerError):
             api.delete_client_token("alice", "secret", token_id=7)
+
+
+class TestExchangePairingCode:
+    def test_posts_code_to_public_exchange_endpoint(self):
+        api, client = _make_api()
+        client.unauthenticated_post_json.return_value = {"id": 5, "raw_token": "rmm_paired"}
+        result = api.exchange_pairing_code("ABCD2345")
+        client.unauthenticated_post_json.assert_called_once_with(
+            "/api/client-tokens/exchange",
+            {"code": "ABCD2345"},
+        )
+        assert result == {"id": 5, "raw_token": "rmm_paired"}
+
+    def test_404_invalid_code_maps_to_pairing_invalid(self):
+        api, client = _make_api()
+        client.unauthenticated_post_json.side_effect = RommNotFoundError("404")
+        with pytest.raises(PairingCodeInvalidError):
+            api.exchange_pairing_code("BADCODE1")
+
+    def test_404_unrelated_detail_maps_to_pairing_invalid(self):
+        api, client = _make_api()
+        err = RommNotFoundError("404")
+        err.detail = "Invalid or expired pairing code"
+        client.unauthenticated_post_json.side_effect = err
+        with pytest.raises(PairingCodeInvalidError):
+            api.exchange_pairing_code("BADCODE1")
+
+    def test_404_token_gone_detail_maps_to_pairing_token_gone(self):
+        api, client = _make_api()
+        err = RommNotFoundError("404")
+        err.detail = "Token no longer exists"
+        client.unauthenticated_post_json.side_effect = err
+        with pytest.raises(PairingCodeTokenGoneError):
+            api.exchange_pairing_code("ABCD2345")
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            "token no longer exists",  # all-lowercase
+            "TOKEN NO LONGER EXISTS",  # all-uppercase
+            "The token no longer exists.",  # embedded + trailing punctuation
+        ],
+    )
+    def test_404_token_gone_detail_case_and_punctuation_insensitive(self, detail):
+        api, client = _make_api()
+        err = RommNotFoundError("404")
+        err.detail = detail
+        client.unauthenticated_post_json.side_effect = err
+        with pytest.raises(PairingCodeTokenGoneError):
+            api.exchange_pairing_code("ABCD2345")
+
+    @pytest.mark.parametrize("detail", [None, 123, {"msg": "token no longer exists"}, ["token no longer exists"]])
+    def test_404_non_string_or_absent_detail_maps_to_pairing_invalid(self, detail):
+        # A non-string / absent detail must never be coerced into the token-gone
+        # branch — it falls back to invalid/expired.
+        api, client = _make_api()
+        err = RommNotFoundError("404")
+        err.detail = detail
+        client.unauthenticated_post_json.side_effect = err
+        with pytest.raises(PairingCodeInvalidError):
+            api.exchange_pairing_code("ABCD2345")
+
+    def test_403_maps_to_owner_disabled(self):
+        api, client = _make_api()
+        client.unauthenticated_post_json.side_effect = RommForbiddenError("403")
+        with pytest.raises(PairingCodeOwnerDisabledError):
+            api.exchange_pairing_code("ABCD2345")
+
+    def test_429_maps_to_rate_limited(self):
+        api, client = _make_api()
+        client.unauthenticated_post_json.side_effect = RommServerError("rate", status_code=429)
+        with pytest.raises(PairingCodeRateLimitedError):
+            api.exchange_pairing_code("ABCD2345")
+
+    def test_5xx_propagates_as_server_error(self):
+        api, client = _make_api()
+        client.unauthenticated_post_json.side_effect = RommServerError("boom", status_code=500)
+        with pytest.raises(RommServerError):
+            api.exchange_pairing_code("ABCD2345")

--- a/tests/contract/test_connect_with_pairing_code.py
+++ b/tests/contract/test_connect_with_pairing_code.py
@@ -1,0 +1,72 @@
+"""Contract test for the ``connect_with_pairing_code`` callable (pairing-code sign-in).
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``connectWithPairingCode = callable<[string, string, boolean], BackendResult>("connect_with_pairing_code")``
+— positional ``(romm_url, code, allow_insecure_ssl)``.
+
+Pins the response SHAPE over the real ``Plugin`` for the happy path (a code
+exchanges for a token → success + persisted with ``"user"`` provenance and no
+server-side id, exactly like a pasted token) and the failure paths (an
+invalid/expired code and a rate-limit both surface the canonical
+``{success: False, reason, message}`` shape with nothing persisted). The
+empty-code guard is exercised too.
+"""
+
+from __future__ import annotations
+
+from lib.errors import PairingCodeInvalidError, PairingCodeRateLimitedError
+
+
+async def test_connect_with_pairing_code_happy_path_persists_user_provenance(harness):
+    harness.romm.heartbeat_response = {"SYSTEM": {"VERSION": "4.9.0"}}
+    harness.romm.exchange_pairing_code_response = {"id": 3, "raw_token": "rmm_paired"}
+
+    result = await harness.plugin.connect_with_pairing_code("http://romm.local", "ABCD2345", False)
+
+    assert result["success"] is True
+    assert result["romm_version"] == "4.9.0"
+    assert "Connected" in result["message"]
+    # Persisted exactly like a pasted token: user provenance, no server-side id;
+    # no mint, no DELETE.
+    assert harness.plugin.settings["romm_api_token"] == "rmm_paired"
+    assert harness.plugin.settings["romm_api_token_id"] is None
+    assert harness.plugin.settings["romm_api_token_origin"] == "http://romm.local"
+    assert harness.plugin.settings["romm_api_token_source"] == "user"
+    assert ("mint_client_token",) not in [(c[0],) for c in harness.romm.call_log]
+    assert harness.romm.deleted_token_ids == []
+    # The code was normalized (uppercased) before the exchange.
+    assert ("exchange_pairing_code", ("ABCD2345",), {}) in harness.romm.call_log
+
+
+async def test_connect_with_pairing_code_invalid_code_returns_canonical_failure(harness):
+    harness.romm.heartbeat_response = {"SYSTEM": {"VERSION": "4.9.0"}}
+    harness.romm.exchange_pairing_code_side_effect = PairingCodeInvalidError("404")
+
+    result = await harness.plugin.connect_with_pairing_code("http://romm.local", "BADCODE1", False)
+
+    assert result["success"] is False
+    assert result["reason"] == "auth_failed"
+    assert "invalid or has expired" in result["message"]
+    # Nothing persisted — the previous (empty) token state stands.
+    assert not harness.plugin.settings.get("romm_api_token")
+    assert harness.plugin.settings.get("romm_api_token_source") is None
+
+
+async def test_connect_with_pairing_code_rate_limited_returns_rate_limited_reason(harness):
+    harness.romm.heartbeat_response = {"SYSTEM": {"VERSION": "4.9.0"}}
+    harness.romm.exchange_pairing_code_side_effect = PairingCodeRateLimitedError("429")
+
+    result = await harness.plugin.connect_with_pairing_code("http://romm.local", "ABCD2345", False)
+
+    assert result["success"] is False
+    assert result["reason"] == "rate_limited"
+    assert "Too many attempts" in result["message"]
+    assert not harness.plugin.settings.get("romm_api_token")
+
+
+async def test_connect_with_pairing_code_blank_code_is_config_error(harness):
+    result = await harness.plugin.connect_with_pairing_code("http://romm.local", "   ", False)
+
+    assert result == {"success": False, "reason": "config_error", "message": "Enter the pairing code from RomM"}
+    # The server was never probed for a blatantly empty code.
+    assert harness.romm.call_log == []

--- a/tests/fakes/fake_romm_api.py
+++ b/tests/fakes/fake_romm_api.py
@@ -148,9 +148,12 @@ class FakeRommApi:
         self.delete_server_saves_side_effect: Exception | None = None
         self.mint_client_token_side_effect: Exception | None = None
         self.delete_client_token_side_effect: Exception | None = None
+        self.exchange_pairing_code_side_effect: Exception | None = None
 
         # Client-token mint: tests stage the response the next mint returns.
         self.mint_client_token_response: dict[str, Any] = {"id": 1, "raw_token": "rmm_faketoken"}
+        # Pairing-code exchange: tests stage the token schema the next exchange returns.
+        self.exchange_pairing_code_response: dict[str, Any] = {"id": 2, "raw_token": "rmm_paired"}
         # Deleted token ids, in call order.
         self.deleted_token_ids: list[int] = []
 
@@ -688,6 +691,11 @@ class FakeRommApi:
         self._log("delete_client_token", (username, password), {"token_id": token_id})
         self._check_fail(self.delete_client_token_side_effect)
         self.deleted_token_ids.append(token_id)
+
+    def exchange_pairing_code(self, code: str) -> dict[str, Any]:
+        self._log("exchange_pairing_code", (code,))
+        self._check_fail(self.exchange_pairing_code_side_effect)
+        return dict(self.exchange_pairing_code_response)
 
     # ------------------------------------------------------------------
     # Test helpers

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -9,7 +9,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lib.errors import RommAuthError, RommConnectionError, RommForbiddenError, RommServerError
+from lib.errors import (
+    PairingCodeInvalidError,
+    PairingCodeOwnerDisabledError,
+    PairingCodeRateLimitedError,
+    PairingCodeTokenGoneError,
+    RommAuthError,
+    RommConnectionError,
+    RommForbiddenError,
+    RommServerError,
+)
 from services.connection import ConnectionService, ConnectionServiceConfig
 
 _MIN_VERSION = (4, 9, 0)
@@ -33,6 +42,7 @@ def romm_api() -> MagicMock:
     api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
     api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
     api.mint_client_token.return_value = {"id": 42, "raw_token": "rmm_minted"}
+    api.exchange_pairing_code.return_value = {"id": 99, "raw_token": "rmm_paired"}
     return api
 
 
@@ -1165,3 +1175,273 @@ class TestProbeReachability:
         romm_api.heartbeat_once.assert_called_once_with()
         # The swallow is diagnosable: a genuine bug is not silently lost.
         assert any("probe_reachability heartbeat failed" in r.message for r in caplog.records)
+
+
+class TestEstablishPairedTokenHappyPath:
+    def test_exchanges_and_stores_token_with_user_provenance(self, event_loop, romm_api, logger, settings_persister):
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is True
+        assert result["romm_version"] == "4.9.0"
+        # A paired token is persisted exactly like a pasted one: user provenance,
+        # no server-side id, and never minted or DELETEd.
+        assert settings["romm_api_token"] == "rmm_paired"
+        assert settings["romm_api_token_id"] is None
+        assert settings["romm_api_token_origin"] == "http://romm.local"
+        assert settings["romm_api_token_source"] == "user"
+        romm_api.mint_client_token.assert_not_called()
+        romm_api.delete_client_token.assert_not_called()
+        assert settings_persister.save_settings.call_count == 1
+
+    def test_validates_token_with_authenticated_users_me_probe(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        romm_api.get_current_user.assert_called_once_with()
+
+    def test_normalizes_code_before_exchange(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ab-cd ef23"))
+        romm_api.exchange_pairing_code.assert_called_once_with("ABCDEF23")
+
+    def test_persists_url_and_ssl_flag(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(
+            service.establish_paired_token("http://romm.local", "ABCD2345", allow_insecure_ssl=True)
+        )
+        assert settings["romm_url"] == "http://romm.local"
+        assert settings["romm_allow_insecure_ssl"] is True
+
+    def test_never_logs_the_code_or_token(self, event_loop, romm_api, logger, caplog):
+        settings: dict[str, Any] = {}
+        romm_api.exchange_pairing_code.return_value = {"id": 1, "raw_token": "rmm_supersecret"}
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        with caplog.at_level(logging.DEBUG, logger="test_connection"):
+            event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "SECRETCODE23"))
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "rmm_supersecret" not in messages
+        assert "SECRETCODE23" not in messages
+
+    def test_forgets_device_on_first_sign_in(self, event_loop, romm_api, logger):
+        settings: dict[str, Any] = {}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        forget_device.assert_called_once_with()
+
+    def test_clears_playtime_scope_notice(self, event_loop, romm_api, logger):
+        clear = MagicMock()
+        settings: dict[str, Any] = {}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            clear_playtime_scope_notice=clear,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is True
+        clear.assert_called_once()
+
+
+class TestEstablishPairedTokenBadPath:
+    def test_empty_url_returns_config_error(self, event_loop, romm_api, logger):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("", "ABCD2345"))
+        assert result == {"success": False, "reason": "config_error", "message": "No server URL configured"}
+        romm_api.heartbeat.assert_not_called()
+
+    @pytest.mark.parametrize("bad_url", ["romm.local", "ftp://romm.local", "   ", "https://"])
+    def test_invalid_url_returns_config_error_without_probing(self, event_loop, romm_api, logger, bad_url):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token(bad_url, "ABCD2345"))
+        assert result == {"success": False, "reason": "config_error", "message": "Enter a valid http(s):// server URL"}
+        romm_api.heartbeat.assert_not_called()
+        romm_api.exchange_pairing_code.assert_not_called()
+
+    @pytest.mark.parametrize("blank_code", ["", "   ", "\t\n", "-", "- -"])
+    def test_blank_code_returns_config_error_without_probing(self, event_loop, romm_api, logger, blank_code):
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", blank_code))
+        assert result == {"success": False, "reason": "config_error", "message": "Enter the pairing code from RomM"}
+        romm_api.heartbeat.assert_not_called()
+        romm_api.exchange_pairing_code.assert_not_called()
+
+    def test_unreachable_server_returns_error_no_exchange(self, event_loop, romm_api, logger):
+        romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        romm_api.exchange_pairing_code.assert_not_called()
+
+    def test_version_gate_failure_returns_version_error_no_exchange(self, event_loop, romm_api, logger):
+        romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "version_error"
+        romm_api.exchange_pairing_code.assert_not_called()
+
+    def test_invalid_code_returns_auth_failed(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeInvalidError("404")
+        service = _make_service(
+            settings={},
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "BADCODE1"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "invalid or has expired" in result["message"]
+        # No validation probe runs after a failed exchange, and nothing persists.
+        romm_api.get_current_user.assert_not_called()
+        settings_persister.save_settings.assert_not_called()
+
+    def test_token_gone_returns_auth_failed_with_own_message(self, event_loop, romm_api, logger):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeTokenGoneError("404")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "no longer exists" in result["message"]
+
+    def test_owner_disabled_returns_auth_failed_with_own_message(self, event_loop, romm_api, logger):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeOwnerDisabledError("403")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "disabled" in result["message"]
+
+    def test_rate_limited_returns_rate_limited_reason(self, event_loop, romm_api, logger):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeRateLimitedError("429")
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "rate_limited"
+        assert "Too many attempts" in result["message"]
+
+    def test_transport_failure_during_exchange_returns_error_response(self, event_loop, romm_api, logger):
+        romm_api.exchange_pairing_code.side_effect = RommServerError("boom", status_code=500)
+        service = _make_service(settings={}, romm_api=romm_api, loop=event_loop, logger=logger)
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+
+    def test_missing_raw_token_returns_error(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.exchange_pairing_code.return_value = {"id": 1}  # no raw_token
+        service = _make_service(
+            settings={},
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "server_unreachable"
+        assert "did not return a usable token" in result["message"]
+        settings_persister.save_settings.assert_not_called()
+
+    def test_users_me_401_after_exchange_returns_auth_failed(self, event_loop, romm_api, logger, settings_persister):
+        # The exchanged token still runs through the shared /users/me validation:
+        # a 401 there rejects it just like a pasted token.
+        romm_api.get_current_user.side_effect = RommAuthError("401")
+        service = _make_service(
+            settings={},
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        assert result["success"] is False
+        assert result["reason"] == "auth_failed"
+        assert "invalid or has been revoked" in result["message"]
+        settings_persister.save_settings.assert_not_called()
+
+
+class TestEstablishPairedTokenSnapshotRestore:
+    """A failed pairing-code sign-in must not clobber the previous working state."""
+
+    def _assert_old_state_intact(self, settings: dict[str, Any]) -> None:
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_id"] == 7
+        assert settings["romm_api_token_origin"] == "https://old.server"
+
+    def test_invalid_code_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeInvalidError("404")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("https://new.server", "BADCODE1"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_rate_limit_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.exchange_pairing_code.side_effect = PairingCodeRateLimitedError("429")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("https://new.server", "ABCD2345"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_probe_failure_restores_old_state_and_never_saves(self, event_loop, romm_api, logger, settings_persister):
+        romm_api.heartbeat.side_effect = RommConnectionError("refused")
+        settings = _working_settings()
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("https://new.server", "ABCD2345"))
+        assert result["success"] is False
+        self._assert_old_state_intact(settings)
+        settings_persister.save_settings.assert_not_called()
+
+    def test_binds_paired_token_to_candidate_origin_during_validation(self, event_loop, romm_api, logger):
+        """The /users/me validation runs with the EXCHANGED token bound to the candidate origin."""
+        seen: dict[str, Any] = {}
+
+        def _capture_get_current_user():
+            seen["token"] = settings.get("romm_api_token")
+            seen["origin"] = settings.get("romm_api_token_origin")
+            return {"id": 1, "username": "tester"}
+
+        romm_api.exchange_pairing_code.return_value = {"id": 1, "raw_token": "rmm_paired"}
+        romm_api.get_current_user.side_effect = _capture_get_current_user
+        settings = _working_settings()
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+        event_loop.run_until_complete(service.establish_paired_token("https://new.server", "ABCD2345"))
+        assert seen["token"] == "rmm_paired"
+        assert seen["origin"] == "https://new.server"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -715,6 +715,7 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_romm_version",
     "connect_with_credentials",
     "connect_with_token",
+    "connect_with_pairing_code",
     "save_server_url",
     "get_settings",
     "get_whitelist_settings",


### PR DESCRIPTION
## What

Third sign-in method: enter an 8-character **pairing code** instead of pasting the full 68-char token — the recommended path for OIDC users and the nicest one on a handheld keyboard.

- **Device side is one unauthenticated call**: `POST /api/client-tokens/exchange` with the normalized code (whitespace/hyphens stripped, uppercased). No polling — the `pair`/`status` endpoints are the web UI's side of the handshake. The response delivers a freshly **rotated** `raw_token`, which then flows through the exact same validation/persist path as a pasted token (`/api/users/me` probe, origin stamping, `romm_api_token_source: "user"`, snapshot-restore on failure) — extracted into a shared `_validate_and_persist_user_token`.
- **Transport**: new `unauthenticated_post_json` — structurally never attaches the bearer, and is strictly **single-attempt**: pairing codes are single-use and the server rate-limits 5 exchange attempts per minute per IP, so a retry can only burn budget.
- **Error taxonomy**: four typed pairing errors mapped to distinct canonical failure messages — invalid/expired/already-used code (server-side indistinguishable, one clear message with the 60-second hint), token deleted (robust case-insensitive substring match on the response detail, pinned to the RomM 4.9.0/4.9.2 source), token owner disabled, rate-limited (bespoke `rate_limited` reason — the server is reachable, so neither auth nor reachability fits).
- **Frontend**: "Pairing code" option in the connect modal's sign-in method dropdown; plain (unmasked) code field with uppercase-on-type — the code lives 60 seconds, typability wins.
- **Docs**: configuration.md now presents pairing (recommended) and paste as the two token sign-in ways, incl. the rotation note (re-pairing a token invalidates the previously delivered bearer — use one token per device); SECURITY.md documents the pairing code as a short-lived single-use credential that is never logged; backend-architecture.md ConnectionService notes updated.

Endpoints verified present in RomM 4.9.0 and 4.9.2 — within the plugin's version floor, no feature detection needed.

## Why

Closes #1331. Follow-up to #1309/#1333: OIDC users can already paste a token; the pairing code removes the 68-char typing and never exposes the raw token to the user at all.

## Testing

- Unit: happy path, code normalization, all four exchange failure classes, version gate, blank code, snapshot-restore on every failure, never-logs (code + token), detail-matching robustness (case/punctuation variants, non-string/absent detail).
- Adapter: `unauthenticated_post_json` omits Authorization even with a stored token, single-attempt on 500, detail attach.
- Contract: `connect_with_pairing_code` frontend-shaped happy + failure with literal response-shape asserts.
- Frontend: third modal mode, no cross-mode submission, routing.
- Full suite green: 4568+ backend, 1511 frontend; ruff, basedpyright (incl. tests/), lint-imports, callable-manifest, failure-shape, event-parity all clean.

On-device smoke test (live exchange, 60-s window, single-use burn, rotation) pending before merge.