### PR TITLE
fix(ui): gate collapsed platform counts on the completion stamp

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -532,6 +532,12 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   Full Sync needs no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no
   skips. The same collapsed counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the
   platform toggles show the number of games a synced platform actually produces rather than the raw server file count.
+  That garnish is **gated on the platform's completion stamp** (`_read_collapsed_counts`, #1412): the count is emitted
+  only for slugs that currently carry a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete,
+  which is exactly when a post-collapse count is meaningful. A never-synced platform legitimately holds only PARTIAL
+  rows (cross-platform collection siblings persist per ADR-0021), so an ungated count would shadow the true server
+  total; with no stamp the field is absent and the toggle label falls back to the raw `rom_count`. Clearing the stamp
+  (local removal / Force Full Sync) reverts the label to the server total until the next completed sync re-stamps.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model: `new_count × NEW_ITEM_SEC` +
   `changed_count × UPDATED_ITEM_SEC` + a flat fetch allowance. The per-item constants (currently ~0.45 s for a created

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -525,19 +525,23 @@ weights + planned totals, via `sync_plan`) and the applying frames.
   collapse's lane selection (ADR-0021): `max(1, bound rows)` per sibling group — so a grandfathered legacy group with
   multiple independently-bound duplicates (§5) prices one shortcut per bound sibling, not one per group — plus one per
   keyless row. Both ride the `sync_plan` payload conditionally-present (absent on collections, never-synced platforms,
-  and failed reads). The payload's `total_roms` stays the raw pre-collapse total (backward compat); an additive
+  and failed reads); `collapsed_count` is additionally **gated on the platform's completion stamp** (#1412, mirroring
+  the `get_platforms` garnish below) — a never-synced platform holds only PARTIAL collection-sibling rows (ADR-0021), so
+  an ungated count would weight the ETA below the true work, and without a stamp the frontend falls back to the raw
+  `rom_count`. The payload's `total_roms` stays the raw pre-collapse total (backward compat); an additive
   `total_estimated_items` sums `0` for predicted skips, else `collapsed_count ?? rom_count`. **Hard constraint
   (ADR-0023): the prediction never feeds the actual skip decision** — `_try_unit_incremental_skip` at fetch time remains
   the sole skip authority, so a mis-prediction can only make the estimate read long or short, never mis-apply. A Force
   Full Sync needs no special case: `clear_sync_cache` deletes every stamp before the run, so a forced plan predicts no
-  skips. The same collapsed counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the
-  platform toggles show the number of games a synced platform actually produces rather than the raw server file count.
-  That garnish is **gated on the platform's completion stamp** (`_read_collapsed_counts`, #1412): the count is emitted
-  only for slugs that currently carry a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete,
-  which is exactly when a post-collapse count is meaningful. A never-synced platform legitimately holds only PARTIAL
-  rows (cross-platform collection siblings persist per ADR-0021), so an ungated count would shadow the true server
-  total; with no stamp the field is absent and the toggle label falls back to the raw `rom_count`. Clearing the stamp
-  (local removal / Force Full Sync) reverts the label to the server total until the next completed sync re-stamps.
+  skips and drops every `collapsed_count` (the forced re-apply is priced at the full `rom_count`). The same collapsed
+  counts also garnish `get_platforms` (an optional per-platform `collapsed_count`), so the platform toggles show the
+  number of games a synced platform actually produces rather than the raw server file count. That garnish is **gated on
+  the platform's completion stamp** (`_read_collapsed_counts`, #1412): the count is emitted only for slugs that
+  currently carry a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete, which is exactly when
+  a post-collapse count is meaningful. A never-synced platform legitimately holds only PARTIAL rows (cross-platform
+  collection siblings persist per ADR-0021), so an ungated count would shadow the true server total; with no stamp the
+  field is absent and the toggle label falls back to the raw `rom_count`. Clearing the stamp (local removal / Force Full
+  Sync) reverts the label to the server total until the next completed sync re-stamps.
 - **Static walk-cost ceiling (pre-run seed).** Before a run — in the preview, and again as the initial "up to X min" the
   instant a skip-preview run starts — the estimate is a pure cost model: `new_count × NEW_ITEM_SEC` +
   `changed_count × UPDATED_ITEM_SEC` + a flat fetch allowance. The per-item constants (currently ~0.45 s for a created

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -531,13 +531,22 @@ class LibraryFetcher:
         return estimates
 
     def _read_collapsed_counts(self) -> dict[str, int]:
-        """Persisted post-collapse shortcut count per platform slug (#1382).
+        """Persisted post-collapse shortcut count per platform slug, gated on the
+        platform's completion stamp (#1382 / #1412).
 
         Groups every persisted ``roms`` row by ``platform_slug`` and collapses
         each platform's sibling-group keys + bound flags
-        (``collapsed_shortcut_count``). Slugs with no persisted rows are
-        absent, so the caller leaves the field off and the frontend falls
-        back to the raw server count. One short read UoW.
+        (``collapsed_shortcut_count``), but emits a count ONLY for slugs that
+        currently carry a ``PlatformSyncState`` completion stamp (ADR-0023). The
+        stamp exists iff the platform's local mirror is complete, which is
+        exactly the condition under which a post-collapse count is meaningful:
+        a never-synced platform legitimately holds PARTIAL rows — cross-platform
+        collection siblings persist per ADR-0021 (e.g. favorited games leave
+        their platform's rows behind without the platform ever being fetched) —
+        so an ungated count would shadow the true server total (#1412). A slug
+        with no stamp (or no persisted rows) is absent, so the caller leaves the
+        field off and the frontend falls back to the raw server count. The stamp
+        lookup shares the one short read UoW.
         """
         rows_by_slug: dict[str, list[tuple[str | None, bool]]] = {}
         with self._uow_factory() as uow:
@@ -545,7 +554,8 @@ class LibraryFetcher:
                 rows_by_slug.setdefault(rom.platform_slug, []).append(
                     (rom.sibling_group_key, rom.shortcut_app_id is not None)
                 )
-        return {slug: collapsed_shortcut_count(rows) for slug, rows in rows_by_slug.items()}
+            stamped = {slug for slug in rows_by_slug if uow.platform_sync_state.get(slug) is not None}
+        return {slug: collapsed_shortcut_count(rows) for slug, rows in rows_by_slug.items() if slug in stamped}
 
     def _read_incremental_baseline(
         self, platform_slug: str

--- a/py_modules/services/library/fetcher.py
+++ b/py_modules/services/library/fetcher.py
@@ -496,11 +496,19 @@ class LibraryFetcher:
         the server count, bound rows exist, no group-key backfill pending) and
         derive the persisted post-collapse shortcut count
         (``collapsed_shortcut_count`` over the rows' sibling-group keys +
-        bound flags; ``None`` when the platform has no persisted rows). The gate's
+        bound flags). The collapsed count is emitted ONLY for slugs that carry
+        a ``PlatformSyncState`` completion stamp (#1412) — the same gate as
+        ``_read_collapsed_counts``: the stamp exists iff the local mirror is
+        complete, so without it a never-synced platform's PARTIAL rows
+        (cross-platform collection siblings, ADR-0021) would mis-weight the ETA
+        below the true work. ``None`` (no stamp, or no persisted rows) rides the
+        payload absent, so the frontend weights the unit at its raw ``rom_count``
+        (``predicted_skip ? 0 : collapsed_count ?? rom_count``). The gate's
         server-delta check (``list_roms_updated_after``) is deliberately NOT
         replayed — no network at plan time. A Force Full Sync clears every
-        stamp before the run, so its plan predicts no skips without a special
-        case. One short read UoW for the whole plan.
+        stamp before the run, so its plan predicts no skips AND drops every
+        collapsed count (the forced re-apply is priced at the full ``rom_count``)
+        without a special case. One short read UoW for the whole plan.
 
         Estimate-ONLY (ADR-0023): the result rides the ``sync_plan`` payload
         and must never feed the actual skip decision —
@@ -524,7 +532,7 @@ class LibraryFetcher:
                     collapsed_shortcut_count(
                         (rom.sibling_group_key, rom.shortcut_app_id is not None) for rom in all_rows
                     )
-                    if all_rows
+                    if stamp is not None and all_rows
                     else None
                 )
                 estimates[unit.slug] = (predicted, collapsed)

--- a/tests/contract/_seed.py
+++ b/tests/contract/_seed.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any
 
+from domain.platform_sync_state import PlatformSyncState
 from domain.rom import Rom
 from domain.rom_install import RomInstall
 from domain.rom_save_state import RomSaveState
@@ -54,6 +55,26 @@ def seed_rom(
                 shortcut_app_id=shortcut_app_id or rom_id,
                 synced_at="2026-01-01T00:00:00",
             )
+        )
+
+
+def seed_platform_stamp(
+    harness: ContractHarness,
+    platform_slug: str,
+    *,
+    rom_count: int,
+    completed_at: str = "2026-01-01T00:00:00",
+) -> None:
+    """Seed a ``PlatformSyncState`` completion stamp (ADR-0023).
+
+    The stamp exists iff the platform's local mirror is complete — it gates the
+    incremental-skip reconstruct and the ``get_platforms`` collapsed-count
+    garnish (#1412), so a contract test that means "this platform was synced"
+    must seed it.
+    """
+    with harness.uow_factory() as uow:
+        uow.platform_sync_state.save(
+            PlatformSyncState.stamp(platform_slug=platform_slug, at=completed_at, rom_count=rom_count)
         )
 
 

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from lib.errors import RommConnectionError
 
-from ._seed import seed_rom
+from ._seed import seed_platform_stamp, seed_rom
 
 # ── get_sync_status ──────────────────────────────────────────────────────
 
@@ -126,13 +126,26 @@ async def test_get_platforms_happy_shape(harness):
 
 
 async def test_get_platforms_collapsed_count_after_sync(harness):
-    """A platform with persisted rows carries the optional collapsed_count (#1382)."""
+    """A synced platform (completion stamp + persisted rows) carries the optional
+    collapsed_count (#1382); the count is gated on the stamp (#1412)."""
     harness.romm.platforms = [{"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3}]
     seed_rom(harness, 11, platform_slug="snes")
+    seed_platform_stamp(harness, "snes", rom_count=3)
     result = await harness.plugin.get_platforms()
     p = result["platforms"][0]
     assert p["collapsed_count"] == 1
     assert p["rom_count"] == 3
+
+
+async def test_get_platforms_collapsed_count_omitted_without_stamp(harness):
+    """#1412: a never-synced platform carrying only partial local rows (no
+    completion stamp) omits collapsed_count so the label shows the server total."""
+    harness.romm.platforms = [{"id": 1, "name": "Super Nintendo", "slug": "snes", "rom_count": 3344}]
+    seed_rom(harness, 11, platform_slug="snes")
+    result = await harness.plugin.get_platforms()
+    p = result["platforms"][0]
+    assert "collapsed_count" not in p
+    assert p["rom_count"] == 3344
 
 
 async def test_get_platforms_server_failure_shape(harness):

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -1066,7 +1066,15 @@ class TestPlanEstimates:
 
 
 class TestGetPlatformsCollapsedCount:
-    """get_platforms attaches the persisted post-collapse count per platform (#1382)."""
+    """get_platforms attaches the persisted post-collapse count per platform,
+    gated on the platform's completion stamp (#1382 / #1412).
+
+    The stamp exists iff the platform's local mirror is complete, so it is the
+    only condition under which a post-collapse count is meaningful. A
+    never-synced platform holds only PARTIAL cross-platform collection siblings
+    (ADR-0021), whose count would shadow the true server total (#1412) — so
+    without a stamp the field is omitted and the frontend shows ``rom_count``.
+    """
 
     @pytest.mark.asyncio
     async def test_synced_platform_carries_collapsed_count(self, plugin, fake_romm_api):
@@ -1076,7 +1084,9 @@ class TestGetPlatformsCollapsedCount:
             {"id": 1, "name": "N64", "slug": "n64", "rom_count": 4},
             {"id": 2, "name": "SNES", "slug": "snes", "rom_count": 5},
         ]
-        # n64: a 3-sibling group + a keyless singleton → 2 shortcuts. snes: never synced.
+        # n64: a synced platform (stamp present) with a 3-sibling group + a keyless
+        # singleton → 2 shortcuts. snes: never synced (no rows, no stamp).
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=4)
         _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
         _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
         _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
@@ -1091,11 +1101,55 @@ class TestGetPlatformsCollapsedCount:
         assert "collapsed_count" not in by_slug["snes"]
 
     @pytest.mark.asyncio
+    async def test_partial_rows_without_stamp_omit_collapsed_count(self, plugin, fake_romm_api):
+        """#1412: a never-synced platform carrying only partial collection-sibling
+        rows (no completion stamp) must NOT surface a collapsed_count — the label
+        falls back to the true server total instead of the partial local count.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        # SNES has a large server total but only a few favorited siblings persisted
+        # locally (ADR-0021) — and no completion stamp, because it was never synced.
+        fake_romm_api.platforms = [{"id": 2, "name": "SNES", "slug": "snes", "rom_count": 3344}]
+        _seed_persisted_rom(uow, 20, app_id=2001, group_key="igdb:200:1", platform_slug="snes")
+        _seed_persisted_rom(uow, 21, app_id=2002, group_key="igdb:201:1", platform_slug="snes")
+
+        result = await plugin._sync_service._fetcher.get_platforms()
+
+        assert result["success"] is True
+        entry = result["platforms"][0]
+        assert "collapsed_count" not in entry
+        assert entry["rom_count"] == 3344
+
+    @pytest.mark.asyncio
+    async def test_stamp_deleted_reverts_to_server_count(self, plugin, fake_romm_api):
+        """Clearing the stamp (local removal / force sync) drops the collapsed_count
+        on the next get_platforms, even while the persisted rows survive."""
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 11, app_id=None, group_key="igdb:100:1")
+        _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")
+
+        before = await plugin._sync_service._fetcher.get_platforms()
+        assert before["platforms"][0]["collapsed_count"] == 1
+
+        with uow:
+            uow.platform_sync_state.delete("n64")
+
+        after = await plugin._sync_service._fetcher.get_platforms()
+        assert "collapsed_count" not in after["platforms"][0]
+        assert after["platforms"][0]["rom_count"] == 3
+
+    @pytest.mark.asyncio
     async def test_grandfathered_group_counts_each_bound_sibling(self, plugin, fake_romm_api):
         """The toggle label prices a two-bound-duplicate legacy group at 2 (ADR-0021 §5)."""
         _wire_fake(plugin, fake_romm_api)
         uow = plugin._uow
         fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
+        _seed_platform_stamp(uow, "n64", at="2025-01-01T00:00:00", rom_count=3)
         _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1")
         _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:100:1")
         _seed_persisted_rom(uow, 12, app_id=None, group_key="igdb:100:1")

--- a/tests/services/library/test_fetcher.py
+++ b/tests/services/library/test_fetcher.py
@@ -963,6 +963,27 @@ class TestPlanEstimates:
         assert units[0].collapsed_count is None
 
     @pytest.mark.asyncio
+    async def test_partial_rows_without_stamp_predict_no_collapsed_count(self, plugin, fake_romm_api):
+        """#1412: a never-synced but enabled platform carrying only partial
+        collection-sibling rows (no completion stamp) must NOT price the ETA at
+        the partial local count — the estimate omits collapsed_count so the
+        frontend weights the unit at the full server rom_count instead.
+        """
+        _wire_fake(plugin, fake_romm_api)
+        uow = plugin._uow
+        # A big platform whose only local rows are a couple of favorited siblings
+        # (ADR-0021) — no stamp, because it was never synced as a platform.
+        fake_romm_api.platforms = [{"id": 1, "name": "SNES", "slug": "snes", "rom_count": 3344}]
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_persisted_rom(uow, 10, app_id=1001, group_key="igdb:100:1", platform_slug="snes")
+        _seed_persisted_rom(uow, 11, app_id=1002, group_key="igdb:101:1", platform_slug="snes")
+
+        units = await plugin._sync_service._fetcher.build_work_queue()
+
+        assert units[0].predicted_skip is False
+        assert units[0].collapsed_count is None
+
+    @pytest.mark.asyncio
     async def test_stamp_count_mismatch_predicts_no_skip_but_keeps_collapsed_count(self, plugin, fake_romm_api):
         _wire_fake(plugin, fake_romm_api)
         uow = plugin._uow
@@ -1038,13 +1059,17 @@ class TestPlanEstimates:
 
         before = await plugin._sync_service._fetcher.build_work_queue()
         assert before[0].predicted_skip is True
+        assert before[0].collapsed_count == 1
 
         plugin._sync_service.clear_sync_cache()
 
         after = await plugin._sync_service._fetcher.build_work_queue()
         assert after[0].predicted_skip is False
-        # The rows survive the cache clear, so the collapsed count still shows.
-        assert after[0].collapsed_count == 1
+        # The stamp clear also drops the collapsed count (#1412 gate): the forced
+        # re-apply recreates every shortcut, so the ETA is priced at the full
+        # server rom_count, not the (now stale) persisted collapse. The rows
+        # survive the clear, but without a stamp the count is not emitted.
+        assert after[0].collapsed_count is None
 
     @pytest.mark.asyncio
     async def test_estimate_read_failure_leaves_fields_none_and_plan_intact(self, plugin, fake_romm_api):


### PR DESCRIPTION
Fixes #1412.

The platform toggle labels showed local partial row counts instead of server totals — Game Gear read "5 ROMs" against a server total of 856, SNES "52" against 3344. `get_platforms` attached `collapsed_count` for every slug with ANY persisted rows, but never-synced platforms legitimately carry partial rows (collection units persist cross-platform sibling rows per ADR-0021 — favorited games leave their platform's rows behind without the platform ever being fetched), and the frontend label prefers `collapsed_count ?? rom_count`, so the partial count shadowed the server total. The user guide already promised the correct behavior ("a platform you have never synced shows the server's raw ROM count until its first sync") — the code had drifted from it.

**Fix:** gate the collapsed count on the platform's ADR-0023 completion stamp, in both places that ship one:

- `_read_collapsed_counts` (the toggle-label read) emits a count only for slugs currently carrying a `PlatformSyncState` stamp — the stamp exists iff the local mirror is complete, which is exactly when a post-collapse count is meaningful. No stamp → key absent → the frontend fallback shows the server total. Stamp cleared (removal, force sync) → the label reverts until the next completed sync re-stamps.
- The sibling site surfaced in review: `_read_plan_estimates` shipped the same un-gated count into the sync-plan ETA weights (`predicted_skip ? 0 : (collapsed_count ?? rom_count)`), so a never-synced platform with partial rows under-weighted the "up to X min" estimate (52 instead of 3344) — the frontend comment explicitly promises the `rom_count` fallback there. Same gate, same read UoW.

Skip prediction is unaffected (it already replays the stamp gate itself); `get_platforms` is the sole consumer of the toggle-label read; frontend untouched.

**Tests:** no-stamp partial rows → count absent (unit + contract), stamped → present, stamp deleted → reverts; plan-estimate variants for the never-synced and stamped cases; existing tests that meant "synced platform" now seed a stamp. Full suite 5348 passed; ruff/basedpyright/lint-imports and all invariant gates green.

**Docs:** `backend-architecture.md` describes the gate; `user-guide/syncing-your-library.md` already documented the now-restored behavior and needed no change.
