### PR TITLE
fix(ui): register new shortcuts as romm-owned at unit-ack time

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -78,6 +78,7 @@ vi.mock("./api/backend", async () => {
 });
 
 import { applyAllPlaytime } from "./patches/metadataPatches";
+import { registerRomMAppId } from "./patches/gameDetailPatch";
 import definePluginResult from "./index";
 
 // `definePlugin` is stubbed in test-setup to return its factory unchanged, so
@@ -417,6 +418,73 @@ describe("index.tsx — sync_complete launch-options reconcile (#1151)", () => {
     expect(logError).toHaveBeenCalledWith(
       expect.stringContaining("sync_reconcile: failed to reconcile launch options"),
     );
+    plugin.onDismount();
+  });
+});
+
+describe("index.tsx — sync_complete registers RomM appIds (#1205)", () => {
+  type SyncCompletePayload = {
+    platform_app_ids: Record<string, number[]>;
+    romm_collection_app_ids?: Record<string, number[]>;
+    total_games: number;
+    cancelled?: boolean;
+  };
+
+  function emitSyncComplete(payload: SyncCompletePayload): void {
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", payload);
+    });
+  }
+
+  beforeEach(() => {
+    vi.mocked(registerRomMAppId).mockClear();
+    logError.mockClear();
+    vi.mocked(getAllPlaytime).mockResolvedValue({ playtime: {} });
+    vi.mocked(getAppIdRomIdMap).mockResolvedValue({});
+    vi.mocked(getSettingsResetNotice).mockResolvedValue({ pending: false, backed_up_to: null });
+    vi.mocked(getInstalledRelaunchOptions).mockReset();
+    vi.mocked(getInstalledRelaunchOptions).mockResolvedValue([]);
+    // Empty collectionStore so the detached stale-cleanup is a no-op here.
+    vi.stubGlobal("collectionStore", { userCollections: [] });
+  });
+
+  it("registers every platform and RomM-collection appId from the payload", async () => {
+    const plugin = pluginFactory();
+    await flush(); // settle startup detaches (they call registerRomMAppId with the empty appIdMap)
+    vi.mocked(registerRomMAppId).mockClear();
+
+    emitSyncComplete({
+      platform_app_ids: { "Nintendo 64": [100, 101], PSX: [200] },
+      romm_collection_app_ids: { "[Faves]": [300], "[RPGs]": [200, 400] },
+      total_games: 5,
+    });
+    await flush();
+
+    // Every appId across BOTH maps is registered (200 spans a platform and a
+    // collection — idempotent, still fine).
+    for (const appId of [100, 101, 200, 300, 400]) {
+      expect(registerRomMAppId).toHaveBeenCalledWith(appId);
+    }
+    plugin.onDismount();
+  });
+
+  it("registers RomM-collection appIds even when platform_app_ids is empty (collection-only sync)", async () => {
+    // The #1205 core repro: a collection-only sync never populates
+    // platform_app_ids, so its new shortcuts land only in romm_collection_app_ids.
+    // The old platform-only loop left them unregistered until a Steam restart.
+    const plugin = pluginFactory();
+    await flush();
+    vi.mocked(registerRomMAppId).mockClear();
+
+    emitSyncComplete({
+      platform_app_ids: {},
+      romm_collection_app_ids: { "[Faves]": [777, 888] },
+      total_games: 2,
+    });
+    await flush();
+
+    expect(registerRomMAppId).toHaveBeenCalledWith(777);
+    expect(registerRomMAppId).toHaveBeenCalledWith(888);
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -310,8 +310,18 @@ export default definePlugin(() => {
     // Defensive reset; sync_plan also resets at the start of the next run.
     resetSyncDelta();
 
-    // Update RomM app ID set with newly synced shortcuts
+    // Update RomM app ID set with newly synced shortcuts. The unit-ack
+    // registration in syncManager is the primary path (registers each appId the
+    // moment it resolves); this is the redundant, no-op-safe net for any appId
+    // the unit loop didn't reach. Iterate BOTH maps: a collection-only sync
+    // touches only romm_collection_app_ids, so skipping it would leave those
+    // shortcuts unregistered until a Steam restart (#1205).
     for (const appIds of Object.values(data.platform_app_ids)) {
+      for (const appId of appIds) {
+        registerRomMAppId(appId);
+      }
+    }
+    for (const appIds of Object.values(data.romm_collection_app_ids ?? {})) {
       for (const appId of appIds) {
         registerRomMAppId(appId);
       }

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -25,6 +25,13 @@ vi.mock("./steamShortcuts", () => ({
   getLiveRomMShortcutAppIds: vi.fn(),
 }));
 
+// gameDetailPatch pulls in Steam-internal @decky/ui + component imports; mock it
+// so the manager's `registerRomMAppId` call is observable without loading them.
+const registerRomMAppId = vi.fn();
+vi.mock("../patches/gameDetailPatch", () => ({
+  registerRomMAppId: (...args: unknown[]) => registerRomMAppId(...args),
+}));
+
 import { initUnitSyncManager, requestSyncCancel, resetSyncCancel, isCancelRequested } from "./syncManager";
 
 function unit(launchOptions: string, runId = "run-1"): SyncApplyUnitData {
@@ -187,6 +194,114 @@ describe("syncManager — group-aware emit: one Steam shortcut per game (ADR-002
     expect(addShortcut).toHaveBeenCalledTimes(2);
     expect(addShortcut.mock.calls.map((c) => c[0].rom_id).sort((a, b) => a - b)).toEqual([10, 20]);
     expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "10": 6000, "20": 6001 }, "run-two-groups", 1);
+  });
+});
+
+describe("syncManager — registers resolved appIds as RomM-owned at ack time (#1205)", () => {
+  const EXE = "/home/deck/homebrew/plugins/decky-romm-sync/bin/rom-launcher";
+
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    registerRomMAppId.mockClear();
+    vi.mocked(backend.getArtworkBase64).mockReset();
+    vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: "ZGF0YQ==" });
+    resetSyncDelta();
+    resetSyncCancel();
+    // The global SteamClient stub is torn down by test-setup after the file's
+    // first test; the update/rebind paths call bare `SteamClient.Apps.Set*`, so
+    // re-stub it here.
+    vi.stubGlobal("SteamClient", {
+      Apps: {
+        AddShortcut: vi.fn(),
+        SetShortcutName: vi.fn(),
+        SetShortcutExe: vi.fn(),
+        SetShortcutStartDir: vi.fn(),
+        SetAppLaunchOptions: vi.fn(),
+        SetCustomArtworkForApp: vi.fn().mockResolvedValue(undefined),
+        RemoveShortcut: vi.fn(),
+      },
+    });
+  });
+
+  function item(overrides: Partial<SyncApplyUnitData["shortcuts"][number]>): SyncApplyUnitData["shortcuts"][number] {
+    return {
+      rom_id: 0,
+      name: "Game",
+      exe: EXE,
+      start_dir: "/home/deck",
+      launch_options: "",
+      platform_name: "PSX",
+      cover_path: "",
+      ...overrides,
+    };
+  }
+
+  function unitOf(shortcuts: SyncApplyUnitData["shortcuts"], runId: string): SyncApplyUnitData {
+    return {
+      run_id: runId,
+      unit_type: "platform",
+      unit_id: 1,
+      unit_name: "PSX",
+      unit_index: 0,
+      total_units: 1,
+      shortcuts,
+    };
+  }
+
+  it("registers a newly created shortcut's appId", async () => {
+    // rom 42 has no existing appId → create path → addShortcut returns 6000.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    addShortcut.mockResolvedValue(6000);
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>(
+        "sync_apply_unit",
+        unitOf([item({ rom_id: 42, name: "Test ROM" })], "run-reg-create"),
+      );
+      await flush(120);
+    });
+
+    expect(registerRomMAppId).toHaveBeenCalledWith(6000);
+  });
+
+  it("registers an existing shortcut's appId on the update path", async () => {
+    // rom 42 already maps to appId 5000 → update path, never addShortcut.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[42, 5000]]));
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>(
+        "sync_apply_unit",
+        unitOf([item({ rom_id: 42, name: "Test ROM" })], "run-reg-update"),
+      );
+      await flush(120);
+    });
+
+    expect(registerRomMAppId).toHaveBeenCalledWith(5000);
+    expect(addShortcut).not.toHaveBeenCalled();
+  });
+
+  it("registers the reused shortcut's appId for a rebind entry (bind_rom_id)", async () => {
+    // Rebind: the entry is keyed to the vanished bound sibling (rom 1, already in
+    // Steam as appId 5000). The shortcut is reused by rom_id, so 5000 is the appId
+    // the game-detail patch + launch interceptor must recognise — NOT the
+    // representative's (bind_rom_id 2, which only steers artwork).
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[1, 5000]]));
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>(
+        "sync_apply_unit",
+        unitOf([item({ rom_id: 1, name: "Zelda (USA)", bind_rom_id: 2 })], "run-reg-rebind"),
+      );
+      await flush(150);
+    });
+
+    expect(registerRomMAppId).toHaveBeenCalledWith(5000);
   });
 });
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -16,6 +16,7 @@ import {
 } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 import { recordSyncCreated } from "./syncDeltaStore";
+import { registerRomMAppId } from "../patches/gameDetailPatch";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 const HEARTBEAT_INTERVAL_MS = 10_000;
@@ -122,6 +123,14 @@ async function processUnitShortcuts(
       const appId = await resolveShortcutAppId(item, existing);
       if (appId) {
         romIdToAppId[String(item.rom_id)] = appId;
+        // Register the appId as RomM-owned the moment the mapping exists — the
+        // earliest point the game-detail patch and launch interceptor can gate
+        // on it. Registering only at sync_complete leaves a newly created
+        // shortcut's detail page rendering native Steam UI for the whole run's
+        // artwork/collection tail, and a collection-only sync's appIds may never
+        // reach platform_app_ids at all (#1205). Idempotent (Set.add); covers
+        // created, updated, and rebind entries alike.
+        registerRomMAppId(appId);
         // Artwork follows the BINDING target: on a rebind entry the shortcut is
         // keyed to the vanished sibling (item.rom_id) but the backend finalizes
         // the REPRESENTATIVE's cover (bind_rom_id), and covers can be


### PR DESCRIPTION
Closes #1205.

Newly-synced shortcuts rendered the **native Steam game page** instead of the RomM detail UI. Root cause (field data in the issue): the `rommAppIds` set that gates both the game-detail injection and the launch interceptor was populated only (a) at plugin boot and (b) on `sync_complete` — and there only from `platform_app_ids`. Two failure modes:

- During a sync's artwork/collections tail (~90 s in the field data), every freshly created shortcut's page showed the wrong UI.
- A **collection-only sync never registered its new appIds at all** — `sync_complete` carries them in `romm_collection_app_ids`, which the registration loop ignored. The set stayed stale until a Steam restart (the "had to restart" report).

Fix, two registrations:

- **Unit-ack seam** (`syncManager.processUnitShortcuts`): each resolved appId is registered the moment the `rom_id→appId` mapping exists — covers the create, existing-update and rebind lanes; idempotent; error paths register nothing. This makes the *first render* of a new game's page correct.
- **`sync_complete`**: the registration loop now folds in `romm_collection_app_ids` alongside `platform_app_ids` (payload already carried it) — closes the collection-only gap as a redundant net. The loop stays deliberately unconditional for cancelled runs: shortcuts that were created before a cancel exist in Steam and should render RomM UI.

Deliberately out of scope: forcing a re-render of a page that is already open at the exact moment its appId registers (Steam router internals) — early registration makes that window practically irrelevant.

Tests: unit-ack registration for all three lanes (exact appIds through the event harness), `sync_complete` registration incl. the **collection-only payload** regression case (previously mocked-but-never-asserted path).

docs: N/A (bug fix — restores the intended behavior; no architecture, flow or UI change)

On-device check before release: after a collection-only sync, a new game's page opens straight into the RomM UI and launch interception works — without a Steam restart.
