### PR TITLE
fix(ui): pin the fine-detail row height and name the next unit at sync boundaries

### DIFF
--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -2147,6 +2147,112 @@ describe("MainPage", () => {
     });
   });
 
+  describe("sync boundary: the anchor names the next unit and the row height is reserved", () => {
+    const fineRow = (c: HTMLElement) => c.querySelector('[data-testid="sync-fine"]') as HTMLElement | null;
+
+    it("replaces the carried line with the boundary anchor's own message (names the new unit)", async () => {
+      // Unit A applying with real fine detail — the row narrates unit A.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 50,
+        total: 50,
+        message: "GBA: 50/50",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+
+      // Unit boundary: the next unit's FETCHING anchor carries no fine detail
+      // (total 0) but a coarse position (totalSteps 8) and names the new unit in
+      // its message. The fine line must snap to the NEW unit immediately, not
+      // keep unit A's stale text during the anchor dwell before the first real
+      // frame lands.
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          step: 3,
+          totalSteps: 8,
+          current: 0,
+          total: 0,
+          message: "Fetching SNES... (3/8)",
+        }),
+      );
+      expect(fineRow(container)!.textContent).toContain("Fetching SNES... (3/8)");
+      expect(fineRow(container)!.textContent).not.toContain("GBA: 50/50");
+
+      // The new unit's first real fetch frame lands — normal formatted text.
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          subStage: "fetch",
+          step: 3,
+          totalSteps: 8,
+          current: 1,
+          total: 5,
+          message: "Fetching SNES (page 1/5)",
+        }),
+      );
+      expect(fineRow(container)!.textContent).toContain("Fetching SNES (page 1/5)");
+    });
+
+    it("reserves the two-line clamp box height on the fine-detail element", async () => {
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 3,
+        total: 10,
+        message: "N64: 3/10",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      const fine = fineRow(container);
+      expect(fine).not.toBeNull();
+      // Two 1.4 line-heights reserved as 2.8em — a 1↔2-line wrap change never
+      // reflows the ETA row / Cancel button below it (the residual jolt).
+      expect(fine!.style.minHeight).toBe("2.8em");
+      expect(fine!.style.lineHeight).toBe("1.4");
+    });
+
+    it("keeps the prior line when a boundary anchor carries an empty message (never blank)", async () => {
+      // The defensive branch: both real apply/preview anchors carry a message,
+      // but an empty-message running frame must never clear the carry — the row
+      // would blank mid-run. Carry replacement, never carry removal.
+      vi.mocked(backend.getSyncStatus).mockResolvedValue({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 8,
+        current: 50,
+        total: 50,
+        message: "GBA: 50/50",
+      });
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+
+      act(() =>
+        setSyncProgress({
+          running: true,
+          stage: "fetching",
+          step: 3,
+          totalSteps: 8,
+          current: 0,
+          total: 0,
+          message: "",
+        }),
+      );
+      expect(fineRow(container)).not.toBeNull();
+      expect(fineRow(container)!.textContent).toContain("GBA: 50/50");
+    });
+  });
+
   describe("QAM remount mid-run preserves fine progress + ETA", () => {
     it("merges the store's fine fields + etaSeconds over the backend's coarse running snapshot", async () => {
       // Module store holds the in-flight run's FINE state — what a live QAM had

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -171,6 +171,15 @@ function formatProgressText(progress: SyncProgress | null): string {
   return progress.message || "Syncing...";
 }
 
+// The fine-detail line is clamped to two lines (``WebkitLineClamp``) and its box
+// is reserved at exactly that height up front. Without the reservation a message
+// that wraps 1→2 lines (or shrinks 2→1 at a unit boundary) reflows the ETA row
+// and Cancel button below it — the visible jolt of the residual boundary flicker.
+// ``minHeight`` in ``em`` ties to the element's own 12px font (``wrapText``), so
+// two 1.4-line-height lines reserve 2.8em with no magic pixel value.
+const FINE_DETAIL_LINE_HEIGHT = 1.4;
+const FINE_DETAIL_CLAMP_LINES = 2;
+
 function formatLastSync(iso: string | null): string {
   if (!iso) return "Never";
   try {
@@ -598,13 +607,23 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       // the re-render chain (on-device freeze, cause not yet reproduced in tests).
       const progress = getSyncProgress();
       setSyncProgress(progress);
-      // Carry the last non-empty fine detail so the fine-detail row survives a
-      // unit boundary's anchor frame (which resets current/total, #1415); drop
-      // it the moment the run ends so the next run starts clean. Kept outside
-      // the try below so the reset can never be skipped by a subscriber throw.
+      // Carry the fine-detail line so the row survives a unit boundary's anchor
+      // frame (which resets current/total, #1415); drop it the moment the run
+      // ends so the next run starts clean. Kept outside the try below so the
+      // reset can never be skipped by a subscriber throw.
+      //
+      // The carry is refreshed by any running frame that has a message AND a
+      // position: a real fine-detail frame (``total`` > 0) OR a unit-boundary
+      // FETCHING anchor (``total`` 0 but ``totalSteps`` > 0). At the boundary the
+      // anchor's own message ("Fetching <next unit>") REPLACES the previous
+      // unit's carried text, so the fine line names the new unit immediately
+      // instead of lagging on the old one until the next real frame lands a
+      // network RTT later. The initial optimistic "Fetching library…" start (no
+      // total, no totalSteps) is excluded, so it keeps the stage-label spinner;
+      // an empty-message frame never clears the carry (replace, never remove).
       if (!progress.running) {
         setCarriedFineDetail(null);
-      } else if (progress.total && progress.message) {
+      } else if (progress.message && (progress.total || progress.totalSteps)) {
         setCarriedFineDetail(progress.message);
       }
       try {
@@ -1116,9 +1135,13 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     style={{
                       ...wrapText,
                       display: "-webkit-box",
-                      WebkitLineClamp: 2,
+                      WebkitLineClamp: FINE_DETAIL_CLAMP_LINES,
                       WebkitBoxOrient: "vertical",
                       overflow: "hidden",
+                      lineHeight: FINE_DETAIL_LINE_HEIGHT,
+                      // Reserve the full two-line clamp box so a 1↔2-line wrap
+                      // change never reflows the ETA row / Cancel button below.
+                      minHeight: `${FINE_DETAIL_CLAMP_LINES * FINE_DETAIL_LINE_HEIGHT}em`,
                     }}
                   >
                     {fineDetailText}


### PR DESCRIPTION
Closes #1434.

## Problem

Residual QAM flicker at sync unit boundaries despite #1420: the carried fine-detail text lagged one anchor dwell behind the step counter, and the snap to the next unit's text could flip the clamped line between 1 and 2 wrapped lines — reflowing the ETA row and Cancel button below.

## Change

- The fine-detail line always reserves its 2-line clamp box (`lineHeight 1.4` + `minHeight 2.8em`, em-tied to the line's own font size) — wrap changes never reflow siblings.
- A boundary anchor frame (`total=0`, `totalSteps>0`, non-empty message) now refreshes the carried text, so the line names the next unit immediately. Never-blank stays: empty-message frames keep the previous carry; the `!running` clear is untouched.
- Side effect, accepted: during finalize the line reads "Finalizing…" instead of the last unit's counts — slightly duplicates the stage label, but more truthful than stale per-unit numbers.

## Tests

Three new tests (boundary content swap, height reservation, never-blank on empty message); the #1415/#1420 mounted-across-boundary assertions are unchanged. Full suites green.

On-device verified: platform-transition flicker gone in both preview and sync.

docs: N/A (cosmetic rendering fix — no documented behavior or flow changes)