### PR TITLE
test(sonar): name assertion operands flagged by S5863

### DIFF
--- a/tests/domain/test_aggregate_decorator.py
+++ b/tests/domain/test_aggregate_decorator.py
@@ -36,8 +36,10 @@ class TestDecoratorMakesDataclass:
             name: str
             count: int
 
-        assert Sample(name="a", count=1) == Sample(name="a", count=1)
-        assert Sample(name="a", count=1) != Sample(name="a", count=2)
+        left = Sample(name="a", count=1)
+        right = Sample(name="a", count=1)
+        assert left == right
+        assert left != Sample(name="a", count=2)
 
 
 class TestDecoratorAppliesSlots:

--- a/tests/domain/test_emulator_commands.py
+++ b/tests/domain/test_emulator_commands.py
@@ -325,7 +325,9 @@ class TestClassificationInvariants:
 
     @pytest.mark.parametrize("text", CORPUS)
     def test_classification_is_deterministic(self, text):
-        assert classify_command("L", text) == classify_command("L", text)
+        first = classify_command("L", text)
+        second = classify_command("L", text)
+        assert first == second
 
     def test_select_default_returns_none_or_bakeable(self):
         options = [classify_command(f"L{i}", text) for i, text in enumerate(self.CORPUS)]

--- a/tests/domain/test_save_hash_property.py
+++ b/tests/domain/test_save_hash_property.py
@@ -46,4 +46,6 @@ def test_output_is_md5_hex(entries):
 @given(entries=_ENTRY_SETS)
 def test_deterministic(entries):
     items = list(entries.items())
-    assert combine_zip_entry_hashes(items) == combine_zip_entry_hashes(items)
+    first = combine_zip_entry_hashes(items)
+    second = combine_zip_entry_hashes(items)
+    assert first == second

--- a/tests/domain/test_save_layout.py
+++ b/tests/domain/test_save_layout.py
@@ -14,7 +14,9 @@ class TestInSaveDir:
         assert layout.sort_by_core is False
 
     def test_equality_by_flags(self):
-        assert InSaveDir(sort_by_content=True, sort_by_core=True) == InSaveDir(sort_by_content=True, sort_by_core=True)
+        left = InSaveDir(sort_by_content=True, sort_by_core=True)
+        right = InSaveDir(sort_by_content=True, sort_by_core=True)
+        assert left == right
 
     def test_inequality_on_differing_flags(self):
         assert InSaveDir(sort_by_content=True, sort_by_core=False) != InSaveDir(
@@ -30,7 +32,9 @@ class TestInSaveDir:
 class TestContentDir:
     def test_construction(self):
         # No fields — purely a tag in the union.
-        assert ContentDir() == ContentDir()
+        left = ContentDir()
+        right = ContentDir()
+        assert left == right
 
     def test_not_equal_to_in_save_dir(self):
         assert ContentDir() != InSaveDir(sort_by_content=True, sort_by_core=False)

--- a/tests/lib/test_list_result.py
+++ b/tests/lib/test_list_result.py
@@ -70,13 +70,17 @@ class TestEquality:
     """Frozen dataclasses get value-based equality for free."""
 
     def test_two_ok_with_same_items_are_equal(self):
-        assert OkListResult(items=[1, 2]) == OkListResult(items=[1, 2])
+        left = OkListResult(items=[1, 2])
+        right = OkListResult(items=[1, 2])
+        assert left == right
 
     def test_two_ok_with_different_items_are_not_equal(self):
         assert OkListResult(items=[1, 2]) != OkListResult(items=[1, 3])
 
     def test_two_failed_with_same_code_are_equal(self):
-        assert FailedListResult(error=ErrorCode.UNKNOWN) == FailedListResult(error=ErrorCode.UNKNOWN)
+        left = FailedListResult(error=ErrorCode.UNKNOWN)
+        right = FailedListResult(error=ErrorCode.UNKNOWN)
+        assert left == right
 
     def test_two_failed_with_same_code_and_message_are_equal(self):
         left = FailedListResult(error=ErrorCode.AUTH_FAILED, error_message="bad password")


### PR DESCRIPTION
SonarCloud's Python analyzer update (rolled out around 2026-07-13) extended S5863 ("same actual and expected expression") to flag textually identical call expressions. That hit 7 intentional assertions — dataclass `__eq__` tests and determinism properties — backdated to their blame dates, dropping the new-code reliability rating to C and failing the quality gate (and with `sonar.qualitygate.wait=true`, CI on main).

This rewrites each flagged assertion so the operands are named variables: `left`/`right` for the equality tests, `first`/`second` for the determinism properties. Same constructors, arguments, and operators — no semantic change. The rule stays active for tests, where it still catches real copy-paste mistakes (`assert result == result` instead of `== expected`).

docs: N/A — test-only assertion rewrite, no behavior or architecture change.