### PR TITLE
fix(saves): keep the device identity across same-server re-sign-ins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,15 @@ silent omission. The CI check enforces this.
   persists URL+SSL+token+id+origin in a single atomic save only on success — a failed sign-in restores the previous
   working state, never clobbering disk. The old-token DELETE on re-auth is fired only when the old origin matches the
   new one (#1038). A legacy token with origin `None` is un-bound: attached, never blocked, until the next sign-in stamps
-  it. A successful sign-in whose origin _differs_ from the old token's origin **forgets the registered device id**
+  it. A successful sign-in that **genuinely changes origin** (old and new origins both known and normalizing to
+  different values — `is_origin_change` in `lib/url_host`) **forgets the registered device id**
   (`kv_config["device_id"]`, via the `DeviceForgetFn` injected into `ConnectionService` → `SaveService.forget_device` →
   `DeviceRegistry.forget_device`) — the id is bound to its minting origin and would 404 against the new server's
-  `negotiate`; local-only + best-effort, the next save-sync re-registers (#1234 Phase 0a, ADR-0016). See
+  `negotiate`; local-only + best-effort, the next save-sync re-registers (#1234 Phase 0a, ADR-0016). A **same-server
+  re-sign-in keeps the device identity**: a token swap on the unchanged URL, URL-formatting variants (trailing slash,
+  default vs explicit port), and a `None`/unstamped old origin are all treated as _not a change_ (an unknown old origin
+  is unknown, not different) — the id survives, so the next post-exit sync attributes uploads as before instead of
+  hitting a spurious conflict (#1437). See
   [ConnectionService notes](docs/architecture/backend-architecture.md#connectionservice-notes).
 - **Decky callables must be async**: Even if the method body is synchronous, Decky's callable framework requires
   `async def`. Do not remove `async` from callable methods in main.py.

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -848,17 +848,24 @@ copied raw value stops working) is host-bound in memory and run through the shar
 tail, so it is persisted with `"user"` provenance and `id = None` exactly like a pasted token — no mint, no server-side
 DELETE. The pairing code and the returned token are never logged.
 
-**The registered device id is forgotten on an origin change.** A device registered with RomM (`POST /api/devices`, its
-id stored in `kv_config["device_id"]`) is bound to the server it was registered against — RomM's `negotiate` save-sync
-transport hard-404s a foreign device id. So a successful sign-in whose origin differs from the previous token's origin
-forgets the stored device id (`SaveService.forget_device` → `DeviceRegistry.forget_device`, wired as the
-`DeviceForgetFn` injected into `ConnectionService`), so the next save-sync run re-registers against the new server. It
-reuses the same origin comparison as the old-token DELETE, but in the opposite sense — forget when the origins differ or
-the old origin is unknown. The forget is **local-only** (the row on the old server is left for RomM's machine-id dedup
-to reconcile on a later re-registration) and **best-effort on the success path** — a failed local clear never turns a
-good sign-in into a failure, and a failed sign-in (in-memory snapshot restored) keeps the still-current server's id.
-This is Phase 0a of the RomM Device Sync negotiate adoption
-([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md)).
+**The registered device id is forgotten only on a genuine origin change.** A device registered with RomM
+(`POST /api/devices`, its id stored in `kv_config["device_id"]`) is bound to the server it was registered against —
+RomM's `negotiate` save-sync transport hard-404s a foreign device id. So a successful sign-in that **genuinely changes
+origin** forgets the stored device id (`SaveService.forget_device` → `DeviceRegistry.forget_device`, wired as the
+`DeviceForgetFn` injected into `ConnectionService`), so the next save-sync run re-registers against the new server. The
+decision is `is_origin_change(old_token_origin, new_url)` in `lib/url_host` — both origins are normalized and the id is
+forgotten **only** when both are known (parseable) and differ. This is deliberately the _opposite_ failure posture to
+the old-token DELETE guard (`same_origin`, which fails closed): a **same-server re-sign-in keeps the device identity**,
+including a token swap on the unchanged URL, URL-formatting variants, and a `None`/unstamped old origin (an unknown old
+origin is treated as unknown, not different — never a change). Without this, a same-server token swap dropped the
+identity and the next post-exit sync flagged a spurious conflict for a save this device itself synced (#1437). The
+`old_token_origin` comparison input is captured from the pre-clear auth-state snapshot, so the leak-safety in-memory
+token clear (which zeroes the origin) never poisons the comparison. The forget is **local-only** (the row on the old
+server is left for RomM's machine-id dedup to reconcile on a later re-registration) and **best-effort on the success
+path** — a failed local clear never turns a good sign-in into a failure, and a failed sign-in (in-memory snapshot
+restored) keeps the still-current server's id. `ensure_device_registered` never deletes the id on any failure, so a
+permission-degraded (403/timeout) session leaves the identity intact. This is Phase 0a of the RomM Device Sync negotiate
+adoption ([ADR-0016](../adr/0016-save-sync-hands-detection-to-romm-negotiate.md)).
 
 The no-sign-in URL change path (`SettingsService.save_server_url`) deliberately does not touch the token, so pointing
 the URL at a different origin leaves the stored token's origin mismatched and the auth-header guard makes subsequent

--- a/py_modules/lib/url_host.py
+++ b/py_modules/lib/url_host.py
@@ -66,6 +66,25 @@ def same_origin(a: str | None, b: str | None) -> bool:
     return origin_a is not None and origin_a == origin_b
 
 
+def is_origin_change(old: str | None, new: str | None) -> bool:
+    """Return True iff *old* and *new* are both known origins that name different servers.
+
+    The "did the server genuinely change?" question — the complement of
+    :func:`same_origin` but with the opposite posture on an *unknown* origin. A
+    ``None`` (or otherwise unparseable) origin on either side is treated as
+    unknown, **not** different: a legacy/unstamped token origin (``None``)
+    against any URL is not a change, and nothing bound to a server origin (the
+    registered device id) is dropped just because the old binding was never
+    recorded. Both sides are normalized before comparing; only two parseable
+    origins that normalize to different values count as a real change.
+    """
+    old_origin = normalize_origin(old) if old is not None else None
+    new_origin = normalize_origin(new) if new is not None else None
+    if old_origin is None or new_origin is None:
+        return False
+    return old_origin != new_origin
+
+
 def is_valid_server_url(url: str) -> bool:
     """Return True iff *url* (after stripping surrounding whitespace) names an http(s) origin.
 

--- a/py_modules/services/connection.py
+++ b/py_modules/services/connection.py
@@ -32,7 +32,7 @@ from lib.errors import (
     error_response,
 )
 from lib.list_result import ErrorCode
-from lib.url_host import is_valid_server_url, normalize_origin, same_origin
+from lib.url_host import is_origin_change, is_valid_server_url, normalize_origin, same_origin
 
 if TYPE_CHECKING:
     import asyncio
@@ -511,16 +511,25 @@ class ConnectionService:
             self._logger.warning(f"Could not clear playtime scope notice after sign-in: {e}")
 
     async def _forget_device_on_origin_change(self, old_token_origin: str | None, new_url: str) -> None:
-        """Forget the registered device id when the sign-in origin changed.
+        """Forget the registered device id only when the sign-in origin genuinely changed.
 
-        A device id is bound to the origin it was minted against, so a server
-        switch must drop it (RomM's negotiate hard-404s a foreign id) and let
-        the next sync re-register. Called on the success path only — a failed
-        sign-in keeps the still-current server's id. Best-effort: the new token
-        is already valid, so a failed local clear must not turn a successful
-        sign-in into a failure.
+        A device id is bound to the origin it was minted against, so a real
+        server switch must drop it (RomM's negotiate hard-404s a foreign id) and
+        let the next sync re-register. A same-server re-sign-in — including a
+        token swap on the unchanged URL — must KEEP the id, or the next post-exit
+        sync flags a spurious conflict for a save this device itself synced
+        (#1437). An *unknown* old origin (``None`` — a legacy/unstamped token, or
+        the origin cleared by a prior sign-out) is treated as unknown, not
+        different, and never forgets; only two known, differing normalized
+        origins are a real change (:func:`is_origin_change`). *old_token_origin*
+        is captured from the pre-clear snapshot by the caller, so the
+        leak-safety in-memory token clear never destroys the comparison input.
+        Called on the success path only — a failed sign-in keeps the
+        still-current server's id. Best-effort: the new token is already valid,
+        so a failed local clear must not turn a successful sign-in into a
+        failure.
         """
-        if same_origin(old_token_origin, new_url):
+        if not is_origin_change(old_token_origin, new_url):
             return
         try:
             await self._loop.run_in_executor(None, self._forget_device)

--- a/tests/lib/test_url_host.py
+++ b/tests/lib/test_url_host.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from lib.url_host import is_valid_server_url, normalize_origin, same_origin
+from lib.url_host import is_origin_change, is_valid_server_url, normalize_origin, same_origin
 
 
 class TestNormalizeOrigin:
@@ -160,6 +160,49 @@ class TestSameOrigin:
 
     def test_trailing_dot_vs_dotless_true(self):
         assert same_origin("https://host.com.", "https://host.com") is True
+
+
+class TestIsOriginChange:
+    """`is_origin_change` — the "real server switch?" question that gates the
+    device-forget hook (#1437). Unlike `same_origin`, an unknown (`None` /
+    unparseable) origin is treated as unknown, NOT different: it never counts as
+    a change, so a legacy/unstamped token origin never drops the device id."""
+
+    def test_different_host_true(self):
+        assert is_origin_change("https://a.local", "https://b.local") is True
+
+    def test_different_scheme_true(self):
+        assert is_origin_change("https://romm.local", "http://romm.local") is True
+
+    def test_different_port_true(self):
+        assert is_origin_change("http://192.168.178.83:8085", "http://192.168.178.83:9090") is True
+
+    def test_same_origin_false(self):
+        assert is_origin_change("http://romm.local", "http://romm.local") is False
+
+    def test_same_origin_trailing_slash_and_default_port_false(self):
+        """URL formatting variants normalize to the same origin — not a change."""
+        assert is_origin_change("https://romm.local", "https://romm.local:443/romm/") is False
+
+    def test_same_origin_explicit_nondefault_port_false(self):
+        """The unchanged-URL token swap from #1437 (host:port stamped) is not a change."""
+        assert is_origin_change("http://192.168.178.83:8085", "http://192.168.178.83:8085") is False
+
+    def test_none_old_against_valid_new_false(self):
+        """The #1437 fix: an unstamped (`None`) old origin is unknown, not different."""
+        assert is_origin_change(None, "http://192.168.178.83:8085") is False
+
+    def test_none_new_false(self):
+        assert is_origin_change("https://romm.local", None) is False
+
+    def test_both_none_false(self):
+        assert is_origin_change(None, None) is False
+
+    def test_unparseable_old_against_valid_new_false(self):
+        assert is_origin_change("not-a-url", "https://romm.local") is False
+
+    def test_unparseable_new_false(self):
+        assert is_origin_change("https://romm.local", "also-not-a-url") is False
 
 
 class TestIsValidServerUrl:

--- a/tests/services/saves/sync_engine/test_devices.py
+++ b/tests/services/saves/sync_engine/test_devices.py
@@ -14,12 +14,13 @@ from fakes.fake_machine_id_reader import FakeMachineIdReader
 from fakes.fake_save_api import FakeSaveApi
 from fakes.fake_unit_of_work import FakeUnitOfWorkFactory
 
-from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommSSLError
+from lib.errors import RommApiError, RommAuthError, RommConnectionError, RommForbiddenError, RommSSLError
 from lib.list_result import ErrorCode
 from services.saves.sync_engine.devices import DeviceRegistry
 from tests.services.saves._helpers import (
     _create_save,
     _enable_sync_with_device,
+    _get_device_id,
     _install_rom,
     make_service,
 )
@@ -300,6 +301,50 @@ class TestEnsureDeviceRegisteredUpdateSwallowLogs:
         assert result["success"] is True
         assert result["device_id"] == "server-uuid"
         assert any("update_device failed" in m and "boom" in m for m in debug_log)
+
+
+class TestPermissionDegradedNeverDropsDeviceId:
+    """#1437 regression guard: a permission-degraded (403) registration must NEVER
+    delete ``kv_config["device_id"]``. The only in-process deleter is
+    ``DeviceRegistry.forget_device`` (reached solely from a sign-in origin
+    change); registration/verification failures leave the id intact so the next
+    sync attributes uploads as before instead of re-registering into a spurious
+    conflict."""
+
+    @pytest.mark.asyncio
+    async def test_forbidden_update_touch_leaves_the_id_intact(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        _enable_sync_with_device(svc, "server-uuid")
+        # Stamp a version so the pre-register heartbeat probe is skipped — the 403
+        # lands on the best-effort update_device touch on the already-registered id.
+        fake.set_version("4.9.0")
+        fake.fail_on_next(RommForbiddenError("403 Forbidden"))
+
+        result = await svc.ensure_device_registered()
+
+        # The touch failed (non-fatal) but registration still reports the existing id.
+        assert result["success"] is True
+        assert result["device_id"] == "server-uuid"
+        # The persisted row is untouched — no forget/delete on a permission failure.
+        assert _get_device_id(svc) == "server-uuid"
+        # The id was NOT dropped-then-re-registered: no register_device call happened.
+        assert _register_call(fake) is None
+
+    @pytest.mark.asyncio
+    async def test_forbidden_registration_creates_no_id_and_deletes_none(self, tmp_path):
+        svc, fake = make_service(tmp_path)
+        svc._config.settings["save_sync_enabled"] = True
+        # No device_id yet → registration branch; stamp a version to skip the probe
+        # so the 403 lands on register_device itself.
+        fake.set_version("4.9.0")
+        fake.fail_on_next(RommForbiddenError("403 Forbidden"))
+
+        result = await svc.ensure_device_registered()
+
+        assert result["success"] is False
+        # No id was minted, and nothing was deleted — kv_config stays absent.
+        assert result["device_id"] == ""
+        assert _get_device_id(svc) is None
 
 
 class TestRegistrationDeviceNameWriteIsBestEffort:

--- a/tests/services/test_connection.py
+++ b/tests/services/test_connection.py
@@ -485,8 +485,11 @@ class TestEstablishTokenOldTokenDeletion:
 
 class TestEstablishTokenDeviceForget:
     """0a (#1234): a registered device id is bound to its minting origin, so a
-    sign-in that changes origin must forget it (negotiate hard-404s a foreign
-    device id). The forget is local-only and best-effort on the success path."""
+    sign-in that GENUINELY changes origin must forget it (negotiate hard-404s a
+    foreign device id). A same-server re-sign-in — including an unstamped
+    (`None`) old origin against the unchanged URL — must KEEP the id (#1437), or
+    the next post-exit sync flags a spurious conflict. The forget is local-only
+    and best-effort on the success path."""
 
     def test_forgets_device_when_origin_differs(self, event_loop, romm_api, logger):
         settings = {"romm_api_token_id": 99, "romm_api_token_origin": "https://old.server"}
@@ -518,25 +521,31 @@ class TestEstablishTokenDeviceForget:
         event_loop.run_until_complete(service.establish_token("https://romm.local:443/romm/", "u", "p"))
         forget_device.assert_not_called()
 
-    def test_forgets_device_when_old_origin_unknown(self, event_loop, romm_api, logger):
-        """A legacy token with no stored origin fails closed — forget conservatively."""
+    def test_keeps_device_when_old_origin_unknown(self, event_loop, romm_api, logger):
+        """#1437: a legacy token with no stored origin is unknown, not different — keep the id.
+
+        An unstamped (`None`) old origin against the unchanged URL must not
+        forget; the sign-in then stamps the origin so the next comparison is
+        precise.
+        """
         settings = {"romm_api_token_id": 99}  # no romm_api_token_origin
         forget_device = MagicMock()
         service = _make_service(
             settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
         )
         event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
-        forget_device.assert_called_once_with()
+        forget_device.assert_not_called()
+        assert settings["romm_api_token_origin"] == "http://romm.local"
 
-    def test_forgets_device_on_first_sign_in(self, event_loop, romm_api, logger):
-        """First-ever sign-in (no prior token) forgets — a harmless no-op (no device yet)."""
+    def test_keeps_device_on_first_sign_in(self, event_loop, romm_api, logger):
+        """#1437: first-ever sign-in (no prior origin) is not an origin change — never forget."""
         settings: dict[str, Any] = {}
         forget_device = MagicMock()
         service = _make_service(
             settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
         )
         event_loop.run_until_complete(service.establish_token("http://romm.local", "u", "p"))
-        forget_device.assert_called_once_with()
+        forget_device.assert_not_called()
 
     def test_does_not_forget_on_failed_mint(self, event_loop, romm_api, logger):
         """A failed mint restores the snapshot — the still-current device id stays."""
@@ -758,13 +767,46 @@ class TestEstablishUserTokenHappyPath:
             event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_supersecret"))
         assert all("rmm_supersecret" not in r.getMessage() for r in caplog.records)
 
-    def test_forgets_device_on_first_sign_in(self, event_loop, romm_api, logger):
+    def test_keeps_device_on_first_sign_in(self, event_loop, romm_api, logger):
+        """#1437: first-ever paste sign-in (no prior origin) is not a change — never forget."""
         settings: dict[str, Any] = {}
         forget_device = MagicMock()
         service = _make_service(
             settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
         )
         event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        forget_device.assert_not_called()
+
+    def test_keeps_device_on_same_server_token_swap(self, event_loop, romm_api, logger):
+        """#1437: pasting a new token for the SAME server keeps the device id."""
+        settings = {"romm_api_token_origin": "http://romm.local"}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        forget_device.assert_not_called()
+
+    def test_keeps_device_when_old_origin_unknown(self, event_loop, romm_api, logger):
+        """#1437: an unstamped (`None`) old origin against the unchanged URL keeps the id."""
+        settings = {"romm_api_token_id": None}  # no romm_api_token_origin
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        event_loop.run_until_complete(service.establish_user_token("http://romm.local", "rmm_pasted"))
+        forget_device.assert_not_called()
+        assert settings["romm_api_token_origin"] == "http://romm.local"
+
+    def test_forgets_device_when_origin_differs(self, event_loop, romm_api, logger):
+        """A genuine server switch on the paste path still forgets the id (ADR-0016 0a)."""
+        settings = {"romm_api_token_origin": "https://old.server"}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        result = event_loop.run_until_complete(service.establish_user_token("https://new.server", "rmm_pasted"))
+        assert result["success"] is True
         forget_device.assert_called_once_with()
 
     def test_clears_playtime_scope_notice(self, event_loop, romm_api, logger):
@@ -1231,13 +1273,35 @@ class TestEstablishPairedTokenHappyPath:
         assert "rmm_supersecret" not in messages
         assert "SECRETCODE23" not in messages
 
-    def test_forgets_device_on_first_sign_in(self, event_loop, romm_api, logger):
+    def test_keeps_device_on_first_sign_in(self, event_loop, romm_api, logger):
+        """#1437: first-ever paired sign-in (no prior origin) is not a change — never forget."""
         settings: dict[str, Any] = {}
         forget_device = MagicMock()
         service = _make_service(
             settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
         )
         event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        forget_device.assert_not_called()
+
+    def test_keeps_device_on_same_server_re_pair(self, event_loop, romm_api, logger):
+        """#1437: re-pairing against the SAME server keeps the device id."""
+        settings = {"romm_api_token_origin": "http://romm.local"}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        event_loop.run_until_complete(service.establish_paired_token("http://romm.local", "ABCD2345"))
+        forget_device.assert_not_called()
+
+    def test_forgets_device_when_origin_differs(self, event_loop, romm_api, logger):
+        """A genuine server switch on the pairing path still forgets the id (ADR-0016 0a)."""
+        settings = {"romm_api_token_origin": "https://old.server"}
+        forget_device = MagicMock()
+        service = _make_service(
+            settings=settings, romm_api=romm_api, loop=event_loop, logger=logger, forget_device=forget_device
+        )
+        result = event_loop.run_until_complete(service.establish_paired_token("https://new.server", "ABCD2345"))
+        assert result["success"] is True
         forget_device.assert_called_once_with()
 
     def test_clears_playtime_scope_notice(self, event_loop, romm_api, logger):


### PR DESCRIPTION
Closes #1437.

## Problem

A same-server re-sign-in could silently delete the registered device identity (`kv_config["device_id"]`). Each drop re-registered a fresh id, so the slot head carried no `device_syncs` entry for "this" device anymore — the decision kernel then honestly flagged a spurious conflict (`_decide_when_no_entry`) for a save this device itself had synced. Reproduced live twice; with repeated token swaps this degrades to a conflict per play session, plus orphaned device records server-side.

## Root cause

The forget hook gated on `same_origin(old, new)`, which fails closed on an unknown old origin: a legacy/unstamped origin (`None`) read as "not the same" → forget fired although the server never changed. (Fail-closed stays correct where `same_origin` guards the old-token DELETE — that site is untouched.)

## Change

- New pure `lib/url_host.is_origin_change(old, new)`: true only when **both origins are known and differ**; the forget hook gates on it. Same-server token swaps and legacy `None`-origin sign-ins keep the identity; a genuine server switch (incl. `http`↔`https` on the same host) still forgets, per ADR-0016.
- Sibling sweep over the other `same_origin` call sites (old-token DELETE guard, auth-header host binding): correct polarity, unchanged.
- Docs: backend-architecture.md documented the buggy "forget when the old origin is unknown" — corrected; CLAUDE.md token-host bullet sharpened.

## Tests

`is_origin_change` edge matrix (scheme/host/port/None/unparseable/formatting variants); keep-identity across all three sign-in paths (token, user token, paired) incl. the legacy `None`-origin case; genuine-origin-change forget still pinned per path; two permission-degraded (403) regression guards proving registration/verification failures never delete the identity. Full gate battery green (5373 backend / 1936 frontend).