### PR TITLE
fix(ui): refresh game-detail ROM File section on download_complete

### DIFF
--- a/src/components/RomMGameInfoPanel.test.tsx
+++ b/src/components/RomMGameInfoPanel.test.tsx
@@ -22,8 +22,9 @@ import {
   uninstallDomEventListenerSpy,
   domListenerCount,
 } from "../test-utils/dom-event-listener-spy";
+import { emitDeckyEvent, deckyEventListenerCount } from "../test-utils/decky-api-mock";
 import { useVersionError } from "./VersionErrorCard";
-import type { MigrationStatus, SaveSortMigrationStatus, RomMetadata } from "../types";
+import type { MigrationStatus, SaveSortMigrationStatus, RomMetadata, DownloadCompleteEvent } from "../types";
 
 // Type-only imports — vi.mock(...) below replaces the runtime impl, but
 // pinning captured-props shapes to the real component keeps assertions in
@@ -605,6 +606,95 @@ describe("RomMGameInfoPanel", () => {
       });
       // Still installed → ROM File section still rendered
       expect(queryByText("ROM File")).not.toBeNull();
+    });
+
+    // download_complete is a Decky backend event (@decky/api bus), the install
+    // counterpart to romm_rom_uninstalled — the fix for #1340.
+    it("registers a download_complete listener on mount and removes it on unmount", async () => {
+      const before = deckyEventListenerCount("download_complete");
+      const { unmount } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(deckyEventListenerCount("download_complete")).toBe(before + 1);
+      unmount();
+      expect(deckyEventListenerCount("download_complete")).toBe(before);
+    });
+
+    it("download_complete: matching rom_id → ROM File section appears without a re-mount (#1340)", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 100,
+        installed: false,
+        platform_name: "Super Nintendo",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.getInstalledRom).mockResolvedValue({
+        rom_id: 100,
+        file_name: "test.sfc",
+        file_path: "/roms/test.sfc",
+        system: "snes",
+        platform_slug: "snes",
+        installed_at: "2024-01-01",
+      });
+      const { queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      // Not installed at mount → ROM File section hidden.
+      expect(queryByText("ROM File")).toBeNull();
+      // Download finishes for this rom → installed flips true + installedRom
+      // populates → section (with the local path) appears live.
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", {
+          rom_id: 100,
+          rom_name: "Test",
+          platform_name: "Super Nintendo",
+          file_path: "/roms/test.sfc",
+          app_id: testAppId,
+          launch_options: "cmd",
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(queryByText("ROM File")).not.toBeNull();
+      expect(vi.mocked(backend.getInstalledRom)).toHaveBeenCalledWith(100);
+      // Cache invalidated so a fast re-mount inside the 3s TTL doesn't re-serve
+      // the stale installed:false.
+      expect(vi.mocked(cachedStore.invalidateCachedGameDetail)).toHaveBeenCalledWith(testAppId);
+    });
+
+    it("download_complete: mismatching rom_id → section stays hidden, no fetch", async () => {
+      vi.mocked(cachedStore.getCachedGameDetail).mockResolvedValue({
+        found: true,
+        rom_id: 100,
+        installed: false,
+        platform_name: "Super Nintendo",
+        metadata: makeMetadata(),
+        stale_fields: [],
+      });
+      vi.mocked(backend.getInstalledRom).mockResolvedValue({
+        rom_id: 100,
+        file_name: "test.sfc",
+        file_path: "/roms/test.sfc",
+        system: "snes",
+        platform_slug: "snes",
+        installed_at: "2024-01-01",
+      });
+      const { queryByText } = render(<RomMGameInfoPanel appId={testAppId} />);
+      await flushAsync();
+      expect(queryByText("ROM File")).toBeNull();
+      await act(async () => {
+        emitDeckyEvent<[DownloadCompleteEvent]>("download_complete", {
+          rom_id: 999,
+          rom_name: "Other",
+          platform_name: "Super Nintendo",
+          file_path: "/roms/other.sfc",
+          app_id: 1,
+          launch_options: "cmd",
+        });
+        await Promise.resolve();
+      });
+      // Guard held: no state change, no installed-rom fetch for the other rom.
+      expect(queryByText("ROM File")).toBeNull();
+      expect(vi.mocked(backend.getInstalledRom)).not.toHaveBeenCalled();
     });
 
     it("romm_tab_switch: detail.tab present → activeTab state updates", async () => {

--- a/src/components/RomMGameInfoPanel.tsx
+++ b/src/components/RomMGameInfoPanel.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useState, useEffect, useRef, FC, createElement } from "react";
+import { addEventListener, removeEventListener } from "@decky/api";
 import { DialogButton, Focusable } from "@decky/ui";
 // DialogButton is natively focusable by Steam's gamepad engine (unlike Focusable
 // wrappers around non-interactive content, which don't register in this injection
@@ -48,6 +49,7 @@ import type {
   AchievementProgress,
   EarnedAchievement,
   SaveSlotSummary,
+  DownloadCompleteEvent,
 } from "../types";
 import type { RommDataChangedDetail } from "../types/events";
 import { biosColorForLevel } from "../utils/biosColor";
@@ -439,6 +441,23 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     };
     globalThis.addEventListener("romm_rom_uninstalled", onUninstall);
 
+    // Listen for download completion — the install counterpart to onUninstall.
+    // The "ROM File" section is gated on installed + installedRom; a fresh
+    // download must flip both so the section (with the local path) appears
+    // without a detail-page re-mount (#1340). Decky backend event (@decky/api),
+    // not a DOM CustomEvent — mirrors DiscSelector's download_complete wiring.
+    const onDownloadComplete = addEventListener<[DownloadCompleteEvent]>(
+      "download_complete",
+      (evt: DownloadCompleteEvent) => {
+        if (evt.rom_id !== romIdRef.current) return;
+        // Invalidate the cached detail so a fast re-mount inside the 3s TTL
+        // doesn't briefly re-serve the stale installed:false.
+        invalidateCachedGameDetail(appId);
+        setState((prev) => ({ ...prev, installed: true }));
+        detach(refreshInstalledRomInBackground(evt.rom_id, () => cancelled, setState));
+      },
+    );
+
     // Per-event-type handlers — each owns one branch of the data-changed dispatch.
     // Defined inside useEffect to share the cancelled/appId/romIdRef/setState closure.
     const handleSaveSyncSettingsChange = async (
@@ -578,6 +597,7 @@ export const RomMGameInfoPanel: FC<RomMGameInfoPanelProps> = ({ appId }) => { //
     return () => {
       cancelled = true;
       globalThis.removeEventListener("romm_rom_uninstalled", onUninstall);
+      removeEventListener("download_complete", onDownloadComplete);
       globalThis.removeEventListener("romm_data_changed", onDataChanged);
       globalThis.removeEventListener("romm_tab_switch", onTabSwitch);
     };


### PR DESCRIPTION
Closes #1340.

## Problem

On the game detail page, the **ROM File** section (which shows the installed ROM's local path) did not appear when a download finished — it only showed up after leaving and re-entering the detail page.

## Root cause

`RomMGameInfoPanel` renders the ROM File section gated on `state.installed && state.installedRom`, but the panel never listened for the `download_complete` Decky event (only `DiscSelector` and `CustomPlayButton` did). Nothing flipped `installed`/`installedRom` after a download, so the section stayed hidden until a re-mount re-read the (now-live) `installed` flag from the backend.

## Fix

Add a `download_complete` listener to `RomMGameInfoPanel`, mirroring the existing `DiscSelector` wiring (`@decky/api` bus, not a DOM CustomEvent):

- On a matching `rom_id`: set `installed: true` and refresh the installed rom via the existing `refreshInstalledRomInBackground`, so the section (with the local path) appears live.
- Invalidate the cached game detail so a fast re-mount inside the 3s TTL doesn't briefly re-serve the stale `installed:false`.
- Remove the listener on unmount.

Backend already carries everything needed (`download_complete` payload has `rom_id` + `file_path`; `get_installed_rom` returns the path) — no backend change.

## Tests

Added three tests to `RomMGameInfoPanel.test.tsx` (via the `@decky/api` event-bus harness): listener registration + cleanup, matching `rom_id` → ROM File section appears + cache invalidated, mismatching `rom_id` → no state change and no fetch.

Full frontend suite green (1557 tests), typecheck + lint + build clean.

docs: N/A — reactivity bug fix; no documented behavior changes (no page describes the ROM File section's download reactivity).