### PR TITLE
fix(sync): count delta-skipped roms in the processed-games numerator

### DIFF
--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -614,7 +614,10 @@ class SyncOrchestrator:
         # final phase. ``synced_rom_ids`` is shared with collection units
         # for dedup. ``collection_memberships`` and ``platform_rom_ids``
         # feed the reporter's ``_build_collection_app_ids`` once every
-        # unit has been applied.
+        # unit has been applied. ``total_games_applied`` is the run's
+        # processed-ROM count — wholesale skips, delta-skips, and committed
+        # applies alike — surfaced as ``total_games`` (the terminal frame's
+        # "N of M games processed" numerator).
         synced_rom_ids: set[int] = set()
         collection_memberships: dict[str, list[int]] = {}
         platform_rom_ids: set[int] = set()
@@ -993,7 +996,7 @@ class SyncOrchestrator:
         collection_memberships: dict[str, list[int]],
         platform_rom_ids: set[int],
     ) -> int:
-        """Process one work unit start-to-finish; return shortcuts applied.
+        """Process one work unit start-to-finish; return its processed-ROM count.
 
         The ROMs for the unit come from a live per-unit fetch. After the
         frontend acks the unit's shortcuts (via ``report_unit_results``),
@@ -1006,7 +1009,11 @@ class SyncOrchestrator:
         matches the server-side platform state), the entire apply +
         commit branch is short-circuited: no frontend roundtrip, no
         registry write. The unit's ROMs still count toward the
-        ``total_games_applied`` total returned to the user.
+        ``total_games_applied`` total returned to the user. Delta-skipped
+        entries (content-unchanged ROMs the delta-restricted apply never
+        re-emits) count the same way: the return value is the unit's
+        processed ROMs — skips plus acked applies — not just the
+        shortcuts written.
         """
         box = self._sync_state
         # Coarse anchor for the unit: FETCHING (not APPLYING) so the whole
@@ -1118,7 +1125,11 @@ class SyncOrchestrator:
             f"{len(rebind_ids)} rebind of {len(emitted)} collapsed ({len(skip_ids)} unchanged skipped)"
         )
         # A skipped entry is already correct on its Steam shortcut — no Set* walk is
-        # owed — so it counts as done the moment the delta is computed (#1383).
+        # owed — so it counts as done the moment the delta is computed (#1383). It is
+        # just as processed as a wholesale-skipped unit's ROMs, so every return below
+        # also adds ``len(skip_ids)`` to the unit's processed count — keeping the
+        # terminal frame's "N of M games processed" numerator (``total_games``)
+        # consistent with this counter on a resumed run.
         box.run_done_items += len(skip_ids)
 
         # Cover-cache invalidation pass (#1386): before any cover is reused, refresh
@@ -1135,7 +1146,7 @@ class SyncOrchestrator:
         )
 
         if box.is_cancelling():
-            return 0
+            return len(skip_ids)
 
         # Download artwork for the shortcuts about to be applied and stamp each
         # delta entry's cover path in place (a no-op when the delta is empty).
@@ -1146,7 +1157,7 @@ class SyncOrchestrator:
         )
 
         if box.is_cancelling():
-            return 0
+            return len(skip_ids)
 
         # Clear this platform's completion stamp now that its apply is actually
         # beginning — the fetch succeeded, artwork is done, and the cancel guard
@@ -1178,7 +1189,7 @@ class SyncOrchestrator:
         box.pending_all_roms = {sd["rom_id"]: sd for sd in shortcuts_data}
         box.pending_cover_sources = confirmed_cover_sources
 
-        return await self._apply_unit_in_chunks(
+        applied_count = await self._apply_unit_in_chunks(
             unit,
             unit_index=unit_index,
             total_units=total_units,
@@ -1188,6 +1199,7 @@ class SyncOrchestrator:
             new_ids=new_ids,
             cover_refreshes=cover_refreshes,
         )
+        return len(skip_ids) + applied_count
 
     async def _attach_unit_cover_paths(
         self,

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -3176,6 +3176,84 @@ class TestSyncOneUnitCollectionAndCancel:
         assert applied == 0
 
     @pytest.mark.asyncio
+    async def test_cancel_after_artwork_still_counts_delta_skips(self, plugin, fake_romm_api):
+        """A mid-unit cancel AFTER the delta is computed returns the delta-skip
+        count: those ROMs were verified already-correct in Steam, so they are
+        processed — same as a wholesale-skipped unit's ROMs — and the terminal
+        frame's "N of M games processed" numerator must not drop them."""
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # rom 10 is content-unchanged (delta-skipped); rom 11 is brand-new, so
+        # the unit reaches the artwork step where the cancel lands.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 10, "name": "Keep", "fs_name": "keep.z64"},
+                {"id": 11, "name": "Fresh", "fs_name": "fresh.z64"},
+            ],
+        )
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+
+        async def cancel_during_artwork(*_a, **_kw):
+            plugin._sync_service._box.sync_state = SyncState.CANCELLING
+            return {}
+
+        plugin._sync_service._orchestrator._download_artwork = cancel_during_artwork
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
+        processed = await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+        assert processed == 1, "the delta-skipped ROM is processed; the cancelled apply is not"
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_cover_refresh_still_counts_delta_skips(self, plugin, fake_romm_api):
+        """Same invariant at the sibling guard: a cancel landing during the
+        cover-refresh pass — after the delta is computed, before the artwork
+        download — still returns the delta-skip count."""
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        # rom 10 is content-unchanged (delta-skipped); the cancel lands inside
+        # the cover-refresh pass, so the guard right after it fires.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Keep", "fs_name": "keep.z64"}],
+        )
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+
+        async def cancel_during_cover_refresh(*_a, **_kw):
+            plugin._sync_service._box.sync_state = SyncState.CANCELLING
+            return []
+
+        plugin._sync_service._orchestrator._refresh_changed_covers = cancel_during_cover_refresh
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=1)
+        processed = await plugin._sync_service._orchestrator._sync_one_unit(
+            unit,
+            unit_index=0,
+            total_units=1,
+            synced_rom_ids=set(),
+            collection_memberships={},
+            platform_rom_ids=set(),
+        )
+        assert processed == 1, "the delta-skipped ROM is processed even on a pre-apply cancel"
+
+    @pytest.mark.asyncio
     async def test_user_cancel_clears_pending_and_drops_event(self, plugin, fake_romm_api):
         """A user cancel during the wait discards in-flight work: pending_sync
         cleared, unit event nulled, no abandoned-unit stash.
@@ -5621,3 +5699,121 @@ class TestRunProgressCounters:
 
         assert result["run_done_items"] is None
         assert result["run_total_items"] is None
+
+
+class TestProcessedGamesNumerator:
+    """``total_games`` — the terminal frame's "N of M games processed" numerator.
+
+    It counts every PROCESSED ROM the same way ``run_done_items`` does: a
+    wholesale-skipped unit's ROMs, a partial unit's delta-skipped entries, and
+    the committed applies. A resumed run that is interrupted again must not
+    understate the one platform it resumed into — a delta-skipped ROM is just
+    as processed as a wholesale-skipped one.
+    """
+
+    @staticmethod
+    def _arm(plugin, fake_romm_api, *, run_id):
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._box.current_sync_id = run_id
+
+    @pytest.mark.asyncio
+    async def test_clean_run_payload_counts_delta_skips(self, plugin, fake_romm_api):
+        import decky
+
+        # rom 10 is content-unchanged (delta-skipped), rom 11 changed and is
+        # acked — both are processed, so the sync_complete payload reports 2.
+        self._arm(plugin, fake_romm_api, run_id="run-numerator-clean")
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 10, "name": "Keep", "fs_name": "keep.z64"},
+                {"id": 11, "name": "New Name", "fs_name": "changed.z64"},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+        _seed_rom_row(plugin, 11, app_id=1011, platform_slug="n64", name="Old Name", fs_name="changed.z64")
+
+        async def fake_wait(_unit, event):
+            event.set()
+            return {"11": 1011}
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = fake_wait
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert complete[-1]["total_games"] == 2, "1 delta-skipped + 1 applied are both processed"
+
+    @pytest.mark.asyncio
+    async def test_resumed_run_interrupt_frame_counts_delta_skips(self, plugin, fake_romm_api, monkeypatch):
+        """The resume-then-interrupt shape: a platform the prior run finished
+        wholesale-skips, the partial platform delta-skips its already-applied
+        ROM and commits one more chunk, then the heartbeat times out. The
+        terminal frame's numerator counts all three kinds of processed ROM
+        (and agrees with the paused banner's ``run_done_items``)."""
+        import decky
+
+        from services.library import sync_orchestrator
+
+        self._arm(plugin, fake_romm_api, run_id="run-resume-interrupt")
+
+        # Unit 1 (N64): wholesale-skipped — its completion stamp matches the
+        # server and its one bound row reconstructs.
+        _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00Z", rom_count=1)
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="A", fs_name="a.z64")
+        fake_romm_api.platforms.append({"id": 1, "name": "N64", "slug": "n64", "rom_count": 1})
+
+        # Unit 2 (GBA): the partial platform — rom 20 is content-unchanged
+        # (delta-skipped), roms 21/22 changed. One item per chunk: chunk 0
+        # acks and commits, chunk 1's wait gives up while the box is still
+        # RUNNING (heartbeat timeout) → the run ends interrupted.
+        _seed_platform(
+            fake_romm_api,
+            platform_id=2,
+            name="GBA",
+            slug="gba",
+            roms=[
+                {"id": 20, "name": "Keep", "fs_name": "keep.gba"},
+                {"id": 21, "name": "New Name", "fs_name": "changed.gba"},
+                {"id": 22, "name": "Other New", "fs_name": "other.gba"},
+            ],
+        )
+        _seed_rom_row(plugin, 20, app_id=1020, platform_slug="gba", name="Keep", fs_name="keep.gba")
+        _seed_rom_row(plugin, 21, app_id=1021, platform_slug="gba", name="Old Name", fs_name="changed.gba")
+        _seed_rom_row(plugin, 22, app_id=1022, platform_slug="gba", name="Old Other", fs_name="other.gba")
+        plugin.settings["enabled_platforms"] = {"1": True, "2": True}
+        monkeypatch.setattr(sync_orchestrator, "_APPLY_CHUNK_SIZE", 1)
+
+        acks: list[dict[str, int] | None] = [{"21": 1021}, None]
+
+        async def wait_ack_then_timeout(_unit, event):
+            ack = acks.pop(0)
+            if ack is not None:
+                event.set()
+                return ack
+            return None  # heartbeat timeout — the box is still RUNNING
+
+        plugin._sync_service._orchestrator._wait_for_unit_complete = wait_ack_then_timeout
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        complete = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_complete"]
+        assert complete[-1]["total_games"] == 3, "1 wholesale-skipped + 1 delta-skipped + 1 committed"
+        assert complete[-1]["interrupted"] is True
+        progress = plugin._sync_service._sync_progress
+        assert progress["stage"] == "cancelled"
+        assert progress["message"] == "Sync interrupted: 3 of 4 games processed"
+        assert progress["current"] == 3
+        assert progress["total"] == 4
+        # The frame's numerator and the paused banner's done counter agree.
+        assert plugin._sync_service._box.run_done_items == 3


### PR DESCRIPTION
Follow-up to #1384/#1399 (found during its review; display-only).

The terminal interrupted/cancelled frame ("Sync interrupted: N of M games processed") counted a wholesale-skipped platform at full size but left a partial platform's delta-skipped ROMs out of N — a resumed-then-interrupted run understated the numerator for the one platform that was mid-flight. Delta-skipped ROMs are processed work exactly like wholesale-skipped ones.

`_sync_one_unit` now includes the unit's delta-skip count in its processed return on every path (the final return and both post-classification cancel guards), mirroring the wholesale-skip branch and restoring `total_games == run_done_items` on all paths — the cancel guards previously returned 0 while the paused banner's counter had already accrued the skips.

Consumer trace before changing semantics: the completion toast provably ignores `total_games` (its delta comes from the sync-delta store; pinned by existing frontend tests), the DONE frame re-counts bound ROMs, and every remaining display site means "processed".

Four new tests, each verified to fail against the unfixed source: the resume-then-interrupt end-to-end scenario pinning the exact frame string, the clean-run payload count, and one pinned-value test per changed cancel guard.

docs: N/A — display-only counter correction; the documented denominator semantics ("compares progress against the run's planned total") are unchanged and no page describes the numerator's composition.