### PR TITLE
fix(sync): refuse danger-zone removals while a sync run is in flight

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -183,6 +183,10 @@ page.
 The **Danger Zone** page provides options for removing shortcuts, ROM files, save files, and BIOS files. All destructive
 actions require confirmation (tap once to see the prompt, tap again to confirm).
 
+While a library sync is running (or cancelling), the shortcut and ROM removal actions are unavailable — the buttons are
+disabled with a short hint, and the backend refuses the request too. Wait for the sync to finish, or cancel it, before
+removing shortcuts or ROMs. Save-file and BIOS deletions are not affected.
+
 ### Remove by Platform
 
 Removes all shortcuts for a specific platform (e.g. all Game Boy Advance games). The associated Steam collection is also

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from bootstrap import (
 )
 
 from lib.migration_gate import migration_blocked
+from lib.sync_gate import sync_active_blocked
 
 
 class Plugin:
@@ -372,10 +373,12 @@ class Plugin:
         return self._sync_service.get_registry_platforms()
 
     @migration_blocked
+    @sync_active_blocked
     async def remove_platform_shortcuts(self, platform_slug):
         return await self._shortcut_removal_service.remove_platform_shortcuts(platform_slug)
 
     @migration_blocked
+    @sync_active_blocked
     async def remove_all_shortcuts(self):
         return self._shortcut_removal_service.remove_all_shortcuts()
 
@@ -461,6 +464,7 @@ class Plugin:
         return await self._rom_removal_service.remove_rom(rom_id)
 
     @migration_blocked
+    @sync_active_blocked
     async def uninstall_all_roms(self):
         return await self._rom_removal_service.uninstall_all_roms()
 

--- a/py_modules/lib/sync_gate.py
+++ b/py_modules/lib/sync_gate.py
@@ -1,0 +1,63 @@
+"""Decorator that blocks destructive Decky callables while a library sync is in flight.
+
+The decorated method must be ``async def`` (every Decky callable is). The wrapped
+method's owner class **must** expose a ``_sync_service`` attribute with an
+``is_sync_in_flight() -> bool`` method — this gate is a data-safety guard and
+refuses to run without it. In flight means the live sync state is RUNNING or
+CANCELLING; IDLE (which paused and completed runs reset to) passes through.
+
+A missing ``_sync_service`` is a wiring regression, not a tolerable state: the
+wrapper raises ``RuntimeError`` rather than silently skipping the gate. In
+correctly-wired production the attribute is always present (``main.py:_main``
+binds it; the contract harness binds the same set), so the raise never fires
+normally — but a regression that drops the wiring fails loud (and the contract
+tests, which drive gated callables over the real bootstrap, catch it in CI)
+instead of silently disabling the gate for every gated callable.
+
+Tests can introspect blocked callables via the ``_sync_active_blocked``
+attribute attached to the wrapper.
+
+Lives in ``lib/`` to stay outside the services/adapters/domain dependency
+graph (per import-linter contracts).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+_BLOCKED_MESSAGE = (
+    "A library sync is in progress — wait for it to finish or cancel it before removing shortcuts or ROMs."
+)
+
+
+def sync_active_blocked(method):
+    """Block this Decky callable when ``is_sync_in_flight()`` is True.
+
+    Returns the canonical failure shape ``{success: False, reason:
+    "sync_active", message}`` instead of running the gated callable while a
+    library-sync run is in flight. Requires the owner to expose
+    ``_sync_service``; raises ``RuntimeError`` if it is missing (a wiring
+    regression) so the safety gate fails loud rather than silently disabling
+    itself for the gated callable.
+    """
+
+    @functools.wraps(method)
+    async def wrapper(self, *args: Any, **kwargs: Any):
+        service = getattr(self, "_sync_service", None)
+        if service is None:
+            raise RuntimeError(
+                f"@sync_active_blocked on {method.__name__!r}: _sync_service is unwired. "
+                "The sync safety gate is a hard requirement; refusing to run the gated "
+                "callable without it (this is a wiring regression, not a tolerable state)."
+            )
+        if service.is_sync_in_flight():
+            return {
+                "success": False,
+                "reason": "sync_active",
+                "message": _BLOCKED_MESSAGE,
+            }
+        return await method(self, *args, **kwargs)
+
+    wrapper._sync_active_blocked = True  # type: ignore[attr-defined]
+    return wrapper

--- a/py_modules/services/library/service.py
+++ b/py_modules/services/library/service.py
@@ -183,6 +183,14 @@ class LibraryService:
         """Current sync state (read-only)."""
         return self._box.sync_state
 
+    def is_sync_in_flight(self) -> bool:
+        """True while a sync run is in flight (RUNNING or CANCELLING; IDLE is not).
+
+        Read-only predicate consumed by the ``@sync_active_blocked`` gate on
+        the destructive removal callables.
+        """
+        return self._box.is_in_flight()
+
     @property
     def pending_sync(self) -> dict[int, dict[str, Any]]:
         """Public accessor for pending sync data (used by SteamGridService)."""

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -167,11 +167,13 @@ export const removePlatformShortcuts = callable<
     success: boolean;
     // The success path returns success/app_ids/rom_ids/platform_name; the
     // @migration_blocked gate short-circuits to success/message/
-    // blocked_by_migration, omitting app_ids/rom_ids. Every field below the
+    // blocked_by_migration and the @sync_active_blocked gate to success/
+    // reason/message, both omitting app_ids/rom_ids. Every field below the
     // discriminant is therefore path-dependent (mirrors removeAllShortcuts).
     app_ids?: number[];
     rom_ids?: (string | number)[];
     platform_name?: string;
+    reason?: string;
     message?: string;
     blocked_by_migration?: boolean;
   }
@@ -182,8 +184,10 @@ export const removeAllShortcuts = callable<
     success: boolean;
     // The success path returns only success/app_ids/rom_ids; the
     // @migration_blocked gate short-circuits to success/message/
-    // blocked_by_migration, omitting app_ids/rom_ids. Every field below the
+    // blocked_by_migration and the @sync_active_blocked gate to success/
+    // reason/message, both omitting app_ids/rom_ids. Every field below the
     // discriminant is therefore path-dependent.
+    reason?: string;
     message?: string;
     app_ids?: number[];
     rom_ids?: (string | number)[];
@@ -242,7 +246,20 @@ export const reconcileShortcuts = callable<
 >("reconcile_shortcuts");
 export const uninstallAllRoms = callable<
   [],
-  { success: boolean; removed_count: number; errors: { rom_id: string; error: string }[]; app_ids: number[] }
+  {
+    success: boolean;
+    // The removal path always carries removed_count/errors/app_ids — success
+    // is False on a PARTIAL failure (some deletions failed) but the payload
+    // stays. The @migration_blocked / @sync_active_blocked gates short-circuit
+    // to success/message (+reason / blocked_by_migration) with NO payload, so
+    // a missing app_ids is the gate-refusal discriminant.
+    removed_count?: number;
+    errors?: { rom_id: string; error: string }[];
+    app_ids?: number[];
+    reason?: string;
+    message?: string;
+    blocked_by_migration?: boolean;
+  }
 >("uninstall_all_roms");
 export const saveSgdbApiKey = callable<[string], { success: boolean; message: string }>("save_sgdb_api_key");
 export const verifySgdbApiKey = callable<[string], { success: boolean; message: string }>("verify_sgdb_api_key");

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -5,8 +5,8 @@
 // change, no log call) are exempt — and even then, prefer dropping the test
 // over keeping one with zero expects.
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, fireEvent, act, waitFor, within } from "@testing-library/react";
 import { createElement, type ReactElement } from "react";
 import { DangerZone } from "./DangerZone";
 import * as backend from "../api/backend";
@@ -14,6 +14,7 @@ import { showModal } from "@decky/ui";
 import { removeShortcut, setLaunchOptionsConfirmed } from "../utils/steamShortcuts";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
+import { setSyncProgress } from "../utils/syncProgress";
 import { stubCollectionStore, stubAppStore } from "../test-utils/steamStubs";
 
 vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
@@ -1154,6 +1155,131 @@ describe("DangerZone", () => {
       // Hide whitelist — also clears confirms via resetRemoveConfirms.
       fireEvent.click(getByText("Hide Whitelist"));
       expect(container.textContent).not.toContain("Are you sure?");
+    });
+  });
+
+  describe("sync-running guard (#1390)", () => {
+    const HINT = "Unavailable while a library sync is running.";
+    const REFUSAL_MESSAGE =
+      "A library sync is in progress — wait for it to finish or cancel it before removing shortcuts or ROMs.";
+
+    // The syncProgress store is real module state (not a vi mock) — it
+    // survives vi.resetAllMocks(), so restore the idle default after each test.
+    afterEach(() => {
+      setSyncProgress({ running: false, stage: "", current: 0, total: 0, message: "", runId: "" });
+    });
+
+    it("disables the bulk removal buttons and shows the hint while a sync runs", async () => {
+      setSyncProgress({ running: true, stage: "applying", current: 1, total: 5, message: "", runId: "run-1" });
+      const { getByText, getAllByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      expect(getByText("Remove All RomM Shortcuts")).toBeDisabled();
+      expect(getByText("Uninstall All Installed ROMs")).toBeDisabled();
+      // Both disabled buttons carry the hint description.
+      expect(getAllByText(HINT)).toHaveLength(2);
+      // Clicking the disabled buttons must not arm the confirm flow.
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      fireEvent.click(getByText("Uninstall All Installed ROMs"));
+      expect(vi.mocked(backend.removeAllShortcuts)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.uninstallAllRoms)).not.toHaveBeenCalled();
+    });
+
+    it("keeps the buttons enabled with no hint when no sync runs", async () => {
+      const { getByText, queryByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+
+      expect(getByText("Remove All RomM Shortcuts")).not.toBeDisabled();
+      expect(getByText("Uninstall All Installed ROMs")).not.toBeDisabled();
+      expect(queryByText(HINT)).toBeNull();
+    });
+
+    it("disables only the modal's Remove Shortcuts button while a sync runs", async () => {
+      setSyncProgress({ running: true, stage: "applying", current: 1, total: 5, message: "", runId: "run-1" });
+      vi.mocked(backend.getRegistryPlatforms).mockResolvedValue({
+        platforms: [{ slug: "snes", name: "Super Nintendo", count: 1 }],
+      });
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (1)"));
+      const modalEl = vi.mocked(showModal).mock.calls[0]?.[0];
+      // Scope queries to the modal's own container — the panel render in the
+      // same document also shows the hint on its two disabled bulk buttons.
+      const { container: modalContainer } = render(modalEl as ReactElement);
+      const modal = within(modalContainer as HTMLElement);
+
+      expect(modal.getByText("Remove Shortcuts (1 game)")).toBeDisabled();
+      expect(modal.getByText(HINT)).toBeTruthy();
+      // The save/BIOS deletions are not sync-gated — they stay pressable.
+      expect(modal.getByText("Delete Save Files")).not.toBeDisabled();
+      expect(modal.getByText("Delete BIOS Files")).not.toBeDisabled();
+    });
+
+    it("surfaces the sync_active refusal and removes nothing on Remove All (raced past the disable)", async () => {
+      // The backend gate is the authority: a sync that starts between render
+      // and click still refuses. The handler must surface the message and
+      // must not touch shortcuts or collections.
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: false,
+        reason: "sync_active",
+        message: REFUSAL_MESSAGE,
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain(REFUSAL_MESSAGE);
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(backend.reportRemovalResults)).not.toHaveBeenCalled();
+      expect(vi.mocked(clearAllRomMCollections)).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the sync_active refusal without crashing on Uninstall All (no app_ids in the refusal)", async () => {
+      // Regression guard: the old handler dereferenced result.app_ids.map(...)
+      // unconditionally — a payload-less refusal threw instead of rendering.
+      vi.mocked(backend.uninstallAllRoms).mockResolvedValue({
+        success: false,
+        reason: "sync_active",
+        message: REFUSAL_MESSAGE,
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Uninstall All Installed ROMs"));
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: delete all ROM files?"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain(REFUSAL_MESSAGE);
+      expect(vi.mocked(setLaunchOptionsConfirmed)).not.toHaveBeenCalled();
+      expect(vi.mocked(formatUninstallStatus)).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the sync_active refusal on a per-platform removal", async () => {
+      vi.mocked(backend.getRegistryPlatforms).mockResolvedValue({
+        platforms: [{ slug: "snes", name: "Super Nintendo", count: 2 }],
+      });
+      vi.mocked(backend.removePlatformShortcuts).mockResolvedValue({
+        success: false,
+        reason: "sync_active",
+        message: REFUSAL_MESSAGE,
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Super Nintendo (2)"));
+      const modalProps = lastShownModalProps<{ onRemoveShortcuts?: () => void }>();
+      await act(async () => {
+        modalProps?.onRemoveShortcuts?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(container.textContent).toContain(REFUSAL_MESSAGE);
+      expect(vi.mocked(removeShortcut)).not.toHaveBeenCalled();
+      expect(vi.mocked(clearPlatformCollection)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -28,6 +28,7 @@ import {
 } from "../api/backend";
 import { removeShortcut } from "../utils/steamShortcuts";
 import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
+import { getSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
@@ -68,50 +69,70 @@ interface NonSteamApp {
   name: string;
 }
 
+// Shown as the disabled-state hint on the removal controls while a library
+// sync is in flight — the backend refuses those callables with reason
+// "sync_active" (#1390), so the UI disables them up front.
+const SYNC_RUNNING_HINT = "Unavailable while a library sync is running.";
+
+// Live "is a library sync in flight?" flag off the module-level sync-progress
+// store. Each consumer subscribes itself: PlatformActionModal is rendered by
+// showModal into a detached tree that never re-renders with the panel, so a
+// prop snapshot taken at open time would go stale while the modal is open.
+const useSyncRunning = (): boolean => {
+  const [syncRunning, setSyncRunning] = useState(getSyncProgress().running);
+  useEffect(() => onSyncProgressChange(() => setSyncRunning(getSyncProgress().running)), []);
+  return syncRunning;
+};
+
 const PlatformActionModal: FC<{
   platform: RegistryPlatform;
   closeModal?: () => void;
   onRemoveShortcuts: () => void;
   onDeleteSaves: () => void;
   onDeleteBios: () => void;
-}> = ({ platform, closeModal, onRemoveShortcuts, onDeleteSaves, onDeleteBios }) => (
-  <ModalRoot closeModal={closeModal}>
-    <div style={{ padding: "16px", minWidth: "320px" }}>
-      <div style={{ fontSize: "16px", fontWeight: "bold", color: "#fff", marginBottom: "16px" }}>
-        Actions for {platform.name}
+}> = ({ platform, closeModal, onRemoveShortcuts, onDeleteSaves, onDeleteBios }) => {
+  const syncRunning = useSyncRunning();
+  return (
+    <ModalRoot closeModal={closeModal}>
+      <div style={{ padding: "16px", minWidth: "320px" }}>
+        <div style={{ fontSize: "16px", fontWeight: "bold", color: "#fff", marginBottom: "16px" }}>
+          Actions for {platform.name}
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          <DialogButton
+            disabled={syncRunning}
+            onClick={() => {
+              closeModal?.();
+              onRemoveShortcuts();
+            }}
+          >
+            Remove Shortcuts ({platform.count} game{platform.count === 1 ? "" : "s"})
+          </DialogButton>
+          {syncRunning && <div style={{ fontSize: "12px", opacity: 0.6 }}>{SYNC_RUNNING_HINT}</div>}
+          <DialogButton
+            onClick={() => {
+              closeModal?.();
+              onDeleteSaves();
+            }}
+          >
+            Delete Save Files
+          </DialogButton>
+          <DialogButton
+            onClick={() => {
+              closeModal?.();
+              onDeleteBios();
+            }}
+          >
+            Delete BIOS Files
+          </DialogButton>
+          <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
+            Cancel
+          </DialogButton>
+        </div>
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-        <DialogButton
-          onClick={() => {
-            closeModal?.();
-            onRemoveShortcuts();
-          }}
-        >
-          Remove Shortcuts ({platform.count} game{platform.count === 1 ? "" : "s"})
-        </DialogButton>
-        <DialogButton
-          onClick={() => {
-            closeModal?.();
-            onDeleteSaves();
-          }}
-        >
-          Delete Save Files
-        </DialogButton>
-        <DialogButton
-          onClick={() => {
-            closeModal?.();
-            onDeleteBios();
-          }}
-        >
-          Delete BIOS Files
-        </DialogButton>
-        <DialogButton onClick={() => closeModal?.()} style={{ opacity: 0.5 }}>
-          Cancel
-        </DialogButton>
-      </div>
-    </div>
-  </ModalRoot>
-);
+    </ModalRoot>
+  );
+};
 
 interface ShortcutRemovalSectionProps {
   platforms: RegistryPlatform[];
@@ -134,13 +155,14 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
   const [uninstallStatus, setUninstallStatus] = useState("");
   const [confirmRemoveAllRomm, setConfirmRemoveAllRomm] = useState(false);
   const [confirmUninstall, setConfirmUninstall] = useState(false);
+  const syncRunning = useSyncRunning();
 
   const handleRemoveShortcuts = async (p: RegistryPlatform) => {
     setActionStatus(`Removing ${p.name} shortcuts...`);
     try {
       const result = await removePlatformShortcuts(p.slug);
-      // The @migration_blocked gate short-circuits to { success: false,
-      // message, blocked_by_migration } with no app_ids/rom_ids — surface
+      // The @migration_blocked / @sync_active_blocked gates short-circuit to
+      // { success: false, message, ... } with no app_ids/rom_ids — surface
       // that message instead of cosmetically reporting a removal.
       if (!result.success) {
         setActionStatus(result.message ?? "Failed to remove shortcuts");
@@ -213,16 +235,22 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     setStatus("Removing all shortcuts...");
     try {
       const result = await removeAllShortcuts();
-      if (result.app_ids) {
-        for (const appId of result.app_ids) {
-          removeShortcut(appId);
+      if (!result.success) {
+        // A gate refusal (@sync_active_blocked / @migration_blocked) carries
+        // no app_ids/rom_ids — surface its message and remove nothing.
+        setStatus(result.message ?? "Failed to remove shortcuts");
+      } else {
+        if (result.app_ids) {
+          for (const appId of result.app_ids) {
+            removeShortcut(appId);
+          }
         }
+        if (result.rom_ids?.length) {
+          await reportRemovalResults(result.rom_ids);
+        }
+        await clearAllRomMCollections();
+        setStatus(result.message ?? "All shortcuts removed");
       }
-      if (result.rom_ids?.length) {
-        await reportRemovalResults(result.rom_ids);
-      }
-      await clearAllRomMCollections();
-      setStatus(result.message ?? "All shortcuts removed");
     } catch {
       setStatus("Failed to remove shortcuts");
     }
@@ -238,16 +266,24 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     try {
       setUninstallStatus("Uninstalling...");
       const result = await uninstallAllRoms();
-      // Reset every kept shortcut's now-stale launch command to the uninstalled
-      // "" placeholder so a raced-past not_installed can't exec a stale
-      // `flatpak run … "<deleted path>"` into a deleted path (#1146, mirrors the
-      // single-ROM fix in #1051). Batched to avoid serializing the per-shortcut
-      // confirm-poll timeouts; best-effort — a failed confirm is logged, not fatal.
-      await batchConfirmLaunchOptions(
-        result.app_ids.map((appId) => ({ app_id: appId, launch_options: "" })),
-        "uninstall-all",
-      );
-      setUninstallStatus(formatUninstallStatus(result.removed_count, result.errors.length));
+      if (!result.success && result.app_ids === undefined) {
+        // A gate refusal (@sync_active_blocked / @migration_blocked) carries no
+        // removal payload — surface its message before touching app_ids. A
+        // PARTIAL failure (success false WITH payload) still falls through to
+        // the launch-options reset + count display below.
+        setUninstallStatus(result.message ?? "Failed to uninstall ROMs");
+      } else {
+        // Reset every kept shortcut's now-stale launch command to the uninstalled
+        // "" placeholder so a raced-past not_installed can't exec a stale
+        // `flatpak run … "<deleted path>"` into a deleted path (#1146, mirrors the
+        // single-ROM fix in #1051). Batched to avoid serializing the per-shortcut
+        // confirm-poll timeouts; best-effort — a failed confirm is logged, not fatal.
+        await batchConfirmLaunchOptions(
+          (result.app_ids ?? []).map((appId) => ({ app_id: appId, launch_options: "" })),
+          "uninstall-all",
+        );
+        setUninstallStatus(formatUninstallStatus(result.removed_count ?? 0, (result.errors ?? []).length));
+      }
     } catch {
       setUninstallStatus("Failed to uninstall ROMs");
     }
@@ -304,6 +340,10 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             onClick={() => {
               detach(handleRemoveAllRomm());
             }}
+            disabled={syncRunning}
+            // Description ONLY for the disabled-while-syncing case, where it
+            // explains why the button can't be pressed (mirrors SessionBudgetBanner).
+            description={syncRunning ? SYNC_RUNNING_HINT : undefined}
           >
             {confirmRemoveAllRomm ? (
               <span style={{ color: "#ff8800" }}>Confirm: remove all RomM shortcuts?</span>
@@ -335,6 +375,8 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
             onClick={() => {
               detach(handleUninstallAll());
             }}
+            disabled={syncRunning}
+            description={syncRunning ? SYNC_RUNNING_HINT : undefined}
           >
             {confirmUninstall ? (
               <span style={{ color: "#ff8800" }}>Confirm: delete all ROM files?</span>

--- a/tests/contract/test_danger_zone_guard.py
+++ b/tests/contract/test_danger_zone_guard.py
@@ -1,0 +1,74 @@
+"""Contract tests for the danger-zone sync guard (#1390).
+
+The three bulk-removal callables (``remove_all_shortcuts``,
+``remove_platform_shortcuts``, ``uninstall_all_roms``) refuse with the
+canonical failure shape ``{success: False, reason: "sync_active", message}``
+while a library-sync run is in flight (RUNNING or CANCELLING) — a bulk
+removal racing a running sync would delete shortcuts the apply is writing
+and corrupt the registry mid-run. At IDLE (which paused and completed runs
+reset the live state to) each callable answers with its normal shape.
+
+Driven through the real callables over the real wired plugin, frontend-shaped
+(positional args), asserting the response shape on both sides of the gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.sync_state import SyncState
+
+_IN_FLIGHT_STATES = [SyncState.RUNNING, SyncState.CANCELLING]
+
+
+def _assert_sync_active_refusal(result):
+    """Pin the gate's canonical failure shape: exactly success/reason/message."""
+    assert set(result) == {"success", "reason", "message"}
+    assert result["success"] is False
+    assert result["reason"] == "sync_active"
+    assert isinstance(result["message"], str)
+    assert result["message"]
+
+
+@pytest.mark.parametrize("state", _IN_FLIGHT_STATES)
+async def test_remove_all_shortcuts_refused_while_in_flight(harness, state):
+    harness.plugin._sync_service._box.sync_state = state
+    result = await harness.plugin.remove_all_shortcuts()
+    _assert_sync_active_refusal(result)
+
+
+@pytest.mark.parametrize("state", _IN_FLIGHT_STATES)
+async def test_remove_platform_shortcuts_refused_while_in_flight(harness, state):
+    harness.plugin._sync_service._box.sync_state = state
+    result = await harness.plugin.remove_platform_shortcuts("n64")
+    _assert_sync_active_refusal(result)
+
+
+@pytest.mark.parametrize("state", _IN_FLIGHT_STATES)
+async def test_uninstall_all_roms_refused_while_in_flight(harness, state):
+    harness.plugin._sync_service._box.sync_state = state
+    result = await harness.plugin.uninstall_all_roms()
+    _assert_sync_active_refusal(result)
+
+
+async def test_remove_all_shortcuts_normal_shape_at_idle(harness):
+    """IDLE: the callable answers its normal success shape (empty registry)."""
+    result = await harness.plugin.remove_all_shortcuts()
+    assert result["success"] is True
+    assert result["app_ids"] == []
+    assert result["rom_ids"] == []
+
+
+async def test_remove_platform_shortcuts_normal_shape_at_idle(harness):
+    """IDLE: the callable answers its normal shape (name degrades to the slug)."""
+    result = await harness.plugin.remove_platform_shortcuts("n64")
+    assert result["success"] is True
+    assert result["app_ids"] == []
+    assert result["rom_ids"] == []
+    assert result["platform_name"] == "n64"
+
+
+async def test_uninstall_all_roms_partial_success_shape_at_idle(harness):
+    """IDLE: the callable answers its partial-success shape (nothing installed)."""
+    result = await harness.plugin.uninstall_all_roms()
+    assert result == {"success": True, "removed_count": 0, "errors": [], "app_ids": []}

--- a/tests/lib/test_sync_gate.py
+++ b/tests/lib/test_sync_gate.py
@@ -1,0 +1,147 @@
+"""Direct unit tests for the @sync_active_blocked decorator.
+
+The decorator wraps Decky callables on Plugin so they short-circuit with the
+canonical failure shape whenever ``self._sync_service.is_sync_in_flight()``
+is True. ``_sync_service`` is a hard requirement: a missing/None service is
+a wiring regression and the wrapper raises ``RuntimeError`` rather than
+silently skipping the safety gate. Tests use a minimal fake class with a
+``_sync_service`` attribute to keep them independent from the full Plugin.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from lib.sync_gate import sync_active_blocked
+
+_EXPECTED_BLOCKED_DICT = {
+    "success": False,
+    "reason": "sync_active",
+    "message": "A library sync is in progress — wait for it to finish or cancel it before removing shortcuts or ROMs.",
+}
+
+
+class _FakeSyncService:
+    def __init__(self, in_flight: bool):
+        self._in_flight = in_flight
+
+    def is_sync_in_flight(self) -> bool:
+        return self._in_flight
+
+
+class _FakeOwner:
+    def __init__(self, in_flight: bool, ret=None):
+        self._sync_service = _FakeSyncService(in_flight)
+        self._ret = ret
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    @sync_active_blocked
+    async def do_thing(self, *args, **kwargs):
+        """Demo docstring used to verify @functools.wraps preservation."""
+        self.calls.append((args, kwargs))
+        return self._ret
+
+
+class TestSyncActiveBlockedDecorator:
+    @pytest.mark.asyncio
+    async def test_returns_canonical_failure_shape_when_in_flight(self):
+        """The refusal dict is pinned exactly: success/reason/message, no extras."""
+        owner = _FakeOwner(in_flight=True, ret={"success": True, "data": "real"})
+        result = await owner.do_thing()
+        assert result == _EXPECTED_BLOCKED_DICT
+        assert owner.calls == []  # wrapped method NOT invoked
+
+    @pytest.mark.asyncio
+    async def test_passes_args_kwargs_when_not_in_flight(self):
+        """A gated callable with args (e.g. platform_slug) passes them through."""
+        owner = _FakeOwner(in_flight=False, ret={"success": True})
+        await owner.do_thing("n64", dry_run=True)
+        assert owner.calls == [(("n64",), {"dry_run": True})]
+
+    @pytest.mark.asyncio
+    async def test_preserves_inner_return_value_when_not_in_flight(self):
+        sentinel = {"success": True, "app_ids": [1001, 1002]}
+        owner = _FakeOwner(in_flight=False, ret=sentinel)
+        result = await owner.do_thing()
+        assert result is sentinel  # exact pass-through, no mutation
+
+    def test_marks_wrapper_with_sync_active_blocked_attribute(self):
+        assert getattr(_FakeOwner.do_thing, "_sync_active_blocked", False) is True
+
+    def test_preserves_function_metadata_via_wraps(self):
+        """@functools.wraps copies __name__ and __doc__ onto the wrapper so
+        introspection (and test reporters) see the original method."""
+        assert _FakeOwner.do_thing.__name__ == "do_thing"
+        assert _FakeOwner.do_thing.__doc__ == ("Demo docstring used to verify @functools.wraps preservation.")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_sync_service_attribute_absent(self):
+        """The gate is a hard data-safety requirement: if _sync_service is
+        missing entirely (no attribute), the wrapper must RAISE rather than
+        silently call through — a wiring regression must fail loud."""
+
+        class _OwnerWithoutService:
+            def __init__(self):
+                self.called = False
+
+            @sync_active_blocked
+            async def do(self):
+                self.called = True
+                return "ok"
+
+        owner = _OwnerWithoutService()
+        with pytest.raises(RuntimeError) as exc_info:
+            await owner.do()
+        # Message names the gated method and explains the unwired gate.
+        assert "do" in str(exc_info.value)
+        assert "_sync_service" in str(exc_info.value)
+        # The gated callable must NOT have run without the safety gate.
+        assert owner.called is False
+
+    @pytest.mark.asyncio
+    async def test_raises_when_sync_service_is_none(self):
+        """A present-but-None _sync_service is also unwired → raises.
+
+        Mirrors the absent-attribute case for the ``getattr(..., None)`` path:
+        an explicitly-None service is just as much a wiring regression.
+        """
+
+        class _OwnerWithNoneService:
+            def __init__(self):
+                self._sync_service = None
+                self.called = False
+
+            @sync_active_blocked
+            async def do(self):
+                self.called = True
+                return "ok"
+
+        owner = _OwnerWithNoneService()
+        with pytest.raises(RuntimeError) as exc_info:
+            await owner.do()
+        assert "do" in str(exc_info.value)
+        assert "_sync_service" in str(exc_info.value)
+        assert owner.called is False
+
+    @pytest.mark.asyncio
+    async def test_returns_blocked_dict_using_mock_service(self):
+        """Mock-based variant of the in-flight check — confirms the wrapper
+        uses ``is_sync_in_flight`` exactly once per call."""
+
+        class _Owner:
+            def __init__(self, svc):
+                self._sync_service = svc
+
+            @sync_active_blocked
+            async def do(self):
+                return "real-call"
+
+        svc = MagicMock()
+        svc.is_sync_in_flight.return_value = True
+        owner = _Owner(svc)
+        result = cast("dict[str, Any]", await owner.do())
+        assert result == _EXPECTED_BLOCKED_DICT
+        svc.is_sync_in_flight.assert_called_once_with()

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -781,6 +781,34 @@ def _seed_platform_names(uow, names: dict[str, str]) -> None:
         uow.kv_config.set("platform_names", json.dumps(names))
 
 
+class TestIsSyncInFlight:
+    """Tests for is_sync_in_flight() — the read the @sync_active_blocked gate uses.
+
+    State is driven ONLY through the box's lifecycle verbs
+    (``try_begin_run`` / ``request_cancel`` / ``finish_run``) — the
+    run-lifecycle fields have no other sanctioned writer (#1202).
+    """
+
+    def test_false_at_idle(self, plugin):
+        assert plugin._sync_service.is_sync_in_flight() is False
+
+    def test_true_while_running(self, plugin):
+        assert plugin._sync_service._box.try_begin_run("run-1") is True
+        assert plugin._sync_service.is_sync_in_flight() is True
+
+    def test_true_while_cancelling(self, plugin):
+        box = plugin._sync_service._box
+        assert box.try_begin_run("run-1") is True
+        assert box.request_cancel("run-1") == "cancelling"
+        assert plugin._sync_service.is_sync_in_flight() is True
+
+    def test_false_again_after_finish_run(self, plugin):
+        box = plugin._sync_service._box
+        assert box.try_begin_run("run-1") is True
+        assert box.finish_run("run-1") is True
+        assert plugin._sync_service.is_sync_in_flight() is False
+
+
 class TestRemoveAllShortcuts:
     @pytest.mark.asyncio
     async def test_returns_app_ids_and_rom_ids(self, plugin):

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -29,10 +29,14 @@ def plugin():
 
     ``_migration_service.is_retrodeck_migration_pending`` returns False
     so ``@migration_blocked`` callables fall through to the wrapped
-    method instead of returning the blocked sentinel.
+    method instead of returning the blocked sentinel. Likewise
+    ``_sync_service.is_sync_in_flight`` returns False so
+    ``@sync_active_blocked`` callables fall through (a bare ``MagicMock``
+    would return a truthy mock and falsely trigger the guard).
     """
     p = _make_testable_plugin()
     p._sync_service = MagicMock()
+    p._sync_service.is_sync_in_flight.return_value = False
     p._download_service = MagicMock()
     p._rom_removal_service = MagicMock()
     p._firmware_service = MagicMock()


### PR DESCRIPTION
Closes #1390.

The danger-zone removal callables (`remove_all_shortcuts`, `remove_platform_shortcuts`, `uninstall_all_roms`) had no guard against a running library sync. Triggered mid-apply, the frontend's `RemoveShortcut` loop races the sync's `AddShortcut`/`Set*` calls — removal churn during apply is the known trigger for Steam's corrupted in-memory shortcut state, and the removal's DB unbinds interleave with the run's chunk commits.

**Backend**
- New `@sync_active_blocked` decorator (`py_modules/lib/sync_gate.py`, modeled on `@migration_blocked`): refuses with the canonical `{success: false, reason: "sync_active", message}` while the live sync state is `running` or `cancelling`. Idle stays allowed — a paused or completed run resets the live state to idle, so a later resume re-fetches fresh and recreates whatever was removed.
- `LibraryService.is_sync_in_flight()` — read-only delegate to the state box's `is_in_flight()`.
- Applied to the three callables in `main.py` beneath the existing `@migration_blocked`.

**Frontend**
- The danger-zone buttons (both bulk buttons and the per-platform modal's "Remove Shortcuts") are disabled with a short hint ("Unavailable while a library sync is running.") while the sync-progress store reports a run. The modal subscribes to the store itself, since `showModal` renders a detached tree that would hold a stale prop.
- `handleUninstallAll` no longer crashes on a payload-less gate refusal: refusals are detected by `!result.success` with no `app_ids` payload, while a partial failure (`success: false` **with** payload) keeps its count display and launch-options reset. This also fixes a latent crash on the pre-existing migration-gate refusal path.
- `handleRemoveAllRomm` surfaces refusal messages explicitly.

**Tests**
- Decorator unit tests (refusal shape pinned; pass-through when idle).
- Contract tests: all three callables × running/cancelling refuse with the exact shape; idle returns the real response shapes.
- `LibraryService.is_sync_in_flight` driven through the box lifecycle verbs.
- Frontend: disabled-state + hint assertions for all three controls, refusal-path tests asserting the visible message and that no Steam calls fire.

Docs: `docs/user-guide/troubleshooting.md` documents the disabled danger zone during a sync.