### PR TITLE
fix(sync): price grandfathered sibling groups per bound duplicate in estimates

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -491,16 +491,17 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   whether the wholesale incremental-skip gate is expected to skip the platform, replaying the gate's **local**
   conditions only (completion stamp present, stamped/persisted row counts match the server's `rom_count`, bound rows
   exist, no sibling-group-key backfill pending; the gate's `list_roms_updated_after` server check is deliberately not
-  replayed — no network at plan time) — and `collapsed_count`, the persisted post-collapse shortcut count (distinct
-  sibling-group keys + keyless singletons, ADR-0021). Both ride the `sync_plan` payload conditionally-present (absent on
-  collections, never-synced platforms, and failed reads). The payload's `total_roms` stays the raw pre-collapse total
-  (backward compat); an additive `total_estimated_items` sums `0` for predicted skips, else
-  `collapsed_count ?? rom_count`. **Hard constraint (ADR-0023): the prediction never feeds the actual skip decision** —
-  `_try_unit_incremental_skip` at fetch time remains the sole skip authority, so a mis-prediction can only make the
-  estimate read long or short, never mis-apply. A Force Full Sync needs no special case: `clear_sync_cache` deletes
-  every stamp before the run, so a forced plan predicts no skips. The same collapsed counts also garnish `get_platforms`
-  (an optional per-platform `collapsed_count`), so the platform toggles show the number of games a synced platform
-  actually produces rather than the raw server file count.
+  replayed — no network at plan time) — and `collapsed_count`, the persisted post-collapse shortcut count, mirroring the
+  collapse's lane selection (ADR-0021): `max(1, bound rows)` per sibling group — so a grandfathered legacy group with
+  multiple independently-bound duplicates (§5) prices one shortcut per bound sibling, not one per group — plus one per
+  keyless row. Both ride the `sync_plan` payload conditionally-present (absent on collections, never-synced platforms,
+  and failed reads). The payload's `total_roms` stays the raw pre-collapse total (backward compat); an additive
+  `total_estimated_items` sums `0` for predicted skips, else `collapsed_count ?? rom_count`. **Hard constraint
+  (ADR-0023): the prediction never feeds the actual skip decision** — `_try_unit_incremental_skip` at fetch time remains
+  the sole skip authority, so a mis-prediction can only make the estimate read long or short, never mis-apply. A Force
+  Full Sync needs no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no
+  skips. The same collapsed counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the
+  platform toggles show the number of games a synced platform actually produces rather than the raw server file count.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model: `new_count × NEW_ITEM_SEC` +
   `changed_count × UPDATED_ITEM_SEC` + a flat fetch allowance. The per-item constants (currently ~0.45 s for a created

--- a/py_modules/domain/skip_prediction.py
+++ b/py_modules/domain/skip_prediction.py
@@ -60,19 +60,25 @@ def predict_unit_skip(
     )
 
 
-def collapsed_shortcut_count(group_keys: Iterable[str | None]) -> int:
+def collapsed_shortcut_count(rows: Iterable[tuple[str | None, bool]]) -> int:
     """Post-collapse shortcut count for one platform's persisted rows.
 
-    The sibling-group collapse (ADR-0021) yields one Steam shortcut per
-    sibling group; a row without a group key is its own singleton. Given
-    every persisted row's ``sibling_group_key``, the collapsed count is the
-    number of distinct non-``None`` keys plus one per ``None`` key.
+    Mirrors the lane selection of ``collapse_sibling_groups`` (ADR-0021)
+    under the plan-time assumption that the next fetch matches the
+    persisted rows: a group with **bound** siblings is grandfathered — one
+    shortcut per bound sibling (§5, a pre-ADR-0021 library keeps its
+    duplicate shortcuts) — while a group with no binding anywhere mints
+    exactly one representative. Given every persisted row as
+    ``(sibling_group_key, is_bound)`` (bound = ``shortcut_app_id`` is set),
+    each non-``None`` group therefore counts ``max(1, bound rows in
+    group)``, and a keyless row is its own singleton (its real group is
+    unknown until the backfill fetch computes the key).
     """
-    distinct_keys: set[str] = set()
+    bound_by_key: dict[str, int] = {}
     singletons = 0
-    for key in group_keys:
+    for key, is_bound in rows:
         if key is None:
             singletons += 1
         else:
-            distinct_keys.add(key)
-    return len(distinct_keys) + singletons
+            bound_by_key[key] = bound_by_key.get(key, 0) + (1 if is_bound else 0)
+    return sum(max(1, bound) for bound in bound_by_key.values()) + singletons

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -495,8 +495,8 @@ class LibraryFetcher:
         (``predict_unit_skip`` — stamp present, stamped/persisted counts match
         the server count, bound rows exist, no group-key backfill pending) and
         derive the persisted post-collapse shortcut count
-        (``collapsed_shortcut_count`` over the rows' sibling-group keys;
-        ``None`` when the platform has no persisted rows). The gate's
+        (``collapsed_shortcut_count`` over the rows' sibling-group keys +
+        bound flags; ``None`` when the platform has no persisted rows). The gate's
         server-delta check (``list_roms_updated_after``) is deliberately NOT
         replayed — no network at plan time. A Force Full Sync clears every
         stamp before the run, so its plan predicts no skips without a special
@@ -520,7 +520,13 @@ class LibraryFetcher:
                     registry_count=sum(1 for rom in all_rows if rom.shortcut_app_id is not None),
                     needs_backfill=any(rom.sibling_group_key is None for rom in all_rows),
                 )
-                collapsed = collapsed_shortcut_count(rom.sibling_group_key for rom in all_rows) if all_rows else None
+                collapsed = (
+                    collapsed_shortcut_count(
+                        (rom.sibling_group_key, rom.shortcut_app_id is not None) for rom in all_rows
+                    )
+                    if all_rows
+                    else None
+                )
                 estimates[unit.slug] = (predicted, collapsed)
         return estimates
 
@@ -528,16 +534,18 @@ class LibraryFetcher:
         """Persisted post-collapse shortcut count per platform slug (#1382).
 
         Groups every persisted ``roms`` row by ``platform_slug`` and collapses
-        each platform's sibling-group keys (``collapsed_shortcut_count``).
-        Slugs with no persisted rows are absent, so the caller leaves the
-        field off and the frontend falls back to the raw server count. One
-        short read UoW.
+        each platform's sibling-group keys + bound flags
+        (``collapsed_shortcut_count``). Slugs with no persisted rows are
+        absent, so the caller leaves the field off and the frontend falls
+        back to the raw server count. One short read UoW.
         """
-        keys_by_slug: dict[str, list[str | None]] = {}
+        rows_by_slug: dict[str, list[tuple[str | None, bool]]] = {}
         with self._uow_factory() as uow:
             for rom in uow.roms.iter_all():
-                keys_by_slug.setdefault(rom.platform_slug, []).append(rom.sibling_group_key)
-        return {slug: collapsed_shortcut_count(keys) for slug, keys in keys_by_slug.items()}
+                rows_by_slug.setdefault(rom.platform_slug, []).append(
+                    (rom.sibling_group_key, rom.shortcut_app_id is not None)
+                )
+        return {slug: collapsed_shortcut_count(rows) for slug, rows in rows_by_slug.items()}
 
     def _read_incremental_baseline(
         self, platform_slug: str

--- a/tests/domain/test_skip_prediction.py
+++ b/tests/domain/test_skip_prediction.py
@@ -57,21 +57,53 @@ class TestPredictUnitSkip:
 
 
 class TestCollapsedShortcutCount:
-    """Distinct group keys count once; keyless rows are singletons."""
+    """Each group counts max(1, bound rows); keyless rows are singletons.
+
+    Rows are ``(sibling_group_key, is_bound)``; the count mirrors the lane
+    selection of ``collapse_sibling_groups`` (ADR-0021) — the property tier
+    (``test_skip_prediction_property.py``) pins the two functions together.
+    """
 
     def test_empty_rows_collapse_to_zero(self):
         assert collapsed_shortcut_count([]) == 0
 
-    def test_distinct_keys_count_once_each(self):
-        assert collapsed_shortcut_count(["igdb:1:1", "igdb:1:1", "igdb:2:1"]) == 2
+    def test_distinct_unbound_groups_count_once_each(self):
+        assert collapsed_shortcut_count([("igdb:1:1", False), ("igdb:1:1", False), ("igdb:2:1", False)]) == 2
 
     def test_none_keys_are_singletons(self):
-        assert collapsed_shortcut_count([None, None, None]) == 3
+        assert collapsed_shortcut_count([(None, False), (None, True), (None, False)]) == 3
 
-    def test_mixed_keys_and_singletons(self):
-        # One 3-sibling group + one 2-sibling group + two keyless singletons.
-        assert collapsed_shortcut_count(["g:a", "g:a", "g:a", "g:b", "g:b", None, None]) == 4
+    def test_mixed_groups_and_singletons(self):
+        # One 3-sibling group (1 bound) + one 2-sibling unbound group + two
+        # keyless singletons.
+        rows = [
+            ("g:a", True),
+            ("g:a", False),
+            ("g:a", False),
+            ("g:b", False),
+            ("g:b", False),
+            (None, False),
+            (None, True),
+        ]
+        assert collapsed_shortcut_count(rows) == 4
 
-    @pytest.mark.parametrize("keys", [["g:a"], [None]])
-    def test_single_row_is_one_shortcut(self, keys):
-        assert collapsed_shortcut_count(keys) == 1
+    @pytest.mark.parametrize("rows", [[("g:a", False)], [("g:a", True)], [(None, False)], [(None, True)]])
+    def test_single_row_is_one_shortcut(self, rows):
+        assert collapsed_shortcut_count(rows) == 1
+
+    def test_grandfathered_group_counts_each_bound_sibling(self):
+        # A legacy group with two independently-bound duplicates keeps BOTH
+        # shortcuts (ADR-0021 §5) — the estimate must not read one-per-group.
+        assert collapsed_shortcut_count([("g:a", True), ("g:a", True), ("g:a", False)]) == 2
+
+    def test_group_with_one_bound_sibling_is_one_shortcut(self):
+        assert collapsed_shortcut_count([("g:a", True), ("g:a", False)]) == 1
+
+    def test_all_unbound_group_mints_one_representative(self):
+        assert collapsed_shortcut_count([("g:a", False), ("g:a", False)]) == 1
+
+    def test_grandfathered_group_mixed_with_null_singletons(self):
+        # 2-bound grandfathered group (2) + all-unbound group (1) + keyless
+        # rows (1 each, bound or not).
+        rows = [("g:a", True), ("g:a", True), ("g:b", False), ("g:b", False), (None, True), (None, False)]
+        assert collapsed_shortcut_count(rows) == 5

--- a/tests/domain/test_skip_prediction_property.py
+++ b/tests/domain/test_skip_prediction_property.py
@@ -1,0 +1,82 @@
+"""Property-based tests for ``domain.skip_prediction.collapsed_shortcut_count``.
+
+The plan-time estimate kernel must mirror the LANE SELECTION of the real
+collapse (``domain.sync_diff.collapse_sibling_groups``, ADR-0021) — a group
+with bound siblings is grandfathered one-shortcut-per-bound-sibling (§5), an
+unbound group mints one representative. The hand-enumerated cases
+(``test_skip_prediction.py``) pin specific shapes; the cross-check property
+here drives BOTH functions from the same sampled rows so the two can never
+drift apart again (the #1382/#1402 undercount class).
+
+Scope: the cross-check samples real (non-``None``) group keys only — a built
+fetch entry always carries a real key, so ``collapse_sibling_groups`` never
+sees a keyless member. The kernel's ``None`` branch models persisted
+pre-backfill rows whose group is unknowable at plan time; its
+one-singleton-per-row rule is pinned by a kernel-only additivity property.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from domain.skip_prediction import collapsed_shortcut_count
+from domain.sync_diff import collapse_sibling_groups
+
+# One persisted row: (group key, bound?, installed?). A handful of key values
+# is enough — the interesting structure is how rows cluster into groups and
+# how many of each group's rows are bound.
+_row = st.tuples(st.sampled_from(["g:a", "g:b", "g:c"]), st.booleans(), st.booleans())
+_rows = st.lists(_row, max_size=12)
+
+
+def _member(rom_id: int, key: str) -> dict[str, Any]:
+    """A fetched shortcut entry, minimal but resolver-complete (rom_id, name,
+    fs_name_no_ext; regions/revision/tags default empty via ``.get``)."""
+    return {
+        "rom_id": rom_id,
+        "name": f"G{rom_id}",
+        "fs_name": f"g{rom_id}.z64",
+        "fs_name_no_ext": f"g{rom_id}",
+        "platform_slug": "n64",
+        "sibling_group_key": key,
+        "launch_options": "",
+    }
+
+
+@given(rows=_rows)
+def test_estimate_matches_real_collapse_emission_count(rows):
+    """Same rows → the kernel's count equals ``len(collapse_sibling_groups(...))``.
+
+    The scenario replayed is the plan-time premise: the next fetch returns
+    exactly the persisted rows (every row fetched, complete platform view),
+    bound rows carry their persisted binding, installed state arbitrary.
+    """
+    shortcuts_data = [_member(rom_id, key) for rom_id, (key, _bound, _installed) in enumerate(rows, start=1)]
+    registry = {
+        str(rom_id): {
+            "app_id": 1000 + rom_id,
+            "name": f"G{rom_id}",
+            "fs_name": f"g{rom_id}.z64",
+            "platform_slug": "n64",
+            "sibling_group_key": key,
+        }
+        for rom_id, (key, bound, _installed) in enumerate(rows, start=1)
+        if bound
+    }
+    installed_rom_ids = {rom_id for rom_id, (_key, _bound, installed) in enumerate(rows, start=1) if installed}
+
+    emitted = collapse_sibling_groups(shortcuts_data, registry, installed_rom_ids, complete_group_view=True)
+    estimated = collapsed_shortcut_count((key, bound) for key, bound, _installed in rows)
+
+    assert len(emitted) == estimated
+
+
+@given(rows=_rows, keyless=st.lists(st.booleans(), max_size=5))
+def test_keyless_rows_add_one_singleton_each(rows, keyless):
+    """Kernel-only ``None`` lane: k keyless rows (bound or not) add exactly k."""
+    base = [(key, bound) for key, bound, _installed in rows]
+    with_keyless = base + [(None, bound) for bound in keyless]
+    assert collapsed_shortcut_count(with_keyless) == collapsed_shortcut_count(base) + len(keyless)

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -930,6 +930,23 @@ class TestPlanEstimates:
         assert units[0].collapsed_count == 1
 
     @pytest.mark.asyncio
+    async def test_grandfathered_group_counts_each_bound_sibling(self, plugin, fake_romm_api):
+        """A pre-ADR-0021 group with two bound duplicates keeps both shortcuts
+        (§5), so the plan estimate prices 2, not one-per-group."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].collapsed_count == 2
+
+    @pytest.mark.asyncio
     async def test_never_synced_platform_predicts_no_skip_and_no_collapsed_count(self, plugin, fake_romm_api):
         _wire_fake(plugin, fake_romm_api)
         fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
@@ -1067,6 +1084,20 @@ class TestGetPlatformsCollapsedCount:
         assert by_slug["n64"]["collapsed_count"] == 2
         assert by_slug["n64"]["rom_count"] == 4
         assert "collapsed_count" not in by_slug["snes"]
+
+    @pytest.mark.asyncio
+    async def test_grandfathered_group_counts_each_bound_sibling(self, plugin, fake_romm_api):
+        """The toggle label prices a two-bound-duplicate legacy group at 2 (ADR-0021 §5)."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["platforms"][0]["collapsed_count"] == 2
 
     @pytest.mark.asyncio
     async def test_collapsed_count_read_failure_falls_back_to_raw_counts(self, plugin, fake_romm_api):


### PR DESCRIPTION
Follow-up to #1382 (found during its review; estimate-only).

`collapsed_shortcut_count` priced every sibling group as one shortcut, but the real collapse's grandfathered lane emits one shortcut per surviving bound sibling for legacy groups with multiple independently-bound duplicates — so the plan payload, the ETA weights, and the platform-toggle counts read slightly low on such platforms.

The kernel now takes `(sibling_group_key, is_bound)` pairs and prices `max(1, bound rows)` per group (keyless rows stay one singleton each), mirroring the lane-selection rule under the plan-time premise that the next fetch matches the persisted rows. Both fetcher readers pass the bound flag; no projection change was needed.

The new Hypothesis property drives `collapse_sibling_groups` and `collapsed_shortcut_count` from the same sampled rows and asserts equal counts — pinning the two functions together so they cannot drift again (verified to fail against the old kernel; stable at 20k examples with the filter health check armed).

Estimate-only: the skip gate and its independence guard test are untouched.

Docs: the estimate section in `docs/architecture/backend-architecture.md` now describes the per-bound-duplicate pricing.