### PR TITLE
feat(ui): advance the sync bar through fetch and cover sub-phases without backwards jumps

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -573,12 +573,13 @@ phase fills its own slice by its own `current/total`, with a later phase's floor
 phases' shares. So the bar advances continuously through a unit's fetch and cover phases instead of resting frozen at
 the unit floor until `applying`, and it never jumps backwards at a phase boundary even though each phase restarts
 `current/total` from zero (each phase's frames land in a strictly-higher band than the phase before). The phase is
-tagged on the `sync_progress` payload's additive `sub_stage` field: the fetcher's per-page frames carry
-`sub_stage: "fetch"`, the artwork download **and** cover-refresh frames carry `sub_stage: "covers"` (both share the
-covers slice), and the frontend-driven apply frames are keyed on the `applying` stage alone — so a merged apply frame
-still carrying a stale `sub_stage` is unaffected. A frame with no sub-stage (the per-unit fetch anchor, or a pre-#1407
-backend) rests at the unit floor, the old behaviour. `emit_progress` writes `sub_stage` into both the emitted event and
-the persisted `get_sync_status` snapshot, so it rides the QAM-remount re-seed path too.
+tagged on the `sync_progress` payload's additive `subStage` field (camelCase, matching the sibling `totalSteps` /
+`runId` keys — the `emit_progress` Python kwarg is `sub_stage`, the emitted key is `subStage`): the fetcher's per-page
+frames carry `subStage: "fetch"`, the artwork download **and** cover-refresh frames carry `subStage: "covers"` (both
+share the covers slice), and the frontend-driven apply frames are keyed on the `applying` stage alone — so a merged
+apply frame still carrying a stale `subStage` is unaffected. A frame with no sub-stage (the per-unit fetch anchor, or a
+pre-#1407 backend) rests at the unit floor, the old behaviour. `emit_progress` writes `subStage` into both the emitted
+event and the persisted `get_sync_status` snapshot, so it rides the QAM-remount re-seed path too.
 
 The whole thing is an approximation by design — though a narrow one since the plan went skip-aware: seed weights and the
 applying frames usually both count post-collapse shortcuts now, the raw pre-collapse `rom_count` survives only as the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -575,11 +575,17 @@ the unit floor until `applying`, and it never jumps backwards at a phase boundar
 `current/total` from zero (each phase's frames land in a strictly-higher band than the phase before). The phase is
 tagged on the `sync_progress` payload's additive `subStage` field (camelCase, matching the sibling `totalSteps` /
 `runId` keys — the `emit_progress` Python kwarg is `sub_stage`, the emitted key is `subStage`): the fetcher's per-page
-frames carry `subStage: "fetch"`, the artwork download **and** cover-refresh frames carry `subStage: "covers"` (both
+frames carry `subStage: "fetch"`, the artwork cover-refresh **and** download frames carry `subStage: "covers"` (both
 share the covers slice), and the frontend-driven apply frames are keyed on the `applying` stage alone — so a merged
-apply frame still carrying a stale `subStage` is unaffected. A frame with no sub-stage (the per-unit fetch anchor, or a
-pre-#1407 backend) rests at the unit floor, the old behaviour. `emit_progress` writes `subStage` into both the emitted
-event and the persisted `get_sync_status` snapshot, so it rides the QAM-remount re-seed path too.
+apply frame still carrying a stale `subStage` is unaffected. Within the covers slice the fill is _not_ strictly
+monotonic: the covers phase runs two sequential passes — the cover-cache refresh first, then the download for the apply
+set — each counting `current/total` from zero, so a mixed unit (changed covers to refresh **and** new covers to
+download) can dip backwards **within** the covers band at the refresh→download handover, bounded to the covers share of
+that unit's slice. The fetch→covers→apply phase handovers themselves stay monotonic (the common cases don't dip either:
+a first full sync refreshes nothing, and a steady incremental sync with no cover changes runs neither pass). A frame
+with no sub-stage (the per-unit fetch anchor, or a pre-#1407 backend) rests at the unit floor, the old behaviour.
+`emit_progress` writes `subStage` into both the emitted event and the persisted `get_sync_status` snapshot, so it rides
+the QAM-remount re-seed path too.
 
 The whole thing is an approximation by design — though a narrow one since the plan went skip-aware: seed weights and the
 applying frames usually both count post-collapse shortcuts now, the raw pre-collapse `rom_count` survives only as the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -566,6 +566,20 @@ bar in proportion to its real work. It falls back to the old equal-per-unit inde
 (QAM opened mid-run before any `sync_plan`, an older backend) or the plan can't apportion (unit-count mismatch, all-zero
 weights).
 
+The **within-unit fill is itself split into three monotonic sub-slices** (#1407, `withinUnitFraction` in
+`src/utils/syncProgress.ts`): fetch (`FETCH_SHARE` 15%) → covers (`COVERS_SHARE` 25%) → apply (`APPLY_SHARE` 60%). A
+unit is worked in that order — paginate the ROM list, download/refresh cover art, then create the shortcuts — and each
+phase fills its own slice by its own `current/total`, with a later phase's floor sitting at the sum of the earlier
+phases' shares. So the bar advances continuously through a unit's fetch and cover phases instead of resting frozen at
+the unit floor until `applying`, and it never jumps backwards at a phase boundary even though each phase restarts
+`current/total` from zero (each phase's frames land in a strictly-higher band than the phase before). The phase is
+tagged on the `sync_progress` payload's additive `sub_stage` field: the fetcher's per-page frames carry
+`sub_stage: "fetch"`, the artwork download **and** cover-refresh frames carry `sub_stage: "covers"` (both share the
+covers slice), and the frontend-driven apply frames are keyed on the `applying` stage alone — so a merged apply frame
+still carrying a stale `sub_stage` is unaffected. A frame with no sub-stage (the per-unit fetch anchor, or a pre-#1407
+backend) rests at the unit floor, the old behaviour. `emit_progress` writes `sub_stage` into both the emitted event and
+the persisted `get_sync_status` snapshot, so it rides the QAM-remount re-seed path too.
+
 The whole thing is an approximation by design — though a narrow one since the plan went skip-aware: seed weights and the
 applying frames usually both count post-collapse shortcuts now, the raw pre-collapse `rom_count` survives only as the
 fallback where the backend doesn't know better, and a unit the plan mis-predicted re-corrects on its first

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -58,10 +58,12 @@ takes no space, and a huge platform fills the bar in proportion to its real work
 
 A few things worth knowing for a large library:
 
-- **The progress line narrates each phase.** For a large platform the sync first pulls the game list from your server
-  page by page and then downloads cover art before it starts creating shortcuts; the line names what it is doing (e.g.
-  "Fetching Game Boy Advance (page 12/62)" then "Preparing covers for Game Boy Advance"), so a fetch that takes minutes
-  never looks stuck.
+- **The progress bar advances through each phase.** For a large platform the sync first pulls the game list from your
+  server page by page, then downloads cover art, then starts creating shortcuts; the line names what it is doing (e.g.
+  "Fetching Game Boy Advance (page 12/62)" then "Preparing covers for Game Boy Advance"), and the bar now edges forward
+  through the fetch and cover phases as well — not only while shortcuts are being created. A platform whose cost is
+  mostly its cover pull no longer shows a bar that sits frozen until the very end, and the bar never jumps backwards as
+  the phases hand over.
 - **Cover art fills in as the run goes.** Covers appear on your library tiles progressively while the sync creates
   shortcuts, not only at the very end, so you can watch the library fill in. A few tiles may stay gray until the first
   time you open that game's page (or the next time Steam restarts) — that is expected and does not mean the cover is

--- a/py_modules/services/artwork.py
+++ b/py_modules/services/artwork.py
@@ -136,11 +136,12 @@ class ArtworkService:
         pending-sync ``cover_path`` that ``finalize_cover_path`` publishes onto
         the grid once the Steam app_id is known.
 
-        Progress is narrated under the ``fetching`` stage (this runs in the
-        per-unit prep phase, before the shortcuts are applied) as "Preparing
-        covers for <label>", throttled to the first/last/every-Nth cover.
-        ``label`` is the owning unit's display name; blank falls back to a
-        bare "Preparing covers".
+        Progress is narrated under the ``fetching`` stage with the ``covers``
+        sub-stage (this runs in the per-unit prep phase, before the shortcuts
+        are applied) as "Preparing covers for <label>", throttled to the
+        first/last/every-Nth cover — the sub-stage places these frames in the
+        unit's covers sub-slice of the bar (#1407). ``label`` is the owning
+        unit's display name; blank falls back to a bare "Preparing covers".
         """
         cover_paths: dict[int, str] = {}
         grid = self._steam_config.grid_dir()
@@ -165,6 +166,7 @@ class ArtworkService:
                     message=f"{cover_target} ({processed}/{total})",
                     step=progress_step,
                     total_steps=progress_total_steps,
+                    sub_stage="covers",
                 )
 
             cover_url = rom.get("path_cover_large") or rom.get("path_cover_small")
@@ -281,8 +283,9 @@ class ArtworkService:
         whose Steam tile the frontend must re-apply via
         ``SetCustomArtworkForApp`` (the grid file alone leaves the in-session
         tile stale until a client restart). One ROM's failure never aborts the
-        pass. Progress is narrated under the ``fetching`` stage, throttled like
-        the cover-download loop.
+        pass. Progress is narrated under the ``fetching`` stage with the
+        ``covers`` sub-stage (the same sub-slice as the cover-download loop,
+        #1407), throttled the same way.
         """
         adoptions, changed = await self._loop.run_in_executor(
             None, self._scan_cover_refresh_candidates, all_roms, registry
@@ -309,6 +312,7 @@ class ArtworkService:
                     message=f"{refresh_target} ({processed}/{total})",
                     step=progress_step,
                     total_steps=progress_total_steps,
+                    sub_stage="covers",
                 )
             ok = await self._loop.run_in_executor(None, self._refresh_one_cover_io, rom_id, app_id, cover_url, grid)
             if ok:

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -748,8 +748,10 @@ class LibraryFetcher:
         main bar holds its position while the fine line advances by page; a
         falsy pair (the preview loop already emits its own per-unit frame,
         standalone callers) leaves the coarse bar indeterminate, as before.
-        The displayed total is clamped to at least ``page`` so a server that
-        grew since the listing never shows ``page 63/62``.
+        The frame carries the ``fetch`` sub-stage so the frontend fills the
+        unit's fetch sub-slice of the bar (#1407). The displayed total is
+        clamped to at least ``page`` so a server that grew since the listing
+        never shows ``page 63/62``.
         """
         if page != 1 and page % _FETCH_PROGRESS_PAGE_INTERVAL != 0:
             return
@@ -761,6 +763,7 @@ class LibraryFetcher:
             message=f"Fetching {unit_name} (page {page}/{shown_total})",
             step=progress_step,
             total_steps=progress_total_steps,
+            sub_stage="fetch",
         )
 
     async def fetch_platform_unit(

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -519,10 +519,13 @@ class SyncOrchestrator:
         stage's phases — ``"fetch"`` (paginated ROM listing) vs ``"covers"``
         (cover download/refresh) — so the frontend can fill each phase's own
         monotonic sub-slice of the running unit's width (#1407); it is empty
-        for every other frame. The snapshot is written to the box first so
-        :meth:`get_sync_status` always returns the latest state even if
-        the event never reaches a freshly remounted QAM — the ``sub_stage``
-        field therefore rides both the event and the remount re-seed.
+        for every other frame. It rides the payload as the camelCase
+        ``subStage`` key, matching the other multi-word snapshot keys
+        (``totalSteps`` / ``runId``); the Python parameter stays snake_case.
+        The snapshot is written to the box first so :meth:`get_sync_status`
+        always returns the latest state even if the event never reaches a
+        freshly remounted QAM — ``subStage`` therefore rides both the event
+        and the remount re-seed.
         """
         self._sync_state.sync_progress = {
             "running": running,
@@ -532,7 +535,7 @@ class SyncOrchestrator:
             "message": message,
             "step": step,
             "totalSteps": total_steps,
-            "sub_stage": sub_stage,
+            "subStage": sub_stage,
             "runId": str(self._sync_state.current_sync_id or ""),
         }
         await self._emit("sync_progress", self._sync_state.sync_progress)

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -505,7 +505,9 @@ class SyncOrchestrator:
 
     # ── Progress & safety ────────────────────────────────────────
 
-    async def emit_progress(self, stage, current=0, total=0, message="", running=True, step=0, total_steps=0):
+    async def emit_progress(
+        self, stage, current=0, total=0, message="", running=True, step=0, total_steps=0, sub_stage=""
+    ):
         """Persist the progress snapshot and emit the sync_progress event.
 
         ``stage`` is a :class:`SyncStage` (or its string value); ``step``
@@ -513,9 +515,14 @@ class SyncOrchestrator:
         drive the determinate main bar — stages without a unit index yet
         (discovering, fetching) pass ``0`` / ``0``, which the frontend
         treats as indeterminate. ``current`` / ``total`` are the fine
-        within-unit counters. The snapshot is written to the box first so
+        within-unit counters. ``sub_stage`` discriminates the ``fetching``
+        stage's phases — ``"fetch"`` (paginated ROM listing) vs ``"covers"``
+        (cover download/refresh) — so the frontend can fill each phase's own
+        monotonic sub-slice of the running unit's width (#1407); it is empty
+        for every other frame. The snapshot is written to the box first so
         :meth:`get_sync_status` always returns the latest state even if
-        the event never reaches a freshly remounted QAM.
+        the event never reaches a freshly remounted QAM — the ``sub_stage``
+        field therefore rides both the event and the remount re-seed.
         """
         self._sync_state.sync_progress = {
             "running": running,
@@ -525,6 +532,7 @@ class SyncOrchestrator:
             "message": message,
             "step": step,
             "totalSteps": total_steps,
+            "sub_stage": sub_stage,
             "runId": str(self._sync_state.current_sync_id or ""),
         }
         await self._emit("sync_progress", self._sync_state.sync_progress)

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -40,7 +40,15 @@ import { createElement, type ReactElement } from "react";
 import { MainPage } from "./MainPage";
 import * as backend from "../api/backend";
 import { useVersionError } from "./VersionErrorCard";
-import { setSyncProgress, updateSyncProgress, onSyncProgressChange, getSyncProgress } from "../utils/syncProgress";
+import {
+  setSyncProgress,
+  updateSyncProgress,
+  onSyncProgressChange,
+  getSyncProgress,
+  FETCH_SHARE,
+  COVERS_SHARE,
+  APPLY_SHARE,
+} from "../utils/syncProgress";
 import { beginEtaRun, resetEta, liveEtaSeconds } from "../utils/syncEta";
 import * as syncEta from "../utils/syncEta";
 import { NEW_ITEM_SEC, UPDATED_ITEM_SEC } from "../utils/syncEstimate";
@@ -57,6 +65,7 @@ import type {
   SessionBudgetStatus,
   DownloadItem,
   PluginSettings,
+  SyncProgress,
 } from "../types";
 
 // -----------------------------------------------------------------------------
@@ -1603,9 +1612,12 @@ describe("MainPage", () => {
       expect(op?.textContent).toContain("Applying shortcuts");
       // The caption's step span still carries the coarse "step/totalSteps" text.
       expect(container.querySelector('[data-testid="sync-step"]')?.textContent).toContain("2/5");
-      // Interpolated: floor (step-1)=1 plus the within-unit fraction 3/10, over
-      // 5 steps → (1 + 0.3)/5 * 100 = 26 (was a frozen 40 before interpolation).
-      expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("26");
+      // Interpolated: floor (step-1)=1 plus the apply sub-slice fill — fetch and
+      // covers already filled their shares, so applying starts at (F+C) and adds
+      // A*(3/10) — over 5 steps (#1407).
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (3 / 10);
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(((1 + within) / 5) * 100, 5);
       expect(container.querySelector('[data-testid="progress-indeterminate"]')?.textContent).toBe("false");
     });
 
@@ -1621,9 +1633,11 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      // (step-1 + current/total) / totalSteps * 100 = (1 + 450/2091)/8*100 ≈ 15.19.
+      // (step-1 + apply sub-slice fill) / totalSteps * 100, where applying fills
+      // (F+C) + A*(450/2091) of the unit's slice (#1407).
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (450 / 2091);
       const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
-      expect(nProgress).toBeCloseTo(((1 + 450 / 2091) / 8) * 100, 5);
+      expect(nProgress).toBeCloseTo(((1 + within) / 8) * 100, 5);
     });
 
     it("main bar weights units by the plan's item weights when a plan is measured (#1382)", async () => {
@@ -1642,10 +1656,12 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      // Weighted: (unit 1's 10 + 450 of PSX's 2091) / 2106. The index-based math
-      // would read (1 + 450/2091)/3 ≈ 40.5 — far past the real position.
+      // Weighted: unit 1's full weight (10) plus PSX's within-unit fill of its
+      // 2091 weight. Applying fills (F+C) + A*(450/2091) of the unit (#1407), so
+      // the running unit contributes within*2091 of the 2106 total.
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (450 / 2091);
       const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
-      expect(nProgress).toBeCloseTo(((10 + 450) / 2106) * 100, 5);
+      expect(nProgress).toBeCloseTo(((10 + within * 2091) / 2106) * 100, 5);
     });
 
     it("a predicted-skip unit occupies no bar width (zero plan weight, #1382)", async () => {
@@ -1663,9 +1679,13 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
-      // Weighted: 50/100 → 50. Index-based would read (1 + 0.5)/2 * 100 = 75,
-      // crediting the skipped unit half the bar.
-      expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("50");
+      // Weighted: the skipped unit 1 has zero weight, so the bar reflects only
+      // unit 2's own within-unit fill — applying at (F+C) + A*(50/100) of its
+      // 100 weight over the 100 total (#1407). Index-based would wrongly credit
+      // the skipped unit half the bar.
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (50 / 100);
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(within * 100, 5);
     });
 
     it("falls back to index weighting when the plan's unit count mismatches the run (stale plan)", async () => {
@@ -1683,14 +1703,17 @@ describe("MainPage", () => {
       });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
+      // Index fallback: (step-1 + apply sub-slice fill) / totalSteps (#1407).
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (450 / 2091);
       const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
-      expect(nProgress).toBeCloseTo(((1 + 450 / 2091) / 8) * 100, 5);
+      expect(nProgress).toBeCloseTo(((1 + within) / 8) * 100, 5);
     });
 
-    it("main bar rests at the unit floor during the fetch phase (no within-unit fill)", async () => {
-      // Fetch frames carry current/total (page counters) to drive the fine line,
-      // but must NOT advance the coarse bar — it rests at (step-1)/totalSteps so
-      // the bar never jumps backwards at the fetch→apply boundary of the unit.
+    it("main bar rests at the unit floor during fetch when no sub-stage is present (old backend)", async () => {
+      // A backend that predates #1407 sends fetch frames with no sub_stage: they
+      // carry current/total (page counters) to drive the fine line, but with no
+      // sub-slice to fill the coarse bar rests at (step-1)/totalSteps — the
+      // pre-#1407 behaviour, never a backwards jump at the fetch→apply boundary.
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
         stage: "fetching",
@@ -1704,6 +1727,106 @@ describe("MainPage", () => {
       await flushAsync();
       // Floor only: (2-1)/8 * 100 = 12.5. The page counter (30/62) does not lift it.
       expect(container.querySelector('[data-testid="progress-progress"]')?.textContent).toBe("12.5");
+    });
+
+    it("fetch sub-stage fills within the fetch sub-slice (#1407)", async () => {
+      // A fetch-phase frame (sub_stage "fetch") lifts the bar within the fetch
+      // share only — page 30/62 → FETCH_SHARE * (30/62) above the unit floor.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        sub_stage: "fetch",
+        step: 2,
+        totalSteps: 8,
+        current: 30,
+        total: 62,
+        message: "Fetching GBA (page 30/62)",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const within = FETCH_SHARE * (30 / 62);
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(((1 + within) / 8) * 100, 5);
+    });
+
+    it("covers sub-stage continues above the fetch share (#1407)", async () => {
+      // A cover-phase frame (sub_stage "covers") starts where fetch ended
+      // (FETCH_SHARE) and fills the covers share by its own current/total.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        sub_stage: "covers",
+        step: 2,
+        totalSteps: 8,
+        current: 500,
+        total: 2000,
+        message: "Preparing covers for GBA (500/2000)",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const within = FETCH_SHARE + COVERS_SHARE * (500 / 2000);
+      expect(within).toBeGreaterThan(FETCH_SHARE);
+      const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+      expect(nProgress).toBeCloseTo(((1 + within) / 8) * 100, 5);
+    });
+
+    it("advances monotonically across a fetch → covers → apply frame sequence (#1407)", async () => {
+      // Drive the running unit (step 2/8) through its three phases and assert the
+      // coarse bar never decreases at any frame — the core #1407 guarantee. The
+      // mount seed is a running fetch anchor so the in-flight bar renders.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "fetching",
+        step: 2,
+        totalSteps: 8,
+        current: 0,
+        total: 0,
+        message: "Fetching GBA",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const barValue = () => Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
+
+      const frames: SyncProgress[] = [];
+      // Fetch anchor (no sub-stage) then paginated fetch frames.
+      frames.push({ running: true, stage: "fetching", step: 2, totalSteps: 8, current: 0, total: 0 });
+      for (let page = 1; page <= 10; page++) {
+        frames.push({
+          running: true,
+          stage: "fetching",
+          sub_stage: "fetch",
+          step: 2,
+          totalSteps: 8,
+          current: page,
+          total: 10,
+        });
+      }
+      // Cover download frames.
+      for (let c = 1; c <= 100; c++) {
+        frames.push({
+          running: true,
+          stage: "fetching",
+          sub_stage: "covers",
+          step: 2,
+          totalSteps: 8,
+          current: c,
+          total: 100,
+        });
+      }
+      // Frontend apply frames.
+      for (let a = 1; a <= 50; a++) {
+        frames.push({ running: true, stage: "applying", step: 2, totalSteps: 8, current: a, total: 50 });
+      }
+
+      let previous = -1;
+      for (const frame of frames) {
+        act(() => setSyncProgress(frame));
+        const value = barValue();
+        expect(value).toBeGreaterThanOrEqual(previous);
+        previous = value;
+      }
+      // The unit ends the apply phase at its full slice ceiling: floor + 1 slice.
+      expect(previous).toBeCloseTo((2 / 8) * 100, 5);
     });
 
     it("main bar reads 100% during finalizing (step == totalSteps, all units done)", async () => {
@@ -1891,9 +2014,11 @@ describe("MainPage", () => {
       await flushAsync();
 
       expect(container.querySelector('[data-testid="sync-stage"]')?.textContent).toContain("Applying shortcuts");
-      // Interpolation stays live: (1 + 1200/3084) / 8, not the 12.5% unit floor.
+      // Interpolation stays live in the apply sub-slice: (1 + (F+C) + A*1200/3084)
+      // / 8, not the 12.5% unit floor (#1407).
+      const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * (1200 / 3084);
       const nProgress = Number(container.querySelector('[data-testid="progress-progress"]')?.textContent);
-      expect(nProgress).toBeCloseTo(((1 + 1200 / 3084) / 8) * 100, 5);
+      expect(nProgress).toBeCloseTo(((1 + within) / 8) * 100, 5);
     });
 
     it("replaces (drops stale fine fields + ETA) when the backend reports a different run", async () => {

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1710,7 +1710,7 @@ describe("MainPage", () => {
     });
 
     it("main bar rests at the unit floor during fetch when no sub-stage is present (old backend)", async () => {
-      // A backend that predates #1407 sends fetch frames with no sub_stage: they
+      // A backend that predates #1407 sends fetch frames with no subStage: they
       // carry current/total (page counters) to drive the fine line, but with no
       // sub-slice to fill the coarse bar rests at (step-1)/totalSteps — the
       // pre-#1407 behaviour, never a backwards jump at the fetch→apply boundary.
@@ -1730,12 +1730,12 @@ describe("MainPage", () => {
     });
 
     it("fetch sub-stage fills within the fetch sub-slice (#1407)", async () => {
-      // A fetch-phase frame (sub_stage "fetch") lifts the bar within the fetch
+      // A fetch-phase frame (subStage "fetch") lifts the bar within the fetch
       // share only — page 30/62 → FETCH_SHARE * (30/62) above the unit floor.
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
         stage: "fetching",
-        sub_stage: "fetch",
+        subStage: "fetch",
         step: 2,
         totalSteps: 8,
         current: 30,
@@ -1750,12 +1750,12 @@ describe("MainPage", () => {
     });
 
     it("covers sub-stage continues above the fetch share (#1407)", async () => {
-      // A cover-phase frame (sub_stage "covers") starts where fetch ended
+      // A cover-phase frame (subStage "covers") starts where fetch ended
       // (FETCH_SHARE) and fills the covers share by its own current/total.
       vi.mocked(backend.getSyncStatus).mockResolvedValue({
         running: true,
         stage: "fetching",
-        sub_stage: "covers",
+        subStage: "covers",
         step: 2,
         totalSteps: 8,
         current: 500,
@@ -1794,7 +1794,7 @@ describe("MainPage", () => {
         frames.push({
           running: true,
           stage: "fetching",
-          sub_stage: "fetch",
+          subStage: "fetch",
           step: 2,
           totalSteps: 8,
           current: page,
@@ -1806,7 +1806,7 @@ describe("MainPage", () => {
         frames.push({
           running: true,
           stage: "fetching",
-          sub_stage: "covers",
+          subStage: "covers",
           step: 2,
           totalSteps: 8,
           current: c,

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -41,7 +41,12 @@ import {
   formatEtaCountdown,
   weightedCoarseFraction,
 } from "../utils/syncEta";
-import { getSyncProgress, setSyncProgress as setStoredSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
+import {
+  getSyncProgress,
+  setSyncProgress as setStoredSyncProgress,
+  onSyncProgressChange,
+  withinUnitFraction,
+} from "../utils/syncProgress";
 import { getDownloadState } from "../utils/downloadStore";
 import { getMigrationState, onMigrationChange, setMigrationStatus } from "../utils/migrationStore";
 import { getSettingsResetState, onSettingsResetChange } from "../utils/settingsResetStore";
@@ -765,28 +770,26 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // Two-level progress. The main determinate bar tracks COARSE unit progress
   // but INTERPOLATES within the running unit so a large unit (e.g. 2091 items at
   // step 2/8) doesn't sit frozen: the bar fills from the step's floor toward the
-  // next notch as the unit's items are applied. Notch positions come from the
-  // plan's per-unit item weights when measured (#1382), else each unit is an
-  // equal 1/totalSteps slice. 0/0 totalSteps means the run hasn't reached a
-  // unit yet → indeterminate. ``nProgress`` is a percentage (0-100), not a
-  // fraction.
+  // next notch as the unit is worked. Notch positions come from the plan's
+  // per-unit item weights when measured (#1382), else each unit is an equal
+  // 1/totalSteps slice. 0/0 totalSteps means the run hasn't reached a unit yet →
+  // indeterminate. ``nProgress`` is a percentage (0-100), not a fraction.
   //
   // While actively working a unit (``fetching``/``applying``) the current unit
   // is not yet done, so the completed count is ``step - 1``; the terminal-ish
   // stages (``finalizing``/``done``) carry ``step == totalSteps`` as a
   // completed count, so they keep the full ``step`` and the bar reads 100%.
-  // The within-unit fill is taken ONLY from the ``applying`` stage: the fetch
-  // and cover frames also carry current/total (to drive the fine line), and
-  // letting those advance the coarse bar would make it jump backwards at each
-  // fetch→cover→apply boundary of the same unit. During fetch the bar therefore
-  // rests at the unit's floor and only the fine line moves.
+  // The within-unit fill splits the running unit's width into three monotonic
+  // sub-slices — fetch → covers → apply (#1407, ``withinUnitFraction``) — each
+  // filling by its own phase's ``current/total`` within a strictly-higher band
+  // than the phase before. So the fetch and cover frames now DO advance the bar
+  // (within their own sub-slice), never backwards at a phase boundary even
+  // though each phase restarts ``current/total`` from zero. An old backend that
+  // sends no sub-stage falls back to resting at the unit floor during fetch.
   const step = syncProgress?.step ?? 0;
   const activeUnit = syncProgress?.stage === "fetching" || syncProgress?.stage === "applying";
   const completedSteps = activeUnit ? Math.max(0, step - 1) : step;
-  const withinUnitFraction =
-    syncProgress?.stage === "applying" && syncProgress.current && syncProgress.total
-      ? syncProgress.current / syncProgress.total
-      : 0;
+  const withinUnit = withinUnitFraction(syncProgress);
   // Weight the bar by the plan's per-unit item weights (#1382) — the same
   // skip-aware, delta-corrected weights the countdown uses — so a
   // predicted-skip unit takes no width and a huge platform takes its real
@@ -794,13 +797,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // measured (QAM opened mid-run before any sync_plan, old backend) or the
   // plan can't apportion (unit-count mismatch, all-zero weights).
   const weightedFraction = syncProgress?.totalSteps
-    ? weightedCoarseFraction(completedSteps, withinUnitFraction, syncProgress.totalSteps)
+    ? weightedCoarseFraction(completedSteps, withinUnit, syncProgress.totalSteps)
     : null;
   const coarseFraction = syncProgress?.totalSteps
-    ? Math.max(
-        0,
-        Math.min(100, (weightedFraction ?? (completedSteps + withinUnitFraction) / syncProgress.totalSteps) * 100),
-      )
+    ? Math.max(0, Math.min(100, (weightedFraction ?? (completedSteps + withinUnit) / syncProgress.totalSteps) * 100))
     : undefined;
   const hasFineDetail = !!(syncProgress?.total && syncProgress.message);
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -47,6 +47,17 @@ export interface SyncProgress {
   /** Coarse: total units. ``0`` means indeterminate. */
   totalSteps?: number;
   /**
+   * Sub-phase of the ``fetching`` stage — ``"fetch"`` (paginated ROM listing)
+   * or ``"covers"`` (cover download/refresh) — so the running unit's width can
+   * fill each phase's own monotonic sub-slice instead of resting frozen until
+   * ``applying`` (#1407). Empty/absent on every other frame (including the
+   * ``fetching`` anchor and old backends), which the bar treats as "rest at the
+   * unit floor" — the pre-#1407 behaviour. Snake_case on the wire because the
+   * backend ``sync_progress`` payload lands in the store verbatim (no casing
+   * translation layer).
+   */
+  sub_stage?: string;
+  /**
    * Backend run identity for the in-flight sync, stamped from the backend's
    * ``current_sync_id``. ``""`` when no run is in flight. The authoritative
    * source a Cancel click scopes itself to — the frontend no longer mirrors a

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -52,11 +52,11 @@ export interface SyncProgress {
    * fill each phase's own monotonic sub-slice instead of resting frozen until
    * ``applying`` (#1407). Empty/absent on every other frame (including the
    * ``fetching`` anchor and old backends), which the bar treats as "rest at the
-   * unit floor" — the pre-#1407 behaviour. Snake_case on the wire because the
-   * backend ``sync_progress`` payload lands in the store verbatim (no casing
-   * translation layer).
+   * unit floor" — the pre-#1407 behaviour. camelCase, matching the sibling
+   * ``totalSteps`` / ``runId`` keys the backend emits on the same payload (the
+   * store spreads the raw event verbatim, so the wire key IS this field name).
    */
-  sub_stage?: string;
+  subStage?: string;
   /**
    * Backend run identity for the in-flight sync, stamped from the backend's
    * ``current_sync_id``. ``""`` when no run is in flight. The authoritative

--- a/src/utils/syncProgress.test.ts
+++ b/src/utils/syncProgress.test.ts
@@ -84,14 +84,14 @@ describe("withinUnitFraction sub-slice model (#1407)", () => {
   });
 
   it("fetch sub-stage fills only the fetch share", () => {
-    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "fetch", current: 3, total: 10 }))).toBeCloseTo(
+    expect(withinUnitFraction(frame({ stage: "fetching", subStage: "fetch", current: 3, total: 10 }))).toBeCloseTo(
       FETCH_SHARE * 0.3,
       10,
     );
   });
 
   it("covers sub-stage starts at the fetch ceiling and fills the covers share", () => {
-    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "covers", current: 1, total: 4 }))).toBeCloseTo(
+    expect(withinUnitFraction(frame({ stage: "fetching", subStage: "covers", current: 1, total: 4 }))).toBeCloseTo(
       FETCH_SHARE + COVERS_SHARE * 0.25,
       10,
     );
@@ -104,10 +104,10 @@ describe("withinUnitFraction sub-slice model (#1407)", () => {
     );
   });
 
-  it("applying ignores a stale merged sub_stage (keyed on the stage alone)", () => {
+  it("applying ignores a stale merged subStage (keyed on the stage alone)", () => {
     // A frontend apply frame merges over a prior covers frame, so it can still
-    // carry sub_stage "covers"; the apply band must win regardless.
-    expect(withinUnitFraction(frame({ stage: "applying", sub_stage: "covers", current: 1, total: 1 }))).toBeCloseTo(
+    // carry subStage "covers"; the apply band must win regardless.
+    expect(withinUnitFraction(frame({ stage: "applying", subStage: "covers", current: 1, total: 1 }))).toBeCloseTo(
       1,
       10,
     );
@@ -124,7 +124,7 @@ describe("withinUnitFraction sub-slice model (#1407)", () => {
 
   it("a falsy current/total yields the phase floor, never a divide", () => {
     // covers with total 0 → the fetch ceiling (its own share contributes 0).
-    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "covers", current: 0, total: 0 }))).toBeCloseTo(
+    expect(withinUnitFraction(frame({ stage: "fetching", subStage: "covers", current: 0, total: 0 }))).toBeCloseTo(
       FETCH_SHARE,
       10,
     );
@@ -134,7 +134,7 @@ describe("withinUnitFraction sub-slice model (#1407)", () => {
       10,
     );
     // fetch with total 0 → 0.
-    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "fetch", current: 0, total: 0 }))).toBe(0);
+    expect(withinUnitFraction(frame({ stage: "fetching", subStage: "fetch", current: 0, total: 0 }))).toBe(0);
   });
 
   it("clamps an overshooting current/total to the phase ceiling", () => {
@@ -154,11 +154,9 @@ describe("withinUnitFraction sub-slice model (#1407)", () => {
   it("is non-decreasing across a fetch → covers → apply frame sequence", () => {
     const frames: SyncProgress[] = [
       frame({ stage: "fetching", current: 0, total: 0 }),
-      ...Array.from({ length: 7 }, (_, i) =>
-        frame({ stage: "fetching", sub_stage: "fetch", current: i + 1, total: 7 }),
-      ),
+      ...Array.from({ length: 7 }, (_, i) => frame({ stage: "fetching", subStage: "fetch", current: i + 1, total: 7 })),
       ...Array.from({ length: 100 }, (_, i) =>
-        frame({ stage: "fetching", sub_stage: "covers", current: i + 1, total: 100 }),
+        frame({ stage: "fetching", subStage: "covers", current: i + 1, total: 100 }),
       ),
       ...Array.from({ length: 50 }, (_, i) => frame({ stage: "applying", current: i + 1, total: 50 })),
     ];

--- a/src/utils/syncProgress.test.ts
+++ b/src/utils/syncProgress.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { setSyncProgress, updateSyncProgress, onSyncProgressChange, getSyncProgress } from "./syncProgress";
+import {
+  setSyncProgress,
+  updateSyncProgress,
+  onSyncProgressChange,
+  getSyncProgress,
+  withinUnitFraction,
+  FETCH_SHARE,
+  COVERS_SHARE,
+  APPLY_SHARE,
+} from "./syncProgress";
+import type { SyncProgress } from "../types";
 
 // The store's notify() runs every subscriber inside its own try/catch so a
 // throwing listener can neither starve later listeners nor break the emitting
@@ -58,5 +68,106 @@ describe("syncProgress store notify hardening", () => {
     setSyncProgress({ running: false, stage: "" });
     // No further notification after unsubscribe.
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The pure within-unit sub-slice model (#1407). The running unit's width is
+// split into fetch → covers → apply bands, each filling by its own current/total
+// within a strictly-higher band than the phase before, so the bar never jumps
+// backwards at a fetch→covers→apply boundary even though each phase restarts
+// current/total from zero.
+describe("withinUnitFraction sub-slice model (#1407)", () => {
+  const frame = (p: Partial<SyncProgress>): SyncProgress => ({ running: true, ...p });
+
+  it("the three shares sum to the full unit width", () => {
+    expect(FETCH_SHARE + COVERS_SHARE + APPLY_SHARE).toBeCloseTo(1, 10);
+  });
+
+  it("fetch sub-stage fills only the fetch share", () => {
+    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "fetch", current: 3, total: 10 }))).toBeCloseTo(
+      FETCH_SHARE * 0.3,
+      10,
+    );
+  });
+
+  it("covers sub-stage starts at the fetch ceiling and fills the covers share", () => {
+    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "covers", current: 1, total: 4 }))).toBeCloseTo(
+      FETCH_SHARE + COVERS_SHARE * 0.25,
+      10,
+    );
+  });
+
+  it("applying starts at the fetch+covers ceiling and fills the apply share", () => {
+    expect(withinUnitFraction(frame({ stage: "applying", current: 1, total: 2 }))).toBeCloseTo(
+      FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * 0.5,
+      10,
+    );
+  });
+
+  it("applying ignores a stale merged sub_stage (keyed on the stage alone)", () => {
+    // A frontend apply frame merges over a prior covers frame, so it can still
+    // carry sub_stage "covers"; the apply band must win regardless.
+    expect(withinUnitFraction(frame({ stage: "applying", sub_stage: "covers", current: 1, total: 1 }))).toBeCloseTo(
+      1,
+      10,
+    );
+  });
+
+  it("a full unit's apply completes exactly at 1.0", () => {
+    expect(withinUnitFraction(frame({ stage: "applying", current: 10, total: 10 }))).toBeCloseTo(1, 10);
+  });
+
+  it("fetching with no sub-stage rests at the unit floor (0) — legacy/anchor behaviour", () => {
+    expect(withinUnitFraction(frame({ stage: "fetching", current: 30, total: 62 }))).toBe(0);
+    expect(withinUnitFraction(frame({ stage: "fetching", current: 0, total: 0 }))).toBe(0);
+  });
+
+  it("a falsy current/total yields the phase floor, never a divide", () => {
+    // covers with total 0 → the fetch ceiling (its own share contributes 0).
+    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "covers", current: 0, total: 0 }))).toBeCloseTo(
+      FETCH_SHARE,
+      10,
+    );
+    // applying with total 0 → the fetch+covers ceiling.
+    expect(withinUnitFraction(frame({ stage: "applying", current: 0, total: 0 }))).toBeCloseTo(
+      FETCH_SHARE + COVERS_SHARE,
+      10,
+    );
+    // fetch with total 0 → 0.
+    expect(withinUnitFraction(frame({ stage: "fetching", sub_stage: "fetch", current: 0, total: 0 }))).toBe(0);
+  });
+
+  it("clamps an overshooting current/total to the phase ceiling", () => {
+    expect(withinUnitFraction(frame({ stage: "applying", current: 99, total: 10 }))).toBeCloseTo(1, 10);
+  });
+
+  it("non-unit stages (discovering/finalizing) contribute no within-unit fill", () => {
+    expect(withinUnitFraction(frame({ stage: "discovering", current: 1, total: 2 }))).toBe(0);
+    expect(withinUnitFraction(frame({ stage: "finalizing", current: 1, total: 2 }))).toBe(0);
+  });
+
+  it("returns 0 for a null/undefined progress", () => {
+    expect(withinUnitFraction(null)).toBe(0);
+    expect(withinUnitFraction(undefined)).toBe(0);
+  });
+
+  it("is non-decreasing across a fetch → covers → apply frame sequence", () => {
+    const frames: SyncProgress[] = [
+      frame({ stage: "fetching", current: 0, total: 0 }),
+      ...Array.from({ length: 7 }, (_, i) =>
+        frame({ stage: "fetching", sub_stage: "fetch", current: i + 1, total: 7 }),
+      ),
+      ...Array.from({ length: 100 }, (_, i) =>
+        frame({ stage: "fetching", sub_stage: "covers", current: i + 1, total: 100 }),
+      ),
+      ...Array.from({ length: 50 }, (_, i) => frame({ stage: "applying", current: i + 1, total: 50 })),
+    ];
+    let previous = -1;
+    for (const f of frames) {
+      const value = withinUnitFraction(f);
+      expect(value).toBeGreaterThanOrEqual(previous);
+      previous = value;
+    }
+    expect(previous).toBeCloseTo(1, 10);
   });
 });

--- a/src/utils/syncProgress.ts
+++ b/src/utils/syncProgress.ts
@@ -19,6 +19,57 @@
 
 import type { SyncProgress } from "../types";
 
+/**
+ * Static sub-slice shares of a running unit's coarse-bar width (#1407). A unit
+ * is worked in three sequential phases — fetch (paginate the ROM list), covers
+ * (download/refresh cover art), apply (create/update the Steam shortcuts) — and
+ * each phase owns a fixed fraction of the unit's slice, so the bar advances
+ * continuously through the whole unit instead of resting frozen until
+ * ``applying``. The three sum to 1; apply dominates because it is the phase the
+ * user waits on longest per shortcut. First-cut static weights (the issue's
+ * agreed 15/25/60); the #1382 plan already knows per-unit item counts if
+ * smarter per-phase apportioning is ever wanted.
+ */
+export const FETCH_SHARE = 0.15;
+export const COVERS_SHARE = 0.25;
+export const APPLY_SHARE = 0.6;
+
+/**
+ * The within-unit fill fraction (0..1) for the running unit, placed in the
+ * phase's own sub-slice so the coarse bar never jumps backwards at a
+ * fetch→covers→apply boundary (#1407). Each phase's slice fills by that phase's
+ * own ``current/total``; a later phase's slice floor sits at the sum of the
+ * earlier phases' shares, so transitions only ever move the bar forward — the
+ * fetch and cover frames each restart ``current/total`` from zero, but land in a
+ * strictly-higher band than the phase before.
+ *
+ * Phase resolution:
+ *   - ``applying`` → the whole fetch+covers width is done; fill the apply slice
+ *     (keyed on the stage alone, so a merged frontend apply frame that still
+ *     carries a stale ``sub_stage`` is unaffected).
+ *   - ``fetching`` + ``sub_stage: "covers"`` → fetch slice done, fill covers.
+ *   - ``fetching`` + ``sub_stage: "fetch"`` → fill the fetch slice.
+ *   - ``fetching`` with no sub-stage (the unit's coarse anchor, or an old
+ *     backend) → 0: rest at the unit floor, the pre-#1407 behaviour.
+ *   - any other stage (discovering, finalizing, …) → 0.
+ *
+ * A falsy ``current``/``total`` yields the phase's floor (its share sum so far),
+ * e.g. a covers frame with ``total: 0`` reads ``FETCH_SHARE`` — never a divide.
+ */
+export function withinUnitFraction(progress: SyncProgress | null | undefined): number {
+  const current = progress?.current ?? 0;
+  const total = progress?.total ?? 0;
+  const frac = current > 0 && total > 0 ? Math.min(1, current / total) : 0;
+  if (progress?.stage === "applying") {
+    return FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * frac;
+  }
+  if (progress?.stage === "fetching") {
+    if (progress.sub_stage === "covers") return FETCH_SHARE + COVERS_SHARE * frac;
+    if (progress.sub_stage === "fetch") return FETCH_SHARE * frac;
+  }
+  return 0;
+}
+
 let _progress: SyncProgress = {
   running: false,
   stage: "",

--- a/src/utils/syncProgress.ts
+++ b/src/utils/syncProgress.ts
@@ -46,9 +46,9 @@ export const APPLY_SHARE = 0.6;
  * Phase resolution:
  *   - ``applying`` → the whole fetch+covers width is done; fill the apply slice
  *     (keyed on the stage alone, so a merged frontend apply frame that still
- *     carries a stale ``sub_stage`` is unaffected).
- *   - ``fetching`` + ``sub_stage: "covers"`` → fetch slice done, fill covers.
- *   - ``fetching`` + ``sub_stage: "fetch"`` → fill the fetch slice.
+ *     carries a stale ``subStage`` is unaffected).
+ *   - ``fetching`` + ``subStage: "covers"`` → fetch slice done, fill covers.
+ *   - ``fetching`` + ``subStage: "fetch"`` → fill the fetch slice.
  *   - ``fetching`` with no sub-stage (the unit's coarse anchor, or an old
  *     backend) → 0: rest at the unit floor, the pre-#1407 behaviour.
  *   - any other stage (discovering, finalizing, …) → 0.
@@ -64,8 +64,8 @@ export function withinUnitFraction(progress: SyncProgress | null | undefined): n
     return FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * frac;
   }
   if (progress?.stage === "fetching") {
-    if (progress.sub_stage === "covers") return FETCH_SHARE + COVERS_SHARE * frac;
-    if (progress.sub_stage === "fetch") return FETCH_SHARE * frac;
+    if (progress.subStage === "covers") return FETCH_SHARE + COVERS_SHARE * frac;
+    if (progress.subStage === "fetch") return FETCH_SHARE * frac;
   }
   return 0;
 }

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -817,9 +817,12 @@ class TestFetchProgressNarration:
 
         frames = _fetching_frames(decky)
         assert [f["current"] for f in frames] == [1, 2, 3, 4, 5, 6, 7]
-        # Every frame keeps the run's coarse position and names the platform+page.
+        # Every frame keeps the run's coarse position and names the platform+page,
+        # and carries the ``fetch`` sub-stage so the bar fills the fetch sub-slice
+        # (#1407).
         for f in frames:
             assert f["stage"] == "fetching"
+            assert f["sub_stage"] == "fetch"
             assert f["step"] == 3
             assert f["totalSteps"] == 12
             assert f["total"] == 7
@@ -881,6 +884,8 @@ class TestFetchProgressNarration:
         assert frames[0]["message"] == "Fetching Favorites (page 1/3)"
         assert frames[0]["step"] == 2
         assert frames[0]["totalSteps"] == 8
+        # A collection fetch narrates under the same ``fetch`` sub-stage (#1407).
+        assert all(f["sub_stage"] == "fetch" for f in frames)
 
     @pytest.mark.asyncio
     async def test_no_step_context_leaves_bar_indeterminate(self, plugin, fake_romm_api):

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -822,7 +822,7 @@ class TestFetchProgressNarration:
         # (#1407).
         for f in frames:
             assert f["stage"] == "fetching"
-            assert f["sub_stage"] == "fetch"
+            assert f["subStage"] == "fetch"
             assert f["step"] == 3
             assert f["totalSteps"] == 12
             assert f["total"] == 7
@@ -885,7 +885,7 @@ class TestFetchProgressNarration:
         assert frames[0]["step"] == 2
         assert frames[0]["totalSteps"] == 8
         # A collection fetch narrates under the same ``fetch`` sub-stage (#1407).
-        assert all(f["sub_stage"] == "fetch" for f in frames)
+        assert all(f["subStage"] == "fetch" for f in frames)
 
     @pytest.mark.asyncio
     async def test_no_step_context_leaves_bar_indeterminate(self, plugin, fake_romm_api):

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -36,6 +36,7 @@ from adapters.persistence import (
 from domain.preview_delta import PreviewDelta
 from domain.shortcut_data import EmulatorInvocation
 from domain.sync_diff import BIND_ROM_ID_KEY
+from domain.sync_stage import SyncStage
 from domain.sync_state import SyncState
 from domain.work_unit import WorkUnit
 from lib.romm_paging import LIST_PAGE_SIZE
@@ -960,6 +961,43 @@ class TestGetSyncStatus:
         assert status == snapshot
         assert status["running"] is True
         assert status["stage"] == "applying"
+
+    @pytest.mark.asyncio
+    async def test_emit_progress_sub_stage_rides_event_and_status(self, plugin):
+        """A ``sub_stage`` passed to ``emit_progress`` lands on BOTH the emitted
+        ``sync_progress`` event payload and the persisted snapshot that
+        ``get_sync_status`` re-seeds a remounted QAM from (#1407)."""
+        import decky
+
+        decky.emit.reset_mock()
+        await plugin._sync_service._orchestrator.emit_progress(
+            SyncStage.FETCHING,
+            current=2,
+            total=7,
+            message="Fetching GBA (page 2/7)",
+            step=3,
+            total_steps=8,
+            sub_stage="fetch",
+        )
+
+        event_payloads = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_progress"]
+        assert event_payloads, "emit_progress must emit a sync_progress event"
+        assert event_payloads[-1]["sub_stage"] == "fetch"
+        # Same value re-seeds a remounted QAM through get_sync_status.
+        assert plugin._sync_service.get_sync_status()["sub_stage"] == "fetch"
+
+    @pytest.mark.asyncio
+    async def test_emit_progress_defaults_sub_stage_empty(self, plugin):
+        """A frame that names no phase carries an empty ``sub_stage`` — the bar
+        reads it as "rest at the unit floor", never a stale phase (#1407)."""
+        import decky
+
+        decky.emit.reset_mock()
+        await plugin._sync_service._orchestrator.emit_progress(
+            SyncStage.FETCHING, message="Fetching GBA", step=3, total_steps=8
+        )
+
+        assert plugin._sync_service.get_sync_status()["sub_stage"] == ""
 
 
 class TestSyncPreviewErrorHandling:

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -964,8 +964,9 @@ class TestGetSyncStatus:
 
     @pytest.mark.asyncio
     async def test_emit_progress_sub_stage_rides_event_and_status(self, plugin):
-        """A ``sub_stage`` passed to ``emit_progress`` lands on BOTH the emitted
-        ``sync_progress`` event payload and the persisted snapshot that
+        """The ``sub_stage`` kwarg rides the payload as the camelCase ``subStage``
+        key (matching ``totalSteps`` / ``runId``) on BOTH the emitted
+        ``sync_progress`` event and the persisted snapshot that
         ``get_sync_status`` re-seeds a remounted QAM from (#1407)."""
         import decky
 
@@ -982,13 +983,13 @@ class TestGetSyncStatus:
 
         event_payloads = [c.args[1] for c in decky.emit.call_args_list if c.args and c.args[0] == "sync_progress"]
         assert event_payloads, "emit_progress must emit a sync_progress event"
-        assert event_payloads[-1]["sub_stage"] == "fetch"
+        assert event_payloads[-1]["subStage"] == "fetch"
         # Same value re-seeds a remounted QAM through get_sync_status.
-        assert plugin._sync_service.get_sync_status()["sub_stage"] == "fetch"
+        assert plugin._sync_service.get_sync_status()["subStage"] == "fetch"
 
     @pytest.mark.asyncio
     async def test_emit_progress_defaults_sub_stage_empty(self, plugin):
-        """A frame that names no phase carries an empty ``sub_stage`` — the bar
+        """A frame that names no phase carries an empty ``subStage`` — the bar
         reads it as "rest at the unit floor", never a stale phase (#1407)."""
         import decky
 
@@ -997,7 +998,7 @@ class TestGetSyncStatus:
             SyncStage.FETCHING, message="Fetching GBA", step=3, total_steps=8
         )
 
-        assert plugin._sync_service.get_sync_status()["sub_stage"] == ""
+        assert plugin._sync_service.get_sync_status()["subStage"] == ""
 
 
 class TestSyncPreviewErrorHandling:

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -737,6 +737,8 @@ class TestRefreshChangedCovers:
         assert frames[0]["message"] == "Refreshing covers for N64 (1/1)"
         assert frames[0]["step"] == 2
         assert frames[0]["total_steps"] == 5
+        # The refresh pass shares the ``covers`` sub-slice with the download loop (#1407).
+        assert frames[0]["sub_stage"] == "covers"
 
 
 # ── TestDownloadArtworkProgress ───────────────────────────────────────────────
@@ -776,6 +778,9 @@ class TestDownloadArtworkProgress:
         assert [f["current"] for f in frames] == [1, 50, 100, 120]
         for f in frames:
             assert f["stage"] == "fetching"
+            # The cover phase carries the ``covers`` sub-stage so the bar fills the
+            # unit's covers sub-slice, above the fetch share (#1407).
+            assert f["sub_stage"] == "covers"
             assert f["total"] == 120
             assert f["step"] == 3
             assert f["total_steps"] == 9


### PR DESCRIPTION
Closes #1407.

During a unit's fetch/cover phase the main sync bar sat frozen at the unit's floor — deliberately, because the fetch and cover frames each count `current/total` from zero, and letting them move the coarse bar would make it jump backwards at every fetch→covers→apply boundary. For a platform whose dominant cost is the cover pull (e.g. ~2000 covers), the bar showed no movement for the entire phase.

**The fix — monotonic sub-slices within the running unit's width:**

- Progress frames now carry an optional `subStage` key (camelCase on the wire, matching the neighboring `totalSteps`/`runId`): the per-page fetch frames stamp `"fetch"`, both artwork passes (cover refresh + cover download) stamp `"covers"`. The field rides the persisted snapshot and `get_sync_status`, so a QAM remount mid-phase re-seeds correctly.
- The frontend's within-unit fill is now phase-aware (`withinUnitFraction` in `syncProgress.ts`, shares 15/25/60): fetch fills 0→0.15 of the unit slice, covers 0.15→0.40, apply 0.40→1.0. Phase transitions continue from the previous ceiling — monotonic by construction. The apply band is keyed on the stage alone, so a stale merged `subStage` can never mis-place it. A `fetching` frame without `subStage` (old snapshot) keeps today's rest-at-floor behavior.
- Skipped units are untouched (no phase frames, no width); ETA/estimates (#1382) and the session-budget gate (#1383) are unchanged.

**Known bounded limitation (documented):** the covers band is filled by two sequential passes (refresh, then download), each counting from zero — a mixed unit (changed covers + new covers) can dip within the covers band at that handover, bounded to the covers share of the unit's slice. The phase handovers themselves stay monotonic, and the common cases (first full sync, steady incremental without cover changes) don't dip.

**Tests:** backend pins `subStage` on the fetch/cover frames and the snapshot/`get_sync_status` round-trip; frontend covers every branch of the fill model including a full simulated frame sequence asserting frame-to-frame monotonicity and the legacy no-subStage fallback. Full suites: 5343 (py) / 1900 (fe) passed; all lint/type/format/build gates and the event-parity/callable-manifest checks green.

**Docs:** `backend-architecture.md` (sub-slice model, `subStage` payload field, the intra-covers-band wiggle disclosure) and `user-guide/syncing-your-library.md` (the bar now advances through fetch/cover phases) updated in this PR.

On-device note: the perceived smoothness on a large real platform in Game Mode still wants a Deck check — unit tests prove the math is monotonic; real frame cadence can't be exercised in CI.
