### PR TITLE
fix(sync): count rebinding platforms correctly in the preview platform diff

### DIFF
--- a/py_modules/domain/sync_diff.py
+++ b/py_modules/domain/sync_diff.py
@@ -320,10 +320,19 @@ def compute_platform_collection_diff(
     Returns ``{"has_changes": bool, "added_count": int, "removed_count": int}``.
     Uses ``should_include_in_platform_collection`` to decide which ROMs
     qualify under the current ``create_platform_groups`` setting.
+
+    A rebind entry (see :func:`_rebind_entry`) is keyed to the vanished bound
+    ``rom_id`` so the frontend reuses its existing shortcut, but that id is never
+    in ``platform_rom_ids`` (which carries the fetched server ids). Its platform
+    membership follows the surviving representative it rebinds ONTO — the
+    ``bind_rom_id`` target, a fetched id present in ``platform_rom_ids``. Keying
+    the predicate on the entry's own ``rom_id`` would drop a fully-rebinding
+    platform out of ``future_platforms`` and mis-count it as removed (#1417); the
+    apply path, which reads the post-commit bound rows, never had this bug.
     """
     future_platforms: set[str] = set()
     for sd in shortcuts_data:
-        rid = sd["rom_id"]
+        rid = sd.get(BIND_ROM_ID_KEY, sd["rom_id"])
         if should_include_in_platform_collection(rid, platform_rom_ids, create_platform_groups):
             pname = sd.get("platform_name", "")
             if pname:

--- a/tests/domain/test_sync_diff.py
+++ b/tests/domain/test_sync_diff.py
@@ -440,6 +440,52 @@ class TestComputePlatformCollectionDiff:
         result = compute_platform_collection_diff(sd, {1, 2}, [], False)
         assert result["added_count"] == 1
 
+    def test_pure_rebind_platform_not_counted_as_removed(self):
+        """A fully-rebinding platform qualifies via bind_rom_id, so it's no change (#1417).
+
+        The rebind entry is keyed to the vanished rom_id (1), absent from the
+        fetched ``platform_rom_ids`` ({2}); only its ``bind_rom_id`` target (2)
+        is present. Keying membership on the entry's own rom_id would drop the
+        platform out of ``future_platforms`` and mis-count it as removed.
+        """
+        rebind = {**_make_sd(1, platform_name="Nintendo 64"), BIND_ROM_ID_KEY: 2}
+        result = compute_platform_collection_diff(
+            [rebind],
+            {2},
+            ["Nintendo 64"],
+            False,
+        )
+        assert result["has_changes"] is False
+        assert result["added_count"] == 0
+        assert result["removed_count"] == 0
+
+    def test_rebind_plus_genuinely_removed_platform_counts_only_the_genuine(self):
+        """A rebinding platform stays; only a truly-gone platform is removed (#1417)."""
+        rebind = {**_make_sd(1, platform_name="Nintendo 64"), BIND_ROM_ID_KEY: 2}
+        result = compute_platform_collection_diff(
+            [rebind],
+            {2},
+            ["Nintendo 64", "Game Boy Advance"],
+            False,
+        )
+        assert result["has_changes"] is True
+        assert result["added_count"] == 0
+        assert result["removed_count"] == 1
+
+    def test_rebind_plus_added_platform(self):
+        """A rebinding platform holds; a freshly-fetched new platform is added (#1417)."""
+        rebind = {**_make_sd(1, platform_name="Nintendo 64"), BIND_ROM_ID_KEY: 2}
+        added = _make_sd(3, platform_name="PlayStation")
+        result = compute_platform_collection_diff(
+            [rebind, added],
+            {2, 3},
+            ["Nintendo 64"],
+            False,
+        )
+        assert result["has_changes"] is True
+        assert result["added_count"] == 1
+        assert result["removed_count"] == 0
+
 
 class TestSelectStaleRemovals:
     """``select_stale_removals`` — drop any stale candidate whose appId this run re-bound (#1036)."""


### PR DESCRIPTION
Fixes #1417.

A preview whose only change is a fully-rebinding platform (every bound rom_id vanished server-side, same sibling-group keys — the re-import scenario, observed live in the 0.27.0 verification round) showed "Platforms: 1 removed". The rebind entry is deliberately keyed to the vanished rom_id (so the frontend reuses the existing shortcut), but that id is never in the preview's `platform_rom_ids` set (fetched server ids) — `should_include_in_platform_collection` dropped the platform out of `future_platforms` and `compute_platform_collection_diff` mis-counted it as removed. The apply path reads post-commit bound rows and was already correct; only the preview line lied.

**Fix:** `compute_platform_collection_diff` resolves an entry's membership via `sd.get(BIND_ROM_ID_KEY, sd["rom_id"])` — a rebind entry qualifies through its bind target (always a fetched id), normal and grandfathered entries fall back to their own rom_id (unchanged). The apply-side consumer operates on post-commit `Rom` rows (no `bind_rom_id`) and is unaffected. `create_platform_groups=True` and the legacy `platform_rom_ids=None` paths are no-ops for the change.

**The issue's second observation — "Estimated duration: 2 min" for a 2-rebind run — resolves as by-design:** rebinds are already priced as updates (never as creates), and the "2 min" is the documented `FETCH_ALLOWANCE_SEC` floor (90s) rounding up under the "up to X min" wording; the live countdown corrects downward. No change.

**Tests:** three new domain tests (pure rebind → no platform changes; rebind + genuine removal → counts only the genuine one; rebind + add), each verified to fail against the old code. Full suite 5351 passed; ruff/basedpyright/invariant gates green.

docs: N/A (preview display accuracy fix, apply path unchanged; nothing in docs/ pins the Changes-panel platform counts)
