### PR TITLE
fix(ui): constrain qam loading spinners to a shared small inline pattern

### DIFF
--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -7,7 +7,6 @@ import {
   Field,
   TextField,
   ToggleField,
-  Spinner,
   ModalRoot,
   DialogButton,
   showModal,
@@ -28,6 +27,7 @@ import {
   updateWhitelistSettings,
 } from "../api/backend";
 import { removeShortcut, getAllNonSteamShortcutAppIds, getLiveRomMShortcutAppIds } from "../utils/steamShortcuts";
+import { LoadingRow } from "./LoadingRow";
 import { batchConfirmLaunchOptions } from "../utils/launchOptionsReconcile";
 import { getSyncProgress, onSyncProgressChange } from "../utils/syncProgress";
 import { scrollToTop } from "../utils/scrollHelpers";
@@ -347,11 +347,7 @@ const ShortcutRemovalSection: FC<ShortcutRemovalSectionProps> = ({
 
   let platformsBody: ReactNode;
   if (loading) {
-    platformsBody = (
-      <PanelSectionRow>
-        <Spinner />
-      </PanelSectionRow>
-    );
+    platformsBody = <LoadingRow />;
   } else if (platforms.length === 0) {
     platformsBody = (
       <PanelSectionRow>
@@ -625,11 +621,7 @@ const WhitelistSection: FC<WhitelistSectionProps> = ({
         </ButtonItem>
       </PanelSectionRow>
 
-      {showWhitelist && !settingsLoaded && (
-        <PanelSectionRow>
-          <Spinner />
-        </PanelSectionRow>
-      )}
+      {showWhitelist && !settingsLoaded && <LoadingRow />}
       {showWhitelist && settingsLoaded && (
         <>
           <PanelSectionRow>

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -1,14 +1,5 @@
 import { useState, useEffect, useMemo, useRef, FC } from "react";
-import {
-  PanelSection,
-  PanelSectionRow,
-  ButtonItem,
-  ToggleField,
-  Spinner,
-  DialogButton,
-  Field,
-  Focusable,
-} from "@decky/ui";
+import { PanelSection, PanelSectionRow, ButtonItem, ToggleField, DialogButton, Field, Focusable } from "@decky/ui";
 import {
   getPlatforms,
   savePlatformSync,
@@ -22,6 +13,7 @@ import {
 import type { PlatformSyncSetting, CollectionSyncSetting, CollectionKind, CollectionScope } from "../types";
 import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
+import { LoadingRow } from "./LoadingRow";
 
 type CollectionSubTab = "my" | "smart" | "franchise";
 
@@ -190,11 +182,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   // --- Platforms tab content ---
   const renderPlatformsContent = () => {
     if (syncLoading) {
-      return (
-        <PanelSectionRow>
-          <Spinner />
-        </PanelSectionRow>
-      );
+      return <LoadingRow />;
     }
     if (syncError) {
       return (
@@ -251,9 +239,7 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     if (collectionsLoading) {
       return (
         <PanelSection title="Collections">
-          <PanelSectionRow>
-            <Spinner />
-          </PanelSectionRow>
+          <LoadingRow />
         </PanelSection>
       );
     }

--- a/src/components/LoadingRow.test.tsx
+++ b/src/components/LoadingRow.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement as ce } from "react";
+import { LoadingRow, LOADING_SPINNER_SIZE } from "./LoadingRow";
+
+// Re-mock @decky/ui so the Spinner echoes its width/height — LoadingRow exists
+// to pin a small fixed size, so the test must be able to see those props (the
+// global stub in test-setup.ts drops them). Per-file mock hoisting wins.
+vi.mock("@decky/ui", () => {
+  type AnyProps = Record<string, unknown> & { children?: unknown };
+  return {
+    PanelSectionRow: (p: AnyProps) => ce("div", { "data-testid": "panel-row" }, p.children as never),
+    Spinner: (p: { width?: number; height?: number }) =>
+      ce("div", { "data-testid": "spinner", "data-width": p.width, "data-height": p.height }),
+  };
+});
+
+describe("LoadingRow (#1414)", () => {
+  it("renders a spinner constrained to the fixed LOADING_SPINNER_SIZE", () => {
+    const { getByTestId } = render(<LoadingRow />);
+    const spinner = getByTestId("spinner");
+    expect(spinner.getAttribute("data-width")).toBe(String(LOADING_SPINNER_SIZE));
+    expect(spinner.getAttribute("data-height")).toBe(String(LOADING_SPINNER_SIZE));
+  });
+
+  it("pins a small size so the SVG can't fill the row (guards the oversized-spinner regression)", () => {
+    expect(LOADING_SPINNER_SIZE).toBeGreaterThan(0);
+    expect(LOADING_SPINNER_SIZE).toBeLessThanOrEqual(32);
+  });
+
+  it("renders inside a PanelSectionRow", () => {
+    const { getByTestId } = render(<LoadingRow />);
+    expect(getByTestId("panel-row")).not.toBeNull();
+  });
+
+  it("shows no caption text when no label is given", () => {
+    const { container } = render(<LoadingRow />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the optional label beside the spinner", () => {
+    const { getByText } = render(<LoadingRow label="Loading platforms…" />);
+    expect(getByText("Loading platforms…")).not.toBeNull();
+  });
+});

--- a/src/components/LoadingRow.tsx
+++ b/src/components/LoadingRow.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { PanelSectionRow, Spinner } from "@decky/ui";
+
+/**
+ * Fixed pixel size for QAM loading spinners. @decky/ui's Spinner is an SVG icon
+ * that fills its container when unconstrained, so a bare `<Spinner />` inside a
+ * PanelSectionRow renders oversized (#1414). Pinning width/height keeps every
+ * section-level loading state the same small size.
+ */
+export const LOADING_SPINNER_SIZE = 24;
+
+interface LoadingRowProps {
+  /** Optional caption rendered beside the spinner (e.g. "Loading platforms…"). */
+  label?: string;
+}
+
+/**
+ * The canonical QAM loading state: a small, fixed-size spinner centered in a
+ * PanelSectionRow. A section that shows a spinner while it loads renders this
+ * instead of a bare `<Spinner />`, whose SVG otherwise fills the row.
+ */
+export const LoadingRow: FC<LoadingRowProps> = ({ label }) => (
+  <PanelSectionRow>
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "8px", padding: "8px 0" }}>
+      <Spinner width={LOADING_SPINNER_SIZE} height={LOADING_SPINNER_SIZE} />
+      {label ? <span style={{ fontSize: "13px", opacity: 0.7 }}>{label}</span> : null}
+    </div>
+  </PanelSectionRow>
+);


### PR DESCRIPTION
Fixes #1414.

@decky/ui's `Spinner` is an SVG that fills its container when no width/height is set — a bare `<Spinner />` inside an unconstrained `PanelSectionRow` renders huge. Audited every spinner site in the frontend (9 total):

**Fixed (4)** — the bare oversized QAM page-loading sites now use a shared `<LoadingRow>` (24px spinner, centered in its own `PanelSectionRow`, exported size constant so future loading rows can't drift): Library page platforms + collections tabs, Data Management shortcut-removal platforms + whitelist settings. The optional `label` caption prop is a deliberate extension point (currently unused by the four call sites).

**Left as-is (5, each already constrained or a different pattern):** the 14px inline status glyphs on the main page, the 32px-wrapped modal spinner in the SGDB picker, and the CSS `romm-throbber` family (game-detail popups/buttons, sized by the style injector).

**Tests:** new `LoadingRow` suite pins the fixed 24px size (regression guard against a future bare spinner), the row structure, and both label branches; existing loading-state tests pass unchanged against the new component. Frontend 1917 passed / 83 files; Python untouched and green.

docs: N/A (visual polish, no behavior/architecture change — no docs page describes the QAM loading-spinner appearance)
