### PR TITLE
fix(ui): say interrupted in the sync summary and use the planned total

### DIFF
--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -93,7 +93,9 @@ complete the job.
   sync completed. If your most recent run ended early, a second line reports that attempt and how it ended — "last
   attempt: 17:48 (interrupted)" if a crash or a Steam reload stopped it, "(paused)" if the memory guard paused it, or
   "(cancelled)" if you tapped Cancel Sync — so a partial run that still added hundreds of games never reads a misleading
-  "Never".
+  "Never". The end-of-run toast and the sync status line make the same distinction: a run stopped by a crash or Steam
+  reload reads "Sync interrupted — … so far." rather than blaming a Cancel you never pressed, and the status line
+  compares progress against the run's planned total (e.g. "3 of 10 games processed").
 - **The Sync button becomes "Resume Sync".** When a run was cancelled, interrupted, or paused and left games in your
   library, the **Sync Library** button changes to **Resume Sync**. Pressing it completes the library: the platforms that
   already synced in full are skipped, and even in the platform that stopped, only the games it hadn't finished are

--- a/py_modules/services/library/_state.py
+++ b/py_modules/services/library/_state.py
@@ -140,12 +140,12 @@ class LibrarySyncStateBox:
     # immediate no-progress pause loop. Incremented after each ``sync_apply_unit``
     # emit; reset at the start of each run (#1383).
     chunks_emitted_this_run: int = 0
-    # Distinct terminal reason for an ``interrupted`` run, when the interrupt was
-    # a deliberate session-budget pause rather than a heartbeat timeout. Set by
-    # the gate alongside ``run_interrupted``; ``None`` leaves the interrupted
-    # write on its default heartbeat-timeout reason. Surfaced in the
-    # ``sync_complete`` payload so the UI shows the pause guidance distinctly.
-    # Reset at the start of each run (#1383).
+    # Distinct terminal reason for a run stopped early on purpose, when the stop
+    # was a deliberate session-budget pause rather than a heartbeat timeout. Set
+    # by the gate alongside ``run_paused`` (never ``run_interrupted``); ``None``
+    # leaves an interrupted write on its default heartbeat-timeout reason.
+    # Surfaced in the ``sync_complete`` payload so the UI shows the pause
+    # guidance distinctly. Reset at the start of each run (#1383).
     interrupt_reason: str | None = None
     # One-shot guard so the session-budget gate logs "RSS unavailable" at most
     # once per run instead of on every chunk boundary (the reading is fail-open —

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -353,36 +353,7 @@ class SyncReporter:
         await self._emit("sync_complete", complete_payload)
 
         if cancelled:
-            # A budget pause carries its own full-sentence guidance — use it as the
-            # terminal message verbatim so the QAM status reads the resume-friendly
-            # reason. Otherwise a heartbeat-timeout run routes through this same
-            # cancelled finalize, so key the leading word on the box's
-            # run_interrupted flag — the frame then reads "interrupted" instead of
-            # blaming the user's Cancel button (stage stays CANCELLED; last_attempt
-            # already reads "interrupted"). The frame's denominator is the run's
-            # PLANNED total (the sync_plan count stamped in the box) so "N of M
-            # games processed" compares against the plan, not the bound-ROM
-            # registry count (which equals N on a first sync, #1384); the registry
-            # count is only the fallback when the box was wiped before plan time
-            # (plugin reload).
-            planned_total = self._sync_state.run_total_items
-            total = (
-                planned_total
-                if planned_total is not None
-                else await self._loop.run_in_executor(None, self._count_bound_roms)
-            )
-            if interrupt_reason:
-                message = interrupt_reason
-            else:
-                lead = "Sync interrupted" if self._sync_state.run_interrupted else "Sync cancelled"
-                message = f"{lead}: {total_games} of {total} games processed"
-            await self._emit_progress(
-                SyncStage.CANCELLED,
-                current=total_games,
-                total=total,
-                message=message,
-                running=False,
-            )
+            await self._emit_cancelled_frame(total_games=total_games, interrupt_reason=interrupt_reason)
         else:
             total = await self._loop.run_in_executor(None, self._count_bound_roms)
             await self._emit_progress(
@@ -392,6 +363,40 @@ class SyncReporter:
                 message=f"Sync complete: {total} games from {len(platform_app_ids)} platforms",
                 running=False,
             )
+
+    async def _emit_cancelled_frame(self, *, total_games: int, interrupt_reason: str | None) -> None:
+        """Emit the terminal progress frame for a cancelled/interrupted run.
+
+        A budget pause carries its own full-sentence guidance — used as the
+        terminal message verbatim so the QAM status reads the resume-friendly
+        reason. Otherwise a heartbeat-timeout run routes through this same
+        cancelled finalize, so the leading word keys on the box's
+        ``run_interrupted`` flag — the frame then reads "interrupted" instead of
+        blaming the user's Cancel button (stage stays CANCELLED; last_attempt
+        already reads "interrupted"). The frame's denominator is the run's
+        PLANNED total (the sync_plan count stamped in the box) so "N of M games
+        processed" compares against the plan, not the bound-ROM registry count
+        (which equals N on a first sync); the registry count is only the
+        fallback when the box was wiped before plan time (plugin reload).
+        """
+        planned_total = self._sync_state.run_total_items
+        total = (
+            planned_total
+            if planned_total is not None
+            else await self._loop.run_in_executor(None, self._count_bound_roms)
+        )
+        if interrupt_reason:
+            message = interrupt_reason
+        else:
+            lead = "Sync interrupted" if self._sync_state.run_interrupted else "Sync cancelled"
+            message = f"{lead}: {total_games} of {total} games processed"
+        await self._emit_progress(
+            SyncStage.CANCELLED,
+            current=total_games,
+            total=total,
+            message=message,
+            running=False,
+        )
 
     def _count_bound_roms(self) -> int:
         """Count ROMs that still carry a Steam-shortcut binding."""

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -328,6 +328,14 @@ class SyncReporter:
         pause guidance distinctly instead of the generic cancelled/interrupted
         wording. ``restart_recommended`` (only on a clean run whose post-run RSS is
         high) sets an additive payload flag the UI turns into a "restart Steam" nudge.
+
+        Heartbeat-timeout surfacing (#1384): an interrupted run (an external death —
+        frontend crash/reload — flagged by the box's ``run_interrupted``) routes
+        through the same cancelled finalize, so the payload carries an additive
+        ``interrupted: True`` alongside ``cancelled`` and the completion toast can
+        say "interrupted" instead of blaming a Cancel the user never pressed. A
+        budget pause sets ``interrupt_reason`` (not ``run_interrupted``) and never
+        carries the flag.
         """
         complete_payload: dict[str, Any] = {
             "platform_app_ids": platform_app_ids,
@@ -336,13 +344,14 @@ class SyncReporter:
         }
         if cancelled:
             complete_payload["cancelled"] = True
+            if self._sync_state.run_interrupted:
+                complete_payload["interrupted"] = True
             if interrupt_reason:
                 complete_payload["interrupt_reason"] = interrupt_reason
         elif restart_recommended:
             complete_payload["restart_recommended"] = True
         await self._emit("sync_complete", complete_payload)
 
-        total = await self._loop.run_in_executor(None, self._count_bound_roms)
         if cancelled:
             # A budget pause carries its own full-sentence guidance — use it as the
             # terminal message verbatim so the QAM status reads the resume-friendly
@@ -350,7 +359,18 @@ class SyncReporter:
             # cancelled finalize, so key the leading word on the box's
             # run_interrupted flag — the frame then reads "interrupted" instead of
             # blaming the user's Cancel button (stage stays CANCELLED; last_attempt
-            # already reads "interrupted").
+            # already reads "interrupted"). The frame's denominator is the run's
+            # PLANNED total (the sync_plan count stamped in the box) so "N of M
+            # games processed" compares against the plan, not the bound-ROM
+            # registry count (which equals N on a first sync, #1384); the registry
+            # count is only the fallback when the box was wiped before plan time
+            # (plugin reload).
+            planned_total = self._sync_state.run_total_items
+            total = (
+                planned_total
+                if planned_total is not None
+                else await self._loop.run_in_executor(None, self._count_bound_roms)
+            )
             if interrupt_reason:
                 message = interrupt_reason
             else:
@@ -364,6 +384,7 @@ class SyncReporter:
                 running=False,
             )
         else:
+            total = await self._loop.run_in_executor(None, self._count_bound_roms)
             await self._emit_progress(
                 SyncStage.DONE,
                 current=total,

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -688,6 +688,7 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     romm_collection_app_ids?: Record<string, number[]>;
     total_games: number;
     cancelled?: boolean;
+    interrupted?: boolean;
     interrupt_reason?: string;
     restart_recommended?: boolean;
   };
@@ -878,6 +879,52 @@ describe("index.tsx — sync_complete toast shows the true delta (#744)", () => 
     await flush();
 
     expect(lastToastBody()).toBe("Sync cancelled.");
+    plugin.onDismount();
+  });
+
+  it("on a heartbeat-timeout interrupt with partial work → 'Sync interrupted — … so far.' (#1384)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 3, total_roms: 10 });
+    });
+    recordSyncCreated(100);
+    recordSyncCreated(200);
+    recordSyncCreated(300);
+    // An interrupted run rides the cancelled finalize — the backend sets BOTH
+    // flags. The additive `interrupted` must win the wording: the run died
+    // externally (frontend crash/reload), the user never pressed Cancel.
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 53,
+        cancelled: true,
+        interrupted: true,
+      });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync interrupted — 3 added so far.");
+    plugin.onDismount();
+  });
+
+  it("on a heartbeat-timeout interrupt before any work → 'Sync interrupted.' (no delta, #1384)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", { run_id: "run-1", units: [], total_units: 3, total_roms: 10 });
+    });
+    act(() => {
+      emitDeckyEvent<[SyncCompletePayload]>("sync_complete", {
+        platform_app_ids: {},
+        total_games: 53,
+        cancelled: true,
+        interrupted: true,
+      });
+    });
+    await flush();
+
+    expect(lastToastBody()).toBe("Sync interrupted.");
     plugin.onDismount();
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,7 +132,7 @@ const QAMPanel: FC = () => {
  * finished sync run from the run outcome and the true created/removed delta.
  */
 function buildSyncCompleteToast(
-  data: { interrupt_reason?: string; cancelled?: boolean; restart_recommended?: boolean },
+  data: { interrupt_reason?: string; interrupted?: boolean; cancelled?: boolean; restart_recommended?: boolean },
   delta: { added: number; removed: number },
 ): { body: string; duration?: number } {
   // Report the TRUE delta, not the total processed set. The library applies
@@ -155,6 +155,12 @@ function buildSyncCompleteToast(
     // longer on-screen duration than the default so the guidance isn't truncated
     // away before it is read (#1383).
     return { body, duration: 15000 };
+  }
+  if (data.interrupted) {
+    // A heartbeat-timeout run (an external death — frontend crash/reload) rides
+    // the cancelled finalize with this additive flag; word the toast honestly
+    // instead of blaming a Cancel the user never pressed (#1384).
+    return { body: summary ? `Sync interrupted — ${summary} so far.` : "Sync interrupted." };
   }
   if (data.cancelled) {
     return { body: summary ? `Sync cancelled — ${summary} so far.` : "Sync cancelled." };
@@ -358,6 +364,12 @@ export default definePlugin(() => {
     romm_collection_app_ids?: Record<string, number[]>;
     total_games: number;
     cancelled?: boolean;
+    /**
+     * Set alongside `cancelled` when the run ended on a heartbeat timeout — an
+     * external death (frontend crash/reload), not the user's Cancel — so the
+     * completion toast says "interrupted" instead of "cancelled" (#1384).
+     */
+    interrupted?: boolean;
     /**
      * Present only when the run paused itself at a chunk boundary because
      * Steam's renderer is near its per-session heap budget (#1383). A

--- a/tests/contract/test_sync_cancel_scope.py
+++ b/tests/contract/test_sync_cancel_scope.py
@@ -93,6 +93,7 @@ async def test_cancel_sync_stale_run_does_not_abort_fresh_run(harness):
     completes = _sync_complete_payloads(harness)
     assert completes, "run B must emit a terminal sync_complete"
     assert "cancelled" not in completes[-1]
+    assert "interrupted" not in completes[-1]
     assert harness.plugin._sync_service._sync_state == SyncState.IDLE
 
 

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1186,6 +1186,7 @@ class TestFinalizePerUnitRun:
         complete_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert len(complete_events) == 1
         assert "cancelled" not in complete_events[0][0][1]
+        assert "interrupted" not in complete_events[0][0][1]
         # The last-run memory delta is retained in the box and read via
         # get_session_budget_status, NOT ridden on the sync_complete wire (#1383 LOW-3).
         assert "memory_delta_kb" not in complete_events[0][0][1]
@@ -1211,7 +1212,7 @@ class TestFinalizePerUnitRun:
     @pytest.mark.asyncio
     async def test_emit_sync_complete_cancelled_frame_says_cancelled_when_not_interrupted(self, plugin):
         """A user cancel (box.run_interrupted False) → the terminal CANCELLED frame
-        leads with 'Sync cancelled:'."""
+        leads with 'Sync cancelled:' and the payload carries no ``interrupted``."""
         import decky
 
         decky.emit.reset_mock()
@@ -1226,6 +1227,8 @@ class TestFinalizePerUnitRun:
             restart_recommended=False,
         )
 
+        complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert "interrupted" not in complete[-1]
         progress = plugin._sync_service._sync_progress
         assert progress["stage"] == "cancelled"
         assert progress["message"].startswith("Sync cancelled: ")
@@ -1233,12 +1236,15 @@ class TestFinalizePerUnitRun:
     @pytest.mark.asyncio
     async def test_emit_sync_complete_frame_says_interrupted_when_run_interrupted(self, plugin):
         """A heartbeat-timeout run routes through the same cancelled emit; with
-        box.run_interrupted set the terminal frame leads with 'Sync interrupted:'
-        (stage stays CANCELLED — no new SyncStage)."""
+        box.run_interrupted set the payload carries ``interrupted: True`` and the
+        terminal frame leads with 'Sync interrupted:' (stage stays CANCELLED — no
+        new SyncStage). The frame's denominator is the PLANNED total from the
+        box, not the bound-ROM count (#1384)."""
         import decky
 
         decky.emit.reset_mock()
         plugin._sync_service._box.run_interrupted = True
+        plugin._sync_service._box.run_total_items = 10
 
         await plugin._sync_service._reporter.emit_sync_complete(
             platform_app_ids={},
@@ -1249,9 +1255,12 @@ class TestFinalizePerUnitRun:
             restart_recommended=False,
         )
 
+        complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert complete[-1]["interrupted"] is True
         progress = plugin._sync_service._sync_progress
         assert progress["stage"] == "cancelled"
-        assert progress["message"].startswith("Sync interrupted: ")
+        assert progress["message"] == "Sync interrupted: 3 of 10 games processed"
+        assert progress["total"] == 10
 
     @pytest.mark.asyncio
     async def test_emit_sync_complete_uses_interrupt_reason_verbatim(self, plugin):
@@ -1272,7 +1281,38 @@ class TestFinalizePerUnitRun:
 
         complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
         assert complete[-1]["interrupt_reason"] == "Sync paused: restart Steam, then Resume Sync."
+        # A budget pause sets run_paused + interrupt_reason, never run_interrupted —
+        # the payload must not read as a heartbeat interrupt (#1384).
+        assert "interrupted" not in complete[-1]
         assert plugin._sync_service._sync_progress["message"] == "Sync paused: restart Steam, then Resume Sync."
+
+    @pytest.mark.asyncio
+    async def test_emit_sync_complete_frame_total_falls_back_to_bound_count(self, plugin):
+        """With no planned total in the box (``run_total_items`` None — pre-plan or
+        the box wiped by a plugin reload), the terminal frame's denominator falls
+        back to the bound-ROM registry count (#1384)."""
+        import decky
+
+        decky.emit.reset_mock()
+        uow = plugin._uow
+        _seed_rom(uow, 1, app_id=1001, platform_slug="n64", name="Game A")
+        _seed_rom(uow, 2, app_id=1002, platform_slug="n64", name="Game B")
+        box = plugin._sync_service._box
+        box.run_interrupted = True
+        assert box.run_total_items is None
+
+        await plugin._sync_service._reporter.emit_sync_complete(
+            platform_app_ids={},
+            romm_collection_app_ids={},
+            total_games=1,
+            cancelled=True,
+            interrupt_reason=None,
+            restart_recommended=False,
+        )
+
+        progress = plugin._sync_service._sync_progress
+        assert progress["message"] == "Sync interrupted: 1 of 2 games processed"
+        assert progress["total"] == 2
 
     @pytest.mark.asyncio
     async def test_finalize_does_not_reset_run_lifecycle(self, plugin):


### PR DESCRIPTION
Closes #1384.

Two truthfulness gaps in the sync terminal surfaces:

**Toast said "cancelled" after an interruption.** The `sync_complete` payload only carried `cancelled: boolean`, so a heartbeat-timeout interruption produced "Sync cancelled — N added so far." The payload now carries an additive `interrupted: true` when the run ended via the heartbeat timeout (`run_interrupted` — the same box flag the reporter already used to pick the progress-frame lead word). The toast gains a matching branch: "Sync interrupted — N added so far." / "Sync interrupted." A session-budget pause is unaffected — it sets `run_paused` + `interrupt_reason` (never `run_interrupted`), and its verbatim-guidance toast keeps precedence. The other `cancelled` consumers (stage teardown, stale-collection guard) intentionally keep treating an interrupted run like a cancelled one.

**Terminal frame denominator.** "Sync interrupted: N of X games processed" computed X from the count of currently bound ROMs, which on a first sync equals the processed count ("12 of 12"). X is now the planned total (`run_total_items`, the same number the `sync_plan` event carries — also correct on resumes, where the work queue still plans the full library), falling back to the bound count when no plan total exists (pre-plan/reload edge). The numeric `total` on the progress frame uses the same value, and the reporter now skips the bound-count DB scan entirely when the planned total is available.

Also corrects a stale comment on `_state.py`'s `interrupt_reason` field (it claimed the budget gate sets the reason alongside `run_interrupted`; it actually accompanies `run_paused`).

Tests: reporter payload/frame assertions for interrupted, user-cancel, budget-pause, clean-run and the None-fallback; contract assertion that a completed run carries no `interrupted`; frontend toast tests pinning both new visible bodies.

Docs: one sentence in `docs/user-guide/syncing-your-library.md` § resuming, covering the new wording and the planned-total denominator.