### PR TITLE
chore(dev): add dev:bpm task to open windowed big picture on a chosen monitor

### DIFF
--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -61,6 +61,9 @@ Concretely: after a save, leave the plugin's QAM panel and re-enter it (back out
 re-navigate to a patched game-detail page — to see the change. Keyboard shortcuts in the BPM window: **Ctrl+2** opens
 the Quick Access Menu, **Ctrl+1** the main menu.
 
+Just want the window, not the loop? `mise run dev:bpm [display]` opens and places the same windowed Big Picture without
+deploying or watching anything — useful for eyeballing a one-off `mise run dev` test build.
+
 ### Choosing the display
 
 The optional argument is matched against the **real outputs** of the machine — output naming varies between Decks and

--- a/mise.toml
+++ b/mise.toml
@@ -238,6 +238,21 @@ run = '''
 exec python3 scripts/dev_ui_scale.py "$usage_mode"
 '''
 
+[tasks."dev:bpm"]
+description = "Open windowed Big Picture on a chosen monitor (no deploy, no watch loop)"
+raw = true
+usage = '''
+arg "[display]" help="Monitor for the Big Picture window: 'internal' or an output name (dp2, DP-3, ...)" default="internal"
+complete "display" run="bash scripts/dev_open_bpm.sh --list"
+'''
+run = '''
+# Opens BPM non-blocking (starting Steam straight into it if it isn't running)
+# and places the window on the chosen display via a short-lived KWin script —
+# the same helper dev:watch and dev:bpm-reset use, without their deploy /
+# restart halves. Pairs with a one-off `mise run dev` test build.
+exec bash scripts/dev_open_bpm.sh "$usage_display"
+'''
+
 [tasks."dev:bpm-reset"]
 description = "Restart Steam into windowed Big Picture (recovers the Decky UI after leaving and re-entering BPM)"
 raw = true


### PR DESCRIPTION
Adds `mise run dev:bpm [display]` — opens and places the windowed Big Picture on the chosen monitor via the existing `scripts/dev_open_bpm.sh` helper, without the deploy/watch halves of `dev:watch` and without the Steam restart of `dev:bpm-reset`. Useful for eyeballing a one-off `mise run dev` test build.

Same optional display argument and tab completion as the sibling tasks. Documented in the frontend-dev-loop guide.