### PR TITLE
fix(ui): show the qam sync status smaller and green on success and keep it visible longer

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -3541,7 +3541,7 @@ describe("MainPage", () => {
       expect(fieldLabels(container)).toContain("Sync cancelled");
     });
 
-    it("the terminal cancel message auto-clears after 8s", async () => {
+    it("the terminal cancel message stays past 8s and auto-clears after 15s", async () => {
       vi.useFakeTimers({
         toFake: ["setInterval", "clearInterval", "setTimeout", "clearTimeout"],
       });
@@ -3566,14 +3566,20 @@ describe("MainPage", () => {
           await Promise.resolve();
           await Promise.resolve();
         });
-        // Terminal stage surfaces the message + arms the 8s auto-clear.
+        // Terminal stage surfaces the message + arms the 15s auto-clear.
         await act(async () => {
           setSyncProgress({ running: false, stage: "cancelled", message: "Sync cancelled" });
           await Promise.resolve();
         });
         expect(fieldLabels(container)).toContain("Sync cancelled");
+        // Past the OLD 8s threshold: still visible (the "stays longer" change).
         await act(async () => {
           await vi.advanceTimersByTimeAsync(8000);
+        });
+        expect(fieldLabels(container)).toContain("Sync cancelled");
+        // Crossing 15s total: now cleared.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(7001);
         });
         expect(fieldLabels(container)).not.toContain("Sync cancelled");
       } finally {
@@ -4151,6 +4157,97 @@ describe("MainPage", () => {
       });
       // Still in-flight after the resolve — store subscription owns teardown.
       expect(buttonByExactText(container, "Cancel Sync")).not.toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // N3. Sync-complete status styling — green + smaller + longer visibility
+  // ===========================================================================
+  describe("sync-complete status styling", () => {
+    const syncStatus = (c: HTMLElement) => c.querySelector('[data-testid="sync-status"]') as HTMLElement | null;
+
+    // Mount into a live run so a terminal sync_progress has an in-flight UI to
+    // tear down, then land the terminal frame through the module store exactly
+    // as a backend event would.
+    async function mountThenTerminal(stage: "done" | "cancelled" | "error", message: string): Promise<HTMLElement> {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 1,
+        message: "Working",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        setSyncProgress({ running: false, stage, message });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      return container;
+    }
+
+    it("renders a clean sync finish smaller and green", async () => {
+      const c = await mountThenTerminal("done", "Sync complete: 7 games");
+      const el = syncStatus(c);
+      expect(el?.textContent).toBe("Sync complete: 7 games");
+      // Non-vacuous: both the affirmative green AND the small caption size sit on
+      // the element — dropping the success tone (or the size) fails this.
+      expect(el?.style.color).toBe("#59bf40");
+      expect(el?.style.fontSize).toBe("12px");
+    });
+
+    it("renders a cancelled finish smaller but NOT green", async () => {
+      const c = await mountThenTerminal("cancelled", "Sync cancelled");
+      const el = syncStatus(c);
+      expect(el?.textContent).toBe("Sync cancelled");
+      // Neutral tone: no colour override, so the panel's default text colour wins.
+      expect(el?.style.color).toBe("");
+      expect(el?.style.fontSize).toBe("12px");
+    });
+
+    it("renders an errored finish smaller but NOT green", async () => {
+      const c = await mountThenTerminal("error", "Sync failed: server unreachable");
+      const el = syncStatus(c);
+      expect(el?.textContent).toBe("Sync failed: server unreachable");
+      expect(el?.style.color).toBe("");
+      expect(el?.style.fontSize).toBe("12px");
+    });
+
+    it("keeps the finish status visible past 8s and clears it only after 15s", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.mocked(backend.getSyncStatus).mockResolvedValue({
+          running: true,
+          stage: "applying",
+          step: 1,
+          totalSteps: 1,
+          message: "Working",
+        });
+        const { container } = render(<MainPage onNavigate={vi.fn()} />);
+        await flushAsync();
+        await act(async () => {
+          setSyncProgress({ running: false, stage: "done", message: "Sync complete: 7 games" });
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(syncStatus(container)?.textContent).toBe("Sync complete: 7 games");
+
+        // Past the OLD 8s auto-clear: still on screen — this guards the "stays
+        // visible a bit longer" ask (the pre-change 8000ms would have cleared it).
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(9000);
+        });
+        expect(syncStatus(container)).not.toBeNull();
+
+        // Crossing 15s total: the auto-clear fires and the line disappears.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(6001);
+        });
+        expect(syncStatus(container)).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -3683,6 +3683,27 @@ describe("MainPage", () => {
       expect(vi.mocked(backend.clearSyncCache)).toHaveBeenCalled();
       expect(fieldLabels(container)).toContain("Cache cleared");
     });
+
+    it("clearSyncCache rejection surfaces 'Failed to clear sync cache' (neutral, not green)", async () => {
+      // Non-vacuous catch coverage: the rejection routes through the catch's
+      // showTransientStatus, so both the message AND its neutral tone (no green
+      // override — the clear failed) must be observable on the status element.
+      vi.mocked(backend.getSyncStats).mockResolvedValue({
+        ...defaultStats(),
+        last_sync: new Date(Date.now() - 30_000).toISOString(),
+      });
+      vi.mocked(backend.clearSyncCache).mockRejectedValue(new Error("io"));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(buttonByExactText(container, "Force Full Sync")!);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const el = container.querySelector('[data-testid="sync-status"]') as HTMLElement | null;
+      expect(el?.textContent).toBe("Failed to clear sync cache");
+      expect(el?.style.color).toBe(""); // neutral tone — no success green
+    });
   });
 
   // ===========================================================================

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -358,6 +358,29 @@ const BlockSeparator: FC = () => (
   </PanelSectionRow>
 );
 
+/** The affirmative green — matches the connection checkmark and the healthy
+ *  memory level — used only for a cleanly-finished sync's status line. */
+const STATUS_SUCCESS_COLOR = "#59bf40";
+
+/** How long the transient status line lingers before auto-clearing. Kept long
+ *  enough to still be readable after a glance away from a just-finished sync. */
+const STATUS_CLEAR_MS = 15000;
+
+/** Tone of the transient status line. Only a clean sync finish is affirmative
+ *  (green); a cancel/error/other keeps the neutral panel-text look. */
+type StatusTone = "success" | "neutral";
+
+interface TransientStatus {
+  text: string;
+  tone: StatusTone;
+}
+
+/** A terminal sync stage's status tone — green only on a clean finish; a
+ *  cancel or error stays neutral so green never reads as "all good". */
+function terminalStatusTone(stage: SyncProgress["stage"]): StatusTone {
+  return stage === "done" ? "success" : "neutral";
+}
+
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const [stats, setStats] = useState<SyncStats | null>(null);
   const [budgetStatus, setBudgetStatus] = useState<SessionBudgetStatus | null>(null);
@@ -383,7 +406,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // the render — the render must stay pure. Progress frames drive the subscriber,
   // so the countdown ticks per frame exactly as before.
   const [liveEtaDisplay, setLiveEtaDisplay] = useState<number | null>(null);
-  const [status, setStatus] = useState("");
+  const [status, setStatus] = useState<TransientStatus | null>(null);
   const [preview, setPreview] = useState<SyncPreview | null>(null);
   const [skipPreview, setSkipPreview] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -397,10 +420,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const downloadPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const showTransientStatus = (msg: string) => {
+  const showTransientStatus = (text: string, tone: StatusTone = "neutral") => {
     if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-    setStatus(msg);
-    statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
+    setStatus({ text, tone });
+    statusTimeoutRef.current = setTimeout(() => setStatus(null), STATUS_CLEAR_MS);
   };
 
   useEffect(() => {
@@ -569,7 +592,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           // True terminal reached — re-arm the button out of any "Cancelling…"
           // drain state (#1202, RC-B).
           setCancelling(false);
-          showTransientStatus(progress.message || "Sync finished");
+          showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
           getSyncStats()
             .then(setStats)
             .catch((e) => logError(`Failed to refresh sync stats: ${e}`));
@@ -650,7 +673,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // front or threw). Reset both the local UI and the MODULE store so the
   // store mirrors reality — the optimistic running:true must not linger.
   const abortOptimisticSync = (msg: string) => {
-    setStatus(msg);
+    setStatus({ text: msg, tone: "neutral" });
     setSyncing(false);
     setLoading(false);
     setCancelling(false);
@@ -669,7 +692,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     setLoading(true);
     setSyncing(true);
     setCancelling(false);
-    setStatus("");
+    setStatus(null);
     setPreview(null);
     setStoredSyncProgress({ running: true, stage: "fetching", message: "Fetching library..." });
     try {
@@ -745,7 +768,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
   const handleDismiss = async () => {
     setPreview(null);
-    setStatus("");
+    setStatus(null);
     try {
       await syncCancelPreview();
     } catch {
@@ -1151,12 +1174,10 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                   (async () => {
                     try {
                       const result = await clearSyncCache();
-                      setStatus(result.message);
+                      showTransientStatus(result.message);
                     } catch {
-                      setStatus("Failed to clear sync cache");
+                      showTransientStatus("Failed to clear sync cache");
                     }
-                    if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
-                    statusTimeoutRef.current = setTimeout(() => setStatus(""), 8000);
                     getSyncStats()
                       .then(setStats)
                       .catch((e) => logError(`Failed to refresh sync stats: ${e}`));
@@ -1328,9 +1349,23 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
 
       <PanelSection>
         {syncBody}
-        {status && !syncing && !preview && (
+        {status?.text && !syncing && !preview && (
           <PanelSectionRow>
-            <Field label={status} focusable={true} bottomSeparator="none" />
+            <Field
+              label={
+                <span
+                  data-testid="sync-status"
+                  style={{
+                    fontSize: "12px",
+                    ...(status.tone === "success" ? { color: STATUS_SUCCESS_COLOR } : {}),
+                  }}
+                >
+                  {status.text}
+                </span>
+              }
+              focusable={true}
+              bottomSeparator="none"
+            />
           </PanelSectionRow>
         )}
         <BlockSeparator />

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -1356,7 +1356,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                 <span
                   data-testid="sync-status"
                   style={{
-                    fontSize: "12px",
+                    ...wrapText,
                     ...(status.tone === "success" ? { color: STATUS_SUCCESS_COLOR } : {}),
                   }}
                 >


### PR DESCRIPTION
User-requested QAM polish from the 0.27.0 verification round: the transient sync status line that appears after a run finishes now renders in the small caption style (via the shared `textStyles.wrapText`, 12px + wrap safety) and in the affirmative green (`#59bf40`, the same green as the Connected checkmark and the healthy memory level) — but only for a cleanly finished sync: the status state now carries a tone, and only the `done` terminal stage maps to success, so a cancelled/interrupted/error line keeps the neutral panel look and green never reads as "all good". The auto-clear window grows from 8 s to 15 s so the line survives a glance away.

**Tests:** success styling asserted on the element (color + size), cancelled/error stay neutral, fake-timer proof of visible-past-8s / gone-at-15s, and the clear-cache failure catch now has its non-vacuous test. Frontend 1928 passed / 83 files; Python untouched.

docs: N/A (visual polish, no behavior/architecture change)
