### PR TITLE
fix(ui): make the qam sync panel gamepad-navigable and compact its layout

### DIFF
--- a/docs/adr/0024-session-budget-rss-gate.md
+++ b/docs/adr/0024-session-budget-rss-gate.md
@@ -100,21 +100,22 @@ is fail-open — a measurement failure never blocks a sync.**
   (conservative fail-open). Because the poll runs only during a sync, the QAM also polls the callable every ~10 s while
   a paused banner is showing, so the flip happens on its own after the user restarts — the user isn't left staring at
   stale "restart Steam" copy over a fresh green reading.
-- **An always-on memory row with the last-run delta.** The QAM Status section carries a permanent "Steam memory: X.X GB"
-  row (the same live reading, omitted entirely when `rss_kb` is null) with a "last run: ±X GB" sub-line — the last run's
-  signed RSS growth, `end - start`, measured at EVERY terminal (completed, paused, cancelled, interrupted) so a paused
-  run reads honestly as _that_ run's consumption-so-far (~+1.5 GB) rather than leaving a prior clean run's number. A
-  **raw** read taken at run start (captured unconditionally in the run-scoped box, so even a fully-incremental-skip run
-  that applies nothing still records a baseline and reports ≈ +0.0 GB) is the start; the terminal RSS read is the end.
-  The delta is an approximation for information only — a raw start baseline (which may hold transient garbage) is fine
-  for it. The signed value is retained in memory so `get_session_budget_status` returns it on a QAM remount
-  (`memory_delta_kb`; in-memory only — a plugin reload loses it, no migration); the UI reads it from that callable, so
-  it is deliberately NOT put on the `sync_complete` wire. It degrades to no sub-line whenever either endpoint was
-  unmeasurable, so a stale number is never shown. The value text is traffic-light coloured — green below the advisory
-  floor, yellow at/above it (`warn_kb`, the same line as the yellow banner), red at/above the pause ceiling
-  (`ceiling_kb`) — and all three thresholds ride the `get_session_budget_status` payload so the frontend holds no
-  threshold magic numbers. While a sync is running the row polls the callable every ~5 s so the number (and its colour)
-  track the climbing RSS instead of the stale mount-time reading.
+- **An always-on memory row with the last-run delta.** The QAM status block carries a permanent Steam memory row (the
+  same live reading, omitted entirely when `rss_kb` is null) with the last run's signed RSS growth appended inline on
+  the same line ("X.X GB · last run +Y", the delta's GB unit dropped as redundant next to the reading) — `end - start`,
+  measured at EVERY terminal (completed, paused, cancelled, interrupted) so a paused run reads honestly as _that_ run's
+  consumption-so-far (~+1.5 GB) rather than leaving a prior clean run's number. A **raw** read taken at run start
+  (captured unconditionally in the run-scoped box, so even a fully-incremental-skip run that applies nothing still
+  records a baseline and reports ≈ +0.0 GB) is the start; the terminal RSS read is the end. The delta is an
+  approximation for information only — a raw start baseline (which may hold transient garbage) is fine for it. The
+  signed value is retained in memory so `get_session_budget_status` returns it on a QAM remount (`memory_delta_kb`;
+  in-memory only — a plugin reload loses it, no migration); the UI reads it from that callable, so it is deliberately
+  NOT put on the `sync_complete` wire. It degrades to no delta segment whenever either endpoint was unmeasurable, so a
+  stale number is never shown. The value text is traffic-light coloured — green below the advisory floor, yellow
+  at/above it (`warn_kb`, the same line as the yellow banner), red at/above the pause ceiling (`ceiling_kb`) — and all
+  three thresholds ride the `get_session_budget_status` payload so the frontend holds no threshold magic numbers. While
+  a sync is running the row polls the callable every ~5 s so the number (and its colour) track the climbing RSS instead
+  of the stale mount-time reading.
 - **"Restart Steam now" — a deterministic full client restart, not a renderer reload.** Both banners carry a **Restart
   Steam now** button that calls `SteamClient.User.StartRestart(false)` directly from the frontend (no backend callable).
   A full Steam client restart deterministically resets the renderer's per-session heap budget to the ~430 MB baseline.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -233,19 +233,20 @@ while paused) so the number tracks the climbing RSS and the blue paused banner n
 memory. That notice is driven by `resume_ready` on the callable (`domain.session_budget.resume_would_proceed`:
 `rss + FULL_CHUNK_WORST_KB < ceiling`, the gate's own full-chunk predictive condition; `None` when RSS is unreadable) —
 when it flips `true` the blue banner reads "Steam memory is free again — press Resume Sync" and hides the restart
-button. That row also shows the **last run's signed RSS growth** ("last run: ±X GB"), measured at EVERY terminal
-(completed / paused / cancelled / interrupted) so a paused run reads as _its own_ consumption-so-far rather than a prior
-clean run's: a RAW read taken unconditionally at run start is the baseline (`run_start_rss_kb` — captured before any
-chunk, so even a fully-incremental-skip run still records one and reports ≈ +0.0 GB), the terminal RSS read is the end,
-and `session_memory_delta` differences them (an approximation for information only, which a raw start baseline is fine
-for). The value is retained in `last_run_delta_kb` so `get_session_budget_status` surfaces it on a QAM remount
-(in-memory only, lost on reload, no migration; `None` when either endpoint was unmeasurable, so a stale delta is never
-shown); the UI reads it from that callable, so it is deliberately NOT put on the `sync_complete` wire. Both banners also
-offer a **Restart Steam now** button that calls `SteamClient.User.StartRestart` directly from the frontend — a
-deterministic full client restart that resets the renderer's per-session budget to the ~430 MB baseline. The button is
-disabled while a game is running and hard-guarded on click (`isAnyAppRunning`) so a restart can never close a game. The
-RSS reader and GC trigger are wired through `SyncOrchestratorConfig`; the gate's per-item cost is a parameter so a later
-per-item cover term can be added without touching the kernel's shape.
+button. That row also shows the **last run's signed RSS growth**, appended inline after the value ("X.X GB · last run
+±Y"), measured at EVERY terminal (completed / paused / cancelled / interrupted) so a paused run reads as _its own_
+consumption-so-far rather than a prior clean run's: a RAW read taken unconditionally at run start is the baseline
+(`run_start_rss_kb` — captured before any chunk, so even a fully-incremental-skip run still records one and reports ≈
++0.0 GB), the terminal RSS read is the end, and `session_memory_delta` differences them (an approximation for
+information only, which a raw start baseline is fine for). The value is retained in `last_run_delta_kb` so
+`get_session_budget_status` surfaces it on a QAM remount (in-memory only, lost on reload, no migration; `None` when
+either endpoint was unmeasurable, so a stale delta is never shown); the UI reads it from that callable, so it is
+deliberately NOT put on the `sync_complete` wire. Both banners also offer a **Restart Steam now** button that calls
+`SteamClient.User.StartRestart` directly from the frontend — a deterministic full client restart that resets the
+renderer's per-session budget to the ~430 MB baseline. The button is disabled while a game is running and hard-guarded
+on click (`isAnyAppRunning`) so a restart can never close a game. The RSS reader and GC trigger are wired through
+`SyncOrchestratorConfig`; the gate's per-item cost is a parameter so a later per-item cover term can be added without
+touching the kernel's shape.
 
 **Run/unit/chunk identity on the ack (#1041).** Every `sync_apply_unit` event carries the `run_id` (the run's
 `current_sync_id` UUID), the `unit_id` (the `WorkUnit.id`), and the `chunk_index`; the frontend echoes all three back on

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -126,8 +126,9 @@ backend-only changes, restarting the plugin loader is sufficient without rebuild
 For frontend iteration there is a much faster loop: after a one-time `mise run dev:setup`,
 `mise run dev:watch [display]` hot-reloads the **frontend** into a windowed Big Picture on the desktop as you save, with
 no loader restarts at all — put it on a second monitor with a display target like `dp2`. Backend changes are pushed on
-demand with `mise run dev:push-backend`. See [Frontend dev loop](frontend-dev-loop.md) for the full workflow, keyboard
-shortcuts, and caveats.
+demand with `mise run dev:push-backend`. That windowed Big Picture gives the QAM panel ~59% more vertical room than the
+Deck does, so judge layout and overflow under `mise run dev:ui-scale`, which forces Steam's display scale to Game
+Mode's. See [Frontend dev loop](frontend-dev-loop.md) for the full workflow, keyboard shortcuts, and caveats.
 
 ## Deploying to Device
 

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -84,19 +84,35 @@ With [mise shell completions](https://mise.jdx.dev/installing-mise.html#shells) 
 
 The windowed Big Picture renders the plugin's real UI, but **not at the Deck's real size**. Measured on-device:
 
-| View                            | Big Picture window   | QuickAccess (QAM) panel  |
-| ------------------------------- | -------------------- | ------------------------ |
-| Game Mode (Deck internal panel) | dpr 1.5, CSS 853x533 | dpr 1.5, CSS **854x454** |
-| Desktop windowed BPM (default)  | dpr 1, CSS 1280x800  | dpr 1, CSS **854x720**   |
+| Configuration                                     | Big Picture window               | QuickAccess (QAM) panel |
+| ------------------------------------------------- | -------------------------------- | ----------------------- |
+| Game Mode (Deck internal panel, scale 1.5)        | 1280x800 physical, CSS 853x533   | CSS **854x454**         |
+| Desktop BPM, 1280x800 window, unscaled (dpr 1)    | 1280x800 physical, CSS 1280x800  | CSS **854x720**         |
+| Desktop BPM fullscreen on 1440p, Steam's auto 1.9 | 2560x1440 physical, CSS 1348x758 | CSS **855x679**         |
+| Desktop BPM fullscreen on 1440p, **forced 1.5**   | 2560x1440 physical, CSS 1707x960 | CSS **854x880**         |
 
-The dev loop hands the QAM panel ~59% more vertical room than the device. CSS **width is 854 in both**, so layout,
+The dev loop hands the QAM panel far more vertical room than the device. CSS **width is ~854 everywhere**, so layout,
 wrapping and truncation are faithful — only **height** lies. A panel that fits comfortably in the windowed BPM can
 overflow in Game Mode.
+
+The last row is the trap, and it is why this tool does two things rather than one. Every number above obeys:
+
+```text
+QAM CSS height = (Big Picture window PHYSICAL height / scale) - 80
+```
+
+- Game Mode: 800 / 1.5 − 80 = 453 → **measured 454**
+- Fullscreen 1440p at Steam's automatic 1.9: 1440 / 1.9 − 80 = 678 → **measured 679**
+- Fullscreen 1440p forced to 1.5: 1440 / 1.5 − 80 = **880** — nearly double the Deck's 454
+
+(Steam lays a view out in `ceil(physical / scale)` CSS px, hence the ±1.) So **forcing the scale alone does not emulate
+the Deck**: on a maximized or fullscreen Big Picture it hands you the Deck's `devicePixelRatio` with the wrong layout —
+a lie that looks like a measurement. The window has to be the Deck panel's **1280x800 physical pixels** as well.
 
 The 1.5 is **Steam's own per-display "GamepadUI display scale"** — not gamescope, and not a Chromium flag (Chromium is
 pinned to `--force-device-scale-factor=1` by `steamclient.so`). Steam derives it from the display's resolution and
 physical size and pushes it into each CEF browser view; it is the same value the user sees under **Settings → Display →
-UI Scale** (range 0.5–2.5). Steam's default is **automatic**, which on the desktop's 1280x800 window comes out as 1.
+UI Scale**. Steam's default is **automatic**, which on a 1280x800 window comes out as 1.
 
 ### `mise run dev:ui-scale`
 
@@ -107,22 +123,39 @@ mise run dev:ui-scale steam    # adopt whatever UI Scale you have set in Steam
 mise run dev:ui-scale auto     # rescue: force automatic scaling back on, and exit
 ```
 
-The task drives the two undocumented calls Steam's own settings UI uses
-(`SteamClient.Window.SetGamepadUIAutoDisplayScale` / `SetGamepadUIManualDisplayScaleFactor`) through the CEF debugger on
-`localhost:8080`, so the views are **really re-laid out and repainted** — unlike CDP's
-`Emulation.setDeviceMetricsOverride`, which only fakes `devicePixelRatio` and leaves the window unpainted. It then
-measures and prints what both views actually became, next to the Game Mode reference:
+The task emulates the Deck with **both halves**:
+
+1. **The window.** KWin scripting over DBus (the same `loadScript`/`run`/`unloadScript` route
+   [`dev_open_bpm.sh`](#choosing-the-display) uses for placement) un-fullscreens the Big Picture window and sizes it so
+   its **client area is exactly 1280x800**, on whatever monitor it already sits on. `frameGeometry` includes the window
+   decoration, so the frame is corrected by the measured frame-vs-client delta until the client area lands exactly —
+   nothing about the decoration is hardcoded.
+2. **The scale.** The two undocumented calls Steam's own settings UI uses
+   (`SteamClient.Window.SetGamepadUIAutoDisplayScale` / `SetGamepadUIManualDisplayScaleFactor`), driven through the CEF
+   debugger on `localhost:8080`, so the views are **really re-laid out and repainted** — unlike CDP's
+   `Emulation.setDeviceMetricsOverride`, which only fakes `devicePixelRatio` and leaves the window unpainted.
+
+It then **verifies that the emulation actually happened** rather than claiming it, comparing the measured QAM against
+what a Deck renders at that scale:
 
 ```text
 $ mise run dev:ui-scale deck
-Captured prior state: AUTOMATIC scaling at dpr 1.0 (source: Steam's live settings store)
+Captured prior state: AUTOMATIC scaling at dpr 1.899999976158142 (source: Steam's live settings store)
+Captured prior window: fullscreen 2560x1440 on DP-2
+Sizing the Big Picture window to a 1280x800 client area (was fullscreen 2560x1440 on DP-2)...
+  window now: windowed 1280x800 on DP-2 (frame 1282x829)
 Forcing GamepadUI display scale 1.5 (auto scaling OFF)...
+  scaling display: External: DP-2 27"|||Windowed
 
 Measured (real, repainted — not a CDP emulation override):
   Big Picture  dpr 1.5  CSS 854x534
   QuickAccess  dpr 1.5  CSS 854x454
-  => QAM matches the Game Mode reference (854x454) — what you see is what the Deck renders.
+  => QAM is 854x454 CSS at dpr 1.5, the 854x454 a Deck renders at scale 1.5 — this is what the Deck renders.
 ```
+
+If the QAM does **not** come out at the expected size (KWin unreachable, or Steam re-asserted the window size), the run
+prints a loud `EMULATION FAILED` block with the measured-vs-expected numbers and the window's real pixel size, and says
+that any layout judgement made on those numbers is invalid. It never reports Deck metrics it did not achieve.
 
 The forcing modes **hold until Ctrl-C**. Useful factors:
 
@@ -135,28 +168,52 @@ The forcing modes **hold until Ctrl-C**. Useful factors:
 
 #### What it restores on exit
 
-The tool **captures the scale you were on before it ran** and puts back exactly that — on Ctrl-C, on SIGTERM, and on any
-error. If you were on automatic scaling, you get automatic scaling back. If you had deliberately set a **manual** UI
-Scale (an accessibility "Larger text" value, say), you get **that factor** back — it is never silently flipped to auto,
-which would destroy the setting. The restore is then verified against Steam's live state and the rendered
-`devicePixelRatio`, and a restore that didn't land is reported as a warning rather than assumed.
+The tool **captures both halves before it touches anything** — the scale you were on, and the Big Picture window's
+geometry and fullscreen state — and puts back exactly that, on Ctrl-C, on SIGTERM, and on any error.
+
+- **Scale.** If you were on automatic scaling, you get automatic scaling back. If you had deliberately set a **manual**
+  UI Scale (an accessibility "Larger text" value, say), you get **that factor** back — it is never silently flipped to
+  auto, which would destroy the setting. The restore is verified against Steam's live state and the rendered
+  `devicePixelRatio`, and a restore that didn't land is reported as a warning rather than assumed.
+- **Window.** It goes back to the geometry and fullscreen state it had — a fullscreen BPM is put back to fullscreen on
+  the same monitor.
+
+The scale is restored **before** the window, and the exit path **ignores further Ctrl-C/SIGTERM while it runs** so an
+impatient second interrupt cannot truncate it half-way (the window half is the slow half — subprocesses and a journal
+read). A stranded forced scale is the damaging outcome; a window left at 1280x800 is merely annoying.
 
 `mise run dev:ui-scale auto` is different on purpose: it **unconditionally** forces automatic scaling back on. It is the
 rescue path for when a previous run was hard-killed and the state it captured died with it — it has nothing to restore,
-so it cannot honour a manual scale. If you are a manual-UI-Scale user and ever have to use it, re-set your scale in
-Steam → Settings → Display afterwards.
+so it cannot honour a manual scale, and it does not touch the window (resize it by hand). If you are a manual-UI-Scale
+user and ever have to use it, re-set your scale in Steam → Settings → Display afterwards.
 
 !!! warning "A hard kill leaves the forced scale behind"
 
     Steam persists the factor to `~/.local/share/Steam/config/config.vdf` (`UI → display → Current → ScaleFactor`,
-    flushed within seconds), keyed by a display identity the Deck **shares with Game Mode**. Ctrl-C, SIGTERM and errors
-    all restore — but a **hard kill (SIGKILL) skips the restore**, and the forced scale is what Steam keeps. If that
-    happens, or if the UI ever comes up at the wrong size, run `mise run dev:ui-scale auto`.
+    flushed within seconds). Ctrl-C, SIGTERM and errors all restore — but a **hard kill (SIGKILL) skips the restore**,
+    and the forced scale is what Steam keeps. If that happens, or if the UI ever comes up at the wrong size, run
+    `mise run dev:ui-scale auto`.
 
     This is also why the prior state is read from Steam's **live settings store**
     (`window.settingsStore.settings`) rather than from `config.vdf`: the file's `AutoScaleFactor` is **not** re-flushed
     in-session (measured: it stayed `1` while a manual factor was applied and rendering), so trusting it would report a
     manual-scale user as "automatic" — and restore them to the wrong thing. `config.vdf` is only the fallback source.
+
+!!! info "The UI Scale is per display — and the window mode is part of the display's identity"
+
+    Steam files the scale under a display identity (`strDisplayName`), and `config.vdf` carries **one entry per
+    identity**. The identity includes the window mode, which the tool prints on every run:
+
+    ```text
+    "External: eDP-1 7"|||Fullscreen-1280x800"    <- Game Mode / the internal panel
+    "External: DP-2 27"|||Fullscreen-2560x1440"   <- a fullscreen BPM on an external 1440p monitor
+    "External: DP-2 27"|||Windowed"               <- any windowed BPM on that monitor
+    ```
+
+    So the blast radius of a forced factor is narrower than "it bleeds into Game Mode": it lands in **the entry the
+    window is currently under**. Because this tool always makes the window *windowed*, it writes a `…|||Windowed`
+    entry — **not** Game Mode's `…|||Fullscreen-1280x800` one, even when the window sits on the Deck's internal panel.
+    A leftover forced factor therefore mis-sizes a future *windowed desktop BPM*, and `dev:ui-scale auto` clears it.
 
 The QAM is a popup view that Steam can recreate; Steam's scale is display state, so a recreated view picks it up. No
 re-apply loop is needed (and none should be added).
@@ -225,8 +282,11 @@ journalctl -u plugin_loader -f
 - **The QAM Performance tab is non-functional in desktop BPM** (it needs gamescope). Irrelevant for this plugin's UI.
 - **Desktop-BPM injection is best-effort** on Decky's side — re-verify the loop still works after Decky or Steam
   updates.
-- **Game Mode comes up at the wrong size** — a `dev:ui-scale` run was hard-killed and left Steam on a forced scale (it
-  persists in `config.vdf` under the display identity Game Mode shares). Run `mise run dev:ui-scale auto`.
-- **Do a final Game Mode pass before a release.** `dev:ui-scale deck` reproduces Game Mode's CSS metrics exactly, so
-  layout and overflow can be judged from the desktop — but controller focus behavior and gamescope rendering are still
-  only real in Game Mode.
+- **Big Picture comes up at the wrong size** — a `dev:ui-scale` run was hard-killed and left Steam on a forced scale (it
+  persists in `config.vdf`, filed under the display identity that run printed — a `…|||Windowed` one). Run
+  `mise run dev:ui-scale auto`.
+- **Big Picture is left windowed at 1280x800** — same cause: a hard-killed `dev:ui-scale` run never restored the window.
+  Re-fullscreen it by hand; nothing else is broken.
+- **Do a final Game Mode pass before a release.** `dev:ui-scale deck` reproduces Game Mode's CSS metrics exactly (and
+  says so out loud when it fails to), so layout and overflow can be judged from the desktop — but controller focus
+  behavior and gamescope rendering are still only real in Game Mode.

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -9,7 +9,9 @@ Three pieces line up:
 
 - **Desktop Big Picture is the real UI.** Desktop Steam's Big Picture window runs the same gamepadui React app as Game
   Mode — same routes, same game-detail pages — and Decky Loader injects into desktop Steam too. What you see in the
-  windowed BPM is the plugin's actual UI, not an approximation.
+  windowed BPM is the plugin's actual UI, not an approximation. It is _not_ WYSIWYG about **vertical space**, though —
+  by default the windowed BPM gives the QAM panel far more height than the Deck does. See
+  [Display scale: the dev loop lies about height](#display-scale-the-dev-loop-lies-about-height).
 - **decky-loader ships a hot-reload watcher.** The loader watches `~/homebrew/plugins` and reacts to create/modify
   events on exactly two files per plugin: `dist/index.js` and `main.py`. On a match it reloads the plugin in place —
   backend subprocess restart plus a cache-busted frontend re-import (the plugin unmounts cleanly first, so router
@@ -78,6 +80,100 @@ and only the placement is skipped. The BPM window stays a normal desktop window:
 With [mise shell completions](https://mise.jdx.dev/installing-mise.html#shells) enabled (requires the `usage` CLI, e.g.
 `eval "$(mise completion bash)"` in your shell rc), the display argument tab-completes with those targets.
 
+## Display scale: the dev loop lies about height
+
+The windowed Big Picture renders the plugin's real UI, but **not at the Deck's real size**. Measured on-device:
+
+| View                            | Big Picture window   | QuickAccess (QAM) panel  |
+| ------------------------------- | -------------------- | ------------------------ |
+| Game Mode (Deck internal panel) | dpr 1.5, CSS 853x533 | dpr 1.5, CSS **854x454** |
+| Desktop windowed BPM (default)  | dpr 1, CSS 1280x800  | dpr 1, CSS **854x720**   |
+
+The dev loop hands the QAM panel ~59% more vertical room than the device. CSS **width is 854 in both**, so layout,
+wrapping and truncation are faithful — only **height** lies. A panel that fits comfortably in the windowed BPM can
+overflow in Game Mode.
+
+The 1.5 is **Steam's own per-display "GamepadUI display scale"** — not gamescope, and not a Chromium flag (Chromium is
+pinned to `--force-device-scale-factor=1` by `steamclient.so`). Steam derives it from the display's resolution and
+physical size and pushes it into each CEF browser view; it is the same value the user sees under **Settings → Display →
+UI Scale** (range 0.5–2.5). Steam's default is **automatic**, which on the desktop's 1280x800 window comes out as 1.
+
+### `mise run dev:ui-scale`
+
+```bash
+mise run dev:ui-scale          # deck (default): force 1.5 — exact Game Mode metrics
+mise run dev:ui-scale 2.4      # a user on "Larger text" — worst case, least vertical room
+mise run dev:ui-scale steam    # adopt whatever UI Scale you have set in Steam
+mise run dev:ui-scale auto     # rescue: force automatic scaling back on, and exit
+```
+
+The task drives the two undocumented calls Steam's own settings UI uses
+(`SteamClient.Window.SetGamepadUIAutoDisplayScale` / `SetGamepadUIManualDisplayScaleFactor`) through the CEF debugger on
+`localhost:8080`, so the views are **really re-laid out and repainted** — unlike CDP's
+`Emulation.setDeviceMetricsOverride`, which only fakes `devicePixelRatio` and leaves the window unpainted. It then
+measures and prints what both views actually became, next to the Game Mode reference:
+
+```text
+$ mise run dev:ui-scale deck
+Captured prior state: AUTOMATIC scaling at dpr 1.0 (source: Steam's live settings store)
+Forcing GamepadUI display scale 1.5 (auto scaling OFF)...
+
+Measured (real, repainted — not a CDP emulation override):
+  Big Picture  dpr 1.5  CSS 854x534
+  QuickAccess  dpr 1.5  CSS 854x454
+  => QAM matches the Game Mode reference (854x454) — what you see is what the Deck renders.
+```
+
+The forcing modes **hold until Ctrl-C**. Useful factors:
+
+| Factor  | What it reproduces              | Measured QAM   |
+| ------- | ------------------------------- | -------------- |
+| 1.5     | Deck internal panel (Game Mode) | 854x454        |
+| 2.0–2.4 | A user who picked "Larger text" | 855x255 @ 2.4  |
+| ~1.28   | Docked 1080p                    | 855x546 @ 1.28 |
+| ~1.71   | Docked 1440p                    | —              |
+
+#### What it restores on exit
+
+The tool **captures the scale you were on before it ran** and puts back exactly that — on Ctrl-C, on SIGTERM, and on any
+error. If you were on automatic scaling, you get automatic scaling back. If you had deliberately set a **manual** UI
+Scale (an accessibility "Larger text" value, say), you get **that factor** back — it is never silently flipped to auto,
+which would destroy the setting. The restore is then verified against Steam's live state and the rendered
+`devicePixelRatio`, and a restore that didn't land is reported as a warning rather than assumed.
+
+`mise run dev:ui-scale auto` is different on purpose: it **unconditionally** forces automatic scaling back on. It is the
+rescue path for when a previous run was hard-killed and the state it captured died with it — it has nothing to restore,
+so it cannot honour a manual scale. If you are a manual-UI-Scale user and ever have to use it, re-set your scale in
+Steam → Settings → Display afterwards.
+
+!!! warning "A hard kill leaves the forced scale behind"
+
+    Steam persists the factor to `~/.local/share/Steam/config/config.vdf` (`UI → display → Current → ScaleFactor`,
+    flushed within seconds), keyed by a display identity the Deck **shares with Game Mode**. Ctrl-C, SIGTERM and errors
+    all restore — but a **hard kill (SIGKILL) skips the restore**, and the forced scale is what Steam keeps. If that
+    happens, or if the UI ever comes up at the wrong size, run `mise run dev:ui-scale auto`.
+
+    This is also why the prior state is read from Steam's **live settings store**
+    (`window.settingsStore.settings`) rather than from `config.vdf`: the file's `AutoScaleFactor` is **not** re-flushed
+    in-session (measured: it stayed `1` while a manual factor was applied and rendering), so trusting it would report a
+    manual-scale user as "automatic" — and restore them to the wrong thing. `config.vdf` is only the fallback source.
+
+The QAM is a popup view that Steam can recreate; Steam's scale is display state, so a recreated view picks it up. No
+re-apply loop is needed (and none should be added).
+
+### What this means for our panels
+
+**The QAM's usable height is a runtime variable, not a constant.** The user can pick any UI Scale, and docking changes
+it automatically — measured on this Deck the same QAM panel ranged from **255 CSS px** (scale 2.4) to **720 CSS px**
+(unscaled desktop window), with Game Mode's 454 in between. So:
+
+- **Never assume a pixel budget.** No fixed heights, no `maxHeight` tuned against one screenshot, nothing that only fits
+  at 454 px.
+- **Every row must be focusable**, so gamepad navigation can reach content that is scrolled out of view.
+- **Let Steam's scroll container do its job** — the panel scrolls; content below the fold is reachable, not lost.
+
+Validate a panel at 1.5 (the device) and at 2.4 (the worst case) before calling a layout done.
+
 ## Backend changes
 
 ```bash
@@ -129,5 +225,8 @@ journalctl -u plugin_loader -f
 - **The QAM Performance tab is non-functional in desktop BPM** (it needs gamescope). Irrelevant for this plugin's UI.
 - **Desktop-BPM injection is best-effort** on Decky's side — re-verify the loop still works after Decky or Steam
   updates.
-- **Do a final Game Mode pass before a release.** The windowed BPM covers UI iteration, but controller focus behavior
-  and gamescope rendering are only real in Game Mode.
+- **Game Mode comes up at the wrong size** — a `dev:ui-scale` run was hard-killed and left Steam on a forced scale (it
+  persists in `config.vdf` under the display identity Game Mode shares). Run `mise run dev:ui-scale auto`.
+- **Do a final Game Mode pass before a release.** `dev:ui-scale deck` reproduces Game Mode's CSS metrics exactly, so
+  layout and overflow can be judged from the desktop — but controller focus behavior and gamescope rendering are still
+  only real in Game Mode.

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -157,6 +157,48 @@ If the QAM does **not** come out at the expected size (KWin unreachable, or Stea
 prints a loud `EMULATION FAILED` block with the measured-vs-expected numbers and the window's real pixel size, and says
 that any layout judgement made on those numbers is invalid. It never reports Deck metrics it did not achieve.
 
+#### Open the QAM once
+
+Steam creates the QuickAccess view together with the Big Picture window but **lays it out only on the first QAM open of
+that session**. Until then it measures **1x1 CSS**, and there is simply nothing to verify — so a run started against a
+fresh Big Picture says so instead of crying wolf:
+
+```text
+Measured (real, repainted — not a CDP emulation override):
+  Big Picture  dpr 1.5  CSS 854x534
+  QuickAccess  dpr 1.5  CSS 1x1 — created, never rendered
+
+QAM NOT VERIFIED YET — the emulation is applied, the QAM has simply never been opened.
+  Big Picture: 1280x800 physical, scale forced to 1.5 (rendering at dpr 1.5).
+  ...
+  => OPEN THE QAM ONCE. This tool re-applies the scale to it the moment it renders, and
+     then verifies it against the 854x454 a Deck shows at scale 1.5.
+```
+
+**Open the QAM once** and the run verifies it and prints the same verdict it would have printed up front — the success
+line, or the loud `EMULATION FAILED` block if the window is not the Deck's size after all. A never-opened QAM is a
+not-yet, not a failure; a QAM that renders at the wrong size still fails loudly.
+
+That laziness has a sharper edge, and it is why the tool **holds in a polling loop rather than idling**: Steam's scale
+push reaches only the views that are **rendered when it lands**. A QuickAccess view that renders _after_ the force can
+therefore come up **unscaled — measured at dpr 1, CSS 854x720**, which is exactly the dev-loop lie this whole tool
+exists to kill. So while it holds, the tool watches that view and re-issues the same two calls the moment it finds it
+rendering at the wrong `devicePixelRatio`:
+
+```text
+QuickAccess view is at dpr 1.899999976158142  CSS 855x343 — not the forced 1.5.
+Re-applying the scale (Steam's push reaches only the views that are rendered when it lands)...
+
+Measured (real, repainted — not a CDP emulation override):
+  Big Picture  dpr 1.5  CSS 854x534
+  QuickAccess  dpr 1.5  CSS 854x454
+  => QAM is 854x454 CSS at dpr 1.5, the 854x454 a Deck renders at scale 1.5 — this is what the Deck renders.
+```
+
+This also covers Steam re-materializing the popup later in the session. It is quiet by construction: it re-applies only
+when a **rendered** view sits at the wrong dpr, and only once per distinct measurement, so a re-apply that does not take
+is reported once rather than every couple of seconds.
+
 The forcing modes **hold until Ctrl-C**. Useful factors:
 
 | Factor  | What it reproduces              | Measured QAM   |
@@ -215,8 +257,10 @@ user and ever have to use it, re-set your scale in Steam → Settings → Displa
     entry — **not** Game Mode's `…|||Fullscreen-1280x800` one, even when the window sits on the Deck's internal panel.
     A leftover forced factor therefore mis-sizes a future *windowed desktop BPM*, and `dev:ui-scale auto` clears it.
 
-The QAM is a popup view that Steam can recreate; Steam's scale is display state, so a recreated view picks it up. No
-re-apply loop is needed (and none should be added).
+The QAM is a popup view that Steam creates lazily and can re-materialize at will, and Steam's scale reaches only the
+views that are **rendered when it is pushed** — a view that renders later comes up unscaled. That is why the tool holds
+in a polling loop and re-applies the scale to a QuickAccess view it finds at the wrong `devicePixelRatio` (see
+[Open the QAM once](#open-the-qam-once)).
 
 ### What this means for our panels
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -32,10 +32,11 @@ collections for platforms the run did not reach.
 
 ## Time estimate and progress
 
-Before you start, the sync preview shows an **Estimated time** for the run. It is a deliberate upper bound — it assumes
-a slower pace than a re-sync usually runs at and counts every game the sync walks through, not just the handful that
-changed — so the real run almost always finishes sooner. If you sync without previewing first, the same upper bound
-appears once the run starts, shown as "up to ~X min".
+Before you start, the sync preview shows an estimated time for the run on the same line as its platform/collection scope
+(for example "3 platforms · 2 collections · ~12 min"). It is a deliberate upper bound — it assumes a slower pace than a
+re-sync usually runs at and counts every game the sync walks through, not just the handful that changed — so the real
+run almost always finishes sooner. If you sync without previewing first, the same upper bound appears once the run
+starts as an **Estimated time** line, shown as "up to ~X min".
 
 Once the sync has been creating shortcuts for a few seconds, that "up to" ceiling is replaced by a **live countdown** —
 "~9 min left" — measured from the actual speed on your device and updated as the run proceeds. Because it reflects the
@@ -62,24 +63,24 @@ A few things worth knowing for a large library:
 - **A very large sync may pause itself to protect Steam.** Steam holds every shortcut it creates in memory for the rest
   of the session, and that memory only frees on a Steam restart. A very large first import can approach that limit, so
   the plugin watches Steam's memory and, when it gets close, pauses cleanly at a safe point rather than risking a Steam
-  crash. If the preview expects this, it shows a blue note up front ("this sync is large enough that it will likely
-  pause partway… that is normal"). When a pause happens, the sync page shows a **blue banner** — "Sync paused — restart
-  Steam when convenient, then Resume Sync. Steam memory: X.X GB…" — that stays until you resume, and a toast says the
-  same. Restarting Steam frees the memory and the resume finishes the job. Once you've restarted, the banner notices on
-  its own — it changes to "Steam memory is free again — press Resume Sync to continue" and drops the restart button, so
-  you know a resume will actually work now rather than pausing again. Nothing is lost, and you are never forced out of
-  what you were doing. After a big run finishes with memory still high, a **yellow banner** recommends a Steam restart
-  before your next large sync; it clears itself once you restart.
+  crash. If the preview expects this, it shows a blue note up front ("will likely pause partway to protect Steam's
+  memory — normal for large syncs"). When a pause happens, the sync page shows a **blue banner** — "Sync paused —
+  restart Steam when convenient, then Resume Sync. Steam memory: X.X GB…" — that stays until you resume, and a toast
+  says the same. Restarting Steam frees the memory and the resume finishes the job. Once you've restarted, the banner
+  notices on its own — it changes to "Steam memory is free again — press Resume Sync to continue" and drops the restart
+  button, so you know a resume will actually work now rather than pausing again. Nothing is lost, and you are never
+  forced out of what you were doing. After a big run finishes with memory still high, a **yellow banner** recommends a
+  Steam restart before your next large sync; it clears itself once you restart.
 - **Tap "Restart Steam now" to free the memory.** Both banners include a **Restart Steam now** button. It restarts the
   Steam client (Steam closes and reopens) — the reliable way to reset its memory — and you can Resume Sync once it comes
   back. The button is disabled while a game is running (a restart would close your game), so close your game first; it
   is also unavailable while a sync is actively running.
-- **The Status section shows Steam's current memory.** A **"Steam memory: X.X GB"** row sits alongside Connection and
-  Last sync, so you can see how close Steam is to its limit at a glance (it's hidden only if the reading can't be
-  taken); while a sync is running it refreshes every few seconds so you can watch the number climb. The number is
-  colour-coded — green when there's plenty of headroom, yellow as it gets high, red once it's near the limit where syncs
-  pause. It also shows a **"last run: ±X GB"** line — how much the last sync (whether it finished, paused, or was
-  cancelled) grew Steam's memory — so a big import showing "+1.5 GB" tells you why the number climbed.
+- **The top of the panel shows Steam's current memory.** A **Steam memory** row sits alongside Connection and Last sync,
+  so you can see how close Steam is to its limit at a glance (it's hidden only if the reading can't be taken); while a
+  sync is running it refreshes every few seconds so you can watch the number climb. The number is colour-coded — green
+  when there's plenty of headroom, yellow as it gets high, red once it's near the limit where syncs pause. On the same
+  line it shows how much the last run (whether it finished, paused, or was cancelled) grew Steam's memory — for example
+  "0.6 GB · last run +1.5" — so a big import tells you why the number climbed.
 
 ## Resuming an interrupted sync
 

--- a/mise.toml
+++ b/mise.toml
@@ -220,7 +220,7 @@ cp -f main.py "$DEST/main.py"
 '''
 
 [tasks."dev:ui-scale"]
-description = "Force the windowed Big Picture to Game Mode's display scale (the dev loop otherwise shows ~59% more QAM height than the Deck)"
+description = "Emulate Game Mode's metrics in Big Picture — size the window to the Deck's 1280x800 AND force its display scale (the dev loop otherwise lies about QAM height)"
 raw = true
 # The optional mode arg reaches the script as $usage_mode (mise exposes usage-spec
 # args as usage_<name> env vars).
@@ -229,10 +229,10 @@ arg "[mode]" help="'deck' (1.5, = Game Mode metrics), a bare factor (2.0-2.4 = '
 complete "mode" run="printf 'deck\\nsteam\\nauto\\n'"
 '''
 run = '''
-# Holds the forced scale until Ctrl-C, then restores the scale that was in force
-# BEFORE the run (auto stays auto; a manual UI Scale is put back as it was, never
-# flipped to auto). Steam persists the forced factor to config.vdf under the same
-# display identity Game Mode uses, so leaving it forced is not harmless.
+# Holds until Ctrl-C, then restores BOTH halves as they were BEFORE the run: the
+# scale (auto stays auto; a manual UI Scale is put back as it was, never flipped to
+# auto) and the Big Picture window's geometry + fullscreen state. Steam persists a
+# forced factor to config.vdf, so leaving it forced is not harmless.
 # `exec` so Ctrl-C / SIGTERM reach the script itself (mise is not left in the
 # signal path, which is what makes the restore reliable).
 exec python3 scripts/dev_ui_scale.py "$usage_mode"

--- a/mise.toml
+++ b/mise.toml
@@ -219,6 +219,25 @@ rsync -a --delete py_modules/ "$DEST/py_modules/"
 cp -f main.py "$DEST/main.py"
 '''
 
+[tasks."dev:ui-scale"]
+description = "Force the windowed Big Picture to Game Mode's display scale (the dev loop otherwise shows ~59% more QAM height than the Deck)"
+raw = true
+# The optional mode arg reaches the script as $usage_mode (mise exposes usage-spec
+# args as usage_<name> env vars).
+usage = '''
+arg "[mode]" help="'deck' (1.5, = Game Mode metrics), a bare factor (2.0-2.4 = 'Larger text', ~1.28 = docked 1080p, ~1.71 = docked 1440p), 'steam' (adopt the UI Scale set in Steam), or 'auto' (restore automatic scaling and exit)" default="deck"
+complete "mode" run="printf 'deck\\nsteam\\nauto\\n'"
+'''
+run = '''
+# Holds the forced scale until Ctrl-C, then restores the scale that was in force
+# BEFORE the run (auto stays auto; a manual UI Scale is put back as it was, never
+# flipped to auto). Steam persists the forced factor to config.vdf under the same
+# display identity Game Mode uses, so leaving it forced is not harmless.
+# `exec` so Ctrl-C / SIGTERM reach the script itself (mise is not left in the
+# signal path, which is what makes the restore reliable).
+exec python3 scripts/dev_ui_scale.py "$usage_mode"
+'''
+
 [tasks."dev:bpm-reset"]
 description = "Restart Steam into windowed Big Picture (recovers the Decky UI after leaving and re-entering BPM)"
 raw = true

--- a/scripts/dev_ui_scale.py
+++ b/scripts/dev_ui_scale.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python3
-"""Force Steam's GamepadUI display scale so the desktop dev loop renders Game Mode metrics.
+"""Emulate the Deck's Game Mode metrics in the desktop dev loop's Big Picture window.
 
 Part of the frontend dev loop (docs/contributing/frontend-dev-loop.md); driven by the
 ``dev:ui-scale`` mise task, usable standalone.
 
-Why this exists: the windowed Big Picture of ``mise run dev:watch`` renders at device
-pixel ratio 1, so the QAM panel gets ~720 CSS px of height where the Deck's internal
-panel (dpr 1.5) gives ~454. The dev loop shows ~59% more vertical room than the device —
-a panel that fits on the desktop can overflow in Game Mode. CSS *width* is 854 in both,
-so only height lies.
+Why this exists: the QAM panel gets ~720 CSS px of height in a stock desktop Big Picture
+where the Deck's internal panel gives ~454 — the dev loop shows vertical room the device
+does not have, so a panel that fits on the desktop can overflow in Game Mode.
 
-The 1.5 is Steam's own per-display "GamepadUI display scale" (Settings -> Display -> UI
-Scale), not gamescope and not a Chromium flag. Steam computes it from the display's
-resolution + physical size and pushes it into each CEF browser view. The same two
-undocumented calls Steam's settings UI uses drive it from here::
+The emulation has TWO halves, and forcing the scale alone is NOT enough. The QAM's CSS
+height follows::
+
+    QAM CSS height = (Big Picture window PHYSICAL height / scale) - 80
+
+so the scale is only half the equation: a fullscreen 2560x1440 Big Picture forced to 1.5
+renders an 880 px QAM — nearly double the Deck's 454 — while reporting the Deck's scale.
+This tool therefore ALSO sizes the Big Picture window to the Deck panel's 1280x800
+physical pixels, and then HARD-VERIFIES the result against the expected QAM size rather
+than claiming metrics it did not achieve.
+
+Half 1 — the scale. The 1.5 is Steam's own per-display "GamepadUI display scale"
+(Settings -> Display -> UI Scale), not gamescope and not a Chromium flag. Steam computes
+it from the display's resolution + physical size and pushes it into each CEF browser view.
+The same two undocumented calls Steam's settings UI uses drive it from here::
 
     SteamClient.Window.SetGamepadUIAutoDisplayScale(bool)
     SteamClient.Window.SetGamepadUIManualDisplayScaleFactor(float)
@@ -22,10 +31,23 @@ Unlike CDP's ``Emulation.setDeviceMetricsOverride`` (which fakes ``devicePixelRa
 leaves the rest of the window unpainted), this is Steam's real scale: the views are
 re-laid out and repainted for real.
 
+Half 2 — the window. KWin scripting over DBus (the same loadScript/run/unloadScript route
+``dev_open_bpm.sh`` uses for window placement) un-fullscreens the Big Picture window and
+sets its geometry so the CLIENT area is exactly 1280x800, on whatever output it already
+sits on. ``frameGeometry`` includes decorations, so the frame is corrected by the measured
+frame-vs-client delta until the client area lands exactly. The window's prior geometry and
+fullscreen state are captured first and restored on exit, alongside the scale.
+
 DANGER — the forced scale PERSISTS: Steam flushes it to
 ``~/.local/share/Steam/config/config.vdf`` (``UI -> display -> Current -> ScaleFactor``)
-within a couple of seconds, keyed by a display identity the Deck shares with Game Mode. A
-factor left forced is a factor Steam keeps.
+within a couple of seconds. A factor left forced is a factor Steam keeps.
+
+The setting is PER DISPLAY, keyed by Steam's display identity (``strDisplayName``, e.g.
+``External: DP-2 27"|||Fullscreen-2560x1440``), and ``config.vdf`` carries one entry per
+identity. So the blast radius depends on where the Big Picture window sits: on the Deck's
+internal panel the identity is the one Game Mode itself uses and a forced factor bleeds
+straight into Game Mode; on an external monitor it writes that monitor's entry and leaves
+Game Mode's alone. The tool prints the identity it is scaling, so this is never a guess.
 
 So the exit path CAPTURES the prior state before applying anything and puts back exactly
 that (SIGINT/SIGTERM/finally): auto stays auto, and a manual UI Scale — an accessibility
@@ -62,18 +84,24 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import math
 import os
+import shutil
 import signal
 import socket
 import struct
+import subprocess
 import sys
+import tempfile
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.error import URLError
 from urllib.request import urlopen
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from types import FrameType
 
 _DEBUGGER_URL = "http://localhost:8080/json"
@@ -92,14 +120,37 @@ _STEAM_CONFIG_VDF = os.path.expanduser("~/.local/share/Steam/config/config.vdf")
 # settles by ~0.5 s. Measure well past that or the printed numbers are a lie.
 _SETTLE_SEC = 1.5
 
-# The Deck's internal panel auto-scales to 1.5 — forcing it on the desktop reproduces
-# Game Mode's CSS metrics exactly.
+# The Deck's internal panel auto-scales to 1.5 — forcing it reproduces Game Mode's CSS
+# metrics, but only once the window is the panel's size too (see _DECK_WINDOW).
 _DECK_SCALE = 1.5
-# Game Mode reference metrics (measured on the Deck's internal panel, dpr 1.5).
-_GAME_MODE_QAM = (854, 454)
+# The Deck's internal panel in PHYSICAL pixels. The window half of the emulation: the QAM's
+# CSS height is (window physical height / scale) - 80, so the scale is meaningless until the
+# window is this size. Measured: fullscreen 2560x1440 at 1.5 renders an 880 px QAM, not 454.
+_DECK_WINDOW = (1280, 800)
+# Steam lays a view out in CEIL(physical / scale) CSS px, and the QAM sits this far below
+# Big Picture's header. Verified against three configurations: 800/1.5 - 80 = 454 (Game
+# Mode, measured 454); 1440/1.5 - 80 = 880 (fullscreen 1440p at 1.5); 1440/1.9 - 80 = 678
+# (fullscreen 1440p at Steam's automatic 1.9, measured 679).
+_QAM_HEADER_CSS = 80
+# The QAM popup is a fixed ~854 CSS px wide in every configuration measured — only its
+# height tracks the window.
+_QAM_CSS_WIDTH = 854
+# Fractional-dpr rounding costs about a pixel (854 at 1.5, 855 at 1.9), so the emulation is
+# "achieved" within a hair, not bit-exactly.
+_QAM_TOLERANCE_PX = 3
 
 _QAM_TITLE_PREFIX = "quickaccess"
 _BPM_TITLE_MARKER = "bigpicture"
+
+# KWin scripting (window half). Same DBus route dev_open_bpm.sh uses for placement.
+_KWIN_SERVICE = "org.kde.KWin"
+_KWIN_SCRIPTING_PATH = "/Scripting"
+_KWIN_SCRIPT_NAME = "decky-romm-sync-ui-scale"
+# A decorated window needs one correction pass (frame != client area); the rest is slack.
+_GEOMETRY_ATTEMPTS = 3
+# KWin resizes asynchronously and Steam repaints into the new size; measured well under
+# this, but a short window is what makes the frame-vs-client delta readable.
+_WINDOW_SETTLE_SEC = 0.6
 
 
 class DevUiScaleError(RuntimeError):
@@ -285,6 +336,334 @@ def _recv_exact(sock: socket.socket, count: int) -> bytes | None:
     return buffer
 
 
+# -------------------------------------------------------------------------- kwin
+
+# One script, three actions. KWin scripts have no return channel over DBus, so the reply
+# comes back through the user journal: print() from a KWin script lands there tagged
+# `js:`, and the per-call token makes a reply unambiguous against a stale line.
+_KWIN_JS = """
+var TOKEN = "@TOKEN@";
+var ACTION = "@ACTION@";
+var PAYLOAD = @PAYLOAD@;
+
+function emit(o) {
+  print("[decky-uiscale:" + TOKEN + "] " + JSON.stringify(o));
+}
+
+function rect(r) {
+  if (!r) {
+    return null;
+  }
+  return {
+    x: Math.round(r.x),
+    y: Math.round(r.y),
+    width: Math.round(r.width),
+    height: Math.round(r.height),
+  };
+}
+
+// Same heuristic as dev_open_bpm.sh: class "steam" covers the desktop client window and
+// Big Picture; BPM keeps the "Big Picture" brand across locales ("Big-Picture-Modus"), and
+// a fullscreen steam window is BPM as well (the client window is never fullscreen).
+function isBigPicture(win) {
+  if (!win || !win.resourceClass ||
+      String(win.resourceClass).toLowerCase() !== "steam") {
+    return false;
+  }
+  var caption = String(win.caption || "").toLowerCase();
+  return caption.indexOf("picture") !== -1 || win.fullScreen === true;
+}
+
+function find() {
+  var wins = workspace.windowList();
+  for (var i = 0; i < wins.length; i++) {
+    if (isBigPicture(wins[i])) {
+      return wins[i];
+    }
+  }
+  return null;
+}
+
+function state(win) {
+  return {
+    ok: true,
+    output: win.output ? win.output.name : null,
+    outputGeometry: win.output ? rect(win.output.geometry) : null,
+    fullScreen: win.fullScreen === true,
+    frame: rect(win.frameGeometry),
+    client: rect(win.clientGeometry),
+  };
+}
+
+try {
+  var win = find();
+  if (!win) {
+    emit({ ok: false, error: "no Big Picture window in KWin's window list" });
+  } else {
+    if (ACTION === "resize") {
+      // A fullscreen or maximized window ignores frameGeometry — clear both first.
+      win.fullScreen = false;
+      win.setMaximize(false, false);
+      win.frameGeometry = PAYLOAD.frame;
+    } else if (ACTION === "restore") {
+      // Geometry BEFORE fullscreen: a window that is already fullscreen would swallow the
+      // geometry write, and this order also leaves KWin the right un-fullscreen geometry.
+      win.frameGeometry = PAYLOAD.frame;
+      win.fullScreen = PAYLOAD.fullScreen === true;
+    }
+    emit(state(win));
+  }
+} catch (e) {
+  emit({ ok: false, error: String(e) });
+}
+"""
+
+
+@dataclass(frozen=True)
+class Rect:
+    """A window rectangle in physical pixels, as KWin reports it."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+    @classmethod
+    def from_json(cls, raw: Any) -> Rect | None:
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return cls(int(raw["x"]), int(raw["y"]), int(raw["width"]), int(raw["height"]))
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def as_json(self) -> dict[str, int]:
+        return {"x": self.x, "y": self.y, "width": self.width, "height": self.height}
+
+    def size(self) -> str:
+        return f"{self.width}x{self.height}"
+
+
+@dataclass(frozen=True)
+class BpmWindow:
+    """The Big Picture window as KWin sees it — the state the exit path has to put back.
+
+    ``frame`` is the decorated rectangle (what ``frameGeometry`` writes); ``client`` is the
+    content area Steam actually renders into, and the one that has to be the Deck's
+    1280x800. The two differ by the decoration, which is why sizing is a measure-and-correct
+    loop rather than a single write.
+    """
+
+    output: str | None
+    output_geometry: Rect | None
+    fullscreen: bool
+    frame: Rect
+    client: Rect
+
+    def describe(self) -> str:
+        where = self.output or "an unknown output"
+        if self.fullscreen:
+            return f"fullscreen {self.frame.size()} on {where}"
+        return f"windowed {self.client.size()} on {where}"
+
+
+def _qdbus_binary() -> str | None:
+    """The qdbus binary to talk to KWin with; ``None`` when neither spelling exists."""
+    for name in ("qdbus6", "qdbus"):
+        found = shutil.which(name)
+        if found is not None:
+            return found
+    return None
+
+
+def _qdbus(binary: str, path: str, method: str, *args: str) -> str | None:
+    """Call a KWin DBus method; ``None`` on any failure (the caller degrades, never crashes)."""
+    try:
+        result = subprocess.run(  # dev tool: not shipped plugin code
+            [binary, _KWIN_SERVICE, path, method, *args],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SEC,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def _kwin_call(action: str, payload: dict[str, Any] | None = None) -> BpmWindow | None:
+    """Run *action* ("capture" / "resize" / "restore") against the Big Picture window.
+
+    ``None`` means KWin could not be driven or the window was not found — every caller
+    degrades to a loud warning, and the emulation check then fails rather than lying.
+    """
+    binary = _qdbus_binary()
+    if binary is None:
+        return None
+    token = os.urandom(4).hex()
+    script = (
+        _KWIN_JS.replace("@TOKEN@", token).replace("@ACTION@", action).replace("@PAYLOAD@", json.dumps(payload or {}))
+    )
+    if not _kwin_run_script(binary, script):
+        return None
+    reply = _kwin_read_reply(token)
+    if reply is None or not reply.get("ok"):
+        if isinstance(reply, dict) and reply.get("error"):
+            print(f"WARNING: KWin: {reply['error']}", file=sys.stderr)
+        return None
+
+    frame = Rect.from_json(reply.get("frame"))
+    client = Rect.from_json(reply.get("client"))
+    if frame is None or client is None:
+        return None
+    output = reply.get("output")
+    return BpmWindow(
+        output=output if isinstance(output, str) else None,
+        output_geometry=Rect.from_json(reply.get("outputGeometry")),
+        fullscreen=bool(reply.get("fullScreen")),
+        frame=frame,
+        client=client,
+    )
+
+
+def _kwin_run_script(binary: str, script: str) -> bool:
+    """Load, run and unload *script* in KWin. The script is short-lived by construction.
+
+    It connects no signals — everything happens in the body during ``run`` — so unloading
+    immediately is safe, and a re-run can never collide with a lingering copy. A fresh temp
+    file per call sidesteps KWin's caching of an already-loaded path.
+    """
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as handle:
+        handle.write(script)
+        path = handle.name
+    try:
+        _qdbus(binary, _KWIN_SCRIPTING_PATH, "org.kde.kwin.Scripting.unloadScript", _KWIN_SCRIPT_NAME)
+        raw = _qdbus(binary, _KWIN_SCRIPTING_PATH, "org.kde.kwin.Scripting.loadScript", path, _KWIN_SCRIPT_NAME)
+        script_id = (raw or "").strip()
+        if not script_id.isdigit():
+            return False
+        return _qdbus(binary, f"{_KWIN_SCRIPTING_PATH}/Script{script_id}", "org.kde.kwin.Script.run") is not None
+    finally:
+        _qdbus(binary, _KWIN_SCRIPTING_PATH, "org.kde.kwin.Scripting.unloadScript", _KWIN_SCRIPT_NAME)
+        os.unlink(path)
+
+
+def _kwin_read_reply(token: str) -> dict[str, Any] | None:
+    """Read the script's emitted line back out of the user journal; ``None`` if it never lands."""
+    marker = f"[decky-uiscale:{token}]"
+    deadline = time.monotonic() + _TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        try:
+            journal = subprocess.run(  # dev tool: not shipped plugin code
+                ["journalctl", "--user", "--since=-2min", "--no-pager", "-o", "cat"],
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT_SEC,
+                check=False,
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return None
+        for line in journal.splitlines():
+            _, found, payload = line.partition(marker)
+            if found:
+                try:
+                    return json.loads(payload)
+                except ValueError:
+                    return None
+        time.sleep(0.15)
+    return None
+
+
+def _capture_window_state() -> BpmWindow | None:
+    """Capture (and print) the Big Picture window's geometry BEFORE this run touches it."""
+    window = _kwin_call("capture")
+    if window is None:
+        print(
+            "WARNING: could not drive KWin — the Big Picture window keeps its current size.\n"
+            "         Forcing the scale ALONE does not reproduce Deck metrics (the QAM's CSS height\n"
+            "         follows window physical height / scale - 80), so the check below will fail.",
+            file=sys.stderr,
+        )
+        return None
+    print(f"Captured prior window: {window.describe()}")
+    return window
+
+
+def _deck_window_origin(prior: BpmWindow, width: int, height: int) -> tuple[int, int]:
+    """Centre a *width* x *height* frame on the output the window is ALREADY on.
+
+    Moving it between screens is dev_open_bpm.sh's job, not this tool's.
+    """
+    geometry = prior.output_geometry
+    if geometry is None:
+        return prior.frame.x, prior.frame.y
+    return (
+        geometry.x + max(0, (geometry.width - width) // 2),
+        geometry.y + max(0, (geometry.height - height) // 2),
+    )
+
+
+def _size_window_to_deck(prior: BpmWindow) -> BpmWindow | None:
+    """Size Big Picture so its CLIENT area is exactly the Deck panel's 1280x800.
+
+    ``frameGeometry`` writes the DECORATED rectangle, so a single write lands the client
+    area short by whatever the decoration adds. Correct by the measured frame-vs-client
+    delta and re-assert until the client area is exact — which also means the tool never
+    has to hardcode a decoration size, on any theme or compositor config.
+    """
+    target_w, target_h = _DECK_WINDOW
+    frame_w, frame_h = target_w, target_h
+    latest: BpmWindow | None = None
+    for _ in range(_GEOMETRY_ATTEMPTS):
+        x, y = _deck_window_origin(prior, frame_w, frame_h)
+        frame = Rect(x, y, frame_w, frame_h)
+        latest = _kwin_call("resize", {"frame": frame.as_json()})
+        if latest is None:
+            return None
+        time.sleep(_WINDOW_SETTLE_SEC)
+        delta_w = target_w - latest.client.width
+        delta_h = target_h - latest.client.height
+        if delta_w == 0 and delta_h == 0:
+            return latest
+        frame_w += delta_w
+        frame_h += delta_h
+    return latest
+
+
+def _emulate_deck_window(prior: BpmWindow | None) -> BpmWindow | None:
+    """Put the Big Picture window at the Deck panel's physical size; ``None`` if it could not be."""
+    if prior is None:
+        return None
+    width, height = _DECK_WINDOW
+    print(f"Sizing the Big Picture window to a {width}x{height} client area (was {prior.describe()})...")
+    window = _size_window_to_deck(prior)
+    if window is None:
+        print("WARNING: KWin would not resize the Big Picture window — the check below will fail.", file=sys.stderr)
+        return None
+    print(f"  window now: {window.describe()} (frame {window.frame.size()})")
+    return window
+
+
+def _restore_window(prior: BpmWindow | None) -> None:
+    """Put the window back exactly as it was — same geometry, same fullscreen state."""
+    if prior is None:
+        return
+    window = _kwin_call("restore", {"frame": prior.frame.as_json(), "fullScreen": prior.fullscreen})
+    if window is None:
+        print(
+            f"\nCOULD NOT RESTORE the Big Picture window ({prior.describe()}).\n"
+            "It is still at the Deck's 1280x800 — resize or re-fullscreen it by hand.",
+            file=sys.stderr,
+        )
+        return
+    print(f"Restored: Big Picture window {window.describe()} (the state captured before this run).")
+    if window.fullscreen != prior.fullscreen or (not prior.fullscreen and window.frame != prior.frame):
+        print(
+            f"WARNING: that is NOT the window state captured before this run ({prior.describe()}).",
+            file=sys.stderr,
+        )
+
+
 # ------------------------------------------------------------------------- steam
 
 
@@ -409,6 +788,30 @@ def _read_live_scale_state() -> tuple[bool, float | None] | None:
     return bool(state["auto"]), float(factor) if isinstance(factor, (int, float)) else None
 
 
+def _read_display_name() -> str | None:
+    """Steam's identity for the display it is currently scaling; ``None`` if unreadable.
+
+    ``strDisplayName`` (e.g. ``External: DP-2 27"|||Fullscreen-2560x1440``) is the key
+    ``config.vdf`` files the UI Scale under — one entry per display. Printing it is what
+    makes the blast radius of a forced factor visible: the same string as Game Mode's means
+    the force bleeds into Game Mode, a different one means it does not.
+    """
+    expression = """
+    (() => {
+      const s = window.settingsStore && window.settingsStore.settings;
+      return s && typeof s.strDisplayName === 'string' ? s.strDisplayName : null;
+    })()
+    """
+    try:
+        ws_url = _find_ws_url(_list_targets(), _normalize_title(_SHARED_JS_CONTEXT), prefix=True)
+        if ws_url is None:
+            return None
+        name = _evaluate(ws_url, expression)
+    except DevUiScaleError:
+        return None
+    return name if isinstance(name, str) else None
+
+
 def _read_config_vdf_scale_state() -> tuple[bool, float | None] | None:
     """Fallback read of ``UI -> display -> Current`` in ``config.vdf``; ``None`` if unreadable.
 
@@ -515,42 +918,110 @@ def _set_scale(factor: float | None) -> None:
     _evaluate(ws_url, expression)
 
 
-def _measure() -> None:
-    """Print the real CSS metrics of both views, next to the Game Mode reference."""
-    targets = _list_targets()
-    views = (
-        ("Big Picture", _find_ws_url(targets, _BPM_TITLE_MARKER, prefix=False)),
-        ("QuickAccess", _find_ws_url(targets, _QAM_TITLE_PREFIX, prefix=True)),
-    )
-    expression = "JSON.stringify({dpr: window.devicePixelRatio, w: window.innerWidth, h: window.innerHeight})"
-    qam: dict[str, Any] | None = None
-    for label, ws_url in views:
-        if ws_url is None:
-            print(f"  {label:<12} target not found (view not open?)")
-            continue
-        metrics = json.loads(str(_evaluate(ws_url, expression)))
-        print(f"  {label:<12} dpr {metrics['dpr']}  CSS {metrics['w']}x{metrics['h']}")
-        if label == "QuickAccess":
-            qam = metrics
+@dataclass(frozen=True)
+class ViewMetrics:
+    """What a CEF view actually rendered — the ground truth every claim here is checked against."""
 
-    ref_w, ref_h = _GAME_MODE_QAM
+    dpr: float
+    css_w: int
+    css_h: int
+
+    @property
+    def physical(self) -> tuple[int, int]:
+        """The view's size in real pixels — for Big Picture, the window's client area."""
+        return round(self.css_w * self.dpr), round(self.css_h * self.dpr)
+
+
+def _measure_view(match: str, *, prefix: bool) -> ViewMetrics | None:
+    """Measure one CEF view's live CSS metrics; ``None`` when the view is not open."""
+    ws_url = _find_ws_url(_list_targets(), match, prefix=prefix)
+    if ws_url is None:
+        return None
+    expression = "JSON.stringify({dpr: window.devicePixelRatio, w: window.innerWidth, h: window.innerHeight})"
+    try:
+        raw = json.loads(str(_evaluate(ws_url, expression)))
+        return ViewMetrics(float(raw["dpr"]), int(raw["w"]), int(raw["h"]))
+    except (DevUiScaleError, KeyError, TypeError, ValueError):
+        return None
+
+
+def _expected_qam_css(factor: float) -> tuple[int, int]:
+    """The QAM's CSS size the Deck renders at *factor*, from the 1280x800 panel.
+
+    Steam lays a view out in CEIL(physical / factor) CSS px and insets the QAM below Big
+    Picture's header, so 1.5 gives Game Mode's 854x454.
+    """
+    _, window_h = _DECK_WINDOW
+    return _QAM_CSS_WIDTH, math.ceil(window_h / factor) - _QAM_HEADER_CSS
+
+
+def _verify_emulation(factor: float, window: BpmWindow | None) -> bool:
+    """Measure both views and check the emulation was actually ACHIEVED, not just requested.
+
+    The whole point of the tool: a forced scale on a window that is not the Deck's size
+    reports the Deck's dpr while rendering a QAM up to twice the Deck's height. So the
+    numbers are compared against what the Deck would render, and a miss is a loud failure —
+    never a quietly-wrong "measured" line the reader would take for a success.
+    """
+    bpm = _measure_view(_BPM_TITLE_MARKER, prefix=False)
+    qam = _measure_view(_QAM_TITLE_PREFIX, prefix=True)
+    for label, view in (("Big Picture", bpm), ("QuickAccess", qam)):
+        if view is None:
+            print(f"  {label:<12} target not found (view not open?)")
+        else:
+            print(f"  {label:<12} dpr {view.dpr}  CSS {view.css_w}x{view.css_h}")
+
+    expected_w, expected_h = _expected_qam_css(factor)
     if qam is None:
-        print(f"  (Game Mode reference: QAM {ref_w}x{ref_h})")
-    elif (qam["w"], qam["h"]) == (ref_w, ref_h):
-        print(f"  => QAM matches the Game Mode reference ({ref_w}x{ref_h}) — what you see is what the Deck renders.")
-    else:
-        delta = qam["h"] - ref_h
-        sign = "+" if delta >= 0 else ""
         print(
-            f"  => QAM is {qam['w']}x{qam['h']} vs the Game Mode reference {ref_w}x{ref_h} "
-            f"({sign}{delta} px of height)."
+            f"\nFAILED to verify the emulation: the QuickAccess view is not open, so its size\n"
+            f"could not be measured (expected {expected_w}x{expected_h} CSS at scale {factor}).\n"
+            "Open the QAM in Big Picture and re-run.",
+            file=sys.stderr,
         )
+        return False
+
+    if abs(qam.css_w - expected_w) <= _QAM_TOLERANCE_PX and abs(qam.css_h - expected_h) <= _QAM_TOLERANCE_PX:
+        print(
+            f"  => QAM is {qam.css_w}x{qam.css_h} CSS at dpr {qam.dpr}, the {expected_w}x{expected_h} "
+            f"a Deck renders at scale {factor} — this is what the Deck renders."
+        )
+        return True
+
+    window_size = _window_physical_size(window, bpm)
+    deck_w, deck_h = _DECK_WINDOW
+    print(
+        f"\nEMULATION FAILED — these are NOT Deck metrics.\n"
+        f"  QAM measured: {qam.css_w}x{qam.css_h} CSS (expected {expected_w}x{expected_h} at scale {factor})\n"
+        f"  Big Picture window: {window_size} physical (must be {deck_w}x{deck_h} — the Deck's panel)\n"
+        f"  The QAM's CSS height is (window physical height / scale) - {_QAM_HEADER_CSS}, so forcing the\n"
+        f"  scale on a window of the wrong size gives the Deck's dpr with the wrong layout.\n"
+        f"  Most likely: the window could not be resized (KWin unreachable, or Steam re-asserted its\n"
+        f"  size). Any layout judgement made on these numbers is invalid.",
+        file=sys.stderr,
+    )
+    return False
+
+
+def _window_physical_size(window: BpmWindow | None, bpm: ViewMetrics | None) -> str:
+    """The Big Picture window's real pixel size, for the failure block; KWin first, CEF as fallback."""
+    if window is not None:
+        return window.client.size()
+    if bpm is not None:
+        width, height = bpm.physical
+        return f"~{width}x{height}"
+    return "unknown"
 
 
 # -------------------------------------------------------------------------- main
 
 
 _USAGE = """usage: dev_ui_scale.py [deck | <factor> | steam | auto]
+
+Emulates the Deck by BOTH sizing the Big Picture window to the panel's 1280x800 physical
+pixels AND forcing Steam's GamepadUI display scale — the QAM's CSS height is
+(window physical height / scale) - 80, so neither half works alone. The result is then
+verified against what the Deck would render, and a miss is reported as a failure.
 
   deck      (default) force 1.5 — the Deck internal panel's auto scale, i.e. exact
             Game Mode metrics (QAM 854x454).
@@ -560,11 +1031,13 @@ _USAGE = """usage: dev_ui_scale.py [deck | <factor> | steam | auto]
             back to 1.5 when Steam is on automatic scaling.
   auto|off  UNCONDITIONALLY re-enable Steam's automatic scaling and exit. This is the
             rescue path for when a previous run was SIGKILLed and its captured state
-            died with it — it does NOT know what you were on, it just forces auto.
+            died with it — it does NOT know what you were on, it just forces auto (and
+            it does not touch the window; resize it by hand).
 
-The forcing modes hold until Ctrl-C, then restore the scale you were on BEFORE the run:
-auto stays auto, and a manual UI Scale (e.g. an accessibility "Larger text" value) is put
-back exactly as it was — never silently flipped to auto."""
+The forcing modes hold until Ctrl-C, then restore what you were on BEFORE the run: auto
+stays auto, a manual UI Scale (e.g. an accessibility "Larger text" value) is put back
+exactly as it was rather than silently flipped to auto, and the Big Picture window goes
+back to the geometry and fullscreen state it had."""
 
 
 def _parse_mode(argv: list[str]) -> float | None:
@@ -595,8 +1068,41 @@ def _on_signal(_signum: int, _frame: FrameType | None) -> None:
     raise KeyboardInterrupt
 
 
-def _restore(prior: SteamScaleState | None) -> None:
-    """Put *prior* back — exactly. Never raises: it runs in a ``finally``.
+def _restore(prior: SteamScaleState | None, prior_window: BpmWindow | None) -> None:
+    """Put the scale AND the window back — exactly. Never raises: it runs in a ``finally``.
+
+    Scale before window, which is the reverse of the apply order and the only safe order for
+    two independent reasons. First, the UI Scale is filed per display identity and the
+    identity depends on the window (Steam keys it ``…|||Fullscreen-2560x1440`` fullscreen but
+    ``…|||Windowed`` once resized), so un-forcing while the window is still at the Deck's size
+    is what clears the entry the force was actually written into. Second, it is the right risk
+    order: a stranded forced scale is the damaging outcome (Steam persists it), a window left
+    at 1280x800 is cosmetic.
+
+    Signals are held off for the duration. The window half is the slow half — subprocesses
+    plus a journal read — and an impatient second Ctrl-C used to truncate the restore right
+    there, leaving the window resized. SIGKILL remains the only way to skip the restore, which
+    is what the docs promise.
+    """
+    with _signals_held_off():
+        _restore_scale(prior)
+        _restore_window(prior_window)
+        _verify_restore(prior)
+
+
+@contextmanager
+def _signals_held_off() -> Iterator[None]:
+    """Ignore SIGINT/SIGTERM inside the block, then put the previous handlers back."""
+    previous = {number: signal.signal(number, signal.SIG_IGN) for number in (signal.SIGINT, signal.SIGTERM)}
+    try:
+        yield
+    finally:
+        for number, handler in previous.items():
+            signal.signal(number, handler)
+
+
+def _restore_scale(prior: SteamScaleState | None) -> None:
+    """Put *prior* back — exactly.
 
     A user who deliberately set a manual UI Scale (an accessibility "Larger text" value,
     say) must get that scale back, not Steam's automatic one — flipping them to auto on
@@ -625,8 +1131,6 @@ def _restore(prior: SteamScaleState | None) -> None:
             "  mise run dev:ui-scale auto",
             file=sys.stderr,
         )
-        return
-    _verify_restore(prior)
 
 
 def _verify_restore(prior: SteamScaleState | None) -> None:
@@ -678,22 +1182,28 @@ def main(argv: list[str]) -> int:
         return 0
 
     signal.signal(signal.SIGTERM, _on_signal)
-    # Capture BEFORE applying — this is the state the exit path has to put back.
+    # Capture BEFORE applying — this is the state the exit path has to put back. Both halves
+    # of it: the scale Steam is on, and the window KWin is about to resize.
     prior = _capture_prior_state()
-    print(f"Forcing GamepadUI display scale {factor} (auto scaling OFF)...")
+    prior_window = _capture_window_state()
     try:
+        window = _emulate_deck_window(prior_window)
+        print(f"Forcing GamepadUI display scale {factor} (auto scaling OFF)...")
         _set_scale(factor)
         # The QAM is a popup view Steam can recreate at will. Steam's own scale (unlike a
         # CDP Emulation override, which is per-view and dies with the view) is display
         # state that any recreated view picks up — so there is nothing to re-apply here.
         # Do not "fix" this by adding a polling loop.
         time.sleep(_SETTLE_SEC)
+        print(f"  scaling display: {_read_display_name() or 'unknown'}")
         print("\nMeasured (real, repainted — not a CDP emulation override):")
-        _measure()
+        _verify_emulation(factor, window)
         print(
-            f"\nHOLDING — Ctrl-C restores what you were on before this run ({_describe(prior)}).\n"
-            "WARNING: Steam persists this scale to config.vdf, under the same display identity\n"
-            "Game Mode uses. A hard kill (SIGKILL) skips the restore — recover with:\n"
+            f"\nHOLDING — Ctrl-C restores what you were on before this run\n"
+            f"  scale:  {_describe(prior)}\n"
+            f"  window: {prior_window.describe() if prior_window else 'unknown — will be left as-is'}\n"
+            "WARNING: Steam persists this scale to config.vdf, filed under the display identity\n"
+            "printed above. A hard kill (SIGKILL) skips the restore — recover with:\n"
             "  mise run dev:ui-scale auto"
         )
         signal.pause()
@@ -704,8 +1214,9 @@ def main(argv: list[str]) -> int:
         return 1
     finally:
         # Covers the apply itself: the forcing expression sets auto=false before it sets
-        # the factor, so even a half-applied scale must be undone.
-        _restore(prior)
+        # the factor, so even a half-applied scale must be undone — and a window that was
+        # resized before a later step failed must still go back.
+        _restore(prior, prior_window)
     return 0
 
 

--- a/scripts/dev_ui_scale.py
+++ b/scripts/dev_ui_scale.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""Force Steam's GamepadUI display scale so the desktop dev loop renders Game Mode metrics.
+
+Part of the frontend dev loop (docs/contributing/frontend-dev-loop.md); driven by the
+``dev:ui-scale`` mise task, usable standalone.
+
+Why this exists: the windowed Big Picture of ``mise run dev:watch`` renders at device
+pixel ratio 1, so the QAM panel gets ~720 CSS px of height where the Deck's internal
+panel (dpr 1.5) gives ~454. The dev loop shows ~59% more vertical room than the device —
+a panel that fits on the desktop can overflow in Game Mode. CSS *width* is 854 in both,
+so only height lies.
+
+The 1.5 is Steam's own per-display "GamepadUI display scale" (Settings -> Display -> UI
+Scale), not gamescope and not a Chromium flag. Steam computes it from the display's
+resolution + physical size and pushes it into each CEF browser view. The same two
+undocumented calls Steam's settings UI uses drive it from here::
+
+    SteamClient.Window.SetGamepadUIAutoDisplayScale(bool)
+    SteamClient.Window.SetGamepadUIManualDisplayScaleFactor(float)
+
+Unlike CDP's ``Emulation.setDeviceMetricsOverride`` (which fakes ``devicePixelRatio`` and
+leaves the rest of the window unpainted), this is Steam's real scale: the views are
+re-laid out and repainted for real.
+
+DANGER — the forced scale PERSISTS: Steam flushes it to
+``~/.local/share/Steam/config/config.vdf`` (``UI -> display -> Current -> ScaleFactor``)
+within a couple of seconds, keyed by a display identity the Deck shares with Game Mode. A
+factor left forced is a factor Steam keeps.
+
+So the exit path CAPTURES the prior state before applying anything and puts back exactly
+that (SIGINT/SIGTERM/finally): auto stays auto, and a manual UI Scale — an accessibility
+"Larger text" value, say — is re-set to its old factor rather than silently flipped to
+auto, which would destroy the user's setting. Only a hard SIGKILL can skip the restore;
+``dev:ui-scale auto`` is the rescue path for exactly that case, and it is the one mode
+that forces auto ON unconditionally (it has no captured state to honour).
+
+The prior state is read from Steam's LIVE settings store (``window.settingsStore.settings``
+in SharedJSContext — the same state Steam's own Display settings page renders), not from
+``config.vdf``, and the restore is verified against it plus the live ``devicePixelRatio``.
+``config.vdf`` is only a fallback source, because it is measurably unreliable in-session:
+Steam re-flushes ``ScaleFactor`` within seconds but leaves ``AutoScaleFactor`` alone (it
+stayed ``1`` on-device while a manual factor was applied and rendering), so the file can
+report a manual scale as automatic — and restoring "automatic" to a user who is on a
+manual scale is exactly the setting-destroying bug this capture exists to prevent.
+
+Transport: the CEF remote-debugging endpoint on ``localhost:8080`` (a Decky platform
+invariant — Decky Loader itself requires CEF debugging enabled). ``GET /json`` lists the
+debuggable targets; ``SharedJSContext`` is where ``SteamClient`` lives, and the
+``Big-Picture-*`` / ``QuickAccess_*`` page targets are the two views we measure.
+
+The RFC 6455 client below is a deliberate copy of the one in
+``py_modules/adapters/renderer_gc.py`` rather than a shared import: that adapter is
+shipped plugin code with a fail-open, single-command, payload-discarding contract, while
+this dev tool needs the evaluate *result*, several commands per run, and loud failures.
+Sharing would mean either widening the shipped adapter's contract for a dev-only need or
+adding a generic client to shipped ``lib/`` that no production path uses (it would land in
+the release zip and in Sonar's scope). RFC 6455 is frozen; these ~80 lines don't drift.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import signal
+import socket
+import struct
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+if TYPE_CHECKING:
+    from types import FrameType
+
+_DEBUGGER_URL = "http://localhost:8080/json"
+_SHARED_JS_CONTEXT = "SharedJSContext"
+# RFC 6455 handshake GUID — appended to the client key to derive the expected
+# Sec-WebSocket-Accept.
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+# Generous by dev-tool standards: a repaint of both views at a new scale is not a
+# hot path, and a spurious timeout here would leave Steam on a forced scale.
+_TIMEOUT_SEC = 8.0
+
+_STEAM_CONFIG_VDF = os.path.expanduser("~/.local/share/Steam/config/config.vdf")
+
+# Steam re-lays out the views asynchronously after the scale call: measured on-device, the
+# new dpr is live at ~0.25 s but the layout is still mid-flight (a transient 570x480), and
+# settles by ~0.5 s. Measure well past that or the printed numbers are a lie.
+_SETTLE_SEC = 1.5
+
+# The Deck's internal panel auto-scales to 1.5 — forcing it on the desktop reproduces
+# Game Mode's CSS metrics exactly.
+_DECK_SCALE = 1.5
+# Game Mode reference metrics (measured on the Deck's internal panel, dpr 1.5).
+_GAME_MODE_QAM = (854, 454)
+
+_QAM_TITLE_PREFIX = "quickaccess"
+_BPM_TITLE_MARKER = "bigpicture"
+
+
+class DevUiScaleError(RuntimeError):
+    """Anything that stops the tool: no debugger, no target, a rejected CDP command."""
+
+
+# --------------------------------------------------------------------------- CDP
+
+
+def _list_targets() -> list[dict[str, Any]]:
+    """Return the CEF debugger's target list, or raise with an actionable message."""
+    try:
+        with urlopen(_DEBUGGER_URL, timeout=_TIMEOUT_SEC) as resp:  # fixed localhost URL
+            targets = json.load(resp)
+    except (URLError, OSError, ValueError) as e:
+        raise DevUiScaleError(
+            f"no CEF debugger on {_DEBUGGER_URL} ({e}). Is Big Picture running? "
+            "Start the dev loop with `mise run dev:watch`. If Steam is up but the endpoint "
+            "is dead, ~/.steam/steam/.cef-enable-remote-debugging is missing (create it and "
+            "restart Steam)."
+        ) from e
+    return [t for t in targets if isinstance(t, dict)]
+
+
+def _normalize_title(title: str) -> str:
+    return "".join(c for c in title.lower() if c.isalnum())
+
+
+def _find_ws_url(targets: list[dict[str, Any]], match: str, *, prefix: bool) -> str | None:
+    """Return the ``webSocketDebuggerUrl`` of the first target whose title matches.
+
+    Titles are normalized (lowercased, non-alphanumerics stripped) before matching:
+    the Big Picture target is localized (``Big-Picture-Modus`` on a German client), and
+    the QAM target carries a per-window suffix (``QuickAccess_uid17``).
+    """
+    for target in targets:
+        title = _normalize_title(str(target.get("title", "")))
+        hit = title.startswith(match) if prefix else match in title
+        if hit:
+            url = target.get("webSocketDebuggerUrl")
+            if isinstance(url, str):
+                return url
+    return None
+
+
+def _evaluate(ws_url: str, expression: str) -> Any:
+    """Run *expression* in the target behind *ws_url* and return its value.
+
+    One short-lived connection per call: the tool sends a handful of commands over a
+    run that can idle for minutes between them (apply -> hold -> restore), and a fresh
+    socket for the restore is what makes the exit path robust after a long hold.
+    """
+    host, port, path = _parse_ws_url(ws_url)
+    sock = socket.create_connection((host, port), timeout=_TIMEOUT_SEC)
+    try:
+        sock.settimeout(_TIMEOUT_SEC)
+        if not _handshake(sock, host, port, path):
+            raise DevUiScaleError("CEF rejected the WebSocket handshake")
+        request = {
+            "id": 1,
+            "method": "Runtime.evaluate",
+            "params": {"expression": expression, "returnByValue": True, "awaitPromise": True},
+        }
+        sock.sendall(_encode_text_frame(json.dumps(request)))
+        reply = _await_reply(sock, request_id=1)
+    finally:
+        sock.close()
+
+    if "exceptionDetails" in reply.get("result", {}):
+        details = reply["result"]["exceptionDetails"]
+        text = details.get("exception", {}).get("description") or details.get("text", "?")
+        raise DevUiScaleError(f"CDP evaluate threw: {text}")
+    if "error" in reply:
+        raise DevUiScaleError(f"CDP error: {reply['error']}")
+    return reply.get("result", {}).get("result", {}).get("value")
+
+
+def _await_reply(sock: socket.socket, *, request_id: int) -> dict[str, Any]:
+    """Read frames until the reply carrying *request_id* arrives."""
+    for _ in range(16):  # bounded: no CDP domains are enabled, so events are not expected
+        frame = _recv_frame(sock)
+        if frame is None:
+            raise DevUiScaleError("CDP connection closed before the reply arrived")
+        opcode, payload = frame
+        if opcode != 0x1:  # close / ping / continuation — not expected for this exchange
+            raise DevUiScaleError(f"unexpected WebSocket frame (opcode {opcode:#x})")
+        message = json.loads(payload)
+        if message.get("id") == request_id:
+            return message
+    raise DevUiScaleError("no CDP reply for the evaluate request")
+
+
+def _parse_ws_url(ws_url: str) -> tuple[str, int, str]:
+    """Split ``ws://host:port/path`` into ``(host, port, path)``; port defaults to 80."""
+    rest = ws_url.split("://", 1)[-1]
+    authority, _, path = rest.partition("/")
+    host, _, port_str = authority.partition(":")
+    return host, int(port_str) if port_str else 80, "/" + path
+
+
+def _handshake(sock: socket.socket, host: str, port: int, path: str) -> bool:
+    """Perform the RFC 6455 Upgrade handshake; validate ``Sec-WebSocket-Accept``."""
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    request = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    )
+    sock.sendall(request.encode("ascii"))
+    response = _recv_until(sock, b"\r\n\r\n")
+    if response is None:
+        return False
+    # RFC 6455 fixes SHA-1 for Sec-WebSocket-Accept; not a security use.
+    accept_digest = hashlib.sha1((key + _WS_GUID).encode("ascii"), usedforsecurity=False).digest()
+    expected = base64.b64encode(accept_digest).decode("ascii")
+    return expected.lower().encode("ascii") in response.lower()
+
+
+def _recv_until(sock: socket.socket, terminator: bytes, limit: int = 8192) -> bytes | None:
+    """Read from *sock* until *terminator* appears; ``None`` on EOF or overrun."""
+    buffer = b""
+    while terminator not in buffer:
+        chunk = sock.recv(1024)
+        if not chunk:
+            return None
+        buffer += chunk
+        if len(buffer) > limit:
+            return None
+    return buffer
+
+
+def _encode_text_frame(message: str) -> bytes:
+    """Encode *message* as a masked client text frame (FIN=1, opcode=0x1)."""
+    payload = message.encode("utf-8")
+    length = len(payload)
+    header = bytearray([0x81])  # FIN + text opcode
+    if length < 126:
+        header.append(0x80 | length)  # mask bit + 7-bit length
+    else:
+        header.append(0x80 | 126)  # mask bit + 16-bit extended length
+        header.extend(struct.pack(">H", length))
+    mask = os.urandom(4)
+    header.extend(mask)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return bytes(header) + masked
+
+
+def _recv_frame(sock: socket.socket) -> tuple[int, bytes] | None:
+    """Read one unmasked server frame; return ``(opcode, payload)`` or ``None`` on EOF."""
+    head = _recv_exact(sock, 2)
+    if head is None:
+        return None
+    opcode = head[0] & 0x0F
+    masked = bool(head[1] & 0x80)
+    length = head[1] & 0x7F
+    if length == 126:
+        ext = _recv_exact(sock, 2)
+        if ext is None:
+            return None
+        length = struct.unpack(">H", ext)[0]
+    elif length == 127:
+        ext = _recv_exact(sock, 8)
+        if ext is None:
+            return None
+        length = struct.unpack(">Q", ext)[0]
+    if masked:
+        return None  # server frames must not be masked
+    payload = _recv_exact(sock, length) if length else b""
+    return None if payload is None else (opcode, payload)
+
+
+def _recv_exact(sock: socket.socket, count: int) -> bytes | None:
+    """Read exactly *count* bytes; ``None`` on EOF before *count* are read."""
+    buffer = b""
+    while len(buffer) < count:
+        chunk = sock.recv(count - len(buffer))
+        if not chunk:
+            return None
+        buffer += chunk
+    return buffer
+
+
+# ------------------------------------------------------------------------- steam
+
+
+def _parse_vdf(text: str) -> dict[str, Any]:
+    """Parse Valve KeyValues text into nested dicts.
+
+    Hand-rolled because the tool is stdlib-only and the file has two traps a line- or
+    regex-based read falls into: keys carry escaped quotes (``External: eDP-1 7\\"|||…``)
+    and some values span multiple lines (``SDL_GamepadBind``).
+    """
+    root: dict[str, Any] = {}
+    stack: list[dict[str, Any]] = [root]
+    pending_key: str | None = None
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            token, i = _read_quoted(text, i + 1)
+            if pending_key is None:
+                pending_key = token
+            else:
+                stack[-1][pending_key] = token
+                pending_key = None
+        elif c == "{":
+            child: dict[str, Any] = {}
+            stack[-1][pending_key or ""] = child
+            stack.append(child)
+            pending_key = None
+            i += 1
+        elif c == "}":
+            if len(stack) > 1:
+                stack.pop()
+            i += 1
+        elif c == "/" and text.startswith("//", i):
+            i = text.find("\n", i)
+            if i == -1:
+                break
+        else:
+            i += 1
+    return root
+
+
+def _read_quoted(text: str, start: int) -> tuple[str, int]:
+    """Read a quoted VDF token starting after the opening quote; return (token, next_index)."""
+    out: list[str] = []
+    i = start
+    while i < len(text):
+        c = text[i]
+        if c == "\\" and i + 1 < len(text):
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if c == '"':
+            return "".join(out), i + 1
+        out.append(c)
+        i += 1
+    return "".join(out), i
+
+
+def _lookup(node: Any, *keys: str) -> Any:
+    """Walk nested dicts case-insensitively (VDF key casing is not guaranteed)."""
+    for key in keys:
+        if not isinstance(node, dict):
+            return None
+        node = next((v for k, v in node.items() if k.lower() == key.lower()), None)
+    return node
+
+
+@dataclass(frozen=True)
+class SteamScaleState:
+    """The UI Scale the user is on, plus the dpr the Big Picture view was rendering at.
+
+    ``auto`` ON means Steam derives the factor from the display; OFF means the user picked
+    a fixed one, and then ``factor`` is that choice — which is why the restore only replays
+    ``factor`` when ``auto`` is OFF (under auto it is a value Steam *computed*, not a
+    setting). ``dpr`` is what the view actually rendered at before the tool touched
+    anything: the ground truth the restore is verified against.
+    """
+
+    auto: bool
+    factor: float | None
+    dpr: float | None
+    source: str
+
+    def describe(self) -> str:
+        if self.auto:
+            return "AUTOMATIC scaling"
+        return f"MANUAL UI Scale {self.factor}"
+
+
+def _read_live_scale_state() -> tuple[bool, float | None] | None:
+    """Read the UI Scale from Steam's live settings store; ``None`` if unavailable.
+
+    ``window.settingsStore.settings`` (in SharedJSContext) is what Steam's own Display
+    settings page renders from — ``bDisplayIsUsingAutoScale`` is the authoritative auto
+    flag and ``flCurrentDisplayScaleFactor`` the factor in force. This is the *live* state,
+    which is what makes it trustworthy: ``config.vdf``'s ``AutoScaleFactor`` is not
+    re-flushed in-session (measured on-device: it stayed ``1`` while a manual factor was
+    applied and rendering), so the file can misreport a manual scale as automatic.
+    """
+    expression = """
+    (() => {
+      const s = window.settingsStore && window.settingsStore.settings;
+      if (!s || typeof s.bDisplayIsUsingAutoScale !== 'boolean') return null;
+      return JSON.stringify({
+        auto: s.bDisplayIsUsingAutoScale,
+        factor: s.flCurrentDisplayScaleFactor,
+      });
+    })()
+    """
+    try:
+        ws_url = _find_ws_url(_list_targets(), _normalize_title(_SHARED_JS_CONTEXT), prefix=True)
+        if ws_url is None:
+            return None
+        raw = _evaluate(ws_url, expression)
+    except DevUiScaleError:
+        return None
+    if not isinstance(raw, str):
+        return None
+    state = json.loads(raw)
+    factor = state.get("factor")
+    return bool(state["auto"]), float(factor) if isinstance(factor, (int, float)) else None
+
+
+def _read_config_vdf_scale_state() -> tuple[bool, float | None] | None:
+    """Fallback read of ``UI -> display -> Current`` in ``config.vdf``; ``None`` if unreadable.
+
+    Read-only. ``AutoScaleFactor "0"`` means a manual UI Scale. Only consulted when the
+    live settings store is unavailable — see ``_read_live_scale_state`` for why the file
+    is the weaker source.
+    """
+    try:
+        with open(_STEAM_CONFIG_VDF, encoding="utf-8", errors="replace") as f:
+            config = _parse_vdf(f.read())
+    except OSError as e:
+        print(f"WARNING: could not read {_STEAM_CONFIG_VDF} ({e})")
+        return None
+
+    current = _lookup(config, "InstallConfigStore", "UI", "display", "Current")
+    if not isinstance(current, dict):
+        print(f"WARNING: {_STEAM_CONFIG_VDF} has no UI/display/Current block")
+        return None
+    auto = str(_lookup(current, "AutoScaleFactor") or "1") != "0"
+    raw = _lookup(current, "ScaleFactor")
+    try:
+        factor = float(str(raw))
+    except (TypeError, ValueError):
+        if not auto:
+            print(f"WARNING: Steam's manual ScaleFactor is unreadable ({raw!r})")
+            return None
+        factor = None
+    return auto, factor
+
+
+def _read_scale_state() -> tuple[tuple[bool, float | None], str] | None:
+    """The UI Scale in force, with the source it came from; ``None`` if neither can be read."""
+    live = _read_live_scale_state()
+    if live is not None:
+        return live, "Steam's live settings store"
+    print("WARNING: Steam's live settings store is unreadable — falling back to config.vdf")
+    stored = _read_config_vdf_scale_state()
+    return None if stored is None else (stored, "config.vdf")
+
+
+def _capture_prior_state() -> SteamScaleState | None:
+    """Capture (and print) the scale the user was on BEFORE this run.
+
+    ``None`` means the prior state is unknown — the caller must then fall back to
+    restoring automatic scaling and say out loud that it is a fallback.
+    """
+    read = _read_scale_state()
+    if read is None:
+        return None
+    (auto, factor), source = read
+    prior = SteamScaleState(auto=auto, factor=factor, dpr=_current_dpr(), source=source)
+    dpr = "unknown" if prior.dpr is None else prior.dpr
+    print(f"Captured prior state: {prior.describe()} at dpr {dpr} (source: {source})")
+    return prior
+
+
+def _steam_configured_scale() -> float:
+    """Return the manual factor the user has set in Steam, or the deck default.
+
+    Auto ON means there is no user-chosen number to adopt — fall back and say so.
+    """
+    read = _read_scale_state()
+    if read is None:
+        print(f"Could not read Steam's UI Scale — falling back to deck default {_DECK_SCALE}")
+        return _DECK_SCALE
+    (auto, factor), _ = read
+    if auto or factor is None:
+        print(f"Steam is on AUTOMATIC UI scaling (no manual factor set) — falling back to deck default {_DECK_SCALE}")
+        return _DECK_SCALE
+    print(f"Adopting the UI Scale you have set in Steam: {factor}")
+    return factor
+
+
+def _current_dpr() -> float | None:
+    """The Big Picture view's live ``devicePixelRatio``; ``None`` if it can't be read."""
+    try:
+        ws_url = _find_ws_url(_list_targets(), _BPM_TITLE_MARKER, prefix=False)
+        if ws_url is None:
+            return None
+        return float(str(_evaluate(ws_url, "String(devicePixelRatio)")))
+    except (DevUiScaleError, ValueError):
+        return None
+
+
+def _set_scale(factor: float | None) -> None:
+    """Force *factor*, or restore Steam's automatic scaling when *factor* is ``None``."""
+    targets = _list_targets()
+    ws_url = _find_ws_url(targets, _normalize_title(_SHARED_JS_CONTEXT), prefix=True)
+    if ws_url is None:
+        raise DevUiScaleError(
+            f"no {_SHARED_JS_CONTEXT} debug target on {_DEBUGGER_URL}. Is Big Picture running? "
+            "Start the dev loop with `mise run dev:watch`."
+        )
+    if factor is None:
+        expression = "(() => { SteamClient.Window.SetGamepadUIAutoDisplayScale(true); return 'auto'; })()"
+    else:
+        expression = (
+            "(() => {"
+            "  SteamClient.Window.SetGamepadUIAutoDisplayScale(false);"
+            f"  SteamClient.Window.SetGamepadUIManualDisplayScaleFactor({factor});"
+            f"  return {factor};"
+            "})()"
+        )
+    _evaluate(ws_url, expression)
+
+
+def _measure() -> None:
+    """Print the real CSS metrics of both views, next to the Game Mode reference."""
+    targets = _list_targets()
+    views = (
+        ("Big Picture", _find_ws_url(targets, _BPM_TITLE_MARKER, prefix=False)),
+        ("QuickAccess", _find_ws_url(targets, _QAM_TITLE_PREFIX, prefix=True)),
+    )
+    expression = "JSON.stringify({dpr: window.devicePixelRatio, w: window.innerWidth, h: window.innerHeight})"
+    qam: dict[str, Any] | None = None
+    for label, ws_url in views:
+        if ws_url is None:
+            print(f"  {label:<12} target not found (view not open?)")
+            continue
+        metrics = json.loads(str(_evaluate(ws_url, expression)))
+        print(f"  {label:<12} dpr {metrics['dpr']}  CSS {metrics['w']}x{metrics['h']}")
+        if label == "QuickAccess":
+            qam = metrics
+
+    ref_w, ref_h = _GAME_MODE_QAM
+    if qam is None:
+        print(f"  (Game Mode reference: QAM {ref_w}x{ref_h})")
+    elif (qam["w"], qam["h"]) == (ref_w, ref_h):
+        print(f"  => QAM matches the Game Mode reference ({ref_w}x{ref_h}) — what you see is what the Deck renders.")
+    else:
+        delta = qam["h"] - ref_h
+        sign = "+" if delta >= 0 else ""
+        print(
+            f"  => QAM is {qam['w']}x{qam['h']} vs the Game Mode reference {ref_w}x{ref_h} "
+            f"({sign}{delta} px of height)."
+        )
+
+
+# -------------------------------------------------------------------------- main
+
+
+_USAGE = """usage: dev_ui_scale.py [deck | <factor> | steam | auto]
+
+  deck      (default) force 1.5 — the Deck internal panel's auto scale, i.e. exact
+            Game Mode metrics (QAM 854x454).
+  <factor>  force a bare number. 2.0-2.4 = a user on "Larger text" (worst case: least
+            vertical room), ~1.28 = docked 1080p, ~1.71 = docked 1440p.
+  steam     adopt the UI Scale the user currently has set in Steam (config.vdf); falls
+            back to 1.5 when Steam is on automatic scaling.
+  auto|off  UNCONDITIONALLY re-enable Steam's automatic scaling and exit. This is the
+            rescue path for when a previous run was SIGKILLed and its captured state
+            died with it — it does NOT know what you were on, it just forces auto.
+
+The forcing modes hold until Ctrl-C, then restore the scale you were on BEFORE the run:
+auto stays auto, and a manual UI Scale (e.g. an accessibility "Larger text" value) is put
+back exactly as it was — never silently flipped to auto."""
+
+
+def _parse_mode(argv: list[str]) -> float | None:
+    """Map the single positional arg to a factor, or ``None`` for restore-and-exit."""
+    if not argv:
+        return _DECK_SCALE
+    arg = argv[0].strip().lower()
+    if arg in ("-h", "--help"):
+        print(_USAGE)
+        raise SystemExit(0)
+    if arg in ("auto", "off"):
+        return None
+    if arg == "deck":
+        return _DECK_SCALE
+    if arg == "steam":
+        return _steam_configured_scale()
+    try:
+        factor = float(arg)
+    except ValueError:
+        raise DevUiScaleError(f"unknown mode {argv[0]!r}\n\n{_USAGE}") from None
+    if not 0.5 <= factor <= 2.5:
+        raise DevUiScaleError(f"factor {factor} is outside Steam's 0.5-2.5 UI Scale range")
+    return factor
+
+
+def _on_signal(_signum: int, _frame: FrameType | None) -> None:
+    """Turn SIGTERM into the same unwind Ctrl-C takes, so the ``finally`` restore runs."""
+    raise KeyboardInterrupt
+
+
+def _restore(prior: SteamScaleState | None) -> None:
+    """Put *prior* back — exactly. Never raises: it runs in a ``finally``.
+
+    A user who deliberately set a manual UI Scale (an accessibility "Larger text" value,
+    say) must get that scale back, not Steam's automatic one — flipping them to auto on
+    exit would silently destroy their setting. Automatic scaling is restored only when
+    that is what they were on, or as an announced fallback when the prior state is unknown.
+    """
+    try:
+        if prior is None:
+            _set_scale(None)
+            print(
+                "FALLBACK: prior state was unknown, so Steam's AUTOMATIC scaling was restored.\n"
+                "If you had a manual UI Scale set, re-set it in Steam (Settings -> Display -> UI Scale).",
+                file=sys.stderr,
+            )
+        elif prior.auto:
+            _set_scale(None)
+            print("Restored: AUTOMATIC scaling (the state captured before this run).")
+        else:
+            _set_scale(prior.factor)
+            print(f"Restored: MANUAL UI Scale {prior.factor} (the state captured before this run).")
+    except DevUiScaleError as e:
+        target = "automatic scaling" if prior is None or prior.auto else f"manual UI Scale {prior.factor}"
+        print(
+            f"\nCOULD NOT RESTORE {target} ({e}).\n"
+            "Steam is STILL on the forced scale, and Steam persists it — fix it with:\n"
+            "  mise run dev:ui-scale auto",
+            file=sys.stderr,
+        )
+        return
+    _verify_restore(prior)
+
+
+def _verify_restore(prior: SteamScaleState | None) -> None:
+    """Check the restore actually landed, rather than just claiming it did.
+
+    Verified against the live settings store and the live ``devicePixelRatio`` — never
+    against ``config.vdf``, whose ``AutoScaleFactor`` is not re-flushed in-session and so
+    cannot tell an auto restore from a forced scale.
+    """
+    time.sleep(_SETTLE_SEC)
+    dpr = _current_dpr()
+    live = _read_live_scale_state()
+    now = "an unreadable state" if live is None else SteamScaleState(live[0], live[1], dpr, "live").describe()
+    print(f"Verified: Steam is on {now}, rendering at dpr {'unknown' if dpr is None else dpr}")
+    if prior is None:
+        return
+
+    auto_drifted = live is not None and live[0] != prior.auto
+    factor_drifted = live is not None and not prior.auto and live[1] != prior.factor
+    dpr_drifted = prior.dpr is not None and dpr is not None and abs(dpr - prior.dpr) > 0.01
+    if auto_drifted or factor_drifted or dpr_drifted:
+        print(
+            f"WARNING: that is NOT the state captured before this run ({prior.describe()} at dpr {prior.dpr}).\n"
+            "The restore did not land — check Steam -> Settings -> Display -> UI Scale.",
+            file=sys.stderr,
+        )
+
+
+def main(argv: list[str]) -> int:
+    # Piped stdout (which is how `mise run` invokes this) is block-buffered by default, so
+    # the progress lines would surface out of order against the unbuffered stderr warnings —
+    # and a warning that appears before the action it refers to is worse than no warning.
+    sys.stdout.reconfigure(line_buffering=True)
+    try:
+        factor = _parse_mode(argv)
+    except DevUiScaleError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    # The rescue path: no prior state to honour (the run that had it was killed), so this
+    # deliberately forces auto ON rather than restoring anything.
+    if factor is None:
+        try:
+            _set_scale(None)
+        except DevUiScaleError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+        print("Steam's automatic UI scaling force-enabled (rescue mode).")
+        return 0
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    # Capture BEFORE applying — this is the state the exit path has to put back.
+    prior = _capture_prior_state()
+    print(f"Forcing GamepadUI display scale {factor} (auto scaling OFF)...")
+    try:
+        _set_scale(factor)
+        # The QAM is a popup view Steam can recreate at will. Steam's own scale (unlike a
+        # CDP Emulation override, which is per-view and dies with the view) is display
+        # state that any recreated view picks up — so there is nothing to re-apply here.
+        # Do not "fix" this by adding a polling loop.
+        time.sleep(_SETTLE_SEC)
+        print("\nMeasured (real, repainted — not a CDP emulation override):")
+        _measure()
+        print(
+            f"\nHOLDING — Ctrl-C restores what you were on before this run ({_describe(prior)}).\n"
+            "WARNING: Steam persists this scale to config.vdf, under the same display identity\n"
+            "Game Mode uses. A hard kill (SIGKILL) skips the restore — recover with:\n"
+            "  mise run dev:ui-scale auto"
+        )
+        signal.pause()
+    except KeyboardInterrupt:
+        print("\nRestoring...")
+    except DevUiScaleError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        # Covers the apply itself: the forcing expression sets auto=false before it sets
+        # the factor, so even a half-applied scale must be undone.
+        _restore(prior)
+    return 0
+
+
+def _describe(prior: SteamScaleState | None) -> str:
+    return "unknown — will fall back to automatic" if prior is None else prior.describe()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/dev_ui_scale.py
+++ b/scripts/dev_ui_scale.py
@@ -38,6 +38,18 @@ sits on. ``frameGeometry`` includes decorations, so the frame is corrected by th
 frame-vs-client delta until the client area lands exactly. The window's prior geometry and
 fullscreen state are captured first and restored on exit, alongside the scale.
 
+The scale reaches only the views that are RENDERED when it is pushed. Steam's QuickAccess
+view is created with the Big Picture window but laid out lazily, on the first QAM open of
+that session: until then it measures 1x1 CSS. A view that renders after the push can come
+up UNSCALED — measured at dpr 1, CSS 854x720, i.e. exactly the dev-loop lie this tool
+exists to kill — and re-issuing the same two calls while it is live flips it to 1.5 /
+854x454 on the spot (also measured). Whether a given view misses the push is not something
+the tool can know up front, so the hold is a polling loop rather than a ``signal.pause()``:
+it watches the QuickAccess view and re-pushes whenever it finds one rendering at the wrong
+dpr, which also covers Steam re-materializing the popup later in the session. An unrendered
+QAM is therefore not a failure — it is a not-yet, and it is reported as one (open the QAM
+once and the tool verifies it).
+
 DANGER — the forced scale PERSISTS: Steam flushes it to
 ``~/.local/share/Steam/config/config.vdf`` (``UI -> display -> Current -> ScaleFactor``)
 within a couple of seconds. A factor left forced is a factor Steam keeps.
@@ -96,6 +108,7 @@ import tempfile
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -138,6 +151,16 @@ _QAM_CSS_WIDTH = 854
 # Fractional-dpr rounding costs about a pixel (854 at 1.5, 855 at 1.9), so the emulation is
 # "achieved" within a hair, not bit-exactly.
 _QAM_TOLERANCE_PX = 3
+# A view Steam has created but never laid out reports 1x1 CSS (measured on a Big Picture
+# whose QAM has not been opened yet). The real QAM is ~854 wide in every configuration, so
+# anything this small is "never rendered", not "rendered wrong" — a not-yet, not a failure.
+_RENDERED_MIN_CSS_PX = 16
+# Steam reports a scale of 1.9 as 1.899999976158142 (float32 round-trip), so dpr equality is
+# a comparison within a hair, never ==.
+_DPR_EPSILON = 0.01
+# How often the hold re-checks the QuickAccess view for a late (unscaled) render. Cheap: one
+# CDP evaluate against a view that is usually already correct.
+_POLL_SEC = 2.0
 
 _QAM_TITLE_PREFIX = "quickaccess"
 _BPM_TITLE_MARKER = "bigpicture"
@@ -931,6 +954,18 @@ class ViewMetrics:
         """The view's size in real pixels — for Big Picture, the window's client area."""
         return round(self.css_w * self.dpr), round(self.css_h * self.dpr)
 
+    @property
+    def rendered(self) -> bool:
+        """Has Steam ever laid this view out? A created-but-never-shown view reports 1x1 CSS."""
+        return min(self.css_w, self.css_h) >= _RENDERED_MIN_CSS_PX
+
+    def scaled_at(self, factor: float) -> bool:
+        """Is this view rendering at *factor*? (Float-tolerant: Steam's 1.9 is 1.899999976158142.)"""
+        return abs(self.dpr - factor) <= _DPR_EPSILON
+
+    def describe(self) -> str:
+        return f"dpr {self.dpr}  CSS {self.css_w}x{self.css_h}"
+
 
 def _measure_view(match: str, *, prefix: bool) -> ViewMetrics | None:
     """Measure one CEF view's live CSS metrics; ``None`` when the view is not open."""
@@ -955,7 +990,22 @@ def _expected_qam_css(factor: float) -> tuple[int, int]:
     return _QAM_CSS_WIDTH, math.ceil(window_h / factor) - _QAM_HEADER_CSS
 
 
-def _verify_emulation(factor: float, window: BpmWindow | None) -> bool:
+class Verdict(Enum):
+    """The outcome of measuring the emulation against what a Deck renders.
+
+    ``PENDING`` is the one that is neither of the other two: the window and the scale are
+    right, but the QAM has never been opened in this Big Picture session, so Steam has not
+    laid its view out and there is nothing to measure yet. Reporting that as ``FAILED``
+    (which it was) cries wolf on the single most common way to start the tool — a fresh Big
+    Picture — and trains the reader to ignore the one block that must never be ignored.
+    """
+
+    ACHIEVED = "achieved"
+    PENDING = "pending"
+    FAILED = "failed"
+
+
+def _verify_emulation(factor: float, window: BpmWindow | None) -> Verdict:
     """Measure both views and check the emulation was actually ACHIEVED, not just requested.
 
     The whole point of the tool: a forced scale on a window that is not the Deck's size
@@ -967,26 +1017,23 @@ def _verify_emulation(factor: float, window: BpmWindow | None) -> bool:
     qam = _measure_view(_QAM_TITLE_PREFIX, prefix=True)
     for label, view in (("Big Picture", bpm), ("QuickAccess", qam)):
         if view is None:
-            print(f"  {label:<12} target not found (view not open?)")
+            print(f"  {label:<12} target not found (view not created yet)")
+        elif not view.rendered:
+            print(f"  {label:<12} {view.describe()} — created, never rendered")
         else:
-            print(f"  {label:<12} dpr {view.dpr}  CSS {view.css_w}x{view.css_h}")
+            print(f"  {label:<12} {view.describe()}")
 
     expected_w, expected_h = _expected_qam_css(factor)
-    if qam is None:
-        print(
-            f"\nFAILED to verify the emulation: the QuickAccess view is not open, so its size\n"
-            f"could not be measured (expected {expected_w}x{expected_h} CSS at scale {factor}).\n"
-            "Open the QAM in Big Picture and re-run.",
-            file=sys.stderr,
-        )
-        return False
+    if qam is None or not qam.rendered:
+        _report_pending(factor, bpm)
+        return Verdict.PENDING
 
     if abs(qam.css_w - expected_w) <= _QAM_TOLERANCE_PX and abs(qam.css_h - expected_h) <= _QAM_TOLERANCE_PX:
         print(
             f"  => QAM is {qam.css_w}x{qam.css_h} CSS at dpr {qam.dpr}, the {expected_w}x{expected_h} "
             f"a Deck renders at scale {factor} — this is what the Deck renders."
         )
-        return True
+        return Verdict.ACHIEVED
 
     window_size = _window_physical_size(window, bpm)
     deck_w, deck_h = _DECK_WINDOW
@@ -1000,7 +1047,73 @@ def _verify_emulation(factor: float, window: BpmWindow | None) -> bool:
         f"  size). Any layout judgement made on these numbers is invalid.",
         file=sys.stderr,
     )
-    return False
+    return Verdict.FAILED
+
+
+def _report_pending(factor: float, bpm: ViewMetrics | None) -> None:
+    """Say that the QAM has not been rendered yet — a not-yet, not a failure.
+
+    Everything the tool controls (window size, forced scale) has landed; the one thing it
+    cannot do is open the QAM for the user. Steam lays that view out lazily, on the first
+    open of the session, so there is nothing to measure until then.
+    """
+    expected_w, expected_h = _expected_qam_css(factor)
+    deck_w, deck_h = _DECK_WINDOW
+    applied = "at the forced scale" if bpm is None else f"at dpr {bpm.dpr}"
+    print(
+        f"\nQAM NOT VERIFIED YET — the emulation is applied, the QAM has simply never been opened.\n"
+        f"  Big Picture: {deck_w}x{deck_h} physical, scale forced to {factor} (rendering {applied}).\n"
+        f"  Steam creates the QuickAccess view with the window but lays it out only on the FIRST\n"
+        f"  QAM open of a Big Picture session — until then it is 1x1, and Steam's scale push reaches\n"
+        f"  only rendered views, so a QAM opened later can come up unscaled (dpr 1).\n"
+        f"  => OPEN THE QAM ONCE. This tool re-applies the scale to it the moment it renders, and\n"
+        f"     then verifies it against the {expected_w}x{expected_h} a Deck shows at scale {factor}."
+    )
+
+
+def _hold(factor: float, window: BpmWindow | None, *, verified: bool) -> None:
+    """Hold until Ctrl-C, re-applying the scale to any QuickAccess view that renders late.
+
+    This is the loop the tool cannot do without. Steam's scale push reaches only the views
+    that are RENDERED when it lands, and the QuickAccess view is laid out lazily on the
+    first QAM open of a Big Picture session — so a QAM opened after the force can come up at
+    dpr 1 / 854x720 (measured), which is precisely the dev-loop lie the tool exists to kill.
+    Re-issuing the same two calls while that view is live flips it to dpr 1.5 / 854x454
+    immediately (measured), and the same applies whenever Steam re-materializes the popup.
+
+    Quiet by construction: it re-applies only when a RENDERED view is at the wrong dpr, and
+    only once per distinct measurement — so a re-apply that does not take (Steam gone, say)
+    prints once instead of every two seconds.
+    """
+    acted_on: tuple[float, int, int] | None = None
+    while True:
+        time.sleep(_POLL_SEC)  # KeyboardInterrupt lands here; the caller's finally restores
+        qam = _measure_view(_QAM_TITLE_PREFIX, prefix=True)
+        if qam is None or not qam.rendered:
+            continue  # the QAM has still never been opened — nothing to scale, nothing to say
+        if qam.scaled_at(factor):
+            if not verified:  # it rendered already correct: verify once, then go quiet
+                _reverify(factor, window)
+                verified = True
+            continue
+        measurement = (qam.dpr, qam.css_w, qam.css_h)
+        if measurement == acted_on:
+            continue  # already re-applied for exactly this view state and it did not take
+        acted_on = measurement
+        print(
+            f"\nQuickAccess view is at {qam.describe()} — not the forced {factor}.\n"
+            f"Re-applying the scale (Steam's push reaches only the views that are rendered when it lands)..."
+        )
+        _set_scale(factor)
+        time.sleep(_SETTLE_SEC)
+        _reverify(factor, window)
+        verified = True
+
+
+def _reverify(factor: float, window: BpmWindow | None) -> None:
+    """Re-run the full verification and print the verdict — same numbers, same loud failure."""
+    print("\nMeasured (real, repainted — not a CDP emulation override):")
+    _verify_emulation(factor, window)
 
 
 def _window_physical_size(window: BpmWindow | None, bpm: ViewMetrics | None) -> str:
@@ -1190,23 +1303,21 @@ def main(argv: list[str]) -> int:
         window = _emulate_deck_window(prior_window)
         print(f"Forcing GamepadUI display scale {factor} (auto scaling OFF)...")
         _set_scale(factor)
-        # The QAM is a popup view Steam can recreate at will. Steam's own scale (unlike a
-        # CDP Emulation override, which is per-view and dies with the view) is display
-        # state that any recreated view picks up — so there is nothing to re-apply here.
-        # Do not "fix" this by adding a polling loop.
         time.sleep(_SETTLE_SEC)
         print(f"  scaling display: {_read_display_name() or 'unknown'}")
         print("\nMeasured (real, repainted — not a CDP emulation override):")
-        _verify_emulation(factor, window)
+        verdict = _verify_emulation(factor, window)
         print(
             f"\nHOLDING — Ctrl-C restores what you were on before this run\n"
             f"  scale:  {_describe(prior)}\n"
             f"  window: {prior_window.describe() if prior_window else 'unknown — will be left as-is'}\n"
+            "The QuickAccess view is watched while this holds: Steam's scale reaches only the views\n"
+            "that are rendered when it is pushed, so a QAM opened later is re-scaled here.\n"
             "WARNING: Steam persists this scale to config.vdf, filed under the display identity\n"
             "printed above. A hard kill (SIGKILL) skips the restore — recover with:\n"
             "  mise run dev:ui-scale auto"
         )
-        signal.pause()
+        _hold(factor, window, verified=verdict is not Verdict.PENDING)
     except KeyboardInterrupt:
         print("\nRestoring...")
     except DevUiScaleError as e:

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -120,8 +120,6 @@ vi.mock("../utils/syncManager", () => ({
   resetSyncCancel: vi.fn(),
 }));
 
-vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
-
 // Local @decky/ui re-mock — global stub lacks ProgressBarWithInfo (used to
 // render sync + download progress). Mirror the rest with thin pass-throughs
 // + a vi.fn showModal so we can capture ConfirmModal calls.
@@ -138,6 +136,9 @@ vi.mock("@decky/ui", async () => {
         p.children as never,
       ),
     PanelSectionRow: passthrough("div"),
+    // Focusable wrappers around read-only rows (info fields, banners, progress) —
+    // pass children through a plain div so the wrapped content stays queryable.
+    Focusable: passthrough("div"),
     ButtonItem: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
       ce("button", { onClick, disabled }, children as never),
     Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
@@ -412,11 +413,14 @@ describe("MainPage", () => {
       expect(queryByTestId("version-error-card")).toBeNull();
     });
 
-    it("renders the full panel with Status / Sync / Settings sections by default", async () => {
+    it("renders the full panel with the untitled status block plus Sync / Settings sections by default", async () => {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       const titles = Array.from(container.querySelectorAll('[data-testid="panel-title"]')).map((n) => n.textContent);
-      expect(titles).toEqual(expect.arrayContaining(["Status", "Sync", "Settings"]));
+      // The status block leads the panel untitled; the section titles provide
+      // the block breaks.
+      expect(titles).toEqual(expect.arrayContaining(["Sync", "Settings"]));
+      expect(titles).not.toContain("Status");
     });
   });
 
@@ -456,11 +460,10 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      // Library line includes "42 games" — the stat counts bound shortcuts
-      // (sibling groups), so the label says games, not ROMs (#1298 audit).
-      expect(container.textContent).toContain("42 games");
-      expect(container.textContent).toContain("3 platforms");
-      expect(container.textContent).toContain("2 collections");
+      // Pin the joined one-line library form (order, "·" separators, plural
+      // forms). The stat counts bound shortcuts (sibling groups), so the label
+      // says games, not ROMs (#1298 audit).
+      expect(container.textContent).toContain("42 games · 3 platforms · 2 collections");
     });
 
     it("testConnection success sets connected=true and clears versionError", async () => {
@@ -972,17 +975,18 @@ describe("MainPage", () => {
       expect(descs).toContain("Everything is up to date.");
     });
 
-    it("renders ROMs section with added/updated/removed counts", async () => {
+    it("renders the Games category in signed notation (added / updated / removed)", async () => {
       const c = await renderPreview({
         new_count: 3,
         changed_count: 1,
         remove_count: 2,
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d.includes("Games: 3 added, 1 updated, 2 removed"))).toBe(true);
+      // U+2212 minus for the removed segment; " / "-separated; " · " between categories.
+      expect(descs.some((d) => d.includes("Games +3 / ~1 / −2"))).toBe(true);
     });
 
-    it("renders Platforms section from platform_collection_diff", async () => {
+    it("renders the Platforms category from platform_collection_diff", async () => {
       const c = await renderPreview({
         platform_collection_diff: {
           has_changes: true,
@@ -991,10 +995,10 @@ describe("MainPage", () => {
         },
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d.includes("Platforms: 2 added, 1 removed"))).toBe(true);
+      expect(descs.some((d) => d.includes("Platforms +2 / −1"))).toBe(true);
     });
 
-    it("renders Collections section from collection_diff", async () => {
+    it("renders the Collections category from collection_diff", async () => {
       const c = await renderPreview({
         collection_diff: {
           has_changes: true,
@@ -1003,19 +1007,32 @@ describe("MainPage", () => {
         },
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      expect(descs.some((d) => d.includes("Collections: 2 added, 1 removed"))).toBe(true);
+      expect(descs.some((d) => d.includes("Collections +2 / −1"))).toBe(true);
     });
 
-    it("filters zero counts from formatChanges (e.g. 0 removed → not rendered)", async () => {
+    it("joins multiple categories with ' · ' and omits zero segments", async () => {
+      const c = await renderPreview({
+        new_count: 1001,
+        changed_count: 50,
+        remove_count: 1200,
+        platform_collection_diff: { has_changes: true, added_count: 1, removed_count: 0 },
+        collection_diff: { has_changes: true, added: ["A", "B"], removed: [] },
+      });
+      const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
+      // Zero segments (platform removed, collection removed) drop out entirely.
+      expect(descs).toContain("Games +1001 / ~50 / −1200 · Platforms +1 · Collections +2");
+    });
+
+    it("omits zero segments within a category (0 removed → not rendered)", async () => {
       const c = await renderPreview({
         new_count: 1,
         changed_count: 0,
         remove_count: 0,
       });
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
-      // Should render "Games: 1 added" — no "updated" or "removed" tokens.
-      const romsLine = descs.find((d) => d.startsWith("Games:"));
-      expect(romsLine).toBe("Games: 1 added");
+      // Should render "Games +1" — no "~" or "−" segments.
+      const gamesLine = descs.find((d) => d.startsWith("Games"));
+      expect(gamesLine).toBe("Games +1");
     });
   });
 
@@ -1053,7 +1070,8 @@ describe("MainPage", () => {
       const c = await renderPreviewWithPause(true);
       const advisory = c.querySelector('[data-testid="budget-advisory"]') as HTMLElement | null;
       expect(advisory).not.toBeNull();
-      expect(advisory?.textContent).toContain("pause partway");
+      expect(advisory?.textContent).toContain("Will likely pause partway to protect Steam");
+      expect(advisory?.textContent).toContain("Restart Steam when prompted, then Resume Sync.");
       // Recolored from amber to blue — it announces normal, planned behavior (#1383).
       expect(advisory?.style.color).toBe("#7fbcff");
     });
@@ -1096,25 +1114,33 @@ describe("MainPage", () => {
       return container;
     }
 
-    it("shows 'N platforms · M collections' with both counts", async () => {
+    // The Scope row now carries the estimate too (the separate "Estimated time"
+    // preview row was merged in): "<scope> · <estimate>". These summaries have zero
+    // diffs, so the estimate is the bare fetch allowance → "~2 min".
+    it("shows 'N platforms · M collections · <estimate>' with both counts", async () => {
       const c = await renderPreviewScope(3, 2);
-      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("3 platforms · 2 collections");
+      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("3 platforms · 2 collections · ~2 min");
     });
 
     it("omits the collections part when the run syncs none, and singularizes", async () => {
       const c = await renderPreviewScope(1, 0);
-      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("1 platform");
+      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("1 platform · ~2 min");
     });
 
     it("omits the platforms part on a collections-only run (LOW-6)", async () => {
       const c = await renderPreviewScope(0, 3);
-      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("3 collections");
+      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("3 collections · ~2 min");
     });
 
     it("renders always (even with zero diffs)", async () => {
       const c = await renderPreviewScope(5, 0);
       // The preview description reads 'Everything is up to date.' yet the scope line still shows.
-      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("5 platforms");
+      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("5 platforms · ~2 min");
+    });
+
+    it("shows the estimate alone when the backend omits both scope counts (empty scope)", async () => {
+      const c = await renderPreviewScope(0, 0);
+      expect(c.querySelector('[data-testid="sync-scope"]')?.textContent).toBe("~2 min");
     });
   });
 
@@ -1323,25 +1349,25 @@ describe("MainPage", () => {
       return container;
     }
 
-    it("shows the live memory value and the signed last-run delta", async () => {
+    it("shows the live memory value and the signed last-run delta on one line", async () => {
       const c = await renderMemoryRow(440_000, 800_000);
       const row = c.querySelector('[data-testid="steam-memory"]');
-      expect(row?.textContent).toContain("0.4 GB");
-      // Label is "last run" (not "last sync"), so a paused run reads honestly as
-      // that run's consumption so far (#36).
-      expect(row?.textContent).toContain("last run: +0.8 GB");
+      // One line "0.4 GB · last run +0.8": the delta drops its GB unit (inline
+      // after the GB reading) and reads "last run" (not "last sync"), so a paused
+      // run reads honestly as that run's consumption so far (#36).
+      expect(row?.textContent).toBe("0.4 GB · last run +0.8");
     });
 
     it("renders a negative delta with a minus sign", async () => {
       const c = await renderMemoryRow(1_000_000, -300_000);
-      expect(c.querySelector('[data-testid="steam-memory"]')?.textContent).toContain("last run: -0.3 GB");
+      expect(c.querySelector('[data-testid="steam-memory"]')?.textContent).toBe("1.0 GB · last run -0.3");
     });
 
-    it("omits the delta line when the delta is unmeasurable (null)", async () => {
+    it("omits the delta part when the delta is unmeasurable (null)", async () => {
       const c = await renderMemoryRow(1_200_000, null);
       const row = c.querySelector('[data-testid="steam-memory"]');
-      expect(row?.textContent).toContain("1.2 GB");
-      expect(row?.textContent).not.toContain("last run:");
+      expect(row?.textContent).toBe("1.2 GB");
+      expect(row?.textContent).not.toContain("last run");
     });
 
     it("omits the whole row when the live reading is unavailable (rss_kb null)", async () => {
@@ -1371,12 +1397,12 @@ describe("MainPage", () => {
       expect(valueColor(c)).toBe("#d4343c");
     });
 
-    it("does not colour the label or the delta sub-line", async () => {
+    it("does not colour the label or the delta part", async () => {
       const c = await renderMemoryRow(2_200_000, 800_000);
-      // The delta sub-line stays uncoloured (only the value carries the colour).
-      const deltaLine = Array.from(c.querySelectorAll("span")).find((s) => s.textContent.startsWith("last run:"));
-      expect(deltaLine).toBeDefined();
-      expect((deltaLine as HTMLElement).style.color).toBe("");
+      // The delta part stays uncoloured (only the value carries the traffic-light colour).
+      const deltaPart = c.querySelector('[data-testid="steam-memory-delta"]') as HTMLElement | null;
+      expect(deltaPart).not.toBeNull();
+      expect(deltaPart!.style.color).toBe("");
     });
   });
 
@@ -1794,34 +1820,50 @@ describe("MainPage", () => {
       return container;
     }
 
+    // Applying-state readout — the separate "Estimated time" Field (sync-scope's
+    // sibling only while a run is in flight).
     function estimateText(container: HTMLElement): string | undefined {
       return container.querySelector('[data-testid="estimate-time"]')?.textContent ?? undefined;
     }
 
-    it("renders an estimate row for a small preview", async () => {
+    // Preview-state readout — the estimate now shares the Scope row (the separate
+    // preview "Estimated time" Field was merged in). These summaries carry no scope
+    // counts, so the scope segment is empty and the row is the bare estimate.
+    function scopeLine(container: HTMLElement): string | undefined {
+      return container.querySelector('[data-testid="sync-scope"]')?.textContent ?? undefined;
+    }
+
+    it("renders an estimate on the scope row for a small preview", async () => {
       // 3 new * 0.45s + 90s fetch allowance = 91.35s → ~2 min (small libraries
       // overshoot; the allowance covers the fetch/prep phase).
       const c = await renderPreviewWithCounts(3, 0);
-      expect(estimateText(c)).toBe("~2 min");
+      expect(scopeLine(c)).toBe("~2 min");
     });
 
-    it("renders an estimate row for a large preview", async () => {
+    it("renders an estimate on the scope row for a large preview", async () => {
       // 1000 new * 0.45s + 90s = 540s → ~9 min.
       const c = await renderPreviewWithCounts(1000, 0);
-      expect(estimateText(c)).toBe("~9 min");
+      expect(scopeLine(c)).toBe("~9 min");
     });
 
     it("prices updated items into the preview estimate", async () => {
       // 100 updated * 0.20s + 90s = 110s → ~2 min.
       const c = await renderPreviewWithCounts(0, 100);
-      expect(estimateText(c)).toBe("~2 min");
+      expect(scopeLine(c)).toBe("~2 min");
     });
 
-    it("shows the always-on info copy alongside the preview estimate", async () => {
+    it("shows the compact info copy alongside the preview estimate (short sync → no sleep caveat)", async () => {
+      // ~2 min preview (< 10 min threshold): the always-shown line only.
       const c = await renderPreviewWithCounts(1, 0);
-      expect(c.textContent).toContain("Progress is saved every ~200 games");
-      expect(c.textContent).toContain("Cancelling is safe");
-      expect(c.textContent).toContain("Long syncs pause while the Deck sleeps and resume on wake");
+      expect(c.textContent).toContain("Progress is saved every ~200 games — cancelling is safe.");
+      expect(c.textContent).not.toContain("Long syncs pause during sleep");
+    });
+
+    it("appends the sleep-pause caveat only when the estimate is ≥ 10 min", async () => {
+      // 1200 new * 0.45s + 90s = 630s ≥ 600s (10 min) → the caveat sentence appears.
+      const c = await renderPreviewWithCounts(1200, 0);
+      expect(c.textContent).toContain("Progress is saved every ~200 games — cancelling is safe.");
+      expect(c.textContent).toContain("Long syncs pause during sleep; keep the Deck powered.");
     });
 
     it("prices the preview row from the WALK cost (new + changed + unchanged), not the raw delta", async () => {
@@ -1850,9 +1892,9 @@ describe("MainPage", () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(estimateText(container)).toBe("~13 min");
+      expect(scopeLine(container)).toBe("~13 min");
       // An estimate must never promise less than reality — the delta-only value is gone.
-      expect(estimateText(container)).not.toBe("~2 min");
+      expect(scopeLine(container)).not.toBe("~2 min");
     });
 
     it("renders 'up to ~X min' while applying when etaSeconds is set", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -827,11 +827,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           />
         </PanelSectionRow>
         <PanelSectionRow>
-          <Field label="Scope" focusable={true} bottomSeparator="none">
-            <span data-testid="sync-scope" style={{ fontSize: "12px" }}>
-              {scopeLine}
-            </span>
-          </Field>
+          {/* Full-width description line like Preview above: the scope+estimate
+              text wraps badly when squeezed into a Field's narrow value column. */}
+          <Field
+            label="Scope"
+            description={
+              <span data-testid="sync-scope" style={{ fontSize: "12px" }}>
+                {scopeLine}
+              </span>
+            }
+            focusable={true}
+            bottomSeparator="none"
+          />
         </PanelSectionRow>
         <PanelSectionRow>
           <Focusable>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -4,6 +4,7 @@ import {
   PanelSectionRow,
   ButtonItem,
   Field,
+  Focusable,
   ProgressBar,
   ProgressBarWithInfo,
   ToggleField,
@@ -31,10 +32,10 @@ import {
   logError,
 } from "../api/backend";
 import { formatBytes } from "../utils/formatters";
+import { pluralize } from "../utils/pluralize";
 import { estimateApplySeconds, formatDuration } from "../utils/syncEstimate";
 import { observeApplyProgress, displayedEtaSeconds, resetEta, formatEtaCountdown } from "../utils/syncEta";
 import { getSyncProgress, setSyncProgress as setStoredSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
-import { scrollToTop } from "../utils/scrollHelpers";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
@@ -87,11 +88,17 @@ const CONNECTION_CALLABLE_TIMEOUT = 5000;
 /** Backend never answered after the retry budget — distinct from `false` ("not connected"). */
 type BackendFailed = "backend_failed";
 
-function formatChanges(pairs: [number, string][]): string {
+/** U+2212 MINUS SIGN — the removed-count prefix in the compact preview notation. */
+const MINUS_SIGN = "−";
+
+/** Compact signed segments — ``[[count, prefix], …]`` → ``"+N / ~M"``: each
+ *  positive count rendered as ``<prefix><count>``, zero counts dropped, joined
+ *  with `` / ``. Empty when every count is zero. */
+function signedSegments(pairs: [number, string][]): string {
   return pairs
     .filter(([n]) => n > 0)
-    .map(([n, label]) => `${n} ${label}`)
-    .join(", ");
+    .map(([n, prefix]) => `${prefix}${n}`)
+    .join(" / ");
 }
 
 const ConnectionIndicator: FC<{ connected: boolean | null | BackendFailed }> = ({ connected }) => {
@@ -209,48 +216,69 @@ function lastSyncValue(stats: SyncStats): ReactNode {
   return <span style={{ fontSize: "12px" }}>Never</span>;
 }
 
+/**
+ * Compact signed change notation for the preview — e.g.
+ * ``"Games +1001 / ~50 / −1200 · Platforms +1 · Collections +2"``. Per category
+ * the segments are added (``+N``), updated (``~N``), removed (``−N``, U+2212), in
+ * that order, ``/``-separated; a zero segment is omitted and a wholly-unchanged
+ * category is dropped. Categories join with `` · ``. Falls back to the unchanged
+ * message when nothing differs.
+ */
 function formatPreviewDescription(s: SyncPreviewSummary): string {
-  const sections: string[] = [];
-  const romChanges = formatChanges([
-    [s.new_count, "added"],
-    [s.changed_count, "updated"],
-    [s.remove_count, "removed"],
+  const categories: string[] = [];
+  const games = signedSegments([
+    [s.new_count, "+"],
+    [s.changed_count, "~"],
+    [s.remove_count, MINUS_SIGN],
   ]);
-  if (romChanges) sections.push(`Games: ${romChanges}`);
+  if (games) categories.push(`Games ${games}`);
   const p = s.platform_collection_diff;
   if (p?.has_changes) {
-    const platChanges = formatChanges([
-      [p.added_count, "added"],
-      [p.removed_count, "removed"],
+    const platforms = signedSegments([
+      [p.added_count, "+"],
+      [p.removed_count, MINUS_SIGN],
     ]);
-    if (platChanges) sections.push(`Platforms: ${platChanges}`);
+    if (platforms) categories.push(`Platforms ${platforms}`);
   }
   const d = s.collection_diff;
   if (d?.has_changes) {
-    const collChanges = formatChanges([
-      [d.added.length, "added"],
-      [d.removed.length, "removed"],
+    const collections = signedSegments([
+      [d.added.length, "+"],
+      [d.removed.length, MINUS_SIGN],
     ]);
-    if (collChanges) sections.push(`Collections: ${collChanges}`);
+    if (collections) categories.push(`Collections ${collections}`);
   }
-  return sections.length > 0 ? sections.join("; ") : "Everything is up to date.";
+  return categories.length > 0 ? categories.join(" · ") : "Everything is up to date.";
 }
 
 /**
  * Informational scope line for the preview — "N platforms · M collections" — the
- * count of enabled platforms/collections the run spans, shown always (independent
- * of the change diffs, #29). Each part is omitted when its count is 0, so a
- * collections-only run reads "3 collections" (not "0 platforms · 3 collections")
- * and a platforms-only run reads "5 platforms". Counts default to 0 when an older
- * backend omits them; a fully-empty scope falls back to "0 platforms".
+ * count of enabled platforms/collections the run spans, shown independent of the
+ * change diffs (#29). Each part is omitted when its count is 0, so a
+ * collections-only run reads "3 collections" and a platforms-only run "5
+ * platforms". Empty when both counts are 0 (an older backend that omits them) —
+ * the caller then shows the estimate alone rather than a misleading "0 platforms".
  */
 function formatSyncScope(s: SyncPreviewSummary): string {
   const platforms = s.sync_platform_count ?? 0;
   const collections = s.sync_collection_count ?? 0;
   const parts: string[] = [];
-  if (platforms > 0) parts.push(`${platforms} platform${platforms === 1 ? "" : "s"}`);
-  if (collections > 0) parts.push(`${collections} collection${collections === 1 ? "" : "s"}`);
-  return parts.length > 0 ? parts.join(" · ") : "0 platforms";
+  if (platforms > 0) parts.push(pluralize(platforms, "platform"));
+  if (collections > 0) parts.push(pluralize(collections, "collection"));
+  return parts.join(" · ");
+}
+
+/**
+ * The Library row's one-line summary — "N games · M platforms · K collections" —
+ * each part correctly singular/plural, zero parts omitted. Games is always
+ * present (the row renders only when ``roms > 0``).
+ */
+function formatLibraryLine(stats: SyncStats): string {
+  const parts = [pluralize(stats.roms, "game")];
+  if (stats.platforms > 0) parts.push(pluralize(stats.platforms, "platform"));
+  const collections = stats.collections ?? 0;
+  if (collections > 0) parts.push(pluralize(collections, "collection"));
+  return parts.join(" · ");
 }
 
 /**
@@ -268,6 +296,11 @@ function formatSyncScope(s: SyncPreviewSummary): string {
 function previewApplySeconds(s: SyncPreviewSummary): number {
   return estimateApplySeconds(s.new_count, s.changed_count + s.unchanged_count);
 }
+
+/** Preview apply-time (seconds) at/above which the hint appends the sleep-pause
+ *  caveat. Below ~10 minutes a sync finishes fast enough that the sleep/resume
+ *  note is noise rather than useful guidance; 10 min = 600 s. */
+const LONG_SYNC_HINT_THRESHOLD_SEC = 600;
 
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [stats, setStats] = useState<SyncStats | null>(null);
@@ -772,49 +805,57 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     // Walk cost, shared with the handleApply seed (previewApplySeconds) so the
     // approved number equals the run's seed. Delta-only pricing here read "~2 min"
     // for a resume whose apply walked ~3100 items.
-    const estimateText = formatDuration(previewApplySeconds(preview.summary));
+    const applySeconds = previewApplySeconds(preview.summary);
+    const estimateText = formatDuration(applySeconds);
+    // Scope and estimate share one row: "1 platform · 2 collections · ~12 min".
+    // An older backend that omits the scope counts leaves scopeText empty, so the
+    // row shows the estimate alone.
     const scopeText = formatSyncScope(preview.summary);
+    const scopeLine = scopeText ? `${scopeText} · ${estimateText}` : estimateText;
+    // The sleep-pause caveat is only worth the extra line for a genuinely long run.
+    const hintText =
+      "Progress is saved every ~200 games — cancelling is safe." +
+      (applySeconds >= LONG_SYNC_HINT_THRESHOLD_SEC ? " Long syncs pause during sleep; keep the Deck powered." : "");
     syncBody = (
       <>
         <PanelSectionRow>
-          <Field label="Preview" description={formatPreviewDescription(preview.summary)} />
+          <Field
+            label="Preview"
+            description={formatPreviewDescription(preview.summary)}
+            focusable={true}
+            bottomSeparator="none"
+          />
         </PanelSectionRow>
         <PanelSectionRow>
-          <Field label="Scope">
+          <Field label="Scope" focusable={true} bottomSeparator="none">
             <span data-testid="sync-scope" style={{ fontSize: "12px" }}>
-              {scopeText}
+              {scopeLine}
             </span>
           </Field>
         </PanelSectionRow>
         <PanelSectionRow>
-          <Field label="Estimated time">
-            <span data-testid="estimate-time" style={{ fontSize: "12px" }}>
-              {estimateText}
-            </span>
-          </Field>
-        </PanelSectionRow>
-        <PanelSectionRow>
-          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.6)", padding: "4px 0" }}>
-            Progress is saved every ~200 games. Cancelling is safe — finished games are kept. Long syncs pause while the
-            Deck sleeps and resume on wake; keep it powered for a large first sync.
-          </div>
+          <Focusable>
+            <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.6)", padding: "4px 0" }}>{hintText}</div>
+          </Focusable>
         </PanelSectionRow>
         {preview.pause_likely ? (
           <PanelSectionRow>
-            <div
-              data-testid="budget-advisory"
-              style={{
-                fontSize: "12px",
-                color: "#7fbcff",
-                borderLeft: "3px solid rgba(61, 157, 246, 0.6)",
-                paddingLeft: "8px",
-                margin: "4px 0",
-                lineHeight: 1.4,
-              }}
-            >
-              This sync is large enough that it will likely pause partway to protect Steam&apos;s memory. That is normal
-              — restart Steam when prompted, then Resume Sync to finish.
-            </div>
+            <Focusable>
+              <div
+                data-testid="budget-advisory"
+                style={{
+                  fontSize: "12px",
+                  color: "#7fbcff",
+                  borderLeft: "3px solid rgba(61, 157, 246, 0.6)",
+                  paddingLeft: "8px",
+                  margin: "4px 0",
+                  lineHeight: 1.4,
+                }}
+              >
+                Will likely pause partway to protect Steam&apos;s memory — normal for large syncs. Restart Steam when
+                prompted, then Resume Sync.
+              </div>
+            </Focusable>
           </PanelSectionRow>
         ) : null}
         {hasChanges ? (
@@ -822,11 +863,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             <PanelSectionRow>
               <ButtonItem
                 layout="below"
+                bottomSeparator="none"
                 onClick={() => {
                   detach(handleApply());
                 }}
-                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                onFocus={scrollToTop}
               >
                 Apply Sync
               </ButtonItem>
@@ -834,6 +874,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             <PanelSectionRow>
               <ButtonItem
                 layout="below"
+                bottomSeparator="none"
                 onClick={() => {
                   detach(handleDismiss());
                 }}
@@ -846,11 +887,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              bottomSeparator="none"
               onClick={() => {
                 detach(handleDismiss());
               }}
-              // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-              onFocus={scrollToTop}
             >
               Dismiss
             </ButtonItem>
@@ -867,8 +907,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               ProgressBarWithInfo is a Steam Field (label column | bar column);
               with no label text the empty column shoves the bar into the right
               half and clips it (#751). The bare ProgressBar is just the bar and
-              spans the full panel width. */}
-          <div style={{ width: "100%" }}>
+              spans the full panel width. Focusable so Steam's focus engine can
+              scroll the progress row into view under gamepad navigation. */}
+          <Focusable style={{ width: "100%" }}>
             <div
               style={{
                 display: "flex",
@@ -893,11 +934,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               indeterminate={coarseFraction === undefined}
               {...(coarseFraction !== undefined ? { nProgress: coarseFraction } : {})}
             />
-          </div>
+          </Focusable>
         </PanelSectionRow>
         {hasFineDetail && (
           <PanelSectionRow>
             <Field
+              focusable={true}
+              bottomSeparator="none"
               label={
                 <div style={{ display: "flex", alignItems: "flex-start", gap: "8px" }}>
                   <Spinner width={14} height={14} />
@@ -925,7 +968,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         )}
         {etaText !== null && (
           <PanelSectionRow>
-            <Field label="Estimated time">
+            <Field label="Estimated time" focusable={true} bottomSeparator="none">
               <span data-testid="estimate-time" style={{ fontSize: "12px" }}>
                 {etaText}
               </span>
@@ -935,12 +978,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
+            bottomSeparator="none"
             disabled={cancelling}
             onClick={() => {
               detach(handleCancel());
             }}
-            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-            onFocus={scrollToTop}
           >
             {cancelling ? "Cancelling…" : "Cancel Sync"}
           </ButtonItem>
@@ -963,12 +1005,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         <PanelSectionRow>
           <ButtonItem
             layout="below"
+            bottomSeparator="none"
             onClick={() => {
               detach(handleSync());
             }}
             disabled={loading || connectionUnavailable}
-            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-            onFocus={scrollToTop}
           >
             {syncButtonLabel}
           </ButtonItem>
@@ -979,6 +1020,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             description="Apply changes immediately without preview"
             checked={skipPreview}
             onChange={setSkipPreview}
+            bottomSeparator="none"
           />
         </PanelSectionRow>
         {/* Visible whenever ANY terminal run is recorded — a completed run OR a
@@ -993,6 +1035,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           <PanelSectionRow>
             <ButtonItem
               layout="below"
+              bottomSeparator="none"
               description="Clear cached sync data to re-fetch all platforms"
               onClick={() => {
                 detach(
@@ -1025,15 +1068,25 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     <>
       {settingsReset.pending && <SettingsResetBanner backedUpTo={settingsReset.backedUpTo} />}
       {playtimeScope.pending && <PlaytimeScopeBanner />}
-      <PanelSection title="Status">
+      {/* Untitled status block (Connection / Last sync / Library / Steam memory)
+          leads the panel — the following PanelSection titles provide the block
+          breaks, so no "Status" title is needed. */}
+      <PanelSection>
         {retrodeckBanner && (
           <PanelSectionRow>
-            <WarningCard title={retrodeckBanner.title} message={retrodeckBanner.message} compact />
+            {/* WarningCard is shared with the game-detail context, so it carries no
+                focusable child of its own — wrap it here (QAM-only) so gamepad focus
+                can reach it. */}
+            <Focusable>
+              <WarningCard title={retrodeckBanner.title} message={retrodeckBanner.message} compact />
+            </Focusable>
           </PanelSectionRow>
         )}
         <PanelSectionRow>
           <Field
             label="Connection"
+            focusable={true}
+            bottomSeparator="none"
             description={
               connected === "backend_failed" ? "Plugin backend failed to start — check Decky logs." : undefined
             }
@@ -1046,17 +1099,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {stats && (
           <>
             <PanelSectionRow>
-              <Field label="Last sync">{lastSyncValue(stats)}</Field>
+              <Field label="Last sync" focusable={true} bottomSeparator="none">
+                {lastSyncValue(stats)}
+              </Field>
             </PanelSectionRow>
             {stats.roms > 0 && (
               <PanelSectionRow>
-                <Field label="Library">
-                  <span style={{ fontSize: "12px", display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
-                    <span>{stats.roms} games</span>
-                    {stats.platforms > 0 && <span>{stats.platforms} platforms</span>}
-                    {(stats.collections ?? 0) > 0 && <span>{stats.collections} collections</span>}
-                  </span>
-                </Field>
+                <Field label="Library" description={formatLibraryLine(stats)} focusable={true} bottomSeparator="none" />
               </PanelSectionRow>
             )}
           </>
@@ -1066,13 +1115,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             reading is unavailable (rss_kb null) rather than shown as a blank. */}
         {budgetStatus?.rss_kb != null && (
           <PanelSectionRow>
-            <Field label="Steam memory">
-              <span
-                data-testid="steam-memory"
-                style={{ fontSize: "12px", display: "flex", flexDirection: "column", alignItems: "flex-end" }}
-              >
+            <Field label="Steam memory" focusable={true} bottomSeparator="none">
+              <span data-testid="steam-memory" style={{ fontSize: "12px" }}>
                 {/* Only the value gets traffic-light colouring (green/yellow/red),
-                    driven by the payload thresholds; the label + delta stay uncoloured. */}
+                    driven by the payload thresholds; the delta stays muted. Both sit
+                    on one line: "0.6 GB · last run +0.7". */}
                 <span
                   data-testid="steam-memory-value"
                   style={{
@@ -1082,7 +1129,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                   {formatGb(budgetStatus.rss_kb)}
                 </span>
                 {budgetStatus.memory_delta_kb != null && (
-                  <span style={{ opacity: 0.6 }}>last run: {formatSignedGb(budgetStatus.memory_delta_kb)}</span>
+                  <span data-testid="steam-memory-delta" style={{ opacity: 0.6 }}>
+                    {" · last run "}
+                    {formatSignedGb(budgetStatus.memory_delta_kb)}
+                  </span>
                 )}
               </span>
             </Field>
@@ -1090,7 +1140,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         )}
         {retroarchWarning?.warning && (
           <PanelSectionRow>
-            <Field label="RetroArch: input_driver issue" description={`Using "${retroarchWarning.current}"`}>
+            <Field
+              label="RetroArch: input_driver issue"
+              description={`Using "${retroarchWarning.current}"`}
+              bottomSeparator="none"
+            >
               <DialogButton
                 onClick={() =>
                   showModal(
@@ -1116,7 +1170,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     />,
                   )
                 }
-                onFocus={scrollToTop}
               >
                 Fix
               </DialogButton>
@@ -1126,30 +1179,27 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {saveSortMigration.pending && (
           <>
             <PanelSectionRow>
-              <div
-                style={{
-                  padding: "8px 12px",
-                  backgroundColor: "rgba(212, 167, 44, 0.15)",
-                  borderLeft: "3px solid #d4a72c",
-                  borderRadius: "4px",
-                  fontSize: "12px",
-                }}
-              >
-                <div style={{ fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" }}>
-                  {"\u26A0\uFE0F"} RetroArch save sorting changed
+              <Focusable>
+                <div
+                  style={{
+                    padding: "8px 12px",
+                    backgroundColor: "rgba(212, 167, 44, 0.15)",
+                    borderLeft: "3px solid #d4a72c",
+                    borderRadius: "4px",
+                    fontSize: "12px",
+                  }}
+                >
+                  <div style={{ fontWeight: "bold", color: "#d4a72c", marginBottom: "4px" }}>
+                    {"\u26A0\uFE0F"} RetroArch save sorting changed
+                  </div>
+                  <div style={{ color: "rgba(255, 255, 255, 0.7)" }}>
+                    {saveSortMigration.saves_count ?? 0} save file(s) to migrate
+                  </div>
                 </div>
-                <div style={{ color: "rgba(255, 255, 255, 0.7)" }}>
-                  {saveSortMigration.saves_count ?? 0} save file(s) to migrate
-                </div>
-              </div>
+              </Focusable>
             </PanelSectionRow>
             <PanelSectionRow>
-              <ButtonItem
-                layout="below"
-                onClick={() => onNavigate("settings")}
-                // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-                onFocus={scrollToTop}
-              >
+              <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("settings")}>
                 Go to Settings
               </ButtonItem>
             </PanelSectionRow>
@@ -1161,7 +1211,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {syncBody}
         {status && !syncing && !preview && (
           <PanelSectionRow>
-            <Field label={status} />
+            <Field label={status} focusable={true} bottomSeparator="none" />
           </PanelSectionRow>
         )}
       </PanelSection>
@@ -1184,16 +1234,20 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           ))}
           {activeDownloads.length > 2 && (
             <PanelSectionRow>
-              <Field label={`+${activeDownloads.length - 2} more downloading`} />
+              <Field
+                label={`+${activeDownloads.length - 2} more downloading`}
+                focusable={true}
+                bottomSeparator="none"
+              />
             </PanelSectionRow>
           )}
           {completedDownloads.length > 0 && (
             <PanelSectionRow>
-              <Field label={`${completedDownloads.length} completed`} />
+              <Field label={`${completedDownloads.length} completed`} focusable={true} bottomSeparator="none" />
             </PanelSectionRow>
           )}
           <PanelSectionRow>
-            <ButtonItem layout="below" onClick={() => onNavigate("downloads")}>
+            <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("downloads")}>
               View All
             </ButtonItem>
           </PanelSectionRow>
@@ -1202,22 +1256,22 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
       <PanelSection title="Settings">
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => onNavigate("library")}>
+          <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("library")}>
             Library
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => onNavigate("system")}>
+          <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("system")}>
             System
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => onNavigate("settings")}>
+          <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("settings")}>
             Settings
           </ButtonItem>
         </PanelSectionRow>
         <PanelSectionRow>
-          <ButtonItem layout="below" onClick={() => onNavigate("data")}>
+          <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("data")}>
             Data Management
           </ButtonItem>
         </PanelSectionRow>

--- a/src/components/SessionBudgetBanner.test.tsx
+++ b/src/components/SessionBudgetBanner.test.tsx
@@ -25,10 +25,10 @@ describe("formatGb", () => {
 });
 
 describe("formatSignedGb", () => {
-  it("prefixes an explicit sign", () => {
-    expect(formatSignedGb(800000)).toBe("+0.8 GB");
-    expect(formatSignedGb(-300000)).toBe("-0.3 GB");
-    expect(formatSignedGb(0)).toBe("+0.0 GB");
+  it("prefixes an explicit sign and drops the unit (rendered inline after the GB reading)", () => {
+    expect(formatSignedGb(800000)).toBe("+0.8");
+    expect(formatSignedGb(-300000)).toBe("-0.3");
+    expect(formatSignedGb(0)).toBe("+0.0");
   });
 });
 

--- a/src/components/SessionBudgetBanner.tsx
+++ b/src/components/SessionBudgetBanner.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import { PanelSectionRow, ButtonItem } from "@decky/ui";
+import { PanelSectionRow, ButtonItem, Focusable } from "@decky/ui";
 import { toaster } from "@decky/api";
 import { isAnyAppRunning } from "../utils/runningApps";
 
@@ -18,14 +18,15 @@ export function formatGb(kb: number): string {
 }
 
 /**
- * Format a signed KB delta as a one-decimal decimal-GB string with an explicit
- * ``+``/``-`` sign, e.g. ``+800000 → "+0.8 GB"``, ``-300000 → "-0.3 GB"``. Zero
- * (and anything rounding to it) reads ``+0.0 GB``. Used for the "last sync" memory
- * delta row (#1383).
+ * Format a signed KB delta as a one-decimal, unit-less decimal-GB string with an
+ * explicit ``+``/``-`` sign, e.g. ``+800000 → "+0.8"``, ``-300000 → "-0.3"``. Zero
+ * (and anything rounding to it) reads ``+0.0``. The GB unit is dropped because the
+ * only caller renders it inline right after the unit-carrying live reading
+ * ("0.6 GB · last run +0.7"), so repeating "GB" would read redundantly (#1383).
  */
 export function formatSignedGb(kb: number): string {
   const gb = kb / 1_000_000;
-  return `${gb >= 0 ? "+" : "-"}${Math.abs(gb).toFixed(1)} GB`;
+  return `${gb >= 0 ? "+" : "-"}${Math.abs(gb).toFixed(1)}`;
 }
 
 /**
@@ -60,18 +61,23 @@ function restartSteam(): void {
 function bannerCard(accent: string, background: string, testId: string, title: string, body: string): ReactNode {
   return (
     <PanelSectionRow>
-      <div
-        data-testid={testId}
-        style={{
-          padding: "8px 12px",
-          backgroundColor: background,
-          borderLeft: `3px solid ${accent}`,
-          borderRadius: "4px",
-        }}
-      >
-        <div style={{ fontSize: "13px", fontWeight: "bold", color: accent, marginBottom: "6px" }}>{title}</div>
-        <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.85)", lineHeight: 1.5 }}>{body}</div>
-      </div>
+      {/* Focusable so Steam's gamepad focus engine can reach and scroll the banner
+          into view — this component is QAM-only. The card div keeps the testId +
+          styling; the wrapper adds only the focus highlight. */}
+      <Focusable>
+        <div
+          data-testid={testId}
+          style={{
+            padding: "8px 12px",
+            backgroundColor: background,
+            borderLeft: `3px solid ${accent}`,
+            borderRadius: "4px",
+          }}
+        >
+          <div style={{ fontSize: "13px", fontWeight: "bold", color: accent, marginBottom: "6px" }}>{title}</div>
+          <div style={{ fontSize: "12px", color: "rgba(255, 255, 255, 0.85)", lineHeight: 1.5 }}>{body}</div>
+        </div>
+      </Focusable>
     </PanelSectionRow>
   );
 }

--- a/src/utils/pluralize.test.ts
+++ b/src/utils/pluralize.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { pluralize } from "./pluralize";
+
+describe("pluralize", () => {
+  it("keeps the singular form for exactly 1", () => {
+    expect(pluralize(1, "game")).toBe("1 game");
+    expect(pluralize(1, "platform")).toBe("1 platform");
+    expect(pluralize(1, "collection")).toBe("1 collection");
+  });
+
+  it("appends 's' for 0 and for counts greater than 1", () => {
+    expect(pluralize(0, "game")).toBe("0 games");
+    expect(pluralize(2, "platform")).toBe("2 platforms");
+    expect(pluralize(2200, "game")).toBe("2200 games");
+  });
+});

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,0 +1,11 @@
+/**
+ * Count-with-noun formatting for UI count lines. Turns a number and a singular
+ * noun into "N noun" / "N nouns" with correct English pluralization (exactly 1
+ * stays singular). Regular "+s" plural only — nouns with irregular plurals need
+ * their own handling.
+ */
+
+/** ``count`` + a space + ``singular``, appending an ``s`` unless ``count`` is 1. */
+export function pluralize(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
## Why

The QAM sync panel outgrew the Deck's internal display. None of the info rows were gamepad-focusable, so focus could only land on buttons — every row above the first button was unreachable — and the `scrollToTop` workaround on those buttons made the view jump away from the focused control.

The dev loop hid this: a windowed Big Picture gives the QAM **854x720** CSS while Game Mode gives it **854x454**, so a panel that overflows on the device looked fine while developing.

## Panel

- Info rows (status fields, preview rows, hint texts, banners, progress) are focusable, so Steam's own focus engine scrolls them into view. The `scrollToTop` hack is gone from the QAM buttons; the helper stays for the game-detail injection context, where it is still needed.
- Compaction: library and memory rows on one line each, the estimate merged into the scope row, shorter hint copy (the "keep it powered" sentence only appears for syncs >= 10 min), compact signed preview notation, shorter pause advisory.
- The status section title and the per-row separators are gone — the section titles divide the blocks.
- Fixes the "1 platforms" pluralization via a shared helper.

## Dev loop

`mise run dev:ui-scale [deck|<factor>|steam|auto]` reproduces Game Mode's display scale in the desktop Big Picture: it forces Steam's per-display GamepadUI scale and sizes the window to a 1280x800 client area, so the QAM renders at 854x454 @ dpr 1.5 — what the Deck actually shows. It holds until Ctrl-C and restores the scale and window geometry you had before, re-applies the scale to the QuickAccess view (Steam lays it out lazily on first open and it can otherwise come up unscaled), and fails loudly instead of claiming metrics it did not achieve.

## Design rule

The QAM's usable height is runtime-variable — roughly 250-820 CSS px depending on the user's UI Scale setting and whether the Deck is docked. Panels must not assume a pixel budget: keep every row focusable, no fixed heights, and let Steam's scroll container do its job. Documented in the contributing guide.

## Testing

Verified on-device in Game Mode and in the desktop loop under `dev:ui-scale deck`. Frontend 1844 tests, backend 5087 tests, lint/typecheck/build green.