### PR TITLE
test(domain): build sibling property inputs by construction

### DIFF
--- a/tests/domain/test_sibling_resolution_property.py
+++ b/tests/domain/test_sibling_resolution_property.py
@@ -241,15 +241,34 @@ def test_canonical_name_ignores_filter_legs(group, preferred):
     del installed, bound
 
 
-@given(_group(), _preferred)
-def test_canonical_name_winner_carries_preferred_region(group, preferred):
-    members, _installed, _bound = group
-    assume(preferred != "auto")
+@st.composite
+def _group_with_preferred_retail_member(draw):
+    """A drawn group plus a non-"auto" preferred region where at least one RETAIL
+    member carries the preferred region — the exact domain of the preferred-region
+    naming theorem, built by construction: one drawn member is rewritten into the
+    witness, its regions re-drawn around a forced ``preferred`` entry (any
+    position, any companions) and its tags re-drawn from the neutral pool only
+    (retail = no prerelease marker). assume()-filtering this domain instead would
+    reject most draws — enough to degenerate generation into rejection sampling —
+    while construction accepts every draw over the same domain."""
+    members, _installed, _bound = draw(_group())
+    preferred = draw(st.sampled_from(_region_pool))
+    companions = draw(st.lists(st.sampled_from([r for r in _region_pool if r != preferred]), max_size=2, unique=True))
+    regions = list(companions)
+    regions.insert(draw(st.integers(min_value=0, max_value=len(regions))), preferred)
+    tags = draw(st.lists(st.sampled_from(_NEUTRAL_TAGS), max_size=2, unique=True))
+    idx = draw(st.integers(min_value=0, max_value=len(members) - 1))
+    members[idx] = {**members[idx], "regions": regions, "tags": tags}
+    return members, preferred
+
+
+@given(_group_with_preferred_retail_member())
+def test_canonical_name_winner_carries_preferred_region(group_and_preferred):
+    members, preferred = group_and_preferred
     # A RETAIL member carrying the preferred region is (retail, preferred-region) =
     # the global minimum of the pure order, so nothing outranks it (prerelease
     # ranks before region, so a demoted preferred-region member could otherwise
     # lose to a retail non-preferred one).
-    assume(any(preferred in m["regions"] and not _is_prerelease(m) for m in members))
     name = canonical_group_name(members, preferred)
     winner = next(m for m in members if m["name"] == name)
     assert preferred in winner["regions"]


### PR DESCRIPTION
Closes #1389.

The flaky red run was not an invariant violation. A 71k-example hunt plus a 200-run Monte Carlo reproduced the CI symptom locally at ~1% per run: Hypothesis' `filter_too_much` health check. `test_canonical_name_winner_carries_preferred_region` filtered its domain through two `assume()`s (`preferred != "auto"`, and "a retail member carries the preferred region"), rejecting ~70% of draws; when 50 invalid draws accumulate before the 10th valid one in the early generate phase, the health check fails the test with no falsifying example — and the next run passes on fresh entropy. Static analysis confirmed the property itself is a theorem over its domain (`_rank_key` ends in the unique rom_id, so ranking is a total order and retail+preferred-region membership is exactly the minimum bucket).

The fix constructs the quantification domain directly instead of filtering: a composite draws the sibling group, draws `preferred` from the non-"auto" pool, and rewrites one member into a retail witness (neutral-only tags, `preferred` inserted into its regions at a drawn position). The generated domain provably has the same support as the assume()-filtered one — witness regions keep the `≤3`-unique any-order shape, neutral-tagged members still count as retail, and the remaining members stay unconstrained — while measured acceptance rises from ~30% to ~98%, putting the health-check trigger out of reach. The assertion block is unchanged.

Verified with a 20k-example run (health check armed) plus `--hypothesis-show-statistics` before/after; the only remaining invalid draws are `_group()`'s internal unique-rom_id retries shared by every property in the file.

docs: N/A — test-only change to a property test's input generation; no behavior, architecture, or user-facing surface.