### PR TITLE
fix(ui): prevent stale sgdb artwork apply from overwriting a newer one

### DIFF
--- a/src/utils/artwork.test.ts
+++ b/src/utils/artwork.test.ts
@@ -71,3 +71,97 @@ describe("applyArtwork", () => {
     expect(vi.mocked(SteamClient.Apps.SetCustomArtworkForApp)).not.toHaveBeenCalled();
   });
 });
+
+type Art = { base64: string | null; no_api_key?: boolean };
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("applyArtwork — newest-apply-wins race guard", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal("SteamClient", {
+      Apps: {
+        SetCustomArtworkForApp: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    vi.mocked(backend.saveShortcutIcon).mockResolvedValue({ success: true });
+  });
+
+  it("a superseded in-flight apply writes nothing — only the newer apply's art lands for that appId", async () => {
+    const appId = 5000;
+    const slow = deferred<Art>();
+    // Apply A (rom 42) hangs on `slow` for every asset; apply B (rom 99) resolves
+    // fast with distinct art and completes its writes first.
+    vi.mocked(backend.getSgdbArtworkBase64).mockImplementation((romId: number): Promise<Art> => {
+      if (romId === 42) return slow.promise;
+      return Promise.resolve({ base64: "BB==", no_api_key: false });
+    });
+
+    // A starts first (claims the older generation), B starts second for the SAME appId.
+    const aPromise = applyArtwork(42, appId);
+    const bPromise = applyArtwork(99, appId);
+    await bPromise;
+
+    // B's art is on the tile.
+    const write = vi.mocked(SteamClient.Apps.SetCustomArtworkForApp);
+    expect(write).toHaveBeenCalledWith(appId, "BB==", "png", 1);
+
+    // Now let A's slow fetches finally resolve with the OLD art.
+    slow.resolve({ base64: "AA==", no_api_key: false });
+    await aPromise;
+
+    // Assert on call CONTENTS, not counts: every write carries B's art, none carry
+    // A's — the stale apply performed no writes after being superseded.
+    expect(write.mock.calls.every((c) => c[1] === "BB==")).toBe(true);
+    expect(write.mock.calls.some((c) => c[1] === "AA==")).toBe(false);
+    // Exactly one hero (assetType 1) write, and it is B's.
+    expect(write.mock.calls.filter((c) => c[3] === 1)).toEqual([[appId, "BB==", "png", 1]]);
+    // The icon path (saveShortcutIcon) only ever received B's art, never A's.
+    expect(vi.mocked(backend.saveShortcutIcon).mock.calls.some((c) => c[1] === "AA==")).toBe(false);
+    // A resolved to the count it managed to write (0) rather than throwing.
+    await expect(aPromise).resolves.toBe(0);
+  });
+
+  it("sequential applies for the same appId both write (no over-suppression)", async () => {
+    const appId = 5000;
+    vi.mocked(backend.getSgdbArtworkBase64).mockImplementation((romId: number): Promise<Art> =>
+      Promise.resolve({ base64: romId === 1 ? "AA==" : "BB==", no_api_key: false }),
+    );
+
+    await expect(applyArtwork(1, appId)).resolves.toBe(4); // A completes fully
+    await expect(applyArtwork(2, appId)).resolves.toBe(4); // then B completes fully
+
+    const write = vi.mocked(SteamClient.Apps.SetCustomArtworkForApp);
+    // Both applies wrote their hero art — the guard only suppresses a call that a
+    // NEWER one overtook while it was still in flight, not a finished predecessor.
+    expect(write).toHaveBeenCalledWith(appId, "AA==", "png", 1);
+    expect(write).toHaveBeenCalledWith(appId, "BB==", "png", 1);
+  });
+
+  it("an in-flight apply for one appId does not suppress a concurrent apply for a different appId", async () => {
+    const slow = deferred<Art>();
+    // appId X's rom (42) hangs; appId Y's rom (99) resolves fast.
+    vi.mocked(backend.getSgdbArtworkBase64).mockImplementation((romId: number): Promise<Art> => {
+      if (romId === 42) return slow.promise;
+      return Promise.resolve({ base64: "YY==", no_api_key: false });
+    });
+
+    const xPromise = applyArtwork(42, 5000); // appId X, in flight
+    await applyArtwork(99, 6000); // appId Y, different appId — completes
+
+    const write = vi.mocked(SteamClient.Apps.SetCustomArtworkForApp);
+    // Y wrote despite X being mid-flight (different appId → independent generation).
+    expect(write).toHaveBeenCalledWith(6000, "YY==", "png", 1);
+
+    // X is NOT superseded — Y bumped a different appId — so X still writes when it resolves.
+    slow.resolve({ base64: "XX==", no_api_key: false });
+    await expect(xPromise).resolves.toBe(4);
+    expect(write).toHaveBeenCalledWith(5000, "XX==", "png", 1);
+  });
+});

--- a/src/utils/artwork.ts
+++ b/src/utils/artwork.ts
@@ -6,12 +6,28 @@
  * component to keep their import graph acyclic.
  */
 
-import { getSgdbArtworkBase64, saveShortcutIcon } from "../api/backend";
+import { getSgdbArtworkBase64, saveShortcutIcon, debugLog } from "../api/backend";
+import { detach } from "./detach";
+
+/**
+ * Newest-apply-wins guard. Each appId's most recent applyArtwork call claims a
+ * generation; an earlier call for the SAME appId that is still mid-flight when a
+ * newer one starts stops writing rather than clobber the newer art. The hazard:
+ * a version switch re-points the shortcut to a new rom and fires a fresh apply
+ * while the old rom's (uncached, seconds-long) artwork fetch is still pending —
+ * without this, the old apply's writes land last and revert the tile. Keyed by
+ * appId so unrelated shortcuts never gate each other.
+ */
+const artworkGenerations = new Map<number, number>();
 
 /** Fetch SGDB artwork (hero, logo, wide grid, icon) and apply to Steam.
  *  Returns count of successfully applied images, or -1 when no SGDB API
  *  key is configured. */
 export async function applyArtwork(romId: number, appId: number): Promise<number> {
+  const generation = (artworkGenerations.get(appId) ?? 0) + 1;
+  artworkGenerations.set(appId, generation);
+  const superseded = (): boolean => artworkGenerations.get(appId) !== generation;
+
   const results = await Promise.all([
     getSgdbArtworkBase64(romId, 1).catch(() => ({ base64: null, no_api_key: false })),
     getSgdbArtworkBase64(romId, 2).catch(() => ({ base64: null, no_api_key: false })),
@@ -22,23 +38,35 @@ export async function applyArtwork(romId: number, appId: number): Promise<number
   if (results.some((r) => r.no_api_key)) return -1;
 
   let applied = 0;
+  // A later apply for this appId can start during any of the awaits above/below,
+  // so re-check before every Steam write. Once superseded, go silent (log once,
+  // keep whatever this call already wrote) instead of overwriting the newer art.
+  const bail = (): number => {
+    detach(debugLog(`applyArtwork: superseded for appId ${appId}, skipping stale writes`));
+    return applied;
+  };
+
   // SGDB type 1 = hero → Steam assetType 1
   if (results[0].base64) {
+    if (superseded()) return bail();
     await SteamClient.Apps.SetCustomArtworkForApp(appId, results[0].base64, "png", 1);
     applied++;
   }
   // SGDB type 2 = logo → Steam assetType 2
   if (results[1].base64) {
+    if (superseded()) return bail();
     await SteamClient.Apps.SetCustomArtworkForApp(appId, results[1].base64, "png", 2);
     applied++;
   }
   // SGDB type 3 = wide grid → Steam assetType 3
   if (results[2].base64) {
+    if (superseded()) return bail();
     await SteamClient.Apps.SetCustomArtworkForApp(appId, results[2].base64, "png", 3);
     applied++;
   }
   // Type 4 = icon (VDF-based)
   if (results[3].base64) {
+    if (superseded()) return bail();
     await saveShortcutIcon(appId, results[3].base64);
     applied++;
   }


### PR DESCRIPTION
Fixes #1356

`applyArtwork` writes SGDB hero/logo/wide-grid/icon to Steam fire-and-forget with no in-flight guard, so after a version switch a still-pending apply for the previous rom could complete after the new rom's apply and overwrite the shared appId's art — observed on device as the hero flashing and then reverting to the previous version's art (last-writer-wins).

The fix adds a per-appId generation counter in `applyArtwork`: each call claims the next generation synchronously before its first await and re-checks ownership before every Steam write, bailing silently once superseded. The newest call wins, user-initiated applies (Refresh Artwork, SGDB picker) always count as newest, and different appIds never gate each other.

Tests: three race-guard tests with deferred-controlled ordering — a superseded in-flight apply writes nothing (fails on the pre-fix code), sequential applies both write, and per-appId independence.

docs: N/A (pure bug fix, no user-facing behavior or architecture change)