### PR TITLE
chore(dev): live frontend dev loop into windowed Big Picture with display targeting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Coverage**: `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev` (build + restart plugin_loader)
+- **Frontend live dev**: `mise run dev:watch [display]` (one-time `mise run dev:setup`) — hot-reloads the **frontend**
+  into a windowed Big Picture in Desktop Mode on every save, no loader restart. Optional display target picks the
+  monitor (`internal` default, or a name like `dp2` / `DP-3`). **Backend** changes don't auto-trigger — push them with
+  `mise run dev:push-backend`. Lost the Decky UI after leaving BPM: `mise run dev:bpm-reset [display]`. Full guide:
+  `docs/contributing/frontend-dev-loop.md`
 - **Tooling**: mise manages node, pnpm, python, uv. Venv auto-creates at `.venv` (via `_.python.venv` in mise.toml)
   using uv as the underlying tool; `mise run setup` installs Python deps via `uv pip install` (uv is the canonical
   Python package manager in this project). Python deps are pinned in `requirements-dev.lock` / `requirements-docs.lock`,

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ details, [save sync](https://danielcopper.github.io/decky-romm-sync/user-guide/s
 Build from source, run the tests, and read the architecture reference on the documentation site:
 
 - [Development setup](https://danielcopper.github.io/decky-romm-sync/contributing/development/)
+- [Frontend dev loop](https://danielcopper.github.io/decky-romm-sync/contributing/frontend-dev-loop/) — live-reload the
+  UI into a windowed Big Picture on the Deck, no Game Mode switching
 - [Backend architecture](https://danielcopper.github.io/decky-romm-sync/architecture/backend-architecture/)
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ documentation site. This README is just the quick tour.
 
 ## Requirements
 
-- [Decky Loader](https://decky.xyz/) on your Steam Deck or Linux HTPC
+- [Decky Loader](https://decky.xyz/) on your Steam Deck or Linux HTPC — the plugin lives in Steam's gamepad UI, so it
+  works in the Deck's Game Mode **or** in Big Picture Mode on any Linux PC
 - A running [RomM](https://github.com/rommapp/romm) server, **version 4.9.0 or newer** (the plugin stays inert against
   older servers)
 - [RetroDECK](https://retrodeck.net/) for launching games

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -123,6 +123,12 @@ against that re-own and fails with `permission denied`. With the loader stopped,
 automatically when the task finishes — even if the build or copy fails, so a failure never leaves the plugin dead. For
 backend-only changes, restarting the plugin loader is sufficient without rebuilding.
 
+For frontend iteration there is a much faster loop: after a one-time `mise run dev:setup`,
+`mise run dev:watch [display]` hot-reloads the **frontend** into a windowed Big Picture on the desktop as you save, with
+no loader restarts at all — put it on a second monitor with a display target like `dp2`. Backend changes are pushed on
+demand with `mise run dev:push-backend`. See [Frontend dev loop](frontend-dev-loop.md) for the full workflow, keyboard
+shortcuts, and caveats.
+
 ## Deploying to Device
 
 For development, symlink the repo into the plugins directory:

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -1,0 +1,133 @@
+# Frontend dev loop
+
+Iterate on the frontend from Desktop Mode on the Steam Deck: edit code next to a windowed Big Picture window and watch
+the real plugin UI hot-reload on every save — no Desktop/Game Mode switching, no `plugin_loader` restarts.
+
+## Why this works
+
+Three pieces line up:
+
+- **Desktop Big Picture is the real UI.** Desktop Steam's Big Picture window runs the same gamepadui React app as Game
+  Mode — same routes, same game-detail pages — and Decky Loader injects into desktop Steam too. What you see in the
+  windowed BPM is the plugin's actual UI, not an approximation.
+- **decky-loader ships a hot-reload watcher.** The loader watches `~/homebrew/plugins` and reacts to create/modify
+  events on exactly two files per plugin: `dist/index.js` and `main.py`. On a match it reloads the plugin in place —
+  backend subprocess restart plus a cache-busted frontend re-import (the plugin unmounts cleanly first, so router
+  patches are removed and re-applied).
+- **The watcher is gated on a `debug` flag.** Hot reload only applies to plugins carrying `"debug"` in the `flags` array
+  of `plugin.json`. `mise run deploy` injects the flag into the **deployed** `plugin.json` only — it is never committed
+  to the repo copy, because the Decky plugin store rejects plugins that ship it.
+
+## One-time setup
+
+```bash
+mise run dev:setup
+```
+
+This changes the system so the daily loop can run without `sudo`:
+
+- Writes the systemd drop-in `/etc/systemd/system/plugin_loader.service.d/10-dev-loop.conf` with
+  `Environment=CHOWN_PLUGIN_PATH=0`. This disables Decky's tamper guard, which otherwise re-owns the plugin dir and
+  `plugin.json` back to root on every plugin load — with the guard off, the deck user can write straight into
+  `~/homebrew/plugins/decky-romm-sync`. Drop-ins survive Decky self-updates (those rewrite only the unit file).
+- Runs `systemctl daemon-reload` and restarts `plugin_loader`.
+- Chowns an existing plugin dir back to the deck user.
+- Warns (without failing) if `~/.steam/steam/.cef-enable-remote-debugging` is missing — see [DevTools](#devtools).
+
+The task is idempotent — safe to re-run at any time. The `debug` flag itself is not part of the setup: it is injected at
+deploy time by `mise run deploy`, on every deploy.
+
+## Daily loop
+
+```bash
+mise run dev:watch          # BPM window on the internal display (default)
+mise run dev:watch dp2      # BPM window on an external monitor
+```
+
+What happens:
+
+1. A full deploy (`mise run deploy`): frontend build plus rsync of everything into the plugin dir. The `main.py` copy
+   inside it is itself a modify event, so the plugin hot-reloads with the fresh backend and frontend right away.
+2. A windowed Big Picture opens on the desktop (a no-op if one is already open; if Steam isn't running, it starts
+   straight into BPM) and its window is placed on the chosen display.
+3. Rollup stays in watch mode. On every save it rebuilds `dist/index.js` and copies it into the deployed `dist/`;
+   decky-loader hot-reloads the plugin about 1–2 seconds later.
+
+The reload is bundle-level, not component-level hot module replacement: the plugin is unmounted and re-imported, so
+component state resets and whatever is currently on screen keeps showing the **old** render until it is mounted again.
+Concretely: after a save, leave the plugin's QAM panel and re-enter it (back out of _RomM Sync_, open it again) — or
+re-navigate to a patched game-detail page — to see the change. Keyboard shortcuts in the BPM window: **Ctrl+2** opens
+the Quick Access Menu, **Ctrl+1** the main menu.
+
+### Choosing the display
+
+The optional argument is matched against the **real outputs** of the machine — output naming varies between Decks and
+docks (external outputs may be `DP-2`/`DP-3` rather than `DP-1`/`DP-2`), so nothing is hardcoded. List the selectable
+targets with `scripts/dev_open_bpm.sh --list`: it prints a lowercase short form per connected **and enabled** output
+(e.g. `edp1`, `dp2`, `dp3`), plus the `internal` alias while the built-in panel is enabled. Disabled outputs are neither
+listed nor resolvable — KWin can't place a window on them. The raw `kscreen-doctor -o` names (e.g. `DP-2`) are accepted
+as well — matching is case- and dash-insensitive, so `dp2`, `DP2` and `DP-2` all mean `DP-2`. The default `internal`
+resolves to the built-in panel (`eDP-*`); a target that matches no enabled output is a hard error before anything opens.
+On a docked Deck whose internal panel is disabled or disconnected, the default prints a warning and the BPM window
+simply opens wherever the window manager puts it.
+
+Placement itself is done by a short-lived KWin script loaded over DBus (`scripts/dev_open_bpm.sh`), which moves the Big
+Picture window to the target output and unloads itself again — if KWin scripting is unavailable, the loop still works
+and only the placement is skipped. The BPM window stays a normal desktop window: it can always be dragged elsewhere.
+
+With [mise shell completions](https://mise.jdx.dev/installing-mise.html#shells) enabled (requires the `usage` CLI, e.g.
+`eval "$(mise completion bash)"` in your shell rc), the display argument tab-completes with those targets.
+
+## Backend changes
+
+```bash
+mise run dev:push-backend
+```
+
+`dev:watch` only watches `src/`, so **frontend** edits reload automatically but **backend** (Python) edits do not — push
+them on demand with this task. It rsyncs `py_modules/` and `main.py` into the deployed plugin during a `dev:watch`
+session. The watcher matches only `dist/index.js` and `main.py`, so a `py_modules/`-only push never triggers a reload —
+the task therefore copies `main.py` **last**, and that copy is the modify event that reloads the plugin. Every reload is
+a full one regardless of which file changed: decky-loader restarts the backend subprocess **and** re-imports the
+frontend bundle. For `bin/` or `defaults/` changes, run the full `mise run deploy` instead.
+
+## DevTools
+
+With `~/.steam/steam/.cef-enable-remote-debugging` present, Steam exposes the CEF DevTools protocol on
+<http://localhost:8080>:
+
+- The **SharedJSContext** target is where all plugin JS runs — console output and JS debugging live here.
+- The **Steam Big Picture Mode** target is the rendered UI — element inspection and live CSS editing.
+
+Decky's developer setting **Allow Remote CEF Debugging** forwards the same protocol to port 8081 on the LAN, for
+DevTools from a second PC. Reload activity from the loader side is visible with:
+
+```bash
+journalctl -u plugin_loader -f
+```
+
+## Troubleshooting and caveats
+
+- **Decky UI gone after leaving and re-entering BPM** — Decky's UI survives only the _first_ Big Picture entry per Steam
+  process; closing the BPM window and reopening it loses the Decky QAM until Steam restarts. Recover with
+  `mise run dev:bpm-reset` (shuts Steam down, waits for it to exit, reopens windowed BPM). It takes the same optional
+  display argument as `dev:watch`, e.g. `mise run dev:bpm-reset dp2`.
+- **Watcher arms ~10 seconds after `plugin_loader` starts.** Edits saved inside that window don't reload — save again
+  once it's up.
+- **Renames and moves are ignored by the watcher** — it reacts only to create/modify events. That's why the loop copies
+  with `cp` (an in-place modify); `mv`, or an rsync that writes a temp file and renames it into place, would silently
+  never trigger a reload for `dist/index.js` / `main.py`.
+- **Big Picture opened on the wrong monitor** — placement matches the window by its title once it appears. Check what
+  the window manager actually saw with `journalctl --user -b | grep decky-bpm`: the log lists every window's caption and
+  output, and whether the move fired. The window stays a normal desktop window, so you can always drag it over yourself.
+- **A "screen sharing" portal dialog pops up when Big Picture opens** — that's Steam's own desktop capture (Game
+  Recording / Remote Play) asking through the xdg-desktop-portal, because there is no gamescope to capture in desktop
+  mode. It is unrelated to this tooling. **Turn Steam's Game Recording off** (Steam → Settings → Game Recording) — you
+  don't want Steam capturing your desktop mid-development anyway, and this removes the dialog for good. Ticking the
+  portal's _"enable restore"_ box instead only hides the dialog: it pins whichever source you picked, so if you pick a
+  single monitor the capture stays on it even after `dev:watch <other-display>` moves Big Picture elsewhere.
+- **The QAM Performance tab is non-functional in desktop BPM** (it needs gamescope). Irrelevant for this plugin's UI.
+- **Desktop-BPM injection is best-effort** on Decky's side — re-verify the loop still works after Decky or Steam
+  updates.
+- **Do a final Game Mode pass before a release.** The windowed BPM covers UI iteration, but controller focus behavior
+  and gamescope rendering are only real in Game Mode.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -19,8 +19,9 @@ Before installing the plugin, you need:
 2. **RetroDECK** — installed on your Steam Deck or Linux PC. RetroDECK handles the actual emulation. The plugin creates
    shortcuts that launch games through RetroDECK.
 
-3. **Decky Loader** — the plugin framework for Steam's Gaming Mode. Install it from [decky.xyz](https://decky.xyz/) if
-   you haven't already.
+3. **Decky Loader** — the plugin framework. Install it from [decky.xyz](https://decky.xyz/) if you haven't already.
+   Decky renders inside Steam's gamepad UI, and the plugin works wherever that UI runs: Gaming Mode on the Steam Deck,
+   or Big Picture Mode on a Linux PC/HTPC — a dedicated Game Mode session is not required.
 
 4. **A personal RomM account** — save sync ties saves to the authenticated user. Use your own account, not a shared one.
 

--- a/mise.toml
+++ b/mise.toml
@@ -66,13 +66,15 @@ run = [
 description = "Deploy plugin files to Decky plugin directory"
 depends = ["build"]
 raw = true
-run = """
+run = '''
 DEST="$HOME/homebrew/plugins/decky-romm-sync"
 # The plugin dir is root-owned: Decky's root plugin_loader continuously re-owns the
 # dir + plugin.json back to root within ~1-2s as a tamper guard, so a plain
 # deck-owned rsync/cp hits "permission denied". The `dev` task makes this safe by
 # stopping plugin_loader and chowning the dir to deck around this deploy, so nothing
 # re-roots mid-flight. Run via `dev`, not `deploy` standalone, on a root-owned dir.
+# (After `mise run dev:setup` the tamper guard is off and the dir is deck-owned,
+# so standalone deploy — e.g. the initial push inside `dev:watch` — is safe.)
 mkdir -p "$DEST/dist" "$DEST/bin" "$DEST/defaults" "$DEST/py_modules"
 rsync -a --delete dist/ "$DEST/dist/"
 rsync -a --delete bin/ "$DEST/bin/"
@@ -85,7 +87,28 @@ rsync -a --delete defaults/ "$DEST/defaults/"
 for f in defaults/*; do rm -f "$DEST/$(basename "$f")"; done
 rsync -a --delete py_modules/ "$DEST/py_modules/"
 cp -f main.py plugin.json package.json "$DEST/"
-"""
+# Every local deploy is a dev deploy — release zips are packaged in CI
+# (release.yml builds with the Decky CLI straight from the repo checkout), so
+# this deployed copy never feeds a release. Injecting "debug" into the DEPLOYED
+# plugin.json turns on decky-loader's built-in hot-reload watcher for this
+# plugin (the watcher only acts on debug-flagged plugins). Never commit the
+# flag to the repo plugin.json — the Decky plugin store rejects plugins that
+# ship it. Idempotent: re-deploys don't duplicate the flag.
+python3 - "$DEST/plugin.json" <<'PYEOF'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    manifest = json.load(f)
+flags = manifest.setdefault("flags", [])
+if "debug" not in flags:
+    flags.append("debug")
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, indent=2)
+    f.write("\n")
+PYEOF
+'''
 
 [tasks.docs]
 description = "Serve the documentation site locally with live reload"
@@ -113,3 +136,123 @@ trap 'sudo systemctl start plugin_loader' EXIT
 [ -d "$DEST" ] && sudo chown -R "$(id -un):$(id -gn)" "$DEST"
 mise run deploy
 """
+
+[tasks."dev:setup"]
+description = "One-time host setup for the live frontend dev loop (systemd drop-in + chown; uses sudo)"
+raw = true
+run = '''
+sudo -v
+DEST="$HOME/homebrew/plugins/decky-romm-sync"
+# Decky's tamper guard (env CHOWN_PLUGIN_PATH, default "1") re-owns the plugin
+# dir + plugin.json back to root on every plugin load, so the deck user can't
+# write deploys into it while the loader runs. The drop-in turns the guard off
+# on this machine; drop-ins survive Decky self-updates (those rewrite only the
+# unit file). Every step below is idempotent — safe to re-run.
+sudo install -d /etc/systemd/system/plugin_loader.service.d
+printf '[Service]\nEnvironment=CHOWN_PLUGIN_PATH=0\n' | sudo tee /etc/systemd/system/plugin_loader.service.d/10-dev-loop.conf >/dev/null
+sudo systemctl daemon-reload
+sudo systemctl restart plugin_loader
+# Hand an existing (root-owned) plugin dir back to the deck user so the watch
+# loop's plain cp works without sudo from here on.
+if [ -d "$DEST" ]; then sudo chown -R "$(id -un):$(id -gn)" "$DEST"; fi
+# CEF DevTools (http://localhost:8080) need this marker file; warn, don't fail —
+# the hot-reload loop itself works without it.
+if [ ! -e "$HOME/.steam/steam/.cef-enable-remote-debugging" ]; then
+  echo "WARNING: ~/.steam/steam/.cef-enable-remote-debugging is missing — CEF DevTools on http://localhost:8080 won't work. Create the empty file and restart Steam to enable them."
+fi
+echo "Setup done. decky-loader's hot-reload watcher arms ~10 s after the restart."
+echo "Next: mise run dev:watch"
+'''
+
+[tasks."dev:watch"]
+description = "Live frontend dev loop: deploy, open windowed Big Picture, rebuild + hot-reload on every save"
+raw = true
+# The optional display arg reaches the script as $usage_display (mise exposes
+# usage-spec args as usage_<name> env vars); the complete directive feeds mise's
+# shell tab completion from the real outputs of this machine.
+usage = '''
+arg "[display]" help="Monitor for the Big Picture window: 'internal' or an output name (dp2, DP-3, ...)" default="internal"
+complete "display" run="bash scripts/dev_open_bpm.sh --list"
+'''
+run = '''
+DEST="$HOME/homebrew/plugins/decky-romm-sync"
+# Preflight: without the dev:setup drop-in, plugin_loader re-owns the plugin dir
+# back to root within ~1-2s and every cp below dies with "permission denied".
+if ! systemctl show plugin_loader -p Environment | grep -q CHOWN_PLUGIN_PATH=0; then
+  echo "plugin_loader still runs Decky's tamper guard — run: mise run dev:setup" >&2
+  exit 1
+fi
+if [ -d "$DEST" ] && [ ! -w "$DEST" ]; then
+  echo "$DEST is not writable — run: mise run dev:setup" >&2
+  exit 1
+fi
+# Fail fast on a typo'd display target before paying for the full deploy.
+bash scripts/dev_open_bpm.sh --resolve "$usage_display" >/dev/null
+# Full initial push (frontend build + rsync of everything). The `cp -f main.py`
+# inside deploy is itself a modify event on a watched file, so the watcher
+# hot-reloads the plugin with the fresh backend + frontend right away.
+mise run deploy
+# Open desktop Big Picture next to the editor — it renders the same gamepadui
+# React app as Game Mode, and Decky injects into desktop Steam too. Harmless
+# no-op if BPM is already open; if Steam isn't running, this starts it straight
+# into BPM. The helper also places the window on the chosen display (default:
+# internal panel) via a short-lived KWin script, and doesn't wait on Steam.
+bash scripts/dev_open_bpm.sh "$usage_display"
+# Rebuild on every src/ change, then cp the bundle into the deployed dist/.
+# cp (in-place modify), never mv/rsync: decky-loader's watcher reacts only to
+# create/modify events on dist/index.js + main.py — moves/renames are ignored.
+# The sourcemap goes first so the watched trigger file (index.js) lands last.
+exec pnpm exec rollup -c rollup.dev.config.js -w --watch.onEnd="cp -f dist/index.js.map '$DEST/dist/' && cp -f dist/index.js '$DEST/dist/'"
+'''
+
+[tasks."dev:push-backend"]
+description = "Push backend changes (py_modules/ + main.py) into the deployed plugin during a dev:watch session"
+raw = true
+run = '''
+DEST="$HOME/homebrew/plugins/decky-romm-sync"
+# decky-loader's watcher matches only dist/index.js and main.py, so a
+# py_modules-only rsync never triggers a reload — that's why the cp of main.py
+# comes LAST: it's the modify event that makes the watcher reload the plugin
+# (backend subprocess restart + frontend re-import). For bin/ or defaults/
+# changes run the full `mise run deploy` instead.
+rsync -a --delete py_modules/ "$DEST/py_modules/"
+cp -f main.py "$DEST/main.py"
+'''
+
+[tasks."dev:bpm-reset"]
+description = "Restart Steam into windowed Big Picture (recovers the Decky UI after leaving and re-entering BPM)"
+raw = true
+usage = '''
+arg "[display]" help="Monitor for the Big Picture window: 'internal' or an output name (dp2, DP-3, ...)" default="internal"
+complete "display" run="bash scripts/dev_open_bpm.sh --list"
+'''
+run = '''
+# Fail fast on a typo'd display target before shutting Steam down.
+bash scripts/dev_open_bpm.sh --resolve "$usage_display" >/dev/null
+# Decky's UI survives only the FIRST Big Picture entry per Steam process:
+# leaving BPM and re-entering loses the Decky QAM until Steam restarts.
+echo "Shutting down Steam..."
+# Run steam through the user systemd manager, not this shell: mise + the venv
+# pollute PATH/VIRTUAL_ENV, which trips steam-jupiter's 32-bit runtime check.
+# systemd-run --user gives it the pristine session environment (see
+# scripts/dev_open_bpm.sh for the full rationale).
+if command -v systemd-run >/dev/null 2>&1; then
+  systemd-run --user --collect --quiet --wait -- steam -shutdown >/dev/null 2>&1 || true
+else
+  env -u VIRTUAL_ENV steam -shutdown >/dev/null 2>&1 || true
+fi
+# Wait for the running instance to actually exit (up to ~30 s) — reopening too
+# early just talks to the dying process.
+for _ in $(seq 1 30); do
+  if ! pgrep -x steam >/dev/null; then break; fi
+  sleep 1
+done
+if pgrep -x steam >/dev/null; then
+  echo "Steam is still running after 30 s — close it manually, then re-run this task." >&2
+  exit 1
+fi
+echo "Reopening Big Picture..."
+# The helper opens BPM non-blocking and places the window on the chosen
+# display (default: internal panel) via a short-lived KWin script.
+bash scripts/dev_open_bpm.sh "$usage_display"
+'''

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,4 +77,5 @@ nav:
       - Steam Remote Play & Cross-Device: architecture/steam-remote-play.md
   - Contributing:
       - Development: contributing/development.md
+      - Frontend dev loop: contributing/frontend-dev-loop.md
       - Dependency management: contributing/dependency-management.md

--- a/scripts/dev_open_bpm.sh
+++ b/scripts/dev_open_bpm.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# Open desktop Big Picture and place its window on a chosen monitor.
+#
+# Part of the frontend dev loop (docs/contributing/frontend-dev-loop.md);
+# called by the `dev:watch` / `dev:bpm-reset` mise tasks, usable standalone.
+#
+# Usage:
+#   dev_open_bpm.sh [target]        open BPM, place the window on <target>
+#   dev_open_bpm.sh --list          print selectable targets, one per line:
+#                                   the normalized (lowercase, dash-stripped)
+#                                   form of each connected + enabled output,
+#                                   plus the "internal" alias while the
+#                                   built-in panel is enabled (drives the mise
+#                                   tab completion — its prefix filter is
+#                                   case-sensitive, so the lowercase forms are
+#                                   what complete)
+#   dev_open_bpm.sh --resolve [t]   print the output name <t> resolves to and
+#                                   exit without side effects (fail-fast guard)
+#
+# Target resolution — always against the REAL outputs of this machine (no
+# hardcoded alias tables: on some Decks the external outputs are DP-2/DP-3,
+# not DP-1/DP-2):
+#   - "internal" (the default) resolves to the enabled output whose name
+#     starts with eDP (the built-in panel).
+#   - anything else matches an enabled output name case- and
+#     dash-insensitively, so `dp2`, `DP2` and `DP-2` all resolve to `DP-2`.
+#   - only connected AND enabled outputs count — KWin can't place a window on
+#     a disabled output, so those are neither listed nor resolvable.
+#   - an explicit target that matches nothing is a hard error (exit 1, before
+#     anything opens); an unresolvable DEFAULT (internal panel disabled or
+#     disconnected while docked) only warns, and Big Picture opens without
+#     window placement.
+#
+# Window placement — KWin scripting over DBus (works on X11 and Wayland, no
+# extra packages): a short-lived KWin script sweeps the existing windows for
+# a caption containing "Big Picture" and watches windowAdded/captionChanged
+# for the window when it appears, moves the first match to the target output
+# (Plasma 6 API: workspace.windowList / workspace.sendClientToScreen /
+# workspace.screens[].name), then goes inert. The script is unloaded again
+# after ~120 s so re-runs never accumulate. If DBus/KWin scripting is
+# unavailable, the placement degrades to a warning and BPM still opens.
+set -euo pipefail
+
+SCRIPT_NAME="decky-romm-sync-bpm-place"
+
+enabled_outputs() {
+  # connected AND enabled: KWin only exposes enabled outputs as screens, so a
+  # connected-but-disabled panel (e.g. internal display switched off in KDE
+  # while docked) can never receive a window — don't offer it as a target.
+  command -v kscreen-doctor >/dev/null 2>&1 || return 0
+  kscreen-doctor --json 2>/dev/null | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(0)
+for output in data.get("outputs", []):
+    if output.get("connected") and output.get("enabled") and output.get("name"):
+        print(output["name"])
+'
+}
+
+normalize() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '-'
+}
+
+list_targets() {
+  # Selectable targets: the normalized form of each enabled output — exactly
+  # the spellings the resolver accepts — plus the "internal" alias, but only
+  # while the built-in panel is actually enabled (offering the alias for a
+  # panel KWin can't place a window on would be a lie). Raw output names
+  # (e.g. DP-2) resolve too; they're just not listed.
+  local name outputs
+  outputs=$(enabled_outputs)
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    case "$(normalize "$name")" in
+      edp*)
+        echo "internal"
+        break
+        ;;
+    esac
+  done <<EOF
+$outputs
+EOF
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    printf '%s\n' "$(normalize "$name")"
+  done <<EOF
+$outputs
+EOF
+}
+
+resolve_target() {
+  # Prints the enabled output name $1 resolves to; status 1 if none matches.
+  local requested normalized name candidate
+  requested="$1"
+  normalized=$(normalize "$requested")
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    candidate=$(normalize "$name")
+    if [ "$normalized" = "internal" ]; then
+      case "$candidate" in edp*) printf '%s\n' "$name"; return 0 ;; esac
+    elif [ "$candidate" = "$normalized" ]; then
+      printf '%s\n' "$name"
+      return 0
+    fi
+  done <<EOF
+$(enabled_outputs)
+EOF
+  return 1
+}
+
+arm_kwin_placement() {
+  # Loads + runs the KWin placement script for output $1.
+  # Status 1 (with nothing armed) if any step of the DBus route fails.
+  local output="$1" qdbus js_file script_id
+  qdbus=$(command -v qdbus6 || command -v qdbus || true)
+  [ -n "$qdbus" ] || return 1
+  js_file=$(mktemp --suffix=.js) || return 1
+  cat > "$js_file" <<'EOF' || { rm -f "$js_file"; return 1; }
+var TARGET_OUTPUT = "@TARGET@";
+// The Big Picture window we manage, and a bounded re-assert budget. Both are
+// set once; see track() for why the budget exists.
+var tracked = null;
+var reasserts = 0;
+var MAX_REASSERTS = 8;
+
+// All log lines land in the user journal (journalctl --user | grep decky-bpm),
+// so a placement that misses is diagnosable without re-instrumenting.
+function log(msg) {
+  print("[decky-bpm] " + msg);
+}
+
+function targetOutput() {
+  var screens = workspace.screens;
+  for (var i = 0; i < screens.length; i++) {
+    if (screens[i].name === TARGET_OUTPUT) {
+      return screens[i];
+    }
+  }
+  return null;
+}
+
+function outputName(win) {
+  return win && win.output ? win.output.name : "?";
+}
+
+function onTarget(win) {
+  return win && win.output && win.output.name === TARGET_OUTPUT;
+}
+
+function isBigPicture(win) {
+  if (!win || !win.resourceClass ||
+      win.resourceClass.toLowerCase() !== "steam") {
+    return false;
+  }
+  // Class "steam" covers both the desktop client window and Big Picture. BPM
+  // keeps the "Big Picture" brand in its title across locales (German is
+  // "Big-Picture-Modus"), so match on "picture" — the English "big picture"
+  // with a space misses the hyphenated forms. A fullscreen steam window is BPM
+  // as well (the desktop client window isn't fullscreen), which covers a locale
+  // that fully translates the title.
+  var caption = (win.caption || "").toLowerCase();
+  return caption.indexOf("picture") !== -1 || win.fullScreen === true;
+}
+
+function place(win) {
+  var output = targetOutput();
+  if (!output) {
+    log("target output " + TARGET_OUTPUT + " not present; leaving window put");
+    return;
+  }
+  // sendClientToScreen is the idiomatic move; wrap it because the accepted
+  // second-arg type has varied across KWin versions (Output vs screen index).
+  try {
+    workspace.sendClientToScreen(win, output);
+  } catch (e) {
+    log("sendClientToScreen threw: " + e);
+  }
+  // Reinforce/fallback for a windowed (non-fullscreen) BPM: put the frame on
+  // the target output. Skipped for fullscreen, which KWin re-lays out per
+  // output on its own.
+  if (!win.fullScreen) {
+    try {
+      var geo = output.geometry;
+      var fg = win.frameGeometry;
+      win.frameGeometry = {
+        x: geo.x + Math.max(0, Math.floor((geo.width - fg.width) / 2)),
+        y: geo.y + Math.max(0, Math.floor((geo.height - fg.height) / 2)),
+        width: fg.width,
+        height: fg.height,
+      };
+    } catch (e) {
+      log("geometry move threw: " + e);
+    }
+  }
+}
+
+function track(win) {
+  if (tracked) {
+    return;
+  }
+  tracked = win;
+  log("BPM opened [" + win.caption + "] on " + outputName(win) +
+    " -> placing on " + TARGET_OUTPUT);
+  place(win);
+  // A cold-started Steam repositions Big Picture onto its remembered monitor a
+  // beat AFTER the window first appears, overriding the initial move. React to
+  // the real event instead of guessing a delay: outputChanged fires whenever
+  // the window changes monitor. Our own move fires it too, but lands on target,
+  // so onTarget() short-circuits and there is no ping-pong. The budget bounds
+  // how many times we fight Steam's startup shuffle, so a later MANUAL drag to
+  // another display is left alone.
+  if (win.outputChanged) {
+    win.outputChanged.connect(function () {
+      if (!tracked || onTarget(tracked)) {
+        return;
+      }
+      if (reasserts >= MAX_REASSERTS) {
+        log("stopped re-asserting after " + reasserts +
+          "; window left on " + outputName(tracked));
+        return;
+      }
+      reasserts++;
+      log("Steam moved BPM to " + outputName(tracked) +
+        "; re-assert #" + reasserts + " -> " + TARGET_OUTPUT);
+      place(tracked);
+    });
+  }
+}
+
+log("armed for " + TARGET_OUTPUT + "; screens=" +
+  workspace.screens.map(function (s) { return s.name; }).join(","));
+
+// Cover a BPM window that is already open (Steam was running) — the sweep.
+var existing = workspace.windowList();
+for (var i = 0; i < existing.length; i++) {
+  var w = existing[i];
+  log("existing win caption=[" + w.caption + "] class=[" +
+    w.resourceClass + "] output=[" + outputName(w) + "]");
+  if (isBigPicture(w)) {
+    track(w);
+  }
+}
+
+// Cover a BPM window that opens after we arm (Steam cold-started).
+workspace.windowAdded.connect(function (win) {
+  log("added win caption=[" + win.caption + "] class=[" +
+    win.resourceClass + "] output=[" + outputName(win) + "]");
+  if (isBigPicture(win)) {
+    track(win);
+  } else if (win.captionChanged) {
+    // resourceClass is set at creation, but the title can arrive a beat later.
+    win.captionChanged.connect(function () {
+      log("retitled -> caption=[" + win.caption + "]");
+      if (isBigPicture(win)) {
+        track(win);
+      }
+    });
+  }
+});
+EOF
+  sed -i "s/@TARGET@/$output/" "$js_file" || { rm -f "$js_file"; return 1; }
+  # Guarded unload first so a re-run never collides with a lingering script.
+  "$qdbus" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "$SCRIPT_NAME" >/dev/null 2>&1 || true
+  script_id=$("$qdbus" org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "$js_file" "$SCRIPT_NAME" 2>/dev/null) || {
+    rm -f "$js_file"
+    return 1
+  }
+  case "$script_id" in
+    '' | *[!0-9]*)
+      rm -f "$js_file"
+      return 1
+      ;;
+  esac
+  "$qdbus" org.kde.KWin "/Scripting/Script$script_id" org.kde.kwin.Script.run >/dev/null 2>&1 || {
+    "$qdbus" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "$SCRIPT_NAME" >/dev/null 2>&1 || true
+    rm -f "$js_file"
+    return 1
+  }
+  # Keep the watcher armed for the window to appear, then self-clean.
+  (
+    sleep 120
+    "$qdbus" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "$SCRIPT_NAME" >/dev/null 2>&1 || true
+    rm -f "$js_file"
+  ) &
+  return 0
+}
+
+MODE="open"
+TARGET="${1:-internal}"
+case "$TARGET" in
+  --list)
+    list_targets
+    exit 0
+    ;;
+  --resolve)
+    MODE="resolve"
+    TARGET="${2:-internal}"
+    ;;
+esac
+
+RESOLVED=$(resolve_target "$TARGET") || RESOLVED=""
+if [ -z "$RESOLVED" ]; then
+  if [ "$(normalize "$TARGET")" = "internal" ]; then
+    echo "warning: no enabled internal (eDP*) panel found — window placement will be skipped" >&2
+  else
+    {
+      echo "error: display target '$TARGET' matches no enabled output. Available targets:"
+      list_targets
+    } >&2
+    exit 1
+  fi
+fi
+
+if [ "$MODE" = "resolve" ]; then
+  [ -n "$RESOLVED" ] && echo "$RESOLVED"
+  exit 0
+fi
+
+# Arm the KWin watcher BEFORE opening Big Picture so the window-added signal
+# is already connected when the window appears (no race). The sweep half
+# covers a BPM window that is already open on the wrong monitor.
+if [ -n "$RESOLVED" ]; then
+  if arm_kwin_placement "$RESOLVED"; then
+    echo "Big Picture window will be placed on $RESOLVED."
+  else
+    echo "warning: could not reach KWin scripting over DBus — opening Big Picture without window placement" >&2
+  fi
+fi
+
+# Open Big Picture. Harmless no-op if it is already open; if Steam is not
+# running, this cold-starts it straight into BPM.
+#
+# Launch through the user's systemd manager, NOT this shell: `mise run` and the
+# project venv prepend their own PATH + set VIRTUAL_ENV, and steam-jupiter's
+# 32-bit runtime check fails in that polluted environment on a cold start
+# ("You are missing the following 32-bit libraries: libc.so.6"). systemd-run
+# --user runs steam in the pristine session environment (clean PATH, but
+# DISPLAY / WAYLAND_DISPLAY / DBUS intact) that Game Mode itself uses.
+if command -v systemd-run >/dev/null 2>&1; then
+  systemd-run --user --collect --quiet -- steam steam://open/bigpicture >/dev/null 2>&1 &
+else
+  # No systemd user manager: best-effort scrub of the venv marker and detach.
+  nohup env -u VIRTUAL_ENV steam steam://open/bigpicture >/dev/null 2>&1 &
+fi


### PR DESCRIPTION
Iterating on the frontend used to mean: build, deploy, restart plugin_loader, switch the whole Deck from Desktop Mode to Game Mode to look at the UI, and switch back to keep coding. This PR replaces that with a live dev loop that runs entirely in Desktop Mode.

**How it works** — three pieces that were already there, now wired together:

- Desktop Steam's windowed Big Picture renders the same gamepadui as Game Mode, and Decky injects into it — so both the QAM panel and the patched game-detail pages are visible next to the editor.
- decky-loader ships a hot-reload watcher (on by default) that reloads a plugin whenever `dist/index.js` or `main.py` changes — gated on a `debug` flag, which `mise run deploy` now injects into the **deployed** plugin.json only (never committed; the plugin store rejects it).
- Decky's tamper guard (`CHOWN_PLUGIN_PATH`) is disabled via a systemd drop-in so the deck user can write deploys directly — no more stop-loader/chown dance in the loop.

**New mise tasks:**

- `dev:setup` — one-time host setup (drop-in, loader restart, chown).
- `dev:watch [display]` — deploy, open windowed BPM, then rollup `--watch`: every save hot-reloads the plugin in ~1–2 s.
- `dev:push-backend` — push `py_modules/` + `main.py` on demand (copies `main.py` last as the reload trigger).
- `dev:bpm-reset [display]` — recover Decky's UI after leaving/re-entering BPM (Steam restart into BPM).

**Display targeting:** the optional argument picks the monitor for the BPM window. Targets are resolved against the machine's real connected+enabled outputs (nothing hardcoded — external outputs may be `DP-2`/`DP-3`), matching is case- and dash-insensitive, and the argument tab-completes via the mise usage spec. Placement is a short-lived KWin script over DBus: it catches the window when it appears and re-asserts via the `outputChanged` signal when Steam's cold-start repositioning moves it back — bounded, so manual drags are left alone. Steam itself is launched through `systemd-run --user`, because a cold start from the mise/venv environment trips steam-jupiter's 32-bit runtime check.

Everything verified on device: placement on DP-2/DP-3, cold-start recovery, hot reload of both UI surfaces, backend push, error paths, and tab completion.

Docs: new `docs/contributing/frontend-dev-loop.md` (workflow, keyboard shortcuts, troubleshooting incl. the screencast-portal dialog and the bundle-level-reload caveat), pointers in `development.md`, README, and CLAUDE.md.
