### PR TITLE
fix(sync): surface cover-only changes in the preview and apply them

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -196,12 +196,30 @@ and a path change). Two compare layers run per unit, both in `ArtworkService`:
   BOUND fetched ROM whose stored fingerprint differs — delta-skipped ROMs included — it re-downloads the cache file
   (atomic tmp+rename), republishes the grid `{app_id}p.png` copy, persists the new fingerprint in a small write UoW (an
   observed server fact, deliberately NOT ack-coupled like `applied_launch_options`), and collects `{rom_id, app_id}`.
-  That list rides the unit's **first** `sync_apply_unit` chunk as `cover_refreshes`, clipped to the session-budget
-  headroom left after the chunk's own projected cost (each refresh ≈ one transient cover, `COVER_TRANSIENT_KB`) —
-  clipped, never pausing the run: the grid files are already updated, a Steam restart shows the rest. The frontend
-  re-applies each entry via `SetCustomArtworkForApp` at the 50 ms cadence before the chunk ack — without that push the
-  tile stays stale in-session, since `rt_custom_image_mtime` only bumps through `SetCustomArtworkForApp` or a client
-  restart.
+  The pass scans against the unit's bound-row registry projection (`_read_apply_registry`, which carries `cover_source`)
+  — the same read the group collapse diffs against, so it opens no per-ROM DB lookups. That list rides the unit's
+  **first** `sync_apply_unit` chunk as `cover_refreshes`, clipped to the session-budget headroom left after the chunk's
+  own projected cost (each refresh ≈ one transient cover, `COVER_TRANSIENT_KB`) — clipped, never pausing the run: the
+  grid files are already updated, a Steam restart shows the rest. The frontend re-applies each entry via
+  `SetCustomArtworkForApp` at the 50 ms cadence before the chunk ack — without that push the tile stays stale
+  in-session, since `rt_custom_image_mtime` only bumps through `SetCustomArtworkForApp` or a client restart.
+- **The preview-side count** (`sync_preview` → `domain/cover_refresh.py::count_cover_refreshes`): `classify_roms` is
+  deliberately cover-blind (ADR-0025), so a cover-only server change yields an empty shortcut delta — and the QAM's
+  preview flow used to short-circuit on "no changes", meaning the apply (and with it the invalidation pass) never ran
+  and the fingerprint stayed stale forever. The preview therefore counts the fingerprint mismatches itself, with the
+  SAME pure kernel the apply pass scans by (`scan_cover_refresh_candidates` — shared via `domain/cover_refresh.py`, so
+  preview count and apply set cannot diverge), as an in-memory compare of the fetched union (platform and collection
+  units alike) against the registry projection the classify already read — no extra DB pass, no downloads, no writes.
+  The result rides the summary as the additive `cover_refresh_count` (absent/0 tolerated by old consumers); the frontend
+  treats a cover-only preview (all diffs zero, count > 0) as apply-able, showing "No shortcut changes — N cover updates"
+  with the normal Apply/Cancel confirm. NULL-fingerprint rows are not counted: their adopt-vs-download fork needs a
+  cache-file check the preview must not perform, and the adopt is invisible to the user. The wholesale platform-skip
+  gate needs no cover awareness — a cover change bumps the ROM's `updated_at`, which already forces the fetch; a skipped
+  platform's registry-reconstructed thin ROMs carry no cover fields and count 0 by construction.
+- **The empty-unit chunk vehicle**: a cover-only unit has an empty apply delta, but `build_unit_chunks` yields exactly
+  one empty chunk for it (ADR-0023's empty-unit round-trip), so the `cover_refreshes` list still rides a
+  `sync_apply_unit` frame with `shortcuts: []`; the frontend processes the refreshes and acks the empty chunk, and the
+  commit advances the unit normally. No special-casing exists on either side.
 
 A `NULL` fingerprint (every pre-migration-016 row) with an existing cache file is **adopted**: the fresh fingerprint is
 persisted without a download, so the upgrade never mass re-downloads a library; a `NULL` with no cache file downloads on
@@ -907,6 +925,7 @@ documented in [Database Design](database-design.md). Selected modules:
 | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `sync_action.py`                                                                  | `compute_sync_action` — the save-sync decision algorithm. Returns `SyncAction` union (`Skip` / `Upload` / `Download` / `Conflict`). See [Save File Sync Architecture](save-file-sync-architecture.md).                                                                                                                         |
 | `sync_diff.py`                                                                    | ROM classification and platform/collection diff computation for the sync preview                                                                                                                                                                                                                                               |
+| `cover_refresh.py`                                                                | cover-fingerprint compare kernel (#1386) — `scan_cover_refresh_candidates` / `count_cover_refreshes`, shared by the apply-path invalidation pass and the preview's cover-work count so the two can never diverge                                                                                                               |
 | `preview_delta.py`                                                                | `PreviewDelta` shape for the sync preview                                                                                                                                                                                                                                                                                      |
 | `work_unit.py`                                                                    | `WorkUnit` — the per-unit sync work item                                                                                                                                                                                                                                                                                       |
 | `rom_save_state.py`                                                               | `RomSaveState` aggregate + `FileSyncState` value object — per-ROM save-sync state, backed by `rom_save_states` + `rom_save_files`                                                                                                                                                                                              |

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -39,6 +39,10 @@ entirely, not re-processed — so a re-sync of a mostly-settled library is quick
 changed work. If you sync without previewing first, the estimate appears once the run starts as an **Estimated time**
 line, shown as "up to X min".
 
+Cover changes count too: if you replaced a game's cover on the server but nothing else changed, the preview reads "No
+shortcut changes — N cover updates" and still offers **Apply Sync** — applying refreshes those tiles without touching
+the shortcuts. Only when there is truly nothing to do does the preview read "Everything is up to date."
+
 That starting estimate is **skip-aware**: when the run is planned, the plugin already knows which platforms haven't
 changed since their last sync and expects to skip them wholesale, so they don't inflate the number — an incremental
 re-sync of an unchanged library reads seconds, not the minutes a full first import would take. The prediction is only an

--- a/py_modules/domain/cover_refresh.py
+++ b/py_modules/domain/cover_refresh.py
@@ -1,0 +1,93 @@
+"""Cover-fingerprint compare kernel — which bound ROMs' server covers changed.
+
+The single decision point for the ``cover_source`` fingerprint compare (#1386):
+given a fetch's raw ROM dicts and the bound-row registry projection, split the
+ROMs into fingerprint-changed covers (re-download + in-session tile refresh)
+and NULL-fingerprint candidates (the pre-fingerprint upgrade path, whose
+adopt-vs-download fork needs a cache-file existence check the caller performs).
+Both the apply-path invalidation pass and the preview's cover-work count run
+this kernel, so the number the preview shows is by construction the set the
+apply pass refreshes. Pure compute — no I/O, no state; anything that reads the
+DB, checks files, or downloads belongs in the calling service.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+
+class CoverRefreshScan(NamedTuple):
+    """The kernel's split of a fetch against the registry's fingerprints.
+
+    ``changed`` holds ``(rom_id, app_id, fresh_source)`` for every bound ROM
+    whose stored fingerprint differs from the fresh cover source — the covers
+    the invalidation pass re-downloads and the preview counts.
+    ``null_fingerprint`` holds ``(rom_id, fresh_source)`` for bound ROMs with
+    no stored fingerprint — adopted without a download when a cache file
+    exists, else left for the apply path (a caller-side I/O fork).
+    """
+
+    changed: list[tuple[int, int, str]]
+    null_fingerprint: list[tuple[int, str]]
+
+
+def fresh_cover_source(rom: dict[str, Any]) -> str | None:
+    """Return *rom*'s fresh cover source string, or ``None`` when it has no cover.
+
+    The fingerprint is the full RomM cover source (``path_cover_large`` else
+    ``path_cover_small``, the embedded ``?ts=…`` cache-buster included),
+    compared as an opaque string. An empty string counts as no cover.
+    """
+    return rom.get("path_cover_large") or rom.get("path_cover_small") or None
+
+
+def scan_cover_refresh_candidates(
+    all_roms: list[dict[str, Any]],
+    registry: dict[str, dict[str, Any]],
+) -> CoverRefreshScan:
+    """Split *all_roms* against *registry* fingerprints into changed / NULL buckets.
+
+    *registry* is the bound-row projection keyed by ``str(rom_id)`` (each entry
+    carrying ``app_id`` and ``cover_source``). A ROM with no fresh cover, no
+    ``id``, no registry entry (unbound rows are never projected), or an
+    unchanged fingerprint is skipped. Order follows *all_roms*; a duplicate
+    ``rom_id`` is counted once (first occurrence wins).
+    """
+    changed: list[tuple[int, int, str]] = []
+    null_fingerprint: list[tuple[int, str]] = []
+    seen: set[int] = set()
+    for rom in all_roms:
+        fresh = fresh_cover_source(rom)
+        if not fresh or "id" not in rom:
+            continue
+        rom_id = int(rom["id"])
+        if rom_id in seen:
+            continue
+        seen.add(rom_id)
+        entry = registry.get(str(rom_id))
+        if entry is None or entry.get("app_id") is None:
+            continue
+        stored = entry.get("cover_source")
+        if stored == fresh:
+            continue
+        if stored is None:
+            null_fingerprint.append((rom_id, fresh))
+            continue
+        changed.append((rom_id, int(entry["app_id"]), fresh))
+    return CoverRefreshScan(changed=changed, null_fingerprint=null_fingerprint)
+
+
+def count_cover_refreshes(
+    all_roms: list[dict[str, Any]],
+    registry: dict[str, dict[str, Any]],
+) -> int:
+    """Count the bound ROMs whose server cover changed — the preview's cover-work number.
+
+    Exactly ``len(scan_cover_refresh_candidates(...).changed)``: the same
+    predicate the apply-path invalidation pass refreshes by, so the preview's
+    count and the run's refresh set can never diverge. NULL-fingerprint rows
+    are not counted — their adopt-vs-download fork depends on a cache-file
+    check the preview must not perform (the preview is side-effect-free and
+    the adopt is invisible to the user).
+    """
+    return len(scan_cover_refresh_candidates(all_roms, registry).changed)

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -33,6 +33,7 @@ from domain.artwork_paths import (
     staging_filename,
     with_tmp_suffix,
 )
+from domain.cover_refresh import scan_cover_refresh_candidates
 from domain.sync_stage import SyncStage
 from lib.list_result import ErrorCode
 
@@ -249,6 +250,7 @@ class ArtworkService:
     async def refresh_changed_covers(
         self,
         all_roms: list[dict[str, Any]],
+        registry: dict[str, dict[str, Any]],
         emit_progress: Callable[..., Awaitable[None]],
         is_cancelling: Callable[[], bool],
         progress_step: int = 4,
@@ -270,6 +272,11 @@ class ArtworkService:
         file it is left for the apply path, as before. Unbound ROMs are the
         apply path's job and are never touched here.
 
+        *registry* is the caller's bound-row projection keyed by ``str(rom_id)``
+        (each entry carrying ``app_id`` and ``cover_source``) — the same read
+        the apply's group collapse diffs against, so the pass opens no extra
+        per-ROM DB lookups of its own.
+
         Returns the refreshed ``[{"rom_id", "app_id"}]`` list — the shortcuts
         whose Steam tile the frontend must re-apply via
         ``SetCustomArtworkForApp`` (the grid file alone leaves the in-session
@@ -277,7 +284,9 @@ class ArtworkService:
         pass. Progress is narrated under the ``fetching`` stage, throttled like
         the cover-download loop.
         """
-        adoptions, changed = await self._loop.run_in_executor(None, self._scan_cover_refresh_candidates, all_roms)
+        adoptions, changed = await self._loop.run_in_executor(
+            None, self._scan_cover_refresh_candidates, all_roms, registry
+        )
         if adoptions:
             await self._loop.run_in_executor(None, self._adopt_cover_sources_io, adoptions)
         if not changed:
@@ -309,7 +318,7 @@ class ArtworkService:
         return refreshed
 
     def _scan_cover_refresh_candidates(
-        self, all_roms: list[dict[str, Any]]
+        self, all_roms: list[dict[str, Any]], registry: dict[str, dict[str, Any]]
     ) -> tuple[list[tuple[int, str]], list[tuple[int, int, str]]]:
         """Split a unit's fetched ROMs into fingerprint adoptions and changed covers.
 
@@ -317,28 +326,19 @@ class ArtworkService:
         pairs whose stored fingerprint is ``None`` but whose cache file exists (adopt
         without download); ``changed`` are ``(rom_id, app_id, fresh_source)`` triples
         whose stored fingerprint differs from the fresh one (re-download + republish).
-        Only BOUND rows qualify; a ROM with no fresh cover, no row, or an unchanged
-        fingerprint is skipped. One short read UoW for the whole scan.
+        Only BOUND rows qualify — *registry* projects them, so a ROM with no fresh
+        cover, no registry entry, or an unchanged fingerprint is skipped without any
+        DB access; the compare itself is :func:`domain.cover_refresh.scan_cover_refresh_candidates`
+        (the kernel the preview count shares). Only the cache-existence check on
+        NULL-fingerprint rows touches I/O here.
         """
-        adoptions: list[tuple[int, str]] = []
-        changed: list[tuple[int, int, str]] = []
-        with self._uow_factory() as uow:
-            for rom in all_roms:
-                fresh = rom.get("path_cover_large") or rom.get("path_cover_small")
-                if not fresh or "id" not in rom:
-                    continue
-                rom_id = int(rom["id"])
-                row = uow.roms.get(rom_id)
-                if row is None or row.shortcut_app_id is None:
-                    continue
-                if row.cover_source == fresh:
-                    continue
-                if row.cover_source is None:
-                    if self._cover_art_file_store.exists(self._cache_path(rom_id)):
-                        adoptions.append((rom_id, fresh))
-                    continue
-                changed.append((rom_id, row.shortcut_app_id, fresh))
-        return adoptions, changed
+        scan = scan_cover_refresh_candidates(all_roms, registry)
+        adoptions = [
+            (rom_id, fresh)
+            for rom_id, fresh in scan.null_fingerprint
+            if self._cover_art_file_store.exists(self._cache_path(rom_id))
+        ]
+        return adoptions, scan.changed
 
     def _adopt_cover_sources_io(self, adoptions: list[tuple[int, str]]) -> None:
         """Persist adopted fingerprints (no download) in one short write UoW."""

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -21,6 +21,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from domain.cover_refresh import count_cover_refreshes
 from domain.platform_sync_state import PlatformSyncState
 from domain.preview_delta import PreviewDelta
 from domain.session_budget import (
@@ -327,6 +328,16 @@ class SyncOrchestrator:
                 registry,
                 platform_name_set,
             )
+            # Cover-only work (#1386): count the bound fetched ROMs whose server
+            # cover fingerprint changed, with the SAME kernel the apply-path
+            # invalidation pass refreshes by — an in-memory compare of the fetch
+            # against the registry projection already read above (no extra DB
+            # pass, no downloads; the preview stays side-effect-free). Runs over
+            # the raw union (platform + collection units alike), not the collapsed
+            # delta: covers are per-ROM, cover-blind classify_roms (ADR-0025)
+            # stays untouched, and without this an empty shortcut delta would
+            # short-circuit the apply and strand a changed cover forever.
+            cover_refresh_count = count_cover_refreshes(all_roms, registry)
 
             # Final cancel checkpoint: a cancel can land after the unit loop's
             # last per-unit check but before the preview is staged. Re-check
@@ -373,6 +384,12 @@ class SyncOrchestrator:
                     "unchanged_count": len(unchanged_ids),
                     "remove_count": len(stale),
                     "disabled_platform_remove_count": disabled_count,
+                    # Bound ROMs whose server-side cover changed (#1386) — work the
+                    # apply run performs even when the shortcut delta is empty, so
+                    # the frontend must offer Apply on a cover-only preview instead
+                    # of short-circuiting on "no changes". Additive: old consumers
+                    # ignore it.
+                    "cover_refresh_count": cover_refresh_count,
                     # Scope of the run (#29): how many platforms / collections this
                     # sync spans, shown as an always-on informational line
                     # independent of the change diffs.
@@ -889,9 +906,11 @@ class SyncOrchestrator:
         where ``registry`` is the ``classify_roms``-shaped dict (keyed by
         ``str(rom_id)``) reconstructed from the bound ``roms`` rows, with
         the platform display name resolved from *slug_to_name* (the live
-        work-queue) and falling back to the slug. The last-synced
-        platform/collection lists come from the newest completed
-        ``SyncRun``.
+        work-queue) and falling back to the slug. Each entry also carries the
+        persisted ``cover_source`` fingerprint so the preview's cover-work
+        count (#1386) compares in memory against the same projection — no
+        second DB pass. The last-synced platform/collection lists come from
+        the newest completed ``SyncRun``.
         """
         with self._uow_factory() as uow:
             registry: dict[str, dict[str, Any]] = {}
@@ -906,6 +925,7 @@ class SyncOrchestrator:
                     "platform_slug": rom.platform_slug,
                     "sibling_group_key": rom.sibling_group_key,
                     "applied_launch_options": rom.applied_launch_options,
+                    "cover_source": rom.cover_source,
                 }
             latest = uow.sync_runs.get_latest_completed()
             last_platforms = list(latest.platforms_completed or []) if latest is not None else []
@@ -924,8 +944,11 @@ class SyncOrchestrator:
         so the collapse must not treat those as vanished (it passes
         ``complete_group_view=False`` and only grandfathers). Only bound rows (a
         live ``shortcut_app_id``) are returned — an unbound sibling is not a
-        shortcut the collapse can grandfather or rebind. The apply path did not
-        read the registry before group-aware sync (ADR-0021).
+        shortcut the collapse can grandfather or rebind. Each entry also carries
+        the persisted ``cover_source`` fingerprint, so the cover-cache
+        invalidation pass (#1386) scans against this same projection instead of
+        per-ROM DB lookups. The apply path did not read the registry before
+        group-aware sync (ADR-0021).
         """
         with self._uow_factory() as uow:
             rows = (
@@ -939,6 +962,7 @@ class SyncOrchestrator:
                     "platform_slug": rom.platform_slug,
                     "sibling_group_key": rom.sibling_group_key,
                     "applied_launch_options": rom.applied_launch_options,
+                    "cover_source": rom.cover_source,
                 }
                 for rom in rows
                 if rom.shortcut_app_id is not None
@@ -1142,7 +1166,7 @@ class SyncOrchestrator:
         # to the EXISTING shortcut via SetCustomArtworkForApp — without that push
         # the Steam tile stays stale in-session until a client restart.
         cover_refreshes = await self._refresh_changed_covers(
-            unit_roms, progress_step=unit_index + 1, progress_total_steps=total_units, label=unit.name
+            unit_roms, registry, progress_step=unit_index + 1, progress_total_steps=total_units, label=unit.name
         )
 
         if box.is_cancelling():
@@ -1829,16 +1853,20 @@ class SyncOrchestrator:
             label=label,
         )
 
-    async def _refresh_changed_covers(self, unit_roms, progress_step=4, progress_total_steps=6, label=""):
+    async def _refresh_changed_covers(self, unit_roms, registry, progress_step=4, progress_total_steps=6, label=""):
         """Delegate the #1386 cover-cache invalidation pass to the ArtworkManager.
 
-        ``label`` is the unit's display name, threaded into the throttled
-        "Refreshing covers for <label>" progress frames. Returns the refreshed
-        ``{rom_id, app_id}`` list the first apply chunk carries to the frontend.
+        ``registry`` is the unit's bound-row projection (``_read_apply_registry``)
+        the pass compares fingerprints against — the same read the group collapse
+        already made. ``label`` is the unit's display name, threaded into the
+        throttled "Refreshing covers for <label>" progress frames. Returns the
+        refreshed ``{rom_id, app_id}`` list the first apply chunk carries to the
+        frontend.
         """
         box = self._sync_state
         return await self._artwork.refresh_changed_covers(
             unit_roms,
+            registry,
             emit_progress=self.emit_progress,
             is_cancelling=box.is_cancelling,
             progress_step=progress_step,

--- a/py_modules/services/protocols/cross_service.py
+++ b/py_modules/services/protocols/cross_service.py
@@ -211,6 +211,7 @@ class ArtworkManager(Protocol):
     async def refresh_changed_covers(
         self,
         all_roms: list[dict[str, Any]],
+        registry: dict[str, dict[str, Any]],
         emit_progress: Any,
         is_cancelling: Any,
         progress_step: int = 4,

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1036,6 +1036,26 @@ describe("MainPage", () => {
       // Should render "Games: 1 new" — no updated or removed segments.
       expect(c.querySelector('[data-testid="sync-changes"]')?.textContent).toBe("Games: 1 new");
     });
+
+    it("names cover-only work when the shortcut delta is empty (#1386 flow gap)", async () => {
+      const c = await renderPreview({ cover_refresh_count: 3 });
+      expect(c.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
+        "No shortcut changes — 3 cover updates.",
+      );
+    });
+
+    it("singularizes a single cover update", async () => {
+      const c = await renderPreview({ cover_refresh_count: 1 });
+      expect(c.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
+        "No shortcut changes — 1 cover update.",
+      );
+    });
+
+    it("keeps 'Everything is up to date.' when covers are explicitly zero (regression pin)", async () => {
+      const c = await renderPreview({ cover_refresh_count: 0 });
+      const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
+      expect(descs).toContain("Everything is up to date.");
+    });
   });
 
   describe("session-budget advisory (#1383)", () => {
@@ -2678,6 +2698,83 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Apply Sync")).toBeNull();
       const descs = Array.from(container.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
       expect(descs).toContain("Everything is up to date.");
+    });
+
+    it("cover-only preview proceeds to Apply with the cover wording (#1386 flow gap)", async () => {
+      // Empty shortcut delta but pending cover refreshes: the flow must offer
+      // the same Apply/Cancel confirm as a non-empty preview — the cover
+      // refresh pass only runs inside the apply, so a "no changes" dead end
+      // strands the stale tiles forever (hardware-reproduced).
+      vi.mocked(backend.syncPreview).mockResolvedValue({
+        success: true,
+        summary: {
+          new_count: 0,
+          changed_count: 0,
+          unchanged_count: 4,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+          cover_refresh_count: 2,
+        },
+        new_names: [],
+        changed_names: [],
+        preview_id: "preview-covers",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+      expect(buttonByExactText(container, "Cancel")).not.toBeNull();
+      expect(buttonByExactText(container, "Dismiss")).toBeNull();
+      expect(container.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
+        "No shortcut changes — 2 cover updates.",
+      );
+      // Same interaction shape as a non-empty preview: the run description rows render.
+      expect(container.querySelector('[data-testid="sync-estimate"]')).not.toBeNull();
+      expect(container.textContent).toContain("Progress is saved");
+      // Apply drives the same delta callable the shortcut path uses.
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Apply Sync")!);
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-covers");
+    });
+
+    it("zero changes with explicit zero covers keeps the exact Dismiss-only shape (regression pin)", async () => {
+      vi.mocked(backend.syncPreview).mockResolvedValue({
+        success: true,
+        summary: {
+          new_count: 0,
+          changed_count: 0,
+          unchanged_count: 4,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+          cover_refresh_count: 0,
+          sync_platform_count: 5,
+        },
+        new_names: [],
+        changed_names: [],
+        preview_id: "preview-zero-covers",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Byte-identical to today's empty-delta preview: unchanged message,
+      // Dismiss only, and none of the run-description rows.
+      const descs = Array.from(container.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
+      expect(descs).toContain("Everything is up to date.");
+      expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+      expect(buttonByExactText(container, "Apply Sync")).toBeNull();
+      expect(container.querySelector('[data-testid="sync-scope"]')).toBeNull();
+      expect(container.querySelector('[data-testid="sync-estimate"]')).toBeNull();
+      expect(container.textContent).not.toContain("Progress is saved");
     });
 
     it("syncPreview success=false surfaces result.message into status field", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -262,12 +262,18 @@ function previewChangeSegments(s: SyncPreviewSummary): string[] {
  * The change line — categories joined with `` · ``, each category unbreakable.
  * A category is a nowrap span, so a line break can only land on a `` · ``
  * separator: "Platforms: 2 new" never splits across two lines the way plain
- * text wrapping split it at the narrow QAM width. Falls back to the unchanged
- * message when nothing differs.
+ * text wrapping split it at the narrow QAM width. An empty shortcut delta with
+ * pending cover work (#1386) names that work — the preview still proceeds to
+ * Apply so the cover refreshes actually run; only a fully-empty preview falls
+ * back to the unchanged message.
  */
 const PreviewChanges: FC<{ summary: SyncPreviewSummary }> = ({ summary }) => {
   const segments = previewChangeSegments(summary);
-  if (segments.length === 0) return <>Everything is up to date.</>;
+  if (segments.length === 0) {
+    const covers = summary.cover_refresh_count ?? 0;
+    if (covers > 0) return <>No shortcut changes — {pluralize(covers, "cover update")}.</>;
+    return <>Everything is up to date.</>;
+  }
   return (
     <>
       {segments.map((segment, i) => (
@@ -855,7 +861,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     const hasChanges =
       preview.summary.new_count + preview.summary.changed_count + preview.summary.remove_count > 0 ||
       !!(preview.summary.collection_diff?.added.length || preview.summary.collection_diff?.removed.length) ||
-      preview.summary.platform_collection_diff?.has_changes;
+      preview.summary.platform_collection_diff?.has_changes ||
+      // Cover-only work (#1386): the refresh pass runs inside the apply, so an
+      // empty shortcut delta with pending cover updates must still offer Apply —
+      // the old "no changes" short-circuit stranded changed covers forever.
+      (preview.summary.cover_refresh_count ?? 0) > 0;
     // Walk cost, shared with the handleApply seed (previewApplySeconds) so the
     // approved number equals the run's seed. Delta-only pricing here read "2 min"
     // for a resume whose apply walked ~3100 items.

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -148,6 +148,14 @@ export interface SyncPreviewSummary {
   unchanged_count: number;
   remove_count: number;
   disabled_platform_remove_count: number;
+  /**
+   * Bound ROMs whose server-side cover changed (#1386) — cover-cache refreshes
+   * the apply run performs even when the shortcut delta is empty. A cover-only
+   * preview (all other diffs zero, this > 0) must still offer Apply, or the
+   * refresh pass never runs and the tiles stay stale. Absent on older backends
+   * (treat as 0).
+   */
+  cover_refresh_count?: number;
   /** Scope of the run — how many platforms this sync spans (always shown, independent of diffs). */
   sync_platform_count?: number;
   /** Scope of the run — how many collections this sync spans. */

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -870,6 +870,35 @@ describe("syncManager — applies cover artwork to created shortcuts via the API
     expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({ "42": 5000 }, "run-cover-refresh", 1, 0);
   });
 
+  it("cover-only chunk: empty shortcuts with cover_refreshes applies every cover and acks (#1386 flow gap)", async () => {
+    // The empty-delta apply vehicle: a cover-only sync emits ONE chunk with
+    // `shortcuts: []` whose only payload is the refresh list. No shortcut work
+    // happens, every refresh entry is pushed to its existing tile, and the
+    // empty ack still fires so the backend commits the unit.
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
+    vi.mocked(backend.getArtworkBase64).mockImplementation(async (romId: number) => ({
+      base64: `COVER-${romId}`,
+    }));
+
+    const data = chunkOf([], "run-cover-only");
+    data.cover_refreshes = [
+      { rom_id: 10, app_id: 7010 },
+      { rom_id: 11, app_id: 7011 },
+    ];
+
+    initUnitSyncManager();
+    await act(async () => {
+      emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", data);
+      await flush(300);
+    });
+
+    expect(addShortcut).not.toHaveBeenCalled();
+    expect(setCustomArtwork).toHaveBeenCalledWith(7010, "COVER-10", "png", 0);
+    expect(setCustomArtwork).toHaveBeenCalledWith(7011, "COVER-11", "png", 0);
+    expect(logErrorSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(backend.reportUnitResults)).toHaveBeenCalledWith({}, "run-cover-only", 1, 0);
+  });
+
   it("fail-soft: one refresh entry's failure never blocks the rest or the ack (#1386)", async () => {
     getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>());
     vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: "COVERPNG" });

--- a/tests/contract/test_cover_refresh.py
+++ b/tests/contract/test_cover_refresh.py
@@ -8,11 +8,20 @@ cache file and carry the ``{rom_id, app_id}`` refresh entry on the emitted
 cover-only change never re-applies the shortcut). The NULL-adopt upgrade path
 (a pre-#1386 row with an existing cache file) is exercised the same way and
 must persist the fingerprint without any download.
+
+The preview→apply flow gap is exercised through the callables the QAM actually
+drives: ``sync_preview`` must count the cover-only work (``cover_refresh_count``)
+without side effects, and the subsequent ``sync_apply_delta`` run must advance
+the fingerprint and carry the refresh entry across the wire — while the pure
+no-changes preview keeps its zero-everything shape.
 """
 
 from __future__ import annotations
 
+import asyncio
+
 from domain.rom import Rom
+from domain.sync_state import SyncState
 
 _COVER_OLD = "/assets/romm/resources/roms/10/cover/big.png?ts=2026-01-01 00:00:00"
 _COVER_NEW = "/assets/romm/resources/roms/10/cover/big.png?ts=2026-07-11 12:00:00"
@@ -80,6 +89,20 @@ async def _run_sync(harness, run_id: str) -> None:
     box = _box(harness)
     assert box.try_begin_run(run_id) is True
     await _orchestrator(harness)._do_sync_per_unit()
+
+
+async def _drain_apply(harness, tries: int = 5000) -> None:
+    """Wait for the background apply task ``sync_apply_delta`` scheduled.
+
+    The callable claims the run slot before returning and the per-unit task
+    resets the box to IDLE on finish, so polling the state drains the task on
+    the harness's own loop (everything behind it is fake/fast).
+    """
+    for _ in range(tries):
+        if harness.plugin._sync_service._sync_state is SyncState.IDLE:
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError("sync_apply_delta's background apply task never finished")
 
 
 async def test_changed_cover_ts_between_runs_re_downloads_and_emits_refresh_entry(harness):
@@ -163,3 +186,84 @@ async def test_null_fingerprint_with_cache_adopts_without_download(harness):
     events = _apply_unit_events(harness)
     assert len(events) == 1
     assert events[0]["cover_refreshes"] == []
+
+
+async def test_cover_only_change_flows_from_preview_to_apply_via_callables(harness):
+    """The QAM flow for a cover-only change (the #1386 flow gap).
+
+    ``sync_preview`` must count the pending cover refresh in its summary — the
+    signal the frontend uses to offer Apply instead of short-circuiting on
+    "no changes" — while staying side-effect-free (no download, fingerprint
+    untouched). The ``sync_apply_delta`` run it gates must then re-download the
+    cover, advance the fingerprint in SQLite, and carry the refresh entry on an
+    empty-``shortcuts`` first chunk.
+    """
+    _make_grid_resolvable(harness)
+    _seed_library(harness, cover=_COVER_OLD)
+    harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"old cover bytes"
+    harness.romm.download_payloads[f"cover:{_COVER_NEW}"] = b"new cover bytes"
+    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+
+    # Seeding run: bind the shortcut and record the OLD fingerprint.
+    await _run_sync(harness, "run-seed")
+    with harness.uow_factory() as uow:
+        rom = uow.roms.get(10)
+    assert rom is not None
+    assert rom.cover_source == _COVER_OLD
+
+    # The server changes ONLY the cover (fresh ?ts= + the updated_at bump RomM
+    # stamps on a cover change, which invalidates the platform's wholesale skip).
+    _seed_library(harness, cover=_COVER_NEW, updated_at="2027-01-01T00:00:00")
+    harness.emit.reset_mock()
+    downloads_before = len(_download_cover_urls(harness))
+
+    preview = await harness.plugin.sync_preview()
+    assert preview["success"] is True
+    summary = preview["summary"]
+    assert summary["cover_refresh_count"] == 1
+    assert summary["new_count"] == 0
+    assert summary["changed_count"] == 0
+    assert summary["remove_count"] == 0
+    # The preview stayed read-only: no cover download, fingerprint unchanged.
+    assert _download_cover_urls(harness)[downloads_before:] == []
+    with harness.uow_factory() as uow:
+        rom = uow.roms.get(10)
+    assert rom is not None
+    assert rom.cover_source == _COVER_OLD
+
+    apply_result = await harness.plugin.sync_apply_delta(preview["preview_id"])
+    assert apply_result == {"success": True, "message": "Applying changes"}
+    await _drain_apply(harness)
+
+    # The apply run refreshed the cache, advanced the fingerprint, and pushed
+    # the refresh entry across the wire on the empty-delta chunk.
+    assert _download_cover_urls(harness)[downloads_before:] == [_COVER_NEW]
+    assert _cache_file(harness).read_bytes() == b"new cover bytes"
+    with harness.uow_factory() as uow:
+        rom = uow.roms.get(10)
+    assert rom is not None
+    assert rom.cover_source == _COVER_NEW
+    events = _apply_unit_events(harness)
+    assert len(events) == 1
+    assert events[0]["shortcuts"] == []
+    assert events[0]["cover_refreshes"] == [{"rom_id": 10, "app_id": 7777}]
+
+
+async def test_pure_no_changes_preview_keeps_zero_cover_count(harness):
+    """A settled library previews all-zero INCLUDING ``cover_refresh_count`` —
+    the frontend's "Everything is up to date." short-circuit stays intact."""
+    _make_grid_resolvable(harness)
+    _seed_library(harness, cover=_COVER_OLD)
+    harness.romm.download_payloads[f"cover:{_COVER_OLD}"] = b"old cover bytes"
+    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    await _run_sync(harness, "run-seed-settled")
+    harness.emit.reset_mock()
+
+    preview = await harness.plugin.sync_preview()
+
+    assert preview["success"] is True
+    summary = preview["summary"]
+    assert summary["new_count"] == 0
+    assert summary["changed_count"] == 0
+    assert summary["remove_count"] == 0
+    assert summary["cover_refresh_count"] == 0

--- a/tests/domain/test_cover_refresh.py
+++ b/tests/domain/test_cover_refresh.py
@@ -1,0 +1,138 @@
+"""Tests for domain/cover_refresh.py — the cover-fingerprint compare kernel (#1386)."""
+
+from domain.cover_refresh import (
+    count_cover_refreshes,
+    fresh_cover_source,
+    scan_cover_refresh_candidates,
+)
+
+_OLD = "/cover/big.png?ts=2026-01-01 00:00:00"
+_NEW = "/cover/big.png?ts=2026-07-11 12:00:00"
+
+
+def _bound(app_id, cover_source):
+    """A bound-row registry entry as the orchestrator projections shape it."""
+    return {"app_id": app_id, "cover_source": cover_source}
+
+
+class TestFreshCoverSource:
+    def test_prefers_path_cover_large(self):
+        rom = {"path_cover_large": "/large.png?ts=1", "path_cover_small": "/small.png?ts=1"}
+        assert fresh_cover_source(rom) == "/large.png?ts=1"
+
+    def test_falls_back_to_path_cover_small(self):
+        assert fresh_cover_source({"path_cover_small": "/small.png?ts=1"}) == "/small.png?ts=1"
+
+    def test_no_cover_fields_is_none(self):
+        assert fresh_cover_source({"id": 1, "name": "Game"}) is None
+
+    def test_empty_strings_are_none(self):
+        assert fresh_cover_source({"path_cover_large": "", "path_cover_small": ""}) is None
+
+
+class TestScanCoverRefreshCandidates:
+    def test_changed_fingerprint_lands_in_changed(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_large": _NEW}],
+            {"10": _bound(1010, _OLD)},
+        )
+        assert scan.changed == [(10, 1010, _NEW)]
+        assert scan.null_fingerprint == []
+
+    def test_null_fingerprint_lands_in_null_bucket(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_large": _NEW}],
+            {"10": _bound(1010, None)},
+        )
+        assert scan.changed == []
+        assert scan.null_fingerprint == [(10, _NEW)]
+
+    def test_unchanged_fingerprint_is_skipped(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_large": _NEW}],
+            {"10": _bound(1010, _NEW)},
+        )
+        assert scan.changed == []
+        assert scan.null_fingerprint == []
+
+    def test_rom_without_registry_entry_is_skipped(self):
+        scan = scan_cover_refresh_candidates([{"id": 999, "path_cover_large": _NEW}], {})
+        assert scan.changed == []
+        assert scan.null_fingerprint == []
+
+    def test_rom_without_cover_or_id_is_skipped(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "name": "No Cover"}, {"path_cover_large": _NEW}],
+            {"10": _bound(1010, _OLD)},
+        )
+        assert scan.changed == []
+        assert scan.null_fingerprint == []
+
+    def test_entry_without_app_id_is_skipped(self):
+        # Defensive: a projection entry that somehow lost its binding is never
+        # a refresh candidate — there is no Steam tile to push the cover to.
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_large": _NEW}],
+            {"10": _bound(None, _OLD)},
+        )
+        assert scan.changed == []
+        assert scan.null_fingerprint == []
+
+    def test_small_cover_fallback_participates_in_the_compare(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_small": _NEW}],
+            {"10": _bound(1010, _OLD)},
+        )
+        assert scan.changed == [(10, 1010, _NEW)]
+
+    def test_order_follows_input_and_buckets_split(self):
+        scan = scan_cover_refresh_candidates(
+            [
+                {"id": 1, "path_cover_large": "/a.png?ts=new"},
+                {"id": 2, "path_cover_large": "/b.png?ts=new"},
+                {"id": 3, "path_cover_large": "/c.png?ts=new"},
+            ],
+            {
+                "1": _bound(1001, "/a.png?ts=old"),
+                "2": _bound(1002, None),
+                "3": _bound(1003, "/c.png?ts=old"),
+            },
+        )
+        assert scan.changed == [(1, 1001, "/a.png?ts=new"), (3, 1003, "/c.png?ts=new")]
+        assert scan.null_fingerprint == [(2, "/b.png?ts=new")]
+
+    def test_duplicate_rom_id_counts_once_first_wins(self):
+        scan = scan_cover_refresh_candidates(
+            [{"id": 10, "path_cover_large": _NEW}, {"id": 10, "path_cover_large": "/other.png?ts=x"}],
+            {"10": _bound(1010, _OLD)},
+        )
+        assert scan.changed == [(10, 1010, _NEW)]
+
+    def test_string_ids_compare_against_string_keys(self):
+        # RomM payloads carry numeric ids, but the kernel normalizes via int()
+        # so a stringly-typed id still matches its registry key.
+        scan = scan_cover_refresh_candidates(
+            [{"id": "10", "path_cover_large": _NEW}],
+            {"10": _bound(1010, _OLD)},
+        )
+        assert scan.changed == [(10, 1010, _NEW)]
+
+
+class TestCountCoverRefreshes:
+    def test_counts_only_the_changed_bucket(self):
+        roms = [
+            {"id": 1, "path_cover_large": "/a.png?ts=new"},  # changed → counted
+            {"id": 2, "path_cover_large": "/b.png?ts=new"},  # NULL fingerprint → not counted
+            {"id": 3, "path_cover_large": "/c.png?ts=same"},  # unchanged → not counted
+            {"id": 4, "path_cover_large": "/d.png?ts=new"},  # unbound (no entry) → not counted
+        ]
+        registry = {
+            "1": _bound(1001, "/a.png?ts=old"),
+            "2": _bound(1002, None),
+            "3": _bound(1003, "/c.png?ts=same"),
+        }
+        assert count_cover_refreshes(roms, registry) == 1
+
+    def test_empty_inputs_count_zero(self):
+        assert count_cover_refreshes([], {}) == 0
+        assert count_cover_refreshes([{"id": 1, "path_cover_large": _NEW}], {}) == 0

--- a/tests/fakes/library_peers.py
+++ b/tests/fakes/library_peers.py
@@ -40,7 +40,7 @@ class FakeArtworkManager:
         self.canned_refreshes: list[dict[str, int]] = canned_refreshes if canned_refreshes is not None else []
         self.finalize_override = finalize_override
         self.download_calls: list[tuple[list[dict[str, Any]], Any, Any, int, int, str]] = []
-        self.refresh_calls: list[tuple[list[dict[str, Any]], Any, Any, int, int, str]] = []
+        self.refresh_calls: list[tuple[list[dict[str, Any]], dict[str, dict[str, Any]], Any, Any, int, int, str]] = []
         self.finalize_calls: list[tuple[str | None, str, int, str]] = []
         self.remove_calls: list[tuple[str, str | int, ShortcutRegistryEntry]] = []
 
@@ -61,6 +61,7 @@ class FakeArtworkManager:
     async def refresh_changed_covers(
         self,
         all_roms: list[dict[str, Any]],
+        registry: dict[str, dict[str, Any]],
         emit_progress: Awaitable[None] | Callable[..., Awaitable[None]],
         is_cancelling: Any,
         progress_step: int = 4,
@@ -68,7 +69,7 @@ class FakeArtworkManager:
         label: str = "",
     ) -> list[dict[str, int]]:
         self.refresh_calls.append(
-            (list(all_roms), emit_progress, is_cancelling, progress_step, progress_total_steps, label)
+            (list(all_roms), dict(registry), emit_progress, is_cancelling, progress_step, progress_total_steps, label)
         )
         return [dict(entry) for entry in self.canned_refreshes]
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -468,6 +468,141 @@ class TestSyncPreview:
         assert plugin._sync_service._sync_state == SyncState.IDLE
 
 
+class TestPreviewCoverRefreshCount:
+    """The preview's cover-only work count (#1386 flow gap).
+
+    A cover-only server change yields an empty shortcut delta, so the frontend
+    would short-circuit on "no changes" and the apply-time invalidation pass
+    would never run. The preview therefore counts fingerprint mismatches with
+    the SAME kernel the apply pass refreshes by, over the registry projection
+    it already reads — side-effect-free: no downloads, no DB writes.
+    """
+
+    _OLD = "/cover/big.png?ts=2026-01-01 00:00:00"
+    _NEW = "/cover/big.png?ts=2026-07-11 12:00:00"
+
+    @staticmethod
+    def _preview_setup(plugin, fake_romm_api):
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+        _use_fake_romm(plugin, fake_romm_api)
+
+    @pytest.mark.asyncio
+    async def test_platform_unit_mismatch_counted_without_downloads_or_writes(self, plugin, fake_romm_api):
+        # A bound, content-unchanged platform ROM whose server cover changed:
+        # the shortcut delta is empty but the cover count is 1 — and the
+        # preview stays read-only (no cover download, fingerprint untouched).
+        self._preview_setup(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Keep", "fs_name": "keep.z64", "path_cover_large": self._NEW}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(
+            plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64", cover_source=self._OLD
+        )
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        summary = result["summary"]
+        assert summary["cover_refresh_count"] == 1
+        assert summary["new_count"] == 0
+        assert summary["changed_count"] == 0
+        assert summary["remove_count"] == 0
+        # Side-effect-free: the fake saw no cover download and the persisted
+        # fingerprint did not advance (the APPLY run owns both).
+        assert all(name != "download_cover" for name, _a, _k in fake_romm_api.call_log)
+        with plugin._uow as uow:
+            assert uow.roms.get(10).cover_source == self._OLD
+
+    @pytest.mark.asyncio
+    async def test_collection_unit_mismatch_is_counted(self, plugin, fake_romm_api):
+        # The hardware repro was a collection-unit ROM: its platform is NOT
+        # enabled, so the ROM only enters the preview union via the enabled
+        # collection — the count must still see it.
+        self._preview_setup(plugin, fake_romm_api)
+        fake_romm_api.roms[20] = {
+            "id": 20,
+            "name": "CGame",
+            "fs_name": "cgame.gba",
+            "platform_id": 2,
+            "platform_name": "GBA",
+            "platform_slug": "gba",
+            "path_cover_large": self._NEW,
+        }
+        _seed_collection(fake_romm_api, collection_id=7, name="Favorites", rom_ids=[20], is_favorite=True)
+        plugin.settings["enabled_platforms"] = {}
+        plugin.settings["enabled_collections"] = {"user": {"7": True}}
+        _seed_rom_row(
+            plugin, 20, app_id=2020, platform_slug="gba", name="CGame", fs_name="cgame.gba", cover_source=self._OLD
+        )
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        assert result["summary"]["cover_refresh_count"] == 1
+        assert result["summary"]["new_count"] == 0
+        assert result["summary"]["changed_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_unchanged_and_null_fingerprints_count_zero(self, plugin, fake_romm_api):
+        # An unchanged fingerprint is no work; a NULL fingerprint is the silent
+        # adopt path (or the apply path's own download) — neither is user-visible
+        # cover work, so the pure no-changes preview keeps its shape.
+        self._preview_setup(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[
+                {"id": 1, "name": "Same", "fs_name": "same.z64", "path_cover_large": self._NEW},
+                {"id": 2, "name": "Null", "fs_name": "null.z64", "path_cover_large": self._NEW},
+            ],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(
+            plugin, 1, app_id=1001, platform_slug="n64", name="Same", fs_name="same.z64", cover_source=self._NEW
+        )
+        _seed_rom_row(plugin, 2, app_id=1002, platform_slug="n64", name="Null", fs_name="null.z64", cover_source=None)
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        assert result["summary"]["cover_refresh_count"] == 0
+        assert result["summary"]["new_count"] == 0
+        assert result["summary"]["changed_count"] == 0
+
+    def test_apply_registry_projection_carries_cover_source(self, plugin):
+        # Round-trip: the bound-row projection the apply scan (and its group
+        # collapse) reads must surface the persisted fingerprint.
+        _seed_rom_row(
+            plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64", cover_source=self._OLD
+        )
+        _seed_rom_row(plugin, 11, app_id=1011, platform_slug="n64", name="Null", fs_name="null.z64", cover_source=None)
+
+        unit = WorkUnit(type="platform", id=1, name="N64", slug="n64", rom_count=2)
+        registry = plugin._sync_service._orchestrator._read_apply_registry(unit)
+
+        assert registry["10"]["cover_source"] == self._OLD
+        assert registry["11"]["cover_source"] is None
+
+    def test_preview_baseline_projection_carries_cover_source(self, plugin):
+        _seed_rom_row(
+            plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64", cover_source=self._OLD
+        )
+
+        registry, _platforms, _collections = plugin._sync_service._orchestrator._read_preview_baseline({"n64": "N64"})
+
+        assert registry["10"]["cover_source"] == self._OLD
+
+
 class TestSyncApplyDelta:
     """Tests for sync_apply_delta().
 
@@ -4840,11 +4975,13 @@ class TestCoverRefreshPass:
         plugin._sync_service._orchestrator._artwork = MagicMock()
         plugin._sync_service._orchestrator._artwork.refresh_changed_covers = fake_refresh
 
+        registry = {"1": {"app_id": 10, "cover_source": "/old.png?ts=1"}}
         result = await plugin._sync_service._orchestrator._refresh_changed_covers(
-            [{"id": 1, "name": "A"}], progress_step=3, progress_total_steps=7, label="N64"
+            [{"id": 1, "name": "A"}], registry, progress_step=3, progress_total_steps=7, label="N64"
         )
 
         assert result == [{"rom_id": 1, "app_id": 10}]
+        assert fake_refresh.call_args.args == ([{"id": 1, "name": "A"}], registry)
         call_kwargs = fake_refresh.call_args.kwargs
         assert call_kwargs["progress_step"] == 3
         assert call_kwargs["progress_total_steps"] == 7

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -65,6 +65,20 @@ def _writing_download(file_store, payload: bytes = b"downloaded"):
     return _dl
 
 
+def _registry(uow):
+    """The bound-row registry projection the orchestrator hands the refresh pass (#1386).
+
+    Mirrors ``_read_apply_registry``'s contract slice: bound rows only, keyed by
+    ``str(rom_id)``, each entry carrying ``app_id`` + ``cover_source``.
+    """
+    with uow:
+        return {
+            str(rom.rom_id): {"app_id": rom.shortcut_app_id, "cover_source": rom.cover_source}
+            for rom in uow.roms.iter_all()
+            if rom.shortcut_app_id is not None
+        }
+
+
 @pytest.fixture
 def cover_cache_dir(tmp_path) -> str:
     """The plugin-owned per-ROM cover cache directory (distinct from the grid)."""
@@ -480,6 +494,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -507,6 +522,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -528,6 +544,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -547,6 +564,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -566,6 +584,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -587,6 +606,7 @@ class TestRefreshChangedCovers:
                 {"id": 999, "name": "No Row", "path_cover_large": self._NEW},
                 {"id": 7, "name": "No Cover"},
             ],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -621,6 +641,7 @@ class TestRefreshChangedCovers:
                 {"id": 1, "name": "One", "path_cover_large": "/1.png?ts=2026-07-11 12:00:00"},
                 {"id": 2, "name": "Two", "path_cover_large": "/2.png?ts=2026-07-11 12:00:00"},
             ],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -649,6 +670,7 @@ class TestRefreshChangedCovers:
 
         refreshed = await artwork_service.refresh_changed_covers(
             [{"id": 42, "name": "Game", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=_not_cancelling,
         )
@@ -681,6 +703,7 @@ class TestRefreshChangedCovers:
                 {"id": 1, "name": "One", "path_cover_large": "/1.png?ts=x"},
                 {"id": 2, "name": "Two", "path_cover_large": "/2.png?ts=x"},
             ],
+            _registry(uow),
             emit_progress=_noop_emit_progress,
             is_cancelling=cancel_after_first,
         )
@@ -702,6 +725,7 @@ class TestRefreshChangedCovers:
 
         await artwork_service.refresh_changed_covers(
             [{"id": 1, "name": "One", "path_cover_large": self._NEW}],
+            _registry(uow),
             emit_progress=record,
             is_cancelling=_not_cancelling,
             progress_step=2,


### PR DESCRIPTION
Hardware-confirmed flow gap in the #1386 cover invalidation (found during on-device testing).

The QAM Sync button runs the preview path, and cover fingerprints are deliberately not part of `classify_roms` — so a cover-only server change produced an empty delta, the preview said "no changes", the apply pipeline (which owns the cover-refresh pass) never ran, and the stale tile never healed. Reproduced on device: fingerprint stayed stale, no run record.

**Fix — the preview counts cover work, for free.** The bound-ROM registry projections the preview/apply classification already read gain the `cover_source` column; a new pure kernel (`domain/cover_refresh.py`) compares them in memory against the fetched cover sources — no extra DB pass, no downloads, no writes, preview stays side-effect-free. The preview summary carries an additive `cover_refresh_count` (deduped across platform and collection units; NULL-fingerprint adopts stay invisible since they download nothing).

**UX.** An empty shortcut delta with pending cover work now reads "No shortcut changes — N cover updates." and offers the normal Apply confirm; the pure no-changes case is byte-identical to before (regression-pinned). Mixed previews are unchanged — covers already ride that path.

**Shared kernel as a side win.** The apply-path candidate scan now consumes the same registry projection instead of per-ROM PK lookups (the O(N) observation from the #1386 review) — one fewer UoW per unit, behavior identical (NULL-adopt, failed-download fingerprint preservation, budget clip, ack semantics all pinned by the existing tests).

The suspected second hole — no chunk vehicle for a unit with zero shortcut items — turned out not to exist (`build_unit_chunks` emits exactly one empty chunk that carries the `cover_refreshes`); it is now regression-pinned across backend, contract, and frontend tests.

Tests: domain kernel suite; preview-count orchestrator tests (platform + collection unit, side-effect-freedom asserting no download call and unchanged SQLite fingerprint); contract end-to-end through the real `sync_preview` → `sync_apply_delta` callables (fingerprint advance + `shortcuts: []` chunk with the refresh entry on the wire) plus the pure-no-changes shape pin; MainPage wording/pluralization/proceed and the Dismiss-only regression pin; syncManager empty-chunk application.

Docs: `docs/architecture/backend-architecture.md` (preview-side count, kernel, empty-chunk vehicle) and `docs/user-guide/syncing-your-library.md` (cover-only preview).