### PR TITLE
feat(sync): make time estimates skip-aware and finish the estimate surfaces

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,6 @@
     "name": "dist/index.js (raw)",
     "path": "dist/index.js",
     "brotli": false,
-    "limit": "700 KB"
+    "limit": "750 KB"
   }
 ]

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -483,9 +483,24 @@ reliable reset.
 #### Sync time estimate and live ETA (frontend)
 
 The QAM's time readout is a two-stage design layered on the `sync_progress` stream. It is pure frontend logic
-(`src/utils/syncEstimate.ts` and `src/utils/syncEta.ts`, both unit-tested); the backend only supplies the plan (per-unit
-weights + planned total, via `sync_plan`) and the applying frames.
+(`src/utils/syncEstimate.ts` and `src/utils/syncEta.ts`, both unit-tested); the backend supplies the plan (per-unit
+weights + planned totals, via `sync_plan`) and the applying frames.
 
+- **The plan is skip-aware (#1382).** At plan time the fetcher stamps every platform `WorkUnit` with two estimate-only
+  riders read in one short UoW (`_read_plan_estimates` + the pure `domain/skip_prediction.py`): `predicted_skip` —
+  whether the wholesale incremental-skip gate is expected to skip the platform, replaying the gate's **local**
+  conditions only (completion stamp present, stamped/persisted row counts match the server's `rom_count`, bound rows
+  exist, no sibling-group-key backfill pending; the gate's `list_roms_updated_after` server check is deliberately not
+  replayed — no network at plan time) — and `collapsed_count`, the persisted post-collapse shortcut count (distinct
+  sibling-group keys + keyless singletons, ADR-0021). Both ride the `sync_plan` payload conditionally-present (absent on
+  collections, never-synced platforms, and failed reads). The payload's `total_roms` stays the raw pre-collapse total
+  (backward compat); an additive `total_estimated_items` sums `0` for predicted skips, else
+  `collapsed_count ?? rom_count`. **Hard constraint (ADR-0023): the prediction never feeds the actual skip decision** —
+  `_try_unit_incremental_skip` at fetch time remains the sole skip authority, so a mis-prediction can only make the
+  estimate read long or short, never mis-apply. A Force Full Sync needs no special case: `clear_sync_cache` deletes
+  every stamp before the run, so a forced plan predicts no skips. The same collapsed counts also garnish `get_platforms`
+  (an optional per-platform `collapsed_count`), so the platform toggles show the number of games a synced platform
+  actually produces rather than the raw server file count.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model: `new_count × NEW_ITEM_SEC` +
   `changed_count × UPDATED_ITEM_SEC` + a flat fetch allowance. The per-item constants (currently ~0.45 s for a created
@@ -493,7 +508,9 @@ weights + planned total, via `sync_plan`) and the applying frames.
   (~90 s) covers the multi-page ROM/save fetch phases the per-item model ignores, so the seed is an honest **upper
   bound** that reads long, never short. It is priced at **walk cost** (every unit the run will actually touch), not at
   the delta only — a resume walks thousands of already-applied games through the cheap update path, so a delta-only
-  price would badly undershoot the real work.
+  price would badly undershoot the real work. The skip-preview seed prices `total_estimated_items ?? total_roms`, so an
+  incremental re-sync whose platforms are all predicted skips seeds near the flat allowance instead of a whole-library
+  ceiling; the live-countdown weights are seeded per unit as `predicted_skip ? 0 : (collapsed_count ?? rom_count)`.
 - **Measured live countdown (takes over within seconds).** Once the apply is underway, `syncEta.ts` measures the
   **real** rate from the applying frames — one throttled sample per second over a ~30 s sliding window — and projects
   `remaining = (planned_total − processed) / rate`, rendered rounded **up** ("9 min left") so it never promises less
@@ -511,9 +528,19 @@ weights + planned total, via `sync_plan`) and the applying frames.
   with a post-gap one would be a tiny item delta over a long span, an absurd rate that would briefly spike the
   countdown.
 
-The whole thing is an approximation by design (the plan's per-unit weight is the raw pre-collapse file count while the
-applying frame's counter is the post-collapse emitted-shortcut count; the measured rate absorbs most of the skew), and
-the readout always carries a leading `~` — it is an estimate, never a guarantee.
+The coarse QAM progress bar reuses the same run weights (`weightedCoarseFraction`, `syncEta.ts`): each unit's bar width
+is its item-weight share — skip-aware at plan time, corrected to the real delta as units dispatch — with the within-unit
+fill scaled by the running unit's share, so a predicted-skip platform occupies no width and a huge platform fills the
+bar in proportion to its real work. It falls back to the old equal-per-unit index weighting when no plan is measured
+(QAM opened mid-run before any `sync_plan`, an older backend) or the plan can't apportion (unit-count mismatch, all-zero
+weights).
+
+The whole thing is an approximation by design — though a narrow one since the plan went skip-aware: seed weights and the
+applying frames usually both count post-collapse shortcuts now, the raw pre-collapse `rom_count` survives only as the
+fallback where the backend doesn't know better, and a unit the plan mis-predicted re-corrects on its first
+`sync_apply_unit` (`observeUnitTotal`). Estimate degradation is strictly one-directional: a wrong prediction or a stale
+collapsed count makes the readout run long or short, never changes what the sync applies. The readout wording ("up to",
+rounded-up countdown) keeps it an estimate, never a guarantee.
 
 #### Save-sync serialization (device gate)
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -39,11 +39,18 @@ entirely, not re-processed — so a re-sync of a mostly-settled library is quick
 changed work. If you sync without previewing first, the estimate appears once the run starts as an **Estimated time**
 line, shown as "up to X min".
 
+That starting estimate is **skip-aware**: when the run is planned, the plugin already knows which platforms haven't
+changed since their last sync and expects to skip them wholesale, so they don't inflate the number — an incremental
+re-sync of an unchanged library reads seconds, not the minutes a full first import would take. The prediction is only an
+estimate (the actual skip is decided per platform as the run reaches it), so a wrong guess can make the readout run long
+or short for a moment, but it never changes what the sync actually does.
+
 Once the sync has been creating shortcuts for a few seconds, that "up to" ceiling is replaced by a **live countdown** —
 "2 min left" — measured from the actual speed on your device and updated as the run proceeds. Both the countdown and the
 progress counter show **net** progress: they count the games this run actually needs to add or update (say "100/801"),
 not every game in your library. It holds steady across the short pauses where the sync fetches the next platform's game
-list, rather than jumping around.
+list, rather than jumping around. The main progress bar apportions its width the same way — a platform expected to skip
+takes no space, and a huge platform fills the bar in proportion to its real work instead of an equal slice per platform.
 
 A few things worth knowing for a large library:
 
@@ -152,6 +159,10 @@ individual platforms.
 3. Toggle platforms on or off
 4. Use **Enable All** / **Disable All** for bulk changes
 5. Only enabled platforms are included in the next sync
+
+For a platform you have already synced, the count shows the number of **games** it syncs into Steam — multiple versions
+of the same game (regional dumps, revisions) collapse into one shortcut, so this can be lower than the raw file count on
+your server. A platform you have never synced shows the server's raw ROM count until its first sync.
 
 All platforms are enabled by default until you change a toggle. Turning one platform off affects only that platform —
 every other platform stays enabled and keeps syncing.

--- a/py_modules/domain/skip_prediction.py
+++ b/py_modules/domain/skip_prediction.py
@@ -1,0 +1,78 @@
+"""Plan-time estimate kernels for the skip-aware sync time estimate.
+
+Pure predictions derived from locally persisted state: whether the
+fetch-time wholesale-skip gate is expected to skip a platform unit, and
+how many Steam shortcuts a platform's persisted rows collapse into.
+Both exist ONLY to price the ``sync_plan`` estimate payload
+(``predicted_skip`` / ``collapsed_count`` / ``total_estimated_items``).
+
+Hard constraint (ADR-0023): the fetch-time gate
+(``LibraryFetcher._try_unit_incremental_skip``) remains the SOLE skip
+authority — nothing computed here may ever feed the actual skip
+decision. A mis-prediction can only mis-estimate (the countdown reads
+long or short); it can never mis-apply.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def predict_unit_skip(
+    *,
+    stamp_completed_at: str | None,
+    stamp_rom_count: int | None,
+    unit_rom_count: int,
+    persisted_count: int,
+    registry_count: int,
+    needs_backfill: bool,
+) -> bool:
+    """Predict whether the wholesale-skip gate will skip a platform unit.
+
+    Replays the gate's LOCAL conditions only: a completion stamp exists
+    (truthy ``completed_at``, non-``None`` ``rom_count``), the stamped ROM
+    count still matches the server's ``rom_count`` for the unit, rows are
+    persisted and at least one is bound, no ``sibling_group_key`` backfill
+    is pending, and the persisted row count matches the server count. The
+    gate's server-delta check (``list_roms_updated_after``) is deliberately
+    NOT replayed — no network at plan time — so a platform whose rows
+    changed server-side since the stamp may be predicted as a skip that the
+    fetch then refuses; the estimate reads short, the apply stays correct.
+
+    A Force Full Sync needs no special case: ``clear_sync_cache`` deletes
+    every stamp before the run starts, so ``stamp_completed_at`` reads
+    ``None`` at plan time and no skip is predicted.
+
+    Estimate-only (ADR-0023): the return value prices the plan payload and
+    must never feed the actual skip decision.
+    """
+    return (
+        bool(stamp_completed_at)
+        and stamp_rom_count is not None
+        and stamp_rom_count == unit_rom_count
+        and persisted_count > 0
+        and persisted_count == unit_rom_count
+        and registry_count > 0
+        and not needs_backfill
+    )
+
+
+def collapsed_shortcut_count(group_keys: Iterable[str | None]) -> int:
+    """Post-collapse shortcut count for one platform's persisted rows.
+
+    The sibling-group collapse (ADR-0021) yields one Steam shortcut per
+    sibling group; a row without a group key is its own singleton. Given
+    every persisted row's ``sibling_group_key``, the collapsed count is the
+    number of distinct non-``None`` keys plus one per ``None`` key.
+    """
+    distinct_keys: set[str] = set()
+    singletons = 0
+    for key in group_keys:
+        if key is None:
+            singletons += 1
+        else:
+            distinct_keys.add(key)
+    return len(distinct_keys) + singletons

--- a/py_modules/domain/work_unit.py
+++ b/py_modules/domain/work_unit.py
@@ -31,6 +31,28 @@ class WorkUnit:
     # Collection-only: dispatches the correct list-roms endpoint at fetch time.
     # ``None`` is only valid when ``type == "platform"``.
     collection_kind: CollectionKind | None = None
+    # Plan-time estimate riders (#1382), platform-only. ``predicted_skip`` is
+    # the plan's local-conditions guess at the fetch-time wholesale-skip gate's
+    # outcome; ``collapsed_count`` the persisted post-collapse shortcut count.
+    # Estimate-ONLY: they price the ``sync_plan`` payload and must never feed
+    # the actual skip decision — ``_try_unit_incremental_skip`` remains the
+    # sole skip authority (ADR-0023). ``None`` means unknown (collections,
+    # never-synced platforms, failed estimate read) and is omitted from the
+    # event payload.
+    predicted_skip: bool | None = None
+    collapsed_count: int | None = None
+
+    def estimated_items(self) -> int:
+        """This unit's weight in the plan's skip-aware estimate total.
+
+        ``0`` when the plan predicts the wholesale skip, else the persisted
+        post-collapse shortcut count, falling back to the raw ``rom_count``
+        when no collapsed count is known. Estimate-only — prices the
+        ``sync_plan`` payload, never the actual skip decision (ADR-0023).
+        """
+        if self.predicted_skip:
+            return 0
+        return self.collapsed_count if self.collapsed_count is not None else self.rom_count
 
     def to_event_payload(self) -> dict[str, Any]:
         """Serialise to the shape emitted in ``sync_plan`` / ``sync_apply_unit``."""
@@ -43,4 +65,8 @@ class WorkUnit:
         }
         if self.type == "collection":
             payload["collection_kind"] = self.collection_kind
+        if self.predicted_skip is not None:
+            payload["predicted_skip"] = self.predicted_skip
+        if self.collapsed_count is not None:
+            payload["collapsed_count"] = self.collapsed_count
         return payload

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -12,10 +12,11 @@ elsewhere (per applied unit) so a fetch never mutates the cache.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from domain.platform_prefs import materialize_enabled_platforms, resolve_sync_enabled
+from domain.skip_prediction import collapsed_shortcut_count, predict_unit_skip
 from domain.sync_stage import SyncStage
 from domain.sync_state import SyncCancelled, SyncState
 from domain.work_unit import CollectionKind, WorkUnit
@@ -148,21 +149,32 @@ class LibraryFetcher:
             self._settings_persister.save_settings()
             enabled = materialized
 
+        # Persisted post-collapse shortcut counts for the toggle labels
+        # (#1382). Display garnish only, so a failed read degrades to the raw
+        # server counts instead of failing the platform list.
+        try:
+            collapsed_counts = await self._loop.run_in_executor(None, self._read_collapsed_counts)
+        except Exception as e:
+            self._logger.warning(f"Collapsed-count read failed, falling back to raw ROM counts: {e}")
+            collapsed_counts = {}
+
         result = []
         for p in platforms:
             rom_count = p.get("rom_count", 0)
             if rom_count == 0:
                 continue
             pid = str(p["id"])
-            result.append(
-                {
-                    "id": p["id"],
-                    "name": p.get("name", ""),
-                    "slug": p.get("slug", ""),
-                    "rom_count": rom_count,
-                    "sync_enabled": resolve_sync_enabled(enabled, pid),
-                }
-            )
+            entry = {
+                "id": p["id"],
+                "name": p.get("name", ""),
+                "slug": p.get("slug", ""),
+                "rom_count": rom_count,
+                "sync_enabled": resolve_sync_enabled(enabled, pid),
+            }
+            collapsed = collapsed_counts.get(entry["slug"])
+            if collapsed is not None:
+                entry["collapsed_count"] = collapsed
+            result.append(entry)
         return {"success": True, "platforms": result}
 
     def save_platform_sync(self, platform_id, enabled):
@@ -389,12 +401,15 @@ class LibraryFetcher:
         first, then user collections, then smart collections, then
         franchise collections) with ROM counts pulled from the listing
         endpoints. No ROMs are fetched here — the queue is a dispatch
-        plan, not a payload.
+        plan, not a payload. Platform units additionally carry the
+        plan-time estimate riders (``predicted_skip`` / ``collapsed_count``,
+        #1382) — estimate-only fields for the ``sync_plan`` payload that
+        never feed the actual skip decision (ADR-0023).
         """
         units: list[WorkUnit] = []
 
         platforms = await self._fetch_enabled_platforms()
-        units.extend(
+        platform_units = [
             WorkUnit(
                 type="platform",
                 id=int(platform["id"]),
@@ -403,7 +418,8 @@ class LibraryFetcher:
                 rom_count=int(platform.get("rom_count", 0)),
             )
             for platform in platforms
-        )
+        ]
+        units.extend(await self._attach_plan_estimates(platform_units))
 
         buckets = self._get_enabled_collections_buckets()
         enabled_user_ids = {k for k, v in buckets["user"].items() if v}
@@ -450,6 +466,78 @@ class LibraryFetcher:
             self._logger.warning(f"Failed to fetch franchise collections for work queue: {e}")
             collections = []
         return _collection_units(collections, enabled_ids, "franchise")
+
+    async def _attach_plan_estimates(self, platform_units: list[WorkUnit]) -> list[WorkUnit]:
+        """Stamp each platform unit with its plan-time estimate riders (#1382).
+
+        Fail-open: the riders only price the ``sync_plan`` estimate, so a
+        failed read leaves every unit's fields ``None`` (the frontend falls
+        back to raw ``rom_count`` weights) rather than failing the plan.
+        """
+        if not platform_units:
+            return platform_units
+        try:
+            estimates = await self._loop.run_in_executor(None, self._read_plan_estimates, platform_units)
+        except Exception as e:
+            self._logger.warning(f"Plan-time skip-estimate read failed, using raw ROM counts: {e}")
+            return platform_units
+        return [
+            replace(unit, predicted_skip=estimates[unit.slug][0], collapsed_count=estimates[unit.slug][1])
+            if unit.slug in estimates
+            else unit
+            for unit in platform_units
+        ]
+
+    def _read_plan_estimates(self, units: list[WorkUnit]) -> dict[str, tuple[bool, int | None]]:
+        """Read the plan-time estimate baseline for platform units (#1382).
+
+        Per unit slug: replay the wholesale-skip gate's LOCAL conditions
+        (``predict_unit_skip`` — stamp present, stamped/persisted counts match
+        the server count, bound rows exist, no group-key backfill pending) and
+        derive the persisted post-collapse shortcut count
+        (``collapsed_shortcut_count`` over the rows' sibling-group keys;
+        ``None`` when the platform has no persisted rows). The gate's
+        server-delta check (``list_roms_updated_after``) is deliberately NOT
+        replayed — no network at plan time. A Force Full Sync clears every
+        stamp before the run, so its plan predicts no skips without a special
+        case. One short read UoW for the whole plan.
+
+        Estimate-ONLY (ADR-0023): the result rides the ``sync_plan`` payload
+        and must never feed the actual skip decision —
+        ``_try_unit_incremental_skip`` at fetch time remains the sole skip
+        authority.
+        """
+        estimates: dict[str, tuple[bool, int | None]] = {}
+        with self._uow_factory() as uow:
+            for unit in units:
+                stamp = uow.platform_sync_state.get(unit.slug)
+                all_rows = list(uow.roms.iter_by_platform(unit.slug))
+                predicted = predict_unit_skip(
+                    stamp_completed_at=stamp.completed_at if stamp is not None else None,
+                    stamp_rom_count=stamp.rom_count if stamp is not None else None,
+                    unit_rom_count=unit.rom_count,
+                    persisted_count=len(all_rows),
+                    registry_count=sum(1 for rom in all_rows if rom.shortcut_app_id is not None),
+                    needs_backfill=any(rom.sibling_group_key is None for rom in all_rows),
+                )
+                collapsed = collapsed_shortcut_count(rom.sibling_group_key for rom in all_rows) if all_rows else None
+                estimates[unit.slug] = (predicted, collapsed)
+        return estimates
+
+    def _read_collapsed_counts(self) -> dict[str, int]:
+        """Persisted post-collapse shortcut count per platform slug (#1382).
+
+        Groups every persisted ``roms`` row by ``platform_slug`` and collapses
+        each platform's sibling-group keys (``collapsed_shortcut_count``).
+        Slugs with no persisted rows are absent, so the caller leaves the
+        field off and the frontend falls back to the raw server count. One
+        short read UoW.
+        """
+        keys_by_slug: dict[str, list[str | None]] = {}
+        with self._uow_factory() as uow:
+            for rom in uow.roms.iter_all():
+                keys_by_slug.setdefault(rom.platform_slug, []).append(rom.sibling_group_key)
+        return {slug: collapsed_shortcut_count(keys) for slug, keys in keys_by_slug.items()}
 
     def _read_incremental_baseline(
         self, platform_slug: str
@@ -542,6 +630,12 @@ class LibraryFetcher:
         no persisted rows, an un-backfilled row, a stamped ROM count that no
         longer matches the server, the delta check raised, or the server reports
         changes.
+
+        This gate is the SOLE skip authority (ADR-0023). The plan-time
+        ``predicted_skip`` rider (``_read_plan_estimates`` /
+        ``domain/skip_prediction.py``) replays this gate's local conditions
+        for the ``sync_plan`` estimate only and must never feed — and is
+        never read by — this decision.
         """
         platform_name = unit.name
         platform_slug = unit.slug

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -672,6 +672,12 @@ class SyncOrchestrator:
 
             total_units = len(work_queue)
             total_roms_planned = sum(u.rom_count for u in work_queue)
+            # Skip-aware estimate total (#1382): predicted-skip units weigh 0,
+            # the rest their persisted collapsed count (raw ``rom_count``
+            # fallback). Estimate-only — it prices the frontend's seeds and
+            # never feeds the actual skip decision (ADR-0023); ``total_roms``
+            # below stays the raw planned total for backward compatibility.
+            total_estimated_items = sum(u.estimated_items() for u in work_queue)
             platforms_planned = sum(1 for u in work_queue if u.type == "platform")
             # Live ``platform_slug → display_name`` map from the work-queue;
             # threaded into finalize so collections key on display names and
@@ -688,6 +694,7 @@ class SyncOrchestrator:
                     "units": [u.to_event_payload() for u in work_queue],
                     "total_units": total_units,
                     "total_roms": total_roms_planned,
+                    "total_estimated_items": total_estimated_items,
                 },
             )
 

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -257,6 +257,28 @@ describe("LibraryPage", () => {
       await flushAsync();
       expect(queryByTestId("spinner")).toBeNull();
     });
+
+    it("shows the collapsed shortcut count in the toggle description when present (#1382)", async () => {
+      vi.mocked(backend.getPlatforms).mockResolvedValue({
+        success: true,
+        platforms: [makePlatform({ id: 1, name: "Genesis", rom_count: 10, collapsed_count: 7 })],
+      });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      const toggle = container.querySelector('[data-label="Genesis"]');
+      expect(toggle?.getAttribute("data-description")).toBe("7 ROMs");
+    });
+
+    it("falls back to the raw rom_count when no collapsed count is present (never synced / old backend)", async () => {
+      vi.mocked(backend.getPlatforms).mockResolvedValue({
+        success: true,
+        platforms: [makePlatform({ id: 1, name: "Genesis", rom_count: 10 })],
+      });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      const toggle = container.querySelector('[data-label="Genesis"]');
+      expect(toggle?.getAttribute("data-description")).toBe("10 ROMs");
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -231,7 +231,10 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
           <PanelSectionRow key={platform.id}>
             <ToggleField
               label={platform.name}
-              description={`${platform.rom_count} ROMs`}
+              // Prefer the persisted post-collapse shortcut count (#1382) — the
+              // number of games the platform actually syncs into Steam — over
+              // the raw server file count; raw is the never-synced fallback.
+              description={`${platform.collapsed_count ?? platform.rom_count} ROMs`}
               checked={platform.sync_enabled}
               onChange={(value: boolean) => {
                 detach(handleToggle(platform.id, value));

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1606,6 +1606,67 @@ describe("MainPage", () => {
       expect(nProgress).toBeCloseTo(((1 + 450 / 2091) / 8) * 100, 5);
     });
 
+    it("main bar weights units by the plan's item weights when a plan is measured (#1382)", async () => {
+      // Plan weights [10, 2091, 5] — the huge PSX unit owns most of the bar, not
+      // an equal 1/3 slice. The run state comes from the real syncEta module,
+      // exactly as the sync_plan listener seeds it.
+      beginEtaRun("run-1", [10, 2091, 5], 2106);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 3,
+        current: 450,
+        total: 2091,
+        message: "PSX: 450/2091",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // Weighted: (unit 1's 10 + 450 of PSX's 2091) / 2106. The index-based math
+      // would read (1 + 450/2091)/3 ≈ 40.5 — far past the real position.
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(((10 + 450) / 2106) * 100, 5);
+    });
+
+    it("a predicted-skip unit occupies no bar width (zero plan weight, #1382)", async () => {
+      // Unit 1 was zero-weighted as a predicted wholesale skip; while unit 2
+      // applies, the bar reflects only unit 2's own items.
+      beginEtaRun("run-1", [0, 100], 100);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 2,
+        current: 50,
+        total: 100,
+        message: "GBA: 50/100",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      // Weighted: 50/100 → 50. Index-based would read (1 + 0.5)/2 * 100 = 75,
+      // crediting the skipped unit half the bar.
+      expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("50");
+    });
+
+    it("falls back to index weighting when the plan's unit count mismatches the run (stale plan)", async () => {
+      // A leftover plan from another run (2 units) cannot apportion an 8-unit
+      // run — the bar falls back to the equal-slice interpolation.
+      beginEtaRun("run-other", [5, 5], 10);
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 450,
+        total: 2091,
+        message: "PSX: 450/2091",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(((1 + 450 / 2091) / 8) * 100, 5);
+    });
+
     it("main bar rests at the unit floor during the fetch phase (no within-unit fill)", async () => {
       // Fetch frames carry current/total (page counters) to drive the fine line,
       // but must NOT advance the coarse bar — it rests at (step-1)/totalSteps so

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -34,7 +34,13 @@ import {
 import { formatBytes } from "../utils/formatters";
 import { pluralize } from "../utils/pluralize";
 import { estimateApplySeconds, formatDuration } from "../utils/syncEstimate";
-import { observeApplyProgress, displayedEtaSeconds, resetEta, formatEtaCountdown } from "../utils/syncEta";
+import {
+  observeApplyProgress,
+  displayedEtaSeconds,
+  resetEta,
+  formatEtaCountdown,
+  weightedCoarseFraction,
+} from "../utils/syncEta";
 import { getSyncProgress, setSyncProgress as setStoredSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
@@ -752,10 +758,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
   // Two-level progress. The main determinate bar tracks COARSE unit progress
   // but INTERPOLATES within the running unit so a large unit (e.g. 2091 items at
-  // step 2/8) doesn't sit frozen: the bar fills from the step's floor
-  // ((step-1)/totalSteps) toward the next notch as the unit's items are applied.
-  // 0/0 totalSteps means the run hasn't reached a unit yet → indeterminate.
-  // ``nProgress`` is a percentage (0-100), not a fraction.
+  // step 2/8) doesn't sit frozen: the bar fills from the step's floor toward the
+  // next notch as the unit's items are applied. Notch positions come from the
+  // plan's per-unit item weights when measured (#1382), else each unit is an
+  // equal 1/totalSteps slice. 0/0 totalSteps means the run hasn't reached a
+  // unit yet → indeterminate. ``nProgress`` is a percentage (0-100), not a
+  // fraction.
   //
   // While actively working a unit (``fetching``/``applying``) the current unit
   // is not yet done, so the completed count is ``step - 1``; the terminal-ish
@@ -773,8 +781,20 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     syncProgress?.stage === "applying" && syncProgress.current && syncProgress.total
       ? syncProgress.current / syncProgress.total
       : 0;
+  // Weight the bar by the plan's per-unit item weights (#1382) — the same
+  // skip-aware, delta-corrected weights the countdown uses — so a
+  // predicted-skip unit takes no width and a huge platform takes its real
+  // share. Falls back to equal-per-unit index weighting when no plan is
+  // measured (QAM opened mid-run before any sync_plan, old backend) or the
+  // plan can't apportion (unit-count mismatch, all-zero weights).
+  const weightedFraction = syncProgress?.totalSteps
+    ? weightedCoarseFraction(completedSteps, withinUnitFraction, syncProgress.totalSteps)
+    : null;
   const coarseFraction = syncProgress?.totalSteps
-    ? Math.max(0, Math.min(100, ((completedSteps + withinUnitFraction) / syncProgress.totalSteps) * 100))
+    ? Math.max(
+        0,
+        Math.min(100, (weightedFraction ?? (completedSteps + withinUnitFraction) / syncProgress.totalSteps) * 100),
+      )
     : undefined;
   const hasFineDetail = !!(syncProgress?.total && syncProgress.message);
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -25,6 +25,7 @@ import {
 import { getSettingsResetState, setSettingsResetState } from "./utils/settingsResetStore";
 import { getSyncProgress, setSyncProgress } from "./utils/syncProgress";
 import { estimateApplySeconds } from "./utils/syncEstimate";
+import { resetEta, weightedCoarseFraction } from "./utils/syncEta";
 import { recordSyncCreated, resetSyncDelta } from "./utils/syncDeltaStore";
 import { resetSyncCancel } from "./utils/syncManager";
 import type { DownloadCompleteEvent, SyncPlanData, SyncProgress, SyncStaleData } from "./types";
@@ -1086,6 +1087,90 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     });
 
     expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(80, 0));
+    plugin.onDismount();
+  });
+
+  it("prefers total_estimated_items over total_roms for the seed (#1382 skip-aware)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [],
+        total_units: 3,
+        total_roms: 120,
+        total_estimated_items: 5,
+      });
+    });
+
+    // An incremental re-sync prices only the predicted work, not the library.
+    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(5, 0));
+    resetEta();
+    plugin.onDismount();
+  });
+
+  it("seeds the live estimator with skip-aware unit weights (predicted_skip → 0, collapsed over raw)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [
+          // Predicted skip: weight 0 even though counts are known.
+          {
+            type: "platform",
+            id: 1,
+            name: "N64",
+            slug: "n64",
+            rom_count: 100,
+            predicted_skip: true,
+            collapsed_count: 60,
+          },
+          // Known collapsed count wins over the raw rom_count.
+          {
+            type: "platform",
+            id: 2,
+            name: "GBA",
+            slug: "gba",
+            rom_count: 100,
+            predicted_skip: false,
+            collapsed_count: 40,
+          },
+          // Never synced: raw rom_count fallback.
+          { type: "platform", id: 3, name: "SNES", slug: "snes", rom_count: 30, predicted_skip: false },
+        ],
+        total_units: 3,
+        total_roms: 230,
+        total_estimated_items: 70,
+      });
+    });
+
+    // Observable through the weighted coarse fraction over the seeded weights
+    // [0, 40, 30]: units 1+2 done (0 + 40) plus half of SNES (15) → 55/70.
+    expect(weightedCoarseFraction(2, 0.5, 3)).toBeCloseTo(55 / 70, 10);
+    resetEta();
+    plugin.onDismount();
+  });
+
+  it("falls back to raw weights and total_roms when the estimate fields are absent (old backend)", async () => {
+    const plugin = pluginFactory();
+
+    act(() => {
+      emitDeckyEvent<[SyncPlanData]>("sync_plan", {
+        run_id: "run-eta",
+        units: [
+          { type: "platform", id: 1, name: "N64", slug: "n64", rom_count: 60 },
+          { type: "platform", id: 2, name: "GBA", slug: "gba", rom_count: 20 },
+        ],
+        total_units: 2,
+        total_roms: 80,
+      });
+    });
+
+    expect(getSyncProgress().etaSeconds).toBe(estimateApplySeconds(80, 0));
+    // Raw rom_count weights: unit 1 done (60) plus half of unit 2 (10) → 70/80.
+    expect(weightedCoarseFraction(1, 0.5, 2)).toBeCloseTo(70 / 80, 10);
+    resetEta();
     plugin.onDismount();
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -534,14 +534,18 @@ export default definePlugin(() => {
     resetSyncCancel();
     // Seed the applying-phase estimate on the walk-cost model (the same
     // ``estimateApplySeconds`` the preview row uses): an honest upper bound that
-    // prices every planned ROM as a new shortcut plus the flat fetch allowance.
-    // The skip-preview path has no delta knowledge here (per-unit skips are only
-    // decided at fetch time), so all-as-new is the ceiling; the delta-restricted
-    // apply skips unchanged items and the live rate estimator corrects the readout
-    // downward within seconds of applying (#1382-M3). Merged (not replaced) so the
-    // running/stage the click set survives, and the sync_progress listener below
-    // preserves it across backend frames. Shown as "up to X min" only until the
-    // live estimator replaces it with a "X min left" countdown.
+    // prices every planned item as a new shortcut plus the flat fetch allowance.
+    // The plan is skip-aware (#1382): ``total_estimated_items`` zero-weights the
+    // platforms the backend predicts its wholesale-skip gate will skip and prices
+    // the rest at their persisted collapsed (post-sibling-group) shortcut count,
+    // so an incremental re-sync no longer seeds a whole-library ceiling. The raw
+    // ``total_roms`` stays the fallback for an older backend that doesn't send
+    // the field. The delta-restricted apply skips unchanged items and the live
+    // rate estimator corrects the readout within seconds of applying (#1382-M3).
+    // Merged (not replaced) so the running/stage the click set survives, and the
+    // sync_progress listener below preserves it across backend frames. Shown as
+    // "up to X min" only until the live estimator replaces it with a "X min
+    // left" countdown.
     //
     // Only seed the bound when the store has NO etaSeconds yet: the preview path
     // (handleApply) already seeded a tighter delta-based estimate into the store,
@@ -550,17 +554,25 @@ export default definePlugin(() => {
     // seed, never a stale prior-run value. The skip-preview path never sets one,
     // so it still gets this bound.
     if (getSyncProgress().etaSeconds === undefined) {
-      updateSyncProgress({ etaSeconds: estimateApplySeconds(data.total_roms, 0) });
+      updateSyncProgress({ etaSeconds: estimateApplySeconds(data.total_estimated_items ?? data.total_roms, 0) });
     }
     // Begin the run-scoped live-ETA estimator with the plan's per-unit weights
-    // (rom_count in plan order) and total. MainPage samples the applying stage
-    // against this to derive the countdown; a fresh plan resets any prior slope.
+    // and total. Weights are skip-aware (#1382): 0 for a predicted-skip unit,
+    // else the persisted collapsed count, falling back to the raw rom_count
+    // when the backend doesn't know it (never-synced platform, collections,
+    // old backend). A mis-predicted skip that actually dispatches re-corrects
+    // via observeUnitTotal on its first chunk. MainPage samples the applying
+    // stage against this to derive the countdown; a fresh plan resets any
+    // prior slope.
     beginEtaRun(
       data.run_id,
-      data.units.map((u) => u.rom_count),
-      data.total_roms,
+      data.units.map((u) => (u.predicted_skip ? 0 : (u.collapsed_count ?? u.rom_count))),
+      data.total_estimated_items ?? data.total_roms,
     );
-    logInfo(`sync_plan received: ${data.total_units} units, ${data.total_roms} ROMs total`);
+    logInfo(
+      `sync_plan received: ${data.total_units} units, ${data.total_roms} ROMs total` +
+        (data.total_estimated_items !== undefined ? ` (${data.total_estimated_items} estimated items)` : ""),
+    );
   });
 
   // ``sync_stale`` arrives after every unit finishes — remove each stale

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -9,6 +9,13 @@ export interface PlatformSyncSetting {
   name: string;
   slug: string;
   rom_count: number;
+  /**
+   * Persisted post-collapse shortcut count — how many Steam shortcuts this
+   * platform's ROMs collapse into (one per sibling group, ADR-0021). Absent
+   * when the platform was never synced (no persisted rows); the toggle label
+   * then falls back to the raw `rom_count`.
+   */
+  collapsed_count?: number;
   sync_enabled: boolean;
 }
 
@@ -183,6 +190,20 @@ interface SyncPlanUnit {
   rom_count: number;
   /** Only present when ``type === "collection"``. Discriminates user/smart/franchise. */
   collection_kind?: CollectionKind;
+  /**
+   * Plan-time prediction of the wholesale incremental skip (#1382) —
+   * estimate-only, the fetch-time gate stays the sole skip authority
+   * (ADR-0023). Present on platform units from current backends; absent on
+   * collections and older backends (treat absent as "will not skip").
+   */
+  predicted_skip?: boolean;
+  /**
+   * Persisted post-collapse shortcut count for this platform (one shortcut
+   * per sibling group, ADR-0021). Absent on collections, never-synced
+   * platforms, and older backends; the estimate then weighs the unit by its
+   * raw `rom_count`.
+   */
+  collapsed_count?: number;
 }
 
 export interface SyncPlanData {
@@ -190,7 +211,14 @@ export interface SyncPlanData {
   run_id: string;
   units: SyncPlanUnit[];
   total_units: number;
+  /** Raw planned ROM total (pre-collapse, skip-blind) — kept for backward compatibility. */
   total_roms: number;
+  /**
+   * Skip-aware estimate total (#1382): sum over units of `0` for a
+   * predicted-skip unit, else `collapsed_count ?? rom_count`. Absent on older
+   * backends; the seeds then fall back to `total_roms`.
+   */
+  total_estimated_items?: number;
 }
 
 export interface SyncApplyUnitData {

--- a/src/utils/syncEta.test.ts
+++ b/src/utils/syncEta.test.ts
@@ -10,6 +10,7 @@ import {
   liveEtaSeconds,
   displayedEtaSeconds,
   resetEta,
+  weightedCoarseFraction,
   type EtaSample,
 } from "./syncEta";
 
@@ -255,6 +256,79 @@ describe("run-scoped estimator", () => {
     // the pre-gap sample and a rate is measured.
     observeApplyProgress(1, 700, 16000);
     expect(liveEtaSeconds()).not.toBeNull();
+  });
+
+  it("a zero-weight (predicted-skip) unit contributes nothing to the remaining total (#1382)", () => {
+    // Unit 0 is a predicted wholesale skip (weight 0); unit 1 carries the run.
+    beginEtaRun("run-1", [0, 2000], 2000);
+    observeApplyProgress(2, 100, 0);
+    observeApplyProgress(2, 700, 6000);
+    // processed = 0 (skipped unit) + 700; rate 100/s;
+    // remaining = (2000 - 700) / 100 = 13s — the skipped unit adds no phantom time.
+    expect(liveEtaSeconds()).toBe(13);
+  });
+
+  it("a mis-predicted skip that actually dispatches re-corrects via observeUnitTotal (#1382)", () => {
+    // The plan zero-weighted unit 0 as a predicted skip, but the fetch-time gate
+    // (the sole skip authority) refused and the unit dispatched a 300-item delta.
+    beginEtaRun("run-1", [0, 1000], 1000);
+    observeUnitTotal(0, 300);
+    observeApplyProgress(1, 100, 0);
+    observeApplyProgress(1, 700, 6000);
+    // totalRoms grew 1000 → 1300; remaining = (1300 - 700) / 100 = 6s.
+    expect(liveEtaSeconds()).toBe(6);
+  });
+});
+
+describe("weightedCoarseFraction", () => {
+  beforeEach(() => resetEta());
+
+  it("apportions the bar by per-unit weight, scaling the within-unit fill by the unit's share", () => {
+    beginEtaRun("run-1", [100, 300, 0, 600], 1000);
+    // Unit 0 done (100) + half of unit 1 (150) over total 1000.
+    expect(weightedCoarseFraction(1, 0.5, 4)).toBeCloseTo(0.25, 10);
+  });
+
+  it("a zero-weight (predicted-skip) running unit adds no width while it runs", () => {
+    beginEtaRun("run-1", [100, 300, 0, 600], 1000);
+    // Units 0+1 done (400); the running unit 2 weighs 0 → bar rests at 0.4.
+    expect(weightedCoarseFraction(2, 0.7, 4)).toBeCloseTo(0.4, 10);
+  });
+
+  it("uses the delta-corrected weights once a unit dispatches (observeUnitTotal)", () => {
+    beginEtaRun("run-1", [100, 900], 1000);
+    // Unit 1 dispatches with a 100-item delta → weights become [100, 100].
+    observeUnitTotal(1, 100);
+    expect(weightedCoarseFraction(1, 0.5, 2)).toBeCloseTo(150 / 200, 10);
+  });
+
+  it("returns null when no run is measured (caller falls back to index weighting)", () => {
+    expect(weightedCoarseFraction(1, 0.5, 4)).toBeNull();
+  });
+
+  it("returns null when the plan's unit count mismatches totalUnits (stale plan)", () => {
+    beginEtaRun("run-1", [100, 300], 400);
+    expect(weightedCoarseFraction(1, 0.5, 4)).toBeNull();
+  });
+
+  it("returns null when the total weight is zero (all-predicted-skip plan)", () => {
+    beginEtaRun("run-1", [0, 0], 0);
+    expect(weightedCoarseFraction(1, 0.5, 2)).toBeNull();
+  });
+
+  it("clamps the within-unit fraction to 0..1 and the result to ≤ 1", () => {
+    beginEtaRun("run-1", [100, 300], 400);
+    // within > 1 clamps to the unit's full weight: (100 + 300) / 400 = 1.
+    expect(weightedCoarseFraction(1, 5, 2)).toBe(1);
+    // within < 0 clamps to the completed floor: 100 / 400 = 0.25.
+    expect(weightedCoarseFraction(1, -3, 2)).toBeCloseTo(0.25, 10);
+    // completedUnits beyond the plan sums everything and caps at 1.
+    expect(weightedCoarseFraction(9, 0.5, 2)).toBe(1);
+  });
+
+  it("reads full (1) at the finalizing/done position (completedUnits === totalUnits)", () => {
+    beginEtaRun("run-1", [100, 300], 400);
+    expect(weightedCoarseFraction(2, 0, 2)).toBe(1);
   });
 });
 

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -14,12 +14,16 @@
  * countdown via ``displayedEtaSeconds`` — the module owns the deadline, so the UI
  * holds no ETA state of its own.
  *
- * Approximation, by design: the plan's per-unit ``rom_count`` is the RAW
- * pre-collapse file count, while the applying stage's ``current`` is the
- * post-collapse EMITTED shortcut count (sibling groups collapse to one shortcut).
- * Mixing the two slightly overstates a grouped unit's completed weight, but the
- * measured rate absorbs most of the skew and the countdown stays close enough to
- * be useful. It is an estimate, never a guarantee.
+ * Approximation, by design — though a narrow one since the plan went skip-aware
+ * (#1382): a unit's seeded weight is 0 when the backend predicts its wholesale
+ * incremental skip, else the persisted post-collapse (sibling-group) shortcut
+ * count, so seed weights and the applying stage's post-collapse ``current``
+ * usually count the same thing. The raw pre-collapse ``rom_count`` remains the
+ * fallback only where the backend doesn't know better (never-synced platforms,
+ * collections, old backends), and a mis-predicted skip re-corrects the moment
+ * the unit dispatches (``observeUnitTotal``). Residual skew is absorbed by the
+ * measured rate. It is an estimate, never a guarantee — a mis-prediction can
+ * only make the readout long or short, never change what the sync applies.
  */
 
 import { formatApproxDuration } from "./syncEstimate";
@@ -117,8 +121,9 @@ let _run: EtaRunState | null = null;
 /**
  * Begin measuring a fresh run, discarding any prior samples — a new run's rate
  * must never inherit the previous run's slope. Called once by the ``sync_plan``
- * listener with the plan's per-unit weights (``rom_count`` in plan order) and the
- * planned ROM total.
+ * listener with the plan's per-unit weights in plan order (skip-aware since
+ * #1382: 0 for predicted skips, else ``collapsed_count ?? rom_count``) and the
+ * planned item total.
  */
 export function beginEtaRun(runId: string, unitWeights: number[], totalRoms: number): void {
   _run = { runId, unitWeights: [...unitWeights], totalRoms, samples: [], lastSampleMs: 0, deadlineMs: null };
@@ -141,9 +146,11 @@ export function resetEta(): void {
  * every chunk of a unit carries the same ``unit_total``, so re-calls no-op once the
  * weight matches. A no-op when no run is measured or the index is out of range.
  *
- * Bounded by the plan: a platform SKIPPED wholesale by its completion stamp never
- * emits a ``sync_apply_unit``, so its weight stays the raw ``rom_count`` — the plan
- * carries no skip knowledge to correct that, matching #1382-M3's scope.
+ * This is also the safety net for the plan's skip prediction (#1382): a unit the
+ * plan zero-weighted as a predicted skip but that actually dispatches re-corrects
+ * here to its real delta size on its first chunk. A unit skipped wholesale never
+ * emits a ``sync_apply_unit`` — its plan weight (0 when predicted, or the stale
+ * seeded weight on a mis-prediction in the other direction) simply stands.
  */
 export function observeUnitTotal(unitIndex: number, unitTotal: number): void {
   if (_run === null) return;
@@ -222,4 +229,41 @@ export function liveEtaSeconds(): number | null {
 export function displayedEtaSeconds(nowMs: number): number | null {
   if (_run?.deadlineMs == null) return null;
   return Math.max(0, (_run.deadlineMs - nowMs) / 1000);
+}
+
+/**
+ * Weighted coarse-bar fraction (0..1) over the run's per-unit plan weights —
+ * the size-aware replacement for MainPage's equal-per-unit index weighting
+ * (#1382). ``completedUnits`` units are done in full; the running unit (index
+ * ``completedUnits``) contributes ``withinUnitFraction`` (clamped to 0..1) of
+ * its own weight share. Uses the SAME weights the countdown uses (skip-aware
+ * seeds, delta-corrected by {@link observeUnitTotal} as units dispatch), so a
+ * predicted-skip unit occupies no bar width and a huge platform occupies its
+ * real share instead of ``1/totalUnits``.
+ *
+ * Returns ``null`` — the caller falls back to index weighting — when no run is
+ * measured (QAM opened mid-run before any plan, old backend), when the plan's
+ * unit count doesn't match ``totalUnits`` (a stale plan from another run), or
+ * when the total weight is zero (an all-predicted-skip plan has no widths to
+ * apportion).
+ */
+export function weightedCoarseFraction(
+  completedUnits: number,
+  withinUnitFraction: number,
+  totalUnits: number,
+): number | null {
+  if (_run === null) return null;
+  const weights = _run.unitWeights;
+  if (weights.length !== totalUnits) return null;
+  let totalWeight = 0;
+  for (const w of weights) totalWeight += Math.max(0, w);
+  if (totalWeight <= 0) return null;
+  let completedWeight = 0;
+  for (let i = 0; i < completedUnits && i < weights.length; i++) {
+    completedWeight += Math.max(0, weights[i] ?? 0);
+  }
+  const runningWeight =
+    completedUnits >= 0 && completedUnits < weights.length ? Math.max(0, weights[completedUnits] ?? 0) : 0;
+  const within = Math.max(0, Math.min(1, withinUnitFraction));
+  return Math.min(1, (completedWeight + within * runningWeight) / totalWeight);
 }

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -118,9 +118,21 @@ async def test_get_platforms_happy_shape(harness):
     # rom_count==0 platform is filtered out
     assert [p["slug"] for p in result["platforms"]] == ["snes"]
     p = result["platforms"][0]
+    # collapsed_count is conditionally-present (#1382): a never-synced platform
+    # (no persisted rows) omits it — absent, not null.
     assert set(p.keys()) == {"id", "name", "slug", "rom_count", "sync_enabled"}
     assert p["id"] == 1
     assert isinstance(p["sync_enabled"], bool)
+
+
+async def test_get_platforms_collapsed_count_after_sync(harness):
+    """A platform with persisted rows carries the optional collapsed_count (#1382)."""
+    harness.romm.platforms = [{"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3}]
+    seed_rom(harness, 11, platform_slug="snes")
+    result = await harness.plugin.get_platforms()
+    p = result["platforms"][0]
+    assert p["collapsed_count"] == 1
+    assert p["rom_count"] == 3
 
 
 async def test_get_platforms_server_failure_shape(harness):

--- a/tests/domain/test_skip_prediction.py
+++ b/tests/domain/test_skip_prediction.py
@@ -1,0 +1,77 @@
+"""Tests for domain/skip_prediction.py — plan-time estimate kernels (#1382)."""
+
+import pytest
+
+from domain.skip_prediction import collapsed_shortcut_count, predict_unit_skip
+
+
+def _kwargs(**overrides):
+    """A baseline input set that predicts a skip; each test flips one field."""
+    base = {
+        "stamp_completed_at": "2025-01-01T00:00:00",
+        "stamp_rom_count": 3,
+        "unit_rom_count": 3,
+        "persisted_count": 3,
+        "registry_count": 1,
+        "needs_backfill": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestPredictUnitSkip:
+    """Every LOCAL condition of the wholesale-skip gate flips the prediction."""
+
+    def test_predicts_skip_when_all_local_conditions_hold(self):
+        assert predict_unit_skip(**_kwargs()) is True
+
+    def test_no_stamp_completed_at_predicts_full_fetch(self):
+        assert predict_unit_skip(**_kwargs(stamp_completed_at=None)) is False
+
+    def test_empty_stamp_completed_at_predicts_full_fetch(self):
+        """A falsy (empty-string) stamp timestamp counts as no stamp — mirrors the gate."""
+        assert predict_unit_skip(**_kwargs(stamp_completed_at="")) is False
+
+    def test_none_stamp_rom_count_predicts_full_fetch(self):
+        assert predict_unit_skip(**_kwargs(stamp_rom_count=None)) is False
+
+    def test_stamp_count_mismatch_predicts_full_fetch(self):
+        assert predict_unit_skip(**_kwargs(stamp_rom_count=2)) is False
+
+    def test_zero_persisted_rows_predicts_full_fetch(self):
+        assert (
+            predict_unit_skip(**_kwargs(persisted_count=0, registry_count=0, stamp_rom_count=0, unit_rom_count=0))
+            is False
+        )
+
+    def test_persisted_count_mismatch_predicts_full_fetch(self):
+        """The gate's final line also requires server rom_count == persisted rows."""
+        assert predict_unit_skip(**_kwargs(persisted_count=2)) is False
+
+    def test_zero_bound_rows_predicts_full_fetch(self):
+        """Unbind-only rows (mass delete, ADR-0007) mirror nothing — the gate re-fetches."""
+        assert predict_unit_skip(**_kwargs(registry_count=0)) is False
+
+    def test_needs_backfill_predicts_full_fetch(self):
+        assert predict_unit_skip(**_kwargs(needs_backfill=True)) is False
+
+
+class TestCollapsedShortcutCount:
+    """Distinct group keys count once; keyless rows are singletons."""
+
+    def test_empty_rows_collapse_to_zero(self):
+        assert collapsed_shortcut_count([]) == 0
+
+    def test_distinct_keys_count_once_each(self):
+        assert collapsed_shortcut_count(["igdb:1:1", "igdb:1:1", "igdb:2:1"]) == 2
+
+    def test_none_keys_are_singletons(self):
+        assert collapsed_shortcut_count([None, None, None]) == 3
+
+    def test_mixed_keys_and_singletons(self):
+        # One 3-sibling group + one 2-sibling group + two keyless singletons.
+        assert collapsed_shortcut_count(["g:a", "g:a", "g:a", "g:b", "g:b", None, None]) == 4
+
+    @pytest.mark.parametrize("keys", [["g:a"], [None]])
+    def test_single_row_is_one_shortcut(self, keys):
+        assert collapsed_shortcut_count(keys) == 1

--- a/tests/domain/test_work_unit.py
+++ b/tests/domain/test_work_unit.py
@@ -1,0 +1,59 @@
+"""Tests for domain/work_unit.py — event-payload shape + estimate weights (#1382)."""
+
+from domain.work_unit import WorkUnit
+
+
+def _platform_unit(**overrides):
+    kwargs = {"type": "platform", "id": 1, "name": "N64", "slug": "n64", "rom_count": 5}
+    kwargs.update(overrides)
+    return WorkUnit(**kwargs)
+
+
+class TestToEventPayload:
+    """Optional fields ride the payload only when known — absent, not null."""
+
+    def test_platform_payload_omits_unset_estimate_fields(self):
+        payload = _platform_unit().to_event_payload()
+        assert payload == {"type": "platform", "id": 1, "name": "N64", "slug": "n64", "rom_count": 5}
+        assert "predicted_skip" not in payload
+        assert "collapsed_count" not in payload
+        assert "collection_kind" not in payload
+
+    def test_platform_payload_carries_estimate_fields_when_set(self):
+        payload = _platform_unit(predicted_skip=True, collapsed_count=3).to_event_payload()
+        assert payload["predicted_skip"] is True
+        assert payload["collapsed_count"] == 3
+
+    def test_predicted_skip_false_is_still_emitted(self):
+        """False is knowledge ("will not skip"), distinct from absent ("unknown")."""
+        payload = _platform_unit(predicted_skip=False).to_event_payload()
+        assert payload["predicted_skip"] is False
+        assert "collapsed_count" not in payload
+
+    def test_collection_payload_carries_kind_but_no_estimate_fields(self):
+        unit = WorkUnit(type="collection", id="7", name="Faves", slug="", rom_count=4, collection_kind="user")
+        payload = unit.to_event_payload()
+        assert payload["collection_kind"] == "user"
+        assert "predicted_skip" not in payload
+        assert "collapsed_count" not in payload
+
+
+class TestEstimatedItems:
+    """The unit's weight in the plan's skip-aware totals (estimate-only, ADR-0023)."""
+
+    def test_predicted_skip_weighs_zero(self):
+        assert _platform_unit(predicted_skip=True, collapsed_count=3).estimated_items() == 0
+
+    def test_collapsed_count_wins_over_raw_rom_count(self):
+        assert _platform_unit(predicted_skip=False, collapsed_count=3).estimated_items() == 3
+
+    def test_falls_back_to_raw_rom_count_when_collapsed_unknown(self):
+        assert _platform_unit(predicted_skip=False).estimated_items() == 5
+
+    def test_unknown_prediction_falls_back_to_raw_rom_count(self):
+        """Collections / failed estimate reads carry None everywhere → raw weight."""
+        assert _platform_unit().estimated_items() == 5
+
+    def test_zero_collapsed_count_weighs_zero_not_raw(self):
+        """0 is a real collapsed count (edge), never confused with the None fallback."""
+        assert _platform_unit(predicted_skip=False, collapsed_count=0).estimated_items() == 0

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -8,6 +8,8 @@ per-method ``*_side_effect`` attributes (persistent) — no
 ``run_in_executor`` patching, no ``MagicMock(romm_api)``.
 """
 
+from dataclasses import replace
+
 import pytest
 
 from domain.sync_state import SyncCancelled, SyncState
@@ -897,3 +899,225 @@ class TestFetchProgressNarration:
         assert len(frames) == 1
         assert frames[0]["step"] == 0
         assert frames[0]["totalSteps"] == 0
+
+
+class TestPlanEstimates:
+    """build_work_queue's plan-time estimate riders (#1382).
+
+    ``predicted_skip`` / ``collapsed_count`` are estimate-only fields that
+    price the ``sync_plan`` payload — the fetch-time gate
+    (``_try_unit_incremental_skip``) stays the sole skip authority
+    (ADR-0023); see :class:`TestPredictionNeverFeedsSkipGate` for the guard.
+    """
+
+    @pytest.mark.asyncio
+    async def test_predicts_skip_and_collapsed_count_when_local_conditions_hold(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
+        # A 3-sibling group: one bound representative + two unbound siblings —
+        # collapses to ONE shortcut.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert len(units) == 1
+        assert units[0].predicted_skip is True
+        assert units[0].collapsed_count == 1
+
+    @pytest.mark.asyncio
+    async def test_never_synced_platform_predicts_no_skip_and_no_collapsed_count(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+        assert units[0].collapsed_count is None
+
+    @pytest.mark.asyncio
+    async def test_stamp_count_mismatch_predicts_no_skip_but_keeps_collapsed_count(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        # Server grew to 4 ROMs since the 3-ROM stamp → the gate will re-fetch,
+        # but the persisted rows still collapse to a displayable count.
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 4}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=1002, group_key="igdb:200:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+        assert units[0].collapsed_count == 2
+
+    @pytest.mark.asyncio
+    async def test_backfill_pending_predicts_no_skip(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=1)
+        # A legacy row with no group key forces the gate's backfill full fetch;
+        # the keyless row is a singleton for the collapsed count.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key=None)
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+        assert units[0].collapsed_count == 1
+
+    @pytest.mark.asyncio
+    async def test_zero_bound_rows_predicts_no_skip(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 2}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=2)
+        # Mass delete left unbind-only rows (ADR-0007) — the gate re-fetches.
+        _seed_persisted_rom(uow, 10, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+
+    @pytest.mark.asyncio
+    async def test_collection_units_carry_no_estimate_fields(self, plugin, fake_romm_api):
+        """Collection membership isn't locally derivable — the scope guard leaves both fields None."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = []
+        fake_romm_api.collections = [{"id": 7, "name": "Faves", "slug": "faves", "rom_count": 4}]
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert [u.type for u in units] == ["collection"]
+        assert units[0].predicted_skip is None
+        assert units[0].collapsed_count is None
+
+    @pytest.mark.asyncio
+    async def test_force_full_sync_clears_stamps_so_plan_predicts_no_skips(self, plugin, fake_romm_api):
+        """clear_sync_cache runs BEFORE the run, so a forced plan reads no stamps."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=1)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+
+        before = await plugin._sync_service._fetcher.build_work_queue()
+        assert before[0].predicted_skip is True
+
+        plugin._sync_service.clear_sync_cache()
+
+        after = await plugin._sync_service._fetcher.build_work_queue()
+        assert after[0].predicted_skip is False
+        # The rows survive the cache clear, so the collapsed count still shows.
+        assert after[0].collapsed_count == 1
+
+    @pytest.mark.asyncio
+    async def test_estimate_read_failure_leaves_fields_none_and_plan_intact(self, plugin, fake_romm_api):
+        """Fail-open: a DB failure degrades the estimate, never the plan."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+
+        def _boom():
+            raise RuntimeError("db down")
+
+        plugin._sync_service._fetcher._uow_factory = _boom
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert len(units) == 1
+        assert units[0].predicted_skip is None
+        assert units[0].collapsed_count is None
+
+
+class TestGetPlatformsCollapsedCount:
+    """get_platforms attaches the persisted post-collapse count per platform (#1382)."""
+
+    @pytest.mark.asyncio
+    async def test_synced_platform_carries_collapsed_count(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 4},
+            {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+        ]
+        # n64: a 3-sibling group + a keyless singleton → 2 shortcuts. snes: never synced.
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 13, app_id=1002, group_key=None)
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["success"] is True
+        by_slug = {p["slug"]: p for p in result["platforms"]}
+        assert by_slug["n64"]["collapsed_count"] == 2
+        assert by_slug["n64"]["rom_count"] == 4
+        assert "collapsed_count" not in by_slug["snes"]
+
+    @pytest.mark.asyncio
+    async def test_collapsed_count_read_failure_falls_back_to_raw_counts(self, plugin, fake_romm_api):
+        """Fail-open: a DB failure drops the garnish, never the platform list."""
+        _wire_fake(plugin, fake_romm_api)
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 4}]
+
+        def _boom():
+            raise RuntimeError("db down")
+
+        plugin._sync_service._fetcher._uow_factory = _boom
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["success"] is True
+        assert "collapsed_count" not in result["platforms"][0]
+        assert result["platforms"][0]["rom_count"] == 4
+
+
+class TestPredictionNeverFeedsSkipGate:
+    """ADR-0023 guard: the plan-time prediction rides the payload only — the
+    fetch-time gate's decision is IDENTICAL whatever the unit's estimate
+    fields say."""
+
+    @pytest.mark.asyncio
+    async def test_skip_eligible_platform_skips_regardless_of_prediction_fields(self, plugin, fake_romm_api):
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=1)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        base = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+
+        results = [
+            await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
+            for unit in (
+                base,
+                replace(base, predicted_skip=False, collapsed_count=None),
+                replace(base, predicted_skip=True, collapsed_count=1),
+            )
+        ]
+
+        assert all(r is not None for r in results)
+        assert [{rom["id"] for rom in r} for r in results] == [{10}] * 3
+
+    @pytest.mark.asyncio
+    async def test_ineligible_platform_full_fetches_even_when_prediction_says_skip(self, plugin, fake_romm_api):
+        """A (wrong) predicted_skip=True can only mis-estimate, never mis-skip."""
+        _wire_fake(plugin, fake_romm_api)
+        # No stamp, no rows — the gate must full-fetch.
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1, predicted_skip=True)
+
+        result = await plugin._sync_service._fetcher._try_unit_incremental_skip(unit)
+
+        assert result is None

--- a/tests/services/library/test_service.py
+++ b/tests/services/library/test_service.py
@@ -40,10 +40,15 @@ class TestGetPlatforms:
         from unittest.mock import AsyncMock, MagicMock
 
         mock_loop = MagicMock()
+        # get_platforms makes two executor calls: list_platforms, then the
+        # collapsed-count read (#1382) — stage both in call order.
         mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
-                {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+            side_effect=[
+                [
+                    {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
+                    {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+                ],
+                {},
             ]
         )
         rebind_loop(plugin._sync_service, mock_loop)
@@ -61,9 +66,12 @@ class TestGetPlatforms:
 
         mock_loop = MagicMock()
         mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
-                {"id": 2, "name": "Empty", "slug": "empty", "rom_count": 0},
+            side_effect=[
+                [
+                    {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
+                    {"id": 2, "name": "Empty", "slug": "empty", "rom_count": 0},
+                ],
+                {},
             ]
         )
         rebind_loop(plugin._sync_service, mock_loop)
@@ -79,9 +87,12 @@ class TestGetPlatforms:
 
         mock_loop = MagicMock()
         mock_loop.run_in_executor = AsyncMock(
-            return_value=[
-                {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
-                {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+            side_effect=[
+                [
+                    {"id": 1, "name": "N64", "slug": "n64", "rom_count": 10},
+                    {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
+                ],
+                {},
             ]
         )
         rebind_loop(plugin._sync_service, mock_loop)
@@ -96,7 +107,9 @@ class TestGetPlatforms:
         from unittest.mock import AsyncMock, MagicMock
 
         mock_loop = MagicMock()
-        mock_loop.run_in_executor = AsyncMock(return_value=[{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}])
+        mock_loop.run_in_executor = AsyncMock(
+            side_effect=[[{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}], {}]
+        )
         rebind_loop(plugin._sync_service, mock_loop)
         plugin.settings["enabled_platforms"] = {}
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -1070,6 +1070,56 @@ class TestDoSyncPerUnit:
         assert payload["run_id"] == "run-plan"
 
     @pytest.mark.asyncio
+    async def test_sync_plan_carries_skip_aware_estimate_fields(self, plugin, fake_romm_api):
+        """#1382: platform units ride predicted_skip / collapsed_count, the raw
+        ``total_roms`` stays untouched (backward compat), and the additive
+        ``total_estimated_items`` zero-weights predicted skips and prices the
+        rest at their collapsed count (raw fallback)."""
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # N64: skip-eligible — stamp matches the server count, 2 persisted rows
+        # in one sibling group with a bound representative → predicted skip,
+        # collapsed count 1. GBA: never synced → no skip, raw-count fallback.
+        fake_romm_api.platforms = [
+            {"id": 1, "name": "N64", "slug": "n64", "rom_count": 2},
+            {"id": 2, "name": "GBA", "slug": "gba", "rom_count": 5},
+        ]
+        plugin.settings["enabled_platforms"] = {"1": True, "2": True}
+        _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00", rom_count=2)
+        _seed_rom_row(plugin, 10, app_id=1001, platform_slug="n64", sibling_group_key="igdb:100:1")
+        _seed_rom_row(plugin, 11, app_id=None, platform_slug="n64", sibling_group_key="igdb:100:1")
+        # A collection unit: membership isn't locally derivable, so it carries
+        # neither estimate field and weighs its raw rom_count.
+        _seed_collection(fake_romm_api, collection_id=7, name="Faves", rom_ids=[20, 21, 22])
+        plugin.settings["enabled_collections"] = {"user": {"7": True}, "smart": {}, "franchise": {}}
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._box.current_sync_id = "run-est"
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        plan_events = [c for c in decky.emit.call_args_list if c[0][0] == "sync_plan"]
+        assert len(plan_events) == 1
+        payload = plan_events[0][0][1]
+        # Raw planned total is untouched: 2 + 5 + 3.
+        assert payload["total_roms"] == 10
+        # Skip-aware: N64 predicted-skip → 0, GBA raw 5, collection raw 3.
+        assert payload["total_estimated_items"] == 8
+        units = {u["name"]: u for u in payload["units"]}
+        assert units["N64"]["predicted_skip"] is True
+        assert units["N64"]["collapsed_count"] == 1
+        assert units["GBA"]["predicted_skip"] is False
+        assert "collapsed_count" not in units["GBA"]
+        assert "predicted_skip" not in units["Faves"]
+        assert "collapsed_count" not in units["Faves"]
+
+    @pytest.mark.asyncio
     async def test_processes_each_unit_in_order(self, plugin, fake_romm_api):
         import decky
 


### PR DESCRIPTION
Closes #1382.

The estimate tier stayed honest as a ceiling but over-promised in known cases: the live countdown weighted wholesale-skipped trailing platforms by their raw server ROM count (an incremental re-sync read "~2 min left" and finished in seconds), the skip-preview seed priced every planned ROM as new, the platform toggles showed raw pre-collapse counts, and the coarse bar advanced one notch per unit regardless of size.

**Plan-time skip prediction (estimate-only).** A new pure kernel (`domain/skip_prediction.py`) replays the wholesale-skip gate's local conditions (stamp present and count-matched, persisted rows complete, bound shortcuts exist, no sibling-key backfill) against the same SQLite state, with zero network. Each platform unit in the `sync_plan` payload carries an optional `predicted_skip`; the one condition the prediction cannot see (the server-side content delta) stays fetch-only, so a wrong prediction can only make the countdown read short and re-correct via the existing `unit_total` observation. **The fetch-time gate remains the sole skip authority** — the prediction feeds nothing but the payload (pinned by a dedicated guard test).

**Persisted collapsed counts.** Distinct sibling-group count (plus keyless singletons) per platform, computed from the local rows: rides the plan units and `get_platforms` as an optional `collapsed_count` (absent for never-synced platforms and collections).

**Consumer surfaces.** The countdown seeds unit weights as `predicted_skip ? 0 : (collapsed_count ?? rom_count)` with an additive `total_estimated_items` (raw `total_roms` unchanged — old payloads keep byte-identical behavior); the skip-preview seed prices only non-skip units; the platform toggles show the collapsed count when known; the coarse bar is weighted by unit size with an index-count fallback when no plan weights exist.

Estimate reads are fail-open — a failed read leaves the fields absent and the plan/list unaffected.

Tests: prediction kernel condition-by-condition, collapsed-count math, plan payload shape (conditionally-present fields, totals), the skip-authority guard test, force-full (stampless at plan time), ETA zero-weight seeding + mis-prediction re-correction, seed fallbacks against old payloads, weighted-bar fallback paths, toggle labels, and a contract test pinning the optional field on the wire.

Docs: `docs/architecture/backend-architecture.md` (estimate/ETA section) and `docs/user-guide/syncing-your-library.md`.