### PR TITLE
feat(library): one steam shortcut per sibling group with deterministic binding

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,6 +109,26 @@ Three things spell similarly; distinct meanings:
 Convention: always write `Rom` (PascalCase) when referring to the aggregate. Write "ROM file" when referring to the
 on-disk artifact.
 
+### Version (RomM: sibling) vs Region / Languages
+
+A **version** is one concrete released dump of a game — its own RomM `rom_id`, its own file, its own save universe
+(saves never carry across versions; matches RomM's per-ROM saves and RetroArch's per-content save naming). All versions
+of one game form a **sibling group** (RomM's `sibling_roms`: same matched metadata id, per platform; unmatched ROMs are
+solo groups). Key derivation: `domain/sibling_group.py`, persisted as `roms.sibling_group_key`
+([ADR-0021](docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md)).
+
+- **Active version** — the sibling currently bound to the group's Steam shortcut (`roms.shortcut_app_id`); the one that
+  installs, launches, and syncs saves. Binding = active version (ADR-0021).
+- **Default version** — RomM's per-user `is_main_sibling` ("SET DEFAULT" in RomM's Switch-version UI). Optional;
+  respected read-only as a preselect, never written back.
+- **Switch version** — the user-facing control (named after RomM's) that changes the active version within a group;
+  rendered only when the group has more than one version (#1297/#1298).
+
+**Region** and **Languages** are **attributes of a single version**, parsed from its filename tags: `(Spain)` → where
+that release shipped; `(En,Fr,De,Es)` → the languages contained in that one dump. A multi-language version is still one
+version. UI rule: Region/Languages render on the game-detail page for the active version only — they are never a version
+list and never the switch mechanism.
+
 ### file_path vs rom_dir (RomInstall paths)
 
 The two path fields on `RomInstall` (`domain/rom_install.py`) answer different questions and must not be conflated:

--- a/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md
+++ b/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md
@@ -63,15 +63,51 @@ version flips only the baked `launch_options` (appId-safe, hardware-validated in
 target row; artwork, collections, playtime and the Steam appId all survive. Renaming is what would change the appId
 (delete + recreate churn), so it never happens implicitly.
 
-### 3. Version resolution chain: installed > existing binding > RomM default > alphabetical; the choice stays local
+### 3. Version resolution chain: installed > existing binding > RomM default > region priority > alphabetical; the choice stays local
 
 Wherever one version must be chosen (shortcut representative, picker preselect), the chain is: an installed sibling
-wins; else an existing binding; else the server-side `is_main_sibling` default (respected read-only); else alphabetical
-`fs_name_no_ext` — the last leg being exactly RomM's own fallback, so an ungroomed library behaves identically to the
-RomM web UI. The user's version choice is expressed solely through which sibling is bound/installed — **no write-back**
-of `is_main_sibling` to the server. Writing it would require the `roms.user.write` scope, and a scope change invalidates
-every user's token (forced re-sign-in) — too high a price for mirroring a preference RomM already lets the user set in
-its own UI.
+wins; else an existing binding; else the server-side `is_main_sibling` default (respected read-only); else **region
+priority**; else alphabetical `fs_name_no_ext`; else `rom_id`. The first three legs are membership filters; the last
+three are the total order applied inside the surviving leg. The alphabetical leg is exactly RomM's own fallback, so an
+ungroomed library with no region signal behaves identically to the RomM web UI. The user's version choice is expressed
+solely through which sibling is bound/installed — **no write-back** of `is_main_sibling` to the server. Writing it would
+require the `roms.user.write` scope, and a scope change invalidates every user's token (forced re-sign-in) — too high a
+price for mirroring a preference RomM already lets the user set in its own UI.
+
+> **Amendment (region priority + canonical naming, same PR as the region-priority slice).** The chain above originally
+> ended at `alphabetical`. On real libraries the alphabetical leg binds — and, because the shortcut name is minted from
+> the winner and is **sticky forever**, permanently names — the wrong dump: e.g. the Japanese dump of Pokémon FireRed,
+> naming the shortcut `ポケットモンスターファイアレッド`. Two amendments, both local-only, no new server scope:
+>
+> - **Region-priority leg** (inserted before alphabetical). A version is ranked by its **best** `regions` entry against
+>   a **fixed** build-time default order — `World > USA > Europe > Japan` (World first for explicit multi-region
+>   international releases; USA before Europe to match the 1G1R convention and avoid PAL-50Hz dumps being the silent
+>   default on older consoles), every other named region after these ranked alphabetically among themselves, and a
+>   version with no region ranked last. This order is a fixed constant, **not** a language/system detection. A single
+>   user override, the `preferred_region` setting (a bucket-1 user-intent config → `settings.json`, per ADR-0003;
+>   default `"auto"` = the fixed order), lifts one region to the very top; the default order continues behind it. The
+>   leg is evaluated **at resolution time** (during a sync's collapse), so the preference takes effect only on the next
+>   sync — no live re-resolution, and an **existing binding shields its group** (the installed/binding legs win before
+>   region priority is even consulted), which is exactly why changing the preference never disturbs already-synced
+>   games. The domain stays pure: the preference enters `resolve_group_representative` (and the naming function below)
+>   as an explicit parameter, read from settings in the service layer and threaded into every collapse call site
+>   (preview + apply) as the same value within a run. The QAM dropdown that sets it is populated from **fixed anchors**
+>   (Default, World, USA, Europe, Japan) plus the distinct regions read from the **local** `roms.regions` of the synced
+>   library (no server scan), and a confirmation modal spells out the apply-at-next-sync / no-retroactive-rename
+>   semantics before persisting.
+> - **Canonical name follows the pure ranking, not the bound member** (mint-time only). `canonical_group_name` returns
+>   the `name` of the member ranked first by the **pure** order (region priority > alphabetical > `rom_id`), ignoring
+>   the installed/binding/default filters — explicitly **not** majority voting (two Japan dumps + one USA yields the USA
+>   member's name). A NEW group's shortcut is minted with this canonical name while its `rom_id`/bind target stays the
+>   resolution-chain representative, so a Japanese _default_ still binds and launches Japan but the shortcut carries the
+>   USA name (the "name can lag the active version" trade-off in Consequences, now made deliberate for the region-
+>   preferred name). The appId is minted from the canonical name by the frontend `AddShortcut`; the DB binding lands on
+>   the representative `rom_id`; the commit path is agnostic to the name↔rom mismatch (it binds on `rom_id` + the acked
+>   appId, and persists each sibling's own RomM name). **Mint only:** an already-bound group (grandfathered / rebind)
+>   carries its persisted bound name verbatim — emitting a different name would flip `classify_roms` to "changed" and
+>   rename the live shortcut, changing its appId; that must never happen. Under a partial (collection) view the
+>   canonical name is chosen among the fetched members only — acceptable and documented, since the group's real
+>   representative rides its own platform unit in the same run.
 
 ### 4. Saves stay per rom_id; a version switch never migrates saves
 

--- a/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md
+++ b/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md
@@ -63,22 +63,36 @@ version flips only the baked `launch_options` (appId-safe, hardware-validated in
 target row; artwork, collections, playtime and the Steam appId all survive. Renaming is what would change the appId
 (delete + recreate churn), so it never happens implicitly.
 
-### 3. Version resolution chain: installed > existing binding > RomM default > region priority > alphabetical; the choice stays local
+### 3. Version resolution chain: installed > existing binding > RomM default > 1G1R ranking; the choice stays local
 
 Wherever one version must be chosen (shortcut representative, picker preselect), the chain is: an installed sibling
-wins; else an existing binding; else the server-side `is_main_sibling` default (respected read-only); else **region
-priority**; else alphabetical `fs_name_no_ext`; else `rom_id`. The first three legs are membership filters; the last
-three are the total order applied inside the surviving leg. The alphabetical leg is exactly RomM's own fallback, so an
-ungroomed library with no region signal behaves identically to the RomM web UI. The user's version choice is expressed
-solely through which sibling is bound/installed — **no write-back** of `is_main_sibling` to the server. Writing it would
-require the `roms.user.write` scope, and a scope change invalidates every user's token (forced re-sign-in) — too high a
-price for mirroring a preference RomM already lets the user set in its own UI.
+wins; else an existing binding; else the server-side `is_main_sibling` default (respected read-only); else the **1G1R
+ranking** — prerelease demotion, then **region priority**, then newest revision, then alphabetical `fs_name_no_ext`,
+then `rom_id`. The first three legs are membership filters; the rest are the total order applied inside the surviving
+leg. The alphabetical leg is exactly RomM's own fallback, so an ungroomed retail library with no region signal behaves
+identically to the RomM web UI. The user's version choice is expressed solely through which sibling is bound/installed —
+**no write-back** of `is_main_sibling` to the server. Writing it would require the `roms.user.write` scope, and a scope
+change invalidates every user's token (forced re-sign-in) — too high a price for mirroring a preference RomM already
+lets the user set in its own UI.
 
-> **Amendment (region priority + canonical naming, same PR as the region-priority slice).** The chain above originally
+> **Amendment (1G1R ranking + canonical naming, same PR as the region-priority slice).** The chain above originally
 > ended at `alphabetical`. On real libraries the alphabetical leg binds — and, because the shortcut name is minted from
 > the winner and is **sticky forever**, permanently names — the wrong dump: e.g. the Japanese dump of Pokémon FireRed,
-> naming the shortcut `ポケットモンスターファイアレッド`. Two amendments, both local-only, no new server scope:
+> naming the shortcut `ポケットモンスターファイアレッド`. These amendments, all local-only, no new server scope:
 >
+> - **1G1R ranking hardening — prerelease demotion + revision (igir / No-Intro convention).** The total order the
+>   fallback legs apply gained two dimensions bracketing the region leg. **Prerelease demotion ranks FIRST, before
+>   region:** a member is prerelease when any of its structured `tags` names a draft build — Alpha, Beta (incl. numbered
+>   `Beta 1` / `Beta 2`), Proto, Sample, Demo (case-insensitive, tolerant of a trailing number) — and is demoted below
+>   **every** retail sibling regardless of region, so a finished `(Japan)` release beats a `(USA) (Beta)` (finals before
+>   prereleases, **across regions** — the cross-region rule). `Unl`, `Aftermarket`, collection-name tags and any unknown
+>   tag carry no finished-vs-draft signal and are neutral (never demoted). **Newest revision ranks after region:**
+>   within one region the higher `revision` wins (natural compare — `(Rev 3)` beats `(Rev 1)` beats the base dump; empty
+>   = lowest), but the leg sits **below** region, so a `(USA)` base still beats a `(Europe) (Rev 9)`. The alphabetical
+>   `fs_name_no_ext` leg stays last-but-one and also keeps a base dump ahead of a filename-only re-dump
+>   (`(Virtual Console)`, `(Extended Edition)`) that RomM does **not** parse into a structured tag. The full fallback
+>   order is therefore **prerelease demotion > region priority > revision (newest) > alphabetical > `rom_id`**. Like
+>   region priority, both new legs are local-only, evaluated at resolution time, and shielded by an existing binding.
 > - **Region-priority leg** (inserted before alphabetical). A version is ranked by its **best** `regions` entry against
 >   a **fixed** build-time default order — `World > USA > Europe > Japan` (World first for explicit multi-region
 >   international releases; USA before Europe to match the 1G1R convention and avoid PAL-50Hz dumps being the silent
@@ -96,18 +110,18 @@ price for mirroring a preference RomM already lets the user set in its own UI.
 >   library (no server scan), and a confirmation modal spells out the apply-at-next-sync / no-retroactive-rename
 >   semantics before persisting.
 > - **Canonical name follows the pure ranking, not the bound member** (mint-time only). `canonical_group_name` returns
->   the `name` of the member ranked first by the **pure** order (region priority > alphabetical > `rom_id`), ignoring
->   the installed/binding/default filters — explicitly **not** majority voting (two Japan dumps + one USA yields the USA
->   member's name). A NEW group's shortcut is minted with this canonical name while its `rom_id`/bind target stays the
->   resolution-chain representative, so a Japanese _default_ still binds and launches Japan but the shortcut carries the
->   USA name (the "name can lag the active version" trade-off in Consequences, now made deliberate for the region-
->   preferred name). The appId is minted from the canonical name by the frontend `AddShortcut`; the DB binding lands on
->   the representative `rom_id`; the commit path is agnostic to the name↔rom mismatch (it binds on `rom_id` + the acked
->   appId, and persists each sibling's own RomM name). **Mint only:** an already-bound group (grandfathered / rebind)
->   carries its persisted bound name verbatim — emitting a different name would flip `classify_roms` to "changed" and
->   rename the live shortcut, changing its appId; that must never happen. Under a partial (collection) view the
->   canonical name is chosen among the fetched members only — acceptable and documented, since the group's real
->   representative rides its own platform unit in the same run.
+>   the `name` of the member ranked first by the **pure** order (prerelease demotion > region priority > revision >
+>   alphabetical > `rom_id`), ignoring the installed/binding/default filters — explicitly **not** majority voting (two
+>   Japan dumps + one USA yields the USA member's name). A NEW group's shortcut is minted with this canonical name while
+>   its `rom_id`/bind target stays the resolution-chain representative, so a Japanese _default_ still binds and launches
+>   Japan but the shortcut carries the USA name (the "name can lag the active version" trade-off in Consequences, now
+>   made deliberate for the region- preferred name). The appId is minted from the canonical name by the frontend
+>   `AddShortcut`; the DB binding lands on the representative `rom_id`; the commit path is agnostic to the name↔rom
+>   mismatch (it binds on `rom_id` + the acked appId, and persists each sibling's own RomM name). **Mint only:** an
+>   already-bound group (grandfathered / rebind) carries its persisted bound name verbatim — emitting a different name
+>   would flip `classify_roms` to "changed" and rename the live shortcut, changing its appId; that must never happen.
+>   Under a partial (collection) view the canonical name is chosen among the fetched members only — acceptable and
+>   documented, since the group's real representative rides its own platform unit in the same run.
 
 ### 4. Saves stay per rom_id; a version switch never migrates saves
 

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -202,6 +202,54 @@ unconditional cancel path rather than a stale prior-run id the backend would rej
 `sync_state`, and `sync_apply_delta` independently validates the `preview_id`, so a stale preview-cancel cannot abort a
 fresh sync.
 
+**Group-aware sync — one Steam shortcut per sibling group
+([ADR-0021](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md)).**
+A game frequently exists in a RomM library as several dumps of the same title (region / language / revision variants).
+These share a **sibling group** (same `roms.sibling_group_key`, derived client-side by `domain/sibling_group.py`). The
+sync pipeline treats a group as one game = at most one **new** Steam shortcut; the sibling row holding `shortcut_app_id`
+is the group's **active version**.
+
+- **Persist all siblings, emit one shortcut per group.** The reporter's per-unit commit upserts a `roms` row (identity +
+  version metadata, via the sync UPSERT) for **every** fetched ROM of the unit, but only the group's representative
+  carries a Steam-shortcut binding — a non-representative sibling is a tracked, unbound row. Persisting the whole group
+  is what the version picker (#1297) and the incremental-skip gate need; binding only the representative is what stops
+  the same-named-collision and duplicate-shortcut bugs the ADR describes.
+- **The collapse happens at the same `build_shortcuts_data` boundary in both paths**
+  (`domain/sync_diff.py::collapse_sibling_groups`). Preview and apply build the full per-ROM shortcut list, then
+  collapse it to one entry per group against the bound-row registry (preview reads `_read_preview_baseline`, apply reads
+  `_read_apply_registry` per unit). The collapse takes an explicit `complete_group_view` flag: a sibling group is
+  per-platform, so the whole-library **preview** union and each **platform** apply unit see a group's whole membership
+  (`complete_group_view=True`) and collapse identically — the preview counts can never diverge from what those units
+  create (the #1292 counts-vs-reality bug class). A **collection** apply unit spans platforms and may fetch only one
+  unbound sibling of a group whose bound member it never fetched, so it is a **partial** view
+  (`complete_group_view=False`): a group that already holds a binding anywhere is grandfathered untouched — never
+  rebound onto the partial member, never given a second shortcut — because the group's real representative rides its own
+  platform unit in the same run. (Inferring "bound sibling absent ⇒ vanished" from a partial view would rebind a live
+  installed game onto an uninstalled sibling — #1296.) `classify_roms` runs over the collapsed set, so its new / changed
+  / unchanged / stale buckets count **games, not dumps**, and an unbound sibling stops reading as a perpetual "new".
+- **Resolution chain** (`domain/sibling_resolution.py::resolve_group_representative`, total + shuffle-stable): an
+  installed sibling wins; else an existing binding; else RomM's per-user default (`is_main_sibling`); else alphabetical
+  `fs_name_no_ext`. Ties break on `fs_name_no_ext` then `rom_id`. Used wherever one version must be chosen (a new
+  group's shortcut, a rebind's target).
+- **Rebind, not remove.** When every bound sibling of a group vanishes from the server but the group still has fetched
+  members — and the collapse sees the group's whole membership (a platform unit or the preview,
+  `complete_group_view=True`; a partial collection view never rebinds) — it emits one **rebind entry** keyed to the
+  vanished sibling's `rom_id` (so the frontend reuses its existing shortcut through the `rom_id → appId` map — no
+  delete + recreate churn), carrying the representative's launch bake and a `bind_rom_id` marker. The commit translates
+  the ack through `bind_rom_id`, so the DB binding moves onto the representative; the collision-safe `Rom` save then
+  unbinds the vanished row. The shortcut's appId, artwork, collections and playtime all survive — only the active
+  version changes. A whole-group disappearance still routes through the normal stale path, and the #1036 committed-appId
+  guard is unchanged (the reused appId is committed this run, so it is never emitted for removal).
+- **Grandfathering.** A group that already carries several bound shortcuts (a library synced before this model) keeps
+  them all — each surviving bound sibling stays its own tracked shortcut; no new shortcut is minted for a group with a
+  binding. Convergence to one-shortcut-per-group happens naturally as the user uninstalls duplicates.
+- **Downstream group semantics.** The incremental-skip gate compares RomM's platform `rom_count` against **all**
+  persisted rows for the platform (not just bound representatives), restoring skip parity on platforms with sibling
+  groups (a NULL `sibling_group_key` still forces a backfill full-fetch). Artwork downloads only for the emitted
+  representatives (+ grandfathered bound siblings), never eager sibling covers. Steam-collection membership resolves
+  each RomM collection `rom_id` with a **group fallback** — an unbound sibling maps to its group's bound sibling's appId
+  — so collecting or favouriting any version puts the game's single shortcut in the collection.
+
 **Single-owner run lifecycle (#1202).** The run-lifecycle pair — `sync_state` (idle/running/cancelling) and
 `current_sync_id` — is mutated **only** through four verb methods on `LibrarySyncStateBox`, never by direct field
 assignment from a sub-service. Confining those two writes to the box makes run admission, cancellation, and termination

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -228,28 +228,34 @@ is the group's **active version**.
   installed game onto an uninstalled sibling — #1296.) `classify_roms` runs over the collapsed set, so its new / changed
   / unchanged / stale buckets count **games, not dumps**, and an unbound sibling stops reading as a perpetual "new".
 - **Resolution chain** (`domain/sibling_resolution.py::resolve_group_representative`, total + shuffle-stable): an
-  installed sibling wins; else an existing binding; else RomM's per-user default (`is_main_sibling`); else **region
-  priority**; else alphabetical `fs_name_no_ext`; else `rom_id`. The first three legs are membership filters; the last
-  three are the total order applied inside the surviving leg. Region priority ranks a version by its best `regions`
-  entry against a **fixed** build-time order — `World > USA > Europe > Japan`, every other named region after these
-  (alphabetically), a no-region version last (a fixed constant, **not** language/system detection) — which the user may
-  re-head with a single `preferred_region` setting (`"auto"` = the fixed order; any other value lifts that region to the
-  top). The leg is evaluated at resolution time, so the setting takes effect on the next sync and an existing binding
-  shields its group (the installed/binding legs win before region priority is consulted). Used wherever one version must
-  be chosen (a new group's shortcut, a rebind's target). The QAM dropdown that sets `preferred_region` is populated from
-  fixed anchors (Default, World, USA, Europe, Japan) plus the distinct regions read from the local library
-  (`get_known_regions` over `roms.regions` — no server call), and a confirmation modal states the apply-at-next-sync /
-  no-rename semantics before persisting.
+  installed sibling wins; else an existing binding; else RomM's per-user default (`is_main_sibling`); else the **1G1R
+  ranking** — prerelease demotion > **region priority** > revision (newest) > alphabetical `fs_name_no_ext` > `rom_id`.
+  The first three legs are membership filters; the rest are the total order applied inside the surviving leg.
+  **Prerelease demotion** ranks first: a member whose structured `tags` name a draft build (Alpha / Beta / Proto /
+  Sample / Demo, case-insensitive, tolerant of a trailing number; `Unl` / `Aftermarket` / unknown tags are neutral) is
+  demoted below every retail sibling **across regions**, so a finished `(Japan)` release beats a `(USA) (Beta)`.
+  **Revision** ranks just after region: within one region the newest `revision` wins (natural compare; base dump =
+  lowest), but never lifts a lower-ranked region (a `(USA)` base still beats a `(Europe) (Rev 9)`). The alphabetical leg
+  also keeps a base dump ahead of a filename-only re-dump (`(Virtual Console)`, `(Extended Edition)`) RomM does not
+  parse into a tag. Region priority ranks a version by its best `regions` entry against a **fixed** build-time order —
+  `World > USA > Europe > Japan`, every other named region after these (alphabetically), a no-region version last (a
+  fixed constant, **not** language/system detection) — which the user may re-head with a single `preferred_region`
+  setting (`"auto"` = the fixed order; any other value lifts that region to the top). The leg is evaluated at resolution
+  time, so the setting takes effect on the next sync and an existing binding shields its group (the installed/binding
+  legs win before region priority is consulted). Used wherever one version must be chosen (a new group's shortcut, a
+  rebind's target). The QAM dropdown that sets `preferred_region` is populated from fixed anchors (Default, World, USA,
+  Europe, Japan) plus the distinct regions read from the local library (`get_known_regions` over `roms.regions` — no
+  server call), and a confirmation modal states the apply-at-next-sync / no-rename semantics before persisting.
 - **Canonical name at mint** (`domain/sibling_resolution.py::canonical_group_name`): a NEW group's shortcut is **named**
-  after the member ranked first by the _pure_ order (region priority > alphabetical > `rom_id`), ignoring the
-  installed/binding/default filters — so a Japanese default still binds Japan but the shortcut carries the USA name
-  (never majority voting: two Japan dumps + one USA yields the USA name). This is mint-time only: the name is sticky
-  forever after (ADR-0021 §2), so a rebind/grandfathered entry carries the persisted bound name verbatim and a live
-  shortcut is never renamed. The appId is minted from the canonical name by the frontend `AddShortcut`; the DB binding
-  lands on the representative `rom_id`; the reporter is agnostic to the name↔rom mismatch (it binds on `rom_id` + the
-  acked appId, and persists each sibling's own RomM name from `pending_all_roms`). `preferred_region` is read from
-  settings by `sync_orchestrator` and threaded into every collapse call site (preview + apply) as the same value within
-  a run.
+  after the member ranked first by the _pure_ order (prerelease demotion > region priority > revision > alphabetical >
+  `rom_id`), ignoring the installed/binding/default filters — so a Japanese default still binds Japan but the shortcut
+  carries the USA name (never majority voting: two Japan dumps + one USA yields the USA name). This is mint-time only:
+  the name is sticky forever after (ADR-0021 §2), so a rebind/grandfathered entry carries the persisted bound name
+  verbatim and a live shortcut is never renamed. The appId is minted from the canonical name by the frontend
+  `AddShortcut`; the DB binding lands on the representative `rom_id`; the reporter is agnostic to the name↔rom mismatch
+  (it binds on `rom_id` + the acked appId, and persists each sibling's own RomM name from `pending_all_roms`).
+  `preferred_region` is read from settings by `sync_orchestrator` and threaded into every collapse call site (preview +
+  apply) as the same value within a run.
 - **Rebind, not remove.** When every bound sibling of a group vanishes from the server but the group still has fetched
   members — and the collapse sees the group's whole membership (a platform unit or the preview,
   `complete_group_view=True`; a partial collection view never rebinds) — it emits one **rebind entry** keyed to the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -228,9 +228,28 @@ is the group's **active version**.
   installed game onto an uninstalled sibling — #1296.) `classify_roms` runs over the collapsed set, so its new / changed
   / unchanged / stale buckets count **games, not dumps**, and an unbound sibling stops reading as a perpetual "new".
 - **Resolution chain** (`domain/sibling_resolution.py::resolve_group_representative`, total + shuffle-stable): an
-  installed sibling wins; else an existing binding; else RomM's per-user default (`is_main_sibling`); else alphabetical
-  `fs_name_no_ext`. Ties break on `fs_name_no_ext` then `rom_id`. Used wherever one version must be chosen (a new
-  group's shortcut, a rebind's target).
+  installed sibling wins; else an existing binding; else RomM's per-user default (`is_main_sibling`); else **region
+  priority**; else alphabetical `fs_name_no_ext`; else `rom_id`. The first three legs are membership filters; the last
+  three are the total order applied inside the surviving leg. Region priority ranks a version by its best `regions`
+  entry against a **fixed** build-time order — `World > USA > Europe > Japan`, every other named region after these
+  (alphabetically), a no-region version last (a fixed constant, **not** language/system detection) — which the user may
+  re-head with a single `preferred_region` setting (`"auto"` = the fixed order; any other value lifts that region to the
+  top). The leg is evaluated at resolution time, so the setting takes effect on the next sync and an existing binding
+  shields its group (the installed/binding legs win before region priority is consulted). Used wherever one version must
+  be chosen (a new group's shortcut, a rebind's target). The QAM dropdown that sets `preferred_region` is populated from
+  fixed anchors (Default, World, USA, Europe, Japan) plus the distinct regions read from the local library
+  (`get_known_regions` over `roms.regions` — no server call), and a confirmation modal states the apply-at-next-sync /
+  no-rename semantics before persisting.
+- **Canonical name at mint** (`domain/sibling_resolution.py::canonical_group_name`): a NEW group's shortcut is **named**
+  after the member ranked first by the _pure_ order (region priority > alphabetical > `rom_id`), ignoring the
+  installed/binding/default filters — so a Japanese default still binds Japan but the shortcut carries the USA name
+  (never majority voting: two Japan dumps + one USA yields the USA name). This is mint-time only: the name is sticky
+  forever after (ADR-0021 §2), so a rebind/grandfathered entry carries the persisted bound name verbatim and a live
+  shortcut is never renamed. The appId is minted from the canonical name by the frontend `AddShortcut`; the DB binding
+  lands on the representative `rom_id`; the reporter is agnostic to the name↔rom mismatch (it binds on `rom_id` + the
+  acked appId, and persists each sibling's own RomM name from `pending_all_roms`). `preferred_region` is read from
+  settings by `sync_orchestrator` and threaded into every collapse call site (preview + apply) as the same value within
+  a run.
 - **Rebind, not remove.** When every bound sibling of a group vanishes from the server but the group still has fetched
   members — and the collapse sees the group's whole membership (a platform unit or the preview,
   `complete_group_view=True`; a partial collection view never rebinds) — it emits one **rebind entry** keyed to the

--- a/docs/architecture/database-design.md
+++ b/docs/architecture/database-design.md
@@ -443,6 +443,15 @@ column to `rom_playtime` ([#1148](https://github.com/danielcopper/decky-romm-syn
 `ALTER TABLE … ADD COLUMN`; NULL until the next `begin_session` stamps it, and a NULL marker on a pre-migration row
 makes `record_session` fall back to the full wall span (the pre-#1148 behavior, never a regression).
 
+`010_add_sibling_group_key_index.sql` (`user_version = 10`) adds a **non-unique** index `idx_roms_sibling_group_key` on
+`roms(sibling_group_key)`
+([ADR-0021](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0021-sibling-group-one-shortcut-binding-active-version.md),
+[#1296](https://github.com/danielcopper/decky-romm-sync/issues/1296)). Group-aware sync persists every fetched sibling
+(not just the bound representative), so two hot paths now read `roms` keyed by `sibling_group_key` — the per-unit group
+collapse and the Steam-collection group fallback — which the index turns into a range scan. Non-unique on purpose: a
+sibling group has many rows sharing one key, and a NULL key (a not-yet-backfilled row) is its own solo group, so no
+partial `WHERE` clause is needed. Pure DDL — a single `CREATE INDEX`.
+
 ## The runtime Unit of Work
 
 The schema is read and written at runtime through a **Unit of Work** (UoW) — the atomic transaction boundary one

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -148,6 +148,31 @@ After changing the mode, tap **Apply to All Shortcuts** to update all existing R
 
 <!-- Screenshot: Steam Input Mode dropdown with the three options -->
 
+## Preferred region
+
+A dropdown in the **Library** section of the settings page. When a game exists in your RomM library as several regional
+dumps (versions), this decides which region the plugin prefers when it picks the version to bind and the name it gives
+the Steam shortcut.
+
+| Option                                   | Effect                                                                                              |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Default (World > USA > Europe)**       | Prefer World, then USA, then Europe, then Japan, then any other region alphabetically (fixed order) |
+| a specific region (World, USA, Japan, …) | Put that region at the top of the order; everything else keeps the default order behind it          |
+
+**"Default" is a fixed order, not auto-detection.** It always prefers `World > USA > Europe > Japan` (then other regions
+alphabetically, then dumps with no region); the plugin never looks at your language or system region.
+
+**The dropdown's options** are the fixed anchors — Default, World, USA, Europe, Japan — followed by every other region
+actually present in the games you have already synced (read from the local database, sorted alphabetically; no server
+request). If your synced library has no other regions, only the anchors are shown.
+
+**When you change it, a short modal explains the effect** and asks you to confirm. The choice is saved immediately, but
+it takes effect on the **next sync** and only affects games synced from then on. It **never** switches the version or
+renames an existing shortcut — shortcut names are fixed when the shortcut is first created, to protect its artwork,
+collections and playtime. Already-synced games keep their bound version and name; run a sync to apply the new preference
+to new games. See [Multiple versions of a game](syncing-your-library.md#multiple-versions-of-a-game) for the full
+picture.
+
 ## Log Level
 
 A dropdown in the **Advanced** section on the main page. Controls how much detail the plugin logs.

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -39,21 +39,26 @@ sync counts (in the preview and the completion toast) count **games**, not indiv
 "added", not five.
 
 The version the shortcut points at (the **active version**) is chosen automatically: a version you have already
-installed wins, otherwise the shortcut follows the "SET DEFAULT" version you picked in RomM, otherwise the one whose
-region ranks highest (see below), otherwise the first alphabetically. Switching versions from inside the plugin is a
-later feature; for now the active version follows what is installed and RomM's default.
+installed wins, otherwise the shortcut follows the "SET DEFAULT" version you picked in RomM, otherwise the plugin picks
+the best dump for you (see below). Switching versions from inside the plugin is a later feature; for now the active
+version follows what is installed and RomM's default.
 
-**Which region wins, and how the shortcut is named.** When nothing is installed and you haven't set a default in RomM,
-the plugin prefers a region in the fixed order **World → USA → Europe → Japan**, then any other region alphabetically,
-and a dump with no region last. (This is a fixed order, not language or system detection.) You can change the preferred
-region — see [Preferred region](configuration.md#preferred-region) in Configuration. The **name** of the Steam shortcut
-follows the same region preference (the pure ranking, ignoring what's installed or set as default), so a multi-region
-game gets a readable name rather than whichever dump happens to sort first: a game with two Japanese dumps and one US
-dump is named after the US dump, while a game that only exists as a Japanese dump honestly gets its Japanese name. The
-name is chosen **once, when the shortcut is created, and never changes automatically** afterwards — even if you later
-switch to a different version, change the RomM default, or change the preferred region. This keeps the shortcut's
-artwork, collections and playtime intact. It does mean the shortcut's name can differ from the version it currently
-launches, and that changing the preferred region only affects games synced **after** the change.
+**How the plugin picks the best dump, and how the shortcut is named.** When nothing is installed and you haven't set a
+default in RomM, the plugin ranks the dumps like a 1G1R (one-game-one-ROM) tool. A **finished release always beats a
+prerelease** — a beta, prototype, alpha, sample or demo dump loses even to a finished release from a less-preferred
+region (so a finished Japanese dump wins over a US beta). Among finished dumps, it prefers a region in the fixed order
+**World → USA → Europe → Japan**, then any other region alphabetically, and a dump with no region last. (This is a fixed
+order, not language or system detection.) Within one region it then prefers the **newest revision** (a `(Rev 1)` dump
+over the plain release, a `(Rev 3)` over a `(Rev 1)`), and finally prefers the plain base game over a filename-only
+re-dump like `(Virtual Console)` or `(Extended Edition)`. You can change the preferred region — see
+[Preferred region](configuration.md#preferred-region) in Configuration. The **name** of the Steam shortcut follows the
+same ranking (ignoring what's installed or set as default), so a multi-region game gets a readable name rather than
+whichever dump happens to sort first: a game with two Japanese dumps and one US dump is named after the US dump, while a
+game that only exists as a Japanese dump honestly gets its Japanese name. The name is chosen **once, when the shortcut
+is created, and never changes automatically** afterwards — even if you later switch to a different version, change the
+RomM default, or change the preferred region. This keeps the shortcut's artwork, collections and playtime intact. It
+does mean the shortcut's name can differ from the version it currently launches, and that changing the preferred region
+only affects games synced **after** the change.
 
 If you synced **before** this update and already have several Steam shortcuts for one game, those existing shortcuts are
 **kept** — the plugin never deletes a shortcut you can see. They converge to a single entry naturally as you uninstall

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -30,6 +30,23 @@ You can tap **Cancel Sync** to stop mid-sync. Games already added will remain. A
 collections — stale-collection cleanup only runs after a sync finishes in full, so cancelling can never wipe the
 collections for platforms the run did not reach.
 
+## Multiple versions of a game
+
+When your RomM library holds several dumps of the same game — region variants like `(USA)` / `(Europe)` / `(Japan)`,
+multi-language dumps, or revisions — the plugin treats them as **one game** and creates **one Steam shortcut** for it,
+not one per dump. RomM already groups these versions together; the plugin mirrors that grouping. Because of this, the
+sync counts (in the preview and the completion toast) count **games**, not individual files: a five-region game is one
+"added", not five.
+
+The version the shortcut points at (the **active version**) is chosen automatically: a version you have already
+installed wins, otherwise the shortcut follows the "SET DEFAULT" version you picked in RomM, otherwise the first
+alphabetically. Switching versions from inside the plugin is a later feature; for now the active version follows what is
+installed and RomM's default.
+
+If you synced **before** this update and already have several Steam shortcuts for one game, those existing shortcuts are
+**kept** — the plugin never deletes a shortcut you can see. They converge to a single entry naturally as you uninstall
+the extra versions.
+
 ## Per-Platform Toggles
 
 Not every platform in your RomM library needs to be synced to Steam. Use the **Platforms** page to enable or disable
@@ -95,7 +112,9 @@ You can refresh artwork for any individual game from its
 ## Re-Syncing
 
 Running sync again updates your library with any changes from RomM (new ROMs, removed platforms, etc.). Existing
-shortcuts are updated rather than duplicated.
+shortcuts are updated rather than duplicated. If the specific version a shortcut pointed at is removed from RomM but the
+game still has other versions on the server, the shortcut is **kept** and quietly re-pointed at a surviving version — it
+is not torn down and re-created, so its artwork, collections, and playtime are preserved.
 
 ## Removing Shortcuts
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -39,9 +39,21 @@ sync counts (in the preview and the completion toast) count **games**, not indiv
 "added", not five.
 
 The version the shortcut points at (the **active version**) is chosen automatically: a version you have already
-installed wins, otherwise the shortcut follows the "SET DEFAULT" version you picked in RomM, otherwise the first
-alphabetically. Switching versions from inside the plugin is a later feature; for now the active version follows what is
-installed and RomM's default.
+installed wins, otherwise the shortcut follows the "SET DEFAULT" version you picked in RomM, otherwise the one whose
+region ranks highest (see below), otherwise the first alphabetically. Switching versions from inside the plugin is a
+later feature; for now the active version follows what is installed and RomM's default.
+
+**Which region wins, and how the shortcut is named.** When nothing is installed and you haven't set a default in RomM,
+the plugin prefers a region in the fixed order **World → USA → Europe → Japan**, then any other region alphabetically,
+and a dump with no region last. (This is a fixed order, not language or system detection.) You can change the preferred
+region — see [Preferred region](configuration.md#preferred-region) in Configuration. The **name** of the Steam shortcut
+follows the same region preference (the pure ranking, ignoring what's installed or set as default), so a multi-region
+game gets a readable name rather than whichever dump happens to sort first: a game with two Japanese dumps and one US
+dump is named after the US dump, while a game that only exists as a Japanese dump honestly gets its Japanese name. The
+name is chosen **once, when the shortcut is created, and never changes automatically** afterwards — even if you later
+switch to a different version, change the RomM default, or change the preferred region. This keeps the shortcut's
+artwork, collections and playtime intact. It does mean the shortcut's name can differ from the version it currently
+launches, and that changing the preferred region only affects games synced **after** the change.
 
 If you synced **before** this update and already have several Steam shortcuts for one game, those existing shortcuts are
 **kept** — the plugin never deletes a shortcut you can see. They converge to a single entry naturally as you uninstall

--- a/main.py
+++ b/main.py
@@ -213,6 +213,12 @@ class Plugin:
     async def save_steam_input_setting(self, mode):
         return self._settings_service.save_steam_input_setting(mode)
 
+    async def save_preferred_region(self, region):
+        return self._settings_service.save_preferred_region(region)
+
+    async def get_known_regions(self):
+        return self._settings_service.get_known_regions()
+
     async def apply_steam_input_setting(self):
         return self._settings_service.apply_steam_input_setting()
 

--- a/py_modules/adapters/persistence.py
+++ b/py_modules/adapters/persistence.py
@@ -44,6 +44,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "enabled_platforms": {},
     "enabled_collections": {"user": {}, "smart": {}, "franchise": {}},
     "collection_create_platform_groups": False,
+    "preferred_region": "auto",
     "steam_input_mode": "default",
     "steamgriddb_api_key": "",
     "romm_allow_insecure_ssl": False,

--- a/py_modules/db/migrations/010_add_sibling_group_key_index.sql
+++ b/py_modules/db/migrations/010_add_sibling_group_key_index.sql
@@ -1,0 +1,26 @@
+-- =============================================================================
+-- 010_add_sibling_group_key_index.sql — index roms(sibling_group_key)
+-- Issue #1296 (group-aware sync: one shortcut per sibling group) / ADR-0021
+-- =============================================================================
+--
+-- Group-aware sync now persists EVERY fetched sibling (not just the bound
+-- representative) so the whole group is queryable. Today's sync readers do NOT
+-- key on this column: the per-unit group collapse and the collections
+-- group-fallback both read the ``roms`` table via iter_all() / iter_by_platform()
+-- and bucket by sibling_group_key in Python, so no ``WHERE sibling_group_key = ?``
+-- runs yet. This index is forward-looking — the download picker (#1297) and the
+-- installed-game version switch (#1298) resolve a single group by its key
+-- (``WHERE sibling_group_key = ?``), which grows O(rows) without an index once a
+-- library holds many siblings; the non-unique index makes that lookup a range
+-- scan. It ships in the same migration that starts persisting siblings so the
+-- column and its index are introduced together.
+--
+-- Non-unique on purpose: a sibling group has many rows (one per version), and a
+-- NULL key (a row not yet backfilled) is a solo/unmatched group — SQLite indexes
+-- NULLs, and the group readers treat NULL as "its own group", so no partial
+-- WHERE clause is needed.
+--
+-- Transaction-safe DDL only — the runner (adapters/sqlite_migrations.py) wraps
+-- BEGIN/COMMIT and stamps PRAGMA user_version = 10.
+-- -----------------------------------------------------------------------------
+CREATE INDEX idx_roms_sibling_group_key ON roms(sibling_group_key);

--- a/py_modules/domain/rom.py
+++ b/py_modules/domain/rom.py
@@ -52,7 +52,7 @@ class Rom:
         platform_slug: str,
         name: str,
         fs_name: str,
-        shortcut_app_id: int,
+        shortcut_app_id: int | None,
         synced_at: str,
         igdb_id: int | None = None,
         sibling_group_key: str | None = None,
@@ -62,7 +62,12 @@ class Rom:
         tags: tuple[str, ...] = (),
         is_main_sibling: bool = False,
     ) -> Rom:
-        """Build a Rom synced from RomM at ISO timestamp ``synced_at``."""
+        """Build a Rom synced from RomM at ISO timestamp ``synced_at``.
+
+        ``shortcut_app_id`` is ``None`` for a non-representative sibling — every
+        fetched ROM is persisted for identity + version metadata (ADR-0021), but
+        only the group's representative carries a Steam-shortcut binding.
+        """
         if rom_id <= 0:
             raise ValueError("rom_id must be positive")
         if not platform_slug:

--- a/py_modules/domain/shortcut_data.py
+++ b/py_modules/domain/shortcut_data.py
@@ -185,6 +185,11 @@ def build_shortcuts_data(
             "rom_id": rom["id"],
             "name": rom["name"],
             "fs_name": rom.get("fs_name", ""),
+            # Alphabetical tie-break key for sibling-group representative
+            # resolution (ADR-0021): RomM ships it on the list endpoint; fall
+            # back to the filename stem when absent. No DB column — carried only
+            # through the sync pipeline, never persisted.
+            "fs_name_no_ext": rom.get("fs_name_no_ext") or os.path.splitext(rom.get("fs_name", ""))[0],
             "exe": exe,
             "start_dir": start_dir,
             "launch_options": (
@@ -201,7 +206,13 @@ def build_shortcuts_data(
             "sgdb_id": rom.get("sgdb_id"),
             "ra_id": rom.get("ra_id"),
             "cover_path": "",
-            "sibling_group_key": compute_sibling_group_key(rom),
+            # Prefer a sibling_group_key already on the dict — the incremental-skip
+            # path reconstructs ROM dicts from persisted rows that carry the
+            # authoritative key (with the real platform_id baked in) but no
+            # ``platform_id`` field, so recomputing would yield ``…:None`` and split
+            # the group's bucket from a freshly-fetched sibling's (#1296). A live
+            # RomM fetch has no such key, so it computes from the raw dict.
+            "sibling_group_key": rom.get("sibling_group_key") or compute_sibling_group_key(rom),
             "regions": list(rom.get("regions") or []),
             "languages": list(rom.get("languages") or []),
             "revision": rom.get("revision") or "",

--- a/py_modules/domain/sibling_resolution.py
+++ b/py_modules/domain/sibling_resolution.py
@@ -8,16 +8,21 @@ compute over the group's fetched members:
   The resolution chain::
 
       installed sibling > existing binding > RomM default (is_main_sibling) >
-      region priority > alphabetical fs_name_no_ext > rom_id
+      prerelease demotion > region priority > revision (newest) >
+      alphabetical fs_name_no_ext > rom_id
 
-  The first three are membership *filters*; the last three are the total order
-  applied to whatever survived the highest non-empty filter. The alphabetical
-  leg is exactly RomM's own grouped-view fallback, so an ungroomed library with
-  no region signal resolves identically to the RomM web UI.
+  The first three are membership *filters*; the last four are the total order
+  (a 1G1R-style ranking, matching igir / the No-Intro convention) applied to
+  whatever survived the highest non-empty filter: a finished (retail) dump beats
+  every prerelease across all regions, then region preference decides, then the
+  newest revision within a region, then RomM's own alphabetical grouped-view
+  fallback (so an ungroomed retail library with no region signal resolves
+  identically to the RomM web UI), then rom_id.
 
 * **What the group's Steam shortcut is named** — :func:`canonical_group_name`.
-  The name follows the *pure* order (region priority > alphabetical > rom_id)
-  over ALL members, ignoring the installed/binding/default filters. This decides
+  The name follows the *pure* order above (prerelease > region > revision >
+  alphabetical > rom_id) over ALL members, ignoring the installed/binding/default
+  filters. This decides
   the mint-time shortcut name only; a shortcut's name is sticky forever after
   (ADR-0021 §2), so this is never re-applied to an already-bound group.
 
@@ -30,6 +35,8 @@ stdlib only, with no I/O and no service/adapter imports.
 
 from __future__ import annotations
 
+import functools
+import re
 from typing import Any
 
 # Build-time region ranking: the order a group's representative and canonical
@@ -83,16 +90,119 @@ def _best_region_rank(member: dict[str, Any], preferred_region: str) -> tuple[in
     return min(_single_region_rank(str(r), preferred_region) for r in regions)
 
 
-def _rank_key(member: dict[str, Any], preferred_region: str) -> tuple[tuple[int, int, str], str, int]:
-    """Total pure order over a group's members: region priority > alphabetical > rom_id.
+# --- Prerelease demotion (ranks BEFORE region) -------------------------------
 
-    ``fs_name_no_ext`` is RomM's own alphabetical fallback key (case-folded to
-    match MariaDB's default collation — RomM parity); ``rom_id`` is the final
-    disambiguator so two dumps with an identical filename stem still order
-    deterministically, independent of fetch order.
+# Structured-tag markers that name a prerelease (draft) build, in RomM's
+# No-Intro-derived tag vocabulary. A member carrying any of these — bare or as a
+# numbered variant ("Beta 1", "Proto 2") — is demoted below EVERY retail sibling,
+# across regions, so a finished (Japan) release beats a (USA) (Beta), matching the
+# 1G1R / igir convention. "Unl", "Aftermarket", collection-name tags and any
+# unknown tag carry no finished-vs-draft signal and are NOT demoted (neutral).
+_PRERELEASE_MARKERS: tuple[str, ...] = ("alpha", "beta", "proto", "sample", "demo")
+
+# Prerelease-rank buckets (lower wins), the first element of the sort key.
+_RANK_RETAIL = 0
+_RANK_PRERELEASE = 1
+
+
+def _is_prerelease_tag(tag: str) -> bool:
+    """True when *tag* names a prerelease build (a marker, bare or numbered).
+
+    Case-insensitive; tolerant of a numbered variant — a marker followed by an
+    optional space and a digit ("Beta 1", "Proto2"). A longer word that merely
+    starts with a marker ("Betamax", "Prototype", "Sampler") is NOT a prerelease.
+    """
+    folded = tag.strip().casefold()
+    for marker in _PRERELEASE_MARKERS:
+        if folded == marker:
+            return True
+        if folded.startswith(marker):
+            rest = folded[len(marker) :].lstrip()
+            if rest and rest[0].isdigit():
+                return True
+    return False
+
+
+def _prerelease_rank(member: dict[str, Any]) -> int:
+    """0 for a retail dump, 1 when any structured tag names a prerelease build."""
+    tags = member.get("tags") or []
+    return _RANK_PRERELEASE if any(_is_prerelease_tag(str(t)) for t in tags) else _RANK_RETAIL
+
+
+# --- Revision, newest wins (ranks AFTER region) ------------------------------
+
+_DIGIT_RUN = re.compile(r"(\d+)")
+
+
+def _natural_sort_key(text: str) -> tuple[tuple[int, int, str], ...]:
+    """Natural-sort key for *text*: digit runs compare numerically, text runs
+    lexicographically (case-folded), never comparing an int against a str.
+
+    Each element is ``(kind, number, text)`` — ``kind`` 0 for a text run, 1 for a
+    digit run — so any two elements are mutually comparable and ``"2"`` sorts
+    before ``"10"`` (numeric) while ``"a"`` sorts before ``"b"`` (lexical).
+    """
+    key: list[tuple[int, int, str]] = []
+    for part in _DIGIT_RUN.split(text.casefold()):
+        if not part:
+            continue
+        # isdecimal(), not isdigit(): superscripts like "²" are isdigit-True but
+        # not int()-parseable — they must route to the text branch, not crash.
+        if part.isdecimal():
+            key.append((1, int(part), ""))
+        else:
+            key.append((0, 0, part))
+    return tuple(key)
+
+
+@functools.total_ordering
+class _RevisionKey:
+    """Sort key ordering revisions newest-first (``min`` picks the highest).
+
+    A higher revision must WIN the tie-break, so this compares *inverted*: an
+    instance is "less than" another when its revision is naturally GREATER. The
+    empty revision (a base dump with no ``(Rev N)``) has the empty natural key —
+    the smallest — so it ranks LAST, and every real revision beats a base dump.
+    """
+
+    __slots__ = ("_key",)
+
+    def __init__(self, revision: str) -> None:
+        self._key = _natural_sort_key(revision)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _RevisionKey):
+            return NotImplemented
+        return self._key == other._key
+
+    def __lt__(self, other: _RevisionKey) -> bool:
+        # Inverted: a naturally-greater revision sorts first (wins under min()).
+        return self._key > other._key
+
+    def __hash__(self) -> int:
+        return hash(self._key)
+
+
+def _rank_key(
+    member: dict[str, Any], preferred_region: str
+) -> tuple[int, tuple[int, int, str], _RevisionKey, str, int]:
+    """Total pure order over a group's members (lower wins): prerelease demotion >
+    region priority > revision (newest) > alphabetical ``fs_name_no_ext`` > rom_id.
+
+    A 1G1R-style ranking: a retail dump outranks every prerelease across all
+    regions; within the same prerelease status the preferred region wins; within
+    the same region the newest ``revision`` wins ((Rev 1) beats the base, (Rev 3)
+    beats (Rev 1)). Ties fall to ``fs_name_no_ext`` — RomM's own alphabetical
+    fallback (case-folded to match MariaDB's default collation), which also keeps
+    a base dump ahead of a filename-only re-dump ("(Virtual Console)",
+    "(Extended Edition)") that RomM does not parse into a tag — then ``rom_id``,
+    so two identical stems still order deterministically, independent of fetch
+    order.
     """
     return (
+        _prerelease_rank(member),
         _best_region_rank(member, preferred_region),
+        _RevisionKey(str(member.get("revision") or "")),
         str(member.get("fs_name_no_ext") or "").lower(),
         int(member["rom_id"]),
     )
@@ -107,14 +217,17 @@ def resolve_group_representative(
     """Return the representative ``rom_id`` for one sibling group's *members*.
 
     *members* are the group's fetched ROM dicts (each carrying ``rom_id``,
-    ``is_main_sibling``, ``regions`` and ``fs_name_no_ext``). The resolution
-    chain (ADR-0021 §3): the first non-empty *filter* leg wins, and inside that
-    leg :func:`_rank_key` (region priority > alphabetical > rom_id) decides —
+    ``is_main_sibling``, ``regions``, ``revision``, ``tags`` and
+    ``fs_name_no_ext``). The resolution chain (ADR-0021 §3): the first non-empty
+    *filter* leg wins, and inside that leg :func:`_rank_key` (prerelease demotion
+    > region priority > revision > alphabetical > rom_id) decides —
 
     1. an **installed** sibling (``rom_id`` in *installed_rom_ids*),
     2. else a sibling with an **existing binding** (``rom_id`` in *bound_rom_ids*),
     3. else RomM's per-user **default** (``is_main_sibling`` truthy),
-    4. else all members, ordered by region priority then alphabetically.
+    4. else all members, ordered by the pure 1G1R ranking (retail before
+       prerelease, then region priority, then newest revision, then
+       alphabetically) — see :func:`_rank_key`.
 
     *preferred_region* re-heads the region ranking (``"auto"`` = no preference).
 
@@ -140,8 +253,9 @@ def resolve_group_representative(
 def canonical_group_name(members: list[dict[str, Any]], preferred_region: str = AUTO_REGION) -> str:
     """Return the group's canonical Steam-shortcut name (ADR-0021 §2/§3).
 
-    The ``name`` of the member ranked first by the **pure** order (region
-    priority > alphabetical ``fs_name_no_ext`` > ``rom_id``) — the
+    The ``name`` of the member ranked first by the **pure** order (prerelease
+    demotion > region priority > revision > alphabetical ``fs_name_no_ext`` >
+    ``rom_id``) — the
     installed/binding/default filters of :func:`resolve_group_representative` are
     deliberately ignored, so the name reflects the region-preferred dump even
     when the *bound* version is forced elsewhere (a Japanese default still yields

--- a/py_modules/domain/sibling_resolution.py
+++ b/py_modules/domain/sibling_resolution.py
@@ -1,0 +1,68 @@
+"""Deterministic sibling-group representative resolution (ADR-0021 §3).
+
+A sibling group is one game with several released dumps (region / language /
+revision variants). When one version of the group must be chosen — the version
+its Steam shortcut binds to, or the picker's preselect — this module answers
+"which one" with a total, shuffle-stable order:
+
+    installed sibling > existing binding > RomM default (is_main_sibling) >
+    alphabetical fs_name_no_ext
+
+The last leg is exactly RomM's own grouped-view fallback, so an ungroomed
+library resolves identically to the RomM web UI. Ties inside any leg break on
+``fs_name_no_ext`` (case-folded) then ``rom_id`` so the choice never depends on
+fetch order. Pure compute, stdlib only — no I/O, no service/adapter imports.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _tie_break_key(member: dict[str, Any]) -> tuple[str, int]:
+    """Stable within-leg order: case-folded ``fs_name_no_ext``, then ``rom_id``.
+
+    ``fs_name_no_ext`` is RomM's own alphabetical fallback key; ``rom_id`` is the
+    final disambiguator so two dumps with an identical filename stem still order
+    deterministically.
+    """
+    # ``.lower()`` must stay: RomM's own grouped-view ordering runs over MariaDB's
+    # default case-insensitive collation, so case-folding here IS RomM parity — a
+    # case-sensitive sort would pick a different representative than the web UI.
+    return (str(member.get("fs_name_no_ext") or "").lower(), int(member["rom_id"]))
+
+
+def resolve_group_representative(
+    members: list[dict[str, Any]],
+    installed_rom_ids: set[int],
+    bound_rom_ids: set[int],
+) -> int:
+    """Return the representative ``rom_id`` for one sibling group's *members*.
+
+    *members* are the group's fetched ROM dicts (each carrying ``rom_id``,
+    ``is_main_sibling`` and ``fs_name_no_ext``). The resolution chain (ADR-0021
+    §3): the first non-empty leg wins, and inside a leg the ``_tie_break_key``
+    order decides —
+
+    1. an **installed** sibling (``rom_id`` in *installed_rom_ids*),
+    2. else a sibling with an **existing binding** (``rom_id`` in *bound_rom_ids*),
+    3. else RomM's per-user **default** (``is_main_sibling`` truthy),
+    4. else the alphabetically-first ``fs_name_no_ext``.
+
+    Raises ``ValueError`` on an empty *members* — a group always has at least one
+    fetched member at the call sites here.
+    """
+    if not members:
+        raise ValueError("cannot resolve a representative for an empty sibling group")
+
+    for leg in (
+        [m for m in members if int(m["rom_id"]) in installed_rom_ids],
+        [m for m in members if int(m["rom_id"]) in bound_rom_ids],
+        [m for m in members if m.get("is_main_sibling")],
+        members,
+    ):
+        if leg:
+            return int(min(leg, key=_tie_break_key)["rom_id"])
+
+    # Unreachable — the final leg is the full member list, always non-empty here.
+    raise AssertionError("resolution chain fell through a non-empty member list")

--- a/py_modules/domain/sibling_resolution.py
+++ b/py_modules/domain/sibling_resolution.py
@@ -1,53 +1,122 @@
-"""Deterministic sibling-group representative resolution (ADR-0021 §3).
+"""Deterministic sibling-group representative resolution + canonical naming (ADR-0021 §3).
 
 A sibling group is one game with several released dumps (region / language /
-revision variants). When one version of the group must be chosen — the version
-its Steam shortcut binds to, or the picker's preselect — this module answers
-"which one" with a total, shuffle-stable order:
+revision variants). Two questions are answered here, both a pure, shuffle-stable
+compute over the group's fetched members:
 
-    installed sibling > existing binding > RomM default (is_main_sibling) >
-    alphabetical fs_name_no_ext
+* **Which version does the group bind to** — :func:`resolve_group_representative`.
+  The resolution chain::
 
-The last leg is exactly RomM's own grouped-view fallback, so an ungroomed
-library resolves identically to the RomM web UI. Ties inside any leg break on
-``fs_name_no_ext`` (case-folded) then ``rom_id`` so the choice never depends on
-fetch order. Pure compute, stdlib only — no I/O, no service/adapter imports.
+      installed sibling > existing binding > RomM default (is_main_sibling) >
+      region priority > alphabetical fs_name_no_ext > rom_id
+
+  The first three are membership *filters*; the last three are the total order
+  applied to whatever survived the highest non-empty filter. The alphabetical
+  leg is exactly RomM's own grouped-view fallback, so an ungroomed library with
+  no region signal resolves identically to the RomM web UI.
+
+* **What the group's Steam shortcut is named** — :func:`canonical_group_name`.
+  The name follows the *pure* order (region priority > alphabetical > rom_id)
+  over ALL members, ignoring the installed/binding/default filters. This decides
+  the mint-time shortcut name only; a shortcut's name is sticky forever after
+  (ADR-0021 §2), so this is never re-applied to an already-bound group.
+
+Region priority ranks a version by its best region against a build-time default
+(:data:`DEFAULT_REGION_PRIORITY`), which the user may re-head with a single
+``preferred_region`` choice. The preference enters as an explicit parameter —
+reading it from settings is the service layer's job; this module stays pure,
+stdlib only, with no I/O and no service/adapter imports.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+# Build-time region ranking: the order a group's representative and canonical
+# name fall back to once no installed / binding / default leg decides. World >
+# USA > Europe > Japan (RomM's full-word region vocabulary) — World first for
+# explicit multi-region international releases; USA before Europe to match the
+# 1G1R community convention and avoid PAL-50Hz dumps being the silent default on
+# older consoles. Every other named region ranks after these, alphabetically
+# among themselves, and a version with no region at all ranks last. This is a
+# fixed constant, NOT a language/system detection. A single ``preferred_region``
+# override lifts one region to the very top — the order below then continues
+# behind it.
+DEFAULT_REGION_PRIORITY: tuple[str, ...] = ("World", "USA", "Europe", "Japan")
+_DEFAULT_REGION_INDEX: dict[str, int] = {name.casefold(): i for i, name in enumerate(DEFAULT_REGION_PRIORITY)}
 
-def _tie_break_key(member: dict[str, Any]) -> tuple[str, int]:
-    """Stable within-leg order: case-folded ``fs_name_no_ext``, then ``rom_id``.
+# Sentinel the ``preferred_region`` setting holds when the user expressed no
+# preference — the ranking is then the pure build-time order.
+AUTO_REGION = "auto"
 
-    ``fs_name_no_ext`` is RomM's own alphabetical fallback key; ``rom_id`` is the
-    final disambiguator so two dumps with an identical filename stem still order
-    deterministically.
+# Region-rank buckets (lower wins), the first element of a region's sort key:
+# 0 = the user's preferred region, 1 = a build-time default region, 2 = any
+# other named region, 3 = the version carries no region.
+_BUCKET_PREFERRED = 0
+_BUCKET_DEFAULT = 1
+_BUCKET_OTHER = 2
+_BUCKET_NONE = 3
+
+
+def _single_region_rank(region: str, preferred_region: str) -> tuple[int, int, str]:
+    """Priority key for ONE region string (lower wins).
+
+    The user's ``preferred_region`` (when set) ranks top; otherwise a region in
+    the build-time default order ranks by that order; any other named region
+    ranks after the defaults, alphabetically (case-folded). Case-folding both
+    sides makes the match and the alphabetical sort collation-stable.
     """
-    # ``.lower()`` must stay: RomM's own grouped-view ordering runs over MariaDB's
-    # default case-insensitive collation, so case-folding here IS RomM parity — a
-    # case-sensitive sort would pick a different representative than the web UI.
-    return (str(member.get("fs_name_no_ext") or "").lower(), int(member["rom_id"]))
+    folded = region.casefold()
+    if preferred_region != AUTO_REGION and folded == preferred_region.casefold():
+        return (_BUCKET_PREFERRED, 0, "")
+    default_idx = _DEFAULT_REGION_INDEX.get(folded)
+    if default_idx is not None:
+        return (_BUCKET_DEFAULT, default_idx, "")
+    return (_BUCKET_OTHER, 0, folded)
+
+
+def _best_region_rank(member: dict[str, Any], preferred_region: str) -> tuple[int, int, str]:
+    """Rank a member by its BEST (lowest-ranked) region; no regions ⇒ ranks last."""
+    regions = member.get("regions") or []
+    if not regions:
+        return (_BUCKET_NONE, 0, "")
+    return min(_single_region_rank(str(r), preferred_region) for r in regions)
+
+
+def _rank_key(member: dict[str, Any], preferred_region: str) -> tuple[tuple[int, int, str], str, int]:
+    """Total pure order over a group's members: region priority > alphabetical > rom_id.
+
+    ``fs_name_no_ext`` is RomM's own alphabetical fallback key (case-folded to
+    match MariaDB's default collation — RomM parity); ``rom_id`` is the final
+    disambiguator so two dumps with an identical filename stem still order
+    deterministically, independent of fetch order.
+    """
+    return (
+        _best_region_rank(member, preferred_region),
+        str(member.get("fs_name_no_ext") or "").lower(),
+        int(member["rom_id"]),
+    )
 
 
 def resolve_group_representative(
     members: list[dict[str, Any]],
     installed_rom_ids: set[int],
     bound_rom_ids: set[int],
+    preferred_region: str = AUTO_REGION,
 ) -> int:
     """Return the representative ``rom_id`` for one sibling group's *members*.
 
     *members* are the group's fetched ROM dicts (each carrying ``rom_id``,
-    ``is_main_sibling`` and ``fs_name_no_ext``). The resolution chain (ADR-0021
-    §3): the first non-empty leg wins, and inside a leg the ``_tie_break_key``
-    order decides —
+    ``is_main_sibling``, ``regions`` and ``fs_name_no_ext``). The resolution
+    chain (ADR-0021 §3): the first non-empty *filter* leg wins, and inside that
+    leg :func:`_rank_key` (region priority > alphabetical > rom_id) decides —
 
     1. an **installed** sibling (``rom_id`` in *installed_rom_ids*),
     2. else a sibling with an **existing binding** (``rom_id`` in *bound_rom_ids*),
     3. else RomM's per-user **default** (``is_main_sibling`` truthy),
-    4. else the alphabetically-first ``fs_name_no_ext``.
+    4. else all members, ordered by region priority then alphabetically.
+
+    *preferred_region* re-heads the region ranking (``"auto"`` = no preference).
 
     Raises ``ValueError`` on an empty *members* — a group always has at least one
     fetched member at the call sites here.
@@ -62,7 +131,30 @@ def resolve_group_representative(
         members,
     ):
         if leg:
-            return int(min(leg, key=_tie_break_key)["rom_id"])
+            return int(min(leg, key=lambda m: _rank_key(m, preferred_region))["rom_id"])
 
     # Unreachable — the final leg is the full member list, always non-empty here.
     raise AssertionError("resolution chain fell through a non-empty member list")
+
+
+def canonical_group_name(members: list[dict[str, Any]], preferred_region: str = AUTO_REGION) -> str:
+    """Return the group's canonical Steam-shortcut name (ADR-0021 §2/§3).
+
+    The ``name`` of the member ranked first by the **pure** order (region
+    priority > alphabetical ``fs_name_no_ext`` > ``rom_id``) — the
+    installed/binding/default filters of :func:`resolve_group_representative` are
+    deliberately ignored, so the name reflects the region-preferred dump even
+    when the *bound* version is forced elsewhere (a Japanese default still yields
+    the USA member's name; two Japan dumps + one USA yield the USA member's name
+    — never majority voting).
+
+    This is a mint-time-only decision: a shortcut's name is sticky forever after
+    creation, so an already-bound group carries its persisted name and never
+    calls this. *preferred_region* re-heads the region ranking as above.
+
+    Raises ``ValueError`` on an empty *members*.
+    """
+    if not members:
+        raise ValueError("cannot derive a canonical name for an empty sibling group")
+    winner = min(members, key=lambda m: _rank_key(m, preferred_region))
+    return str(winner.get("name") or "")

--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -14,6 +14,14 @@ from __future__ import annotations
 
 from typing import Any, NamedTuple
 
+from domain.sibling_resolution import resolve_group_representative
+
+# Marker key a rebind entry carries so the per-unit commit moves the DB binding
+# from the vanished bound sibling (the entry's ``rom_id``, kept so the frontend
+# reuses its existing shortcut) onto the surviving representative. Absent on
+# normal / grandfathered entries. See :func:`collapse_sibling_groups`.
+BIND_ROM_ID_KEY = "bind_rom_id"
+
 
 class ClassificationResult(NamedTuple):
     new: list[dict[str, Any]]
@@ -77,6 +85,130 @@ def classify_roms(
         1 for rid in stale if registry.get(str(rid), {}).get("platform_name") not in fetched_platform_names
     )
     return ClassificationResult(new, changed, unchanged_ids, stale, disabled_count)
+
+
+def collapse_sibling_groups(
+    shortcuts_data: list[dict[str, Any]],
+    registry: dict[str, dict[str, Any]],
+    installed_rom_ids: set[int],
+    *,
+    complete_group_view: bool,
+) -> list[dict[str, Any]]:
+    """Collapse per-ROM shortcut entries to one Steam shortcut per sibling group.
+
+    A sibling group (same ``sibling_group_key``) is one game = at most one NEW
+    Steam shortcut (ADR-0021 §2). *shortcuts_data* is the built entry for every
+    fetched ROM; *registry* is the bound ``roms`` rows keyed by ``str(rom_id)``
+    (each carrying ``app_id``, ``name``, ``fs_name``, ``platform_slug`` and
+    ``sibling_group_key``); *installed_rom_ids* are the ROMs currently on disk.
+
+    *complete_group_view* asserts whether *shortcuts_data* holds the WHOLE
+    membership of every group a bound row belongs to — the load-bearing safety
+    input. A sibling group is per-platform, so a **platform** unit fetch and the
+    whole-library **preview** union are complete views; a **collection** unit is
+    a PARTIAL view (it spans platforms and may fetch just one unbound sibling of
+    a group whose other members — including the bound one — were never in this
+    fetch). Only a complete view may conclude "bound sibling absent from members
+    ⇒ vanished from the server"; inferring that from a partial view would rebind
+    a live installed game's shortcut onto an uninstalled sibling (#1296 CRITICAL).
+
+    Returns the subset of entries to actually emit as shortcuts, one lane per
+    group:
+
+    * **Grandfathered** — the group has ≥1 bound sibling still fetched: every
+      surviving bound sibling keeps its own entry (ADR-0021 §5). No new shortcut
+      is minted; an unbound fetched sibling becomes a tracked row with no
+      shortcut, and (complete view only) a vanished bound sibling is torn down by
+      the stale path.
+    * **Rebind** (complete view only) — every bound sibling vanished from the
+      server but the group still has fetched members: one synthetic entry (see
+      :func:`_rebind_entry`) keeps the vanished sibling's shortcut and moves its
+      binding to the surviving representative.
+    * **New** — no binding anywhere in the group: emit the single representative
+      chosen by :func:`resolve_group_representative`.
+    * **Grandfathered untouched** (partial view only) — the group holds a binding
+      that is not in THIS fetch: emit nothing. Absence from a partial view is not
+      absence from the server, so the binding is left alone (no rebind, no second
+      shortcut). The group's real representative rides its own platform unit in
+      the same run; the unbound fetched members still persist via
+      ``pending_all_roms`` and the reporter's collection group-fallback places the
+      group's shortcut in the Steam collection.
+
+    Bound rows are grouped by their FETCHED sibling key when the row is in this
+    fetch (so a legacy row whose stored key is still NULL is placed in its real
+    group and grandfathered rather than churned), falling back to the stored key
+    for a vanished bound row.
+    """
+    # Keys are ``str | None``: a built entry always carries a real key, but a
+    # legacy bound row may still hold NULL (its own solo/unmatched group).
+    by_group: dict[str | None, list[dict[str, Any]]] = {}
+    for sd in shortcuts_data:
+        by_group.setdefault(sd.get("sibling_group_key"), []).append(sd)
+
+    fetched_key_by_id: dict[Any, str | None] = {sd["rom_id"]: sd.get("sibling_group_key") for sd in shortcuts_data}
+    bound_by_group: dict[str | None, list[tuple[int, dict[str, Any]]]] = {}
+    bound_rom_ids: set[int] = set()
+    for rid_str, reg in registry.items():
+        if not reg.get("app_id"):
+            continue
+        rid = int(rid_str)
+        bound_rom_ids.add(rid)
+        group_key = fetched_key_by_id.get(rid, reg.get("sibling_group_key"))
+        bound_by_group.setdefault(group_key, []).append((rid, reg))
+
+    emitted: list[dict[str, Any]] = []
+    for group_key, members in by_group.items():
+        fetched_ids = {m["rom_id"] for m in members}
+        bound_here = bound_by_group.get(group_key, [])
+        surviving_ids = {rid for rid, _ in bound_here if rid in fetched_ids}
+        if surviving_ids:
+            # ≥1 bound sibling still fetched → grandfather every surviving one.
+            emitted.extend(m for m in members if m["rom_id"] in surviving_ids)
+        elif not bound_here:
+            # No binding anywhere in the group → mint the single representative.
+            rep_id = resolve_group_representative(members, installed_rom_ids, bound_rom_ids)
+            emitted.append(_member_by_id(members, rep_id))
+        elif complete_group_view:
+            # Complete view: every bound sibling truly vanished from the server →
+            # rebind the shortcut onto the surviving representative (ADR-0021 §2,
+            # never remove).
+            rep = _member_by_id(members, resolve_group_representative(members, installed_rom_ids, bound_rom_ids))
+            kept_rom_id, kept_reg = min(bound_here, key=lambda item: item[0])
+            emitted.append(_rebind_entry(rep, kept_rom_id, kept_reg))
+        # else: partial view (collection unit) — the group holds a binding not in
+        # THIS fetch, so its absence here is not absence from the server.
+        # Grandfather it untouched (no rebind, no new shortcut); its real
+        # representative is owned by the group's platform unit in the same run.
+    return emitted
+
+
+def _member_by_id(members: list[dict[str, Any]], rom_id: int) -> dict[str, Any]:
+    """Return the group member whose ``rom_id`` matches (the resolver picks from *members*)."""
+    return next(m for m in members if m["rom_id"] == rom_id)
+
+
+def _rebind_entry(rep: dict[str, Any], kept_rom_id: int, kept_reg: dict[str, Any]) -> dict[str, Any]:
+    """Synthesize the emitted entry for a rebinding group (ADR-0021 §2).
+
+    Keyed by the vanished bound sibling (*kept_rom_id*) so the frontend REUSES
+    that sibling's existing Steam shortcut (its appId is already in the
+    rom_id→appId map) and the preview diff reads the group as unchanged. The
+    entry carries the representative's launch bake (its installed path, or the
+    empty placeholder when the representative is uninstalled) plus a
+    ``bind_rom_id`` marker so the per-unit commit moves the DB binding onto the
+    representative — the shortcut's appId, artwork, collections and playtime all
+    survive; only the active version changes. Identity fields stay the vanished
+    sibling's (sticky name — never rename automatically, which would change the
+    appId).
+    """
+    return {
+        **rep,
+        "rom_id": kept_rom_id,
+        "name": kept_reg.get("name", rep.get("name", "")),
+        "fs_name": kept_reg.get("fs_name", ""),
+        "platform_slug": kept_reg.get("platform_slug", rep.get("platform_slug", "")),
+        BIND_ROM_ID_KEY: rep["rom_id"],
+    }
 
 
 def select_stale_removals(

--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any, NamedTuple
 
-from domain.sibling_resolution import resolve_group_representative
+from domain.sibling_resolution import AUTO_REGION, canonical_group_name, resolve_group_representative
 
 # Marker key a rebind entry carries so the per-unit commit moves the DB binding
 # from the vanished bound sibling (the entry's ``rom_id``, kept so the frontend
@@ -93,6 +93,7 @@ def collapse_sibling_groups(
     installed_rom_ids: set[int],
     *,
     complete_group_view: bool,
+    preferred_region: str = AUTO_REGION,
 ) -> list[dict[str, Any]]:
     """Collapse per-ROM shortcut entries to one Steam shortcut per sibling group.
 
@@ -125,7 +126,12 @@ def collapse_sibling_groups(
       :func:`_rebind_entry`) keeps the vanished sibling's shortcut and moves its
       binding to the surviving representative.
     * **New** — no binding anywhere in the group: emit the single representative
-      chosen by :func:`resolve_group_representative`.
+      chosen by :func:`resolve_group_representative`, but with its display
+      ``name`` replaced by :func:`canonical_group_name` — the region-preferred
+      member's name mints the sticky Steam shortcut (ADR-0021 §2/§3), while the
+      representative's ``rom_id`` / launch bake stay the bind target. This is the
+      only lane that renames: an already-bound group (grandfathered / rebind)
+      carries its persisted name verbatim, so a live shortcut is never renamed.
     * **Grandfathered untouched** (partial view only) — the group holds a binding
       that is not in THIS fetch: emit nothing. Absence from a partial view is not
       absence from the server, so the binding is left alone (no rebind, no second
@@ -138,6 +144,11 @@ def collapse_sibling_groups(
     fetch (so a legacy row whose stored key is still NULL is placed in its real
     group and grandfathered rather than churned), falling back to the stored key
     for a vanished bound row.
+
+    *preferred_region* re-heads the region ranking that both the representative
+    and the canonical name fall back to (``"auto"`` = the build-time default
+    order); it is read from settings by the caller and must be the same value at
+    every collapse call site within one sync run.
     """
     # Keys are ``str | None``: a built entry always carries a real key, but a
     # legacy bound row may still hold NULL (its own solo/unmatched group).
@@ -165,14 +176,22 @@ def collapse_sibling_groups(
             # ≥1 bound sibling still fetched → grandfather every surviving one.
             emitted.extend(m for m in members if m["rom_id"] in surviving_ids)
         elif not bound_here:
-            # No binding anywhere in the group → mint the single representative.
-            rep_id = resolve_group_representative(members, installed_rom_ids, bound_rom_ids)
-            emitted.append(_member_by_id(members, rep_id))
+            # No binding anywhere in the group → mint the single representative,
+            # named after the region-preferred (canonical) member. The bind
+            # target stays the representative's rom_id + launch bake; only the
+            # sticky Steam name follows the pure region ranking (ADR-0021 §2/§3).
+            # Copy so the original member dict (also staged in pending_all_roms
+            # for the per-sibling identity upsert) keeps its own real name.
+            rep_id = resolve_group_representative(members, installed_rom_ids, bound_rom_ids, preferred_region)
+            emitted.append({**_member_by_id(members, rep_id), "name": canonical_group_name(members, preferred_region)})
         elif complete_group_view:
             # Complete view: every bound sibling truly vanished from the server →
             # rebind the shortcut onto the surviving representative (ADR-0021 §2,
-            # never remove).
-            rep = _member_by_id(members, resolve_group_representative(members, installed_rom_ids, bound_rom_ids))
+            # never remove). The rebind entry keeps the vanished sibling's
+            # persisted name (sticky) — canonical naming is mint-only.
+            rep = _member_by_id(
+                members, resolve_group_representative(members, installed_rom_ids, bound_rom_ids, preferred_region)
+            )
             kept_rom_id, kept_reg = min(bound_here, key=lambda item: item[0])
             emitted.append(_rebind_entry(rep, kept_rom_id, kept_reg))
         # else: partial view (collection unit) — the group holds a binding not in

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -59,6 +59,14 @@ class LibrarySyncStateBox:
     sync_last_heartbeat: float = 0.0
     sync_progress: dict[str, Any] = field(default_factory=_default_progress)
     pending_sync: dict[int, dict[str, Any]] = field(default_factory=dict)
+    # Every fetched ROM of the active unit (built shortcut-shape, keyed by
+    # rom_id), not just the emitted representatives in ``pending_sync``. The
+    # per-unit commit upserts an identity + version-metadata row for ALL of them
+    # (ADR-0021 group-aware persist) while only representatives carry a binding.
+    # Populated alongside ``pending_sync`` in ``_sync_one_unit`` and reset with
+    # it; kept across the heartbeat-timeout abandon window so a late ack can
+    # still drive the full persist.
+    pending_all_roms: dict[int, dict[str, Any]] = field(default_factory=dict)
     pending_delta: PreviewDelta | None = None
     pending_collection_memberships: dict[str, list[int]] = field(default_factory=dict)
     pending_platform_rom_ids: set[int] | None = None

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -442,74 +442,99 @@ class LibraryFetcher:
             collections = []
         return _collection_units(collections, enabled_ids, "franchise")
 
-    def _read_incremental_baseline(self, platform_slug: str) -> tuple[str | None, list[dict[str, Any]]]:
-        """Read ``(last_sync_iso, reconstructed_roms)`` for *platform_slug* from SQLite.
+    def _read_incremental_baseline(self, platform_slug: str) -> tuple[str | None, list[dict[str, Any]], int, bool]:
+        """Read the incremental-skip baseline for *platform_slug* from SQLite.
 
-        ``last_sync`` is the ``finished_at`` of the newest completed
-        ``SyncRun``; the reconstructed list is the platform's bound ``roms``
-        rows shaped like a RomM list response (thin — no ``metadatum``, so
-        the orchestrator's skip-guard keeps them out of the metadata
-        stamp). Only one short read UoW is opened.
+        Returns ``(last_sync_iso, reconstructed_roms, persisted_count,
+        needs_backfill)``:
+
+        * ``last_sync`` — ``finished_at`` of the newest completed ``SyncRun``.
+        * ``reconstructed_roms`` — the platform's **bound** ``roms`` rows shaped
+          like a RomM list response (thin — no ``metadatum``, so the skip-guard
+          keeps them out of the metadata stamp). This is the shortcut set the
+          skip reconstructs as the unit's ROMs.
+        * ``persisted_count`` — **all** persisted rows for the platform (bound +
+          unbound siblings). Group-aware sync persists every sibling (ADR-0021),
+          so this is what RomM's platform ``rom_count`` is compared against.
+        * ``needs_backfill`` — any persisted row still carries a NULL
+          ``sibling_group_key`` (predates the version-metadata capture), so the
+          platform must full-fetch to fill it in.
+
+        Only one short read UoW is opened.
         """
         with self._uow_factory() as uow:
             latest = uow.sync_runs.get_latest_completed()
             last_sync = latest.finished_at if latest is not None else None
-            roms = [
-                {
-                    "id": rom.rom_id,
-                    "name": rom.name,
-                    "fs_name": rom.fs_name,
-                    "platform_slug": rom.platform_slug,
-                    "igdb_id": rom.igdb_id,
-                    "sgdb_id": rom.sgdb_id,
-                    "ra_id": rom.ra_id,
-                    "sibling_group_key": rom.sibling_group_key,
-                }
-                for rom in uow.roms.iter_by_platform(platform_slug)
-                if rom.shortcut_app_id is not None
-            ]
-        return last_sync, roms
+            all_rows = list(uow.roms.iter_by_platform(platform_slug))
+        reconstructed = [
+            {
+                "id": rom.rom_id,
+                "name": rom.name,
+                "fs_name": rom.fs_name,
+                "platform_slug": rom.platform_slug,
+                "igdb_id": rom.igdb_id,
+                "sgdb_id": rom.sgdb_id,
+                "ra_id": rom.ra_id,
+                "sibling_group_key": rom.sibling_group_key,
+            }
+            for rom in all_rows
+            if rom.shortcut_app_id is not None
+        ]
+        needs_backfill = any(rom.sibling_group_key is None for rom in all_rows)
+        return last_sync, reconstructed, len(all_rows), needs_backfill
 
     @staticmethod
     def _decorate_reconstructed(
-        roms: list[dict[str, Any]], platform_name: str, platform_slug: str
+        roms: list[dict[str, Any]], platform_name: str, platform_slug: str, platform_id: int
     ) -> list[dict[str, Any]]:
-        """Stamp the live platform display name/slug onto reconstructed ROM dicts."""
+        """Stamp the live platform display name/slug/id onto reconstructed ROM dicts.
+
+        ``platform_id`` is the unit's own platform id (every reconstructed row is
+        this one platform's), stamped so a reconstructed dict is shaped like a live
+        RomM fetch — the persisted ``sibling_group_key`` is already authoritative,
+        but stamping the id keeps ``compute_sibling_group_key`` correct as a
+        fallback rather than yielding ``…:None`` (#1296).
+        """
         for rom in roms:
             rom["platform_name"] = platform_name
             rom["platform_slug"] = platform_slug
             rom["platform_display_name"] = platform_name
+            rom["platform_id"] = platform_id
         return roms
 
     async def _try_unit_incremental_skip(self, unit: WorkUnit) -> list[dict[str, Any]] | None:
         """Per-unit incremental-skip pre-check for a platform unit.
 
-        Returns the roms-reconstructed ROM list when the platform is
-        unchanged (server reports zero rows updated after ``last_sync``
-        and the unit's ``rom_count`` matches the bound-ROM count for this
-        platform). Returns ``None`` to signal "fall through to a full
-        paginated fetch" — either no bound ROMs exist for this platform,
-        no prior completed sync exists, the delta check raised, or the
-        server reports changes.
+        Returns the roms-reconstructed ROM list (the platform's bound rows =
+        its shortcuts) when the platform is unchanged: the server reports zero
+        rows updated after ``last_sync`` AND the unit's ``rom_count`` matches
+        the count of ALL persisted rows for the platform. Group-aware sync
+        persists every sibling (ADR-0021), so the count compares against all
+        persisted rows — not the bound representatives — restoring skip parity
+        on platforms that hold sibling groups. Returns ``None`` to fall through
+        to a full paginated fetch — no persisted rows, no prior completed sync,
+        an un-backfilled row, the delta check raised, or the server reports
+        changes.
         """
         platform_name = unit.name
         platform_slug = unit.slug
 
-        last_sync, reconstructed = await self._loop.run_in_executor(
+        last_sync, reconstructed, persisted_count, needs_backfill = await self._loop.run_in_executor(
             None, self._read_incremental_baseline, platform_slug
         )
         registry_count = len(reconstructed)
 
-        if not last_sync or registry_count == 0:
+        if not last_sync or persisted_count == 0:
             return None
 
-        # Version-metadata backfill (#1295 / ADR-0021): a bound ROM whose
-        # sibling_group_key is still NULL predates the version-metadata capture
-        # and must be re-fetched to fill it in. Skipping the platform would leave
-        # it NULL forever, so any un-backfilled ROM forces a full fetch — the
-        # commit then persists every row's group key + version dimensions. Once
-        # every ROM carries a key this is a no-op and the skip resumes.
-        if any(not rom.get("sibling_group_key") for rom in reconstructed):
+        # Version-metadata backfill (#1295 / #1296 / ADR-0021): a persisted ROM
+        # whose sibling_group_key is still NULL predates the version-metadata
+        # capture and must be re-fetched to fill it in (and to persist its
+        # siblings). Skipping would leave it NULL forever, so any un-backfilled
+        # ROM forces a full fetch — the commit then persists every sibling's
+        # group key + version dimensions. Once every row carries a key this is a
+        # no-op and the skip resumes.
+        if needs_backfill:
             self._logger.info(f"Per-unit fetch {platform_name}: version-metadata backfill needed — full fetch")
             return None
 
@@ -532,13 +557,16 @@ class LibraryFetcher:
             return None
 
         server_total = delta_resp.get("total", 0) if isinstance(delta_resp, dict) else 0
-        if server_total == 0 and unit.rom_count == registry_count:
-            self._logger.info(f"Per-unit skip: {platform_name} unchanged ({registry_count} ROMs in registry)")
-            return self._decorate_reconstructed(reconstructed, platform_name, platform_slug)
+        if server_total == 0 and unit.rom_count == persisted_count:
+            self._logger.info(
+                f"Per-unit skip: {platform_name} unchanged "
+                f"({persisted_count} ROMs persisted, {registry_count} shortcuts)"
+            )
+            return self._decorate_reconstructed(reconstructed, platform_name, platform_slug, int(unit.id))
 
         self._logger.info(
             f"Per-unit fetch {platform_name}: {server_total} updated, "
-            f"server={unit.rom_count} registry={registry_count} — full fetch"
+            f"server={unit.rom_count} persisted={persisted_count} shortcuts={registry_count} — full fetch"
         )
         return None
 

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 from domain.platform_names import decode_platform_names
 from domain.rom import Rom
 from domain.rom_metadata_mapping import build_rom_metadata
-from domain.sync_diff import should_include_in_platform_collection
+from domain.sync_diff import BIND_ROM_ID_KEY, should_include_in_platform_collection
 from domain.sync_stage import SyncStage
 
 if TYPE_CHECKING:
@@ -116,28 +116,50 @@ class SyncReporter:
         (every bound ROM, including ones an incremental sync skipped —
         they remain rows), keyed by the platform's live display name
         resolved from *platform_names* (the work-queue), falling back to
-        the slug when absent. RomM collections keep the per-run
-        membership accumulator and resolve each ``rom_id`` to its bound
-        ``shortcut_app_id`` via ``uow.roms``. Both loops EXCLUDE rows
-        whose ``shortcut_app_id`` is ``None`` (unbound / stale).
+        the slug when absent.
+
+        RomM collections keep the per-run membership accumulator and resolve
+        each member ``rom_id`` to a Steam appId with a **sibling-group
+        fallback** (ADR-0021): a bound member uses its own binding; an unbound
+        member maps to its group's bound sibling's appId, so favouriting /
+        collecting ANY version of a game puts the game's single shortcut into
+        the Steam collection. Per-collection appIds are de-duplicated — several
+        siblings of one group collapse onto the one shortcut. The platform loop
+        still excludes rows whose ``shortcut_app_id`` is ``None``.
         """
         create_groups = self._settings.get("collection_create_platform_groups", False)
         platform_app_ids: dict[str, list[int]] = {}
+        # Each sibling group's bound appId, keyed by sibling_group_key. When a
+        # group carries several bound rows (grandfathered duplicates) the
+        # smallest rom_id's binding wins, deterministically.
+        group_bound: dict[str, tuple[int, int]] = {}
         for rom in uow.roms.iter_all():
             if rom.shortcut_app_id is None:
                 continue
-            if not should_include_in_platform_collection(rom.rom_id, pending_platform_rom_ids, create_groups):
-                continue
-            display = platform_names.get(rom.platform_slug, rom.platform_slug)
-            platform_app_ids.setdefault(display, []).append(rom.shortcut_app_id)
+            if should_include_in_platform_collection(rom.rom_id, pending_platform_rom_ids, create_groups):
+                display = platform_names.get(rom.platform_slug, rom.platform_slug)
+                platform_app_ids.setdefault(display, []).append(rom.shortcut_app_id)
+            group_key = rom.sibling_group_key
+            if group_key is not None:
+                current = group_bound.get(group_key)
+                if current is None or rom.rom_id < current[0]:
+                    group_bound[group_key] = (rom.rom_id, rom.shortcut_app_id)
 
+        group_bound_app_id = {key: app_id for key, (_rid, app_id) in group_bound.items()}
         romm_collection_app_ids: dict[str, list[int]] = {}
         for coll_name, rom_ids in pending_collection_memberships.items():
-            app_ids = [
-                rom.shortcut_app_id
-                for rid in rom_ids
-                if (rom := uow.roms.get(rid)) is not None and rom.shortcut_app_id is not None
-            ]
+            seen: set[int] = set()
+            app_ids: list[int] = []
+            for rid in rom_ids:
+                rom = uow.roms.get(rid)
+                if rom is None:
+                    continue
+                app_id = rom.shortcut_app_id
+                if app_id is None and rom.sibling_group_key is not None:
+                    app_id = group_bound_app_id.get(rom.sibling_group_key)
+                if app_id is not None and app_id not in seen:
+                    seen.add(app_id)
+                    app_ids.append(app_id)
             if app_ids:
                 romm_collection_app_ids[coll_name] = app_ids
 
@@ -258,88 +280,104 @@ class SyncReporter:
 
     # ── Report unit results (per-unit pipeline) ──────────────────
 
-    def _commit_unit_results_io(self, rom_id_to_app_id, acked_roms):
-        """Sync helper: finalise artwork file names, then upsert ``roms`` + metadata for one unit.
+    def _commit_unit_results_io(self, rom_id_to_app_id, unit_roms):
+        """Finalise artwork names, then persist EVERY fetched ROM of the unit.
 
-        ADR-0006 two-pass: cover-file RENAME is filesystem I/O so it runs
-        FIRST (outside any UoW); the final paths are collected, then one
-        short write UoW upserts every acked ROM via
-        :meth:`_upsert_acked_rom`, which lands each ROM row and its cached
-        metadata atomically. ``acked_roms`` is the live RomM fetch keyed by
-        rom_id so the per-rom upsert can stamp metadata in the same write
-        UoW as the ``roms`` row.
+        Group-aware commit (ADR-0021): the unit's whole live RomM fetch
+        (*unit_roms*) is upserted — one ``roms`` row per sibling for its
+        identity + version metadata — while only the acked representatives
+        carry a Steam-shortcut binding. A non-representative sibling keeps
+        whatever binding it already had (usually none); a bound row not
+        re-acked this cycle is never silently unbound.
+
+        The frontend ack is **translated through any rebind** first: a rebind
+        entry is keyed by the vanished bound sibling (so the frontend reused its
+        shortcut), but the binding — and the finalised cover — move onto the
+        surviving representative named in ``bind_rom_id``.
+
+        ADR-0006 two-pass: cover-file RENAME is filesystem I/O so it runs FIRST
+        (outside any UoW); the final paths are collected, then one short write
+        UoW upserts every ROM (Rom row first, cached metadata second — FK-safe),
+        so a ROM and its metadata land atomically.
         """
         grid = self._steam_config.grid_dir()
         box = self._sync_state
 
-        # ``acked_roms`` is the live RomM fetch for the ROMs the frontend
-        # acked — the only source of ``metadatum``. Keyed by rom_id so the
-        # Pass-2 loop can stamp metadata in the same iteration as the upsert.
-        roms_by_id = {int(r["id"]): r for r in acked_roms if "id" in r}
-
-        # Pass 1: rename staged covers to their final ``{app_id}p.png``
-        # path (file I/O — no UoW open).
-        finalized: dict[str, str] = {}
+        # Translate the ack onto binding targets (rebind moves the binding off
+        # the vanished sibling onto its representative) and finalise the staged
+        # cover to ``{app_id}p.png``, keyed by the target rom_id.
+        binding: dict[int, int] = {}
+        finalized: dict[int, str] = {}
         for rom_id_str, app_id in rom_id_to_app_id.items():
-            pending = box.pending_sync.get(int(rom_id_str), {})
-            finalized[rom_id_str] = self._finalize_cover_path(grid, pending.get("cover_path", ""), app_id, rom_id_str)
+            entry = box.pending_sync.get(int(rom_id_str), {})
+            target = int(entry.get(BIND_ROM_ID_KEY, int(rom_id_str)))
+            binding[target] = int(app_id)
+            finalized[target] = self._finalize_cover_path(grid, entry.get("cover_path", ""), int(app_id), str(target))
 
-        # Pass 2: one write UoW for the whole unit's ROM + metadata upserts.
+        # ``unit_roms`` is the live RomM fetch for the whole unit — the source of
+        # each ROM's ``metadatum``. Keyed by rom_id so the persist loop can stamp
+        # metadata in the same iteration as the upsert.
+        roms_by_id = {int(r["id"]): r for r in unit_roms if "id" in r}
+
         with self._uow_factory() as uow:
-            for rom_id_str, app_id in rom_id_to_app_id.items():
-                self._upsert_acked_rom(uow, rom_id_str, app_id, finalized, roms_by_id)
+            for raw in unit_roms:
+                if "id" in raw:
+                    self._persist_synced_rom(uow, int(raw["id"]), binding, finalized, roms_by_id)
 
         steam_input_mode = self._settings.get("steam_input_mode", "default")
-        if steam_input_mode != "default" and rom_id_to_app_id:
+        if steam_input_mode != "default" and binding:
             try:
-                self._steam_config.set_steam_input_config(
-                    [int(aid) for aid in rom_id_to_app_id.values()], mode=steam_input_mode
-                )
+                self._steam_config.set_steam_input_config([int(aid) for aid in binding.values()], mode=steam_input_mode)
             except Exception as e:
                 self._logger.error(f"Failed to set Steam Input config: {e}")
 
-    def _upsert_acked_rom(self, uow, rom_id_str, app_id, finalized, roms_by_id) -> None:
-        """Upsert one acked ROM + its cached metadata into the open write UoW.
+    def _persist_synced_rom(self, uow, rom_id, binding, finalized, roms_by_id) -> None:
+        """Upsert one fetched ROM + its cached metadata into the open write UoW.
 
-        Builds the ``Rom`` via ``Rom.synced`` (which validates untrusted
-        RomM fields; a ``ValueError`` is caught here so one bad row is
-        skipped while the rest of the unit still commits), read-merges the
-        plugin-resolved ids (``sgdb_id`` / ``ra_id`` / ``cover_path`` follow
-        "non-None new wins, else preserve existing, else None"), saves the
-        Rom, then stamps its cached metadata. Saving the Rom before its
-        metadata satisfies the ``rom_metadata.rom_id → roms(rom_id)`` FK at
-        commit, so a ROM and its metadata land atomically.
+        Reads the built identity + version fields from ``pending_all_roms`` (the
+        whole unit's shortcut-shaped build), binds the ROM only when it is a
+        binding target this cycle (else preserves its existing binding — a
+        non-representative sibling stays unbound, a bound row not re-acked keeps
+        its shortcut), read-merges the plugin-resolved ids
+        (``sgdb_id`` / ``ra_id`` / ``cover_path`` follow "non-None new wins,
+        else preserve existing, else None"), saves the Rom, then stamps its
+        cached metadata. Saving the Rom before its metadata satisfies the
+        ``rom_metadata.rom_id → roms(rom_id)`` FK at commit. ``Rom.synced``
+        validates untrusted RomM fields; a ``ValueError`` is caught so one bad
+        row is skipped while the rest of the unit still commits.
         """
-        box = self._sync_state
-        pending = box.pending_sync.get(int(rom_id_str), {})
-        rom_id = int(rom_id_str)
+        built = self._sync_state.pending_all_roms.get(rom_id, {})
         existing = uow.roms.get(rom_id)
+        # Bind a binding target this cycle; otherwise preserve any existing
+        # binding (a non-representative sibling stays unbound, a bound row not
+        # re-acked keeps its shortcut).
+        app_id = binding.get(rom_id, existing.shortcut_app_id if existing is not None else None)
         try:
             rom = Rom.synced(
                 rom_id=rom_id,
-                platform_slug=pending.get("platform_slug", ""),
-                name=pending.get("name", ""),
-                fs_name=pending.get("fs_name", ""),
-                shortcut_app_id=int(app_id),
+                platform_slug=built.get("platform_slug", ""),
+                name=built.get("name", ""),
+                fs_name=built.get("fs_name", ""),
+                shortcut_app_id=app_id,
                 synced_at=self._clock.now().isoformat(),
-                igdb_id=pending.get("igdb_id"),
-                sibling_group_key=pending.get("sibling_group_key"),
-                regions=tuple(pending.get("regions") or ()),
-                languages=tuple(pending.get("languages") or ()),
-                revision=pending.get("revision") or "",
-                tags=tuple(pending.get("tags") or ()),
-                is_main_sibling=bool(pending.get("is_main_sibling", False)),
+                igdb_id=built.get("igdb_id"),
+                sibling_group_key=built.get("sibling_group_key"),
+                regions=tuple(built.get("regions") or ()),
+                languages=tuple(built.get("languages") or ()),
+                revision=built.get("revision") or "",
+                tags=tuple(built.get("tags") or ()),
+                is_main_sibling=bool(built.get("is_main_sibling", False)),
             )
         except ValueError as e:
-            self._logger.warning(f"Skipping invalid ROM {rom_id_str} during commit: {e}")
+            self._logger.warning(f"Skipping invalid ROM {rom_id} during commit: {e}")
             return
-        cover_path = finalized.get(rom_id_str) or (existing.cover_path if existing is not None else None)
+        cover_path = finalized.get(rom_id) or (existing.cover_path if existing is not None else None)
         if cover_path:
             rom.update_cover_path(cover_path)
-        sgdb_id = self._merge_optional_id(pending.get("sgdb_id"), existing.sgdb_id if existing else None)
+        sgdb_id = self._merge_optional_id(built.get("sgdb_id"), existing.sgdb_id if existing else None)
         if sgdb_id is not None:
             rom.assign_sgdb_id(sgdb_id)
-        ra_id = self._merge_optional_id(pending.get("ra_id"), existing.ra_id if existing else None)
+        ra_id = self._merge_optional_id(built.get("ra_id"), existing.ra_id if existing else None)
         if ra_id is not None:
             rom.assign_ra_id(ra_id)
         uow.roms.save(rom)
@@ -396,9 +434,11 @@ class SyncReporter:
         * The orchestrator abandoned the unit on a heartbeat timeout
           (``unit_abandoned``): the frontend already created the Steam
           shortcuts, so commit the delivered bindings here rather than
-          discard them (#1052). Rebuilds ``acked_roms`` from the stashed
-          unit ROMs (the ``metadatum`` source) so metadata is stamped too,
-          then clears the abandoned-unit stash.
+          discard them (#1052). Passes the whole stashed unit fetch
+          (``box.pending_unit_roms``) to ``commit_unit_results`` — every
+          fetched sibling is upserted (identity + metadata, the ``metadatum``
+          source) and only the acked representatives bind — then clears the
+          abandoned-unit stash.
         * Neither (a stray duplicate ack for the active unit): no-op, so
           nothing is double-committed.
         """
@@ -414,11 +454,11 @@ class SyncReporter:
         if box.unit_complete_event is not None:
             box.unit_complete_event.set()
         elif box.unit_abandoned:
-            acked_roms = [r for r in box.pending_unit_roms if str(r["id"]) in rom_id_to_app_id]
-            await self.commit_unit_results(dict(rom_id_to_app_id), acked_roms)
+            await self.commit_unit_results(dict(rom_id_to_app_id), box.pending_unit_roms)
             box.unit_abandoned = False
             box.pending_unit_roms = []
             box.pending_sync = {}
+            box.pending_all_roms = {}
             box.last_unit_results = None
             box.active_unit_id = None
 
@@ -442,23 +482,23 @@ class SyncReporter:
             return False
         return str(run_id) == str(box.current_sync_id) and str(unit_id) == str(box.active_unit_id)
 
-    async def commit_unit_results(self, rom_id_to_app_id, acked_roms):
+    async def commit_unit_results(self, rom_id_to_app_id, unit_roms):
         """Per-unit commit: cover-path finalize then atomic ``roms`` + metadata upsert.
 
         Called once the frontend has acked the unit's shortcuts — by the
         orchestrator on the happy path, or by :meth:`report_unit_results`
-        itself on the heartbeat-timeout late-ack path (#1052). The ``roms``
-        upsert and the cached-metadata stamp land in one write UoW (Rom row
-        first, then ``rom_metadata`` — FK-safe), so a ROM and its metadata
-        are always consistent across a crash. ``acked_roms`` is the live
-        RomM fetch for the acked ROMs — the source of each ROM's
-        ``metadatum``.
+        itself on the heartbeat-timeout late-ack path (#1052). ``unit_roms`` is
+        the whole unit's live RomM fetch: a ``roms`` row is upserted for EVERY
+        sibling (identity + version metadata, ADR-0021), but only the acked
+        representatives carry a binding. The upsert and the cached-metadata
+        stamp land in one write UoW (Rom row first, then ``rom_metadata`` —
+        FK-safe), so a ROM and its metadata are always consistent across a crash.
 
         Records every bound appId in the shared box so the stale-removal scan
         excludes appIds this run committed, whichever path drove the commit —
         a new rom_id reusing an old appId must not look stale (#1036).
         """
-        await self._loop.run_in_executor(None, self._commit_unit_results_io, rom_id_to_app_id, acked_roms)
+        await self._loop.run_in_executor(None, self._commit_unit_results_io, rom_id_to_app_id, unit_roms)
         self._sync_state.committed_app_ids.update(int(aid) for aid in rom_id_to_app_id.values())
 
     # ── Registry queries ─────────────────────────────────────────

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -153,12 +153,18 @@ class SyncReporter:
             if should_include_in_platform_collection(rom.rom_id, pending_platform_rom_ids, create_groups):
                 display = platform_names.get(rom.platform_slug, rom.platform_slug)
                 platform_app_ids.setdefault(display, []).append(rom.shortcut_app_id)
-            group_key = rom.sibling_group_key
-            if group_key is not None:
-                current = group_bound.get(group_key)
-                if current is None or rom.rom_id < current[0]:
-                    group_bound[group_key] = (rom.rom_id, rom.shortcut_app_id)
+            self._note_group_binding(group_bound, rom)
         return platform_app_ids, {key: app_id for key, (_rid, app_id) in group_bound.items()}
+
+    @staticmethod
+    def _note_group_binding(group_bound: dict[str, tuple[int, int]], rom: Rom) -> None:
+        """Record the group's winning binding: smallest bound rom_id wins."""
+        group_key = rom.sibling_group_key
+        if group_key is None or rom.shortcut_app_id is None:
+            return
+        current = group_bound.get(group_key)
+        if current is None or rom.rom_id < current[0]:
+            group_bound[group_key] = (rom.rom_id, rom.shortcut_app_id)
 
     def _resolve_collection_memberships(
         self,

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -127,11 +127,25 @@ class SyncReporter:
         siblings of one group collapse onto the one shortcut. The platform loop
         still excludes rows whose ``shortcut_app_id`` is ``None``.
         """
+        platform_app_ids, group_bound_app_id = self._scan_bound_rows(uow, pending_platform_rom_ids, platform_names)
+        romm_collection_app_ids = self._resolve_collection_memberships(
+            uow, pending_collection_memberships, group_bound_app_id
+        )
+        return platform_app_ids, romm_collection_app_ids
+
+    def _scan_bound_rows(
+        self,
+        uow: UnitOfWork,
+        pending_platform_rom_ids: set[int] | None,
+        platform_names: dict[str, str],
+    ) -> tuple[dict[str, list[int]], dict[str, int]]:
+        """One pass over the bound rows: platform buckets + each group's bound appId.
+
+        When a group carries several bound rows (grandfathered duplicates) the
+        smallest rom_id's binding wins, deterministically.
+        """
         create_groups = self._settings.get("collection_create_platform_groups", False)
         platform_app_ids: dict[str, list[int]] = {}
-        # Each sibling group's bound appId, keyed by sibling_group_key. When a
-        # group carries several bound rows (grandfathered duplicates) the
-        # smallest rom_id's binding wins, deterministically.
         group_bound: dict[str, tuple[int, int]] = {}
         for rom in uow.roms.iter_all():
             if rom.shortcut_app_id is None:
@@ -144,8 +158,20 @@ class SyncReporter:
                 current = group_bound.get(group_key)
                 if current is None or rom.rom_id < current[0]:
                     group_bound[group_key] = (rom.rom_id, rom.shortcut_app_id)
+        return platform_app_ids, {key: app_id for key, (_rid, app_id) in group_bound.items()}
 
-        group_bound_app_id = {key: app_id for key, (_rid, app_id) in group_bound.items()}
+    def _resolve_collection_memberships(
+        self,
+        uow: UnitOfWork,
+        pending_collection_memberships: dict[str, list[int]],
+        group_bound_app_id: dict[str, int],
+    ) -> dict[str, list[int]]:
+        """Resolve each collection's member rom_ids to de-duplicated appIds.
+
+        A bound member uses its own binding; an unbound member falls back to
+        its sibling group's bound appId (ADR-0021). Collections that resolve
+        to no appId are omitted.
+        """
         romm_collection_app_ids: dict[str, list[int]] = {}
         for coll_name, rom_ids in pending_collection_memberships.items():
             seen: set[int] = set()
@@ -162,8 +188,7 @@ class SyncReporter:
                     app_ids.append(app_id)
             if app_ids:
                 romm_collection_app_ids[coll_name] = app_ids
-
-        return platform_app_ids, romm_collection_app_ids
+        return romm_collection_app_ids
 
     # ── Finalise per-unit run ────────────────────────────────────
 

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -183,18 +183,25 @@ class SyncReporter:
             seen: set[int] = set()
             app_ids: list[int] = []
             for rid in rom_ids:
-                rom = uow.roms.get(rid)
-                if rom is None:
-                    continue
-                app_id = rom.shortcut_app_id
-                if app_id is None and rom.sibling_group_key is not None:
-                    app_id = group_bound_app_id.get(rom.sibling_group_key)
+                app_id = self._member_app_id(uow, rid, group_bound_app_id)
                 if app_id is not None and app_id not in seen:
                     seen.add(app_id)
                     app_ids.append(app_id)
             if app_ids:
                 romm_collection_app_ids[coll_name] = app_ids
         return romm_collection_app_ids
+
+    @staticmethod
+    def _member_app_id(uow: UnitOfWork, rid: int, group_bound_app_id: dict[str, int]) -> int | None:
+        """A member's appId: its own binding, else its sibling group's bound appId."""
+        rom = uow.roms.get(rid)
+        if rom is None:
+            return None
+        if rom.shortcut_app_id is not None:
+            return rom.shortcut_app_id
+        if rom.sibling_group_key is None:
+            return None
+        return group_bound_app_id.get(rom.sibling_group_key)
 
     # ── Finalise per-unit run ────────────────────────────────────
 

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -24,7 +24,9 @@ from typing import TYPE_CHECKING, Any
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import EmulatorInvocation, build_shortcuts_data
 from domain.sync_diff import (
+    BIND_ROM_ID_KEY,
     classify_roms,
+    collapse_sibling_groups,
     compute_collection_diff,
     compute_platform_collection_diff,
     select_stale_removals,
@@ -220,8 +222,18 @@ class SyncOrchestrator:
             registry, last_synced_platforms, last_synced_collections = await self._loop.run_in_executor(
                 None, self._read_preview_baseline, slug_to_name
             )
+            # Collapse to one entry per sibling group (ADR-0021) so the preview
+            # counts games, not individual dumps: a multi-version game becomes one
+            # shortcut and its unbound siblings stop reading as perpetual "new".
+            # The preview union is a COMPLETE view of every group (a group is
+            # per-platform, and every enabled platform is fully fetched), which the
+            # apply path's platform units match — so the preview counts can't
+            # diverge from what those units produce (the #1292 bug class). A
+            # collection apply unit is a partial view and only grandfathers, so it
+            # never adds a shortcut the preview didn't already count.
+            emitted = collapse_sibling_groups(shortcuts_data, registry, set(installed_paths), complete_group_view=True)
             new, changed, unchanged_ids, stale, disabled_count = classify_roms(
-                shortcuts_data,
+                emitted,
                 registry,
                 platform_name_set,
             )
@@ -258,7 +270,7 @@ class SyncOrchestrator:
                         last_synced_collections,
                     ),
                     "platform_collection_diff": compute_platform_collection_diff(
-                        shortcuts_data,
+                        emitted,
                         platform_rom_ids,
                         last_synced_platforms,
                         self._settings.get("collection_create_platform_groups", False),
@@ -648,11 +660,43 @@ class SyncOrchestrator:
                     "fs_name": rom.fs_name,
                     "platform_name": slug_to_name.get(rom.platform_slug, rom.platform_slug),
                     "platform_slug": rom.platform_slug,
+                    "sibling_group_key": rom.sibling_group_key,
                 }
             latest = uow.sync_runs.get_latest_completed()
             last_platforms = list(latest.platforms_completed or []) if latest is not None else []
             last_collections = list(latest.collections_completed or []) if latest is not None else []
         return registry, last_platforms, last_collections
+
+    def _read_apply_registry(self, unit: WorkUnit) -> dict[str, dict[str, Any]]:
+        """Read the bound-row registry the per-unit group collapse diffs against.
+
+        Platform units scope to their own platform's rows (a sibling group is
+        per-platform, so a vanished bound sibling shares the platform); collection
+        units read the whole registry since their ROMs span platforms. A platform
+        unit's fetch is therefore a COMPLETE view of every group it touches (the
+        collapse may rebind); a collection unit's fetch is a PARTIAL view — the
+        whole registry surfaces bindings for groups the unit only partly fetched,
+        so the collapse must not treat those as vanished (it passes
+        ``complete_group_view=False`` and only grandfathers). Only bound rows (a
+        live ``shortcut_app_id``) are returned — an unbound sibling is not a
+        shortcut the collapse can grandfather or rebind. The apply path did not
+        read the registry before group-aware sync (ADR-0021).
+        """
+        with self._uow_factory() as uow:
+            rows = (
+                uow.roms.iter_by_platform(unit.slug) if unit.type == "platform" and unit.slug else uow.roms.iter_all()
+            )
+            return {
+                str(rom.rom_id): {
+                    "app_id": rom.shortcut_app_id,
+                    "name": rom.name,
+                    "fs_name": rom.fs_name,
+                    "platform_slug": rom.platform_slug,
+                    "sibling_group_key": rom.sibling_group_key,
+                }
+                for rom in rows
+                if rom.shortcut_app_id is not None
+            }
 
     async def _sync_one_unit(
         self,
@@ -715,8 +759,8 @@ class SyncOrchestrator:
             self._logger.info(f"Per-unit apply skipped: {unit.name} ({len(unit_roms)} ROMs unchanged)")
             return len(unit_roms)
 
-        # Build shortcut data for this unit. Installed ROMs carry the full
-        # launch command; uninstalled ROMs get an empty placeholder until
+        # Build shortcut data for every fetched ROM. Installed ROMs carry the
+        # full launch command; uninstalled ROMs get an empty placeholder until
         # they are downloaded.
         installed_paths = await self._loop.run_in_executor(
             None, self._read_installed_paths, {rom["id"] for rom in unit_roms}
@@ -724,22 +768,42 @@ class SyncOrchestrator:
         core_overrides = await self._loop.run_in_executor(None, self._build_core_overrides, unit_roms)
         shortcuts_data = build_shortcuts_data(unit_roms, self._plugin_dir, installed_paths, core_overrides)
 
-        # Download artwork for this unit. Empty unit_roms is a defensive
-        # guard — an empty platform that survived planning still has no
-        # artwork to fetch.
-        if unit_roms:
+        # Collapse to one Steam shortcut per sibling group (ADR-0021): only the
+        # representative (plus any grandfathered bound siblings) is emitted; a
+        # rebinding group's entry is keyed to its vanished sibling so the
+        # frontend reuses that shortcut. A PLATFORM unit fetches a group's whole
+        # membership (a group is per-platform), so it is a complete view and may
+        # rebind; a COLLECTION unit is a partial view (it fetches only its
+        # members, not a group's bound sibling on another/skipped platform) — the
+        # collapse then only grandfathers, never rebinds a live binding onto an
+        # uninstalled sibling (#1296).
+        registry = await self._loop.run_in_executor(None, self._read_apply_registry, unit)
+        emitted = collapse_sibling_groups(
+            shortcuts_data, registry, set(installed_paths), complete_group_view=(unit.type == "platform")
+        )
+
+        # Download artwork only for the ROMs that actually get a shortcut (the
+        # representatives + grandfathered siblings), not every dump — no eager
+        # covers for versions with no shortcut. A rebind entry pulls its cover
+        # from the representative it binds (``bind_rom_id``), whose raw dict is
+        # the one present in unit_roms.
+        if emitted:
+            artwork_ids = {int(e.get(BIND_ROM_ID_KEY, e["rom_id"])) for e in emitted}
+            artwork_roms = [rom for rom in unit_roms if rom["id"] in artwork_ids]
             cover_paths = await self._download_artwork(
-                unit_roms, progress_step=unit_index + 1, progress_total_steps=total_units
+                artwork_roms, progress_step=unit_index + 1, progress_total_steps=total_units
             )
-            for sd in shortcuts_data:
-                sd["cover_path"] = cover_paths.get(sd["rom_id"], "")
+            for e in emitted:
+                e["cover_path"] = cover_paths.get(int(e.get(BIND_ROM_ID_KEY, e["rom_id"])), "")
 
         if box.is_cancelling():
             return 0
 
-        # Stage pending_sync for this unit so the reporter's commit step
-        # can finalise cover paths + build registry entries against it.
-        box.pending_sync = {sd["rom_id"]: sd for sd in shortcuts_data}
+        # Stage the emitted representatives for cover finalise + binding, and the
+        # full built set for the ack-independent identity + version persist (the
+        # reporter upserts a row for every sibling, binds only representatives).
+        box.pending_sync = {e["rom_id"]: e for e in emitted}
+        box.pending_all_roms = {sd["rom_id"]: sd for sd in shortcuts_data}
 
         # Emit per-unit apply event + wait for the frontend callback.
         box.unit_complete_event = asyncio.Event()
@@ -762,7 +826,7 @@ class SyncOrchestrator:
                 "unit_name": unit.name,
                 "unit_index": unit_index,
                 "total_units": total_units,
-                "shortcuts": shortcuts_data,
+                "shortcuts": emitted,
             },
         )
 
@@ -776,30 +840,32 @@ class SyncOrchestrator:
                 # Drop the pending state, null the event, and clear the unit
                 # identity so a stray late ack can't commit a cancelled unit.
                 box.pending_sync = {}
+                box.pending_all_roms = {}
                 box.unit_complete_event = None
                 box.active_unit_id = None
             else:
                 # Heartbeat timeout: the frontend has already created this
                 # unit's Steam shortcuts and will still fire its late
                 # ``report_unit_results`` ack. Keep ``pending_sync`` +
-                # ``unit_complete_event`` and stash the unit's ROMs so the
-                # late ack commits the delivered bindings instead of leaving
-                # orphan shortcuts (#1052). Flag the unit abandoned so the
-                # reporter drives that commit itself.
+                # ``pending_all_roms`` + ``unit_complete_event`` and stash the
+                # unit's ROMs so the late ack commits the delivered bindings
+                # instead of leaving orphan shortcuts (#1052). Flag the unit
+                # abandoned so the reporter drives that commit itself.
                 box.unit_abandoned = True
                 box.pending_unit_roms = unit_roms
                 box.request_cancel()
             return 0
 
-        # Per-unit commit: the reporter upserts each acked ROM into the
-        # ``roms`` aggregate and stamps its cached ``rom_metadata`` in one
-        # write UoW (Rom row first, metadata second — FK-safe), so a ROM
-        # and its metadata always land atomically. ``acked_roms`` is the
-        # live RomM fetch for the acked ROMs — the source of ``metadatum``.
-        acked_roms = [r for r in unit_roms if str(r["id"]) in applied]
-        await self._reporter.get().commit_unit_results(applied, acked_roms)
+        # Per-unit commit: the reporter upserts EVERY fetched ROM into the
+        # ``roms`` aggregate (identity + version metadata, unbound for non-
+        # representatives) and binds only the acked representatives, stamping
+        # each ROM's cached ``rom_metadata`` in the same write UoW (Rom row
+        # first, metadata second — FK-safe). ``unit_roms`` is the live RomM
+        # fetch for the whole unit — the source of ``metadatum``.
+        await self._reporter.get().commit_unit_results(applied, unit_roms)
 
         box.pending_sync = {}
+        box.pending_all_roms = {}
         box.unit_complete_event = None
         box.active_unit_id = None
         return len(applied)

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import EmulatorInvocation, build_shortcuts_data
+from domain.sibling_resolution import AUTO_REGION
 from domain.sync_diff import (
     BIND_ROM_ID_KEY,
     classify_roms,
@@ -231,7 +232,13 @@ class SyncOrchestrator:
             # diverge from what those units produce (the #1292 bug class). A
             # collection apply unit is a partial view and only grandfathers, so it
             # never adds a shortcut the preview didn't already count.
-            emitted = collapse_sibling_groups(shortcuts_data, registry, set(installed_paths), complete_group_view=True)
+            emitted = collapse_sibling_groups(
+                shortcuts_data,
+                registry,
+                set(installed_paths),
+                complete_group_view=True,
+                preferred_region=self._settings.get("preferred_region", AUTO_REGION),
+            )
             new, changed, unchanged_ids, stale, disabled_count = classify_roms(
                 emitted,
                 registry,
@@ -779,7 +786,11 @@ class SyncOrchestrator:
         # uninstalled sibling (#1296).
         registry = await self._loop.run_in_executor(None, self._read_apply_registry, unit)
         emitted = collapse_sibling_groups(
-            shortcuts_data, registry, set(installed_paths), complete_group_view=(unit.type == "platform")
+            shortcuts_data,
+            registry,
+            set(installed_paths),
+            complete_group_view=(unit.type == "platform"),
+            preferred_region=self._settings.get("preferred_region", AUTO_REGION),
         )
 
         # Download artwork only for the ROMs that actually get a shortcut (the

--- a/py_modules/services/settings.py
+++ b/py_modules/services/settings.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from domain.sibling_resolution import AUTO_REGION
 from lib.list_result import ErrorCode
 from lib.url_host import is_valid_server_url
 
@@ -105,6 +106,7 @@ class SettingsService:
             "log_level": self._settings.get("log_level", "warn"),
             "romm_allow_insecure_ssl": self._settings.get("romm_allow_insecure_ssl", False),
             "collection_create_platform_groups": self._settings.get("collection_create_platform_groups", False),
+            "preferred_region": self._settings.get("preferred_region", AUTO_REGION),
         }
 
     # ── Log level ────────────────────────────────────────────────────────
@@ -116,6 +118,41 @@ class SettingsService:
         self._settings["log_level"] = level
         self._settings_persister.save_settings()
         return {"success": True}
+
+    # ── Preferred region (sibling-group naming/binding) ──────────────────
+
+    def save_preferred_region(self, region: object) -> dict[str, Any]:
+        """Validate and persist the preferred sibling-group region (ADR-0021 §3).
+
+        ``"auto"`` (the default) means no preference — the fixed build-time region
+        order (World > USA > Europe > Japan) decides. Any other value lifts that
+        region to the top of the ranking used to pick a group's representative
+        and mint its shortcut name; it takes effect on the next sync (existing
+        shortcuts keep their bound version and name). A blank value normalises to
+        ``"auto"``. The region vocabulary is open-ended (RomM ships full-word
+        regions), so any string is accepted as-is; a non-string from the
+        untrusted frontend wire is rejected.
+        """
+        if not isinstance(region, str):
+            return {"success": False, "reason": "invalid_region", "message": "Invalid region"}
+        self._settings["preferred_region"] = region.strip() or AUTO_REGION
+        self._settings_persister.save_settings()
+        return {"success": True}
+
+    def get_known_regions(self) -> list[str]:
+        """Return the distinct region values present in the locally synced library.
+
+        Reads the ``regions`` of every persisted ``roms`` row (ADR-0021 version
+        metadata) and returns the distinct values, sorted alphabetically. This
+        is the source for the "Preferred region" dropdown's non-anchor options —
+        a purely local read, no server call. An empty library yields ``[]`` (the
+        dropdown then shows only its fixed anchors).
+        """
+        regions: set[str] = set()
+        with self._uow_factory() as uow:
+            for rom in uow.roms.iter_all():
+                regions.update(rom.regions)
+        return sorted(regions)
 
     def frontend_log(self, level: str, message: str) -> None:
         """Log a frontend message respecting the configured log_level threshold.

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -342,6 +342,12 @@ export const getDiscSelection = callable<[number], DiscSelection>("get_disc_sele
 export const selectDisc = callable<[number, string | null], SelectDiscResult>("select_disc");
 
 export const saveLogLevel = callable<[string], { success: boolean }>("save_log_level");
+// Preferred sibling-group region (ADR-0021 §3). "auto" = build-time default
+// order; any RomM region string heads the ranking on the next sync.
+export const savePreferredRegion = callable<[string], { success: boolean }>("save_preferred_region");
+// Distinct region values present in the locally synced library — the non-anchor
+// options for the Preferred-region dropdown. Pure local DB read, no server call.
+export const getKnownRegions = callable<[], string[]>("get_known_regions");
 export const debugLog = callable<[string], void>("debug_log");
 const frontendLog = callable<[string, string], void>("frontend_log");
 export const logInfo = (msg: string) => {

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -29,6 +29,8 @@ import type { SaveSyncSection } from "./settings/SaveSyncSection";
 import type { RegisteredDevicesSection } from "./settings/RegisteredDevicesSection";
 import type { ControllerSection } from "./settings/ControllerSection";
 import type { AdvancedSection } from "./settings/AdvancedSection";
+import type { LibrarySection } from "./settings/LibrarySection";
+import { showPreferredRegionModal } from "./settings/PreferredRegionModal";
 import type { SaveSortMigrationSection } from "./settings/SaveSortMigrationSection";
 
 type ConnectionProps = ComponentProps<typeof ConnectionSection>;
@@ -37,6 +39,7 @@ type SaveSyncProps = ComponentProps<typeof SaveSyncSection>;
 type RegisteredDevicesProps = ComponentProps<typeof RegisteredDevicesSection>;
 type ControllerProps = ComponentProps<typeof ControllerSection>;
 type AdvancedProps = ComponentProps<typeof AdvancedSection>;
+type LibraryProps = ComponentProps<typeof LibrarySection>;
 type SaveSortMigrationProps = ComponentProps<typeof SaveSortMigrationSection>;
 
 // Captured props arrays — reset in beforeEach. Each child mock pushes the
@@ -48,6 +51,7 @@ const capturedSaveSync: SaveSyncProps[] = [];
 const capturedDevices: RegisteredDevicesProps[] = [];
 const capturedController: ControllerProps[] = [];
 const capturedAdvanced: AdvancedProps[] = [];
+const capturedLibrary: LibraryProps[] = [];
 const capturedMigration: SaveSortMigrationProps[] = [];
 
 vi.mock("./settings/ConnectionSection", () => ({
@@ -85,6 +89,23 @@ vi.mock("./settings/AdvancedSection", () => ({
     capturedAdvanced.push(p);
     return createElement("div", { "data-testid": "advanced-section" });
   },
+}));
+vi.mock("./settings/LibrarySection", async (importOriginal) => {
+  // Keep the real AUTO_REGION / DEFAULT_REGION_LABEL constants (SettingsPage
+  // imports them), but stub the component to capture props.
+  const actual = await importOriginal<typeof import("./settings/LibrarySection")>();
+  return {
+    ...actual,
+    LibrarySection: (p: LibraryProps) => {
+      capturedLibrary.push(p);
+      return createElement("div", { "data-testid": "library-section" });
+    },
+  };
+});
+
+// The Preferred-region change modal — mocked so tests control confirm/cancel.
+vi.mock("./settings/PreferredRegionModal", () => ({
+  showPreferredRegionModal: vi.fn(() => Promise.resolve(true)),
 }));
 vi.mock("./settings/SaveSortMigrationSection", () => ({
   SaveSortMigrationSection: (p: SaveSortMigrationProps) => {
@@ -191,6 +212,7 @@ describe("SettingsPage", () => {
     capturedDevices.length = 0;
     capturedController.length = 0;
     capturedAdvanced.length = 0;
+    capturedLibrary.length = 0;
     capturedMigration.length = 0;
     saveSortListeners.length = 0;
     currentSortState = { pending: false };
@@ -199,6 +221,8 @@ describe("SettingsPage", () => {
     }
     // Defaults — many tests override per case.
     vi.mocked(backend.getSettings).mockResolvedValue(defaultSettings());
+    vi.mocked(backend.getKnownRegions).mockResolvedValue([]);
+    vi.mocked(showPreferredRegionModal).mockResolvedValue(true);
     vi.mocked(backend.getSaveSyncSettings).mockResolvedValue(defaultSaveSyncSettings());
     vi.mocked(backend.getSaveSortMigrationStatus).mockResolvedValue({ pending: false });
     vi.mocked(backend.listDevices).mockResolvedValue({ success: true, devices: [] });
@@ -1451,6 +1475,73 @@ describe("SettingsPage", () => {
       });
       expect(vi.mocked(backend.saveLogLevel)).toHaveBeenCalledWith("debug");
       expect(capturedAdvanced[capturedAdvanced.length - 1]?.logLevel).toBe("debug");
+    });
+  });
+
+  describe("Library handlers", () => {
+    it("hydrates preferredRegion from getSettings", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue({
+        ...defaultSettings(),
+        preferred_region: "Japan",
+      });
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("Japan");
+    });
+
+    it("defaults preferredRegion to 'auto' when getSettings omits it", async () => {
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("auto");
+    });
+
+    it("forwards library regions from getKnownRegions to LibrarySection", async () => {
+      vi.mocked(backend.getKnownRegions).mockResolvedValue(["Korea", "Brazil"]);
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.libraryRegions).toEqual(["Korea", "Brazil"]);
+    });
+
+    it("change → confirm shows the explanation modal, then persists and updates the dropdown", async () => {
+      vi.mocked(showPreferredRegionModal).mockResolvedValue(true);
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("Japan");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The modal is shown with the human-readable old→new labels ("auto" → default label).
+      expect(vi.mocked(showPreferredRegionModal)).toHaveBeenCalledWith("Default (World > USA > Europe)", "Japan");
+      expect(vi.mocked(backend.savePreferredRegion)).toHaveBeenCalledWith("Japan");
+      expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("Japan");
+    });
+
+    it("change → cancel shows the modal but does NOT persist and leaves the dropdown unchanged", async () => {
+      vi.mocked(showPreferredRegionModal).mockResolvedValue(false);
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("Japan");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(showPreferredRegionModal)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(backend.savePreferredRegion)).not.toHaveBeenCalled();
+      expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("auto");
+    });
+
+    it("selecting the already-current region is a no-op (no modal, no save)", async () => {
+      render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("auto");
+        await Promise.resolve();
+      });
+      expect(vi.mocked(showPreferredRegionModal)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.savePreferredRegion)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -17,6 +17,8 @@ import {
   updateSaveSyncSettings,
   syncAllSaves,
   saveLogLevel,
+  savePreferredRegion,
+  getKnownRegions,
   fixRetroarchInputDriver,
   ensureDeviceRegistered,
   listDevices,
@@ -44,6 +46,8 @@ import { SaveSyncSection } from "./settings/SaveSyncSection";
 import { RegisteredDevicesSection } from "./settings/RegisteredDevicesSection";
 import { ControllerSection } from "./settings/ControllerSection";
 import { AdvancedSection } from "./settings/AdvancedSection";
+import { LibrarySection, AUTO_REGION, DEFAULT_REGION_LABEL } from "./settings/LibrarySection";
+import { showPreferredRegionModal } from "./settings/PreferredRegionModal";
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -88,6 +92,10 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // Advanced state
   const [logLevel, setLogLevel] = useState("warn");
 
+  // Library state (preferred sibling-group region, ADR-0021)
+  const [preferredRegion, setPreferredRegion] = useState(AUTO_REGION);
+  const [libraryRegions, setLibraryRegions] = useState<string[]>([]);
+
   useEffect(() => {
     getSettings()
       .then((s) => {
@@ -98,6 +106,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         setSgdbApiKey(s.sgdb_api_key_masked);
         setSteamInputMode(s.steam_input_mode);
         setLogLevel(s.log_level);
+        setPreferredRegion(s.preferred_region ?? AUTO_REGION);
         if (s.retroarch_input_check) {
           setRetroarchWarning(s.retroarch_input_check);
         }
@@ -106,6 +115,12 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
         logError(`Failed to load settings: ${e}`);
         setStatus("Failed to load settings");
       });
+
+    // Distinct regions in the locally synced library — the non-anchor options
+    // for the Preferred-region dropdown. Failure degrades to anchors only.
+    getKnownRegions()
+      .then((regions) => setLibraryRegions(regions))
+      .catch(() => {});
 
     // Load save sync settings and conflicts
     getSaveSyncSettings()
@@ -427,6 +442,25 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     detach(saveLogLevel(level));
   };
 
+  // --- Library handlers ---
+  const regionLabel = (value: string) => (value === AUTO_REGION ? DEFAULT_REGION_LABEL : value);
+
+  const handlePreferredRegionChange = (region: string) => {
+    if (region === preferredRegion) return;
+    // Explain the apply-at-next-sync / no-retroactive-rename semantics before
+    // persisting. Confirm saves + updates the dropdown; cancel leaves the state
+    // (and therefore the dropdown selection) unchanged.
+    detach(
+      (async () => {
+        const proceed = await showPreferredRegionModal(regionLabel(preferredRegion), regionLabel(region));
+        if (proceed) {
+          setPreferredRegion(region);
+          detach(savePreferredRegion(region));
+        }
+      })(),
+    );
+  };
+
   // --- Save sort migration handlers ---
   const handleMigrateSaveSort = async () => {
     setSaveSortMigrating(true);
@@ -556,6 +590,12 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
           detach(handleFixInputDriver());
         }}
       />
+      <LibrarySection
+        preferredRegion={preferredRegion}
+        libraryRegions={libraryRegions}
+        onPreferredRegionChange={handlePreferredRegionChange}
+      />
+
       <AdvancedSection logLevel={logLevel} onLogLevelChange={handleLogLevelChange} />
     </>
   );

--- a/src/components/settings/LibrarySection.test.tsx
+++ b/src/components/settings/LibrarySection.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { LibrarySection, buildRegionOptions, DEFAULT_REGION_LABEL, AUTO_REGION } from "./LibrarySection";
+
+// DropdownItem isn't in the global @decky/ui stub. Capture rgOptions +
+// selectedOption + onChange so we can drive the onChange callback and assert
+// the wiring without rendering a real Steam Dropdown.
+interface DropdownOption {
+  data: unknown;
+  label: string;
+}
+interface DropdownItemProps {
+  label?: string;
+  rgOptions?: DropdownOption[];
+  selectedOption?: unknown;
+  onChange?: (option: DropdownOption) => void;
+}
+const captured: { items: DropdownItemProps[] } = { items: [] };
+
+vi.mock("@decky/ui", () => {
+  type AnyProps = Record<string, unknown> & { children?: unknown };
+  const passthrough = (tag: string) => (p: AnyProps) => createElement(tag, {}, p.children as never);
+  return {
+    PanelSection: passthrough("section"),
+    PanelSectionRow: passthrough("div"),
+    DropdownItem: (p: DropdownItemProps) => {
+      captured.items.push(p);
+      return createElement("div", { "data-testid": "dropdown" }, p.label as never);
+    },
+  };
+});
+
+describe("buildRegionOptions", () => {
+  it("lists the Default sentinel + fixed anchors first, in build-time order", () => {
+    const opts = buildRegionOptions([], AUTO_REGION);
+    expect(opts.map((o) => o.data)).toEqual([AUTO_REGION, "World", "USA", "Europe", "Japan"]);
+    expect(opts[0]?.label).toBe(DEFAULT_REGION_LABEL);
+    expect(opts[0]?.label).not.toMatch(/auto/i);
+  });
+
+  it("appends distinct library regions after the anchors, sorted, de-duped against anchors", () => {
+    const opts = buildRegionOptions(["Korea", "Brazil", "USA", "Korea"], AUTO_REGION);
+    // "USA" is an anchor → not duplicated; "Korea"/"Brazil" appended sorted.
+    expect(opts.map((o) => o.data)).toEqual([AUTO_REGION, "World", "USA", "Europe", "Japan", "Brazil", "Korea"]);
+  });
+
+  it("empty library → anchors only", () => {
+    expect(buildRegionOptions([], AUTO_REGION).map((o) => o.data)).toEqual([
+      AUTO_REGION,
+      "World",
+      "USA",
+      "Europe",
+      "Japan",
+    ]);
+  });
+
+  it("always includes the current selection even if absent from anchors + library", () => {
+    const opts = buildRegionOptions([], "Germany");
+    expect(opts.map((o) => o.data)).toContain("Germany");
+  });
+
+  it("ignores empty/blank library region strings", () => {
+    const opts = buildRegionOptions(["", "Brazil"], AUTO_REGION);
+    expect(opts.map((o) => o.data)).toEqual([AUTO_REGION, "World", "USA", "Europe", "Japan", "Brazil"]);
+  });
+});
+
+describe("LibrarySection", () => {
+  beforeEach(() => {
+    captured.items = [];
+  });
+
+  it("renders the preferred-region dropdown with anchors + library regions", () => {
+    render(
+      <LibrarySection preferredRegion={AUTO_REGION} libraryRegions={["Korea"]} onPreferredRegionChange={vi.fn()} />,
+    );
+    expect(captured.items).toHaveLength(1);
+    const item = captured.items[0];
+    expect(item?.label).toBe("Preferred region");
+    expect(item?.rgOptions?.map((o) => o.data)).toEqual([AUTO_REGION, "World", "USA", "Europe", "Japan", "Korea"]);
+  });
+
+  it("forwards the current preferredRegion as selectedOption", () => {
+    render(<LibrarySection preferredRegion="Japan" libraryRegions={[]} onPreferredRegionChange={vi.fn()} />);
+    expect(captured.items[0]?.selectedOption).toBe("Japan");
+  });
+
+  it("dispatches onPreferredRegionChange with option.data when the dropdown fires", () => {
+    const onChange = vi.fn();
+    render(<LibrarySection preferredRegion={AUTO_REGION} libraryRegions={[]} onPreferredRegionChange={onChange} />);
+    captured.items[0]?.onChange?.({ data: "Japan", label: "Japan" });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("Japan");
+  });
+
+  it("passes the auto sentinel straight through", () => {
+    const onChange = vi.fn();
+    render(<LibrarySection preferredRegion="Europe" libraryRegions={[]} onPreferredRegionChange={onChange} />);
+    captured.items[0]?.onChange?.({ data: AUTO_REGION, label: DEFAULT_REGION_LABEL });
+    expect(onChange).toHaveBeenCalledWith(AUTO_REGION);
+  });
+});

--- a/src/components/settings/LibrarySection.tsx
+++ b/src/components/settings/LibrarySection.tsx
@@ -1,0 +1,75 @@
+/**
+ * Library-wide sync preferences. Currently houses the preferred-region
+ * dropdown (ADR-0021 §3): which region wins when a game has several dumps
+ * (versions) and the plugin must pick one to bind and to name the Steam
+ * shortcut after. Pure renderer: parent owns the current value, the list of
+ * regions discovered in the local library, and the save/confirm flow.
+ */
+
+import { FC } from "react";
+import { PanelSection, PanelSectionRow, DropdownItem } from "@decky/ui";
+
+interface LibrarySectionProps {
+  preferredRegion: string;
+  // Distinct region values found in the locally synced library (from the
+  // backend get_known_regions read). Appended after the fixed anchors.
+  libraryRegions: string[];
+  onPreferredRegionChange: (region: string) => void;
+}
+
+// The internal sentinel for "no preference — use the fixed build-time order".
+export const AUTO_REGION = "auto";
+
+// The fixed anchor regions, in the build-time default order. MIRRORS the backend
+// constant DEFAULT_REGION_PRIORITY (py_modules/domain/sibling_resolution.py) —
+// keep the two in sync. This is a fixed order, NOT language/system detection.
+export const ANCHOR_REGIONS: readonly string[] = ["World", "USA", "Europe", "Japan"];
+
+// The default option's label states the order explicitly so it never reads as
+// auto-detection.
+export const DEFAULT_REGION_LABEL = "Default (World > USA > Europe)";
+
+/**
+ * Build the dropdown options: the "Default" sentinel + the fixed anchors, then
+ * every OTHER region found in the local library (sorted, de-duped against the
+ * anchors). The currently-selected value is always included so a preference for
+ * a region no longer in the library still renders as selected.
+ */
+export function buildRegionOptions(libraryRegions: string[], selected: string): { data: string; label: string }[] {
+  const options: { data: string; label: string }[] = [
+    { data: AUTO_REGION, label: DEFAULT_REGION_LABEL },
+    ...ANCHOR_REGIONS.map((r) => ({ data: r, label: r })),
+  ];
+  const known = new Set<string>([AUTO_REGION, ...ANCHOR_REGIONS]);
+  const extras = Array.from(new Set(libraryRegions))
+    .filter((r) => r && !known.has(r))
+    .sort((a, b) => a.localeCompare(b));
+  for (const r of extras) {
+    options.push({ data: r, label: r });
+    known.add(r);
+  }
+  if (selected !== AUTO_REGION && !known.has(selected)) {
+    options.push({ data: selected, label: selected });
+  }
+  return options;
+}
+
+export const LibrarySection: FC<LibrarySectionProps> = ({
+  preferredRegion,
+  libraryRegions,
+  onPreferredRegionChange,
+}) => {
+  return (
+    <PanelSection title="Library">
+      <PanelSectionRow>
+        <DropdownItem
+          label="Preferred region"
+          description="When a game has several regional versions, prefer this region for the shortcut and its name. Applies to games synced from now on; existing shortcuts keep their name."
+          rgOptions={buildRegionOptions(libraryRegions, preferredRegion)}
+          selectedOption={preferredRegion}
+          onChange={(option) => onPreferredRegionChange(option.data)}
+        />
+      </PanelSectionRow>
+    </PanelSection>
+  );
+};

--- a/src/components/settings/PreferredRegionModal.test.tsx
+++ b/src/components/settings/PreferredRegionModal.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { cloneElement, createElement, type ReactElement } from "react";
+import { showModal } from "@decky/ui";
+import { showPreferredRegionModal } from "./PreferredRegionModal";
+import { detach } from "../../utils/detach";
+
+// Per-file @decky/ui mock: capture each ModalRoot's closeModal so the X-button /
+// outside-click path is observable, and render DialogButtons as <button>.
+type ModalCloseFn = (() => void) | undefined;
+const capturedModalCloseFns: ModalCloseFn[] = [];
+
+vi.mock("@decky/ui", () => {
+  type AnyProps = Record<string, unknown> & { children?: unknown };
+  return {
+    ModalRoot: (p: AnyProps & { closeModal?: () => void }) => {
+      capturedModalCloseFns.push(p.closeModal);
+      return createElement("div", { "data-testid": "modal-root" }, p.children as never);
+    },
+    DialogButton: ({ children, onClick }: AnyProps) => createElement("button", { onClick }, children as never),
+    showModal: vi.fn(),
+  };
+});
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll("button")).find((b) => b.textContent === text);
+  if (!btn) throw new Error(`button "${text}" not found`);
+  return btn as HTMLButtonElement;
+}
+
+interface ContentProps {
+  oldLabel: string;
+  newLabel: string;
+  closeModal?: () => void;
+  onDone: (proceed: boolean) => void;
+}
+function lastShownElement(): ReactElement<ContentProps> {
+  const calls = vi.mocked(showModal).mock.calls;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<ContentProps> | undefined;
+  if (!el) throw new Error("showModal was not called");
+  return el;
+}
+function withCloseModal(el: ReactElement<ContentProps>, closeModal: () => void): ReactElement<ContentProps> {
+  return cloneElement(el, { closeModal });
+}
+
+describe("PreferredRegionModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedModalCloseFns.length = 0;
+  });
+
+  it("renders the title, label arrow, and the apply-at-next-sync explanation", () => {
+    detach(showPreferredRegionModal("Default (World > USA > Europe)", "Japan"));
+    const { container } = render(lastShownElement());
+    expect(container.textContent).toContain("Change Preferred Region");
+    expect(container.textContent).toContain("Default (World > USA > Europe) → Japan");
+    expect(container.textContent).toContain("from now on");
+    expect(container.textContent).toContain("already synced keep their current version and shortcut name");
+  });
+
+  it("resolves true when Save is clicked", async () => {
+    const closeModal = vi.fn();
+    const promise = showPreferredRegionModal("Default (World > USA > Europe)", "USA");
+    const { container } = render(withCloseModal(lastShownElement(), closeModal));
+    fireEvent.click(buttonByText(container, "Save"));
+    expect(closeModal).toHaveBeenCalledTimes(1);
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false when Cancel is clicked", async () => {
+    const closeModal = vi.fn();
+    const promise = showPreferredRegionModal("USA", "Japan");
+    const { container } = render(withCloseModal(lastShownElement(), closeModal));
+    fireEvent.click(buttonByText(container, "Cancel"));
+    expect(closeModal).toHaveBeenCalledTimes(1);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("resolves false when ModalRoot closeModal fires (X / outside-click)", async () => {
+    const promise = showPreferredRegionModal("USA", "Japan");
+    render(lastShownElement());
+    const modalClose = capturedModalCloseFns[capturedModalCloseFns.length - 1];
+    expect(typeof modalClose).toBe("function");
+    modalClose?.();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("Save does not throw when closeModal is undefined", async () => {
+    const promise = showPreferredRegionModal("A", "B");
+    const { container } = render(lastShownElement());
+    expect(() => fireEvent.click(buttonByText(container, "Save"))).not.toThrow();
+    await expect(promise).resolves.toBe(true);
+  });
+});

--- a/src/components/settings/PreferredRegionModal.tsx
+++ b/src/components/settings/PreferredRegionModal.tsx
@@ -1,0 +1,75 @@
+import { FC } from "react";
+import { ModalRoot, DialogButton, showModal } from "@decky/ui";
+
+interface PreferredRegionModalProps {
+  oldLabel: string;
+  newLabel: string;
+  closeModal?: () => void;
+  onDone: (proceed: boolean) => void;
+}
+
+/**
+ * Explains what changing the Preferred-region setting does BEFORE it is saved
+ * (ADR-0021 §3). The key semantics the copy must make unmistakable: the setting
+ * persists immediately, but it only affects shortcuts minted from the NEXT sync
+ * onward (new games / groups without a binding). Already-synced games keep their
+ * bound version and shortcut name — the plugin never implicitly switches
+ * versions or renames a shortcut. No resync is forced; this modal only explains.
+ */
+const PreferredRegionModalContent: FC<PreferredRegionModalProps> = ({ oldLabel, newLabel, closeModal, onDone }) => {
+  const handleChoice = (proceed: boolean) => {
+    closeModal?.();
+    onDone(proceed);
+  };
+
+  return (
+    <ModalRoot
+      closeModal={() => {
+        closeModal?.();
+        onDone(false);
+      }}
+    >
+      <div style={{ padding: "16px", minWidth: "320px" }}>
+        <div style={{ fontSize: "16px", fontWeight: "bold", marginBottom: "4px", color: "#fff" }}>
+          Change Preferred Region
+        </div>
+        <div style={{ fontSize: "13px", color: "rgba(255, 255, 255, 0.6)", marginBottom: "16px" }}>
+          {oldLabel} → {newLabel}
+        </div>
+
+        <div
+          style={{
+            padding: "10px",
+            background: "rgba(26, 159, 255, 0.12)",
+            borderRadius: "4px",
+            border: "1px solid rgba(26, 159, 255, 0.3)",
+            marginBottom: "12px",
+          }}
+        >
+          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.8)", lineHeight: "1.4" }}>
+            This applies to games synced <b>from now on</b>. When a game has several regional versions, the plugin will
+            prefer this region for the version it binds and the name it gives the new Steam shortcut.
+            <br />
+            <br />
+            Games you have <b>already synced keep their current version and shortcut name</b> — changing this never
+            switches a game&apos;s version or renames an existing shortcut. Run a sync to apply it to new games.
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          <DialogButton onClick={() => handleChoice(true)}>Save</DialogButton>
+          <DialogButton onClick={() => handleChoice(false)} style={{ opacity: 0.5 }}>
+            Cancel
+          </DialogButton>
+        </div>
+      </div>
+    </ModalRoot>
+  );
+};
+
+/** Show the modal; resolves true if the user confirms, false on cancel / dismiss. */
+export function showPreferredRegionModal(oldLabel: string, newLabel: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    showModal(<PreferredRegionModalContent oldLabel={oldLabel} newLabel={newLabel} onDone={resolve} />);
+  });
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -48,6 +48,11 @@ export interface PluginSettings {
   romm_allow_insecure_ssl: boolean;
   retroarch_input_check?: RetroArchInputCheck;
   collection_create_platform_groups?: boolean;
+  // Preferred sibling-group region (ADR-0021 §3). "auto" = the fixed build-time
+  // default order (World > USA > Europe > Japan); any other value heads the
+  // ranking with that region on the next sync. Optional: the backend always
+  // sends it, but older payloads / test fixtures may omit it.
+  preferred_region?: string;
 }
 
 export interface RomMetadata {

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -70,6 +70,17 @@ export interface SyncAddItem {
   launch_options: string;
   platform_name: string;
   cover_path: string;
+  /**
+   * Present only on a sibling-group REBIND entry (ADR-0021 §2): the entry is
+   * keyed to the vanished bound sibling's `rom_id` so the frontend reuses its
+   * existing shortcut, while the backend moves the DB binding onto this
+   * representative at commit. Shortcut reuse is still keyed by `rom_id` through
+   * the existing-shortcut map, but the frontend DOES read this to fetch the
+   * representative's artwork (covers can be language-/edition-specific, so the
+   * shortcut must show the bound version's art, not the vanished sibling's). A
+   * plain optional number, JSON-safe.
+   */
+  bind_rom_id?: number;
 }
 
 export interface SyncPreviewSummary {

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -81,6 +81,115 @@ describe("syncManager — existing-shortcut update uses confirm-poll", () => {
   });
 });
 
+describe("syncManager — group-aware emit: one Steam shortcut per game (ADR-0021)", () => {
+  const EXE = "/home/deck/homebrew/plugins/decky-romm-sync/bin/rom-launcher";
+
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    vi.mocked(backend.reportUnitResults).mockClear();
+    resetSyncDelta();
+    resetSyncCancel();
+    // The global `SteamClient` stub is torn down by test-setup's
+    // `vi.unstubAllGlobals()` after the file's first test, so the update path's
+    // bare `SteamClient.Apps.Set*` calls would throw here — re-stub it.
+    vi.stubGlobal("SteamClient", {
+      Apps: {
+        AddShortcut: vi.fn(),
+        SetShortcutName: vi.fn(),
+        SetShortcutExe: vi.fn(),
+        SetShortcutStartDir: vi.fn(),
+        SetAppLaunchOptions: vi.fn(),
+        SetCustomArtworkForApp: vi.fn().mockResolvedValue(undefined),
+        RemoveShortcut: vi.fn(),
+      },
+    });
+  });
+
+  function groupItem(
+    overrides: Partial<SyncApplyUnitData["shortcuts"][number]>,
+  ): SyncApplyUnitData["shortcuts"][number] {
+    return {
+      rom_id: 0,
+      name: "Game",
+      exe: EXE,
+      start_dir: "/home/deck",
+      launch_options: "",
+      platform_name: "N64",
+      cover_path: "",
+      ...overrides,
+    };
+  }
+
+  it("reuses the existing shortcut for a rebind entry and fetches the representative's artwork", async () => {
+    // The backend collapsed a rebinding group to ONE entry keyed to the vanished
+    // bound sibling's rom_id (already in Steam as appId 5000), naming the
+    // representative in bind_rom_id. The frontend reuses that shortcut.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[1, 5000]]));
+    vi.mocked(backend.getArtworkBase64).mockClear();
+    vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: "ZGF0YQ==" });
+    const jpCmd = 'flatpak run net.retrodeck.retrodeck "/games/zelda_jp.z64"';
+    const data: SyncApplyUnitData = {
+      run_id: "run-rebind",
+      unit_type: "platform",
+      unit_id: 1,
+      unit_name: "N64",
+      unit_index: 0,
+      total_units: 1,
+      shortcuts: [groupItem({ rom_id: 1, name: "Zelda (USA)", launch_options: jpCmd, bind_rom_id: 2 })],
+    };
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", data);
+      await flush(150);
+    });
+
+    // Reused via the existing-shortcut update path — launch options re-baked to
+    // the representative's path via the confirm-poll; never a second AddShortcut.
+    expect(setLaunchOptionsConfirmed).toHaveBeenCalledWith(5000, jpCmd);
+    expect(addShortcut).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "1": 5000 }, "run-rebind", 1);
+    // Artwork follows the BINDING target (representative rom 2), NOT the vanished
+    // sibling (rom 1) the shortcut is keyed to — covers can be edition-specific.
+    expect(vi.mocked(backend.getArtworkBase64)).toHaveBeenCalledWith(2);
+    expect(vi.mocked(backend.getArtworkBase64)).not.toHaveBeenCalledWith(1);
+    // And the fetched art was applied to the reused shortcut's appId.
+    expect(SteamClient.Apps.SetCustomArtworkForApp).toHaveBeenCalledWith(5000, "ZGF0YQ==", "png", 0);
+  });
+
+  it("creates exactly one shortcut per group — a collapsed multi-version game never fans out", async () => {
+    // The backend already collapsed each sibling group to ONE entry, so a unit
+    // holding two games (both new) yields exactly two AddShortcut calls — never
+    // one per underlying dump.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    let next = 6000;
+    addShortcut.mockImplementation(async () => next++);
+    const data: SyncApplyUnitData = {
+      run_id: "run-two-groups",
+      unit_type: "platform",
+      unit_id: 1,
+      unit_name: "N64",
+      unit_index: 0,
+      total_units: 1,
+      shortcuts: [groupItem({ rom_id: 10, name: "Zelda" }), groupItem({ rom_id: 20, name: "Mario" })],
+    };
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", data);
+      await flush(250);
+    });
+
+    // Two groups → exactly two shortcuts, one per game.
+    expect(addShortcut).toHaveBeenCalledTimes(2);
+    expect(addShortcut.mock.calls.map((c) => c[0].rom_id).sort((a, b) => a - b)).toEqual([10, 20]);
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "10": 6000, "20": 6001 }, "run-two-groups", 1);
+  });
+});
+
 describe("syncManager — does not ack a cancelled unit (#1041)", () => {
   beforeEach(() => {
     setLaunchOptionsConfirmed.mockClear();

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -122,7 +122,11 @@ async function processUnitShortcuts(
       const appId = await resolveShortcutAppId(item, existing);
       if (appId) {
         romIdToAppId[String(item.rom_id)] = appId;
-        artworkTargets.push({ appId, romId: item.rom_id, name: item.name });
+        // Artwork follows the BINDING target: on a rebind entry the shortcut is
+        // keyed to the vanished sibling (item.rom_id) but the backend finalizes
+        // the REPRESENTATIVE's cover (bind_rom_id), and covers can be
+        // language-/edition-specific — so fetch the representative's art (ADR-0021).
+        artworkTargets.push({ appId, romId: item.bind_rom_id ?? item.rom_id, name: item.name });
       }
     } catch (e) {
       logError(`Per-unit: failed to process shortcut for rom ${item.rom_id}: ${e}`);

--- a/tests/adapters/test_sqlite_migrations.py
+++ b/tests/adapters/test_sqlite_migrations.py
@@ -71,8 +71,8 @@ def _set_user_version(db_path: str, version: int) -> None:
 # + 003_unique_shortcut_app_id + 004_add_selected_disc
 # + 005_unconfirm_legacy_slot_confirmations + 006_native_play_sessions
 # + 007_add_last_played + 008_add_version_metadata
-# + 009_add_last_session_start_monotonic).
-_SHIPPED_VERSION = 9
+# + 009_add_last_session_start_monotonic + 010_add_sibling_group_key_index).
+_SHIPPED_VERSION = 10
 
 # Tables after every shipped migration: the v1 set plus 006's play-session outbox.
 _SHIPPED_TABLES = _V1_TABLES | {"rom_playtime_sessions"}
@@ -612,6 +612,43 @@ class Test009AddLastSessionStartMonotonic:
             conn.close()
         # Pre-existing scalars survive; the new column defaults to NULL.
         assert row == (3600, 5, None)
+
+
+class Test010SiblingGroupKeyIndex:
+    """010 — non-unique index on roms(sibling_group_key) for the group readers (#1296)."""
+
+    def test_index_exists_after_full_apply(self, tmp_path: Path):
+        db_path = str(tmp_path / "romm_sync.db")
+
+        apply_migrations(db_path)
+
+        assert _user_version(db_path) == _SHIPPED_VERSION
+        assert "idx_roms_sibling_group_key" in _indexes(db_path, "roms")
+
+    def test_index_absent_before_010(self, tmp_path: Path):
+        # The index is added by 010 — a DB at v9 does not yet carry it.
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path, str(_only_migrations_through(tmp_path, 9)))
+
+        assert _user_version(db_path) == 9
+        assert "idx_roms_sibling_group_key" not in _indexes(db_path, "roms")
+
+    def test_index_is_non_unique_allows_duplicate_group_keys(self, tmp_path: Path):
+        # A sibling group has many rows sharing one key — the index must be
+        # non-unique so two rows with the same sibling_group_key coexist.
+        db_path = str(tmp_path / "romm_sync.db")
+        apply_migrations(db_path)
+
+        conn = sqlite3.connect(db_path, isolation_level=None)
+        try:
+            conn.execute("PRAGMA foreign_keys=ON")
+            _insert_rom(conn, 1, None)
+            _insert_rom(conn, 2, None)
+            conn.execute("UPDATE roms SET sibling_group_key = 'igdb:42:7' WHERE rom_id IN (1, 2)")
+            count = conn.execute("SELECT COUNT(*) FROM roms WHERE sibling_group_key = 'igdb:42:7'").fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 2
 
 
 def test_shipped_migrations_dir_resolves_to_real_schema():

--- a/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
+++ b/tests/contract/test_saves_setup_migration_005_reconfirms_legacy_rom.py
@@ -28,10 +28,12 @@ def _rewind_to_v4(db_path: str) -> None:
 
     Bootstrap stamps the DB at the latest version with the full schema. To replay
     the real 005 upgrade path the runner must see a genuine v4 database: the
-    version stamp AND the pre-006/007/008/009 schema (006's play-session outbox
-    table absent and ``note_id`` present, 007's ``last_played`` column absent,
-    008's version-metadata columns absent, and 009's ``last_session_start_monotonic``
-    column absent) so the sequential 005→006→007→008→009 re-run applies cleanly.
+    version stamp AND the pre-006/007/008/009/010 schema (006's play-session
+    outbox table absent and ``note_id`` present, 007's ``last_played`` column
+    absent, 008's version-metadata columns absent, 009's
+    ``last_session_start_monotonic`` column absent, and 010's
+    sibling_group_key index absent) so the sequential 005→…→010 re-run applies
+    cleanly.
     """
     conn = sqlite3.connect(db_path, isolation_level=None)
     try:
@@ -40,6 +42,9 @@ def _rewind_to_v4(db_path: str) -> None:
         conn.execute("ALTER TABLE rom_playtime DROP COLUMN last_played")
         # Reverse 009 so its ADD COLUMN re-applies instead of duplicating.
         conn.execute("ALTER TABLE rom_playtime DROP COLUMN last_session_start_monotonic")
+        # Reverse 010's index before dropping its column (SQLite rejects dropping
+        # a column an index still references), so 010 re-creates it cleanly.
+        conn.execute("DROP INDEX IF EXISTS idx_roms_sibling_group_key")
         # Reverse 008 so its ADD COLUMNs re-apply instead of duplicating.
         for column in ("sibling_group_key", "regions", "languages", "revision", "tags", "is_main_sibling"):
             conn.execute(f"ALTER TABLE roms DROP COLUMN {column}")

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -213,14 +213,17 @@ async def test_report_unit_results_late_ack_binds_orphan(harness):
     # Run + unit identity survives the abandon window so the late ack validates.
     box.current_sync_id = "run-1"
     box.active_unit_id = 1
-    box.pending_sync = {
-        42: {
-            "name": "Orphan Game",
-            "fs_name": "orphan.gba",
-            "platform_slug": "gba",
-            "cover_path": "",
-        },
+    _entry = {
+        "name": "Orphan Game",
+        "fs_name": "orphan.gba",
+        "platform_slug": "gba",
+        "cover_path": "",
     }
+    # ``pending_all_roms`` is the identity source for the group-aware persist;
+    # ``pending_sync`` holds the emitted representative. Both survive the abandon
+    # window so the late ack can drive the full commit (ADR-0021).
+    box.pending_sync = {42: _entry}
+    box.pending_all_roms = {42: _entry}
     box.unit_complete_event = None
     box.unit_abandoned = True
     box.pending_unit_roms = [{"id": 42}]

--- a/tests/domain/test_shortcut_data.py
+++ b/tests/domain/test_shortcut_data.py
@@ -434,3 +434,27 @@ class TestBuildShortcutsDataVersionMetadata:
         assert result[0]["languages"] == []
         assert result[0]["tags"] == []
         assert result[0]["revision"] == ""
+
+    def test_persisted_group_key_is_authoritative_over_recompute(self):
+        # #1296: an incremental-skip reconstructed row carries the persisted
+        # sibling_group_key but NO platform_id — recomputing it would yield
+        # "igdb:100:None" and split the group's bucket from a freshly-fetched
+        # sibling that DOES carry platform_id. The persisted key must win verbatim.
+        reconstructed = {"id": 10, "name": "Zelda (USA)", "igdb_id": 100, "sibling_group_key": "igdb:100:57"}
+        result = build_shortcuts_data([reconstructed], "/plugin", {}, {})
+        assert result[0]["sibling_group_key"] == "igdb:100:57"
+
+    def test_reconstructed_and_fetched_sibling_land_in_one_bucket(self):
+        # The end-to-end #1296 regression: a reconstructed representative (persisted
+        # key, no platform_id) and a freshly fetched sibling of the same game
+        # (platform_id + igdb_id, no key) must resolve to the SAME group key so the
+        # preview collapse buckets them as ONE game — not a phantom "new".
+        from domain.sync_diff import collapse_sibling_groups
+
+        reconstructed = {"id": 10, "name": "Zelda (USA)", "sibling_group_key": "igdb:100:57"}
+        fetched = {"id": 11, "name": "Zelda (JP)", "igdb_id": 100, "platform_id": 57}
+        result = build_shortcuts_data([reconstructed, fetched], "/plugin", {}, {})
+        assert {sd["sibling_group_key"] for sd in result} == {"igdb:100:57"}
+
+        emitted = collapse_sibling_groups(result, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1  # one bucket → one representative

--- a/tests/domain/test_sibling_resolution.py
+++ b/tests/domain/test_sibling_resolution.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import pytest
 
-from domain.sibling_resolution import resolve_group_representative
+from domain.sibling_resolution import canonical_group_name, resolve_group_representative
 
 
-def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False):
+def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False, regions=(), name=""):
     """A group member dict as build_shortcuts_data shapes it for the resolver."""
-    return {"rom_id": rom_id, "fs_name_no_ext": fs_name_no_ext, "is_main_sibling": is_main_sibling}
+    return {
+        "rom_id": rom_id,
+        "fs_name_no_ext": fs_name_no_ext,
+        "is_main_sibling": is_main_sibling,
+        "regions": list(regions),
+        "name": name,
+    }
 
 
 class TestResolveGroupRepresentative:
@@ -81,3 +87,148 @@ class TestResolveGroupRepresentative:
         forward = resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set())
         reversed_ = resolve_group_representative(list(reversed(members)), installed_rom_ids=set(), bound_rom_ids=set())
         assert forward == reversed_ == 2
+
+
+class TestRegionPriorityLeg:
+    """The region-priority leg (ADR-0021 §3): region rank > alphabetical > rom_id."""
+
+    def test_region_priority_beats_alphabetical_when_no_earlier_leg(self):
+        # Japan's fs_name_no_ext sorts first alphabetically, but USA outranks Japan
+        # in the build-time order, so USA is the representative — the Pokémon fix.
+        members = [
+            _m(1, fs_name_no_ext="game_japan", regions=["Japan"]),
+            _m(2, fs_name_no_ext="game_usa", regions=["USA"]),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_full_default_order_world_usa_europe_japan(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Japan"]),
+            _m(2, fs_name_no_ext="b", regions=["World"]),
+            _m(3, fs_name_no_ext="c", regions=["USA"]),
+            _m(4, fs_name_no_ext="d", regions=["Europe"]),
+        ]
+        # World tops the build-time order → rom 2.
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_multi_region_member_ranked_by_best_region(self):
+        # rom 1 carries [Japan, World]; its BEST region (World) outranks rom 2's USA.
+        members = [
+            _m(1, fs_name_no_ext="z", regions=["Japan", "World"]),
+            _m(2, fs_name_no_ext="a", regions=["USA"]),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 1
+
+    def test_unknown_regions_rank_after_known_alphabetically(self):
+        # Neither region is in the default order → both bucket-2, ranked
+        # alphabetically among themselves: "brazil" < "korea" → rom 1.
+        members = [
+            _m(1, fs_name_no_ext="z", regions=["Brazil"]),
+            _m(2, fs_name_no_ext="a", regions=["Korea"]),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 1
+
+    def test_known_region_outranks_unknown_region(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Brazil"]),  # unknown → bucket 2
+            _m(2, fs_name_no_ext="z", regions=["Japan"]),  # known → bucket 1
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_no_region_member_ranks_last(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=[]),  # no region → ranks last
+            _m(2, fs_name_no_ext="z", regions=["Brazil"]),  # any region beats none
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_region_falls_through_to_alphabetical_when_regions_tie(self):
+        # Same region on both → region rank ties → alphabetical fs_name_no_ext.
+        members = [
+            _m(1, fs_name_no_ext="z", regions=["USA"]),
+            _m(2, fs_name_no_ext="a", regions=["USA"]),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_installed_leg_still_wins_over_region(self):
+        # The installed filter fires before region priority: even though USA
+        # outranks Japan, the installed Japan dump is the representative.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"]),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids={2}, bound_rom_ids=set()) == 2
+
+    def test_override_puts_chosen_region_on_top(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Europe"]),  # tops the DEFAULT order
+            _m(2, fs_name_no_ext="z", regions=["Germany"]),  # user prefers Germany
+        ]
+        assert resolve_group_representative(members, set(), set(), preferred_region="Germany") == 2
+        # Without the override, Europe (default order) wins.
+        assert resolve_group_representative(members, set(), set(), preferred_region="auto") == 1
+
+    def test_override_case_insensitive_match(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Europe"]),
+            _m(2, fs_name_no_ext="z", regions=["Germany"]),
+        ]
+        assert resolve_group_representative(members, set(), set(), preferred_region="germany") == 2
+
+
+class TestCanonicalGroupName:
+    """``canonical_group_name`` — the sticky mint name follows the PURE ranking (ADR-0021 §2/§3)."""
+
+    def test_two_japan_one_usa_yields_usa_name(self):
+        # The exact user scenario: majority Japan, one USA → the USA member's
+        # name, NOT majority voting.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Japan"], name="ポケットモンスター 1"),
+            _m(2, fs_name_no_ext="b", regions=["Japan"], name="ポケットモンスター 2"),
+            _m(3, fs_name_no_ext="c", regions=["USA"], name="Pokemon FireRed"),
+        ]
+        assert canonical_group_name(members) == "Pokemon FireRed"
+
+    def test_only_japan_group_yields_japanese_name(self):
+        members = [
+            _m(1, fs_name_no_ext="b", regions=["Japan"], name="ファイアレッド B"),
+            _m(2, fs_name_no_ext="a", regions=["Japan"], name="ファイアレッド A"),
+        ]
+        # Regions tie → alphabetical fs_name_no_ext → rom 2 ("a").
+        assert canonical_group_name(members) == "ファイアレッド A"
+
+    def test_ignores_installed_binding_default_legs(self):
+        # A Japanese RomM default; the canonical NAME still follows region
+        # priority (USA), decoupled from the bound/default version.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Japan"], is_main_sibling=True, name="Japan Default"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], name="USA Name"),
+        ]
+        assert canonical_group_name(members) == "USA Name"
+
+    def test_override_selects_preferred_region_name(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Europe"], name="Euro Name"),
+            _m(2, fs_name_no_ext="z", regions=["Germany"], name="German Name"),
+        ]
+        assert canonical_group_name(members, preferred_region="Germany") == "German Name"
+
+    def test_no_region_falls_back_to_alphabetical_name(self):
+        members = [
+            _m(1, fs_name_no_ext="zelda", name="Z Name"),
+            _m(2, fs_name_no_ext="alpha", name="A Name"),
+        ]
+        assert canonical_group_name(members) == "A Name"
+
+    def test_partial_view_uses_only_fetched_members(self):
+        # Only the Japanese member was fetched (a collection partial view) → its
+        # name is canonical among what's present; documented behaviour.
+        members = [_m(1, fs_name_no_ext="a", regions=["Japan"], name="Japan Only")]
+        assert canonical_group_name(members) == "Japan Only"
+
+    def test_solo_group_returns_its_name(self):
+        assert canonical_group_name([_m(9, name="Solo")]) == "Solo"
+
+    def test_empty_members_raises_value_error(self):
+        with pytest.raises(ValueError, match="empty sibling group"):
+            canonical_group_name([])

--- a/tests/domain/test_sibling_resolution.py
+++ b/tests/domain/test_sibling_resolution.py
@@ -7,7 +7,7 @@ import pytest
 from domain.sibling_resolution import canonical_group_name, resolve_group_representative
 
 
-def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False, regions=(), name=""):
+def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False, regions=(), name="", revision="", tags=()):
     """A group member dict as build_shortcuts_data shapes it for the resolver."""
     return {
         "rom_id": rom_id,
@@ -15,6 +15,8 @@ def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False, regions=(), name="")
         "is_main_sibling": is_main_sibling,
         "regions": list(regions),
         "name": name,
+        "revision": revision,
+        "tags": list(tags),
     }
 
 
@@ -176,6 +178,184 @@ class TestRegionPriorityLeg:
         assert resolve_group_representative(members, set(), set(), preferred_region="germany") == 2
 
 
+class TestRevisionLeg:
+    """The revision leg (ADR-0021 §3): newest revision wins, but only within a region."""
+
+    def test_rev1_beats_base_same_region(self):
+        # (USA) (Rev 1) beats (USA) base — a real revision outranks the empty one.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision=""),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="1"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_rev3_beats_rev1_same_region(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision="1"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="3"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_rev10_beats_rev2_natural_numeric(self):
+        # Natural numeric compare, not lexical: "10" > "2" (lexically "10" < "2").
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision="2"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="10"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_alphanumeric_revision_b_beats_a(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision="A"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="B"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_alphanumeric_revision_case_insensitive_tie(self):
+        # "B" and "b" are the same revision → the leg ties, alphabetical fs decides.
+        members = [
+            _m(1, fs_name_no_ext="z", regions=["USA"], revision="B"),
+            _m(2, fs_name_no_ext="a", regions=["USA"], revision="b"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_empty_revision_is_lowest(self):
+        # Base (empty revision) loses to any real revision, even a low one.
+        members = [
+            _m(1, fs_name_no_ext="z", regions=["USA"], revision="1"),
+            _m(2, fs_name_no_ext="a", regions=["USA"], revision=""),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+    def test_non_decimal_digit_revision_does_not_crash(self):
+        # "²" is isdigit()-True but not int()-parseable — it must rank as text,
+        # not raise ValueError and abort the resolution (LOW review finding).
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision="²"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="1"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_revision_only_breaks_ties_within_a_region(self):
+        # (USA) base beats (Europe) (Rev 9): region ranks BEFORE revision, so a
+        # higher revision never lifts a lower-ranked region.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision=""),
+            _m(2, fs_name_no_ext="z", regions=["Europe"], revision="9"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+
+class TestPrereleaseDemotion:
+    """The prerelease leg (ADR-0021 §3): a retail dump beats every prerelease, across regions."""
+
+    def test_beta_loses_to_base_same_region(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=["Beta"]),
+            _m(2, fs_name_no_ext="z", regions=["USA"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_prerelease_demotion_crosses_regions(self):
+        # THE cross-region case: a finished (Japan) release beats a (USA) (Beta),
+        # even though USA outranks Japan — prerelease demotion ranks before region.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=["Beta"]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    @pytest.mark.parametrize("tag", ["Alpha", "Beta", "Beta 1", "Beta 2", "Proto", "Sample", "Demo"])
+    def test_all_prerelease_markers_recognized(self, tag):
+        # The retail Japan dump wins over the USA prerelease regardless of marker.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=[tag]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    @pytest.mark.parametrize("tag", ["ALPHA", "beta", "PrOtO", "demo 3", "Beta1"])
+    def test_marker_match_is_case_insensitive(self, tag):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=[tag]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    @pytest.mark.parametrize("tag", ["Unl", "Aftermarket", "Castlevania Advance Collection", "Rumble Version"])
+    def test_neutral_tags_not_demoted(self, tag):
+        # "Unl" / "Aftermarket" / a collection-name / an unknown tag carry no draft
+        # signal → the USA member stays retail and its region wins over Japan.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=[tag]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+    @pytest.mark.parametrize("tag", ["Betamax", "Prototype", "Sampler"])
+    def test_word_starting_with_marker_not_demoted(self, tag):
+        # A longer word that merely starts with a marker (not a numbered variant)
+        # is neutral → the USA member keeps its region win over Japan.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=[tag]),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+    def test_prerelease_demotion_beats_higher_revision(self):
+        # A (USA) retail base beats a (USA) (Beta) (Rev 2): prerelease ranks before
+        # revision, so a higher revision cannot rescue a prerelease.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=["Beta"], revision="2"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], tags=[], revision=""),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+    def test_two_prereleases_fall_through_to_region(self):
+        # Both prerelease → the demotion ties, so region priority decides among them.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["Japan"], tags=["Beta"]),
+            _m(2, fs_name_no_ext="z", regions=["USA"], tags=["Proto"]),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 2
+
+
+class TestFilenameOnlyVariants:
+    """Filename-only re-dumps RomM does NOT parse into tags fall to the alphabetical leg.
+
+    "(Virtual Console)" and "(Extended Edition)" appear only in ``fs_name_no_ext``,
+    not as structured ``tags`` / ``regions`` / ``revision``. With every ranked
+    dimension equal, the alphabetical prefix rule keeps the base dump (the shorter
+    stem) ahead of the re-dump.
+    """
+
+    def test_base_beats_virtual_console_redump(self):
+        members = [
+            _m(1, fs_name_no_ext="game", regions=["USA"], name="Game"),
+            _m(2, fs_name_no_ext="game (virtual console)", regions=["USA"], name="Game (Virtual Console)"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+    def test_base_beats_extended_edition_redump(self):
+        members = [
+            _m(1, fs_name_no_ext="game", regions=["USA"], name="Game"),
+            _m(2, fs_name_no_ext="game (extended edition)", regions=["USA"], name="Game (Extended Edition)"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 1
+
+    def test_discussed_example_world_usa_extended_edition(self):
+        # The discussed group: (World), (USA), (USA) (Extended Edition) → World wins
+        # on region priority, before the filename leg is even consulted.
+        members = [
+            _m(1, fs_name_no_ext="game (usa)", regions=["USA"], name="Game (USA)"),
+            _m(
+                2, fs_name_no_ext="game (usa) (extended edition)", regions=["USA"], name="Game (USA) (Extended Edition)"
+            ),
+            _m(3, fs_name_no_ext="game (world)", regions=["World"], name="Game (World)"),
+        ]
+        assert resolve_group_representative(members, set(), set()) == 3
+
+
 class TestCanonicalGroupName:
     """``canonical_group_name`` — the sticky mint name follows the PURE ranking (ADR-0021 §2/§3)."""
 
@@ -219,6 +399,31 @@ class TestCanonicalGroupName:
             _m(2, fs_name_no_ext="alpha", name="A Name"),
         ]
         assert canonical_group_name(members) == "A Name"
+
+    def test_name_follows_prerelease_demotion_cross_region(self):
+        # (Japan) retail + (USA) (Beta): the canonical NAME comes from the Japan
+        # retail member — prerelease demotion outranks region for naming too.
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], tags=["Beta"], name="USA Beta"),
+            _m(2, fs_name_no_ext="z", regions=["Japan"], tags=[], name="Japan Final"),
+        ]
+        assert canonical_group_name(members) == "Japan Final"
+
+    def test_name_follows_newest_revision_within_region(self):
+        members = [
+            _m(1, fs_name_no_ext="a", regions=["USA"], revision="1", name="USA Rev1"),
+            _m(2, fs_name_no_ext="z", regions=["USA"], revision="3", name="USA Rev3"),
+        ]
+        assert canonical_group_name(members) == "USA Rev3"
+
+    def test_name_base_beats_filename_only_variant(self):
+        # RomM does not parse "(Virtual Console)" into tags → the alphabetical leg
+        # keeps the base dump's name as canonical.
+        members = [
+            _m(1, fs_name_no_ext="game", regions=["USA"], name="Game"),
+            _m(2, fs_name_no_ext="game (virtual console)", regions=["USA"], name="Game (Virtual Console)"),
+        ]
+        assert canonical_group_name(members) == "Game"
 
     def test_partial_view_uses_only_fetched_members(self):
         # Only the Japanese member was fetched (a collection partial view) → its

--- a/tests/domain/test_sibling_resolution.py
+++ b/tests/domain/test_sibling_resolution.py
@@ -1,0 +1,83 @@
+"""Tests for domain.sibling_resolution — the sibling-group representative chain (ADR-0021 §3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.sibling_resolution import resolve_group_representative
+
+
+def _m(rom_id, *, fs_name_no_ext="", is_main_sibling=False):
+    """A group member dict as build_shortcuts_data shapes it for the resolver."""
+    return {"rom_id": rom_id, "fs_name_no_ext": fs_name_no_ext, "is_main_sibling": is_main_sibling}
+
+
+class TestResolveGroupRepresentative:
+    def test_installed_wins_over_binding_default_and_alphabetical(self):
+        members = [
+            _m(1, fs_name_no_ext="a_first", is_main_sibling=True),  # default + alphabetically first
+            _m(2, fs_name_no_ext="z_last"),  # only this one is installed
+        ]
+        # rom 2 is installed AND bound; rom 1 is the default and alphabetically first.
+        assert resolve_group_representative(members, installed_rom_ids={2}, bound_rom_ids={2}) == 2
+
+    def test_multiple_installed_break_by_alphabetical_then_rom_id(self):
+        members = [
+            _m(5, fs_name_no_ext="beta"),
+            _m(3, fs_name_no_ext="alpha"),  # alphabetically first among installed
+            _m(9, fs_name_no_ext="alpha"),
+        ]
+        # roms 3 and 9 tie on fs_name_no_ext="alpha" → lower rom_id (3) wins.
+        assert resolve_group_representative(members, installed_rom_ids={3, 5, 9}, bound_rom_ids=set()) == 3
+
+    def test_existing_binding_wins_when_none_installed(self):
+        members = [
+            _m(1, fs_name_no_ext="a_first", is_main_sibling=True),
+            _m(2, fs_name_no_ext="z_last"),
+        ]
+        # Nothing installed; rom 2 carries the existing binding → it wins over the default.
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids={2}) == 2
+
+    def test_default_wins_when_none_installed_or_bound(self):
+        members = [
+            _m(1, fs_name_no_ext="z_last", is_main_sibling=True),  # RomM default
+            _m(2, fs_name_no_ext="a_first"),  # alphabetically first but not default
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 1
+
+    def test_alphabetical_fallback_when_no_installed_bound_or_default(self):
+        members = [
+            _m(1, fs_name_no_ext="Zelda"),
+            _m(2, fs_name_no_ext="alpha"),  # lower-cased "alpha" < "zelda"
+            _m(3, fs_name_no_ext="Mario"),
+        ]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_rom_id_is_final_tie_break_on_equal_names(self):
+        members = [_m(7, fs_name_no_ext="Game"), _m(3, fs_name_no_ext="Game")]
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 3
+
+    def test_multiple_defaults_break_alphabetically(self):
+        members = [
+            _m(1, fs_name_no_ext="z", is_main_sibling=True),
+            _m(2, fs_name_no_ext="a", is_main_sibling=True),
+        ]
+        # Both are RomM defaults → alphabetical fs_name_no_ext decides.
+        assert resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set()) == 2
+
+    def test_solo_group_returns_its_only_member(self):
+        assert resolve_group_representative([_m(42)], installed_rom_ids=set(), bound_rom_ids=set()) == 42
+
+    def test_empty_members_raises_value_error(self):
+        with pytest.raises(ValueError, match="empty sibling group"):
+            resolve_group_representative([], installed_rom_ids=set(), bound_rom_ids=set())
+
+    def test_result_ignores_member_order(self):
+        members = [
+            _m(1, fs_name_no_ext="z_last"),
+            _m(2, fs_name_no_ext="a_first", is_main_sibling=True),
+            _m(3, fs_name_no_ext="m_mid"),
+        ]
+        forward = resolve_group_representative(members, installed_rom_ids=set(), bound_rom_ids=set())
+        reversed_ = resolve_group_representative(list(reversed(members)), installed_rom_ids=set(), bound_rom_ids=set())
+        assert forward == reversed_ == 2

--- a/tests/domain/test_sibling_resolution_property.py
+++ b/tests/domain/test_sibling_resolution_property.py
@@ -3,9 +3,11 @@
 The resolver must be a **total, shuffle-stable** order over a group's members:
 the chosen representative can never depend on the order the members arrive in
 (fetch order is not stable), and the chain priority — installed > existing
-binding > RomM default > alphabetical — must hold exactly. A representative that
-flips under a reshuffle would flip which sibling a group's shortcut binds to on
-every sync (churn), so these properties are live regression guards.
+binding > RomM default > region priority > alphabetical — must hold exactly. A
+representative that flips under a reshuffle would flip which sibling a group's
+shortcut binds to on every sync (churn), so these properties are live regression
+guards. ``canonical_group_name`` shares the same pure order (ignoring the
+installed/binding/default filters) and carries the same determinism guarantee.
 
 See ``tests.domain.test_sync_action_property`` for the convention note on the
 ``xfail(strict=True)`` pinning of properties that encode an open bug. These
@@ -16,26 +18,41 @@ from __future__ import annotations
 
 import random
 
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
-from domain.sibling_resolution import resolve_group_representative
+from domain.sibling_resolution import (
+    DEFAULT_REGION_PRIORITY,
+    canonical_group_name,
+    resolve_group_representative,
+)
 
 # A small pool of filename stems (with repeats likely across a group, to exercise
 # the fs_name_no_ext tie-break and its rom_id final disambiguator).
 _stems = st.sampled_from(["alpha", "Alpha", "beta", "mario", "Zelda", "game", "game (usa)"])
 
+# Known (in the build-time default order) + unknown regions + the empty list, so
+# the strategy exercises every region bucket (preferred / default / other / none).
+_region_pool = ["Europe", "USA", "World", "Japan", "Germany", "Brazil", "Korea"]
+_regions = st.lists(st.sampled_from(_region_pool), max_size=3, unique=True)
+
+# "auto" (no preference) plus any pool region as a user override.
+_preferred = st.sampled_from(["auto", *_region_pool])
+
 
 @st.composite
 def _group(draw):
-    """A non-empty group: unique rom_ids, each with a stem + a default flag, plus
-    an installed subset and a bound subset drawn from the group's rom_ids."""
+    """A non-empty group: unique rom_ids, each with a stem, region list, unique
+    name + default flag, plus an installed subset and a bound subset drawn from
+    the group's rom_ids."""
     rom_ids = draw(st.lists(st.integers(min_value=1, max_value=9999), min_size=1, max_size=8, unique=True))
     members = [
         {
             "rom_id": rid,
             "fs_name_no_ext": draw(_stems),
+            "regions": draw(_regions),
             "is_main_sibling": draw(st.booleans()),
+            "name": f"n{rid}",  # unique per member (rom_ids are unique)
         }
         for rid in rom_ids
     ]
@@ -45,27 +62,27 @@ def _group(draw):
     return members, installed, bound
 
 
-@given(_group())
-def test_result_is_always_a_member(group):
+@given(_group(), _preferred)
+def test_result_is_always_a_member(group, preferred):
     members, installed, bound = group
-    rep = resolve_group_representative(members, installed, bound)
+    rep = resolve_group_representative(members, installed, bound, preferred)
     assert rep in {m["rom_id"] for m in members}
 
 
-@given(_group(), st.integers())
-def test_shuffle_invariant(group, seed):
+@given(_group(), st.integers(), _preferred)
+def test_shuffle_invariant(group, seed, preferred):
     members, installed, bound = group
     shuffled = list(members)
     random.Random(seed).shuffle(shuffled)
-    assert resolve_group_representative(members, installed, bound) == resolve_group_representative(
-        shuffled, installed, bound
+    assert resolve_group_representative(members, installed, bound, preferred) == resolve_group_representative(
+        shuffled, installed, bound, preferred
     )
 
 
-@given(_group())
-def test_chain_priority_holds(group):
+@given(_group(), _preferred)
+def test_chain_priority_holds(group, preferred):
     members, installed, bound = group
-    rep = resolve_group_representative(members, installed, bound)
+    rep = resolve_group_representative(members, installed, bound, preferred)
     ids = {m["rom_id"] for m in members}
     installed_here = installed & ids
     bound_here = bound & ids
@@ -77,5 +94,85 @@ def test_chain_priority_holds(group):
         assert rep in bound_here
     elif defaults:
         assert rep in defaults
-    # else: any member is admissible — the alphabetical/rom_id fallback, covered
-    # by the shuffle-invariance + determinism properties above.
+    # else: the region/alphabetical fallback leg — covered below.
+
+
+def _region_fallback_group(group):
+    """The subset of a drawn group with NO filter leg active: empty installed +
+    bound sets and no RomM default, so only the region/alphabetical order decides.
+    Returns the members (all is_main_sibling forced False)."""
+    members, _installed, _bound = group
+    return [{**m, "is_main_sibling": False} for m in members]
+
+
+@given(_group(), _preferred)
+def test_region_override_respected_in_fallback(group, preferred):
+    """With no filter leg and an override set, a member carrying the preferred
+    region always wins over one that doesn't."""
+    members = _region_fallback_group(group)
+    assume(preferred != "auto")
+    has_pref = [m for m in members if preferred in m["regions"]]
+    assume(bool(has_pref))
+    rep = resolve_group_representative(members, set(), set(), preferred)
+    rep_member = next(m for m in members if m["rom_id"] == rep)
+    assert preferred in rep_member["regions"]
+
+
+@given(_group())
+def test_no_region_member_never_wins_over_a_regioned_one(group):
+    """With no filter leg, a version with no region ranks last — it is never the
+    representative when some member carries a region (auto ranking)."""
+    members = _region_fallback_group(group)
+    assume(any(m["regions"] for m in members) and not all(m["regions"] for m in members))
+    rep = resolve_group_representative(members, set(), set(), "auto")
+    rep_member = next(m for m in members if m["rom_id"] == rep)
+    assert rep_member["regions"]
+
+
+@given(_group())
+def test_known_region_beats_unknown_in_fallback(group):
+    """A build-time default region outranks any other named region (auto)."""
+    members = _region_fallback_group(group)
+    default_set = {r.casefold() for r in DEFAULT_REGION_PRIORITY}
+    has_known = [m for m in members if any(r.casefold() in default_set for r in m["regions"])]
+    assume(bool(has_known))
+    rep = resolve_group_representative(members, set(), set(), "auto")
+    rep_member = next(m for m in members if m["rom_id"] == rep)
+    assert any(r.casefold() in default_set for r in rep_member["regions"])
+
+
+@given(_group(), _preferred)
+def test_canonical_name_is_always_a_member_name(group, preferred):
+    members, _installed, _bound = group
+    name = canonical_group_name(members, preferred)
+    assert name in {m["name"] for m in members}
+
+
+@given(_group(), st.integers(), _preferred)
+def test_canonical_name_shuffle_invariant(group, seed, preferred):
+    members, _installed, _bound = group
+    shuffled = list(members)
+    random.Random(seed).shuffle(shuffled)
+    assert canonical_group_name(members, preferred) == canonical_group_name(shuffled, preferred)
+
+
+@given(_group(), _preferred)
+def test_canonical_name_ignores_filter_legs(group, preferred):
+    """The canonical name is a pure function of members + preference — the
+    installed/binding/default inputs of the resolver cannot change it."""
+    members, installed, bound = group
+    baseline = canonical_group_name(members, preferred)
+    # Flipping every member's default flag / claiming everything installed+bound
+    # must not move the canonical name.
+    flipped = [{**m, "is_main_sibling": not m["is_main_sibling"]} for m in members]
+    assert canonical_group_name(flipped, preferred) == baseline
+    del installed, bound
+
+
+@given(_group(), _preferred)
+def test_canonical_name_winner_carries_preferred_region(group, preferred):
+    members, _installed, _bound = group
+    assume(preferred != "auto" and any(preferred in m["regions"] for m in members))
+    name = canonical_group_name(members, preferred)
+    winner = next(m for m in members if m["name"] == name)
+    assert preferred in winner["regions"]

--- a/tests/domain/test_sibling_resolution_property.py
+++ b/tests/domain/test_sibling_resolution_property.py
@@ -1,0 +1,81 @@
+"""Property-based tests for the sibling-group representative chain (ADR-0021 §3).
+
+The resolver must be a **total, shuffle-stable** order over a group's members:
+the chosen representative can never depend on the order the members arrive in
+(fetch order is not stable), and the chain priority — installed > existing
+binding > RomM default > alphabetical — must hold exactly. A representative that
+flips under a reshuffle would flip which sibling a group's shortcut binds to on
+every sync (churn), so these properties are live regression guards.
+
+See ``tests.domain.test_sync_action_property`` for the convention note on the
+``xfail(strict=True)`` pinning of properties that encode an open bug. These
+properties encode a TRUE invariant that holds today, so they run live.
+"""
+
+from __future__ import annotations
+
+import random
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.sibling_resolution import resolve_group_representative
+
+# A small pool of filename stems (with repeats likely across a group, to exercise
+# the fs_name_no_ext tie-break and its rom_id final disambiguator).
+_stems = st.sampled_from(["alpha", "Alpha", "beta", "mario", "Zelda", "game", "game (usa)"])
+
+
+@st.composite
+def _group(draw):
+    """A non-empty group: unique rom_ids, each with a stem + a default flag, plus
+    an installed subset and a bound subset drawn from the group's rom_ids."""
+    rom_ids = draw(st.lists(st.integers(min_value=1, max_value=9999), min_size=1, max_size=8, unique=True))
+    members = [
+        {
+            "rom_id": rid,
+            "fs_name_no_ext": draw(_stems),
+            "is_main_sibling": draw(st.booleans()),
+        }
+        for rid in rom_ids
+    ]
+    id_set = set(rom_ids)
+    installed = draw(st.sets(st.sampled_from(sorted(id_set)), max_size=len(id_set))) if id_set else set()
+    bound = draw(st.sets(st.sampled_from(sorted(id_set)), max_size=len(id_set))) if id_set else set()
+    return members, installed, bound
+
+
+@given(_group())
+def test_result_is_always_a_member(group):
+    members, installed, bound = group
+    rep = resolve_group_representative(members, installed, bound)
+    assert rep in {m["rom_id"] for m in members}
+
+
+@given(_group(), st.integers())
+def test_shuffle_invariant(group, seed):
+    members, installed, bound = group
+    shuffled = list(members)
+    random.Random(seed).shuffle(shuffled)
+    assert resolve_group_representative(members, installed, bound) == resolve_group_representative(
+        shuffled, installed, bound
+    )
+
+
+@given(_group())
+def test_chain_priority_holds(group):
+    members, installed, bound = group
+    rep = resolve_group_representative(members, installed, bound)
+    ids = {m["rom_id"] for m in members}
+    installed_here = installed & ids
+    bound_here = bound & ids
+    defaults = {m["rom_id"] for m in members if m["is_main_sibling"]}
+
+    if installed_here:
+        assert rep in installed_here
+    elif bound_here:
+        assert rep in bound_here
+    elif defaults:
+        assert rep in defaults
+    # else: any member is admissible — the alphabetical/rom_id fallback, covered
+    # by the shuffle-invariance + determinism properties above.

--- a/tests/domain/test_sibling_resolution_property.py
+++ b/tests/domain/test_sibling_resolution_property.py
@@ -3,11 +3,12 @@
 The resolver must be a **total, shuffle-stable** order over a group's members:
 the chosen representative can never depend on the order the members arrive in
 (fetch order is not stable), and the chain priority — installed > existing
-binding > RomM default > region priority > alphabetical — must hold exactly. A
-representative that flips under a reshuffle would flip which sibling a group's
-shortcut binds to on every sync (churn), so these properties are live regression
-guards. ``canonical_group_name`` shares the same pure order (ignoring the
-installed/binding/default filters) and carries the same determinism guarantee.
+binding > RomM default > prerelease demotion > region priority > revision
+(newest) > alphabetical — must hold exactly. A representative that flips under a
+reshuffle would flip which sibling a group's shortcut binds to on every sync
+(churn), so these properties are live regression guards. ``canonical_group_name``
+shares the same pure order (ignoring the installed/binding/default filters) and
+carries the same determinism guarantee.
 
 See ``tests.domain.test_sync_action_property`` for the convention note on the
 ``xfail(strict=True)`` pinning of properties that encode an open bug. These
@@ -39,18 +40,41 @@ _regions = st.lists(st.sampled_from(_region_pool), max_size=3, unique=True)
 # "auto" (no preference) plus any pool region as a user override.
 _preferred = st.sampled_from(["auto", *_region_pool])
 
+# Revision strings: empty (base dump), numeric (natural compare), alphanumeric.
+_revisions = st.sampled_from(["", "1", "2", "3", "10", "A", "B"])
+
+# Bare, unambiguous prerelease markers vs. neutral tags. Bare markers let the
+# local ``_is_prerelease`` oracle mirror the module's classifier exactly (an exact
+# casefold match), so these properties never re-implement the prefix/numbered
+# logic — that is the unit tests' job.
+_PRERELEASE_TAGS = ["Alpha", "Beta", "Proto", "Sample", "Demo"]
+_NEUTRAL_TAGS = ["Unl", "Aftermarket", "Rumble Version"]
+_tags = st.lists(st.sampled_from([*_PRERELEASE_TAGS, *_NEUTRAL_TAGS]), max_size=2, unique=True)
+
+
+def _is_prerelease(member) -> bool:
+    """Oracle: a member is prerelease iff it carries a bare prerelease marker.
+
+    Valid only because the generators draw ``tags`` from ``_PRERELEASE_TAGS`` /
+    ``_NEUTRAL_TAGS`` (all bare), where the module's classifier reduces to an
+    exact-match membership test.
+    """
+    return any(tag in _PRERELEASE_TAGS for tag in member["tags"])
+
 
 @st.composite
 def _group(draw):
-    """A non-empty group: unique rom_ids, each with a stem, region list, unique
-    name + default flag, plus an installed subset and a bound subset drawn from
-    the group's rom_ids."""
+    """A non-empty group: unique rom_ids, each with a stem, region list, revision,
+    tag list, unique name + default flag, plus an installed subset and a bound
+    subset drawn from the group's rom_ids."""
     rom_ids = draw(st.lists(st.integers(min_value=1, max_value=9999), min_size=1, max_size=8, unique=True))
     members = [
         {
             "rom_id": rid,
             "fs_name_no_ext": draw(_stems),
             "regions": draw(_regions),
+            "revision": draw(_revisions),
+            "tags": draw(_tags),
             "is_main_sibling": draw(st.booleans()),
             "name": f"n{rid}",  # unique per member (rom_ids are unique)
         }
@@ -98,11 +122,15 @@ def test_chain_priority_holds(group, preferred):
 
 
 def _region_fallback_group(group):
-    """The subset of a drawn group with NO filter leg active: empty installed +
-    bound sets and no RomM default, so only the region/alphabetical order decides.
-    Returns the members (all is_main_sibling forced False)."""
+    """A drawn group reduced so ONLY the region/revision/alphabetical order can
+    decide: no RomM default (``is_main_sibling`` forced False) and every member
+    forced retail (``tags`` cleared). Clearing tags neutralizes the prerelease leg
+    that ranks BEFORE region, so region-leg properties are not confounded by a
+    retail-vs-prerelease demotion; revision is left varied because it ranks AFTER
+    region and so never disturbs a region-vs-region or region-vs-none outcome. The
+    caller still passes empty installed/bound sets to defeat the filter legs."""
     members, _installed, _bound = group
-    return [{**m, "is_main_sibling": False} for m in members]
+    return [{**m, "is_main_sibling": False, "tags": []} for m in members]
 
 
 @given(_group(), _preferred)
@@ -142,6 +170,50 @@ def test_known_region_beats_unknown_in_fallback(group):
 
 
 @given(_group(), _preferred)
+def test_retail_beats_prerelease_region_independent(group, preferred):
+    """With no filter leg, a retail dump is ALWAYS the representative when both a
+    retail and a prerelease member exist — prerelease demotion ranks before region,
+    so this holds for any region layout and any ``preferred_region``."""
+    members, _installed, _bound = group
+    members = [{**m, "is_main_sibling": False} for m in members]  # defeat the default filter
+    assume(any(not _is_prerelease(m) for m in members) and any(_is_prerelease(m) for m in members))
+    rep = resolve_group_representative(members, set(), set(), preferred)
+    rep_member = next(m for m in members if m["rom_id"] == rep)
+    assert not _is_prerelease(rep_member)
+
+
+@st.composite
+def _numeric_rev_same_region_group(draw):
+    """A group where every member shares one region and is retail, varying only the
+    revision (numeric or empty). Region + prerelease tie, so the revision leg alone
+    decides — with pure-numeric revisions natural order == integer order (empty =
+    lowest), a simple oracle for 'newest wins'."""
+    rom_ids = draw(st.lists(st.integers(min_value=1, max_value=9999), min_size=1, max_size=6, unique=True))
+    return [
+        {
+            "rom_id": rid,
+            "fs_name_no_ext": draw(_stems),
+            "regions": ["USA"],
+            "revision": draw(st.sampled_from(["", "1", "2", "3", "10"])),
+            "tags": [],
+            "is_main_sibling": False,
+            "name": f"n{rid}",
+        }
+        for rid in rom_ids
+    ]
+
+
+@given(_numeric_rev_same_region_group())
+def test_newest_numeric_revision_wins(members):
+    """Within one region + retail status, the newest revision wins. Pure-numeric
+    revisions make integer order the oracle; the empty (base) revision is lowest."""
+    rep = resolve_group_representative(members, set(), set(), "auto")
+    rep_member = next(m for m in members if m["rom_id"] == rep)
+    max_rev = max(int(m["revision"]) if m["revision"] else -1 for m in members)
+    assert (int(rep_member["revision"]) if rep_member["revision"] else -1) == max_rev
+
+
+@given(_group(), _preferred)
 def test_canonical_name_is_always_a_member_name(group, preferred):
     members, _installed, _bound = group
     name = canonical_group_name(members, preferred)
@@ -172,7 +244,23 @@ def test_canonical_name_ignores_filter_legs(group, preferred):
 @given(_group(), _preferred)
 def test_canonical_name_winner_carries_preferred_region(group, preferred):
     members, _installed, _bound = group
-    assume(preferred != "auto" and any(preferred in m["regions"] for m in members))
+    assume(preferred != "auto")
+    # A RETAIL member carrying the preferred region is (retail, preferred-region) =
+    # the global minimum of the pure order, so nothing outranks it (prerelease
+    # ranks before region, so a demoted preferred-region member could otherwise
+    # lose to a retail non-preferred one).
+    assume(any(preferred in m["regions"] and not _is_prerelease(m) for m in members))
     name = canonical_group_name(members, preferred)
     winner = next(m for m in members if m["name"] == name)
     assert preferred in winner["regions"]
+
+
+@given(_group(), _preferred)
+def test_canonical_name_prefers_retail_over_prerelease(group, preferred):
+    """The canonical name never comes from a prerelease member when a retail member
+    exists — the naming order shares the resolver's prerelease demotion."""
+    members, _installed, _bound = group
+    assume(any(not _is_prerelease(m) for m in members) and any(_is_prerelease(m) for m in members))
+    name = canonical_group_name(members, preferred)
+    winner = next(m for m in members if m["name"] == name)
+    assert not _is_prerelease(winner)

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -3,8 +3,10 @@
 from typing import Any
 
 from domain.sync_diff import (
+    BIND_ROM_ID_KEY,
     ClassificationResult,
     classify_roms,
+    collapse_sibling_groups,
     compute_collection_diff,
     compute_platform_collection_diff,
     select_stale_removals,
@@ -425,3 +427,226 @@ class TestSelectStaleRemovals:
         candidate_stale = [(3, 3000), (1, 1000), (2, 2000)]
         result = select_stale_removals(candidate_stale, set())
         assert result == [(3, 3000), (1, 1000), (2, 2000)]
+
+
+def _gsd(
+    rom_id,
+    *,
+    name="Game",
+    group_key="g1",
+    fs_name="game.z64",
+    fs_name_no_ext="game",
+    is_main_sibling=False,
+    platform_slug="n64",
+    launch_options="",
+):
+    """A built shortcut entry as build_shortcuts_data shapes it, with the
+    sibling-group fields the collapse + resolver read."""
+    return {
+        "rom_id": rom_id,
+        "name": name,
+        "fs_name": fs_name,
+        "fs_name_no_ext": fs_name_no_ext,
+        "platform_name": "N64",
+        "platform_slug": platform_slug,
+        "launch_options": launch_options,
+        "cover_path": "",
+        "sibling_group_key": group_key,
+        "is_main_sibling": is_main_sibling,
+        "igdb_id": None,
+        "sgdb_id": None,
+        "ra_id": None,
+    }
+
+
+def _greg(rom_id, *, app_id, name="Game", group_key: str | None = "g1", fs_name="game.z64", platform_slug="n64"):
+    """A bound-registry entry as _read_apply_registry / _read_preview_baseline shape it."""
+    return {
+        "app_id": app_id,
+        "name": name,
+        "fs_name": fs_name,
+        "platform_slug": platform_slug,
+        "platform_name": "N64",
+        "sibling_group_key": group_key,
+    }
+
+
+class TestCollapseSiblingGroups:
+    """``collapse_sibling_groups`` — one Steam shortcut per sibling group (ADR-0021)."""
+
+    def test_new_group_emits_single_representative(self):
+        # 3 siblings, no binding anywhere; rom 2 is the RomM default → the one rep.
+        members = [
+            _gsd(1, name="Game (USA)", fs_name_no_ext="game_usa"),
+            _gsd(2, name="Game (JP)", fs_name_no_ext="game_jp", is_main_sibling=True),
+            _gsd(3, name="Game (EU)", fs_name_no_ext="game_eu"),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [2]
+
+    def test_installed_sibling_wins_representative(self):
+        members = [
+            _gsd(1, is_main_sibling=True, fs_name_no_ext="a"),
+            _gsd(2, fs_name_no_ext="z"),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids={2}, complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [2]
+
+    def test_unbound_siblings_not_counted_as_new(self):
+        # The #1292-class phantom fix: a group with one bound sibling + two unbound
+        # siblings collapses to the bound entry — classify reads it as unchanged,
+        # NOT the unbound siblings as perpetual "new".
+        members = [
+            _gsd(1, name="Game", fs_name="game.z64"),
+            _gsd(2, name="Game (JP)", fs_name="game_jp.z64"),
+            _gsd(3, name="Game (EU)", fs_name="game_eu.z64"),
+        ]
+        registry = {"1": _greg(1, app_id=1001, name="Game", fs_name="game.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [1]
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.new == []
+        assert result.unchanged_ids == [1]
+        assert result.stale == []
+
+    def test_grandfathered_multiple_bound_siblings_all_kept(self):
+        # Two DIFFERENT-name siblings each already carry a shortcut (a pre-ADR-0021
+        # library). Both are still fetched → both stay emitted; no new shortcut for
+        # the unbound third sibling.
+        members = [
+            _gsd(1, name="Game", fs_name="game.z64"),
+            _gsd(2, name="Game JP", fs_name="game_jp.z64"),
+            _gsd(3, name="Game EU", fs_name="game_eu.z64"),
+        ]
+        registry = {
+            "1": _greg(1, app_id=1001, name="Game", fs_name="game.z64"),
+            "2": _greg(2, app_id=1002, name="Game JP", fs_name="game_jp.z64"),
+        }
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert sorted(e["rom_id"] for e in emitted) == [1, 2]
+        assert 3 not in {e["rom_id"] for e in emitted}
+
+    def test_whole_group_vanished_is_stale(self):
+        # The bound row's group has NO fetched member at all → collapse emits
+        # nothing for it, and classify flags it stale.
+        members = [_gsd(9, name="Other", group_key="g2")]
+        registry = {"1": _greg(1, app_id=1001, name="Gone", group_key="g1")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert 1 not in {e["rom_id"] for e in emitted}
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.stale == [1]
+
+    def test_vanished_bound_sibling_rebinds_to_representative(self):
+        # rom 1 is the group's bound sibling but vanished from the server; roms 2/3
+        # survive. Collapse emits ONE rebind entry keyed to rom 1 (frontend reuses
+        # its shortcut) carrying bind_rom_id → the surviving representative.
+        members = [
+            _gsd(
+                2,
+                name="Game (JP)",
+                fs_name="game_jp.z64",
+                fs_name_no_ext="game_jp",
+                is_main_sibling=True,
+                launch_options="run /jp.z64",
+            ),
+            _gsd(3, name="Game (EU)", fs_name="game_eu.z64", fs_name_no_ext="game_eu"),
+        ]
+        registry = {"1": _greg(1, app_id=1001, name="Game (USA)", fs_name="game_usa.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1
+        entry = emitted[0]
+        # Keyed to the vanished bound sibling (sticky identity) so the frontend
+        # reuses its shortcut and the preview reads it as unchanged.
+        assert entry["rom_id"] == 1
+        assert entry["name"] == "Game (USA)"
+        # The binding moves onto the representative (rom 2 = the RomM default), and
+        # the representative's launch bake rides along.
+        assert entry[BIND_ROM_ID_KEY] == 2
+        assert entry["launch_options"] == "run /jp.z64"
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.unchanged_ids == [1]
+        assert result.stale == []
+        assert result.new == []
+
+    def test_rebind_keeps_smallest_rom_id_binding_others_stale(self):
+        # A group with TWO bound siblings (grandfathered), both vanished. One appId
+        # is kept (smallest rom_id) and rebound; the other goes stale.
+        members = [_gsd(5, name="Game (EU)", fs_name_no_ext="game_eu")]
+        registry = {
+            "1": _greg(1, app_id=1001, name="Game (USA)"),
+            "2": _greg(2, app_id=1002, name="Game (JP)"),
+        }
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1
+        assert emitted[0]["rom_id"] == 1
+        assert emitted[0][BIND_ROM_ID_KEY] == 5
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.stale == [2]
+
+    def test_legacy_null_key_bound_row_grandfathered_via_fetched_key(self):
+        # A bound row whose stored sibling_group_key is still NULL (pre-capture) is
+        # grouped by its FETCHED key, so it is grandfathered (kept), never churned
+        # into a delete + recreate.
+        members = [_gsd(1, name="Game", group_key="igdb:42:7")]
+        registry = {"1": _greg(1, app_id=1001, name="Game", group_key=None)}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [1]
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.unchanged_ids == [1]
+
+    def test_solo_unmatched_group_degrades_to_per_rom(self):
+        # An unmatched ROM is a solo group — collapse emits it exactly as before.
+        members = [_gsd(7, name="Homebrew", group_key="romm:7:1")]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [7]
+
+
+class TestCollapseSiblingGroupsPartialView:
+    """``collapse_sibling_groups`` under a PARTIAL group view (collection units, #1296).
+
+    A collection unit spans platforms and fetches only its own members, so the
+    whole-registry read surfaces bound siblings the unit never fetched. Absence
+    from that partial fetch is NOT absence from the server, so the collapse must
+    never rebind (which would move a live installed game's shortcut onto an
+    uninstalled sibling) — it only grandfathers.
+    """
+
+    def test_bound_sibling_absent_from_partial_fetch_is_grandfathered_not_rebound(self):
+        # The worked #1296 failure in miniature: rom 1 is bound + installed but on
+        # a platform this collection unit never fetched; the collection fetches
+        # only the UNBOUND sibling rom 2. A partial view must leave the binding
+        # untouched — emit nothing, never a rebind entry onto the uninstalled rom 2.
+        members = [_gsd(2, name="Game (JP)", fs_name="game_jp.z64", fs_name_no_ext="game_jp")]
+        registry = {"1": _greg(1, app_id=1001, name="Game (USA)", fs_name="game_usa.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids={1}, complete_group_view=False)
+        assert emitted == []
+        # And the contrast: the SAME inputs under a complete view DO rebind — the
+        # only thing separating "grandfather" from "rebind" is view-completeness.
+        rebound = collapse_sibling_groups(members, registry, installed_rom_ids={1}, complete_group_view=True)
+        assert len(rebound) == 1
+        assert rebound[0]["rom_id"] == 1
+        assert rebound[0][BIND_ROM_ID_KEY] == 2
+
+    def test_partial_view_group_with_no_binding_anywhere_mints_representative(self):
+        # A group with NO binding in the whole registry IS a genuinely new game —
+        # a collection-only unit still mints its single representative among the
+        # fetched members (RomM default rom 2 here).
+        members = [
+            _gsd(1, name="Game (USA)", fs_name_no_ext="game_usa"),
+            _gsd(2, name="Game (JP)", fs_name_no_ext="game_jp", is_main_sibling=True),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=False)
+        assert [e["rom_id"] for e in emitted] == [2]
+
+    def test_partial_view_fetched_bound_sibling_still_emits_as_update(self):
+        # A bound sibling that IS in the partial fetch still emits (as an update
+        # entry) so its identity/launch refresh; the unbound fetched sibling does
+        # not mint a second shortcut. No rebind either — the group is grandfathered.
+        members = [
+            _gsd(1, name="Game", fs_name="game.z64"),
+            _gsd(2, name="Game (JP)", fs_name="game_jp.z64"),
+        ]
+        registry = {"1": _greg(1, app_id=1001, name="Game", fs_name="game.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=False)
+        assert [e["rom_id"] for e in emitted] == [1]
+        assert all(BIND_ROM_ID_KEY not in e for e in emitted)

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -439,6 +439,7 @@ def _gsd(
     is_main_sibling=False,
     platform_slug="n64",
     launch_options="",
+    regions=(),
 ):
     """A built shortcut entry as build_shortcuts_data shapes it, with the
     sibling-group fields the collapse + resolver read."""
@@ -453,6 +454,7 @@ def _gsd(
         "cover_path": "",
         "sibling_group_key": group_key,
         "is_main_sibling": is_main_sibling,
+        "regions": list(regions),
         "igdb_id": None,
         "sgdb_id": None,
         "ra_id": None,
@@ -599,6 +601,88 @@ class TestCollapseSiblingGroups:
         members = [_gsd(7, name="Homebrew", group_key="romm:7:1")]
         emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
         assert [e["rom_id"] for e in emitted] == [7]
+
+
+class TestCollapseSiblingGroupsCanonicalNaming:
+    """Mint entries carry the region-canonical name; bound lanes keep the persisted name (ADR-0021 §2/§3)."""
+
+    def test_mint_binds_region_representative_and_names_it_canonically(self):
+        # The Pokémon fix: no binding anywhere, USA + Japan dumps. Region priority
+        # binds USA AND names the shortcut after USA — not the alphabetically-first
+        # Japanese dump.
+        members = [
+            _gsd(1, name="ポケットモンスターファイアレッド", fs_name_no_ext="game_japan", regions=["Japan"]),
+            _gsd(2, name="Pokemon FireRed", fs_name_no_ext="game_usa", regions=["USA"]),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1
+        assert emitted[0]["rom_id"] == 2
+        assert emitted[0]["name"] == "Pokemon FireRed"
+
+    def test_mint_name_decoupled_from_bound_target_when_default_forces_it(self):
+        # RomM default = the Japanese dump, so the BIND target is Japan, but the
+        # canonical NAME still follows region priority (USA) — name decoupled from
+        # the bound version (ADR-0021 "name can lag the active version").
+        members = [
+            _gsd(1, name="Japan Default", fs_name_no_ext="game_japan", regions=["Japan"], is_main_sibling=True),
+            _gsd(2, name="USA Name", fs_name_no_ext="game_usa", regions=["USA"]),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1
+        assert emitted[0]["rom_id"] == 1  # bind the RomM default (Japan)
+        assert emitted[0]["name"] == "USA Name"  # but name it canonically (USA)
+
+    def test_mint_does_not_mutate_the_source_member(self):
+        # The emitted entry is a copy: the original member dict (also staged in
+        # pending_all_roms for the per-sibling identity upsert) keeps its own name.
+        japan = _gsd(1, name="Japan Name", fs_name_no_ext="game_japan", regions=["Japan"], is_main_sibling=True)
+        members = [japan, _gsd(2, name="USA Name", fs_name_no_ext="game_usa", regions=["USA"])]
+        collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert japan["name"] == "Japan Name"
+
+    def test_mint_respects_preferred_region_override(self):
+        members = [
+            _gsd(1, name="Euro Name", fs_name_no_ext="game_eu", regions=["Europe"]),
+            _gsd(2, name="German Name", fs_name_no_ext="game_de", regions=["Germany"]),
+        ]
+        emitted = collapse_sibling_groups(
+            members, registry={}, installed_rom_ids=set(), complete_group_view=True, preferred_region="Germany"
+        )
+        assert emitted[0]["rom_id"] == 2
+        assert emitted[0]["name"] == "German Name"
+
+    def test_grandfathered_bound_sibling_keeps_persisted_name_no_rename(self):
+        # A bound group must never be renamed by canonical naming — the emitted
+        # grandfathered entry carries the fetched member's own name, matching the
+        # persisted registry name, so classify reads it as unchanged (no churn).
+        members = [
+            _gsd(1, name="Japan Name", fs_name_no_ext="game_japan", regions=["Japan"]),
+            _gsd(2, name="USA Name", fs_name_no_ext="game_usa", regions=["USA"]),
+        ]
+        registry = {"1": _greg(1, app_id=1001, name="Japan Name", fs_name="game.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [1]
+        assert emitted[0]["name"] == "Japan Name"
+        result = classify_roms(emitted, registry, {"N64"})
+        assert result.unchanged_ids == [1]
+        assert result.changed == []
+
+    def test_rebind_entry_keeps_persisted_name_not_canonical(self):
+        # A rebinding group is already bound → sticky: the rebind entry carries the
+        # vanished sibling's PERSISTED name, never the region-canonical name, so the
+        # live shortcut is not renamed.
+        members = [
+            _gsd(2, name="USA Name", fs_name_no_ext="game_usa", regions=["USA"]),
+            _gsd(3, name="Euro Name", fs_name_no_ext="game_eu", regions=["Europe"]),
+        ]
+        registry = {"1": _greg(1, app_id=1001, name="Original Bound Name", fs_name="game_x.z64")}
+        emitted = collapse_sibling_groups(members, registry, installed_rom_ids=set(), complete_group_view=True)
+        assert len(emitted) == 1
+        assert emitted[0]["rom_id"] == 1
+        assert emitted[0]["name"] == "Original Bound Name"
+        # The binding still moves onto the region representative (USA outranks
+        # Europe in the build-time order → rom 2).
+        assert emitted[0][BIND_ROM_ID_KEY] == 2
 
 
 class TestCollapseSiblingGroupsPartialView:

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -440,6 +440,8 @@ def _gsd(
     platform_slug="n64",
     launch_options="",
     regions=(),
+    revision="",
+    tags=(),
 ):
     """A built shortcut entry as build_shortcuts_data shapes it, with the
     sibling-group fields the collapse + resolver read."""
@@ -455,6 +457,8 @@ def _gsd(
         "sibling_group_key": group_key,
         "is_main_sibling": is_main_sibling,
         "regions": list(regions),
+        "revision": revision,
+        "tags": list(tags),
         "igdb_id": None,
         "sgdb_id": None,
         "ra_id": None,
@@ -485,6 +489,19 @@ class TestCollapseSiblingGroups:
         ]
         emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
         assert [e["rom_id"] for e in emitted] == [2]
+
+    def test_new_group_representative_and_name_follow_hardened_ranking(self):
+        # A New group with a (USA) (Beta) prerelease + a (Japan) retail final: the
+        # 1G1R ranking (prerelease demotion before region) picks the Japan retail
+        # dump as BOTH the emitted representative (bind target) and the canonical
+        # shortcut name — the region-preferred USA dump is a prerelease, so it loses.
+        members = [
+            _gsd(1, name="Game (USA) (Beta)", fs_name_no_ext="game_usa_beta", regions=["USA"], tags=["Beta"]),
+            _gsd(2, name="Game (Japan)", fs_name_no_ext="game_japan", regions=["Japan"]),
+        ]
+        emitted = collapse_sibling_groups(members, registry={}, installed_rom_ids=set(), complete_group_view=True)
+        assert [e["rom_id"] for e in emitted] == [2]
+        assert emitted[0]["name"] == "Game (Japan)"
 
     def test_installed_sibling_wins_representative(self):
         members = [

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -302,6 +302,87 @@ class TestTryUnitIncrementalSkip:
         assert result is None
 
 
+def _seed_completed_run(uow):
+    """A completed SyncRun so the skip gate has a ``last_sync`` to diff against."""
+    from domain.sync_run import SyncRun
+
+    run = SyncRun.start(id="r1", at="2025-01-01T00:00:00", platforms_planned=1, roms_planned=3)
+    run.complete("2025-01-01T00:00:00", ["N64"], [])
+    with uow:
+        uow.sync_runs.save(run)
+
+
+def _seed_persisted_rom(uow, rom_id, *, app_id, group_key, platform_slug="n64"):
+    """Persist one ``roms`` row (bound when app_id is set, else an unbound sibling)."""
+    from domain.rom import Rom
+
+    with uow:
+        uow.roms.save(
+            Rom(
+                rom_id=rom_id,
+                platform_slug=platform_slug,
+                name=f"G{rom_id}",
+                fs_name=f"g{rom_id}.z64",
+                shortcut_app_id=app_id,
+                last_synced_at="2025-01-01T00:00:00",
+                sibling_group_key=group_key,
+            )
+        )
+
+
+class TestIncrementalSkipGroupParity:
+    """Skip-gate parity with sibling groups (#1296 / ADR-0021): the platform
+    rom_count is compared against ALL persisted rows, not just the bound reps."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_all_persisted_rows_match_server_count(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        _seed_completed_run(uow)
+        # A 3-sibling group: one bound representative + two unbound siblings.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+        # No server rows updated after last_sync → delta total 0. RomM's rom_count
+        # (all siblings) matches the 3 persisted rows → skip. Under the old
+        # bound-only count this platform full-fetched forever.
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)
+
+        result = await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
+
+        assert result is not None
+        # The reconstructed unit_roms are the bound representatives (the shortcuts).
+        assert {r["id"] for r in result} == {10}
+
+    @pytest.mark.asyncio
+    async def test_no_skip_when_server_count_differs_from_persisted(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        _seed_completed_run(uow)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        # Server reports 3 ROMs but only 2 are persisted → a new sibling appeared.
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=3)
+
+        result = await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_null_group_key_forces_full_fetch_backfill(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        _seed_completed_run(uow)
+        # A legacy bound row whose sibling_group_key was never captured — even
+        # though the count matches, the backfill forces a full fetch.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key=None)
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+
+        result = await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
+
+        assert result is None
+
+
 class TestFetchPlatformUnit:
     """Tests for fetch_platform_unit() — wrong-type guard, error propagation, pagination."""
 

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -7,11 +7,14 @@ import pytest
 from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
 
 from domain.rom import Rom
+from domain.sync_diff import BIND_ROM_ID_KEY
 
 # conftest.py patches decky before this import
 
 
-def _seed_rom(uow, rom_id, *, app_id, platform_slug, name="Game", cover_path=None, sgdb_id=None, igdb_id=None):
+def _seed_rom(
+    uow, rom_id, *, app_id, platform_slug, name="Game", cover_path=None, sgdb_id=None, igdb_id=None, group_key=None
+):
     """Insert a bound (or unbound when app_id is None) ROM into the shared fake UoW."""
     rom = Rom(
         rom_id=rom_id,
@@ -23,6 +26,7 @@ def _seed_rom(uow, rom_id, *, app_id, platform_slug, name="Game", cover_path=Non
         cover_path=cover_path,
         sgdb_id=sgdb_id,
         igdb_id=igdb_id,
+        sibling_group_key=group_key,
     )
     with uow:
         uow.roms.save(rom)
@@ -32,6 +36,20 @@ def _seed_platform_names(uow, names: dict[str, str]) -> None:
     """Seed the offline ``platform_slug → display_name`` cache."""
     with uow:
         uow.kv_config.set("platform_names", json.dumps(names))
+
+
+def _stage(box, rom_id, entry, *, emitted=True):
+    """Stage a fetched ROM's built entry for the group-aware per-unit commit.
+
+    ``pending_all_roms`` is the identity + version source for EVERY fetched ROM;
+    ``pending_sync`` holds the emitted representatives (cover-path + bind_rom_id
+    marker). A bound representative appears in both; a non-representative sibling
+    is staged only in ``pending_all_roms`` (``emitted=False``) so the commit
+    persists it unbound.
+    """
+    box.pending_all_roms[rom_id] = entry
+    if emitted:
+        box.pending_sync[rom_id] = entry
 
 
 class TestGetSyncStats:
@@ -260,18 +278,22 @@ class TestCommitUnitResults:
     def test_commit_upserts_rom_from_pending(self, plugin):
         """A unit's acked ROM is upserted into ``uow.roms`` from its pending entry."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_name": "Game Boy",
-            "platform_slug": "gb",
-            "cover_path": "",
-            "igdb_id": 555,
-            "sgdb_id": 999,
-            "ra_id": 777,
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_name": "Game Boy",
+                "platform_slug": "gb",
+                "cover_path": "",
+                "igdb_id": 555,
+                "sgdb_id": 999,
+                "ra_id": 777,
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         assert uow.committed is True
         with uow:
@@ -289,20 +311,24 @@ class TestCommitUnitResults:
         """The sibling-group key + version dimensions ride the pending entry onto
         the upserted ``Rom`` (#1295)."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-            "sibling_group_key": "igdb:3404:57",
-            "regions": ["USA", "Europe"],
-            "languages": ["En"],
-            "revision": "1",
-            "tags": ["Demo"],
-            "is_main_sibling": True,
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_slug": "gb",
+                "cover_path": "",
+                "sibling_group_key": "igdb:3404:57",
+                "regions": ["USA", "Europe"],
+                "languages": ["En"],
+                "revision": "1",
+                "tags": ["Demo"],
+                "is_main_sibling": True,
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         with uow:
             rom = uow.roms.get(42)
@@ -318,14 +344,18 @@ class TestCommitUnitResults:
         """A pending entry with no version fields upserts a Rom carrying the
         aggregate defaults — never raises on the missing keys."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_slug": "gb",
+                "cover_path": "",
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         with uow:
             rom = uow.roms.get(42)
@@ -338,14 +368,18 @@ class TestCommitUnitResults:
     def test_commit_stamps_cover_path_when_present(self, plugin):
         """A finalized cover path is recorded on the upserted ROM row."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "/covers/staging.png",
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_slug": "gb",
+                "cover_path": "/covers/staging.png",
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         with uow:
             rom = uow.roms.get(42)
@@ -355,20 +389,28 @@ class TestCommitUnitResults:
     def test_commit_skips_invalid_rom_keeps_rest(self, plugin):
         """An invariant ValueError (missing platform_slug) skips one ROM; the rest still commit."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[10] = {
-            "name": "Bad",
-            "fs_name": "bad.z64",
-            "platform_slug": "",  # invalid — Rom.synced raises ValueError
-            "cover_path": "",
-        }
-        plugin._sync_service._box.pending_sync[20] = {
-            "name": "Good",
-            "fs_name": "good.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            10,
+            {
+                "name": "Bad",
+                "fs_name": "bad.z64",
+                "platform_slug": "",  # invalid — Rom.synced raises ValueError
+                "cover_path": "",
+            },
+        )
+        _stage(
+            plugin._sync_service._box,
+            20,
+            {
+                "name": "Good",
+                "fs_name": "good.z64",
+                "platform_slug": "gb",
+                "cover_path": "",
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"10": 1010, "20": 1020}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"10": 1010, "20": 1020}, [{"id": 10}, {"id": 20}])
 
         assert uow.committed is True
         with uow:
@@ -397,19 +439,23 @@ class TestCommitUnitResults:
             existing.assign_ra_id(7777)
             uow.roms.save(existing)
 
-        # The re-sync's pending entry (live RomM fetch) lacks sgdb_id / ra_id /
+        # The re-sync's built entry (live RomM fetch) lacks sgdb_id / ra_id /
         # cover_path entirely.
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-            "igdb_id": 555,
-            "sgdb_id": None,
-            "ra_id": None,
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_slug": "gb",
+                "cover_path": "",
+                "igdb_id": 555,
+                "sgdb_id": None,
+                "ra_id": None,
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         with uow:
             rom = uow.roms.get(42)
@@ -424,18 +470,138 @@ class TestCommitUnitResults:
         uow = plugin._uow
         _seed_rom(uow, 42, app_id=100001, platform_slug="gb", name="Game", sgdb_id=4242)
 
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-            "sgdb_id": 9999,
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {
+                "name": "Game",
+                "fs_name": "game.z64",
+                "platform_slug": "gb",
+                "cover_path": "",
+                "sgdb_id": 9999,
+            },
+        )
 
-        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [])
+        plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, [{"id": 42}])
 
         with uow:
             assert uow.roms.get(42).sgdb_id == 9999
+
+
+class TestGroupAwareCommit:
+    """Group-aware per-unit commit (ADR-0021): persist every fetched sibling,
+    bind only representatives, and move a binding on a rebind."""
+
+    def test_persists_non_representative_sibling_unbound(self, plugin):
+        """A fetched sibling that is not the emitted representative lands a ``roms``
+        row for its identity + version, but carries no shortcut binding."""
+        uow = plugin._uow
+        box = plugin._sync_service._box
+        rep = {
+            "name": "Game (USA)",
+            "fs_name": "usa.z64",
+            "platform_slug": "n64",
+            "cover_path": "",
+            "sibling_group_key": "g",
+        }
+        sibling = {
+            "name": "Game (JP)",
+            "fs_name": "jp.z64",
+            "platform_slug": "n64",
+            "cover_path": "",
+            "sibling_group_key": "g",
+        }
+        box.pending_sync = {10: rep}  # only rom 10 is emitted
+        box.pending_all_roms = {10: rep, 11: sibling}
+
+        plugin._sync_service._reporter._commit_unit_results_io({"10": 9001}, [{"id": 10}, {"id": 11}])
+
+        with uow:
+            rep_row = uow.roms.get(10)
+            sibling_row = uow.roms.get(11)
+        assert rep_row is not None and rep_row.shortcut_app_id == 9001
+        assert sibling_row is not None
+        assert sibling_row.shortcut_app_id is None
+        assert sibling_row.name == "Game (JP)"
+        assert sibling_row.sibling_group_key == "g"
+
+    def test_non_acked_bound_sibling_keeps_its_existing_binding(self, plugin):
+        """A bound sibling NOT acked this cycle keeps its existing binding — the
+        `_persist_synced_rom` fallback (`existing.shortcut_app_id`) is load-bearing.
+
+        Regression guard for the single most dangerous line in #1296: a
+        grandfathered group has rom 11 already bound (app 7777) while rom 10 is the
+        emitted representative bound this cycle (app 9001). Only rom 10 is acked, so
+        the commit must PRESERVE rom 11's 7777 from the existing row — the broken
+        `binding.get(rom_id)` variant (no existing fallback) would silently unbind
+        it, orphaning a live shortcut. ``test_persists_non_representative_sibling_unbound``
+        seeds no prior row for rom 11, so it passes with or without the fallback;
+        this one seeds the prior binding and only passes with it.
+        """
+        uow = plugin._uow
+        # rom 11 already carries a shortcut (grandfathered duplicate of group "g").
+        _seed_rom(uow, 11, app_id=7777, platform_slug="n64", name="Game (JP)", group_key="g")
+        box = plugin._sync_service._box
+        rep = {
+            "name": "Game (USA)",
+            "fs_name": "usa.z64",
+            "platform_slug": "n64",
+            "cover_path": "",
+            "sibling_group_key": "g",
+        }
+        sibling = {
+            "name": "Game (JP)",
+            "fs_name": "jp.z64",
+            "platform_slug": "n64",
+            "cover_path": "",
+            "sibling_group_key": "g",
+        }
+        box.pending_sync = {10: rep}  # only rom 10 is emitted / acked this cycle
+        box.pending_all_roms = {10: rep, 11: sibling}
+
+        plugin._sync_service._reporter._commit_unit_results_io({"10": 9001}, [{"id": 10}, {"id": 11}])
+
+        with uow:
+            rep_row = uow.roms.get(10)
+            sibling_row = uow.roms.get(11)
+        # rom 10 binds the acked appId; rom 11 KEEPS its pre-existing binding.
+        assert rep_row is not None and rep_row.shortcut_app_id == 9001
+        assert sibling_row is not None and sibling_row.shortcut_app_id == 7777
+
+    def test_rebind_moves_binding_to_representative(self, plugin):
+        """A rebind entry (keyed to the vanished bound sibling, carrying
+        ``bind_rom_id``) moves the DB binding onto the surviving representative:
+        the appId survives, the old sibling is unbound (ADR-0021 §2)."""
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=5000, platform_slug="n64", name="Game (USA)", group_key="g")
+        box = plugin._sync_service._box
+        # The emitted rebind entry is keyed to the vanished bound sibling (rom 1)
+        # and names the representative (rom 2) in bind_rom_id.
+        box.pending_sync = {1: {"name": "Game (USA)", "cover_path": "", BIND_ROM_ID_KEY: 2}}
+        box.pending_all_roms = {
+            2: {
+                "name": "Game (JP)",
+                "fs_name": "jp.z64",
+                "platform_slug": "n64",
+                "cover_path": "",
+                "sibling_group_key": "g",
+            },
+        }
+
+        # The frontend reused the old shortcut's appId (5000) under rom_id 1.
+        plugin._sync_service._reporter._commit_unit_results_io({"1": 5000}, [{"id": 2}])
+
+        with uow:
+            rep = uow.roms.get(2)
+            old = uow.roms.get(1)
+        # The binding moved onto the representative, which keeps its own real name.
+        assert rep is not None
+        assert rep.shortcut_app_id == 5000
+        assert rep.name == "Game (JP)"
+        assert rep.sibling_group_key == "g"
+        # The vanished sibling is unbound by the collision-safe save (row survives).
+        assert old is not None
+        assert old.shortcut_app_id is None
 
 
 class TestCommitUnitMetadataStamp:
@@ -451,12 +617,11 @@ class TestCommitUnitMetadataStamp:
         a ``rom_metadata`` row in the same commit, with fields mapped + ms→s +
         steam_categories computed."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""},
+        )
         acked = [
             {
                 "id": 42,
@@ -501,12 +666,11 @@ class TestCommitUnitMetadataStamp:
         import logging
 
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""},
+        )
         # first_release_date is non-numeric → int(...) raises ValueError in the
         # mapping, caught per-rom.
         acked = [{"id": 42, "summary": "Bad", "metadatum": {"first_release_date": "not-a-number"}}]
@@ -525,12 +689,11 @@ class TestCommitUnitMetadataStamp:
         """An acked ROM without a ``metadatum`` field commits the Rom but no
         ``rom_metadata`` row (defensive guard against thin-ROM cache erasure)."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[42] = {
-            "name": "Game",
-            "fs_name": "game.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            42,
+            {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""},
+        )
         acked = [{"id": 42, "name": "Thin"}]  # no metadatum
 
         plugin._sync_service._reporter._commit_unit_results_io({"42": 100001}, acked)
@@ -543,18 +706,16 @@ class TestCommitUnitMetadataStamp:
     def test_falsy_metadatum_writes_no_metadata_row(self, plugin):
         """``metadatum: None`` and ``metadatum: {}`` both skip the metadata stamp."""
         uow = plugin._uow
-        plugin._sync_service._box.pending_sync[10] = {
-            "name": "A",
-            "fs_name": "a.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
-        plugin._sync_service._box.pending_sync[20] = {
-            "name": "B",
-            "fs_name": "b.z64",
-            "platform_slug": "gb",
-            "cover_path": "",
-        }
+        _stage(
+            plugin._sync_service._box,
+            10,
+            {"name": "A", "fs_name": "a.z64", "platform_slug": "gb", "cover_path": ""},
+        )
+        _stage(
+            plugin._sync_service._box,
+            20,
+            {"name": "B", "fs_name": "b.z64", "platform_slug": "gb", "cover_path": ""},
+        )
         acked = [{"id": 10, "metadatum": None}, {"id": 20, "metadatum": {}}]
 
         plugin._sync_service._reporter._commit_unit_results_io({"10": 1010, "20": 1020}, acked)
@@ -661,7 +822,51 @@ class TestFinalizePerUnitRun:
 
         collections_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_collections"]
         payload = collections_events[0][0][1]
-        # rom 2 is unbound → excluded; only rom 1's app_id appears.
+        # rom 2 is unbound AND has no sibling group → excluded; only rom 1 appears.
+        assert payload["romm_collection_app_ids"] == {"Faves": [1001]}
+
+    @pytest.mark.asyncio
+    async def test_romm_collection_group_fallback_maps_unbound_sibling(self, plugin):
+        """A collection membership on an UNBOUND sibling maps to its group's bound
+        sibling's appId (ADR-0021) — collecting any version collects the game."""
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        # A bound representative + an unbound sibling in the SAME group.
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="Game (USA)", group_key="g")
+        _seed_rom(uow, 2, app_id=None, platform_slug="n64", name="Game (JP)", group_key="g")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={"Faves": [2]},  # the UNBOUND sibling is collected
+            pending_platform_rom_ids={1},
+            total_games=1,
+            platform_names={"n64": "Nintendo 64"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
+        # rom 2 is unbound, but its group's bound sibling (rom 1 → 1001) stands in.
+        assert payload["romm_collection_app_ids"] == {"Faves": [1001]}
+
+    @pytest.mark.asyncio
+    async def test_romm_collection_dedups_group_members_onto_one_shortcut(self, plugin):
+        """A collection holding several siblings of one group yields the group's
+        single shortcut appId once, not duplicated."""
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="Game (USA)", group_key="g")
+        _seed_rom(uow, 2, app_id=None, platform_slug="n64", name="Game (JP)", group_key="g")
+
+        await plugin._sync_service._reporter.finalize_per_unit_run(
+            pending_collection_memberships={"Faves": [1, 2]},  # BOTH siblings collected
+            pending_platform_rom_ids={1},
+            total_games=1,
+            platform_names={"n64": "Nintendo 64"},
+        )
+
+        payload = next(c for c in decky.emit.call_args_list if c[0][0] == "sync_collections")[0][1]
         assert payload["romm_collection_app_ids"] == {"Faves": [1001]}
 
     @pytest.mark.asyncio

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -35,6 +35,7 @@ from adapters.persistence import (
 )
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import EmulatorInvocation
+from domain.sync_diff import BIND_ROM_ID_KEY
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 
@@ -1488,6 +1489,292 @@ class TestDoSyncPerUnit:
         assert stale_events == [{"remove": [{"rom_id": 99, "app_id": 9900}]}]
 
     @pytest.mark.asyncio
+    async def test_group_emits_one_shortcut_per_sibling_group(self, plugin, fake_romm_api):
+        """A platform with a 3-version sibling group emits ONE shortcut for the
+        game (ADR-0021); the non-representative dumps are persisted unbound."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                # Three dumps of one game (shared igdb_id) + one unrelated game.
+                {
+                    "id": 10,
+                    "name": "Zelda (USA)",
+                    "igdb_id": 100,
+                    "fs_name_no_ext": "zelda_usa",
+                    "rom_user": {"is_main_sibling": True},
+                },
+                {"id": 11, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp"},
+                {"id": 12, "name": "Zelda (EU)", "igdb_id": 100, "fs_name_no_ext": "zelda_eu"},
+                {"id": 20, "name": "Mario", "igdb_id": 200, "fs_name_no_ext": "mario"},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def ack_reps(_unit, event):
+            event.set()
+            return {str(rid): 9000 + rid for rid in plugin._sync_service._box.pending_sync}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reps
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        emitted_ids = {sd["rom_id"] for sd in unit_events[0]["shortcuts"]}
+        # ONE shortcut for the Zelda group (rep = the RomM default, rom 10) + Mario.
+        assert emitted_ids == {10, 20}
+        with plugin._uow as uow:
+            # All four siblings are persisted; only the representatives bind.
+            assert uow.roms.get(10).shortcut_app_id == 9010
+            assert uow.roms.get(20).shortcut_app_id == 9020
+            assert uow.roms.get(11).shortcut_app_id is None
+            assert uow.roms.get(12).shortcut_app_id is None
+            assert uow.roms.get(11).sibling_group_key == "igdb:100:1"
+
+    @pytest.mark.asyncio
+    async def test_vanished_bound_sibling_rebinds_without_stale_removal(self, plugin, fake_romm_api):
+        """A bound sibling that disappears while its group survives rebinds to a
+        surviving sibling — the appId is preserved (no sync_stale removal), and the
+        binding moves onto the representative (ADR-0021 §2)."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        # rom 1 was the bound USA dump (app 5000); it is GONE from the server now.
+        _seed_rom_row(
+            plugin,
+            1,
+            app_id=5000,
+            platform_slug="n64",
+            name="Zelda (USA)",
+            fs_name="zelda_usa.z64",
+            sibling_group_key="igdb:100:1",
+        )
+        # The server still serves the JP + EU dumps of the same game.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {
+                    "id": 2,
+                    "name": "Zelda (JP)",
+                    "igdb_id": 100,
+                    "fs_name_no_ext": "zelda_jp",
+                    "rom_user": {"is_main_sibling": True},
+                },
+                {"id": 3, "name": "Zelda (EU)", "igdb_id": 100, "fs_name_no_ext": "zelda_eu"},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def ack_reuse(_unit, event):
+            event.set()
+            # The frontend reuses the vanished sibling's shortcut (app 5000) under
+            # its rom_id — the emitted rebind entry is keyed to rom 1.
+            return {str(rid): 5000 for rid in plugin._sync_service._box.pending_sync}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reuse
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # ONE shortcut emitted, keyed to the vanished sibling (rom 1) for reuse,
+        # rebinding to the RomM default (rom 2).
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        emitted = unit_events[0]["shortcuts"]
+        assert len(emitted) == 1
+        assert emitted[0]["rom_id"] == 1
+        assert emitted[0][BIND_ROM_ID_KEY] == 2
+
+        # No stale removal — the appId is preserved, not wiped.
+        stale_events = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert stale_events == [{"remove": []}]
+
+        # The binding moved onto the surviving representative (rom 2); the vanished
+        # sibling row is unbound (kept per ADR-0007).
+        with plugin._uow as uow:
+            assert uow.roms.get(2).shortcut_app_id == 5000
+            assert uow.roms.get(1).shortcut_app_id is None
+
+    @pytest.mark.asyncio
+    async def test_skipped_platform_collection_unbound_sibling_never_rebinds(self, plugin, fake_romm_api):
+        """#1296 CRITICAL: a skipped platform + a collection holding an UNBOUND
+        sibling of a group must NEVER rebind the live installed game.
+
+        Worked failure: the platform incremental-SKIPS, so only its BOUND rows
+        enter ``synced_rom_ids`` and the collection fetches the group's unbound
+        sibling un-deduped. The collection is a PARTIAL group view — the bound
+        installed representative (rom 10) is absent from its fetch but alive on the
+        server — so the collapse must grandfather the group untouched, not read the
+        binding as "vanished" and rebind it onto the uninstalled sibling (which
+        would blank the launch options and orphan the installed ROM).
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # A 2-version Zelda group on N64: rom 10 bound + installed (active
+        # version), rom 11 the unbound JP sibling. Both persisted + backfilled so
+        # the platform incremental-skips this run.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 10, "name": "Zelda (USA)", "igdb_id": 100, "fs_name_no_ext": "zelda_usa"},
+                {"id": 11, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp"},
+            ],
+        )
+        # The collection holds ONLY the unbound sibling.
+        _seed_collection(fake_romm_api, collection_id=7, name="Faves", rom_ids=[11], is_favorite=True)
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}}
+
+        _seed_completed_run(plugin, at="2025-01-01T00:00:00Z")
+        # Install first so the binding survives the _seed_rom_row overwrite.
+        _seed_install(plugin, 10, file_path="/roms/n64/zelda_usa.z64", platform_slug="n64")
+        _seed_rom_row(
+            plugin,
+            10,
+            app_id=5000,
+            platform_slug="n64",
+            name="Zelda (USA)",
+            fs_name="zelda_usa.z64",
+            sibling_group_key="igdb:100:1",
+        )
+        _seed_rom_row(
+            plugin,
+            11,
+            app_id=None,
+            platform_slug="n64",
+            name="Zelda (JP)",
+            fs_name="zelda_jp.z64",
+            sibling_group_key="igdb:100:1",
+        )
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # Prove the exact worked scenario ran: the platform incremental-SKIPPED
+        # (never paginated ``list_roms``), so its bound rows — but NOT the unbound
+        # sibling — entered ``synced_rom_ids`` and the collection fetched rom 11
+        # un-deduped, exercising the partial-view collapse branch.
+        call_names = [c[0] for c in fake_romm_api.call_log]
+        assert "list_roms" not in call_names
+        assert "list_roms_by_collection" in call_names
+
+        # The platform skipped its apply; the collection emitted but grandfathered
+        # the group → NO shortcut entry, and above all NO rebind entry.
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        all_emitted = [sd for e in unit_events for sd in e["shortcuts"]]
+        assert all(BIND_ROM_ID_KEY not in sd for sd in all_emitted)
+        assert all(sd["rom_id"] != 11 for sd in all_emitted)
+
+        # No stale removal of the live binding.
+        stale_events = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert stale_events == [{"remove": []}]
+
+        # Binding + version untouched: rom 10 still bound to app 5000, rom 11 stays
+        # an unbound tracked sibling.
+        with plugin._uow as uow:
+            assert uow.roms.get(10).shortcut_app_id == 5000
+            assert uow.roms.get(11).shortcut_app_id is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_platform_bound_row_stale_removed_collection_does_not_rebind(self, plugin, fake_romm_api):
+        """Disabled-platform variant of #1296: the bound row is stale-removed by the
+        normal path; the collection still does NOT rebind in the same run.
+
+        The group's platform is disabled, so no platform unit re-affirms rom 10 —
+        it is correctly stale-removed (unbound, shortcut torn down). An enabled
+        collection fetches the group's unbound sibling (rom 11), but as a partial
+        view it grandfathers rather than rebinding rom 11 onto the just-freed appId.
+        The result is eventually-consistent: re-enabling the platform on a later
+        sync re-establishes the group's shortcut; nothing is rebound off a partial
+        view here.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # rom 11 (the unbound sibling) lives on N64 + in the collection; rom 10 is
+        # a bound DB row on the (now disabled) platform.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 11, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp"}],
+        )
+        _seed_collection(fake_romm_api, collection_id=7, name="Faves", rom_ids=[11], is_favorite=True)
+        plugin.settings["enabled_platforms"] = {"1": False}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}}
+
+        _seed_rom_row(
+            plugin,
+            10,
+            app_id=5000,
+            platform_slug="n64",
+            name="Zelda (USA)",
+            fs_name="zelda_usa.z64",
+            sibling_group_key="igdb:100:1",
+        )
+        _seed_rom_row(
+            plugin,
+            11,
+            app_id=None,
+            platform_slug="n64",
+            name="Zelda (JP)",
+            fs_name="zelda_jp.z64",
+            sibling_group_key="igdb:100:1",
+        )
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # rom 10 is stale-removed by the normal path (its platform is gone).
+        stale_events = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_stale"]
+        assert stale_events == [{"remove": [{"rom_id": 10, "app_id": 5000}]}]
+
+        # The collection did NOT rebind onto the freed appId — no rebind entry, no
+        # shortcut for the unbound sibling.
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        all_emitted = [sd for e in unit_events for sd in e["shortcuts"]]
+        assert all(BIND_ROM_ID_KEY not in sd for sd in all_emitted)
+        assert all(sd["rom_id"] != 11 for sd in all_emitted)
+
+        # rom 10 ends unbound (stale path); rom 11 stays unbound (grandfathered).
+        with plugin._uow as uow:
+            assert uow.roms.get(10).shortcut_app_id is None
+            assert uow.roms.get(11).shortcut_app_id is None
+
+    @pytest.mark.asyncio
     async def test_downloads_artwork_when_not_skipped(self, plugin, fake_romm_api):
         import decky
 
@@ -1968,9 +2255,9 @@ class TestReportUnitResults:
         # the abandon window so the late ack for the SAME unit validates.
         box.current_sync_id = "run-1"
         box.active_unit_id = 1
-        box.pending_sync = {
-            42: {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""},
-        }
+        _entry = {"name": "Game", "fs_name": "game.z64", "platform_slug": "gb", "cover_path": ""}
+        box.pending_sync = {42: _entry}
+        box.pending_all_roms = {42: _entry}
         box.unit_complete_event = None
         box.unit_abandoned = True
         box.pending_unit_roms = [{"id": 42, "metadatum": {"genres": ["RPG"]}}]
@@ -1997,20 +2284,20 @@ class TestReportUnitResults:
         assert box.active_unit_id is None
 
     @pytest.mark.asyncio
-    async def test_late_ack_stamps_only_stashed_acked_roms(self, plugin):
-        """A ROM acked but absent from the stash still binds, but stamps no
-        metadata (its ``metadatum`` source is gone) — the binding is the
-        load-bearing data, metadata is best-effort (#1052)."""
+    async def test_late_ack_binds_stashed_rom_without_metadatum_stamps_no_metadata(self, plugin):
+        """A stashed ROM carrying no ``metadatum`` still binds via the late ack,
+        but stamps no metadata — the binding is load-bearing, metadata is
+        best-effort (#1052)."""
         box = plugin._sync_service._box
         box.current_sync_id = "run-1"
         box.active_unit_id = 1
-        box.pending_sync = {
-            42: {"name": "A", "fs_name": "a.z64", "platform_slug": "gb", "cover_path": ""},
-        }
+        _entry = {"name": "A", "fs_name": "a.z64", "platform_slug": "gb", "cover_path": ""}
+        box.pending_sync = {42: _entry}
+        box.pending_all_roms = {42: _entry}
         box.unit_complete_event = None
         box.unit_abandoned = True
-        # The stash carries a DIFFERENT rom than the one acked.
-        box.pending_unit_roms = [{"id": 99, "metadatum": {"genres": ["RPG"]}}]
+        # The stash (the whole unit fetch) carries rom 42 without a metadatum.
+        box.pending_unit_roms = [{"id": 42}]
 
         result = await plugin.report_unit_results({"42": 100001}, "run-1", 1)
 
@@ -2021,7 +2308,7 @@ class TestReportUnitResults:
         # Binding still committed.
         assert rom is not None
         assert rom.shortcut_app_id == 100001
-        # No metadata: rom 42 was not in the stash → empty acked_roms.
+        # No metadata: rom 42 carried no metadatum.
         assert meta is None
 
     @pytest.mark.asyncio
@@ -2077,9 +2364,9 @@ class TestLateAckReconciliationWithStaleScan:
         # rom_id (2), which the frontend acks with the SAME reused appId.
         box.current_sync_id = "run-1"
         box.active_unit_id = 1
-        box.pending_sync = {
-            2: {"name": "A", "fs_name": "a.z64", "platform_slug": "n64", "cover_path": ""},
-        }
+        _entry = {"name": "A", "fs_name": "a.z64", "platform_slug": "n64", "cover_path": ""}
+        box.pending_sync = {2: _entry}
+        box.pending_all_roms = {2: _entry}
         box.unit_complete_event = None
         box.unit_abandoned = True
         box.pending_unit_roms = [{"id": 2}]
@@ -2112,12 +2399,15 @@ class TestCommitUnitResults:
 
     @pytest.mark.asyncio
     async def test_updates_registry_for_unit_roms(self, plugin):
-        plugin._sync_service._pending_sync = {
+        box = plugin._sync_service._box
+        entries = {
             10: {"rom_id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
             11: {"rom_id": 11, "name": "B", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
         }
+        box.pending_sync = entries
+        box.pending_all_roms = entries
 
-        await plugin._sync_service._reporter.commit_unit_results({"10": 9001, "11": 9002}, [])
+        await plugin._sync_service._reporter.commit_unit_results({"10": 9001, "11": 9002}, [{"id": 10}, {"id": 11}])
 
         with plugin._uow as uow:
             assert uow.roms.get(10).shortcut_app_id == 9001
@@ -2126,15 +2416,42 @@ class TestCommitUnitResults:
     @pytest.mark.asyncio
     async def test_commits_roms_for_unit(self, plugin):
         """commit_unit_results lands the unit's ROM upserts in one committed UoW."""
-        plugin._sync_service._pending_sync = {
-            10: {"rom_id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""},
-        }
+        box = plugin._sync_service._box
+        entries = {10: {"rom_id": 10, "name": "A", "platform_name": "N64", "platform_slug": "n64", "cover_path": ""}}
+        box.pending_sync = entries
+        box.pending_all_roms = entries
 
-        await plugin._sync_service._reporter.commit_unit_results({"10": 9001}, [])
+        await plugin._sync_service._reporter.commit_unit_results({"10": 9001}, [{"id": 10}])
 
         assert plugin._uow.committed is True
         with plugin._uow as uow:
             assert uow.roms.get(10) is not None
+
+    @pytest.mark.asyncio
+    async def test_persists_unbound_non_representative_siblings(self, plugin):
+        """Group-aware persist (ADR-0021): every fetched ROM gets an identity row,
+        but a sibling absent from the ack lands UNBOUND — only representatives
+        carry a binding."""
+        box = plugin._sync_service._box
+        entries = {
+            10: {"rom_id": 10, "name": "A (USA)", "platform_slug": "n64", "cover_path": "", "sibling_group_key": "g"},
+            11: {"rom_id": 11, "name": "A (JP)", "platform_slug": "n64", "cover_path": "", "sibling_group_key": "g"},
+        }
+        # Only rom 10 is the representative (emitted + acked); rom 11 is a sibling.
+        box.pending_sync = {10: entries[10]}
+        box.pending_all_roms = entries
+
+        await plugin._sync_service._reporter.commit_unit_results({"10": 9001}, [{"id": 10}, {"id": 11}])
+
+        with plugin._uow as uow:
+            rep = uow.roms.get(10)
+            sibling = uow.roms.get(11)
+        assert rep is not None and rep.shortcut_app_id == 9001
+        # The non-representative sibling is persisted for its identity + version,
+        # but carries no shortcut binding.
+        assert sibling is not None
+        assert sibling.shortcut_app_id is None
+        assert sibling.sibling_group_key == "g"
 
 
 class TestShutdown:
@@ -2792,8 +3109,10 @@ class TestPerUnitMetadataStamping:
             assert uow.rom_metadata.get(10) is None
 
     @pytest.mark.asyncio
-    async def test_acked_roms_filter(self, plugin, fake_romm_api):
-        """Only the ROMs the frontend ack'd are threaded into ``commit_unit_results``."""
+    async def test_all_fetched_roms_threaded_ack_subset_binds(self, plugin, fake_romm_api):
+        """Group-aware persist (ADR-0021): the WHOLE unit fetch is threaded into
+        ``commit_unit_results`` (every sibling gets an identity row), while the
+        frontend ack — a subset — decides which representatives bind."""
         plugin.loop = asyncio.get_event_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -2813,8 +3132,8 @@ class TestPerUnitMetadataStamping:
 
         commit_calls: list[tuple[Any, Any]] = []
 
-        async def capture_commit(rid_to_aid, acked_roms):
-            commit_calls.append((rid_to_aid, acked_roms))
+        async def capture_commit(rid_to_aid, unit_roms):
+            commit_calls.append((rid_to_aid, unit_roms))
 
         plugin._sync_service._reporter.commit_unit_results = capture_commit  # type: ignore[method-assign]
         plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
@@ -2838,8 +3157,10 @@ class TestPerUnitMetadataStamping:
         )
 
         assert len(commit_calls) == 1
-        _rid_to_aid, acked = commit_calls[0]
-        assert {r["id"] for r in acked} == {1, 3, 5}
+        rid_to_aid, unit_roms = commit_calls[0]
+        # The whole fetch is threaded (all 5 siblings), the ack binds only 3.
+        assert {r["id"] for r in unit_roms} == {1, 2, 3, 4, 5}
+        assert set(rid_to_aid.keys()) == {"1", "3", "5"}
 
 
 class TestRegression738CacheCorruption:

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1541,6 +1541,91 @@ class TestDoSyncPerUnit:
             assert uow.roms.get(12).shortcut_app_id is None
             assert uow.roms.get(11).sibling_group_key == "igdb:100:1"
 
+    async def _apply_group_and_get_shortcuts(self, plugin, fake_romm_api, roms):
+        """Seed a single-platform sibling group, run one apply unit, return the
+        emitted ``sync_apply_unit`` shortcut dicts. Shared by the region tests."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=roms)
+        plugin.settings["enabled_platforms"] = {"1": True}
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+
+        async def ack_reps(_unit, event):
+            event.set()
+            return {str(rid): 9000 + rid for rid in plugin._sync_service._box.pending_sync}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = ack_reps
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        return unit_events[0]["shortcuts"]
+
+    @pytest.mark.asyncio
+    async def test_region_priority_picks_and_names_representative(self, plugin, fake_romm_api):
+        """No default/installed/bound: region priority binds the USA dump AND
+        names the shortcut after it, even though Japan sorts first alphabetically
+        (ADR-0021 §3 region leg + canonical naming)."""
+        shortcuts = await self._apply_group_and_get_shortcuts(
+            plugin,
+            fake_romm_api,
+            [
+                {"id": 10, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp", "regions": ["Japan"]},
+                {"id": 11, "name": "Zelda (USA)", "igdb_id": 100, "fs_name_no_ext": "zelda_usa", "regions": ["USA"]},
+            ],
+        )
+        assert len(shortcuts) == 1
+        assert shortcuts[0]["rom_id"] == 11
+        assert shortcuts[0]["name"] == "Zelda (USA)"
+
+    @pytest.mark.asyncio
+    async def test_preferred_region_setting_threads_into_apply_collapse(self, plugin, fake_romm_api):
+        """Setting ``preferred_region`` re-heads the ranking: with Japan preferred,
+        the Japanese dump becomes the representative + shortcut name — proving the
+        setting is threaded into the apply collapse call site."""
+        plugin.settings["preferred_region"] = "Japan"
+        shortcuts = await self._apply_group_and_get_shortcuts(
+            plugin,
+            fake_romm_api,
+            [
+                {"id": 10, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp", "regions": ["Japan"]},
+                {"id": 11, "name": "Zelda (USA)", "igdb_id": 100, "fs_name_no_ext": "zelda_usa", "regions": ["USA"]},
+            ],
+        )
+        assert len(shortcuts) == 1
+        assert shortcuts[0]["rom_id"] == 10
+        assert shortcuts[0]["name"] == "Zelda (JP)"
+
+    @pytest.mark.asyncio
+    async def test_preview_new_names_follow_region_canonical(self, plugin, fake_romm_api):
+        """The preview collapse call site also applies region priority: the new
+        game's reported name is the region-canonical (USA) name."""
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+        _use_fake_romm(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 10, "name": "Zelda (JP)", "igdb_id": 100, "fs_name_no_ext": "zelda_jp", "regions": ["Japan"]},
+                {"id": 11, "name": "Zelda (USA)", "igdb_id": 100, "fs_name_no_ext": "zelda_usa", "regions": ["USA"]},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        result = await plugin.sync_preview()
+        assert result["success"] is True
+        assert result["summary"]["new_count"] == 1  # one game, not two dumps
+        assert result["new_names"] == ["Zelda (USA)"]
+
     @pytest.mark.asyncio
     async def test_vanished_bound_sibling_rebinds_without_stale_removal(self, plugin, fake_romm_api):
         """A bound sibling that disappears while its group survives rebinds to a

--- a/tests/services/test_settings.py
+++ b/tests/services/test_settings.py
@@ -140,6 +140,7 @@ class TestGetSettings:
                 "log_level": "info",
                 "romm_allow_insecure_ssl": True,
                 "collection_create_platform_groups": True,
+                "preferred_region": "USA",
             }
         )
         steam_config.check_retroarch_input_driver.return_value = {"warning": False}
@@ -151,6 +152,7 @@ class TestGetSettings:
         assert result["log_level"] == "info"
         assert result["romm_allow_insecure_ssl"] is True
         assert result["collection_create_platform_groups"] is True
+        assert result["preferred_region"] == "USA"
         assert result["retroarch_input_check"] == {"warning": False}
 
     def test_never_returns_credentials_or_token(self, service, settings):
@@ -198,6 +200,7 @@ class TestGetSettings:
         assert result["log_level"] == "warn"
         assert result["romm_allow_insecure_ssl"] is False
         assert result["collection_create_platform_groups"] is False
+        assert result["preferred_region"] == "auto"
 
     def test_includes_retroarch_input_check_payload(self, service, steam_config):
         steam_config.check_retroarch_input_driver.return_value = {
@@ -232,6 +235,64 @@ class TestSaveLogLevel:
         result = service.save_log_level("")
         assert result["success"] is False
         assert "log_level" not in settings
+
+
+# ── save_preferred_region ──────────────────────────────────────────────
+
+
+class TestSavePreferredRegion:
+    @pytest.mark.parametrize("region", ["auto", "Europe", "USA", "Japan", "Germany"])
+    def test_valid_regions_persist(self, service, settings, settings_persister, region):
+        result = service.save_preferred_region(region)
+        assert result == {"success": True}
+        assert settings["preferred_region"] == region
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_trims_and_persists(self, service, settings):
+        service.save_preferred_region("  Japan  ")
+        assert settings["preferred_region"] == "Japan"
+
+    def test_blank_normalises_to_auto(self, service, settings, settings_persister):
+        result = service.save_preferred_region("   ")
+        assert result == {"success": True}
+        assert settings["preferred_region"] == "auto"
+        settings_persister.save_settings.assert_called_once_with()
+
+    def test_non_string_rejected_without_writing(self, service, settings, settings_persister):
+        result = service.save_preferred_region(42)
+        assert result["success"] is False
+        assert result["reason"] == "invalid_region"
+        assert "preferred_region" not in settings
+        settings_persister.save_settings.assert_not_called()
+
+
+# ── get_known_regions ──────────────────────────────────────────────────
+
+
+class TestGetKnownRegions:
+    @staticmethod
+    def _seed(uow: FakeUnitOfWork, rom_id: int, regions: tuple[str, ...]) -> None:
+        with uow:
+            uow.roms.save(
+                Rom(
+                    rom_id=rom_id,
+                    platform_slug="snes",
+                    name=f"Game {rom_id}",
+                    fs_name=f"game_{rom_id}.sfc",
+                    shortcut_app_id=None,
+                    last_synced_at="2026-01-01T00:00:00",
+                    regions=regions,
+                )
+            )
+
+    def test_empty_library_returns_empty(self, service):
+        assert service.get_known_regions() == []
+
+    def test_distinct_sorted_regions_across_roms(self, service, uow):
+        self._seed(uow, 1, ("USA", "Europe"))
+        self._seed(uow, 2, ("Japan", "USA"))  # USA repeats across rows
+        self._seed(uow, 3, ())  # a region-less ROM contributes nothing
+        assert service.get_known_regions() == ["Europe", "Japan", "USA"]
 
 
 # ── frontend_log ───────────────────────────────────────────────────────

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -723,6 +723,11 @@ _MIGRATION_BLOCKED_WHITELIST: set[str] = {
     "get_whitelist_settings",
     "update_whitelist_settings",
     "save_collection_platform_groups",
+    # Preferred sibling-group region — a settings.json-only write (ADR-0021 §3),
+    # never touches RetroDECK state; takes effect on the next sync. Its companion
+    # read (distinct regions in the local library) is a pure local DB read.
+    "save_preferred_region",
+    "get_known_regions",
     # Persistent corrupt-settings-reset notice — the read (banner/card) and the
     # user's explicit QAM ack must both work regardless of a pending migration.
     "get_settings_reset_notice",


### PR DESCRIPTION
Second slice of #1267 — closes #1296. Implements ADR-0021 (§3 amended in this PR).

A sibling group is now one game in Steam:

- **One shortcut per group.** The bound sibling is the active version; the representative resolves deterministically: installed > existing binding > RomM default (`is_main_sibling`) > region priority > alphabetical. Same-named siblings stop racing for one appId (the nondeterministic last-sibling-wins binding and the permanently-"unsynced" phantom rows are gone); differently-named siblings stop producing duplicate shortcuts.
- **Every fetched sibling is persisted** independently of the shortcut ack (identity + version metadata, unbound) — the foundation the version picker (#1297) will read from, and what makes preview counts stop reporting unbound siblings as perpetually new.
- **Preview and apply collapse identically** at the shortcuts_data boundary. The rebind lane (bound sibling deleted server-side → binding moves to the surviving representative, appId preserved) only runs where the fetch covers the whole group: platform units and the preview. Collection units are a partial view and grandfather instead — a collection can never silently switch a game's active version.
- **1G1R-style version choice**: prerelease dumps (alpha/beta/proto/sample/demo tags) lose to finished releases across all regions; within a region the newest revision wins (natural sort); base dumps beat filename-only re-dumps (Virtual Console / edition variants, which RomM does not parse into tags). Region order: World > USA > Europe > Japan > others alphabetically.
- **Preferred region setting** (QAM → Settings → Library): re-heads the region ranking; default is the fixed order above — no language/system detection. Options are the fixed anchors plus the regions present in the locally synced library. Changing it shows an explanation modal: it applies only to shortcuts minted from the next sync; already-synced games keep their bound version and name.
- **Canonical shortcut naming**: a new shortcut is named after the member ranked first by the pure region ranking, not the bound version — a bound Japanese dump no longer names the shortcut in Japanese (unless the group only has Japanese dumps). Existing shortcuts are never renamed (sticky identity protects appId, artwork, collections, playtime).
- **Counts speak in games** (groups), the incremental-skip gate compares RomM's rom_count against all persisted rows (parity restored on platforms with sibling groups), RomM collection/favorite membership maps through the group (favoriting any sibling surfaces the game's shortcut), and artwork downloads only for emitted entries.
- **Grandfathering**: pre-existing duplicate shortcuts (differently-named siblings) are kept and converge on uninstall; no migration deletes anything a user can see. Migration 010 adds the sibling-group-key index (forward-looking for #1297/#1298).

Docs: backend-architecture.md (group-aware pipeline, complete- vs partial-view collapse, resolution chain), database-design.md (migration 010), configuration.md (Preferred region), syncing-your-library.md (grouping, naming, 1G1R behavior), CONTEXT.md (Version vs Region/Languages vocabulary), ADR-0021 §3 amendment.

Tests: resolver unit + Hypothesis property tier (determinism, shuffle-invariance, chain priority, retail-beats-prerelease, newest-revision-wins), group-keyed diff incl. partial-view cases, ack-independent persist incl. the binding-preservation regression guard, rebind + late-ack/cancel windows, skip-gate parity, collections fallback, migration replay, settings/modal component tests, frontend group scenarios (no duplicate AddShortcut; rebind artwork targets the representative).

On-device (Steam Deck, Game Mode): grouping, deterministic bindings (region + Rev-1 picks), canonical naming, the Preferred-region UI, and the collection-unit no-rebind case are hardware-verified against a real multi-version RomM library. Still worth a hardware pass before release: rebind on server-side deletion and grandfathered-duplicate convergence (SetShortcutName/SetAppLaunchOptions on existing appIds — same class as #827).
