### PR TITLE
fix(sync): run the apply pipeline for unstamped platforms so recovery re-stamps and the run status heals

### DIFF
--- a/docs/adr/0023-chunked-per-unit-apply.md
+++ b/docs/adr/0023-chunked-per-unit-apply.md
@@ -93,12 +93,18 @@ mid-unit failure forfeits only the in-flight chunk.**
   `last_sync` is deliberately **not** a fallback for the skip: a run-scoped timestamp cannot see a platform whose
   shortcuts were locally removed and only partially re-applied since, so trusting it can silently skip a platform with
   missing shortcuts — the same gap in a second coat. No stamp means a full fetch; installations from before this
-  contract carry no stamps, so their first sync re-walks once (update-path cheap) and stamps everything it completes.
-  Two rules keep the contract true. (1) The stamp is **cleared at a platform unit's apply start** (in `_sync_one_unit`,
-  once the fetch has succeeded and the apply is about to emit its first chunk) and re-written only by that unit's final
-  chunk, so an apply interrupted by a crash / cancel / heartbeat-timeout before the final chunk leaves **no** stamp —
-  never a stale one from a prior run. (2) The **local destructive flows** invalidate the stamp of every platform whose
-  shortcuts they unbind: the DangerZone remove-all and per-platform removals (both via `report_removal_results`) and the
+  contract carry no stamps, so their first sync re-walks once (update-path cheap) and stamps everything it completes. A
+  **preview-gated** sync would otherwise strand a complete-but-unstamped platform (a late-ack recovery leaves one,
+  #1416): its shortcut delta is empty, so the preview short-circuits on "no changes" before the re-walk that would
+  re-stamp it ever runs, and the run's `interrupted` status lingers because only an apply run records a fresh `SyncRun`.
+  So `sync_preview` counts enabled platforms lacking a stamp and offers Apply on that alone (`restamp_platform_count`);
+  the re-walk's empty final chunk re-writes the stamp and records a fresh `SyncRun`. The stamp is still written **only**
+  by the pipeline's final chunk — the preview counts unstamped platforms, it never stamps. Two rules keep the contract
+  true. (1) The stamp is **cleared at a platform unit's apply start** (in `_sync_one_unit`, once the fetch has succeeded
+  and the apply is about to emit its first chunk) and re-written only by that unit's final chunk, so an apply
+  interrupted by a crash / cancel / heartbeat-timeout before the final chunk leaves **no** stamp — never a stale one
+  from a prior run. (2) The **local destructive flows** invalidate the stamp of every platform whose shortcuts they
+  unbind: the DangerZone remove-all and per-platform removals (both via `report_removal_results`) and the
   Steam-UI-deletion reconcile (`reconcile_live_shortcuts`) delete the touched platforms' stamps in the same write UoW as
   the unbind. Both rules exist because unbinding keeps the `roms` row (ADR-0007), so a platform's persisted-row count is
   unchanged and a surviving stamp with a matching `rom_count` would let the skip gate skip a half-mirrored platform and

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -229,6 +229,20 @@ the apply path as before. The fingerprint is only ever advanced when the cache i
 old fingerprint and the change is retried next sync. A cover-only change never re-applies the shortcut itself (that
 apply path writes launch options under the ADR-0025 invariant — pure churn for a cover).
 
+**Unstamped-platform re-run: the `restamp_platform_count` signal (#1416).** A heartbeat-timeout run's late-ack recovery
+(ADR-0023) leaves a platform **complete but unstamped**: the timed-out apply cleared the stamp at its start and its late
+ack re-binds the chunk without re-writing it (the late-ack path never passes a `platform_stamp`). The wholesale-skip
+gate then full-fetches that platform on every future sync (no stamp = no skip authority), and — because its shortcut
+delta is otherwise empty — the QAM's preview would short-circuit on "no changes", so the re-walk that would re-stamp it
+never runs and the run's `interrupted` status lingers indefinitely (only an apply run records a fresh `SyncRun`).
+`sync_preview` therefore counts the enabled platforms lacking a `PlatformSyncState` stamp (`_count_unstamped_platforms`,
+a side-effect-free read) and rides it as the additive summary field `restamp_platform_count` (absent/0 tolerated by old
+consumers). The frontend treats a restamp-only preview (all diffs zero, count > 0) as apply-able — "No changes —
+finishing an interrupted sync." with the normal Apply/Cancel confirm — mirroring the cover-only flow. The gated apply
+then runs the unstamped platform (the skip gate never skips it), and its 0-delta empty final chunk re-writes the stamp
+and records a fresh completed `SyncRun`, healing both symptoms. The stamp write stays pipeline-owned: the preview only
+counts unstamped platforms, it never stamps (`check_sync_lifecycle_owner` / the final-chunk-only rule).
+
 **Per-unit apply is chunked, durable per chunk
 ([ADR-0023](https://github.com/danielcopper/decky-romm-sync/blob/main/docs/adr/0023-chunked-per-unit-apply.md)).** The
 delta emit list is split into fixed-size chunks (`_APPLY_CHUNK_SIZE`, 200) by the pure

--- a/py_modules/services/library/sync_orchestrator.py
+++ b/py_modules/services/library/sync_orchestrator.py
@@ -307,6 +307,16 @@ class SyncOrchestrator:
             registry, last_synced_platforms, last_synced_collections = await self._loop.run_in_executor(
                 None, self._read_preview_baseline, slug_to_name
             )
+            # Enabled platforms lacking a completion stamp (#1416): a
+            # late-ack-recovered platform is complete but unstamped, so the
+            # wholesale-skip gate full-fetches it forever and its run status
+            # never heals. Counted here (side-effect-free read) so the preview
+            # can still offer Apply on an otherwise-empty delta — the apply's
+            # 0-delta empty final chunk re-writes the stamp and records a fresh
+            # SyncRun (the one-time re-walk ADR-0023 intends).
+            restamp_platform_count = await self._loop.run_in_executor(
+                None, self._count_unstamped_platforms, set(slug_to_name)
+            )
             # Collapse to one entry per sibling group (ADR-0021) so the preview
             # counts games, not individual dumps: a multi-version game becomes one
             # shortcut and its unbound siblings stop reading as perpetual "new".
@@ -390,6 +400,13 @@ class SyncOrchestrator:
                     # of short-circuiting on "no changes". Additive: old consumers
                     # ignore it.
                     "cover_refresh_count": cover_refresh_count,
+                    # Enabled platforms lacking a completion stamp (#1416) — a
+                    # late-ack-recovered platform is complete but unstamped. Its
+                    # apply is a 0-delta empty final chunk that re-writes the
+                    # stamp and records a fresh SyncRun, so a restamp-only preview
+                    # must still offer Apply instead of short-circuiting on "no
+                    # changes". Additive: old consumers ignore it.
+                    "restamp_platform_count": restamp_platform_count,
                     # Scope of the run (#29): how many platforms / collections this
                     # sync spans, shown as an always-on informational line
                     # independent of the change diffs.
@@ -942,6 +959,20 @@ class SyncOrchestrator:
             last_platforms = list(latest.platforms_completed or []) if latest is not None else []
             last_collections = list(latest.collections_completed or []) if latest is not None else []
         return registry, last_platforms, last_collections
+
+    def _count_unstamped_platforms(self, platform_slugs: set[str]) -> int:
+        """Count enabled platform slugs without a ``PlatformSyncState`` stamp.
+
+        A platform lacking a completion stamp has no wholesale-skip authority —
+        ``LibraryFetcher._try_unit_incremental_skip`` full-fetches it — so its
+        apply runs even at a zero shortcut delta and the empty final chunk
+        re-writes the stamp (the one-time re-walk ADR-0023 intends after a
+        late-ack recovery leaves a platform complete-but-unstamped). Surfaced as
+        the preview's ``restamp_platform_count`` so the frontend still offers
+        Apply on an otherwise-empty delta (#1416). One short read UoW.
+        """
+        with self._uow_factory() as uow:
+            return sum(1 for slug in platform_slugs if uow.platform_sync_state.get(slug) is None)
 
     def _read_apply_registry(self, unit: WorkUnit) -> dict[str, dict[str, Any]]:
         """Read the bound-row registry the per-unit group collapse diffs against.

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1069,7 +1069,7 @@ describe("MainPage", () => {
     it("names the re-stamp work when an unstamped platform has an empty delta (#1416)", async () => {
       const c = await renderPreview({ restamp_platform_count: 1 });
       expect(c.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
-        "No changes — finishing an interrupted sync.",
+        "No changes — finishing a previous sync.",
       );
     });
 
@@ -3039,7 +3039,7 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Cancel")).not.toBeNull();
       expect(buttonByExactText(container, "Dismiss")).toBeNull();
       expect(container.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
-        "No changes — finishing an interrupted sync.",
+        "No changes — finishing a previous sync.",
       );
       await act(async () => {
         fireEvent.click(buttonByExactText(container, "Apply Sync")!);

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1065,6 +1065,19 @@ describe("MainPage", () => {
       const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
       expect(descs).toContain("Everything is up to date.");
     });
+
+    it("names the re-stamp work when an unstamped platform has an empty delta (#1416)", async () => {
+      const c = await renderPreview({ restamp_platform_count: 1 });
+      expect(c.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
+        "No changes — finishing an interrupted sync.",
+      );
+    });
+
+    it("keeps 'Everything is up to date.' when restamp is explicitly zero (regression pin)", async () => {
+      const c = await renderPreview({ restamp_platform_count: 0 });
+      const descs = Array.from(c.querySelectorAll('[data-testid="field-desc"]')).map((n) => n.textContent);
+      expect(descs).toContain("Everything is up to date.");
+    });
   });
 
   describe("session-budget advisory (#1383)", () => {
@@ -2993,6 +3006,46 @@ describe("MainPage", () => {
         await Promise.resolve();
       });
       expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-covers");
+    });
+
+    it("unstamped-platform preview proceeds to Apply with the re-stamp wording (#1416)", async () => {
+      // Empty shortcut delta but a platform lacking a completion stamp: the
+      // apply must still run once to re-stamp it and heal the lingering
+      // "interrupted" status, so the flow offers Apply/Cancel rather than the
+      // "no changes" dead end.
+      vi.mocked(backend.syncPreview).mockResolvedValue({
+        success: true,
+        summary: {
+          new_count: 0,
+          changed_count: 0,
+          unchanged_count: 4,
+          remove_count: 0,
+          disabled_platform_remove_count: 0,
+          cover_refresh_count: 0,
+          restamp_platform_count: 1,
+        },
+        new_names: [],
+        changed_names: [],
+        preview_id: "preview-restamp",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Sync Library")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(buttonByExactText(container, "Apply Sync")).not.toBeNull();
+      expect(buttonByExactText(container, "Cancel")).not.toBeNull();
+      expect(buttonByExactText(container, "Dismiss")).toBeNull();
+      expect(container.querySelector('[data-testid="sync-changes"]')?.textContent).toBe(
+        "No changes — finishing an interrupted sync.",
+      );
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Apply Sync")!);
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.syncApplyDelta)).toHaveBeenCalledWith("preview-restamp");
     });
 
     it("zero changes with explicit zero covers keeps the exact Dismiss-only shape (regression pin)", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -277,6 +277,10 @@ const PreviewChanges: FC<{ summary: SyncPreviewSummary }> = ({ summary }) => {
   if (segments.length === 0) {
     const covers = summary.cover_refresh_count ?? 0;
     if (covers > 0) return <>No shortcut changes — {pluralize(covers, "cover update")}.</>;
+    // A late-ack-recovered platform is complete but unstamped (#1416): the delta
+    // is empty, but the apply must still run once to re-stamp it and heal the
+    // lingering "interrupted" status.
+    if ((summary.restamp_platform_count ?? 0) > 0) return <>No changes — finishing an interrupted sync.</>;
     return <>Everything is up to date.</>;
   }
   return (
@@ -889,7 +893,11 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // Cover-only work (#1386): the refresh pass runs inside the apply, so an
       // empty shortcut delta with pending cover updates must still offer Apply —
       // the old "no changes" short-circuit stranded changed covers forever.
-      (preview.summary.cover_refresh_count ?? 0) > 0;
+      (preview.summary.cover_refresh_count ?? 0) > 0 ||
+      // Unstamped platforms (#1416): a late-ack-recovered platform needs a
+      // 0-delta apply run to re-stamp itself and heal the lingering
+      // "interrupted" status, so offer Apply even when every change count is zero.
+      (preview.summary.restamp_platform_count ?? 0) > 0;
     // Walk cost, shared with the handleApply seed (previewApplySeconds) so the
     // approved number equals the run's seed. Delta-only pricing here read "2 min"
     // for a resume whose apply walked ~3100 items.

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -277,10 +277,11 @@ const PreviewChanges: FC<{ summary: SyncPreviewSummary }> = ({ summary }) => {
   if (segments.length === 0) {
     const covers = summary.cover_refresh_count ?? 0;
     if (covers > 0) return <>No shortcut changes — {pluralize(covers, "cover update")}.</>;
-    // A late-ack-recovered platform is complete but unstamped (#1416): the delta
-    // is empty, but the apply must still run once to re-stamp it and heal the
-    // lingering "interrupted" status.
-    if ((summary.restamp_platform_count ?? 0) > 0) return <>No changes — finishing an interrupted sync.</>;
+    // An unstamped platform is complete but carries no completion stamp (#1416) —
+    // a late-ack recovery, a pre-stamp-era install, or a zero-ROM platform: the
+    // delta is empty, but the apply must still run once to re-stamp it and heal
+    // the lingering "interrupted" status.
+    if ((summary.restamp_platform_count ?? 0) > 0) return <>No changes — finishing a previous sync.</>;
     return <>Everything is up to date.</>;
   }
   return (

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -167,6 +167,15 @@ export interface SyncPreviewSummary {
    * (treat as 0).
    */
   cover_refresh_count?: number;
+  /**
+   * Enabled platforms lacking a completion stamp (#1416) — a late-ack-recovered
+   * platform is complete but unstamped, so its apply is a 0-delta empty final
+   * chunk that re-writes the stamp and records a fresh run. A restamp-only
+   * preview (all other diffs zero, this > 0) must still offer Apply, or the
+   * stamp never returns and "Last sync: interrupted" lingers. Absent on older
+   * backends (treat as 0).
+   */
+  restamp_platform_count?: number;
   /** Scope of the run — how many platforms this sync spans (always shown, independent of diffs). */
   sync_platform_count?: number;
   /** Scope of the run — how many collections this sync spans. */

--- a/tests/contract/test_cover_refresh.py
+++ b/tests/contract/test_cover_refresh.py
@@ -224,6 +224,9 @@ async def test_cover_only_change_flows_from_preview_to_apply_via_callables(harne
     assert summary["new_count"] == 0
     assert summary["changed_count"] == 0
     assert summary["remove_count"] == 0
+    # The seeding run stamped the platform, so a cover-only change reports no
+    # re-stamp — Apply is offered on the cover work alone (#1416 regression pin).
+    assert summary["restamp_platform_count"] == 0
     # The preview stayed read-only: no cover download, fingerprint unchanged.
     assert _download_cover_urls(harness)[downloads_before:] == []
     with harness.uow_factory() as uow:
@@ -267,3 +270,6 @@ async def test_pure_no_changes_preview_keeps_zero_cover_count(harness):
     assert summary["changed_count"] == 0
     assert summary["remove_count"] == 0
     assert summary["cover_refresh_count"] == 0
+    # Fully stamped + unchanged → no re-stamp owed either: the "Everything is up
+    # to date." short-circuit stays intact (#1416).
+    assert summary["restamp_platform_count"] == 0

--- a/tests/contract/test_unstamped_platform_rerun.py
+++ b/tests/contract/test_unstamped_platform_rerun.py
@@ -1,0 +1,130 @@
+"""Contract test for the unstamped-platform re-run (#1416).
+
+After a heartbeat-timeout run's late ack recovers a chunk (#1367 / #1409), the
+platform is complete but carries no ``PlatformSyncState`` stamp — the late-ack
+path never stamps (ADR-0023). The next preview finds a zero shortcut delta, so
+without a re-run signal the frontend short-circuits: the platform never
+re-stamps (every future sync full-fetches it) and "Last sync: interrupted"
+lingers indefinitely.
+
+This drives the real Plugin through the real bootstrap: it builds that
+complete-but-unstamped residue with real verbs (the repository stamp delete a
+timeout leaves un-rewritten, plus a ``SyncRun.mark_interrupted`` newest attempt),
+asserts the preview surfaces ``restamp_platform_count``, then asserts the gated
+apply re-stamps the platform and records a fresh completed ``SyncRun`` that heals
+the run status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from domain.sync_run import SyncRun
+from domain.sync_state import SyncState
+
+_ONE_DAY_SEC = 86400
+
+
+def _orchestrator(harness):
+    return harness.plugin._sync_service._orchestrator
+
+
+def _ack_with(bindings):
+    """A ``_wait_for_unit_complete`` stand-in acking with *bindings*."""
+
+    async def _wait(_unit, event):
+        event.set()
+        return dict(bindings)
+
+    return _wait
+
+
+def _make_grid_resolvable(harness) -> None:
+    """Materialise a Steam userdata dir so ``grid_dir()`` resolves for cover finalise."""
+    (harness.tmp_path / "home" / ".steam" / "steam" / "userdata" / "12345").mkdir(parents=True)
+
+
+def _seed_library(harness) -> None:
+    harness.romm.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 1}]
+    harness.romm.roms[10] = {
+        "id": 10,
+        "name": "Game",
+        "fs_name": "game.z64",
+        "platform_id": 1,
+        "platform_name": "N64",
+        "platform_slug": "n64",
+    }
+    harness.plugin.settings["enabled_platforms"] = {"1": True}
+
+
+async def _run_sync(harness, run_id: str) -> None:
+    assert harness.plugin._sync_service._box.try_begin_run(run_id) is True
+    await _orchestrator(harness)._do_sync_per_unit()
+
+
+async def _drain_apply(harness, tries: int = 5000) -> None:
+    for _ in range(tries):
+        if harness.plugin._sync_service._sync_state is SyncState.IDLE:
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError("sync_apply_delta's background apply task never finished")
+
+
+async def test_unstamped_platform_rerun_restamps_and_heals_run_status(harness):
+    _make_grid_resolvable(harness)
+    _seed_library(harness)
+
+    # Seeding run at t0: the platform is stamped and the ROM bound.
+    _orchestrator(harness)._wait_for_unit_complete = _ack_with({"10": 7777})
+    await _run_sync(harness, "run-seed")
+    with harness.uow_factory() as uow:
+        assert uow.platform_sync_state.get("n64") is not None
+
+    # Reproduce the ADR-0023 late-ack residue: the apply-start stamp clear a
+    # heartbeat timeout then leaves un-rewritten (bound rows, no stamp), plus the
+    # timed-out run surfaced as the newest 'interrupted' attempt. Both are built
+    # with real verbs — the repository delete and SyncRun.mark_interrupted.
+    harness.clock.advance(_ONE_DAY_SEC)  # t1
+    with harness.uow_factory() as uow:
+        uow.platform_sync_state.delete("n64")
+    interrupted = SyncRun.start(id="run-timeout", at="2026-01-01T00:00:00", platforms_planned=1, roms_planned=1)
+    interrupted.mark_interrupted(harness.clock.now().isoformat(), "Sync interrupted (Steam UI stopped responding)")
+    with harness.uow_factory() as uow:
+        uow.sync_runs.save(interrupted)
+
+    # Pre-state: no stamp, and the lingering interrupted attempt.
+    with harness.uow_factory() as uow:
+        assert uow.platform_sync_state.get("n64") is None
+    stats = await harness.plugin.get_sync_stats()
+    assert stats["last_attempt"]["status"] == "interrupted"
+
+    # The next preview surfaces the re-stamp need with an otherwise-empty delta,
+    # so the frontend offers Apply instead of short-circuiting on "no changes".
+    harness.clock.advance(_ONE_DAY_SEC)  # t2 — the heal run becomes the newest terminal
+    preview = await harness.plugin.sync_preview()
+    assert preview["success"] is True
+    summary = preview["summary"]
+    assert summary["restamp_platform_count"] == 1
+    assert summary["new_count"] == 0
+    assert summary["changed_count"] == 0
+    assert summary["remove_count"] == 0
+    assert summary["cover_refresh_count"] == 0
+
+    # The gated apply's empty chunk re-stamps the platform and records a fresh
+    # completed SyncRun. The empty chunk acks nothing (no shortcut to bind).
+    _orchestrator(harness)._wait_for_unit_complete = _ack_with({})
+    apply_result = await harness.plugin.sync_apply_delta(preview["preview_id"])
+    assert apply_result == {"success": True, "message": "Applying changes"}
+    await _drain_apply(harness)
+
+    with harness.uow_factory() as uow:
+        stamp = uow.platform_sync_state.get("n64")
+        assert stamp is not None
+        assert stamp.rom_count == 1
+        completed = uow.sync_runs.get_latest_completed()
+        assert completed is not None
+        assert completed.id not in ("run-seed", "run-timeout")
+
+    # The interrupted attempt no longer lingers — the fresh completed run heals it.
+    healed = await harness.plugin.get_sync_stats()
+    assert healed["last_attempt"] is None

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -640,6 +640,99 @@ class TestPreviewCoverRefreshCount:
         assert registry["10"]["cover_source"] == self._OLD
 
 
+class TestPreviewRestampPlatformCount:
+    """The preview's unstamped-platform re-run count (#1416).
+
+    A late-ack-recovered platform is complete but carries no ``PlatformSyncState``
+    stamp, so its shortcut delta is empty yet its apply must still run once to
+    re-stamp it. The preview counts enabled platforms without a completion stamp
+    (``restamp_platform_count``) so the frontend offers Apply on an otherwise-empty
+    delta instead of short-circuiting — a fully-stamped library keeps counting 0
+    and short-circuits exactly as before.
+    """
+
+    @staticmethod
+    def _preview_setup(plugin, fake_romm_api):
+        import decky
+
+        plugin.loop = asyncio.get_event_loop()
+        decky.emit.reset_mock()
+        _use_fake_romm(plugin, fake_romm_api)
+
+    @pytest.mark.asyncio
+    async def test_unstamped_platform_counted_with_empty_delta(self, plugin, fake_romm_api):
+        # A bound, content-unchanged platform ROM with NO completion stamp: the
+        # shortcut delta is empty (0 new / changed / removed) but the platform
+        # needs a re-stamp run, so restamp_platform_count is 1.
+        self._preview_setup(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Keep", "fs_name": "keep.z64"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        summary = result["summary"]
+        assert summary["restamp_platform_count"] == 1
+        assert summary["new_count"] == 0
+        assert summary["changed_count"] == 0
+        assert summary["remove_count"] == 0
+        assert summary["cover_refresh_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stamped_platform_not_counted(self, plugin, fake_romm_api):
+        # The same unchanged platform WITH a matching completion stamp: no
+        # re-stamp is owed, so the count stays 0 and the "up to date"
+        # short-circuit is preserved.
+        self._preview_setup(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Keep", "fs_name": "keep.z64"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+        _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00", rom_count=1)
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        summary = result["summary"]
+        assert summary["restamp_platform_count"] == 0
+        assert summary["new_count"] == 0
+        assert summary["changed_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_counts_only_unstamped_across_mixed_platforms(self, plugin, fake_romm_api):
+        # Two enabled platforms, one stamped and one not: only the unstamped one
+        # is counted (the count is not a whole-library boolean).
+        self._preview_setup(plugin, fake_romm_api)
+        _seed_platform(
+            fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A", "fs_name": "a.z64"}]
+        )
+        _seed_platform(
+            fake_romm_api, platform_id=2, name="GBA", slug="gba", roms=[{"id": 20, "name": "B", "fs_name": "b.gba"}]
+        )
+        plugin.settings["enabled_platforms"] = {"1": True, "2": True}
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="A", fs_name="a.z64")
+        _seed_rom_row(plugin, 20, app_id=2020, platform_slug="gba", name="B", fs_name="b.gba")
+        # Only n64 carries a stamp; gba is the unstamped late-ack survivor.
+        _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00", rom_count=1)
+
+        result = await plugin.sync_preview()
+
+        assert result["success"] is True
+        assert result["summary"]["restamp_platform_count"] == 1
+
+
 class TestSyncApplyDelta:
     """Tests for sync_apply_delta().
 
@@ -1328,6 +1421,59 @@ class TestDoSyncPerUnit:
         assert "collapsed_count" not in units["GBA"]
         assert "predicted_skip" not in units["Faves"]
         assert "collapsed_count" not in units["Faves"]
+
+    @pytest.mark.asyncio
+    async def test_unstamped_zero_delta_platform_restamps_and_records_run(self, plugin, fake_romm_api):
+        """#1416: an unstamped platform with a 0 shortcut delta still runs the apply.
+
+        A late-ack recovery leaves the platform complete but unstamped. The next
+        apply must NOT wholesale-skip it (no stamp): its delta-restricted apply
+        emits a single empty final chunk whose commit re-writes the completion
+        stamp, and the run records a fresh completed ``SyncRun`` — so the platform
+        stops full-fetching forever and the "interrupted" status heals.
+        """
+        import decky
+
+        decky.emit.reset_mock()
+        plugin.loop = asyncio.get_event_loop()
+        _use_fake_romm(plugin, fake_romm_api)
+
+        _seed_platform(
+            fake_romm_api,
+            platform_id=1,
+            name="N64",
+            slug="n64",
+            roms=[{"id": 10, "name": "Keep", "fs_name": "keep.z64"}],
+        )
+        plugin.settings["enabled_platforms"] = {"1": True}
+        # Bound + content-unchanged → empty delta. NO completion stamp: the
+        # complete-but-unstamped residue a heartbeat-timeout's late ack leaves.
+        _seed_rom_row(plugin, 10, app_id=1010, platform_slug="n64", name="Keep", fs_name="keep.z64")
+        with plugin._uow as uow:
+            assert uow.platform_sync_state.get("n64") is None
+
+        plugin._sync_service._orchestrator._download_artwork = AsyncMock(return_value={})
+        plugin._sync_service._orchestrator._wait_for_unit_complete = _fake_wait_set_event
+        plugin._sync_service._box.sync_state = SyncState.RUNNING
+        plugin._sync_service._box.current_sync_id = "run-restamp"
+
+        await plugin._sync_service._orchestrator._do_sync_per_unit()
+
+        # The apply ran despite the empty delta: a single empty final chunk fired.
+        unit_events = [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_apply_unit"]
+        assert len(unit_events) == 1
+        assert unit_events[0]["shortcuts"] == []
+        assert unit_events[0]["chunk_count"] == 1
+
+        # The empty chunk's commit re-wrote the platform stamp, and the run
+        # recorded a fresh completed SyncRun.
+        with plugin._uow as uow:
+            stamp = uow.platform_sync_state.get("n64")
+            assert stamp is not None
+            assert stamp.rom_count == 1
+            completed = uow.sync_runs.get_latest_completed()
+            assert completed is not None
+            assert completed.id == "run-restamp"
 
     @pytest.mark.asyncio
     async def test_processes_each_unit_in_order(self, plugin, fake_romm_api):


### PR DESCRIPTION
Fixes #1416.

Found on-device in the 0.27.0 verification round: after a heartbeat-timeout run whose chunk the late ack recovered (#1409), the state is fully consistent — but the platform stays unstamped (the late-ack path deliberately never stamps, ADR-0023) and the next Sync's preview reports "everything is up to date" and never starts the apply pipeline. Since only the pipeline's final chunk stamps a platform and records a fresh `SyncRun`, two things linger indefinitely while the library is unchanged: the platform full-fetches on every future sync, and "Last sync: interrupted" keeps reading like an unresolved failure.

**Fix — a preview signal, not new pipeline plumbing.** The up-to-date short-circuit lives in the frontend's has-changes gate, so the preview summary gains an additive `restamp_platform_count`: the number of enabled platforms currently lacking a completion stamp (one read-only count in the preview; the preview never stamps — stamp writes stay pipeline-owned). The frontend folds it into the gate: a restamp-only preview shows "No changes — finishing a previous sync." with the normal Apply, which drives the same delta apply as ever. The pipeline machinery already does the rest — an unstamped platform is never fetch-skipped, a 0-delta unit yields exactly one empty final chunk, and that chunk's commit writes the stamp and a fresh successful run, healing the lingering status. Self-heals in one apply for every unstamped cohort (late-ack residue, pre-stamp-era installs, zero-ROM platforms). An all-stamped unchanged library short-circuits exactly as before.

Estimate weights are deliberately unchanged: an unstamped platform's plan weight stays the conservative full server count (anything cheaper would require fetching at plan time or trusting the stampless local mirror — the #1412 bug), and the restamp-only Apply seeds its ETA from the fetch allowance alone.

**Tests:** orchestrator units for the count (unstamped/stamped/mixed) and the 0-delta restamp-and-record path; a contract-tier acceptance chain over the real Plugin/bootstrap that builds the late-ack residue with real verbs, sees `restamp_platform_count == 1` on an otherwise-empty preview, applies, and asserts the stamp plus the healed last-attempt status; frontend tests for the restamp-only copy, the zero-count regression pin, and the Apply flow. Short-circuit shape re-pinned. Full suites: 5356 (py) / 1923 (fe) passed; all invariant gates green.

**Docs:** ADR-0023 stamp-lifecycle bullet + a new `restamp_platform_count` section in `backend-architecture.md`.
