### PR TITLE
feat(auth): sign out and signed-in connection actions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,7 +47,9 @@ This plugin handles:
   sign-in. If the configured server URL no longer matches, the bearer is withheld rather than sent — a changed or
   hostile host never receives the credential.
 - The plugin **never deletes or modifies a user-supplied token** on the RomM server — that token's lifecycle is managed
-  by you in RomM; only tokens the plugin itself minted are revoked on re-sign-in.
+  by you in RomM; only tokens the plugin itself minted are revoked on re-sign-in. **Signing out clears the token locally
+  only** — it forgets the token on this device but does **not** revoke it server-side; revoke it yourself in RomM if you
+  no longer want it.
 - The **pairing code** used to sign in without pasting a token is a short-lived (60-second), single-use, 8-character
   code exchanged over an unauthenticated endpoint (the code is the only credential). It is never logged and is discarded
   after the exchange; the RomM server delivers the freshly rotated raw token only to this device in the exchange

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -468,6 +468,23 @@ the URL at a different origin leaves the stored token's origin mismatched and th
 data flows fail fast with `config_error` until the user signs in again. Because every data flow (including device
 registration) is inert until that sign-in, a stale device id from this path cannot be used before the sign-in clears it.
 
+**Sign-out (`sign_out`) is a local forget — never a server-side delete.** `sign_out` clears the token quad
+(`romm_api_token` / `romm_api_token_id` / `romm_api_token_origin` / `romm_api_token_source`) in the in-memory settings
+dict and persists them in a **single** `save_settings()` (the same atomic-write funnel `_persist_token` uses), keeping
+`romm_url` and the SSL flag so the user need not re-enter them. It mirrors the sign-in paths' persist discipline: the
+auth state is snapshotted first, and a failed save rolls the in-memory quad back to the snapshot and returns the
+canonical failure shape (via `error_response`), so a disk error never strands the user with a half-forgotten but
+still-valid token. Only on a **successful** save does it drop the cached RomM server version (`set_version(None)`) so no
+stale value lingers. It is synchronous — no `run_in_executor`, no network — and idempotent (signing out when already
+signed out still returns success). It **never** issues the server-side token DELETE: a minted token deliberately lacks
+`me.write` (deleting it would require re-entering the password, which sign-out does not have), and a user-supplied token
+belongs to the user. That is why the direct re-authentication path stays as **Sign in again** (not sign-out-then-in):
+`establish_token`'s same-origin minted-token cleanup (#1038) only fires while the old token id is still stored, so
+signing out first would strand the old minted token on RomM (which caps tokens per user). After sign-out,
+`test_connection` returns the canonical "Not signed in" `config_error` because `romm_url` survives but the token is
+gone. Signing out (like re-signing-in) while a sync or download is in flight needs no guard: once the token is gone the
+in-flight operation simply fails authentication and surfaces its normal error — deliberate, not a race to defend.
+
 **Server-supplied paths are validated, fail-stop on traversal**: every server-supplied path component — the firmware
 `file_name`, the ROM platform slug, and post-extraction URL-decoded ZIP member names — is checked through
 `lib/path_safety` (`safe_join` for realpath containment, `safe_path_component` for single-component names) before any

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -24,10 +24,29 @@ The Connection Settings page manages your RomM server connection.
     [Sign in with an API token (OIDC)](#sign-in-with-an-api-token-oidc) below.
 
   Both the credentials and the pasted token are write-only — they are never pre-filled or shown back to you.
+
+  Once you are signed in, this button reads **Sign in again** and a **Sign out** button appears below it (see
+  [Sign out](#sign-out)).
 - **Allow Insecure SSL** — shown only for `https://` URLs; skips certificate verification for self-signed certs (LAN
   only).
 - **Test Connection** — available once you are signed in; verifies the plugin can reach and authenticate with your RomM
   server using the stored token.
+
+### Sign out
+
+The **Sign out** button (shown only while signed in) forgets the stored token **on this device**: it clears the token,
+its server-side id, its origin, and its provenance from the plugin's settings, but keeps the **server URL** and the SSL
+setting so you do not have to re-enter them. It asks for confirmation first.
+
+Signing out **never deletes or revokes the token in RomM** — the token stays valid on the server. A token the plugin
+minted from your username and password can only be deleted during a same-server re-sign-in (the stored token
+deliberately lacks the permission to delete itself), and a token you supplied (pasted or paired) is yours to manage. To
+revoke a token for good, delete it in RomM's web UI under **Settings → API Tokens**.
+
+If you just want to switch accounts or re-authenticate, prefer **Sign in again** over signing out and back in. For
+username/password accounts, re-signing in on the **same** server revokes the token the plugin minted before — a path
+that a sign-out then sign-in cannot take, since sign-out has already forgotten the old token's id. RomM caps the number
+of Client API Tokens per user, so avoiding stranded minted tokens matters.
 
 ### Sign in with an API token (OIDC)
 

--- a/main.py
+++ b/main.py
@@ -195,6 +195,9 @@ class Plugin:
     async def connect_with_pairing_code(self, romm_url, code, allow_insecure_ssl=None):
         return await self._connection_service.establish_paired_token(romm_url, code, allow_insecure_ssl)
 
+    async def sign_out(self):
+        return self._connection_service.sign_out()
+
     async def save_server_url(self, romm_url, allow_insecure_ssl=None):
         return self._settings_service.save_server_url(romm_url, allow_insecure_ssl)
 

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -81,6 +81,12 @@ _PAIRING_OWNER_DISABLED_MESSAGE = (
 _PAIRING_RATE_LIMITED_MESSAGE = "Too many attempts — wait a minute and generate a new code."
 _RATE_LIMITED_REASON = "rate_limited"
 
+# Sign-out (``sign_out``). Local-forget only — the plugin never deletes the
+# token on the server, so the copy tells the user it stays valid in RomM.
+_SIGNED_OUT_MESSAGE = (
+    "Signed out. The token is still valid in RomM — revoke it there (Settings → API Tokens) if you no longer want it."
+)
+
 
 def _normalize_pairing_code(code: str) -> str:
     """Normalize a pairing code the way RomM does: drop all whitespace and ``-``, then uppercase.
@@ -560,6 +566,39 @@ class ConnectionService:
             self._logger.warning(f"Legacy credential migration failed: {e}")
             return
         self._logger.info("Migrated legacy credentials to a Client API Token")
+
+    def sign_out(self) -> dict[str, Any]:
+        """Forget the stored Client API Token on this device — local only.
+
+        Clears the token, its server-side id, its minting origin, and its
+        provenance from settings and persists them in a single atomic save,
+        keeping ``romm_url`` and the SSL flag so the user need not re-enter
+        them. Mirrors the sign-in paths' persist discipline: the auth state is
+        snapshotted first, and if the atomic save fails the in-memory state is
+        rolled back to *snapshot* and the canonical failure shape is returned,
+        so a disk error never strands the user with a half-forgotten but
+        still-valid token. Only on a successful save is the cached RomM server
+        version dropped (``set_version(None)``) so a stale value cannot linger.
+        No server-side token deletion ever happens: a plugin-minted token
+        deliberately lacks the ``me.write`` scope needed to delete it (that
+        would require re-entering the password), and a user-supplied token
+        belongs to the user, who manages it in RomM's web UI. Idempotent —
+        signing out when already signed out still succeeds and is harmless.
+        Returns the canonical success shape on success, the canonical failure
+        shape on a persist error.
+        """
+        snapshot = self._snapshot_auth_state()
+        self._settings["romm_api_token"] = None
+        self._settings["romm_api_token_id"] = None
+        self._settings["romm_api_token_origin"] = None
+        self._settings["romm_api_token_source"] = None
+        try:
+            self._settings_persister.save_settings()
+        except Exception as e:
+            self._restore_auth_state(snapshot)
+            return error_response(e)
+        self._romm_api.set_version(None)
+        return {"success": True, "message": _SIGNED_OUT_MESSAGE}
 
     # ── Internal helpers ─────────────────────────────────────────────────
 

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -103,6 +103,7 @@ export const connectWithCredentials = callable<[string, string, string, boolean]
 );
 export const connectWithToken = callable<[string, string, boolean], BackendResult>("connect_with_token");
 export const connectWithPairingCode = callable<[string, string, boolean], BackendResult>("connect_with_pairing_code");
+export const signOut = callable<[], BackendResult>("sign_out");
 
 export interface WhitelistSettings {
   disabled_defaults: string[];

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -836,6 +836,76 @@ describe("SettingsPage", () => {
     });
   });
 
+  describe("handleSignOut (local token forget)", () => {
+    it("calls signOut, surfaces the message, and flips hasToken to false on success", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: true,
+      });
+      vi.mocked(backend.signOut).mockResolvedValue({
+        success: true,
+        message: "Signed out. The token is still valid in RomM.",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      // Precondition: signed in.
+      expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(true);
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onSignOut();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(backend.signOut)).toHaveBeenCalledTimes(1);
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Signed out. The token is still valid in RomM.");
+      expect(conn?.hasToken).toBe(false);
+    });
+
+    it("keeps hasToken true when signOut reports failure", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: true,
+      });
+      vi.mocked(backend.signOut).mockResolvedValue({
+        success: false,
+        message: "Could not save settings.",
+        reason: "config_error",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onSignOut();
+        await Promise.resolve();
+      });
+
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Could not save settings.");
+      expect(conn?.hasToken).toBe(true);
+    });
+
+    it("sets status='Sign-out failed' when signOut throws", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        has_token: true,
+      });
+      vi.mocked(backend.signOut).mockRejectedValue(new Error("net"));
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onSignOut();
+        await Promise.resolve();
+      });
+
+      const conn = capturedConnection[capturedConnection.length - 1];
+      expect(conn?.status).toBe("Sign-out failed");
+      // A thrown sign-out leaves the session intact.
+      expect(conn?.hasToken).toBe(true);
+    });
+  });
+
   describe("handleTest", () => {
     it("forwards the result message into ConnectionSection.status on success", async () => {
       vi.mocked(backend.testConnection).mockResolvedValue({

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   connectWithCredentials,
   connectWithToken,
   connectWithPairingCode,
+  signOut,
   testConnection,
   saveSgdbApiKey,
   verifySgdbApiKey,
@@ -341,6 +342,18 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
       setStatus("Sign-in failed");
     }
   };
+  const handleSignOut = async () => {
+    setStatus("");
+    try {
+      const result = await signOut();
+      setStatus(result.message);
+      if (result.success) {
+        setHasToken(false);
+      }
+    } catch {
+      setStatus("Sign-out failed");
+    }
+  };
 
   // --- SteamGridDB handlers ---
   const handleSgdbKeySubmit = async (value: string) => {
@@ -490,6 +503,9 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         onAllowInsecureSslChange={handleAllowInsecureSslChange}
         onTestConnection={() => {
           detach(handleTest());
+        }}
+        onSignOut={() => {
+          detach(handleSignOut());
         }}
       />
       <SteamGridDBSection

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@decky/ui", () => ({
       onChange: (e: { target: { checked: boolean } }) => p.onChange?.(e.target.checked),
     });
   },
+  ConfirmModal: (p: AnyProps) => createElement("div", { "data-testid": "confirm-modal" }, p.children as never),
   showModal: vi.fn(),
 }));
 
@@ -69,6 +70,13 @@ interface ConnectModalProps {
   onConnect?: (username: string, password: string) => void;
   onConnectToken?: (token: string) => void;
   onConnectPairing?: (code: string) => void;
+}
+interface ConfirmModalProps {
+  strTitle?: string;
+  strDescription?: string;
+  strOKButtonText?: string;
+  strCancelButtonText?: string;
+  onOK?: () => void;
 }
 
 function lastShownModalProps<T>(): T | null {
@@ -91,6 +99,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof ConnectionS
     onConnectPairing: vi.fn(),
     onAllowInsecureSslChange: vi.fn(),
     onTestConnection: vi.fn(),
+    onSignOut: vi.fn(),
     ...overrides,
   };
 }
@@ -171,6 +180,59 @@ describe("ConnectionSection", () => {
       expect(props?.onConnect).toBe(onConnect);
       expect(props?.onConnectToken).toBe(onConnectToken);
       expect(props?.onConnectPairing).toBe(onConnectPairing);
+    });
+  });
+
+  describe("account actions by sign-in state", () => {
+    it("shows a single 'Sign in' action and no sign-out when signed out", () => {
+      const { getByText, queryByText } = render(<ConnectionSection {...defaultProps({ hasToken: false })} />);
+      expect(getByText("Sign in")).toBeTruthy();
+      expect(queryByText("Sign in again")).toBeNull();
+      expect(queryByText("Sign out")).toBeNull();
+    });
+
+    it("shows 'Sign in again' and 'Sign out' actions when signed in", () => {
+      const { getByText, queryByText } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
+      expect(getByText("Sign in again")).toBeTruthy();
+      expect(getByText("Sign out")).toBeTruthy();
+      // The bare "Sign in" label is replaced by "Sign in again" once signed in.
+      expect(queryByText("Sign in")).toBeNull();
+    });
+
+    it("'Sign in again' opens the same ConnectModal as first sign-in", () => {
+      const onConnect = vi.fn();
+      const onConnectToken = vi.fn();
+      const onConnectPairing = vi.fn();
+      const { getByText } = render(
+        <ConnectionSection {...defaultProps({ hasToken: true, onConnect, onConnectToken, onConnectPairing })} />,
+      );
+      fireEvent.click(getByText("Sign in again"));
+      const props = lastShownModalProps<ConnectModalProps>();
+      expect(props?.onConnect).toBe(onConnect);
+      expect(props?.onConnectToken).toBe(onConnectToken);
+      expect(props?.onConnectPairing).toBe(onConnectPairing);
+    });
+  });
+
+  describe("Sign out button", () => {
+    it("opens a ConfirmModal noting the token stays valid in RomM", () => {
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true })} />);
+      fireEvent.click(getByText("Sign out"));
+      const props = lastShownModalProps<ConfirmModalProps>();
+      expect(props?.strTitle).toBe("Sign out of RomM?");
+      expect(props?.strOKButtonText).toBe("Sign out");
+      expect(props?.strDescription).toContain("stays valid in RomM");
+    });
+
+    it("fires onSignOut only when the confirm modal is accepted", () => {
+      const onSignOut = vi.fn();
+      const { getByText } = render(<ConnectionSection {...defaultProps({ hasToken: true, onSignOut })} />);
+      fireEvent.click(getByText("Sign out"));
+      // Opening the modal must not sign out on its own.
+      expect(onSignOut).not.toHaveBeenCalled();
+      const props = lastShownModalProps<ConfirmModalProps>();
+      props?.onOK?.();
+      expect(onSignOut).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -6,10 +6,24 @@
  */
 
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, DialogButton, Field, showModal, ToggleField } from "@decky/ui";
+import {
+  PanelSection,
+  PanelSectionRow,
+  ButtonItem,
+  ConfirmModal,
+  DialogButton,
+  Field,
+  showModal,
+  ToggleField,
+} from "@decky/ui";
 import { TextInputModal } from "./TextInputModal";
 import { ConnectModal } from "./ConnectModal";
 import { isHttpsUrl } from "../../utils/serverUrl";
+
+// Sign-out only forgets the token on this device; it never revokes it in RomM.
+const SIGN_OUT_CONFIRM_DESCRIPTION =
+  "This only forgets the RomM token on this device. The token itself stays valid in RomM — " +
+  "revoke it there (Settings → API Tokens) if you no longer want it.";
 
 interface ConnectionSectionProps {
   url: string;
@@ -23,6 +37,7 @@ interface ConnectionSectionProps {
   onConnectPairing: (code: string) => void;
   onAllowInsecureSslChange: (value: boolean) => void;
   onTestConnection: () => void;
+  onSignOut: () => void;
 }
 
 export const ConnectionSection: FC<ConnectionSectionProps> = ({
@@ -37,6 +52,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
   onConnectPairing,
   onAllowInsecureSslChange,
   onTestConnection,
+  onSignOut,
 }) => {
   return (
     <PanelSection title="Connection">
@@ -66,10 +82,31 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
               )
             }
           >
-            Sign in
+            {hasToken ? "Sign in again" : "Sign in"}
           </DialogButton>
         </Field>
       </PanelSectionRow>
+      {hasToken && (
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            description="Forgets the RomM token on this device. The token stays valid in RomM."
+            onClick={() =>
+              showModal(
+                <ConfirmModal
+                  strTitle="Sign out of RomM?"
+                  strDescription={SIGN_OUT_CONFIRM_DESCRIPTION}
+                  strOKButtonText="Sign out"
+                  strCancelButtonText="Cancel"
+                  onOK={onSignOut}
+                />,
+              )
+            }
+          >
+            Sign out
+          </ButtonItem>
+        </PanelSectionRow>
+      )}
       {isHttpsUrl(url) && (
         <PanelSectionRow>
           <ToggleField

--- a/tests/contract/test_sign_out.py
+++ b/tests/contract/test_sign_out.py
@@ -1,0 +1,53 @@
+"""Contract test for the ``sign_out`` callable.
+
+Driven frontend-shaped per ``src/api/backend.ts``:
+``signOut = callable<[], BackendResult>("sign_out")`` — no arguments.
+
+Pins the response SHAPE over the real ``Plugin``: signing out returns the
+canonical success shape, clears the stored token locally while keeping
+``romm_url`` + the SSL flag, and never deletes the token on the server. A
+follow-up ``test_connection`` then reports the canonical "Not signed in"
+``config_error`` because the token is gone but the URL survives.
+"""
+
+from __future__ import annotations
+
+
+def _seed_signed_in(harness) -> None:
+    harness.plugin.settings["romm_url"] = "http://romm.local"
+    harness.plugin.settings["romm_allow_insecure_ssl"] = False
+    harness.plugin.settings["romm_api_token"] = "rmm_token"
+    harness.plugin.settings["romm_api_token_id"] = 42
+    harness.plugin.settings["romm_api_token_origin"] = "http://romm.local"
+    harness.plugin.settings["romm_api_token_source"] = "minted"
+
+
+async def test_sign_out_clears_token_locally_and_keeps_url(harness):
+    _seed_signed_in(harness)
+
+    result = await harness.plugin.sign_out()
+
+    assert result["success"] is True
+    assert "Signed out" in result["message"]
+    # Token trio + provenance cleared; URL + SSL flag kept.
+    assert harness.plugin.settings["romm_api_token"] is None
+    assert harness.plugin.settings["romm_api_token_id"] is None
+    assert harness.plugin.settings["romm_api_token_origin"] is None
+    assert harness.plugin.settings["romm_api_token_source"] is None
+    assert harness.plugin.settings["romm_url"] == "http://romm.local"
+    assert harness.plugin.settings["romm_allow_insecure_ssl"] is False
+    # No server-side token deletion — sign-out is local-forget only.
+    assert harness.romm.deleted_token_ids == []
+
+
+async def test_test_connection_after_sign_out_is_not_signed_in(harness):
+    _seed_signed_in(harness)
+
+    await harness.plugin.sign_out()
+    result = await harness.plugin.test_connection()
+
+    assert result == {
+        "success": False,
+        "reason": "config_error",
+        "message": "Not signed in — sign in to RomM first",
+    }

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -1445,3 +1445,102 @@ class TestEstablishPairedTokenSnapshotRestore:
         event_loop.run_until_complete(service.establish_paired_token("https://new.server", "ABCD2345"))
         assert seen["token"] == "rmm_paired"
         assert seen["origin"] == "https://new.server"
+
+
+class TestSignOut:
+    """``sign_out`` forgets the token locally — one atomic save, no server call."""
+
+    def test_clears_token_keys_keeps_url_and_ssl_and_persists_once(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        settings = _working_settings()
+        settings["romm_api_token_source"] = "minted"
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = service.sign_out()
+
+        assert result["success"] is True
+        assert "Signed out" in result["message"]
+        # The four token keys are cleared to None.
+        assert settings["romm_api_token"] is None
+        assert settings["romm_api_token_id"] is None
+        assert settings["romm_api_token_origin"] is None
+        assert settings["romm_api_token_source"] is None
+        # URL + SSL flag are kept for convenience.
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_allow_insecure_ssl"] is False
+        # Persisted in exactly one atomic save; version cache cleared.
+        settings_persister.save_settings.assert_called_once_with()
+        romm_api.set_version.assert_called_once_with(None)
+
+    def test_never_deletes_token_on_server(self, event_loop, romm_api, logger):
+        settings = _working_settings()
+        settings["romm_api_token_source"] = "minted"
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        service.sign_out()
+
+        romm_api.delete_client_token.assert_not_called()
+
+    def test_idempotent_when_already_signed_out(self, event_loop, romm_api, logger, settings_persister):
+        """Signing out with no stored token still succeeds and persists cleanly."""
+        settings: dict[str, Any] = {"romm_url": "https://old.server", "romm_allow_insecure_ssl": True}
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = service.sign_out()
+
+        assert result["success"] is True
+        assert settings["romm_api_token"] is None
+        assert settings["romm_url"] == "https://old.server"
+        assert settings["romm_allow_insecure_ssl"] is True
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_mutates_settings_dict_in_place(self, event_loop, romm_api, logger):
+        """The live settings dict identity is preserved (mutated, not rebound)."""
+        settings = _working_settings()
+        service = _make_service(settings=settings, romm_api=romm_api, loop=event_loop, logger=logger)
+
+        service.sign_out()
+
+        assert service._settings is settings
+
+    def test_persist_failure_returns_canonical_failure_and_restores_keys(
+        self, event_loop, romm_api, logger, settings_persister
+    ):
+        """A failed atomic save rolls the token quad back so the still-valid token survives."""
+        settings = _working_settings()
+        settings["romm_api_token_source"] = "minted"
+        settings_persister.save_settings.side_effect = OSError("disk full")
+        service = _make_service(
+            settings=settings,
+            romm_api=romm_api,
+            loop=event_loop,
+            logger=logger,
+            settings_persister=settings_persister,
+        )
+
+        result = service.sign_out()
+
+        # Canonical failure shape (reason + message both present).
+        assert result["success"] is False
+        assert result["reason"] == "unknown"
+        assert "disk full" in result["message"]
+        # All four token keys restored in-memory — the token is still stored.
+        assert settings["romm_api_token"] == "rmm_old"
+        assert settings["romm_api_token_id"] == 7
+        assert settings["romm_api_token_origin"] == "https://old.server"
+        assert settings["romm_api_token_source"] == "minted"
+        # The version cache is cleared only after a successful save.
+        romm_api.set_version.assert_not_called()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -716,6 +716,8 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "connect_with_credentials",
     "connect_with_token",
     "connect_with_pairing_code",
+    # Local-forget-only token clear — mutates settings.json, never RetroDECK state.
+    "sign_out",
     "save_server_url",
     "get_settings",
     "get_whitelist_settings",


### PR DESCRIPTION
## What

- **New `sign_out` callable — local forget only.** Clears the stored token, its server-side id, its origin binding, and its provenance marker in one atomic save; keeps `romm_url` and the SSL flag. Mirrors the sign-in paths' persist discipline: auth state is snapshotted first, a failed save rolls back in-memory state and returns the canonical failure shape; the cached server version is dropped only after a successful save. **No server-side token deletion, ever** — a plugin-minted token deliberately lacks the `me.write` scope needed to delete it, and a user-supplied (pasted/paired) token belongs to the user, who manages it in RomM's web UI.
- **Signed-in connection actions**: the QAM connection section now shows **Sign in again** (direct re-sign-in — kept deliberately, since the same-origin cleanup of plugin-minted tokens on re-sign-in (#1038) only works while the old token id is still stored; a signout-first toggle would strand minted tokens server-side) plus **Sign out** behind a confirm modal whose copy notes the token stays valid in RomM. Signed out, the single **Sign in** button is unchanged. After sign-out the section flips to "Not signed in" without a plugin reload.
- Signing out (like re-signing-in) while a sync/download is in flight needs no guard: the in-flight operation simply fails authentication and surfaces its normal error — deliberate, documented.
- **Docs**: configuration.md sign-out paragraph (incl. how to revoke a token in RomM manually), backend-architecture ConnectionService notes, SECURITY.md clause (local clear ≠ server-side revoke).

## Why

Closes #1332. Completes the sign-in surface built in #1333 / #1335: there was no sign-out at all, and the connection section always showed "Sign in" regardless of state.

## Testing

- Unit: sign_out clears exactly the four token keys, keeps URL/SSL, persists once, in-place dict mutation, idempotent when signed out, persist-failure rollback (canonical failure, keys restored, version cache untouched).
- Contract: frontend-shaped no-arg call, literal response shape, subsequent `test_connection` returns the canonical "Not signed in" config_error.
- Frontend: both-actions rendering per state, confirm-modal flow, post-signout state flip, failure path keeps signed-in state — non-vacuous asserts.
- Full suite green: 4581+ backend, 1527 frontend; ruff, basedpyright (incl. tests/), lint-imports, callable-manifest, failure-shape, settings-owner, event-parity all clean.