### PR TITLE
fix(ui): keep sync fine-detail rows mounted across unit boundaries

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1943,6 +1943,133 @@ describe("MainPage", () => {
     });
   });
 
+  describe("fine-detail row stays mounted across unit boundaries (#1415)", () => {
+    const fineRow = (c: HTMLElement) => c.querySelector('[data-testid="sync-fine"]');
+
+    it("keeps the fine row mounted (with the carried content) across a boundary anchor frame", async () => {
+      // Unit N applying with real fine detail — the row is mounted and narrates.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 50,
+        total: 50,
+        message: "GBA: 50/50",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(fineRow(container)).not.toBeNull();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+
+      // Unit boundary: the next unit's FETCHING anchor frame resets current/total
+      // to 0 (worst case: also an empty message). Pre-#1415 this flipped
+      // hasFineDetail false and unmounted the row for a frame; now the row stays
+      // mounted, carrying unit N's last line.
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          step: 3,
+          totalSteps: 8,
+          current: 0,
+          total: 0,
+          message: "",
+        }),
+      );
+      expect(fineRow(container)).not.toBeNull();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+
+      // The next unit's first real fetch frame arrives — the row updates to its
+      // content, still without ever unmounting.
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          subStage: "fetch",
+          step: 3,
+          totalSteps: 8,
+          current: 1,
+          total: 5,
+          message: "Fetching SNES (page 1/5)",
+        }),
+      );
+      expect(fineRow(container)).not.toBeNull();
+      expect(fineRow(container)!.textContent).toContain("Fetching SNES (page 1/5)");
+    });
+
+    it("does not flash the stage-label spinner at a boundary — the fine line keeps the only spinner", async () => {
+      // The inline stage-label spinner appears only when hasFineDetail is false;
+      // a boundary that unmounted the fine row would flash it on for that frame.
+      // With the carry, hasFineDetail stays true, so no stage-label spinner ever
+      // appears and the count stays at one (the fine line's).
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 50,
+        total: 50,
+        message: "GBA: 50/50",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(container.querySelectorAll('[data-testid="spinner"]')).toHaveLength(1);
+
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          step: 3,
+          totalSteps: 8,
+          current: 0,
+          total: 0,
+          message: "",
+        }),
+      );
+      const stage = container.querySelector('[data-testid="sync-stage"]');
+      expect(stage!.parentElement?.querySelector('[data-testid="spinner"]')).toBeNull();
+      expect(container.querySelectorAll('[data-testid="spinner"]')).toHaveLength(1);
+    });
+
+    it("clears the carry when the run ends — no stale line on the done state nor the next run's start", async () => {
+      // Run A applies with fine detail (row mounted).
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 8,
+        totalSteps: 8,
+        current: 50,
+        total: 50,
+        message: "GBA: 50/50",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+
+      // Run A terminates (running:false) — the carried line is dropped and the
+      // in-flight UI tears down, so the done/summary state shows no fine row.
+      act(() => setSyncProgress({ running: false, stage: "done", message: "Sync complete: 50 games" }));
+      await flushAsync();
+      expect(fineRow(container)).toBeNull();
+
+      // Run B starts via Skip Preview → the optimistic coarse fetch anchor carries
+      // no fine detail. Because the prior run's carry was cleared, the fine row is
+      // absent — no stale "GBA: 50/50" leaks into the new run's start. (Without the
+      // reset, hasFineDetail would fall back to the carried line and show it here.)
+      const toggle = container.querySelector('[data-testid="toggle-input"]') as HTMLInputElement | null;
+      expect(toggle).not.toBeNull();
+      fireEvent.click(toggle!);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(fineRow(container)).toBeNull();
+    });
+  });
+
   describe("QAM remount mid-run preserves fine progress + ETA", () => {
     it("merges the store's fine fields + etaSeconds over the backend's coarse running snapshot", async () => {
       // Module store holds the in-flight run's FINE state — what a live QAM had

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -365,6 +365,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // sync_in_progress reject and look like an instant finish (#1202, RC-B).
   const [cancelling, setCancelling] = useState(false);
   const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
+  // Last non-empty fine-detail line, carried across unit-boundary anchor frames
+  // so the fine-detail row (and its inline spinner) stay MOUNTED when the next
+  // unit's FETCHING anchor frame resets current/total to 0 (#1415) — otherwise
+  // the row unmounts for a frame and the panel flickers. Populated by the store
+  // subscriber from any frame with real fine detail; reset to null when the run
+  // ends, so a terminal/idle state never surfaces a stale line.
+  const [carriedFineDetail, setCarriedFineDetail] = useState<string | null>(null);
   // A dumb mirror of syncEta's live countdown (seconds), or null when not measured
   // yet / between runs. syncEta owns the sticky deadline; the impure now-read that
   // resolves it to seconds lives in the store subscriber (an event handler), NOT
@@ -537,6 +544,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // the re-render chain (on-device freeze, cause not yet reproduced in tests).
       const progress = getSyncProgress();
       setSyncProgress(progress);
+      // Carry the last non-empty fine detail so the fine-detail row survives a
+      // unit boundary's anchor frame (which resets current/total, #1415); drop
+      // it the moment the run ends so the next run starts clean. Kept outside
+      // the try below so the reset can never be skipped by a subscriber throw.
+      if (!progress.running) {
+        setCarriedFineDetail(null);
+      } else if (progress.total && progress.message) {
+        setCarriedFineDetail(progress.message);
+      }
       try {
         if (isTerminalStage(progress.stage)) {
           // Tear down the run's live-ETA state (deadline included) so the next run
@@ -802,7 +818,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const coarseFraction = syncProgress?.totalSteps
     ? Math.max(0, Math.min(100, (weightedFraction ?? (completedSteps + withinUnit) / syncProgress.totalSteps) * 100))
     : undefined;
-  const hasFineDetail = !!(syncProgress?.total && syncProgress.message);
+  const currentHasFineDetail = !!(syncProgress?.total && syncProgress.message);
+  // Keep the fine-detail row mounted across unit boundaries: the next unit's
+  // FETCHING anchor frame resets current/total (#1415), so fall back to the last
+  // non-empty fine detail carried by the store subscriber. Cleared when the run
+  // ends, so terminal/idle states never surface a stale line. The bar's own
+  // within-unit fill still reads the live current/total (never the carry), so
+  // this affects only which rows mount, not the bar (#1407).
+  const hasFineDetail = currentHasFineDetail || carriedFineDetail !== null;
+  const fineDetailText = currentHasFineDetail ? formatProgressText(syncProgress) : (carriedFineDetail ?? "");
 
   // Estimated-time readout for the in-flight run. Prefer the live measured
   // countdown ("9 min left") once the estimator has a rate; before that, fall
@@ -1039,7 +1063,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                       overflow: "hidden",
                     }}
                   >
-                    {formatProgressText(syncProgress)}
+                    {fineDetailText}
                   </span>
                 </div>
               }


### PR DESCRIPTION
Fixes #1415.

QAM sync-panel rows flickered at unit boundaries — observed on-device in both the preview and the apply run, at some platform jumps only. Root cause: every unit's coarse anchor frame (preview and apply) is emitted without `total`, so it arrives as `total=0` while carrying a message; the `hasFineDetail = !!(total && message)` gate flips false for exactly that frame, the fine-detail row unmounts and the stage-label spinner flashes on until the next real frame (page/cover/apply, `total>0`) restores it. Timing-dependent: visible only when a render lands on the anchor frame — matching the "only some jumps" observation.

**Fix (frontend only):** a component-level "last known fine detail" carry in the sync panel — the store subscriber records the last message seen with a real `total`, the render falls back to it on anchor frames so the row stays mounted, and the carry clears on every `running: false` terminal frame (done, cancelled, error), so no stale line leaks onto the summary or a following run's start. Live frames always win over the carry; the bar (#1407), step counter and ETA rows were verified not to drop at boundaries and are untouched.

**Consciously accepted trade-off** (surfaced in review): on an incremental sync, a cascade of skipped platforms emits only anchor frames, so the previous applied unit's fine line is held (briefly mismatched against the advancing stage label) until the next real frame. Skips flash by in well under a second each, and the alternatives — clearing on anchors (reintroduces the unmount) or surfacing the anchor's own message (puts a fine row into deliberately silent phases) — are worse. Revisit only if it ever reads badly on-device.

**Tests:** boundary survival with carried content, no stage-spinner flash at the boundary (location-asserted), terminal clear incl. the next run's optimistic start — the first two fail against the old code. Frontend 1915 passed; Python untouched and green.

docs: N/A (visual-glitch fix, no contract change — the emission model and coarse-bar docs are unchanged)
