### PR TITLE
fix(danger-zone): remove live-scanned orphan shortcuts in remove-all and re-count after settle

### DIFF
--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -867,6 +867,43 @@ describe("DangerZone", () => {
         logSpy.mockRestore();
       }
     });
+
+    it("re-counts immediately when the collection store is unreadable during removal (#1381)", async () => {
+      // Readable at mount, then unreadable before the removal completes:
+      // recountAfterStoreSettles must read null and re-count right away rather
+      // than poll a store it can't read (exercises the null store-size branch).
+      stubCollectionStore([10, 20]);
+      stubAppStore({ 10: { strDisplayName: "Game Ten" }, 20: { strDisplayName: "Game Twenty" } });
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: [10, 20],
+        rom_ids: [1, 2],
+      });
+      const warnSpy = vi.spyOn(backend, "logWarn").mockImplementation(() => {});
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      // Mount re-counted against the readable store — no warning yet.
+      expect(container.textContent).toContain("Remove 2 Non-Steam Games");
+      expect(warnSpy).not.toHaveBeenCalled();
+      // The store goes unreadable between arming and confirming.
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      vi.stubGlobal("collectionStore", undefined);
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The settle poll was skipped (null baseline) and loadNonSteamApps still
+      // ran immediately: it warned about the unreadable store and cleared the
+      // list — a non-vacuous observable of the immediate re-count.
+      await waitFor(() => {
+        expect(container.textContent).toContain("No non-steam games found");
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("collectionStore not available"));
+      warnSpy.mockRestore();
+    });
   });
 
   describe("ShortcutRemovalSection — handleUninstallAll", () => {

--- a/src/components/DangerZone.test.tsx
+++ b/src/components/DangerZone.test.tsx
@@ -11,7 +11,12 @@ import { createElement, type ReactElement } from "react";
 import { DangerZone } from "./DangerZone";
 import * as backend from "../api/backend";
 import { showModal } from "@decky/ui";
-import { removeShortcut, setLaunchOptionsConfirmed, getAllNonSteamShortcutAppIds } from "../utils/steamShortcuts";
+import {
+  removeShortcut,
+  setLaunchOptionsConfirmed,
+  getAllNonSteamShortcutAppIds,
+  getLiveRomMShortcutAppIds,
+} from "../utils/steamShortcuts";
 import { clearPlatformCollection, clearAllRomMCollections } from "../utils/collections";
 import { formatUninstallStatus } from "../utils/formatters";
 import { setSyncProgress } from "../utils/syncProgress";
@@ -25,6 +30,7 @@ vi.mock("../utils/steamShortcuts", () => ({
   removeShortcut: vi.fn(),
   setLaunchOptionsConfirmed: vi.fn(),
   getAllNonSteamShortcutAppIds: vi.fn(),
+  getLiveRomMShortcutAppIds: vi.fn(),
 }));
 vi.mock("../utils/collections", () => ({
   clearPlatformCollection: vi.fn(),
@@ -99,6 +105,9 @@ describe("DangerZone", () => {
     });
     vi.mocked(setLaunchOptionsConfirmed).mockResolvedValue(true);
     vi.mocked(getAllNonSteamShortcutAppIds).mockReturnValue([]);
+    // Default: the live exe-ownership scan finds nothing beyond the backend
+    // list, so the union removal is a no-op unless a test overrides it.
+    vi.mocked(getLiveRomMShortcutAppIds).mockResolvedValue([]);
     vi.mocked(backend.cleanupOrphanedGridImages).mockResolvedValue({
       success: true,
       candidate_count: 0,
@@ -121,8 +130,18 @@ describe("DangerZone", () => {
     // test-setup's vi.stubGlobal calls run once at module-load; afterEach's
     // vi.unstubAllGlobals() strips them. Re-stub SteamClient.Apps.RemoveShortcut
     // here so RetroDeckSection.handleRemoveAll can fire without ReferenceError.
+    // The mock drops the app from the collection store, mirroring Steam's real
+    // behavior, so the post-removal settle-poll (recountAfterStoreSettles) sees
+    // the store shrink and re-counts immediately instead of waiting out its
+    // timeout on a real timer (#1381).
     vi.stubGlobal("SteamClient", {
-      Apps: { RemoveShortcut: vi.fn() },
+      Apps: {
+        RemoveShortcut: vi.fn((appId: number) => {
+          if (typeof collectionStore !== "undefined") {
+            collectionStore.deckDesktopApps?.apps.delete(appId);
+          }
+        }),
+      },
     });
   });
 
@@ -697,6 +716,156 @@ describe("DangerZone", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(backend.reportRemovalResults)).not.toHaveBeenCalled();
+    });
+
+    it("removes the UNION of backend app_ids and live-scanned orphans, deduped (#1381)", async () => {
+      // Backend binding map returns [1, 2]; the live exe-ownership scan also
+      // finds 3 — an orphan a crashed sync left in Steam with no DB binding.
+      // All three are removed; 2 (present in both lists) is removed once.
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: [1, 2],
+        rom_ids: [50, 51],
+      });
+      vi.mocked(getLiveRomMShortcutAppIds).mockResolvedValue([2, 3]);
+      const logSpy = vi.spyOn(backend, "logInfo").mockImplementation(() => {});
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The orphan (3) is removed only after the scan resolves — wait for it.
+      await waitFor(() => {
+        expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(3);
+      });
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(1);
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(2);
+      // 2 is in both lists → removed once, not twice: three calls total.
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(3);
+      // rom_ids stay the backend set exactly — orphans have no DB row.
+      expect(vi.mocked(backend.reportRemovalResults)).toHaveBeenCalledWith([50, 51]);
+      // Non-vacuous: the one orphan not in the backend list is logged.
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("1 live-scanned RomM shortcut"));
+      logSpy.mockRestore();
+    });
+
+    it("falls back to backend app_ids and warns when the live scan is unavailable (#1381)", async () => {
+      // A null scan means Steam's shortcut store was unreadable — remove the
+      // backend-bound set alone rather than skip removal entirely.
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: [1, 2],
+        rom_ids: [50],
+      });
+      vi.mocked(getLiveRomMShortcutAppIds).mockResolvedValue(null);
+      const warnSpy = vi.spyOn(backend, "logWarn").mockImplementation(() => {});
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      await act(async () => {
+        fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // The flow completes: the success message is surfaced.
+      await waitFor(() => {
+        expect(container.textContent).toContain("Removed all");
+      });
+      // Backend-bound shortcuts still removed; no orphan sweep ran.
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(1);
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledWith(2);
+      expect(vi.mocked(removeShortcut)).toHaveBeenCalledTimes(2);
+      // Non-vacuous null-branch assertion: the warning text is surfaced.
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Live RomM shortcut scan unavailable"));
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("post-removal re-count settles the store (#1381)", () => {
+    it("waits for the shortcut store to shrink before re-counting the non-steam games", async () => {
+      // Two RomM-owned shortcuts live in Steam. Removing them via the backend
+      // path leaves the store momentarily unchanged (Steam settles async), so
+      // the "Remove N" label must not re-count until the store actually shrinks.
+      stubCollectionStore([10, 20]);
+      stubAppStore({ 10: { strDisplayName: "Game Ten" }, 20: { strDisplayName: "Game Twenty" } });
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: [10, 20],
+        rom_ids: [1, 2],
+      });
+      const { getByText, container } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      // Mount re-counted the store: two non-steam games.
+      expect(container.textContent).toContain("Remove 2 Non-Steam Games");
+      // Arm the confirm under real timers, then drive the settle poll under fake
+      // timers so the 250ms cadence fires without a real wait.
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+          // Drain the removal chain (mock promise awaits), then run one poll
+          // cadence. removeShortcut is the mocked util (no-op) so the store is
+          // still full — the label must stay at 2.
+          for (let i = 0; i < 8; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(300);
+        });
+        expect(container.textContent).toContain("Remove 2 Non-Steam Games");
+        // Steam settles: the two shortcuts leave the collection store.
+        collectionStore.deckDesktopApps!.apps.delete(10);
+        collectionStore.deckDesktopApps!.apps.delete(20);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(300);
+        });
+        // The settle poll saw the drop → re-count ran → the list is now empty.
+        expect(container.textContent).toContain("No non-steam games found");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("re-counts after the timeout even if the store never shrinks", async () => {
+      stubCollectionStore([10, 20]);
+      stubAppStore({ 10: { strDisplayName: "Game Ten" }, 20: { strDisplayName: "Game Twenty" } });
+      vi.mocked(backend.removeAllShortcuts).mockResolvedValue({
+        success: true,
+        message: "Removed all",
+        app_ids: [10, 20],
+        rom_ids: [1, 2],
+      });
+      const logSpy = vi.spyOn(backend, "logInfo").mockImplementation(() => {});
+      const { getByText } = render(<DangerZone onBack={vi.fn()} />);
+      await flushAsync();
+      // loadNonSteamApps logs the store size on every re-count; count the
+      // size-2 logs emitted by the mount re-count.
+      const isSizeTwoLog = (c: unknown[]) => String(c[0]).includes("deckDesktopApps.apps size: 2");
+      const countsAtMount = logSpy.mock.calls.filter(isSizeTwoLog).length;
+      fireEvent.click(getByText("Remove All RomM Shortcuts"));
+      vi.useFakeTimers();
+      try {
+        await act(async () => {
+          fireEvent.click(getByText("Confirm: remove all RomM shortcuts?"));
+          // The store never shrinks (removeShortcut util is a no-op). Advance
+          // past the 3s deadline — the poll gives up and re-counts anyway.
+          for (let i = 0; i < 8; i++) await Promise.resolve();
+          await vi.advanceTimersByTimeAsync(3500);
+        });
+        // loadNonSteamApps re-ran after the timeout, re-reading the (unchanged)
+        // store — its size-2 log fired at least once more than at mount.
+        const countsAfter = logSpy.mock.calls.filter(isSizeTwoLog).length;
+        expect(countsAfter).toBeGreaterThan(countsAtMount);
+      } finally {
+        vi.useRealTimers();
+        logSpy.mockRestore();
+      }
     });
   });
 

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -27,7 +27,7 @@ import {
   getWhitelistSettings,
   updateWhitelistSettings,
 } from "../api/backend";
-import { removeShortcut, getAllNonSteamShortcutAppIds } from "../utils/steamShortcuts";
+import { removeShortcut, getAllNonSteamShortcutAppIds, getLiveRomMShortcutAppIds } from "../utils/steamShortcuts";
 import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 import { getSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { scrollToTop } from "../utils/scrollHelpers";
@@ -84,6 +84,36 @@ const useSyncRunning = (): boolean => {
   useEffect(() => onSyncProgressChange(() => setSyncRunning(getSyncProgress().running)), []);
   return syncRunning;
 };
+
+const SETTLE_POLL_MS = 250;
+const SETTLE_TIMEOUT_MS = 3000;
+
+const readShortcutStoreSize = (): number | null => {
+  if (typeof collectionStore === "undefined") return null;
+  const apps = collectionStore.deckDesktopApps?.apps;
+  return apps ? apps.size : null;
+};
+
+// Steam drops a removed shortcut from `deckDesktopApps.apps` a beat after
+// `RemoveShortcut` fires — the store settles asynchronously. Poll until the
+// store size has fallen by `removedCount` (or a short timeout elapses), THEN
+// re-count via `loadNonSteamApps`, so the "Remove N Non-Steam Games" label
+// isn't left showing the pre-removal count (#1381). Deliberately dumb: fixed
+// cadence, single timeout, no retries. If the store is unreadable or nothing
+// was removed, re-count immediately.
+async function recountAfterStoreSettles(removedCount: number, loadNonSteamApps: () => void): Promise<void> {
+  const baseline = readShortcutStoreSize();
+  if (baseline !== null && removedCount > 0) {
+    const target = Math.max(0, baseline - removedCount);
+    const deadline = Date.now() + SETTLE_TIMEOUT_MS;
+    for (;;) {
+      const size = readShortcutStoreSize();
+      if (size === null || size <= target || Date.now() >= deadline) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, SETTLE_POLL_MS));
+    }
+  }
+  loadNonSteamApps();
+}
 
 const PlatformActionModal: FC<{
   platform: RegistryPlatform;
@@ -234,6 +264,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
     }
     setConfirmRemoveAllRomm(false);
     setStatus("Removing all shortcuts...");
+    let removedCount = 0;
     try {
       const result = await removeAllShortcuts();
       if (!result.success) {
@@ -241,11 +272,32 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
         // no app_ids/rom_ids — surface its message and remove nothing.
         setStatus(result.message ?? "Failed to remove shortcuts");
       } else {
-        if (result.app_ids) {
-          for (const appId of result.app_ids) {
+        // The backend list is the DB binding map (roms.shortcut_app_id). A
+        // crashed sync run's in-flight chunk can leave RomM-owned shortcuts in
+        // Steam (exe = bin/rom-launcher) that were never committed — no binding,
+        // so the backend never returns them. The live exe-ownership scan sees
+        // them; remove the UNION so no orphan is left behind (#1381).
+        const removed = new Set<number>();
+        for (const appId of result.app_ids ?? []) {
+          removeShortcut(appId);
+          removed.add(appId);
+        }
+        const liveAppIds = await getLiveRomMShortcutAppIds();
+        if (liveAppIds === null) {
+          // The scan could not run (Steam's shortcut store was unreadable) —
+          // fall back to the backend-bound list alone rather than skip removal.
+          logWarn("Live RomM shortcut scan unavailable — removed backend-bound shortcuts only.");
+        } else {
+          const orphans = liveAppIds.filter((appId) => !removed.has(appId));
+          logInfo(`Remove-all: ${orphans.length} live-scanned RomM shortcut(s) were not in the backend list.`);
+          for (const appId of orphans) {
             removeShortcut(appId);
+            removed.add(appId);
           }
         }
+        removedCount = removed.size;
+        // rom_ids are backend DB rows — orphans have none, so report only the
+        // backend set exactly as before.
         if (result.rom_ids?.length) {
           await reportRemovalResults(result.rom_ids);
         }
@@ -256,7 +308,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
       setStatus("Failed to remove shortcuts");
     }
     await refreshPlatforms();
-    loadNonSteamApps();
+    await recountAfterStoreSettles(removedCount, loadNonSteamApps);
   };
 
   const handleUninstallAll = async () => {
@@ -661,8 +713,8 @@ const RetroDeckSection: FC<RetroDeckSectionProps> = ({
     setStatus(`Removed ${toRemove.length} non-steam game${toRemove.length === 1 ? "" : "s"}`);
     setConfirmRemoveAll(false);
     setConfirmRetrodeck(false);
-    loadNonSteamApps();
     refreshPlatforms().catch((e) => logError(`Failed to refresh platforms: ${e}`));
+    await recountAfterStoreSettles(toRemove.length, loadNonSteamApps);
   };
 
   const removeButtonLabel = () => {


### PR DESCRIPTION
Fixes #1381.

The DangerZone removal flows left a varying number of RomM-owned shortcuts behind, and the "Remove N Non-Steam Games" label kept its stale count after a removal completed. Two causes, two fixes:

**Removal now uses the live exe-ownership scan, not just the DB binding map.** "Remove All RomM Shortcuts" removed only the app_ids the backend returns from `roms.shortcut_app_id`. Shortcuts created by a crashed run's in-flight chunk exist in Steam (exe = `bin/rom-launcher`) but were never committed — no binding, invisible to the removal, and they accumulate across interrupted runs. The flow now removes the union of the backend app_ids and `getLiveRomMShortcutAppIds()` (deduped); a `null` scan (store unreadable) falls back to the backend list with a warning. `reportRemovalResults` is unchanged — orphans have no DB rows to unbind. The whitelist semantics are untouched: the orphan sweep only ever targets `bin/rom-launcher` shortcuts, so foreign apps are never candidates.

**Re-count waits for Steam's store to settle.** Both remove-all flows re-counted immediately after firing `RemoveShortcut` calls, reading a not-yet-settled `collectionStore`. A small bounded helper now polls the store size (250ms cadence) until it drops by the number of removed shortcuts or a 3s timeout, then re-counts. An unreadable store re-counts immediately.

Out of scope, unchanged: removal pacing (#977), whitelist logic.

**Tests:** 5 new (union removal incl. dedupe + orphan logging, null-scan fallback, settle-drop and settle-timeout under fake timers, unreadable-store immediate re-count). Frontend suite 1885 passed / 82 files; Python suite untouched and green (5330).

docs: N/A (bug fix restoring already-documented behavior — `docs/user-guide/troubleshooting.md` §"Remove All RomM Shortcuts" already promises exactly this)
