### PR TITLE
chore(mise): add gate task mirroring the full ci battery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ Latest release and shipped features: see `git tag --sort=-v:refname` and GitHub 
 - **Build**: `pnpm build` (Rollup -> dist/index.js)
 - **Tests**: `python -m pytest tests/ -q` or `mise run test`
 - **Coverage**: `python -m pytest tests/ -q --cov=py_modules --cov=main --cov-report=term --cov-branch`
+- **Gate**: `mise run gate` (the full CI battery in one command — mirrors every PR check in `.github/workflows/ci.yml`;
+  slow: full pytest + frontend build. Run before pushing.)
 - **Setup**: `mise run setup` (installs JS + Python dependencies)
 - **Dev reload**: `mise run dev` (build + restart plugin_loader)
 - **Frontend live dev**: `mise run dev:watch [display]` (one-time `mise run dev:setup`) — hot-reloads the **frontend**

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -192,6 +192,19 @@ keeps all settings writes in the single crash-safe owner.
 
 See [Backend Architecture](../architecture/backend-architecture.md) for details.
 
+## Full CI gate
+
+```bash
+mise run gate         # run every PR check from .github/workflows/ci.yml, locally
+```
+
+`mise run gate` is the single local battery that mirrors CI. It runs the backend tests (`mise run test`) and the
+architecture/lint gates (`mise run lint`), then adds the rest of what CI enforces: `ruff check` + `ruff format --check`,
+`basedpyright`, the frontend `eslint` / `prettier --check` / build / `tsc` typecheck / bundle-size budget, the frontend
+tests (`pnpm test`), and `deno fmt --check` for Markdown. It is slow — a full pytest run plus a production frontend
+build — so it is a pre-push check, not something to run on every save. The only CI jobs it can't reproduce are the
+SonarCloud scan and its `sonar-gate` (they need `SONAR_TOKEN` and the CI coverage artifacts).
+
 ## Code Quality
 
 - **SonarCloud** — CI-based analysis on every human PR and push to main. Quality Gate enforces 80% coverage on new code,

--- a/mise.toml
+++ b/mise.toml
@@ -62,6 +62,30 @@ run = [
     "python scripts/check_lock_sync.py",
 ]
 
+[tasks.gate]
+description = "Run the full CI battery locally — every PR check in ci.yml, in one command (slow: full pytest + frontend build)"
+# depends: `test` (pytest) + `lint` (import-linter, the check_* scripts, markdownlint)
+# cover the Python-test and architecture-gate CI jobs. The run list below adds the
+# rest of ci.yml: the ruff/basedpyright half of the `lint` job, the whole `build`
+# job (eslint/prettier/build/typecheck/size), the `frontend-test` job (`pnpm test`
+# stands in for CI's `pnpm test:coverage` — pass/fail parity), and `markdown-format`
+# (`deno fmt --check`). `pnpm build` precedes `pnpm size` because size-limit measures
+# the built bundle. Not reproducible locally, so omitted: the SonarCloud scan +
+# sonar-gate (need SONAR_TOKEN and CI coverage artifacts).
+depends = ["test", "lint"]
+run = [
+    "ruff check .",
+    "ruff format --check .",
+    "basedpyright",
+    "pnpm lint",
+    "pnpm format:check",
+    "pnpm build",
+    "pnpm typecheck",
+    "pnpm size",
+    "pnpm test",
+    "deno fmt --check",
+]
+
 [tasks.deploy]
 description = "Deploy plugin files to Decky plugin directory"
 depends = ["build"]


### PR DESCRIPTION
Adds a `gate` mise task that runs everything CI enforces on a PR as one local command.

## Why

`mise run test` (pytest) and `mise run lint` (import-linter + check scripts + markdownlint) covered only part of the CI surface — ruff, basedpyright, and the entire frontend battery (eslint, prettier check, tsc, vitest, build, size limit) plus `deno fmt --check` could only be verified by pushing. A change could pass everything locally and still fail CI.

## What

- `[tasks.gate]` in mise.toml: `depends = ["test", "lint"]`, plus the ci.yml checks that had no local task: `ruff check .`, `ruff format --check .`, `basedpyright`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm size`, and the markdown `deno fmt --check`.
- Omitted: the sonarcloud/sonar-gate jobs (need `SONAR_TOKEN` + CI coverage artifacts; documented in the task comment). Coverage flags are dropped locally — they feed Sonar only, pass/fail parity is unchanged.
- Docs updated in the same PR: CLAUDE.md Development section + `docs/contributing/development.md`.

Verified: `mise run gate` passes end-to-end on this branch.
